### PR TITLE
[ML] Remove erroneous warning that test configs are used in documentation

### DIFF
--- a/sdk/ml/azure-ai-ml/tests/test_configs/dsl_pipeline/nyc_taxi_data_regression/green_data.yml
+++ b/sdk/ml/azure-ai-ml/tests/test_configs/dsl_pipeline/nyc_taxi_data_regression/green_data.yml
@@ -1,7 +1,3 @@
-## IMPORTANT: this file and accompanying assets are the source for snippets in https://docs.microsoft.com/azure/machine-learning!
-## Please reach out to the Azure ML docs & samples team before editing for the first time.
-
-# <data>
 $schema: https://azuremlsdk2.blob.core.windows.net/latest/asset.schema.json
 name: greendata
 version: 3
@@ -9,4 +5,3 @@ description: sample green taxi dataset
 datastore: azureml:workspaceblobstore
 local_path: ./data
 path: /sample/data/path
-# </data>

--- a/sdk/ml/azure-ai-ml/tests/test_configs/dsl_pipeline/nyc_taxi_data_regression/pipeline.yml
+++ b/sdk/ml/azure-ai-ml/tests/test_configs/dsl_pipeline/nyc_taxi_data_regression/pipeline.yml
@@ -1,9 +1,4 @@
-## IMPORTANT: this file and accompanying assets are the source for snippets in https://docs.microsoft.com/azure/machine-learning!
-## Please reach out to the Azure ML docs & samples team before editing for the first time.
-
 type: pipeline
-
-# <inputs_and_outputs>
 inputs:
   pipeline_job_input: #using dataset, can use datastore + datapath also
     path: ./data
@@ -83,4 +78,3 @@ jobs:
       model: ${{parent.jobs.train_job.outputs.model_output}}
     outputs:
       score_report: ${{parent.outputs.pipeline_job_score_report}}
-# </jobs>

--- a/sdk/ml/azure-ai-ml/tests/test_configs/dsl_pipeline/nyc_taxi_data_regression/predict.yml
+++ b/sdk/ml/azure-ai-ml/tests/test_configs/dsl_pipeline/nyc_taxi_data_regression/predict.yml
@@ -1,7 +1,3 @@
-## IMPORTANT: this file and accompanying assets are the source for snippets in https://docs.microsoft.com/azure/machine-learning!
-## Please reach out to the Azure ML docs & samples team before editing for the first time.
-
-# <component>
 name: predict_taxi_fares
 version: 1
 display_name: PredictTaxiFares
@@ -21,4 +17,3 @@ command: >-
   --model_input ${{inputs.model_input}}
   --test_data ${{inputs.test_data}}
   --predictions ${{outputs.predictions}}
-# </component>

--- a/sdk/ml/azure-ai-ml/tests/test_configs/dsl_pipeline/nyc_taxi_data_regression/prep.yml
+++ b/sdk/ml/azure-ai-ml/tests/test_configs/dsl_pipeline/nyc_taxi_data_regression/prep.yml
@@ -1,7 +1,3 @@
-## IMPORTANT: this file and accompanying assets are the source for snippets in https://docs.microsoft.com/azure/machine-learning!
-## Please reach out to the Azure ML docs & samples team before editing for the first time.
-
-# <component>
 name: prep_taxi_data
 display_name: PrepTaxiData
 version: 1
@@ -18,4 +14,3 @@ command: >-
   python prep.py
   --raw_data ${{inputs.raw_data}}
   --prep_data ${{outputs.prep_data}}
-# </component>

--- a/sdk/ml/azure-ai-ml/tests/test_configs/dsl_pipeline/nyc_taxi_data_regression/score.yml
+++ b/sdk/ml/azure-ai-ml/tests/test_configs/dsl_pipeline/nyc_taxi_data_regression/score.yml
@@ -1,7 +1,3 @@
-## IMPORTANT: this file and accompanying assets are the source for snippets in https://docs.microsoft.com/azure/machine-learning!
-## Please reach out to the Azure ML docs & samples team before editing for the first time.
-
-# <component>
 name: score_model
 version: 1
 display_name: ScoreModel
@@ -21,4 +17,3 @@ command: >-
   --predictions ${{inputs.predictions}}
   --model ${{inputs.model}}
   --score_report ${{outputs.score_report}}
-# </component>

--- a/sdk/ml/azure-ai-ml/tests/test_configs/dsl_pipeline/nyc_taxi_data_regression/train.yml
+++ b/sdk/ml/azure-ai-ml/tests/test_configs/dsl_pipeline/nyc_taxi_data_regression/train.yml
@@ -1,7 +1,3 @@
-## IMPORTANT: this file and accompanying assets are the source for snippets in https://docs.microsoft.com/azure/machine-learning!
-## Please reach out to the Azure ML docs & samples team before editing for the first time.
-
-# <component>
 name: train_linear_regression_model
 display_name: TrainLinearRegressionModel
 version: 1
@@ -21,4 +17,3 @@ command: >-
   --training_data ${{inputs.training_data}}
   --test_data ${{outputs.test_data}}
   --model_output ${{outputs.model_output}}
-# </component>

--- a/sdk/ml/azure-ai-ml/tests/test_configs/dsl_pipeline/nyc_taxi_data_regression/transform.yml
+++ b/sdk/ml/azure-ai-ml/tests/test_configs/dsl_pipeline/nyc_taxi_data_regression/transform.yml
@@ -1,7 +1,3 @@
-## IMPORTANT: this file and accompanying assets are the source for snippets in https://docs.microsoft.com/azure/machine-learning!
-## Please reach out to the Azure ML docs & samples team before editing for the first time.
-
-# <component>
 name: taxi_feature_engineering
 display_name: TaxiFeatureEngineering
 version: 1
@@ -18,4 +14,3 @@ command: >-
   python transform.py
   --clean_data ${{inputs.clean_data}}
   --transformed_data ${{outputs.transformed_data}}
-# </component>

--- a/sdk/ml/azure-ai-ml/tests/test_configs/dsl_pipeline/nyc_taxi_data_regression/yellow_data.yml
+++ b/sdk/ml/azure-ai-ml/tests/test_configs/dsl_pipeline/nyc_taxi_data_regression/yellow_data.yml
@@ -1,7 +1,3 @@
-## IMPORTANT: this file and accompanying assets are the source for snippets in https://docs.microsoft.com/azure/machine-learning!
-## Please reach out to the Azure ML docs & samples team before editing for the first time.
-
-# <data>
 $schema: https://azuremlsdk2.blob.core.windows.net/latest/asset.schema.json
 name: yellowdata
 version: 3
@@ -9,4 +5,3 @@ description: sample yellow taxi dataset
 datastore: azureml:workspaceblobstore
 local_path: ./data
 path: /sample/data/path
-# </data>


### PR DESCRIPTION
# Description

Some of our test configs have a warning asking for the Docs and Samples team to be alerted when making changes to those files. 

These files are not actually in use, and can be freely edited.

This PR removes the warning from those files.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
