### PR TITLE
[Cosmos] removing six dependency from SDK

### DIFF
--- a/sdk/cosmos/azure-cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Fixed bug in method `create_container_if_not_exists()` of async database client for unexpected kwargs being passed into `read()` method used internally.
 
 #### Other Changes
+* Removed use of `six` package within the SDK.
 
 ### 4.3.1 (2023-02-23)
 

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_execution_context/execution_dispatcher.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_execution_context/execution_dispatcher.py
@@ -24,7 +24,6 @@ Cosmos database service.
 """
 
 import json
-from six.moves import xrange
 from azure.cosmos.exceptions import CosmosHttpResponseError
 from azure.cosmos._execution_context import multi_execution_aggregator
 from azure.cosmos._execution_context.base_execution_context import _QueryExecutionContextBase
@@ -197,7 +196,7 @@ class _PipelineExecutionContext(_QueryExecutionContextBase):  # pylint: disable=
         """
 
         results = []
-        for _ in xrange(self._page_size):
+        for _ in range(self._page_size):
             try:
                 results.append(next(self))
             except StopIteration:

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_global_endpoint_manager.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_global_endpoint_manager.py
@@ -25,7 +25,7 @@ database service.
 
 import threading
 
-from six.moves.urllib.parse import urlparse
+from urllib.parse import urlparse
 
 from . import _constants as constants
 from . import exceptions

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_partition.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_partition.py
@@ -23,9 +23,6 @@
 database service.
 """
 
-from six.moves import xrange
-
-
 class Partition(object):
     """A class that holds the hash value and node name for a partition.
     """
@@ -56,7 +53,7 @@ class Partition(object):
 
         # The hash byte array that is returned from ComputeHash method has the MSB at the end of the array
         # so comparing the bytes from the end for compare operations.
-        for i in xrange(0, len(self.hash_value)):
+        for i in range(0, len(self.hash_value)):
             if self.hash_value[len(self.hash_value) - i - 1] < other_hash_value[len(self.hash_value) - i - 1]:
                 return -1
             if self.hash_value[len(self.hash_value) - i - 1] > other_hash_value[len(self.hash_value) - i - 1]:

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_routing/collection_routing_map.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_routing/collection_routing_map.py
@@ -24,9 +24,6 @@ database service.
 """
 
 import bisect
-
-from six.moves import xrange
-
 from azure.cosmos._routing import routing_range
 from azure.cosmos._routing.routing_range import PartitionKeyRange
 
@@ -138,7 +135,7 @@ class CollectionRoutingMap(object):
             if maxIndex >= len(sortedHigh):
                 maxIndex = maxIndex - 1
 
-            for i in xrange(minIndex, maxIndex + 1):
+            for i in range(minIndex, maxIndex + 1):
                 if routing_range.Range.overlaps(self._orderedRanges[i], providedRange):
                     minToPartitionRange[
                         self._orderedPartitionKeyRanges[i][PartitionKeyRange.MinInclusive]

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/database.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/database.py
@@ -742,7 +742,7 @@ class DatabaseProxy(object):
         :rtype: ~azure.cosmos.ThroughputProperties
         """
         warnings.warn(
-            "read_offer is a deprecated method name, use read_throughput instead",
+            "read_offer is a deprecated method name, use get_throughput instead",
             DeprecationWarning
         )
         return self.get_throughput(**kwargs)

--- a/sdk/cosmos/azure-cosmos/test/test_aggregate.py
+++ b/sdk/cosmos/azure-cosmos/test/test_aggregate.py
@@ -25,9 +25,6 @@ import unittest
 import uuid
 import pytest
 
-from six import with_metaclass
-from six.moves import xrange
-
 import azure.cosmos.cosmos_client as cosmos_client
 import azure.cosmos.documents as documents
 import test_config
@@ -78,7 +75,7 @@ class AggregationQueryTest(unittest.TestCase):
             d = {_config.PARTITION_KEY: value, 'id': str(uuid.uuid4())}
             document_definitions.append(d)
 
-        for i in xrange(_config.DOCS_WITH_SAME_PARTITION_KEY):
+        for i in range(_config.DOCS_WITH_SAME_PARTITION_KEY):
             d = {_config.PARTITION_KEY: _config.UNIQUE_PARTITION_KEY,
                  'resourceId': i,
                  _config.FIELD: i + 1,
@@ -87,7 +84,7 @@ class AggregationQueryTest(unittest.TestCase):
 
         _config.docs_with_numeric_id = \
             _config.DOCUMENTS_COUNT - len(values) - _config.DOCS_WITH_SAME_PARTITION_KEY
-        for i in xrange(_config.docs_with_numeric_id):
+        for i in range(_config.docs_with_numeric_id):
             d = {_config.PARTITION_KEY: i + 1, 'id': str(uuid.uuid4())}
             document_definitions.append(d)
 

--- a/sdk/cosmos/azure-cosmos/test/test_orderby.py
+++ b/sdk/cosmos/azure-cosmos/test/test_orderby.py
@@ -23,12 +23,10 @@ import unittest
 import uuid
 import pytest
 from azure.core.paging import ItemPaged
-import azure.cosmos.documents as documents
 from azure.cosmos.partition_key import PartitionKey
 import azure.cosmos.cosmos_client as cosmos_client
 from azure.cosmos import _query_iterable as query_iterable
 import azure.cosmos._base as base
-from six.moves import xrange
 import test_config
 
 pytestmark = pytest.mark.cosmosEmulator
@@ -91,7 +89,7 @@ class CrossPartitionTopOrderByTest(unittest.TestCase):
 
         # create a document using the document definition
         cls.document_definitions = []
-        for i in xrange(20):
+        for i in range(20):
             d = {'id': str(i),
                  'name': 'sample document',
                  'spam': 'eggs' + str(i),
@@ -470,7 +468,7 @@ class CrossPartitionTopOrderByTest(unittest.TestCase):
             return next(it)
                     
         # validate that invocations of next() produces the same results as expected_ordered_ids
-        for i in xrange(len(expected_ordered_ids)):
+        for i in range(len(expected_ordered_ids)):
             item = invokeNext()
             self.assertEqual(item['id'], expected_ordered_ids[i])
 

--- a/sdk/cosmos/azure-cosmos/test/test_query_execution_context.py
+++ b/sdk/cosmos/azure-cosmos/test/test_query_execution_context.py
@@ -22,7 +22,6 @@
 import unittest
 import uuid
 import pytest
-from six.moves import xrange
 import azure.cosmos.cosmos_client as cosmos_client
 from azure.cosmos._execution_context import base_execution_context as base_execution_context
 import azure.cosmos._base as base
@@ -69,7 +68,7 @@ class QueryExecutionContextEndToEndTests(unittest.TestCase):
         cls.document_definitions = []
 
         # create a document using the document definition
-        for i in xrange(20):
+        for i in range(20):
             d = {'id': str(i),
                  'name': 'sample document',
                  'spam': 'eggs' + str(i),
@@ -165,7 +164,7 @@ class QueryExecutionContextEndToEndTests(unittest.TestCase):
                     
         results = {}            
         # validate that invocations of next() produces the same results as expected
-        for _ in xrange(expected_number_of_results):
+        for _ in range(expected_number_of_results):
             item = invokeNext()
             results[item['id']] = item
        


### PR DESCRIPTION
Request from https://github.com/Azure/azure-sdk-for-python/issues/26895. Removing the six package from the SDK entirely as part of the efforts of aligning the SDKs with Python3.