### PR TITLE
Changing default evaluation interval value from 0 to 1

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/sweep/early_termination_policy.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/sweep/early_termination_policy.py
@@ -105,7 +105,7 @@ class MedianStoppingPolicy(EarlyTerminationPolicy):
         self,
         *,
         delay_evaluation: int = 0,
-        evaluation_interval: int = 0,
+        evaluation_interval: int = 1,
     ) -> None:
         super().__init__(delay_evaluation=delay_evaluation, evaluation_interval=evaluation_interval)
         self.type = camel_to_snake(EarlyTerminationPolicyType.MEDIAN_STOPPING)


### PR DESCRIPTION
# Description
Fixing default value of evaluation interval for medianstoppingpolicy form 0 to 1
Related bug : https://dev.azure.com/msdata/Vienna/_workitems/edit/1884030
Tested experiment: https://ml.azure.com/experiments/id/4b59aa5a-f03c-4e40-9de4-09339d60de8d/runs/test_494226976163?wsid=/subscriptions/b17253fa-f327-42d6-9686-f3e553e24763/resourceGroups/nilesh-new-rg/providers/Microsoft.MachineLearningServices/workspaces/sdk_vnext_cli&tid=72f988bf-86f1-41af-91ab-2d7cd011db47#hyperdriveOverview

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
