### PR TITLE
run verifytypes check independent of pyright

### DIFF
--- a/doc/eng_sys_checks.md
+++ b/doc/eng_sys_checks.md
@@ -97,6 +97,10 @@ This is the most useful skip, but the following skip variables are also supporte
   - Omit `bandit` checks in `analyze` job.
 - `Skip.Pylint`
   - Omit linting checks in `analyze` job.
+- `Skip.VerifyTypes`
+  - Omit `VerifyTypes` check in `analyze` job.
+- `Skip.Pyright`
+  - Omit `Pyright` check in `analyze` job.
 - `Skip.BreakingChanges`
   - Don't verify if a changeset includes breaking changes.
 - `Skip.MyPy`

--- a/eng/pipelines/templates/steps/run_pyright.yml
+++ b/eng/pipelines/templates/steps/run_pyright.yml
@@ -19,7 +19,7 @@ steps:
   - script: |
       pip install -r eng/ci_tools.txt
     displayName: 'Prep Environment'
-    condition: or(succeededOrFailed(), ne(variables['Skip.Pyright'],'true'), ne(variables['Skip.Verifytypes'],'true'))
+    condition: and(succeededOrFailed(), or(ne(variables['Skip.Pyright'],'true'), ne(variables['Skip.Verifytypes'],'true')))
 
   - task: PythonScript@0
     displayName: 'Run Pyright'

--- a/eng/pipelines/templates/steps/run_pyright.yml
+++ b/eng/pipelines/templates/steps/run_pyright.yml
@@ -14,7 +14,7 @@ steps:
     displayName: 'Use Python 3.7'
     inputs:
      versionSpec: '3.7'
-    condition: or(succeededOrFailed(), ne(variables['Skip.Pyright'],'true'), ne(variables['Skip.Verifytypes'],'true'))
+    condition: and(succeededOrFailed(), or(ne(variables['Skip.Pyright'],'true'), ne(variables['Skip.Verifytypes'],'true')))
 
   - script: |
       pip install -r eng/ci_tools.txt

--- a/eng/pipelines/templates/steps/run_pyright.yml
+++ b/eng/pipelines/templates/steps/run_pyright.yml
@@ -14,12 +14,12 @@ steps:
     displayName: 'Use Python 3.7'
     inputs:
      versionSpec: '3.7'
-    condition: and(succeededOrFailed(), ne(variables['Skip.Pyright'],'true'), ne(variables['Skip.Verifytypes'],'true'))
+    condition: or(succeededOrFailed(), ne(variables['Skip.Pyright'],'true'), ne(variables['Skip.Verifytypes'],'true'))
 
   - script: |
       pip install -r eng/ci_tools.txt
     displayName: 'Prep Environment'
-    condition: and(succeededOrFailed(), ne(variables['Skip.Pyright'],'true'), ne(variables['Skip.Verifytypes'],'true'))
+    condition: or(succeededOrFailed(), ne(variables['Skip.Pyright'],'true'), ne(variables['Skip.Verifytypes'],'true'))
 
   - task: PythonScript@0
     displayName: 'Run Pyright'

--- a/eng/pipelines/templates/steps/run_pyright.yml
+++ b/eng/pipelines/templates/steps/run_pyright.yml
@@ -14,12 +14,12 @@ steps:
     displayName: 'Use Python 3.7'
     inputs:
      versionSpec: '3.7'
-    condition: and(succeededOrFailed(), ne(variables['Skip.Pyright'],'true'))
+    condition: and(succeededOrFailed(), ne(variables['Skip.Pyright'],'true'), ne(variables['Skip.Verifytypes'],'true'))
 
   - script: |
       pip install -r eng/ci_tools.txt
     displayName: 'Prep Environment'
-    condition: and(succeededOrFailed(), ne(variables['Skip.Pyright'],'true'))
+    condition: and(succeededOrFailed(), ne(variables['Skip.Pyright'],'true'), ne(variables['Skip.Verifytypes'],'true'))
 
   - task: PythonScript@0
     displayName: 'Run Pyright'
@@ -43,4 +43,4 @@ steps:
         --service="${{ parameters.ServiceDirectory }}"
         --toxenv="verifytypes"
         --disablecov
-    condition: and(succeededOrFailed(), ne(variables['Skip.Pyright'],'true'))
+    condition: and(succeededOrFailed(), ne(variables['Skip.Verifytypes'],'true'))


### PR DESCRIPTION
pyright and verifytypes share the same template since they run the same tool/type checker. However, this led to a bug where, if a library disabled pyright, but enabled verifytypes, the verifytypes check would get skipped. Luckily, there were few libraries in this state and they still pass. This PR fixes the skip logic such that each will run independently.