### PR TITLE
[Cosmos] Bugfix: Surface authentication errors properly

### DIFF
--- a/sdk/cosmos/azure-cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 #### Bugs Fixed
 * Fixed bug in method `create_container_if_not_exists()` of async database client for unexpected kwargs being passed into `read()` method used internally.
-* Fixed bug with client not properly surfacing errors for invalid credentials and identities with insufficient permissions. Users running into 'NoneType has no attribute ConsistencyPolicy' errors when initializing their clients will now see proper authentication exceptions.
+* Fixed bug with client not properly surfacing errors for invalid credentials and identities with insufficient permissions. Users running into 'NoneType has no attribute ConsistencyPolicy' errors when initializing their clients will now see proper authentication exceptions. See [PR 29256](https://github.com/Azure/azure-sdk-for-python/pull/29256).
 
 #### Other Changes
 

--- a/sdk/cosmos/azure-cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 #### Bugs Fixed
 * Fixed bug in method `create_container_if_not_exists()` of async database client for unexpected kwargs being passed into `read()` method used internally.
-* Fixed bug with client not properly surfacing errors for invalid credentials and identities with insufficient permissions.
+* Fixed bug with client not properly surfacing errors for invalid credentials and identities with insufficient permissions. Users running into 'NoneType has no attribute ConsistencyPolicy' errors when initializing their clients will now see proper authentication exceptions.
 
 #### Other Changes
 

--- a/sdk/cosmos/azure-cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 #### Bugs Fixed
 * Fixed bug in method `create_container_if_not_exists()` of async database client for unexpected kwargs being passed into `read()` method used internally.
+* Fixed bug with client not properly surfacing errors for invalid credentials and identities with insufficient permissions.
 
 #### Other Changes
 

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_global_endpoint_manager.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_global_endpoint_manager.py
@@ -28,7 +28,7 @@ import threading
 from six.moves.urllib.parse import urlparse
 
 from . import _constants as constants
-from . import exceptions, http_constants
+from . import exceptions
 from ._location_cache import LocationCache
 
 # pylint: disable=protected-access
@@ -129,10 +129,7 @@ class _GlobalEndpointManager(object):
         # specified (by creating a locational endpoint) and keeping eating the exception
         # until we get the database account and return None at the end, if we are not able
         # to get that info from any endpoints
-        except exceptions.CosmosHttpResponseError as e:
-            if e.status_code == http_constants.StatusCodes.UNAUTHORIZED or \
-                    e.status_code == http_constants.StatusCodes.FORBIDDEN:
-                raise
+        except exceptions.CosmosHttpResponseError:
             for location_name in self.PreferredLocations:
                 locational_endpoint = _GlobalEndpointManager.GetLocationalEndpoint(self.DefaultEndpoint, location_name)
                 try:

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_global_endpoint_manager.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_global_endpoint_manager.py
@@ -28,7 +28,7 @@ import threading
 from six.moves.urllib.parse import urlparse
 
 from . import _constants as constants
-from . import exceptions
+from . import exceptions, http_constants
 from ._location_cache import LocationCache
 
 # pylint: disable=protected-access
@@ -129,7 +129,10 @@ class _GlobalEndpointManager(object):
         # specified (by creating a locational endpoint) and keeping eating the exception
         # until we get the database account and return None at the end, if we are not able
         # to get that info from any endpoints
-        except exceptions.CosmosHttpResponseError:
+        except exceptions.CosmosHttpResponseError as e:
+            if e.status_code == http_constants.StatusCodes.UNAUTHORIZED or \
+                    e.status_code == http_constants.StatusCodes.FORBIDDEN:
+                raise
             for location_name in self.PreferredLocations:
                 locational_endpoint = _GlobalEndpointManager.GetLocationalEndpoint(self.DefaultEndpoint, location_name)
                 try:
@@ -137,8 +140,7 @@ class _GlobalEndpointManager(object):
                     return database_account
                 except exceptions.CosmosHttpResponseError:
                     pass
-
-            return None
+            raise #Should help us catch more errors on client initialization
 
     def _GetDatabaseAccountStub(self, endpoint, **kwargs):
         """Stub for getting database account from the client.

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_global_endpoint_manager.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_global_endpoint_manager.py
@@ -137,7 +137,7 @@ class _GlobalEndpointManager(object):
                     return database_account
                 except exceptions.CosmosHttpResponseError:
                     pass
-            raise #Should help us catch more errors on client initialization
+            raise
 
     def _GetDatabaseAccountStub(self, endpoint, **kwargs):
         """Stub for getting database account from the client.

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_global_endpoint_manager_async.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_global_endpoint_manager_async.py
@@ -132,7 +132,7 @@ class _GlobalEndpointManager(object):
                 except exceptions.CosmosHttpResponseError:
                     pass
 
-            return None
+            raise
 
     async def _GetDatabaseAccountStub(self, endpoint, **kwargs):
         """Stub for getting database account from the client.

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_global_endpoint_manager_async.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_global_endpoint_manager_async.py
@@ -131,7 +131,6 @@ class _GlobalEndpointManager(object):
                     return database_account
                 except exceptions.CosmosHttpResponseError:
                     pass
-
             raise
 
     async def _GetDatabaseAccountStub(self, endpoint, **kwargs):

--- a/sdk/cosmos/azure-cosmos/test/test_crud.py
+++ b/sdk/cosmos/azure-cosmos/test/test_crud.py
@@ -1347,10 +1347,9 @@ class CRUDTests(unittest.TestCase):
             return entities
 
         # Client without any authorization will fail.
-        client = cosmos_client.CosmosClient(CRUDTests.host, {}, "Session", connection_policy=CRUDTests.connectionPolicy)
         self.__AssertHTTPFailureWithStatus(StatusCodes.UNAUTHORIZED,
                                            list,
-                                           client.list_databases())
+                                           cosmos_client.CosmosClient(CRUDTests.host, {}, "Session", connection_policy=CRUDTests.connectionPolicy))
         # Client with master key.
         client = cosmos_client.CosmosClient(CRUDTests.host,
                                             CRUDTests.masterKey,

--- a/sdk/cosmos/azure-cosmos/test/test_crud.py
+++ b/sdk/cosmos/azure-cosmos/test/test_crud.py
@@ -1351,7 +1351,7 @@ class CRUDTests(unittest.TestCase):
             cosmos_client.CosmosClient(CRUDTests.host, {}, "Session", connection_policy=CRUDTests.connectionPolicy)
             raise Exception("Test did not fail as expected.")
         except exceptions.CosmosHttpResponseError as error:
-            assert error.status_code == StatusCodes.UNAUTHORIZED
+            self.assertEqual(error.status_code, StatusCodes.UNAUTHORIZED)
 
         # Client with master key.
         client = cosmos_client.CosmosClient(CRUDTests.host,

--- a/sdk/cosmos/azure-cosmos/test/test_crud.py
+++ b/sdk/cosmos/azure-cosmos/test/test_crud.py
@@ -1347,9 +1347,12 @@ class CRUDTests(unittest.TestCase):
             return entities
 
         # Client without any authorization will fail.
-        self.__AssertHTTPFailureWithStatus(StatusCodes.UNAUTHORIZED,
-                                           list,
-                                           cosmos_client.CosmosClient(CRUDTests.host, {}, "Session", connection_policy=CRUDTests.connectionPolicy))
+        try:
+            cosmos_client.CosmosClient(CRUDTests.host, {}, "Session", connection_policy=CRUDTests.connectionPolicy)
+            raise Exception("Test did not fail as expected.")
+        except exceptions.CosmosHttpResponseError as error:
+            assert error.status_code == StatusCodes.UNAUTHORIZED
+
         # Client with master key.
         client = cosmos_client.CosmosClient(CRUDTests.host,
                                             CRUDTests.masterKey,

--- a/sdk/cosmos/azure-cosmos/test/test_crud_async.py
+++ b/sdk/cosmos/azure-cosmos/test/test_crud_async.py
@@ -1326,11 +1326,11 @@ class CRUDTests(unittest.TestCase):
             return entities
 
         # Client without any authorization will fail.
-        async with CosmosClient(CRUDTests.host, {}, consistency_level="Session", connection_policy=CRUDTests.connectionPolicy) as client:
+        async with CosmosClient(url=CRUDTests.host, credential="wrong_key", consistency_level="Session", connection_policy=CRUDTests.connectionPolicy) as client:
             try:
-                db_list = [db async for db in client.list_databases()]
+                [db async for db in client.list_databases()]
             except exceptions.CosmosHttpResponseError as e:
-                assert e.status_code == 401
+                self.assertEqual(e.status_code, StatusCodes.UNAUTHORIZED)
 
         # Client with master key.
         async with CosmosClient(CRUDTests.host,

--- a/sdk/cosmos/azure-cosmos/test/test_crud_async.py
+++ b/sdk/cosmos/azure-cosmos/test/test_crud_async.py
@@ -1326,7 +1326,7 @@ class CRUDTests(unittest.TestCase):
             return entities
 
         # Client without any authorization will fail.
-        async with CosmosClient(url=CRUDTests.host, credential="wrong_key", consistency_level="Session", connection_policy=CRUDTests.connectionPolicy) as client:
+        async with CosmosClient(CRUDTests.host, {}, consistency_level="Session", connection_policy=CRUDTests.connectionPolicy) as client:
             try:
                 [db async for db in client.list_databases()]
             except exceptions.CosmosHttpResponseError as e:

--- a/sdk/cosmos/azure-cosmos/test/test_user_configs.py
+++ b/sdk/cosmos/azure-cosmos/test/test_user_configs.py
@@ -72,8 +72,7 @@ class TestUserConfigs(unittest.TestCase):
         try:
             cosmos_client.CosmosClient(url=_test_config.host, credential="wrong_key")
         except exceptions.CosmosHttpResponseError as e:
-            assert e.status_code == 401
-            assert e.reason == "Unauthorized"
+            self.assertEqual(e.status_code, http_constants.StatusCodes.UNAUTHORIZED)
 
     def test_default_account_consistency(self):
         # These tests use the emulator, which has a default consistency of "Session".

--- a/sdk/cosmos/azure-cosmos/test/test_user_configs.py
+++ b/sdk/cosmos/azure-cosmos/test/test_user_configs.py
@@ -68,6 +68,13 @@ class TestUserConfigs(unittest.TestCase):
         self.assertTrue(client_default.client_connection.connection_policy.EnableEndpointDiscovery)
         self.assertTrue(client_true.client_connection.connection_policy.EnableEndpointDiscovery)
 
+    def test_authentication_error(self):
+        try:
+            cosmos_client.CosmosClient(url=_test_config.host, credential="wrong_key")
+        except exceptions.CosmosHttpResponseError as e:
+            assert e.status_code == 401
+            assert e.reason == "Unauthorized"
+
     def test_default_account_consistency(self):
         # These tests use the emulator, which has a default consistency of "Session".
         # If your account has a different level of consistency, make sure it's not the same as the custom_level below.


### PR DESCRIPTION
Currently, if the user runs into authentication errors or issues with using a managed identity/ service principal without the proper permissions, they will see the wrong error  'NoneType has no attribute ConsistencyPolicy'.

This is due to when we make a call to retrieve the user's database account information within the client initialization. When it fails to work, the database_account variable gets initialized to None, and the error above gets surfaced. With these new changes, users should be seeing more informative methods that actually have to do with the credentials being used.

Solves https://github.com/Azure/azure-sdk-for-python/issues/27753 and https://github.com/Azure/azure-sdk-for-python/issues/26123.

New errors:
401
![image](https://user-images.githubusercontent.com/30335873/224134019-503aadbf-3032-4588-a4d4-a023f733e5dc.png)
403
![image](https://user-images.githubusercontent.com/30335873/224134431-aad361bc-f68e-47c6-a48b-f87d9de6aa3a.png)
