### PR TITLE
[TA] revert auto LD change

### DIFF
--- a/sdk/textanalytics/azure-ai-textanalytics/CHANGELOG.md
+++ b/sdk/textanalytics/azure-ai-textanalytics/CHANGELOG.md
@@ -14,9 +14,6 @@ This version of the client library defaults to the service API version `2022-10-
 - Removed models `BaseResolution` and `BooleanResolution`.
 - Renamed model `AbstractSummaryAction` to `AbstractiveSummaryAction`.
 - Renamed model `AbstractSummaryResult` to `AbstractiveSummaryResult`.
-- Changed automatic language detection, it is now controlled by the boolean keyword argument `auto_detect_language`.
-  Pass `True` to enable automatic language detection for text documents analyzed by long-running operation APIs.
-- Removed keyword argument `autodetect_default_language` - use `language` to provide a default/fallback language.
 
 ### Bugs Fixed
 

--- a/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/_models.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/_models.py
@@ -398,7 +398,7 @@ class RecognizeEntitiesResult(DictMixin):
     """If `show_stats=True` was specified in the request this
         field will contain information about the document payload."""
     detected_language: Optional[DetectedLanguage] = None
-    """If automatic language detection is enabled, then this
+    """If 'language' is set to 'auto' for the document in the request this
         field will contain the DetectedLanguage for the document."""
     is_error: Literal[False] = False
     """Boolean check for error item when iterating over list of
@@ -449,7 +449,7 @@ class RecognizePiiEntitiesResult(DictMixin):
     """If `show_stats=True` was specified in the request this
         field will contain information about the document payload."""
     detected_language: Optional[DetectedLanguage] = None
-    """If automatic language detection is enabled, then this
+    """If 'language' is set to 'auto' for the document in the request this
         field will contain the DetectedLanguage for the document."""
     is_error: Literal[False] = False
     """Boolean check for error item when iterating over list of
@@ -508,7 +508,7 @@ class AnalyzeHealthcareEntitiesResult(DictMixin):
         FHIR compatible object for consumption in other Healthcare tools. For additional
         information see https://www.hl7.org/fhir/overview.html."""
     detected_language: Optional[str] = None
-    """If automatic language detection is enabled, then this
+    """If 'language' is set to 'auto' for the document in the request this
         field will contain the detected language for the document."""
     is_error: Literal[False] = False
     """Boolean check for error item when iterating over list of
@@ -1061,7 +1061,7 @@ class ExtractKeyPhrasesResult(DictMixin):
     """If `show_stats=True` was specified in the request this
         field will contain information about the document payload."""
     detected_language: Optional[DetectedLanguage] = None
-    """If automatic language detection is enabled, then this
+    """If 'language' is set to 'auto' for the document in the request this
         field will contain the DetectedLanguage for the document."""
     is_error: Literal[False] = False
     """Boolean check for error item when iterating over list of
@@ -1107,7 +1107,7 @@ class RecognizeLinkedEntitiesResult(DictMixin):
     """If `show_stats=True` was specified in the request this
         field will contain information about the document payload."""
     detected_language: Optional[DetectedLanguage] = None
-    """If automatic language detection is enabled, then this
+    """If 'language' is set to 'auto' for the document in the request this
         field will contain the DetectedLanguage for the document."""
     is_error: Literal[False] = False
     """Boolean check for error item when iterating over list of
@@ -1161,7 +1161,7 @@ class AnalyzeSentimentResult(DictMixin):
     """If `show_stats=True` was specified in the request this
         field will contain information about the document payload."""
     detected_language: Optional[DetectedLanguage] = None
-    """If automatic language detection is enabled, then this
+    """If 'language' is set to 'auto' for the document in the request this
         field will contain the DetectedLanguage for the document."""
     is_error: Literal[False] = False
     """Boolean check for error item when iterating over list of
@@ -1441,7 +1441,12 @@ class TextDocumentInput(DictMixin, MultiLanguageInput):
     :keyword str text: Required. The input text to process.
     :keyword str language: This is the 2 letter ISO 639-1 representation
      of a language. For example, use "en" for English; "es" for Spanish etc.
-     If not set, uses "en" for English as default.
+     For automatic language detection, use "auto" (Only supported by long-running
+     operation APIs with API version 2022-10-01-preview or newer). If
+     not set, uses "en" for English as default.
+
+    .. versionadded:: 2022-10-01-preview
+        The 'auto' option for language.
     """
 
     id: str  # pylint: disable=redefined-builtin
@@ -1451,7 +1456,9 @@ class TextDocumentInput(DictMixin, MultiLanguageInput):
     language: Optional[str] = None
     """This is the 2 letter ISO 639-1 representation
      of a language. For example, use "en" for English; "es" for Spanish etc.
-     If not set, uses "en" for English as default."""
+     For automatic language detection, use "auto" (Only supported by long-running
+     operation APIs with API version 2022-10-01-preview or newer). If
+     not set, uses "en" for English as default."""
 
     def __init__(
         self,
@@ -2329,7 +2336,7 @@ class RecognizeCustomEntitiesResult(DictMixin):
     """If `show_stats=True` was specified in the request this
         field will contain information about the document payload."""
     detected_language: Optional[DetectedLanguage] = None
-    """If automatic language detection is enabled, then this
+    """If 'language' is set to 'auto' for the document in the request this
         field will contain the DetectedLanguage for the document."""
     is_error: Literal[False] = False
     """Boolean check for error item when iterating over list of
@@ -2458,7 +2465,7 @@ class ClassifyDocumentResult(DictMixin):
     """If `show_stats=True` was specified in the request this
         field will contain information about the document payload."""
     detected_language: Optional[DetectedLanguage] = None
-    """If automatic language detection is enabled, then this
+    """If 'language' is set to 'auto' for the document in the request this
         field will contain the DetectedLanguage for the document."""
     is_error: Literal[False] = False
     """Boolean check for error item when iterating over list of
@@ -2792,7 +2799,7 @@ class ExtractSummaryResult(DictMixin):
     """If `show_stats=True` was specified in the request this
         field will contain information about the document payload."""
     detected_language: Optional[DetectedLanguage] = None
-    """If automatic language detection is enabled, then this
+    """If 'language' is set to 'auto' for the document in the request this
         field will contain the DetectedLanguage for the document."""
     is_error: Literal[False] = False
     """Boolean check for error item when iterating over list of
@@ -2899,7 +2906,7 @@ class AbstractiveSummaryResult(DictMixin):
     """Warnings encountered while processing document. Results will still be returned
         if there are warnings, but they may not be fully accurate."""
     detected_language: Optional[DetectedLanguage] = None
-    """If automatic language detection is enabled, then this
+    """If 'language' is set to 'auto' for the document in the request this
         field will contain the DetectedLanguage for the document."""
     statistics: Optional[TextDocumentStatistics] = None
     """If `show_stats=True` was specified in the request this

--- a/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/_text_analytics_client.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/_text_analytics_client.py
@@ -639,7 +639,7 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
     @validate_multiapi_args(
         version_method_added="v3.1",
         args_mapping={
-            "2022-10-01-preview": ["fhir_version", "document_type", "auto_detect_language"],
+            "2022-10-01-preview": ["fhir_version", "document_type", "autodetect_default_language"],
             "2022-05-01": ["display_name"]
         }
     )
@@ -647,7 +647,7 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
         self,
         documents: Union[List[str], List[TextDocumentInput], List[Dict[str, str]]],
         *,
-        auto_detect_language: Optional[bool] = None,
+        autodetect_default_language: Optional[str] = None,
         continuation_token: Optional[str] = None,
         disable_service_logs: Optional[bool] = None,
         display_name: Optional[str] = None,
@@ -682,13 +682,12 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
         :keyword bool show_stats: If set to true, response will contain document level statistics.
         :keyword str language: The 2 letter ISO 639-1 representation of language for the
             entire batch. For example, use "en" for English; "es" for Spanish etc.
-            If not set, uses "en" for English as default.
+            For automatic language detection, use "auto" (Only supported by API version
+            2022-10-01-preview and newer). If not set, uses "en" for English as default.
             Per-document language will take precedence over whole batch language.
             See https://aka.ms/talangs for supported languages in Language API.
-        :keyword bool auto_detect_language: If True, the service will automatically detect the
-            language of each text document (Only supported by API version 2022-10-01-preview and newer).
-            Optionally use the `language` keyword argument to provide a default/fallback language
-            to use for the batch in the event that the service is unable to detect the language.
+        :keyword str autodetect_default_language: Default/fallback language to use for documents requesting
+            automatic language detection.
         :keyword str display_name: An optional display name to set for the requested analysis.
         :keyword str string_index_type: Specifies the method used to interpret string offsets.
             `UnicodeCodePoint`, the Python encoding, is the default. To override the Python default,
@@ -729,7 +728,7 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
         .. versionadded:: 2022-05-01
             The *display_name* keyword argument.
         .. versionadded:: 2022-10-01-preview
-            The *fhir_version*, *document_type*, and *auto_detect_language* keyword arguments.
+            The *fhir_version*, *document_type*, and *autodetect_default_language* keyword arguments.
 
         .. admonition:: Example:
 
@@ -762,10 +761,8 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
                     self._healthcare_result_callback
                 )
             )
-        if auto_detect_language is True:
-            docs = _validate_input(documents, "language", "auto")
-        else:
-            docs = _validate_input(documents, "language", language_arg)
+
+        docs = _validate_input(documents, "language", language_arg)
         doc_id_order = [doc.get("id") for doc in docs]
         my_cls = kwargs.pop(
             "cls",
@@ -788,7 +785,7 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
                         body=models.AnalyzeTextJobsInput(
                             analysis_input=input_docs,
                             display_name=display_name,
-                            default_language=language_arg if auto_detect_language is True else None,
+                            default_language=autodetect_default_language,
                             tasks=[
                                 models.HealthcareLROTask(
                                     task_name="0",
@@ -1102,7 +1099,7 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
         version_method_added="v3.1",
         custom_wrapper=check_for_unsupported_actions_types,
         args_mapping={
-            "2022-10-01-preview": ["auto_detect_language"],
+            "2022-10-01-preview": ["autodetect_default_language"],
         }
     )
     def begin_analyze_actions(
@@ -1124,7 +1121,7 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
             ]
         ],
         *,
-        auto_detect_language: Optional[bool] = None,
+        autodetect_default_language: Optional[str] = None,
         continuation_token: Optional[str] = None,
         display_name: Optional[str] = None,
         language: Optional[str] = None,
@@ -1181,13 +1178,12 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
         :keyword str display_name: An optional display name to set for the requested analysis.
         :keyword str language: The 2 letter ISO 639-1 representation of language for the
             entire batch. For example, use "en" for English; "es" for Spanish etc.
-            If not set, uses "en" for English as default.
+            For automatic language detection, use "auto" (Only supported by API version
+            2022-10-01-preview and newer). If not set, uses "en" for English as default.
             Per-document language will take precedence over whole batch language.
             See https://aka.ms/talangs for supported languages in Language API.
-        :keyword bool auto_detect_language: If True, the service will automatically detect the
-            language of each text document (Only supported by API version 2022-10-01-preview and newer).
-            Optionally use the `language` keyword argument to provide a default/fallback language
-            to use for the batch in the event that the service is unable to detect the language.
+        :keyword str autodetect_default_language: Default/fallback language to use for documents requesting
+            automatic language detection.
         :keyword bool show_stats: If set to true, response will contain document level statistics.
         :keyword int polling_interval: Waiting time between two polls for LRO operations
             if no Retry-After header is present. Defaults to 5 seconds.
@@ -1222,9 +1218,9 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
             corresponding *RecognizeCustomEntitiesResult*, *ClassifyDocumentResult*,
             and *AnalyzeHealthcareEntitiesResult* result objects
         .. versionadded:: 2022-10-01-preview
-            The *ExtractSummaryAction* and *AbstractiveSummaryAction* input options and the corresponding
-            *ExtractSummaryResult* and *AbstractiveSummaryResult* result objects.
-            The *auto_detect_language* keyword argument.
+            The *ExtractSummaryAction* and *AbstractSummaryAction* input options and the corresponding
+            *ExtractSummaryResult* and *AbstractSummaryResult* result objects.
+            The *autodetect_default_language* keyword argument.
 
         .. admonition:: Example:
 
@@ -1262,14 +1258,9 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
 
         input_model_cls = \
             models.MultiLanguageAnalysisInput if is_language_api(self._api_version) else models.MultiLanguageBatchInput
-        if auto_detect_language is True:
-            docs = input_model_cls(
-                documents=_validate_input(documents, "language", "auto")
-            )
-        else:
-            docs = input_model_cls(
-                documents=_validate_input(documents, "language", language_arg)
-            )
+        docs = input_model_cls(
+            documents=_validate_input(documents, "language", language_arg)
+        )
         doc_id_order = [doc.get("id") for doc in docs.documents]
         try:
             generated_tasks = [
@@ -1300,7 +1291,7 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
                         body=models.AnalyzeTextJobsInput(
                             analysis_input=docs,
                             display_name=display_name,
-                            default_language=language_arg if auto_detect_language is True else None,
+                            default_language=autodetect_default_language,
                             tasks=generated_tasks
                         ),
                         cls=response_cls,
@@ -1377,7 +1368,7 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
     @validate_multiapi_args(
         version_method_added="2022-05-01",
         args_mapping={
-            "2022-10-01-preview": ["auto_detect_language"],
+            "2022-10-01-preview": ["autodetect_default_language"],
         }
     )
     def begin_recognize_custom_entities(
@@ -1386,7 +1377,7 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
         project_name: str,
         deployment_name: str,
         *,
-        auto_detect_language: Optional[bool] = None,
+        autodetect_default_language: Optional[str] = None,
         continuation_token: Optional[str] = None,
         disable_service_logs: Optional[bool] = None,
         display_name: Optional[str] = None,
@@ -1412,13 +1403,12 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
         :param str deployment_name: This field indicates the deployment name for the model.
         :keyword str language: The 2 letter ISO 639-1 representation of language for the
             entire batch. For example, use "en" for English; "es" for Spanish etc.
-            If not set, uses "en" for English as default.
+            For automatic language detection, use "auto" (Only supported by API version
+            2022-10-01-preview and newer). If not set, uses "en" for English as default.
             Per-document language will take precedence over whole batch language.
             See https://aka.ms/talangs for supported languages in Language API.
-        :keyword bool auto_detect_language: If True, the service will automatically detect the
-            language of each text document (Only supported by API version 2022-10-01-preview and newer).
-            Optionally use the `language` keyword argument to provide a default/fallback language
-            to use for the batch in the event that the service is unable to detect the language.
+        :keyword str autodetect_default_language: Default/fallback language to use for documents requesting
+            automatic language detection.
         :keyword bool show_stats: If set to true, response will contain document level statistics.
         :keyword bool disable_service_logs: If set to true, you opt-out of having your text input
             logged on the service side for troubleshooting. By default, the Language service logs your
@@ -1451,7 +1441,7 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
         .. versionadded:: 2022-05-01
             The *begin_recognize_custom_entities* client method.
         .. versionadded:: 2022-10-01-preview
-            The *auto_detect_language* keyword argument.
+            The *autodetect_default_language* keyword argument.
 
         .. admonition:: Example:
 
@@ -1498,7 +1488,7 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
                             disable_service_logs=disable_service_logs
                         )
                     ],
-                    auto_detect_language=auto_detect_language,
+                    autodetect_default_language=autodetect_default_language,
                     display_name=display_name,
                     show_stats=show_stats,
                     language=language,
@@ -1515,7 +1505,7 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
     @validate_multiapi_args(
         version_method_added="2022-05-01",
         args_mapping={
-            "2022-10-01-preview": ["auto_detect_language"],
+            "2022-10-01-preview": ["autodetect_default_language"],
         }
     )
     def begin_single_label_classify(
@@ -1524,7 +1514,7 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
         project_name: str,
         deployment_name: str,
         *,
-        auto_detect_language: Optional[bool] = None,
+        autodetect_default_language: Optional[str] = None,
         continuation_token: Optional[str] = None,
         disable_service_logs: Optional[bool] = None,
         display_name: Optional[str] = None,
@@ -1549,13 +1539,12 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
         :param str deployment_name: This field indicates the deployment name for the model.
         :keyword str language: The 2 letter ISO 639-1 representation of language for the
             entire batch. For example, use "en" for English; "es" for Spanish etc.
-            If not set, uses "en" for English as default.
+            For automatic language detection, use "auto" (Only supported by API version
+            2022-10-01-preview and newer). If not set, uses "en" for English as default.
             Per-document language will take precedence over whole batch language.
             See https://aka.ms/talangs for supported languages in Language API.
-        :keyword bool auto_detect_language: If True, the service will automatically detect the
-            language of each text document (Only supported by API version 2022-10-01-preview and newer).
-            Optionally use the `language` keyword argument to provide a default/fallback language
-            to use for the batch in the event that the service is unable to detect the language.
+        :keyword str autodetect_default_language: Default/fallback language to use for documents requesting
+            automatic language detection.
         :keyword bool show_stats: If set to true, response will contain document level statistics.
         :keyword bool disable_service_logs: If set to true, you opt-out of having your text input
             logged on the service side for troubleshooting. By default, the Language service logs your
@@ -1584,7 +1573,7 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
         .. versionadded:: 2022-05-01
             The *begin_single_label_classify* client method.
         .. versionadded:: 2022-10-01-preview
-            The *auto_detect_language* keyword argument.
+            The *autodetect_default_language* keyword argument.
 
         .. admonition:: Example:
 
@@ -1630,7 +1619,7 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
                         )
                     ],
                     polling_interval=polling_interval_arg,
-                    auto_detect_language=auto_detect_language,
+                    autodetect_default_language=autodetect_default_language,
                     display_name=display_name,
                     show_stats=show_stats,
                     language=language,
@@ -1646,7 +1635,7 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
     @validate_multiapi_args(
         version_method_added="2022-05-01",
         args_mapping={
-            "2022-10-01-preview": ["auto_detect_language"],
+            "2022-10-01-preview": ["autodetect_default_language"],
         }
     )
     def begin_multi_label_classify(
@@ -1655,7 +1644,7 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
         project_name: str,
         deployment_name: str,
         *,
-        auto_detect_language: Optional[bool] = None,
+        autodetect_default_language: Optional[str] = None,
         continuation_token: Optional[str] = None,
         disable_service_logs: Optional[bool] = None,
         display_name: Optional[str] = None,
@@ -1680,13 +1669,12 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
         :param str deployment_name: This field indicates the deployment name for the model.
         :keyword str language: The 2 letter ISO 639-1 representation of language for the
             entire batch. For example, use "en" for English; "es" for Spanish etc.
-            If not set, uses "en" for English as default.
+            For automatic language detection, use "auto" (Only supported by API version
+            2022-10-01-preview and newer). If not set, uses "en" for English as default.
             Per-document language will take precedence over whole batch language.
             See https://aka.ms/talangs for supported languages in Language API.
-        :keyword bool auto_detect_language: If True, the service will automatically detect the
-            language of each text document (Only supported by API version 2022-10-01-preview and newer).
-            Optionally use the `language` keyword argument to provide a default/fallback language
-            to use for the batch in the event that the service is unable to detect the language.
+        :keyword str autodetect_default_language: Default/fallback language to use for documents requesting
+            automatic language detection.
         :keyword bool show_stats: If set to true, response will contain document level statistics.
         :keyword bool disable_service_logs: If set to true, you opt-out of having your text input
             logged on the service side for troubleshooting. By default, the Language service logs your
@@ -1715,7 +1703,7 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
         .. versionadded:: 2022-05-01
             The *begin_multi_label_classify* client method.
         .. versionadded:: 2022-10-01-preview
-            The *auto_detect_language* keyword argument.
+            The *autodetect_default_language* keyword argument.
 
         .. admonition:: Example:
 
@@ -1761,7 +1749,7 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
                         )
                     ],
                     polling_interval=polling_interval_arg,
-                    auto_detect_language=auto_detect_language,
+                    autodetect_default_language=autodetect_default_language,
                     display_name=display_name,
                     show_stats=show_stats,
                     language=language,
@@ -1883,7 +1871,7 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
         self,
         documents: Union[List[str], List[TextDocumentInput], List[Dict[str, str]]],
         *,
-        auto_detect_language: Optional[bool] = None,
+        autodetect_default_language: Optional[str] = None,
         continuation_token: Optional[str] = None,
         disable_service_logs: Optional[bool] = None,
         display_name: Optional[str] = None,
@@ -1910,13 +1898,12 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
             list[str] or list[~azure.ai.textanalytics.TextDocumentInput] or list[dict[str, str]]
         :keyword str language: The 2 letter ISO 639-1 representation of language for the
             entire batch. For example, use "en" for English; "es" for Spanish etc.
-            If not set, uses "en" for English as default.
+            For automatic language detection, use "auto" (Only supported by API version
+            2022-10-01-preview and newer). If not set, uses "en" for English as default.
             Per-document language will take precedence over whole batch language.
             See https://aka.ms/talangs for supported languages in Language API.
-        :keyword bool auto_detect_language: If True, the service will automatically detect the
-            language of each text document (Only supported by API version 2022-10-01-preview and newer).
-            Optionally use the `language` keyword argument to provide a default/fallback language
-            to use for the batch in the event that the service is unable to detect the language.
+        :keyword str autodetect_default_language: Default/fallback language to use for documents requesting
+            automatic language detection.
         :keyword bool show_stats: If set to true, response will contain document level statistics.
         :keyword Optional[int] max_sentence_count: Maximum number of sentences to return. Defaults to 3.
         :keyword Optional[str] order_by:  Possible values include: "Offset", "Rank". Default value: "Offset".
@@ -1996,7 +1983,7 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
                         )
                     ],
                     polling_interval=polling_interval_arg,
-                    auto_detect_language=auto_detect_language,
+                    autodetect_default_language=autodetect_default_language,
                     display_name=display_name,
                     show_stats=show_stats,
                     language=language,
@@ -2016,7 +2003,7 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
         self,
         documents: Union[List[str], List[TextDocumentInput], List[Dict[str, str]]],
         *,
-        auto_detect_language: Optional[bool] = None,
+        autodetect_default_language: Optional[str] = None,
         continuation_token: Optional[str] = None,
         disable_service_logs: Optional[bool] = None,
         display_name: Optional[str] = None,
@@ -2045,13 +2032,12 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
             list[str] or list[~azure.ai.textanalytics.TextDocumentInput] or list[dict[str, str]]
         :keyword str language: The 2 letter ISO 639-1 representation of language for the
             entire batch. For example, use "en" for English; "es" for Spanish etc.
-            If not set, uses "en" for English as default.
+            For automatic language detection, use "auto" (Only supported by API version
+            2022-10-01-preview and newer). If not set, uses "en" for English as default.
             Per-document language will take precedence over whole batch language.
             See https://aka.ms/talangs for supported languages in Language API.
-        :keyword bool auto_detect_language: If True, the service will automatically detect the
-            language of each text document (Only supported by API version 2022-10-01-preview and newer).
-            Optionally use the `language` keyword argument to provide a default/fallback language
-            to use for the batch in the event that the service is unable to detect the language.
+        :keyword str autodetect_default_language: Default/fallback language to use for documents requesting
+            automatic language detection.
         :keyword bool show_stats: If set to true, response will contain document level statistics.
         :keyword Optional[int] sentence_count: It controls the approximate number of sentences in the output summaries.
         :keyword Optional[str] model_version: The model version to use for the analysis.
@@ -2129,7 +2115,7 @@ class TextAnalyticsClient(TextAnalyticsClientBase):
                         )
                     ],
                     polling_interval=polling_interval_arg,
-                    auto_detect_language=auto_detect_language,
+                    autodetect_default_language=autodetect_default_language,
                     display_name=display_name,
                     show_stats=show_stats,
                     language=language,

--- a/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/aio/_text_analytics_client_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/aio/_text_analytics_client_async.py
@@ -861,7 +861,7 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
     @validate_multiapi_args(
         version_method_added="v3.1",
         args_mapping={
-            "2022-10-01-preview": ["fhir_version", "document_type", "auto_detect_language"],
+            "2022-10-01-preview": ["fhir_version", "document_type", "autodetect_default_language"],
             "2022-05-01": ["display_name"]
         }
     )
@@ -869,7 +869,7 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
         self,
         documents: Union[List[str], List[TextDocumentInput], List[Dict[str, str]]],
         *,
-        auto_detect_language: Optional[bool] = None,
+        autodetect_default_language: Optional[str] = None,
         continuation_token: Optional[str] = None,
         disable_service_logs: Optional[bool] = None,
         display_name: Optional[str] = None,
@@ -906,13 +906,12 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
         :keyword bool show_stats: If set to true, response will contain document level statistics.
         :keyword str language: The 2 letter ISO 639-1 representation of language for the
             entire batch. For example, use "en" for English; "es" for Spanish etc.
-            If not set, uses "en" for English as default.
+            For automatic language detection, use "auto" (Only supported by API version
+            2022-10-01-preview and newer). If not set, uses "en" for English as default.
             Per-document language will take precedence over whole batch language.
             See https://aka.ms/talangs for supported languages in Language API.
-        :keyword bool auto_detect_language: If True, the service will automatically detect the
-            language of each text document (Only supported by API version 2022-10-01-preview and newer).
-            Optionally use the `language` keyword argument to provide a default/fallback language
-            to use for the batch in the event that the service is unable to detect the language.
+        :keyword str autodetect_default_language: Default/fallback language to use for documents requesting
+            automatic language detection.
         :keyword str display_name: An optional display name to set for the requested analysis.
         :keyword str string_index_type: Specifies the method used to interpret string offsets.
             Can be one of 'UnicodeCodePoint' (default), 'Utf16CodeUnit', or 'TextElement_v8'.
@@ -952,7 +951,7 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
         .. versionadded:: 2022-05-01
             The *display_name* keyword argument.
         .. versionadded:: 2022-10-01-preview
-            The *fhir_version*, *document_type*, and *auto_detect_language* keyword arguments.
+            The *fhir_version*, *document_type*, and *autodetect_default_language* keyword arguments.
 
         .. admonition:: Example:
 
@@ -985,10 +984,8 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
                     self._healthcare_result_callback
                 )
             )
-        if auto_detect_language is True:
-            docs = _validate_input(documents, "language", "auto")
-        else:
-            docs = _validate_input(documents, "language", language_arg)
+
+        docs = _validate_input(documents, "language", language_arg)
         doc_id_order = [doc.get("id") for doc in docs]
         my_cls = kwargs.pop(
             "cls",
@@ -1011,7 +1008,7 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
                         body=models.AnalyzeTextJobsInput(
                             analysis_input=input_docs,
                             display_name=display_name,
-                            default_language=language_arg if auto_detect_language is True else None,
+                            default_language=autodetect_default_language,
                             tasks=[
                                 models.HealthcareLROTask(
                                     task_name="0",
@@ -1097,7 +1094,7 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
         version_method_added="v3.1",
         custom_wrapper=check_for_unsupported_actions_types,
         args_mapping={
-            "2022-10-01-preview": ["auto_detect_language"],
+            "2022-10-01-preview": ["autodetect_default_language"],
         }
     )
     async def begin_analyze_actions(
@@ -1119,7 +1116,7 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
             ]
         ],
         *,
-        auto_detect_language: Optional[bool] = None,
+        autodetect_default_language: Optional[str] = None,
         continuation_token: Optional[str] = None,
         display_name: Optional[str] = None,
         language: Optional[str] = None,
@@ -1176,13 +1173,12 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
         :keyword str display_name: An optional display name to set for the requested analysis.
         :keyword str language: The 2 letter ISO 639-1 representation of language for the
             entire batch. For example, use "en" for English; "es" for Spanish etc.
-            If not set, uses "en" for English as default.
+            For automatic language detection, use "auto" (Only supported by API version
+            2022-10-01-preview and newer). If not set, uses "en" for English as default.
             Per-document language will take precedence over whole batch language.
             See https://aka.ms/talangs for supported languages in Language API.
-        :keyword bool auto_detect_language: If True, the service will automatically detect the
-            language of each text document (Only supported by API version 2022-10-01-preview and newer).
-            Optionally use the `language` keyword argument to provide a default/fallback language
-            to use for the batch in the event that the service is unable to detect the language.
+        :keyword str autodetect_default_language: Default/fallback language to use for documents requesting
+            automatic language detection.
         :keyword bool show_stats: If set to true, response will contain document level statistics.
         :keyword int polling_interval: Waiting time between two polls for LRO operations
             if no Retry-After header is present. Defaults to 5 seconds.
@@ -1217,9 +1213,9 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
             corresponding *RecognizeCustomEntitiesResult*, *ClassifyDocumentResult*,
             and *AnalyzeHealthcareEntitiesResult* result objects
         .. versionadded:: 2022-10-01-preview
-            The *ExtractSummaryAction* and *AbstractiveSummaryAction* input options and the corresponding
-            *ExtractSummaryResult* and *AbstractiveSummaryResult* result objects.
-            The *auto_detect_language* keyword argument.
+            The *ExtractSummaryAction* and *AbstractSummaryAction* input options and the corresponding
+            *ExtractSummaryResult* and *AbstractSummaryResult* result objects.
+            The *autodetect_default_language* keyword argument.
 
         .. admonition:: Example:
 
@@ -1257,14 +1253,9 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
 
         input_model_cls = \
             models.MultiLanguageAnalysisInput if is_language_api(self._api_version) else models.MultiLanguageBatchInput
-        if auto_detect_language is True:
-            docs = input_model_cls(
-                documents=_validate_input(documents, "language", "auto")
-            )
-        else:
-            docs = input_model_cls(
-                documents=_validate_input(documents, "language", language_arg)
-            )
+        docs = input_model_cls(
+            documents=_validate_input(documents, "language", language_arg)
+        )
         doc_id_order = [doc.get("id") for doc in docs.documents]
         try:
             generated_tasks = [
@@ -1296,7 +1287,7 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
                         body=models.AnalyzeTextJobsInput(
                             analysis_input=docs,
                             display_name=display_name,
-                            default_language=language_arg if auto_detect_language is True else None,
+                            default_language=autodetect_default_language,
                             tasks=generated_tasks
                         ),
                         cls=response_cls,
@@ -1373,7 +1364,7 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
     @validate_multiapi_args(
         version_method_added="2022-05-01",
         args_mapping={
-            "2022-10-01-preview": ["auto_detect_language"],
+            "2022-10-01-preview": ["autodetect_default_language"],
         }
     )
     async def begin_recognize_custom_entities(
@@ -1382,7 +1373,7 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
         project_name: str,
         deployment_name: str,
         *,
-        auto_detect_language: Optional[bool] = None,
+        autodetect_default_language: Optional[str] = None,
         continuation_token: Optional[str] = None,
         disable_service_logs: Optional[bool] = None,
         display_name: Optional[str] = None,
@@ -1408,13 +1399,12 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
         :param str deployment_name: This field indicates the deployment name for the model.
         :keyword str language: The 2 letter ISO 639-1 representation of language for the
             entire batch. For example, use "en" for English; "es" for Spanish etc.
-            If not set, uses "en" for English as default.
+            For automatic language detection, use "auto" (Only supported by API version
+            2022-10-01-preview and newer). If not set, uses "en" for English as default.
             Per-document language will take precedence over whole batch language.
             See https://aka.ms/talangs for supported languages in Language API.
-        :keyword bool auto_detect_language: If True, the service will automatically detect the
-            language of each text document (Only supported by API version 2022-10-01-preview and newer).
-            Optionally use the `language` keyword argument to provide a default/fallback language
-            to use for the batch in the event that the service is unable to detect the language.
+        :keyword str autodetect_default_language: Default/fallback language to use for documents requesting
+            automatic language detection.
         :keyword bool show_stats: If set to true, response will contain document level statistics.
         :keyword bool disable_service_logs: If set to true, you opt-out of having your text input
             logged on the service side for troubleshooting. By default, the Language service logs your
@@ -1447,7 +1437,7 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
         .. versionadded:: 2022-05-01
             The *begin_recognize_custom_entities* client method.
         .. versionadded:: 2022-10-01-preview
-            The *auto_detect_language* keyword argument.
+            The *autodetect_default_language* keyword argument.
 
         .. admonition:: Example:
 
@@ -1494,7 +1484,7 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
                             disable_service_logs=disable_service_logs
                         )
                     ],
-                    auto_detect_language=auto_detect_language,
+                    autodetect_default_language=autodetect_default_language,
                     display_name=display_name,
                     show_stats=show_stats,
                     language=language,
@@ -1511,7 +1501,7 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
     @validate_multiapi_args(
         version_method_added="2022-05-01",
         args_mapping={
-            "2022-10-01-preview": ["auto_detect_language"],
+            "2022-10-01-preview": ["autodetect_default_language"],
         }
     )
     async def begin_single_label_classify(
@@ -1520,7 +1510,7 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
         project_name: str,
         deployment_name: str,
         *,
-        auto_detect_language: Optional[bool] = None,
+        autodetect_default_language: Optional[str] = None,
         continuation_token: Optional[str] = None,
         disable_service_logs: Optional[bool] = None,
         display_name: Optional[str] = None,
@@ -1545,13 +1535,12 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
         :param str deployment_name: This field indicates the deployment name for the model.
         :keyword str language: The 2 letter ISO 639-1 representation of language for the
             entire batch. For example, use "en" for English; "es" for Spanish etc.
-            If not set, uses "en" for English as default.
+            For automatic language detection, use "auto" (Only supported by API version
+            2022-10-01-preview and newer). If not set, uses "en" for English as default.
             Per-document language will take precedence over whole batch language.
             See https://aka.ms/talangs for supported languages in Language API.
-        :keyword bool auto_detect_language: If True, the service will automatically detect the
-            language of each text document (Only supported by API version 2022-10-01-preview and newer).
-            Optionally use the `language` keyword argument to provide a default/fallback language
-            to use for the batch in the event that the service is unable to detect the language.
+        :keyword str autodetect_default_language: Default/fallback language to use for documents requesting
+            automatic language detection.
         :keyword bool show_stats: If set to true, response will contain document level statistics.
         :keyword bool disable_service_logs: If set to true, you opt-out of having your text input
             logged on the service side for troubleshooting. By default, the Language service logs your
@@ -1580,7 +1569,7 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
         .. versionadded:: 2022-05-01
             The *begin_single_label_classify* client method.
         .. versionadded:: 2022-10-01-preview
-            The *auto_detect_language* keyword argument.
+            The *autodetect_default_language* keyword argument.
 
         .. admonition:: Example:
 
@@ -1626,7 +1615,7 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
                         )
                     ],
                     polling_interval=polling_interval_arg,
-                    auto_detect_language=auto_detect_language,
+                    autodetect_default_language=autodetect_default_language,
                     display_name=display_name,
                     show_stats=show_stats,
                     language=language,
@@ -1642,7 +1631,7 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
     @validate_multiapi_args(
         version_method_added="2022-05-01",
         args_mapping={
-            "2022-10-01-preview": ["auto_detect_language"],
+            "2022-10-01-preview": ["autodetect_default_language"],
         }
     )
     async def begin_multi_label_classify(
@@ -1651,7 +1640,7 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
         project_name: str,
         deployment_name: str,
         *,
-        auto_detect_language: Optional[bool] = None,
+        autodetect_default_language: Optional[str] = None,
         continuation_token: Optional[str] = None,
         disable_service_logs: Optional[bool] = None,
         display_name: Optional[str] = None,
@@ -1676,13 +1665,12 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
         :param str deployment_name: This field indicates the deployment name for the model.
         :keyword str language: The 2 letter ISO 639-1 representation of language for the
             entire batch. For example, use "en" for English; "es" for Spanish etc.
-            If not set, uses "en" for English as default.
+            For automatic language detection, use "auto" (Only supported by API version
+            2022-10-01-preview and newer). If not set, uses "en" for English as default.
             Per-document language will take precedence over whole batch language.
             See https://aka.ms/talangs for supported languages in Language API.
-        :keyword bool auto_detect_language: If True, the service will automatically detect the
-            language of each text document (Only supported by API version 2022-10-01-preview and newer).
-            Optionally use the `language` keyword argument to provide a default/fallback language
-            to use for the batch in the event that the service is unable to detect the language.
+        :keyword str autodetect_default_language: Default/fallback language to use for documents requesting
+            automatic language detection.
         :keyword bool show_stats: If set to true, response will contain document level statistics.
         :keyword bool disable_service_logs: If set to true, you opt-out of having your text input
             logged on the service side for troubleshooting. By default, the Language service logs your
@@ -1711,7 +1699,7 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
         .. versionadded:: 2022-05-01
             The *begin_multi_label_classify* client method.
         .. versionadded:: 2022-10-01-preview
-            The *auto_detect_language* keyword argument.
+            The *autodetect_default_language* keyword argument.
 
         .. admonition:: Example:
 
@@ -1757,7 +1745,7 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
                         )
                     ],
                     polling_interval=polling_interval_arg,
-                    auto_detect_language=auto_detect_language,
+                    autodetect_default_language=autodetect_default_language,
                     display_name=display_name,
                     show_stats=show_stats,
                     language=language,
@@ -1879,7 +1867,7 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
         self,
         documents: Union[List[str], List[TextDocumentInput], List[Dict[str, str]]],
         *,
-        auto_detect_language: Optional[bool] = None,
+        autodetect_default_language: Optional[str] = None,
         continuation_token: Optional[str] = None,
         disable_service_logs: Optional[bool] = None,
         display_name: Optional[str] = None,
@@ -1906,13 +1894,12 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
             list[str] or list[~azure.ai.textanalytics.TextDocumentInput] or list[dict[str, str]]
         :keyword str language: The 2 letter ISO 639-1 representation of language for the
             entire batch. For example, use "en" for English; "es" for Spanish etc.
-            If not set, uses "en" for English as default.
+            For automatic language detection, use "auto" (Only supported by API version
+            2022-10-01-preview and newer). If not set, uses "en" for English as default.
             Per-document language will take precedence over whole batch language.
             See https://aka.ms/talangs for supported languages in Language API.
-        :keyword bool auto_detect_language: If True, the service will automatically detect the
-            language of each text document (Only supported by API version 2022-10-01-preview and newer).
-            Optionally use the `language` keyword argument to provide a default/fallback language
-            to use for the batch in the event that the service is unable to detect the language.
+        :keyword str autodetect_default_language: Default/fallback language to use for documents requesting
+            automatic language detection.
         :keyword bool show_stats: If set to true, response will contain document level statistics.
         :keyword Optional[int] max_sentence_count: Maximum number of sentences to return. Defaults to 3.
         :keyword Optional[str] order_by:  Possible values include: "Offset", "Rank". Default value: "Offset".
@@ -1992,7 +1979,7 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
                         )
                     ],
                     polling_interval=polling_interval_arg,
-                    auto_detect_language=auto_detect_language,
+                    autodetect_default_language=autodetect_default_language,
                     display_name=display_name,
                     show_stats=show_stats,
                     language=language,
@@ -2012,7 +1999,7 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
         self,
         documents: Union[List[str], List[TextDocumentInput], List[Dict[str, str]]],
         *,
-        auto_detect_language: Optional[bool] = None,
+        autodetect_default_language: Optional[str] = None,
         continuation_token: Optional[str] = None,
         disable_service_logs: Optional[bool] = None,
         display_name: Optional[str] = None,
@@ -2041,13 +2028,12 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
             list[str] or list[~azure.ai.textanalytics.TextDocumentInput] or list[dict[str, str]]
         :keyword str language: The 2 letter ISO 639-1 representation of language for the
             entire batch. For example, use "en" for English; "es" for Spanish etc.
-            If not set, uses "en" for English as default.
+            For automatic language detection, use "auto" (Only supported by API version
+            2022-10-01-preview and newer). If not set, uses "en" for English as default.
             Per-document language will take precedence over whole batch language.
             See https://aka.ms/talangs for supported languages in Language API.
-        :keyword bool auto_detect_language: If True, the service will automatically detect the
-            language of each text document (Only supported by API version 2022-10-01-preview and newer).
-            Optionally use the `language` keyword argument to provide a default/fallback language
-            to use for the batch in the event that the service is unable to detect the language.
+        :keyword str autodetect_default_language: Default/fallback language to use for documents requesting
+            automatic language detection.
         :keyword bool show_stats: If set to true, response will contain document level statistics.
         :keyword Optional[int] sentence_count: It controls the approximate number of sentences in the output summaries.
         :keyword Optional[str] model_version: The model version to use for the analysis.
@@ -2125,7 +2111,7 @@ class TextAnalyticsClient(AsyncTextAnalyticsClientBase):
                         )
                     ],
                     polling_interval=polling_interval_arg,
-                    auto_detect_language=auto_detect_language,
+                    autodetect_default_language=autodetect_default_language,
                     display_name=display_name,
                     show_stats=show_stats,
                     language=language,

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_analyze.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_analyze.py
@@ -2083,8 +2083,8 @@ class TestAnalyze(TextAnalyticsTest):
         poller = client.begin_analyze_actions(
             docs,
             actions,
-            auto_detect_language=True,
-            language="es",
+            language="auto",
+            autodetect_default_language="es",
             polling_interval=self._interval(),
         )
 

--- a/sdk/textanalytics/azure-ai-textanalytics/tests/test_analyze_async.py
+++ b/sdk/textanalytics/azure-ai-textanalytics/tests/test_analyze_async.py
@@ -2205,8 +2205,8 @@ class TestAnalyzeAsync(TextAnalyticsTest):
         poller = await client.begin_analyze_actions(
             docs,
             actions,
-            auto_detect_language=True,
-            language="es",
+            language="auto",
+            autodetect_default_language="es",
             polling_interval=self._interval(),
         )
 


### PR DESCRIPTION
Reverting back to what we released for autoLD in the last beta. 
TBD remove `autodetect_default_language`