### PR TITLE
Rename intellectual property publisher

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/core/intellectual_property_schema.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/core/intellectual_property_schema.py
@@ -1,0 +1,8 @@
+from marshmallow import fields, post_load
+from azure.ai.ml._schema.core.schema import PatchedSchemaMeta
+from azure.ai.ml._utils._experimental import experimental
+
+@experimental
+class IntellectualPropertySchema(metaclass=PatchedSchemaMeta):
+
+    publisher = fields.Str()

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/core/intellectual_property_schema.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/core/intellectual_property_schema.py
@@ -1,4 +1,8 @@
-from marshmallow import fields, post_load
+# ---------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# ---------------------------------------------------------
+
+from marshmallow import fields
 from azure.ai.ml._schema.core.schema import PatchedSchemaMeta
 from azure.ai.ml._utils._experimental import experimental
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/core/intellectual_property_schema.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/core/intellectual_property_schema.py
@@ -6,6 +6,7 @@ from marshmallow import fields
 from azure.ai.ml._schema.core.schema import PatchedSchemaMeta
 from azure.ai.ml._utils._experimental import experimental
 
+
 @experimental
 class IntellectualPropertySchema(metaclass=PatchedSchemaMeta):
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/registry/registry.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/registry/registry.py
@@ -30,7 +30,7 @@ class RegistrySchema(ResourceSchema):
         casing_transform=snake_to_pascal,
     )
     replication_locations = fields.List(NestedField(RegistryRegionDetailsSchema))
-    intellectual_property_publisher = fields.Str()
+    intellectual_property = fields.Str()
     # This is an acr account which will be applied to every registryRegionArmDetail defined
     # in replication_locations. This is different from the internal swagger
     # definition, which has a per-region list of acr accounts.

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/registry/registry.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/registry/registry.py
@@ -5,6 +5,7 @@
 from marshmallow import fields
 
 from azure.ai.ml._schema.core.fields import DumpableStringField, NestedField, StringTransformedEnum, UnionField
+from azure.ai.ml._schema.core.intellectual_property_schema import IntellectualPropertySchema
 from azure.ai.ml._schema.core.resource import ResourceSchema
 from azure.ai.ml._schema.workspace.identity import IdentitySchema
 from azure.ai.ml._utils.utils import snake_to_pascal
@@ -30,7 +31,7 @@ class RegistrySchema(ResourceSchema):
         casing_transform=snake_to_pascal,
     )
     replication_locations = fields.List(NestedField(RegistryRegionDetailsSchema))
-    intellectual_property = fields.Str()
+    intellectual_property = NestedField(IntellectualPropertySchema)
     # This is an acr account which will be applied to every registryRegionArmDetail defined
     # in replication_locations. This is different from the internal swagger
     # definition, which has a per-region list of acr accounts.

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_registry/registry.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_registry/registry.py
@@ -24,7 +24,7 @@ from .registry_support_classes import RegistryRegionDetails
 
 CONTAINER_REGISTRY = "container_registry"
 REPLICATION_LOCATIONS = "replication_locations"
-
+INTELLECTUAL_PROPERTY = "intellectual_property"
 
 class Registry(Resource):
     def __init__(
@@ -36,7 +36,7 @@ class Registry(Resource):
         tags: Optional[Dict[str, str]] = None,
         public_network_access: Optional[str] = None,
         discovery_url: Optional[str] = None,
-        intellectual_property: Optional[str] = None,
+        intellectual_property_publisher: Optional[str] = None,
         managed_resource_group: Optional[str] = None,
         mlflow_registry_uri: Optional[str] = None,
         replication_locations: List[RegistryRegionDetails],
@@ -56,8 +56,8 @@ class Registry(Resource):
         :type public_network_access: str
         :param discovery_url: Backend service base url for the registry.
         :type discovery_url: str
-        :param intellectual_property: Intellectual property publisher.
-        :type intellectual_property: str
+        :param intellectual_property_publisher: Intellectual property publisher.
+        :type intellectual_property_publisher: str
         :param managed_resource_group: Managed resource group created for the registry.
         :type managed_resource_group: str
         :param mlflow_registry_uri: Ml flow tracking uri for the registry.
@@ -75,7 +75,7 @@ class Registry(Resource):
         self.identity = identity
         self.replication_locations = replication_locations
         self.public_network_access = public_network_access
-        self.intellectual_property = intellectual_property
+        self.intellectual_property_publisher = intellectual_property_publisher
         self.managed_resource_group = managed_resource_group
         self.discovery_url = discovery_url
         self.mlflow_registry_uri = mlflow_registry_uri
@@ -162,7 +162,7 @@ class Registry(Resource):
             location=rest_obj.location,
             public_network_access=real_registry.public_network_access,
             discovery_url=real_registry.discovery_url,
-            intellectual_property=real_registry.intellectual_property_publisher,
+            intellectual_property_publisher=real_registry.intellectual_property_publisher,
             managed_resource_group=real_registry.managed_resource_group,
             mlflow_registry_uri=real_registry.ml_flow_registry_uri,
             replication_locations=replication_locations,
@@ -189,6 +189,11 @@ class Registry(Resource):
             if global_acr_exists:
                 if not hasattr(region_detail, "acr_details") or len(region_detail.acr_details) == 0:
                     region_detail.acr_config = [acr_input]
+        if INTELLECTUAL_PROPERTY in input:
+            intellectual_property = input.pop(INTELLECTUAL_PROPERTY)
+            publisher = intellectual_property.get("publisher", None)
+            if publisher:
+                input["intellectual_property_publisher"] = publisher
 
     def _to_rest_object(self) -> RestRegistry:
         """Build current parameterized schedule instance to a registry object before submission.
@@ -214,7 +219,7 @@ class Registry(Resource):
             properties=RegistryProperties(
                 public_network_access=self.public_network_access,
                 discovery_url=self.discovery_url,
-                intellectual_property_publisher=self.intellectual_property,
+                intellectual_property_publisher=self.intellectual_property_publisher,
                 managed_resource_group=self.managed_resource_group,
                 ml_flow_registry_uri=self.mlflow_registry_uri,
                 region_details=replication_locations,

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_registry/registry.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_registry/registry.py
@@ -36,7 +36,7 @@ class Registry(Resource):
         tags: Optional[Dict[str, str]] = None,
         public_network_access: Optional[str] = None,
         discovery_url: Optional[str] = None,
-        intellectual_property_publisher: Optional[str] = None,
+        intellectual_property: Optional[str] = None,
         managed_resource_group: Optional[str] = None,
         mlflow_registry_uri: Optional[str] = None,
         replication_locations: List[RegistryRegionDetails],
@@ -56,8 +56,8 @@ class Registry(Resource):
         :type public_network_access: str
         :param discovery_url: Backend service base url for the registry.
         :type discovery_url: str
-        :param intellectual_property_publisher: Intellectual property publisher.
-        :type intellectual_property_publisher: str
+        :param intellectual_property: Intellectual property publisher.
+        :type intellectual_property: str
         :param managed_resource_group: Managed resource group created for the registry.
         :type managed_resource_group: str
         :param mlflow_registry_uri: Ml flow tracking uri for the registry.
@@ -75,7 +75,7 @@ class Registry(Resource):
         self.identity = identity
         self.replication_locations = replication_locations
         self.public_network_access = public_network_access
-        self.intellectual_property_publisher = intellectual_property_publisher
+        self.intellectual_property = intellectual_property
         self.managed_resource_group = managed_resource_group
         self.discovery_url = discovery_url
         self.mlflow_registry_uri = mlflow_registry_uri
@@ -162,7 +162,7 @@ class Registry(Resource):
             location=rest_obj.location,
             public_network_access=real_registry.public_network_access,
             discovery_url=real_registry.discovery_url,
-            intellectual_property_publisher=real_registry.intellectual_property_publisher,
+            intellectual_property=real_registry.intellectual_property_publisher,
             managed_resource_group=real_registry.managed_resource_group,
             mlflow_registry_uri=real_registry.ml_flow_registry_uri,
             replication_locations=replication_locations,
@@ -214,7 +214,7 @@ class Registry(Resource):
             properties=RegistryProperties(
                 public_network_access=self.public_network_access,
                 discovery_url=self.discovery_url,
-                intellectual_property_publisher=self.intellectual_property_publisher,
+                intellectual_property_publisher=self.intellectual_property,
                 managed_resource_group=self.managed_resource_group,
                 ml_flow_registry_uri=self.mlflow_registry_uri,
                 region_details=replication_locations,

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_registry/registry.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_registry/registry.py
@@ -26,6 +26,7 @@ CONTAINER_REGISTRY = "container_registry"
 REPLICATION_LOCATIONS = "replication_locations"
 INTELLECTUAL_PROPERTY = "intellectual_property"
 
+
 class Registry(Resource):
     def __init__(
         self,

--- a/sdk/ml/azure-ai-ml/tests/registry/unittests/test_registry_entity.py
+++ b/sdk/ml/azure-ai-ml/tests/registry/unittests/test_registry_entity.py
@@ -106,7 +106,7 @@ class TestRegistryEntity:
         assert registry_entity.tags == exterior_tags
         assert registry_entity.public_network_access == pna
         assert registry_entity.discovery_url == discovery_url
-        assert registry_entity.intellectual_property == ipp
+        assert registry_entity.intellectual_property_publisher == ipp
         assert registry_entity.managed_resource_group == mrg
         assert registry_entity.mlflow_registry_uri == registry_uri
 

--- a/sdk/ml/azure-ai-ml/tests/registry/unittests/test_registry_entity.py
+++ b/sdk/ml/azure-ai-ml/tests/registry/unittests/test_registry_entity.py
@@ -106,7 +106,7 @@ class TestRegistryEntity:
         assert registry_entity.tags == exterior_tags
         assert registry_entity.public_network_access == pna
         assert registry_entity.discovery_url == discovery_url
-        assert registry_entity.intellectual_property_publisher == ipp
+        assert registry_entity.intellectual_property == ipp
         assert registry_entity.managed_resource_group == mrg
         assert registry_entity.mlflow_registry_uri == registry_uri
 

--- a/sdk/ml/azure-ai-ml/tests/registry/unittests/test_registry_schema.py
+++ b/sdk/ml/azure-ai-ml/tests/registry/unittests/test_registry_schema.py
@@ -26,7 +26,7 @@ class TestRegistrySchema:
             assert registry["tags"] == {"purpose": "testing", "other_tag": "value"}
             assert registry["location"] == "EastUS2"
             assert registry["public_network_access"] == PublicNetworkAccess.DISABLED
-            assert registry["intellectual_property_publisher"] == "registry_publisher"
+            assert registry["intellectual_property"]["publisher"] == "registry_publisher"
             assert (
                 registry["container_registry"]
                 == "/subscriptions/sub_id/resourceGroups/some_rg/providers/Microsoft.ContainerRegistry/registries/acr_id"

--- a/sdk/ml/azure-ai-ml/tests/test_configs/internal/ipp-component/spec.yaml
+++ b/sdk/ml/azure-ai-ml/tests/test_configs/internal/ipp-component/spec.yaml
@@ -12,8 +12,8 @@ tags:
 # STEP 1. reference an existing component yaml, which implement the logic
 reference: file:gpt3finetune.spec.yaml
 
-# STEP 2. Define the "Intellectual Property Publisher" for the "IP-Protected" component
-intellectual_property_publisher: Contoso
+# STEP 2. Define the "Intellectual Property" for the "IP-Protected" component
+intellectual_property: Contoso
 
 # STEP 3. Specify "Intellectual Property Protected" input and output ports, not listed ports are ip-protected
 intellectual_property_protected_inputs:

--- a/sdk/ml/azure-ai-ml/tests/test_configs/internal/ipp-component/spec.yaml
+++ b/sdk/ml/azure-ai-ml/tests/test_configs/internal/ipp-component/spec.yaml
@@ -13,7 +13,8 @@ tags:
 reference: file:gpt3finetune.spec.yaml
 
 # STEP 2. Define the "Intellectual Property" for the "IP-Protected" component
-intellectual_property: Contoso
+intellectual_property:
+  publisher: Contoso
 
 # STEP 3. Specify "Intellectual Property Protected" input and output ports, not listed ports are ip-protected
 intellectual_property_protected_inputs:

--- a/sdk/ml/azure-ai-ml/tests/test_configs/registry/registry_bad_arm_resource_id.yaml
+++ b/sdk/ml/azure-ai-ml/tests/test_configs/registry/registry_bad_arm_resource_id.yaml
@@ -6,7 +6,7 @@ tags:
   other_tag: value
 location: EastUS2
 public_network_access: Enabled
-intellectual_property_publisher: registry_publisher
+intellectual_property: registry_publisher
 replication_locations:
   - location: EastUS
     storage_config:

--- a/sdk/ml/azure-ai-ml/tests/test_configs/registry/registry_bad_arm_resource_id.yaml
+++ b/sdk/ml/azure-ai-ml/tests/test_configs/registry/registry_bad_arm_resource_id.yaml
@@ -6,7 +6,8 @@ tags:
   other_tag: value
 location: EastUS2
 public_network_access: Enabled
-intellectual_property: registry_publisher
+intellectual_property:
+  publisher: registry_publisher
 replication_locations:
   - location: EastUS
     storage_config:

--- a/sdk/ml/azure-ai-ml/tests/test_configs/registry/registry_bad_replication_count.yaml
+++ b/sdk/ml/azure-ai-ml/tests/test_configs/registry/registry_bad_replication_count.yaml
@@ -6,7 +6,7 @@ tags:
   other_tag: value
 location: EastUS2
 public_network_access: Disabled
-intellectual_property_publisher: registry_publisher
+intellectual_property: registry_publisher
 replication_locations:
   - location: EastUS
     storage_config:

--- a/sdk/ml/azure-ai-ml/tests/test_configs/registry/registry_bad_replication_count.yaml
+++ b/sdk/ml/azure-ai-ml/tests/test_configs/registry/registry_bad_replication_count.yaml
@@ -6,7 +6,8 @@ tags:
   other_tag: value
 location: EastUS2
 public_network_access: Disabled
-intellectual_property: registry_publisher
+intellectual_property: 
+  publisher: registry_publisher
 replication_locations:
   - location: EastUS
     storage_config:

--- a/sdk/ml/azure-ai-ml/tests/test_configs/registry/registry_bad_storage_account_type.yaml
+++ b/sdk/ml/azure-ai-ml/tests/test_configs/registry/registry_bad_storage_account_type.yaml
@@ -6,7 +6,7 @@ tags:
   other_tag: value
 location: EastUS2
 public_network_access: Disabled
-intellectual_property_publisher: registry_publisher
+intellectual_property: registry_publisher
 replication_locations:
   - location: EastUS
     storage_config:

--- a/sdk/ml/azure-ai-ml/tests/test_configs/registry/registry_bad_storage_account_type.yaml
+++ b/sdk/ml/azure-ai-ml/tests/test_configs/registry/registry_bad_storage_account_type.yaml
@@ -6,7 +6,8 @@ tags:
   other_tag: value
 location: EastUS2
 public_network_access: Disabled
-intellectual_property: registry_publisher
+intellectual_property: 
+  publisher: registry_publisher
 replication_locations:
   - location: EastUS
     storage_config:

--- a/sdk/ml/azure-ai-ml/tests/test_configs/registry/registry_valid.yaml
+++ b/sdk/ml/azure-ai-ml/tests/test_configs/registry/registry_valid.yaml
@@ -6,7 +6,8 @@ tags:
   other_tag: value
 location: EastUS2
 public_network_access: Disabled
-intellectual_property: registry_publisher
+intellectual_property:
+  publisher: registry_publisher
 replication_locations:
   - location: EastUS
     storage_config:

--- a/sdk/ml/azure-ai-ml/tests/test_configs/registry/registry_valid.yaml
+++ b/sdk/ml/azure-ai-ml/tests/test_configs/registry/registry_valid.yaml
@@ -6,7 +6,7 @@ tags:
   other_tag: value
 location: EastUS2
 public_network_access: Disabled
-intellectual_property_publisher: registry_publisher
+intellectual_property: registry_publisher
 replication_locations:
   - location: EastUS
     storage_config:

--- a/sdk/ml/azure-ai-ml/tests/test_configs/registry/registry_valid_2.yaml
+++ b/sdk/ml/azure-ai-ml/tests/test_configs/registry/registry_valid_2.yaml
@@ -6,7 +6,7 @@ tags:
   other_tag: value
 location: EastUS2
 public_network_access: Disabled
-intellectual_property_publisher: registry_publisher
+intellectual_property: registry_publisher
 replication_locations:
   - location: EastUS
     storage_config:

--- a/sdk/ml/azure-ai-ml/tests/test_configs/registry/registry_valid_2.yaml
+++ b/sdk/ml/azure-ai-ml/tests/test_configs/registry/registry_valid_2.yaml
@@ -6,7 +6,8 @@ tags:
   other_tag: value
 location: EastUS2
 public_network_access: Disabled
-intellectual_property: registry_publisher
+intellectual_property: 
+  publisher: registry_publisher
 replication_locations:
   - location: EastUS
     storage_config:

--- a/sdk/ml/azure-ai-ml/tests/test_configs/registry/registry_valid_3.yaml
+++ b/sdk/ml/azure-ai-ml/tests/test_configs/registry/registry_valid_3.yaml
@@ -6,7 +6,8 @@ tags:
   other_tag: value
 location: EastUS2
 public_network_access: Disabled
-intellectual_property: registry_publisher
+intellectual_property:
+  publisher: registry_publisher
 replication_locations:
   - location: EastUS
     storage_config:

--- a/sdk/ml/azure-ai-ml/tests/test_configs/registry/registry_valid_3.yaml
+++ b/sdk/ml/azure-ai-ml/tests/test_configs/registry/registry_valid_3.yaml
@@ -6,7 +6,7 @@ tags:
   other_tag: value
 location: EastUS2
 public_network_access: Disabled
-intellectual_property_publisher: registry_publisher
+intellectual_property: registry_publisher
 replication_locations:
   - location: EastUS
     storage_config:

--- a/sdk/ml/azure-ai-ml/tests/test_configs/registry/registry_valid_lone_replication_count.yaml
+++ b/sdk/ml/azure-ai-ml/tests/test_configs/registry/registry_valid_lone_replication_count.yaml
@@ -6,7 +6,8 @@ tags:
   other_tag: value
 location: EastUS2
 public_network_access: Disabled
-intellectual_property: registry_publisher
+intellectual_property:
+  publisher: registry_publisher
 replication_locations:
   - location: EastUS
     storage_config:

--- a/sdk/ml/azure-ai-ml/tests/test_configs/registry/registry_valid_lone_replication_count.yaml
+++ b/sdk/ml/azure-ai-ml/tests/test_configs/registry/registry_valid_lone_replication_count.yaml
@@ -6,7 +6,7 @@ tags:
   other_tag: value
 location: EastUS2
 public_network_access: Disabled
-intellectual_property_publisher: registry_publisher
+intellectual_property: registry_publisher
 replication_locations:
   - location: EastUS
     storage_config:

--- a/sdk/ml/azure-ai-ml/tests/test_configs/registry/registry_valid_replication_count.yaml
+++ b/sdk/ml/azure-ai-ml/tests/test_configs/registry/registry_valid_replication_count.yaml
@@ -6,7 +6,8 @@ tags:
   other_tag: value
 location: EastUS2
 public_network_access: Disabled
-intellectual_property: registry_publisher
+intellectual_property:
+  publisher: registry_publisher
 replication_locations:
   - location: EastUS
     storage_config:

--- a/sdk/ml/azure-ai-ml/tests/test_configs/registry/registry_valid_replication_count.yaml
+++ b/sdk/ml/azure-ai-ml/tests/test_configs/registry/registry_valid_replication_count.yaml
@@ -6,7 +6,7 @@ tags:
   other_tag: value
 location: EastUS2
 public_network_access: Disabled
-intellectual_property_publisher: registry_publisher
+intellectual_property: registry_publisher
 replication_locations:
   - location: EastUS
     storage_config:


### PR DESCRIPTION
# Description

Rename `intellectual_property_publisher` to `intellectual_property` in the YAML files we use for registry operations.
Registry entity property will remain the same.

If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
