### PR TITLE
[Cosmos] Bugfix: async create_container_if_not_exists throwing unexpected keyword argument on read() method

### DIFF
--- a/sdk/cosmos/azure-cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos/CHANGELOG.md
@@ -7,15 +7,16 @@
 #### Breaking Changes
 
 #### Bugs Fixed
+* Fixed bug in method `create_container_if_not_exists()` of async database client for unexpected kwargs being passed into `read()` method used internally.
 
 #### Other Changes
 
 ### 4.3.1 (2023-02-23)
 
 #### Features Added
- - Added `correlated_activity_id` for query operations
- - Added cross regional retries for Service Unavailable/Request Timeouts for read/Query Plan operations
- - GA release of CosmosHttpLoggingPolicy and autoscale feature
+ - Added `correlated_activity_id` for query operations.
+ - Added cross regional retries for Service Unavailable/Request Timeouts for read/Query Plan operations.
+ - GA release of CosmosHttpLoggingPolicy and autoscale feature.
 
 #### Bugs Fixed
 - Bug fix to address queries with VALUE MAX (or any other aggregate) that run into an issue if the query is executed on a container with at least one "empty" partition.

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_database.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_database.py
@@ -278,19 +278,17 @@ class DatabaseProxy(object):
         :returns: A `ContainerProxy` instance representing the new container.
         :rtype: ~azure.cosmos.aio.ContainerProxy
         """
-
+        indexing_policy = kwargs.pop('indexing_policy', None)
+        default_ttl = kwargs.pop('default_ttl', None)
+        unique_key_policy = kwargs.pop('unique_key_policy', None)
+        conflict_resolution_policy = kwargs.pop('conflict_resolution_policy', None)
+        analytical_storage_ttl = kwargs.pop("analytical_storage_ttl", None)
+        offer_throughput = kwargs.pop('offer_throughput', None)
         try:
             container_proxy = self.get_container_client(id)
             await container_proxy.read(**kwargs)
             return container_proxy
         except CosmosResourceNotFoundError:
-            indexing_policy = kwargs.pop('indexing_policy', None)
-            default_ttl = kwargs.pop('default_ttl', None)
-            unique_key_policy = kwargs.pop('unique_key_policy', None)
-            conflict_resolution_policy = kwargs.pop('conflict_resolution_policy', None)
-            analytical_storage_ttl = kwargs.pop("analytical_storage_ttl", None)
-            offer_throughput = kwargs.pop('offer_throughput', None)
-            response_hook = kwargs.pop('response_hook', None)
             return await self.create_container(
                 id=id,
                 partition_key=partition_key,
@@ -299,8 +297,7 @@ class DatabaseProxy(object):
                 offer_throughput=offer_throughput,
                 unique_key_policy=unique_key_policy,
                 conflict_resolution_policy=conflict_resolution_policy,
-                analytical_storage_ttl=analytical_storage_ttl,
-                response_hook=response_hook
+                analytical_storage_ttl=analytical_storage_ttl
             )
 
     def get_container_client(self, container: Union[str, ContainerProxy, Dict[str, Any]]) -> ContainerProxy:


### PR DESCRIPTION
Closes https://github.com/Azure/azure-sdk-for-python/issues/25318.
Bugfix for create_if_not_exists() when passing in kwargs that don't apply to read method. Now we pop the kwargs pre-emptively  to calling read() and ensure that the method is not populated with irrelevant options, matching behavior of sync client.
![image](https://user-images.githubusercontent.com/30335873/222827617-5a1dd4ed-51bb-4ddd-8f62-7ccb4672681a.png)
