### PR TITLE
Corrected unknown OS use case for sdkVersion prefix

### DIFF
--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
@@ -16,6 +16,8 @@
 
 - Add sdkVersion prefix during App Service attach
     ([#28637](https://github.com/Azure/azure-sdk-for-python/pull/28637))
+- Correcting sdkVersion prefix
+    ([#29227](https://github.com/Azure/azure-sdk-for-python/pull/29227))
 
 ### Bugs Fixed
 

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_utils.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_utils.py
@@ -28,7 +28,7 @@ def _get_sdk_version_prefix():
     is_attach_enabled = getenv("ApplicationInsightsAgent_EXTENSION_VERSION") == "~3"
     sdk_version_prefix = ''
     if is_on_app_service and is_attach_enabled:
-        os = None
+        os = ''
         system = platform.system()
         if system == "Linux":
             os = 'l'

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/test_utils.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/test_utils.py
@@ -109,3 +109,10 @@ class TestUtils(unittest.TestCase):
     def test_get_sdk_version_prefix_windows_attach(self, mock_system, mock_getenv):
         result = _utils._get_sdk_version_prefix()
         self.assertEqual(result, "awd_")
+
+    @patch("azure.monitor.opentelemetry.exporter._utils.environ", {"WEBSITE_SITE_NAME": TEST_WEBSITE_SITE_NAME})
+    @patch("azure.monitor.opentelemetry.exporter._utils.getenv", return_value="~3")
+    @patch("azure.monitor.opentelemetry.exporter._utils.platform.system", return_value="")
+    def test_get_sdk_version_prefix_unknown_attach(self, mock_system, mock_getenv):
+        result = _utils._get_sdk_version_prefix()
+        self.assertEqual(result, "ad_")


### PR DESCRIPTION
# Description

Previously, the prefix would be set as "aNoned_" when OS is unable to be determined.

If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
