### PR TITLE
[Core][OTel] Support OTel schema versioning

### DIFF
--- a/sdk/core/azure-core-tracing-opentelemetry/azure/core/tracing/ext/opentelemetry_span/_schema.py
+++ b/sdk/core/azure-core-tracing-opentelemetry/azure/core/tracing/ext/opentelemetry_span/_schema.py
@@ -1,0 +1,42 @@
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+from enum import Enum
+from typing import Dict
+
+from azure.core import CaseInsensitiveEnumMeta
+
+
+class OpenTelemetrySchemaVersion(
+    str, Enum, metaclass=CaseInsensitiveEnumMeta
+):  # pylint: disable=enum-must-inherit-case-insensitive-enum-meta
+
+    V1_19_0 = "1.19.0"
+
+
+class OpenTelemetrySchema:
+
+    SUPPORTED_VERSIONS = [
+        OpenTelemetrySchemaVersion.V1_19_0,
+    ]
+
+    # Mappings of attributes potentially reported by Azure SDKs to corresponding ones that follow
+    # OpenTelemetry semantic conventions.
+    _ATTRIBUTE_MAPPINGS = {
+        OpenTelemetrySchemaVersion.V1_19_0: {
+            "x-ms-client-request-id": "az.client_request_id",
+            "x-ms-request-id": "az.service_request_id",
+            "http.user_agent": "user_agent.original",
+            "messaging_bus.destination": "messaging.destination.name",
+            "peer.address": "net.peer.name",
+        }
+    }
+
+    @classmethod
+    def get_latest_version(cls) -> OpenTelemetrySchemaVersion:
+        return cls.SUPPORTED_VERSIONS[-1]
+
+    @classmethod
+    def get_attribute_mappings(cls, version: OpenTelemetrySchemaVersion) -> Dict[str, str]:
+        return cls._ATTRIBUTE_MAPPINGS[version]

--- a/sdk/core/azure-core-tracing-opentelemetry/tests/test_schema.py
+++ b/sdk/core/azure-core-tracing-opentelemetry/tests/test_schema.py
@@ -1,0 +1,31 @@
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+import uuid
+
+from opentelemetry.trace import SpanKind as OpenTelemetrySpanKind
+
+from azure.core.tracing.ext.opentelemetry_span import OpenTelemetrySpan
+from azure.core.tracing.ext.opentelemetry_span._schema import OpenTelemetrySchema
+
+
+class TestOpenTelemetrySchema:
+    def test_latest_schema_attributes_renamed(self, tracer):
+        with tracer.start_as_current_span("Root", kind=OpenTelemetrySpanKind.CLIENT) as parent:
+            wrapped_class = OpenTelemetrySpan(span=parent)
+            schema_version = OpenTelemetrySchema.get_latest_version()
+            attribute_mappings = OpenTelemetrySchema.get_attribute_mappings(schema_version)
+            attribute_values = {}
+            for key, value in attribute_mappings.items():
+                attribute_values[value] = uuid.uuid4().hex
+                # Add attribute using key that is not following OpenTelemetry semantic conventions.
+                wrapped_class.add_attribute(key, attribute_values[value])
+
+            for attribute, expected_value in attribute_values.items():
+                # Check that expected renamed attribute is present with the correct value.
+                assert wrapped_class.span_instance.attributes.get(attribute) == expected_value
+
+            for key in attribute_mappings:
+                # Check that original attribute is not present.
+                assert wrapped_class.span_instance.attributes.get(key) is None

--- a/sdk/core/azure-core-tracing-opentelemetry/tests/test_tracing_implementations.py
+++ b/sdk/core/azure-core-tracing-opentelemetry/tests/test_tracing_implementations.py
@@ -2,23 +2,15 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
-"""The tests for opencensus_span.py"""
-
-import unittest
-
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+"""The tests for opentelemetry_span.py"""
+from unittest import mock
 
 from opentelemetry import trace
 from opentelemetry.trace import SpanKind as OpenTelemetrySpanKind
+import pytest
 
 from azure.core.tracing.ext.opentelemetry_span import OpenTelemetrySpan
 from azure.core.tracing import SpanKind
-import os
-
-import pytest
 
 
 class TestOpentelemetryWrapper:
@@ -142,7 +134,7 @@ class TestOpentelemetryWrapper:
             wrapped_class = OpenTelemetrySpan(span=parent)
             request = mock.Mock()
             setattr(request, "method", "GET")
-            setattr(request, "url", "some url")
+            setattr(request, "url", "https://foo.bar/path")
             response = mock.Mock()
             setattr(request, "headers", {})
             setattr(response, "status_code", 200)
@@ -152,11 +144,19 @@ class TestOpentelemetryWrapper:
             assert wrapped_class.span_instance.attributes.get("component") == "http"
             assert wrapped_class.span_instance.attributes.get("http.url") == request.url
             assert wrapped_class.span_instance.attributes.get("http.status_code") == 504
-            assert wrapped_class.span_instance.attributes.get("http.user_agent") is None
+            assert wrapped_class.span_instance.attributes.get("user_agent.original") is None
+
             request.headers["User-Agent"] = "some user agent"
+            request.url = "http://foo.bar:8080/path"
             wrapped_class.set_http_attributes(request, response)
             assert wrapped_class.span_instance.attributes.get("http.status_code") == response.status_code
-            assert wrapped_class.span_instance.attributes.get("http.user_agent") == request.headers.get("User-Agent")
+            assert wrapped_class.span_instance.attributes.get("user_agent.original") == request.headers.get(
+                "User-Agent"
+            )
+
+            if wrapped_class.span_instance.attributes.get("net.peer.name"):
+                assert wrapped_class.span_instance.attributes.get("net.peer.name") == "foo.bar"
+                assert wrapped_class.span_instance.attributes.get("net.peer.port") == 8080
 
     def test_span_kind(self, tracer):
         with tracer.start_as_current_span("Root") as parent:

--- a/sdk/core/azure-core/azure/core/tracing/_abstract_span.py
+++ b/sdk/core/azure-core/azure/core/tracing/_abstract_span.py
@@ -221,12 +221,11 @@ class HttpSpanMixin(_MIXIN_BASE):
         self.add_attribute(self._HTTP_METHOD, request.method)
         self.add_attribute(self._HTTP_URL, request.url)
 
-        host = urlparse(request.url).netloc
-        if host:
-            host_parts = host.split(":")
-            self.add_attribute(self._NET_PEER_NAME, host_parts[0])
-            if len(host_parts) > 1 and host_parts[1] not in ["80", "443"]:
-                self.add_attribute(self._NET_PEER_PORT, int(host_parts[1]))
+        parsed_url = urlparse(request.url)
+        if parsed_url.hostname:
+            self.add_attribute(self._NET_PEER_NAME, parsed_url.hostname)
+        if parsed_url.port and parsed_url.port not in [80, 443]:
+            self.add_attribute(self._NET_PEER_PORT, parsed_url.port)
 
         user_agent = request.headers.get("User-Agent")
         if user_agent:


### PR DESCRIPTION
This adds support for OpenTelemetry scheme versioning, and also adds support for attribute mapping to ensure that attributes are mapped to the corresponding semantic convention that we are trying to converge on.

Missing network attributes were also added in the part where http attributes are added. 

Ref: https://github.com/Azure/azure-sdk-for-python/issues/25838