### PR TITLE
[Storage] Add `undelete_path` to public interface

### DIFF
--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_data_lake_directory_client.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_data_lake_directory_client.py
@@ -111,10 +111,12 @@ class DataLakeDirectoryClient(PathClient):
             account_url, file_system_name=file_system_name, directory_name=directory_name,
             credential=credential, **kwargs)
 
-    def is_directory(self) -> bool:
+    @staticmethod
+    def is_directory() -> bool:
         return True
 
-    def is_file(self) -> bool:
+    @staticmethod
+    def is_file() -> bool:
         return False
 
     def create_directory(self, metadata=None,  # type: Optional[Dict[str, str]]

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_data_lake_directory_client.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_data_lake_directory_client.py
@@ -111,6 +111,12 @@ class DataLakeDirectoryClient(PathClient):
             account_url, file_system_name=file_system_name, directory_name=directory_name,
             credential=credential, **kwargs)
 
+    def is_directory(self) -> bool:
+        return True
+
+    def is_file(self) -> bool:
+        return False
+
     def create_directory(self, metadata=None,  # type: Optional[Dict[str, str]]
                          **kwargs):
         # type: (...) -> Dict[str, Union[str, datetime]]

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_data_lake_file_client.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_data_lake_file_client.py
@@ -119,6 +119,12 @@ class DataLakeFileClient(PathClient):
             account_url, file_system_name=file_system_name, file_path=file_path,
             credential=credential, **kwargs)
 
+    def is_directory(self) -> bool:
+        return False
+
+    def is_file(self) -> bool:
+        return True
+
     def create_file(self, content_settings=None,  # type: Optional[ContentSettings]
                     metadata=None,  # type: Optional[Dict[str, str]]
                     **kwargs):

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_data_lake_file_client.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_data_lake_file_client.py
@@ -119,10 +119,12 @@ class DataLakeFileClient(PathClient):
             account_url, file_system_name=file_system_name, file_path=file_path,
             credential=credential, **kwargs)
 
-    def is_directory(self) -> bool:
+    @staticmethod
+    def is_directory() -> bool:
         return False
 
-    def is_file(self) -> bool:
+    @staticmethod
+    def is_file() -> bool:
         return True
 
     def create_file(self, content_settings=None,  # type: Optional[ContentSettings]

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_file_system_client.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_file_system_client.py
@@ -881,15 +881,15 @@ class FileSystemClient(StorageAccountHostsMixin):
 
         return quoted_path, url, undelete_source
 
-    def _undelete_path(self, deleted_path_name, deletion_id, **kwargs):
-        # type: (str, str, **Any) -> Union[DataLakeDirectoryClient, DataLakeFileClient]
+    def undelete_path(
+            self, deleted_path_name: str,
+            deletion_id: str,
+            **kwargs: Any
+        ) -> Union[DataLakeDirectoryClient, DataLakeFileClient]:
         """Restores soft-deleted path.
 
         Operation will only be successful if used within the specified number of days
         set in the delete retention policy.
-
-        .. versionadded:: 12.4.0
-            This operation was introduced in API version '2020-06-12'.
 
         :param str deleted_path_name:
             Specifies the path (file or directory) to restore.
@@ -902,6 +902,15 @@ class FileSystemClient(StorageAccountHostsMixin):
             see `here <https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/storage/azure-storage-file-datalake
             #other-client--per-operation-configuration>`_.
         :rtype: ~azure.storage.file.datalake.DataLakeDirectoryClient or azure.storage.file.datalake.DataLakeFileClient
+
+        .. admonition:: Example:
+
+            .. literalinclude:: ../samples/datalake_samples_file_system.py
+                :start-after: [START undelete_path_from_file_system]
+                :end-before: [END undelete_path_from_file_system]
+                :language: python
+                :dedent: 8
+                :caption: Undeleting a file from file system.
         """
         _, url, undelete_source = self._undelete_path_options(deleted_path_name, deletion_id)
 

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/aio/_file_system_client_async.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/aio/_file_system_client_async.py
@@ -827,15 +827,15 @@ class FileSystemClient(AsyncStorageAccountHostsMixin, FileSystemClientBase):
         return file_client
 
     @distributed_trace_async
-    async def _undelete_path(self, deleted_path_name, deletion_id, **kwargs):
-        # type: (str, str, **Any) -> Union[DataLakeDirectoryClient, DataLakeFileClient]
+    async def undelete_path(
+            self, deleted_path_name: str,
+            deletion_id: str,
+            **kwargs: Any
+        ) -> Union[DataLakeDirectoryClient, DataLakeFileClient]:
         """Restores soft-deleted path.
 
         Operation will only be successful if used within the specified number of days
         set in the delete retention policy.
-
-        .. versionadded:: 12.4.0
-            This operation was introduced in API version '2020-06-12'.
 
         :param str deleted_path_name:
             Specifies the name of the deleted container to restore.
@@ -849,6 +849,15 @@ class FileSystemClient(AsyncStorageAccountHostsMixin, FileSystemClientBase):
             #other-client--per-operation-configuration>`_.
         :rtype: ~azure.storage.file.datalake.aio.DataLakeDirectoryClient
                 or azure.storage.file.datalake.aio.DataLakeFileClient
+
+        .. admonition:: Example:
+
+            .. literalinclude:: ../samples/datalake_samples_file_system_async.py
+                :start-after: [START undelete_path_from_file_system]
+                :end-before: [END undelete_path_from_file_system]
+                :language: python
+                :dedent: 12
+                :caption: Undeleting a file from file system.
         """
         _, url, undelete_source = self._undelete_path_options(deleted_path_name, deletion_id)
 

--- a/sdk/storage/azure-storage-file-datalake/samples/datalake_samples_file_system.py
+++ b/sdk/storage/azure-storage-file-datalake/samples/datalake_samples_file_system.py
@@ -209,6 +209,26 @@ class FileSystemSamples(object):
 
         file_system_client.delete_file_system()
 
+    def undelete_path_from_file_system(self):
+        from azure.storage.filedatalake import FileSystemClient
+        file_system_client = FileSystemClient.from_connection_string(self.connection_string, "filesystem")
+
+        file_system_client.create_file_system()
+
+        # [START undelete_path_from_file_system]
+        # Create a file and delete it
+        file_client = file_system_client.create_file("myfile")
+        delete_response = file_client.delete_file()
+
+        # Restore the file
+        undelete_client = file_system_client.undelete_path('myfile', delete_response['deletion_id'])
+
+        # Check what resource type was returned, then get properties
+        if undelete_client.is_file():
+            props = undelete_client.get_file_properties()
+        # [END undelete_path_from_file_system]
+
+
 if __name__ == '__main__':
     sample = FileSystemSamples()
     sample.file_system_sample()
@@ -217,3 +237,4 @@ if __name__ == '__main__':
     sample.list_paths_in_file_system()
     sample.get_file_client_from_file_system()
     sample.create_file_from_file_system()
+    sample.undelete_path_from_file_system()

--- a/sdk/storage/azure-storage-file-datalake/samples/datalake_samples_file_system_async.py
+++ b/sdk/storage/azure-storage-file-datalake/samples/datalake_samples_file_system_async.py
@@ -217,6 +217,27 @@ class FileSystemSamplesAsync(object):
 
             await file_system_client.delete_file_system()
 
+    async def undelete_path_from_file_system(self):
+        from azure.storage.filedatalake.aio import FileSystemClient
+        file_system_client = FileSystemClient.from_connection_string(self.connection_string, "filesystem")
+
+        async with file_system_client:
+            await file_system_client.create_file_system()
+
+            # [START undelete_path_from_file_system]
+            # Create a file and delete it
+            file_client = await file_system_client.create_file("myfile")
+            delete_response = await file_client.delete_file()
+
+            # Restore the file
+            undelete_client = await file_system_client.undelete_path('myfile', delete_response['deletion_id'])
+
+            # Check what resource type was returned, then get properties
+            if undelete_client.is_file():
+                props = await undelete_client.get_file_properties()
+            # [END undelete_path_from_file_system]
+
+
 async def main():
     sample = FileSystemSamplesAsync()
     await sample.file_system_sample()
@@ -225,6 +246,7 @@ async def main():
     await sample.list_paths_in_file_system()
     await sample.get_file_client_from_file_system()
     await sample.create_file_from_file_system()
+    await sample.undelete_path_from_file_system()
 
 if __name__ == '__main__':
     asyncio.run(main())

--- a/sdk/storage/azure-storage-file-datalake/tests/recordings/test_file_system.pyTestFileSystemtest_undelete_dir.json
+++ b/sdk/storage/azure-storage-file-datalake/tests/recordings/test_file_system.pyTestFileSystemtest_undelete_dir.json
@@ -1,144 +1,150 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://storagesoftdelname.blob.core.windows.net/fs288434b0?restype=container",
+      "RequestUri": "https://storagesoftdelname.blob.core.windows.net/fs2c39c2928?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Accept-Encoding": "gzip, deflate",
+        "Connection": "keep-alive",
         "Content-Length": "0",
-        "User-Agent": "azsdk-python-storage-dfs/12.9.0b2 Python/3.10.2 (Windows-10-10.0.19044-SP0)",
-        "x-ms-date": "Mon, 19 Sep 2022 23:30:33 GMT",
-        "x-ms-version": "2021-08-06"
+        "User-Agent": "azsdk-python-storage-dfs/12.11.0b1 Python/3.10.7 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Fri, 10 Mar 2023 01:35:33 GMT",
+        "x-ms-version": "2022-11-02"
       },
       "RequestBody": null,
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 19 Sep 2022 23:30:33 GMT",
-        "ETag": "\u00220x8DA9A96F3400253\u0022",
-        "Last-Modified": "Mon, 19 Sep 2022 23:30:34 GMT",
+        "Date": "Fri, 10 Mar 2023 01:35:33 GMT",
+        "ETag": "\u00220x8DB2107BDDEB1CE\u0022",
+        "Last-Modified": "Fri, 10 Mar 2023 01:35:33 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-version": "2021-08-06"
+        "x-ms-version": "2022-11-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://storagesoftdelname.dfs.core.windows.net/fs288434b0/dir10%2Ffile%C5%87?resource=file",
+      "RequestUri": "https://storagesoftdelname.dfs.core.windows.net/fs2c39c2928/dir10?resource=directory",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip, deflate",
+        "Connection": "keep-alive",
         "Content-Length": "0",
-        "User-Agent": "azsdk-python-storage-dfs/12.9.0b2 Python/3.10.2 (Windows-10-10.0.19044-SP0)",
-        "x-ms-date": "Mon, 19 Sep 2022 23:30:34 GMT",
-        "x-ms-version": "2021-08-06"
+        "User-Agent": "azsdk-python-storage-dfs/12.11.0b1 Python/3.10.7 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Fri, 10 Mar 2023 01:35:33 GMT",
+        "x-ms-version": "2022-11-02"
       },
       "RequestBody": null,
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 19 Sep 2022 23:30:33 GMT",
-        "ETag": "\u00220x8DA9A96F382D350\u0022",
-        "Last-Modified": "Mon, 19 Sep 2022 23:30:34 GMT",
+        "Date": "Fri, 10 Mar 2023 01:35:33 GMT",
+        "ETag": "\u00220x8DB2107BE1AF9FD\u0022",
+        "Last-Modified": "Fri, 10 Mar 2023 01:35:34 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-request-server-encrypted": "true",
-        "x-ms-version": "2021-08-06"
+        "x-ms-version": "2022-11-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://storagesoftdelname.dfs.core.windows.net/fs288434b0/dir10%2Ffile%C5%87",
+      "RequestUri": "https://storagesoftdelname.dfs.core.windows.net/fs2c39c2928/dir10?recursive=true",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip, deflate",
+        "Connection": "keep-alive",
         "Content-Length": "0",
-        "User-Agent": "azsdk-python-storage-dfs/12.9.0b2 Python/3.10.2 (Windows-10-10.0.19044-SP0)",
-        "x-ms-date": "Mon, 19 Sep 2022 23:30:34 GMT",
-        "x-ms-version": "2021-08-06"
+        "User-Agent": "azsdk-python-storage-dfs/12.11.0b1 Python/3.10.7 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Fri, 10 Mar 2023 01:35:34 GMT",
+        "x-ms-version": "2022-11-02"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 19 Sep 2022 23:30:34 GMT",
+        "Date": "Fri, 10 Mar 2023 01:35:33 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-delete-type-permanent": "false",
-        "x-ms-deletion-id": "133081038349064340",
-        "x-ms-version": "2021-08-06"
+        "x-ms-deletion-id": "133228857342048725",
+        "x-ms-version": "2022-11-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://storagesoftdelname.blob.core.windows.net/fs288434b0/dir10/file%C5%87",
+      "RequestUri": "https://storagesoftdelname.blob.core.windows.net/fs2c39c2928/dir10",
       "RequestMethod": "HEAD",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Accept-Encoding": "gzip, deflate",
-        "User-Agent": "azsdk-python-storage-dfs/12.9.0b2 Python/3.10.2 (Windows-10-10.0.19044-SP0)",
-        "x-ms-date": "Mon, 19 Sep 2022 23:30:34 GMT",
-        "x-ms-version": "2021-08-06"
+        "Connection": "keep-alive",
+        "User-Agent": "azsdk-python-storage-dfs/12.11.0b1 Python/3.10.7 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Fri, 10 Mar 2023 01:35:34 GMT",
+        "x-ms-version": "2022-11-02"
       },
       "RequestBody": null,
       "StatusCode": 404,
       "ResponseHeaders": {
-        "Date": "Mon, 19 Sep 2022 23:30:34 GMT",
+        "Date": "Fri, 10 Mar 2023 01:35:33 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "Transfer-Encoding": "chunked",
         "x-ms-error-code": "BlobNotFound",
-        "x-ms-version": "2021-08-06"
+        "x-ms-version": "2022-11-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://storagesoftdelname.blob.core.windows.net/fs288434b0/dir10/file%C5%87?comp=undelete",
+      "RequestUri": "https://storagesoftdelname.blob.core.windows.net/fs2c39c2928/dir10?comp=undelete",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip, deflate",
+        "Connection": "keep-alive",
         "Content-Length": "0",
-        "User-Agent": "azsdk-python-storage-dfs/12.9.0b2 Python/3.10.2 (Windows-10-10.0.19044-SP0)",
-        "x-ms-date": "Mon, 19 Sep 2022 23:30:34 GMT",
-        "x-ms-undelete-source": "dir10/file%C5%87?deletionid=133081038349064340",
+        "User-Agent": "azsdk-python-storage-dfs/12.11.0b1 Python/3.10.7 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Fri, 10 Mar 2023 01:35:34 GMT",
+        "x-ms-undelete-source": "dir10?deletionid=133228857342048725",
         "x-ms-version": "2021-06-08"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 19 Sep 2022 23:30:34 GMT",
+        "Date": "Fri, 10 Mar 2023 01:35:33 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-creation-time": "Mon, 19 Sep 2022 23:30:34 GMT",
-        "x-ms-resource-type": "file",
+        "x-ms-creation-time": "Fri, 10 Mar 2023 01:35:34 GMT",
+        "x-ms-resource-type": "directory",
         "x-ms-version": "2021-06-08"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://storagesoftdelname.blob.core.windows.net/fs288434b0/dir10/file%C5%87",
+      "RequestUri": "https://storagesoftdelname.blob.core.windows.net/fs2c39c2928/dir10",
       "RequestMethod": "HEAD",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Accept-Encoding": "gzip, deflate",
-        "User-Agent": "azsdk-python-storage-dfs/12.9.0b2 Python/3.10.2 (Windows-10-10.0.19044-SP0)",
-        "x-ms-date": "Mon, 19 Sep 2022 23:30:35 GMT",
-        "x-ms-version": "2021-08-06"
+        "Connection": "keep-alive",
+        "User-Agent": "azsdk-python-storage-dfs/12.11.0b1 Python/3.10.7 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Fri, 10 Mar 2023 01:35:34 GMT",
+        "x-ms-version": "2022-11-02"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -146,9 +152,9 @@
         "Accept-Ranges": "bytes",
         "Content-Length": "0",
         "Content-Type": "application/octet-stream",
-        "Date": "Mon, 19 Sep 2022 23:30:34 GMT",
-        "ETag": "\u00220x8DA9A96F382D350\u0022",
-        "Last-Modified": "Mon, 19 Sep 2022 23:30:34 GMT",
+        "Date": "Fri, 10 Mar 2023 01:35:34 GMT",
+        "ETag": "\u00220x8DB2107BE1AF9FD\u0022",
+        "Last-Modified": "Fri, 10 Mar 2023 01:35:34 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
@@ -156,15 +162,16 @@
         "x-ms-access-tier": "Hot",
         "x-ms-access-tier-inferred": "true",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-creation-time": "Mon, 19 Sep 2022 23:30:34 GMT",
+        "x-ms-creation-time": "Fri, 10 Mar 2023 01:35:34 GMT",
         "x-ms-group": "$superuser",
         "x-ms-lease-state": "available",
         "x-ms-lease-status": "unlocked",
+        "x-ms-meta-hdi_isfolder": "true",
         "x-ms-owner": "$superuser",
-        "x-ms-permissions": "rw-r-----",
-        "x-ms-resource-type": "file",
+        "x-ms-permissions": "rwxr-x---",
+        "x-ms-resource-type": "directory",
         "x-ms-server-encrypted": "true",
-        "x-ms-version": "2021-08-06"
+        "x-ms-version": "2022-11-02"
       },
       "ResponseBody": null
     }

--- a/sdk/storage/azure-storage-file-datalake/tests/recordings/test_file_system.pyTestFileSystemtest_undelete_file.json
+++ b/sdk/storage/azure-storage-file-datalake/tests/recordings/test_file_system.pyTestFileSystemtest_undelete_file.json
@@ -1,150 +1,150 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://storagesoftdelname.blob.core.windows.net/fs3cd6a3035?restype=container",
+      "RequestUri": "https://storagesoftdelname.blob.core.windows.net/fs3edbf2989?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Accept-Encoding": "gzip, deflate",
         "Connection": "keep-alive",
         "Content-Length": "0",
-        "User-Agent": "azsdk-python-storage-dfs/12.9.0b2 Python/3.10.2 (Windows-10-10.0.19044-SP0)",
-        "x-ms-date": "Mon, 19 Sep 2022 23:30:18 GMT",
-        "x-ms-version": "2021-08-06"
+        "User-Agent": "azsdk-python-storage-dfs/12.11.0b1 Python/3.10.7 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Fri, 10 Mar 2023 01:35:59 GMT",
+        "x-ms-version": "2022-11-02"
       },
       "RequestBody": null,
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 19 Sep 2022 23:30:18 GMT",
-        "ETag": "\u00220x8DA9A96EA08E820\u0022",
-        "Last-Modified": "Mon, 19 Sep 2022 23:30:18 GMT",
+        "Date": "Fri, 10 Mar 2023 01:35:58 GMT",
+        "ETag": "\u00220x8DB2107CD329257\u0022",
+        "Last-Modified": "Fri, 10 Mar 2023 01:35:59 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-version": "2021-08-06"
+        "x-ms-version": "2022-11-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://storagesoftdelname.dfs.core.windows.net/fs3cd6a3035/dir10%2Ffile%C5%87?resource=file",
+      "RequestUri": "https://storagesoftdelname.dfs.core.windows.net/fs3edbf2989/dir10%2Ffile%C5%87?resource=file",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip, deflate",
         "Connection": "keep-alive",
         "Content-Length": "0",
-        "User-Agent": "azsdk-python-storage-dfs/12.9.0b2 Python/3.10.2 (Windows-10-10.0.19044-SP0)",
-        "x-ms-date": "Mon, 19 Sep 2022 23:30:18 GMT",
-        "x-ms-version": "2021-08-06"
+        "User-Agent": "azsdk-python-storage-dfs/12.11.0b1 Python/3.10.7 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Fri, 10 Mar 2023 01:35:59 GMT",
+        "x-ms-version": "2022-11-02"
       },
       "RequestBody": null,
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 19 Sep 2022 23:30:18 GMT",
-        "ETag": "\u00220x8DA9A96EA4E2BCF\u0022",
-        "Last-Modified": "Mon, 19 Sep 2022 23:30:19 GMT",
+        "Date": "Fri, 10 Mar 2023 01:35:59 GMT",
+        "ETag": "\u00220x8DB2107CD5A3E9B\u0022",
+        "Last-Modified": "Fri, 10 Mar 2023 01:35:59 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-request-server-encrypted": "true",
-        "x-ms-version": "2021-08-06"
+        "x-ms-version": "2022-11-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://storagesoftdelname.dfs.core.windows.net/fs3cd6a3035/dir10%2Ffile%C5%87",
+      "RequestUri": "https://storagesoftdelname.dfs.core.windows.net/fs3edbf2989/dir10%2Ffile%C5%87",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip, deflate",
         "Connection": "keep-alive",
         "Content-Length": "0",
-        "User-Agent": "azsdk-python-storage-dfs/12.9.0b2 Python/3.10.2 (Windows-10-10.0.19044-SP0)",
-        "x-ms-date": "Mon, 19 Sep 2022 23:30:19 GMT",
-        "x-ms-version": "2021-08-06"
+        "User-Agent": "azsdk-python-storage-dfs/12.11.0b1 Python/3.10.7 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Fri, 10 Mar 2023 01:35:59 GMT",
+        "x-ms-version": "2022-11-02"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 19 Sep 2022 23:30:18 GMT",
+        "Date": "Fri, 10 Mar 2023 01:35:59 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-delete-type-permanent": "false",
-        "x-ms-deletion-id": "133081038194284588",
-        "x-ms-version": "2021-08-06"
+        "x-ms-deletion-id": "133228857597646113",
+        "x-ms-version": "2022-11-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://storagesoftdelname.blob.core.windows.net/fs3cd6a3035/dir10/file%C5%87",
+      "RequestUri": "https://storagesoftdelname.blob.core.windows.net/fs3edbf2989/dir10/file%C5%87",
       "RequestMethod": "HEAD",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Accept-Encoding": "gzip, deflate",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-python-storage-dfs/12.9.0b2 Python/3.10.2 (Windows-10-10.0.19044-SP0)",
-        "x-ms-date": "Mon, 19 Sep 2022 23:30:19 GMT",
-        "x-ms-version": "2021-08-06"
+        "User-Agent": "azsdk-python-storage-dfs/12.11.0b1 Python/3.10.7 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Fri, 10 Mar 2023 01:35:59 GMT",
+        "x-ms-version": "2022-11-02"
       },
       "RequestBody": null,
       "StatusCode": 404,
       "ResponseHeaders": {
-        "Date": "Mon, 19 Sep 2022 23:30:19 GMT",
+        "Date": "Fri, 10 Mar 2023 01:35:59 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "Transfer-Encoding": "chunked",
         "x-ms-error-code": "BlobNotFound",
-        "x-ms-version": "2021-08-06"
+        "x-ms-version": "2022-11-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://storagesoftdelname.blob.core.windows.net/fs3cd6a3035/dir10/file%C5%87?comp=undelete",
+      "RequestUri": "https://storagesoftdelname.blob.core.windows.net/fs3edbf2989/dir10/file%C5%87?comp=undelete",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip, deflate",
         "Connection": "keep-alive",
         "Content-Length": "0",
-        "User-Agent": "azsdk-python-storage-dfs/12.9.0b2 Python/3.10.2 (Windows-10-10.0.19044-SP0)",
-        "x-ms-date": "Mon, 19 Sep 2022 23:30:19 GMT",
-        "x-ms-undelete-source": "dir10/file%C5%87?deletionid=133081038194284588",
+        "User-Agent": "azsdk-python-storage-dfs/12.11.0b1 Python/3.10.7 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Fri, 10 Mar 2023 01:36:00 GMT",
+        "x-ms-undelete-source": "dir10/file%C5%87?deletionid=133228857597646113",
         "x-ms-version": "2021-06-08"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 19 Sep 2022 23:30:19 GMT",
+        "Date": "Fri, 10 Mar 2023 01:35:59 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-creation-time": "Mon, 19 Sep 2022 23:30:19 GMT",
+        "x-ms-creation-time": "Fri, 10 Mar 2023 01:35:59 GMT",
         "x-ms-resource-type": "file",
         "x-ms-version": "2021-06-08"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://storagesoftdelname.blob.core.windows.net/fs3cd6a3035/dir10/file%C5%87",
+      "RequestUri": "https://storagesoftdelname.blob.core.windows.net/fs3edbf2989/dir10/file%C5%87",
       "RequestMethod": "HEAD",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Accept-Encoding": "gzip, deflate",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-python-storage-dfs/12.9.0b2 Python/3.10.2 (Windows-10-10.0.19044-SP0)",
-        "x-ms-date": "Mon, 19 Sep 2022 23:30:19 GMT",
-        "x-ms-version": "2021-08-06"
+        "User-Agent": "azsdk-python-storage-dfs/12.11.0b1 Python/3.10.7 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Fri, 10 Mar 2023 01:36:00 GMT",
+        "x-ms-version": "2022-11-02"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -152,9 +152,9 @@
         "Accept-Ranges": "bytes",
         "Content-Length": "0",
         "Content-Type": "application/octet-stream",
-        "Date": "Mon, 19 Sep 2022 23:30:19 GMT",
-        "ETag": "\u00220x8DA9A96EA4E2BCF\u0022",
-        "Last-Modified": "Mon, 19 Sep 2022 23:30:19 GMT",
+        "Date": "Fri, 10 Mar 2023 01:35:59 GMT",
+        "ETag": "\u00220x8DB2107CD5A3E9B\u0022",
+        "Last-Modified": "Fri, 10 Mar 2023 01:35:59 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
@@ -162,7 +162,7 @@
         "x-ms-access-tier": "Hot",
         "x-ms-access-tier-inferred": "true",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-creation-time": "Mon, 19 Sep 2022 23:30:19 GMT",
+        "x-ms-creation-time": "Fri, 10 Mar 2023 01:35:59 GMT",
         "x-ms-group": "$superuser",
         "x-ms-lease-state": "available",
         "x-ms-lease-status": "unlocked",
@@ -170,7 +170,7 @@
         "x-ms-permissions": "rw-r-----",
         "x-ms-resource-type": "file",
         "x-ms-server-encrypted": "true",
-        "x-ms-version": "2021-08-06"
+        "x-ms-version": "2022-11-02"
       },
       "ResponseBody": null
     }

--- a/sdk/storage/azure-storage-file-datalake/tests/recordings/test_file_system_async.pyTestFileSystemAsynctest_undelete_dir.json
+++ b/sdk/storage/azure-storage-file-datalake/tests/recordings/test_file_system_async.pyTestFileSystemAsynctest_undelete_dir.json
@@ -1,150 +1,144 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://storagesoftdelname.blob.core.windows.net/fs29d372fd4?restype=container",
+      "RequestUri": "https://storagesoftdelname.blob.core.windows.net/fs2b27c2da3?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Accept-Encoding": "gzip, deflate",
-        "Connection": "keep-alive",
         "Content-Length": "0",
-        "User-Agent": "azsdk-python-storage-dfs/12.9.0b2 Python/3.10.2 (Windows-10-10.0.19044-SP0)",
-        "x-ms-date": "Mon, 19 Sep 2022 23:30:53 GMT",
-        "x-ms-version": "2021-08-06"
+        "User-Agent": "azsdk-python-storage-dfs/12.11.0b1 Python/3.10.7 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Fri, 10 Mar 2023 20:17:28 GMT",
+        "x-ms-version": "2022-11-02"
       },
       "RequestBody": null,
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 19 Sep 2022 23:30:53 GMT",
-        "ETag": "\u00220x8DA9A96FF221427\u0022",
-        "Last-Modified": "Mon, 19 Sep 2022 23:30:54 GMT",
+        "Date": "Fri, 10 Mar 2023 20:17:27 GMT",
+        "ETag": "\u00220x8DB21A478A405D5\u0022",
+        "Last-Modified": "Fri, 10 Mar 2023 20:17:28 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-version": "2021-08-06"
+        "x-ms-version": "2022-11-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://storagesoftdelname.dfs.core.windows.net/fs29d372fd4/dir10?resource=directory",
+      "RequestUri": "https://storagesoftdelname.dfs.core.windows.net/fs2b27c2da3/dir10?resource=directory",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip, deflate",
-        "Connection": "keep-alive",
         "Content-Length": "0",
-        "User-Agent": "azsdk-python-storage-dfs/12.9.0b2 Python/3.10.2 (Windows-10-10.0.19044-SP0)",
-        "x-ms-date": "Mon, 19 Sep 2022 23:30:54 GMT",
-        "x-ms-version": "2021-08-06"
+        "User-Agent": "azsdk-python-storage-dfs/12.11.0b1 Python/3.10.7 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Fri, 10 Mar 2023 20:17:28 GMT",
+        "x-ms-version": "2022-11-02"
       },
       "RequestBody": null,
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 19 Sep 2022 23:30:54 GMT",
-        "ETag": "\u00220x8DA9A96FF9192F0\u0022",
-        "Last-Modified": "Mon, 19 Sep 2022 23:30:54 GMT",
+        "Date": "Fri, 10 Mar 2023 20:17:28 GMT",
+        "ETag": "\u00220x8DB21A47DB86DEE\u0022",
+        "Last-Modified": "Fri, 10 Mar 2023 20:17:37 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-request-server-encrypted": "true",
-        "x-ms-version": "2021-08-06"
+        "x-ms-version": "2022-11-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://storagesoftdelname.dfs.core.windows.net/fs29d372fd4/dir10?recursive=true",
+      "RequestUri": "https://storagesoftdelname.dfs.core.windows.net/fs2b27c2da3/dir10?recursive=true",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip, deflate",
-        "Connection": "keep-alive",
         "Content-Length": "0",
-        "User-Agent": "azsdk-python-storage-dfs/12.9.0b2 Python/3.10.2 (Windows-10-10.0.19044-SP0)",
-        "x-ms-date": "Mon, 19 Sep 2022 23:30:54 GMT",
-        "x-ms-version": "2021-08-06"
+        "User-Agent": "azsdk-python-storage-dfs/12.11.0b1 Python/3.10.7 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Fri, 10 Mar 2023 20:17:28 GMT",
+        "x-ms-version": "2022-11-02"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 19 Sep 2022 23:30:54 GMT",
+        "Date": "Fri, 10 Mar 2023 20:17:28 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-delete-type-permanent": "false",
-        "x-ms-deletion-id": "133081038550871125",
-        "x-ms-version": "2021-08-06"
+        "x-ms-deletion-id": "133229530488464514",
+        "x-ms-version": "2022-11-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://storagesoftdelname.blob.core.windows.net/fs29d372fd4/dir10",
+      "RequestUri": "https://storagesoftdelname.blob.core.windows.net/fs2b27c2da3/dir10",
       "RequestMethod": "HEAD",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Accept-Encoding": "gzip, deflate",
-        "Connection": "keep-alive",
-        "User-Agent": "azsdk-python-storage-dfs/12.9.0b2 Python/3.10.2 (Windows-10-10.0.19044-SP0)",
-        "x-ms-date": "Mon, 19 Sep 2022 23:30:55 GMT",
-        "x-ms-version": "2021-08-06"
+        "User-Agent": "azsdk-python-storage-dfs/12.11.0b1 Python/3.10.7 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Fri, 10 Mar 2023 20:17:28 GMT",
+        "x-ms-version": "2022-11-02"
       },
       "RequestBody": null,
       "StatusCode": 404,
       "ResponseHeaders": {
-        "Date": "Mon, 19 Sep 2022 23:30:54 GMT",
+        "Date": "Fri, 10 Mar 2023 20:17:28 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "Transfer-Encoding": "chunked",
         "x-ms-error-code": "BlobNotFound",
-        "x-ms-version": "2021-08-06"
+        "x-ms-version": "2022-11-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://storagesoftdelname.blob.core.windows.net/fs29d372fd4/dir10?comp=undelete",
+      "RequestUri": "https://storagesoftdelname.blob.core.windows.net/fs2b27c2da3/dir10?comp=undelete",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip, deflate",
-        "Connection": "keep-alive",
         "Content-Length": "0",
-        "User-Agent": "azsdk-python-storage-dfs/12.9.0b2 Python/3.10.2 (Windows-10-10.0.19044-SP0)",
-        "x-ms-date": "Mon, 19 Sep 2022 23:30:55 GMT",
-        "x-ms-undelete-source": "dir10?deletionid=133081038550871125",
+        "User-Agent": "azsdk-python-storage-dfs/12.11.0b1 Python/3.10.7 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Fri, 10 Mar 2023 20:17:29 GMT",
+        "x-ms-undelete-source": "dir10?deletionid=133229530488464514",
         "x-ms-version": "2021-06-08"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 19 Sep 2022 23:30:55 GMT",
+        "Date": "Fri, 10 Mar 2023 20:17:28 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-creation-time": "Mon, 19 Sep 2022 23:30:54 GMT",
+        "x-ms-creation-time": "Fri, 10 Mar 2023 20:17:37 GMT",
         "x-ms-resource-type": "directory",
         "x-ms-version": "2021-06-08"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://storagesoftdelname.blob.core.windows.net/fs29d372fd4/dir10",
+      "RequestUri": "https://storagesoftdelname.blob.core.windows.net/fs2b27c2da3/dir10",
       "RequestMethod": "HEAD",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Accept-Encoding": "gzip, deflate",
-        "Connection": "keep-alive",
-        "User-Agent": "azsdk-python-storage-dfs/12.9.0b2 Python/3.10.2 (Windows-10-10.0.19044-SP0)",
-        "x-ms-date": "Mon, 19 Sep 2022 23:30:55 GMT",
-        "x-ms-version": "2021-08-06"
+        "User-Agent": "azsdk-python-storage-dfs/12.11.0b1 Python/3.10.7 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Fri, 10 Mar 2023 20:17:29 GMT",
+        "x-ms-version": "2022-11-02"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -152,9 +146,9 @@
         "Accept-Ranges": "bytes",
         "Content-Length": "0",
         "Content-Type": "application/octet-stream",
-        "Date": "Mon, 19 Sep 2022 23:30:55 GMT",
-        "ETag": "\u00220x8DA9A96FF9192F0\u0022",
-        "Last-Modified": "Mon, 19 Sep 2022 23:30:54 GMT",
+        "Date": "Fri, 10 Mar 2023 20:17:28 GMT",
+        "ETag": "\u00220x8DB21A47DB86DEE\u0022",
+        "Last-Modified": "Fri, 10 Mar 2023 20:17:37 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
@@ -162,7 +156,7 @@
         "x-ms-access-tier": "Hot",
         "x-ms-access-tier-inferred": "true",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-creation-time": "Mon, 19 Sep 2022 23:30:54 GMT",
+        "x-ms-creation-time": "Fri, 10 Mar 2023 20:17:37 GMT",
         "x-ms-group": "$superuser",
         "x-ms-lease-state": "available",
         "x-ms-lease-status": "unlocked",
@@ -171,7 +165,7 @@
         "x-ms-permissions": "rwxr-x---",
         "x-ms-resource-type": "directory",
         "x-ms-server-encrypted": "true",
-        "x-ms-version": "2021-08-06"
+        "x-ms-version": "2022-11-02"
       },
       "ResponseBody": null
     }

--- a/sdk/storage/azure-storage-file-datalake/tests/recordings/test_file_system_async.pyTestFileSystemAsynctest_undelete_file.json
+++ b/sdk/storage/azure-storage-file-datalake/tests/recordings/test_file_system_async.pyTestFileSystemAsynctest_undelete_file.json
@@ -1,144 +1,144 @@
 {
   "Entries": [
     {
-      "RequestUri": "https://storagesoftdelname.blob.core.windows.net/fs2d3c7344f?restype=container",
+      "RequestUri": "https://storagesoftdelname.blob.core.windows.net/fs2e11a2e04?restype=container",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Accept-Encoding": "gzip, deflate",
         "Content-Length": "0",
-        "User-Agent": "azsdk-python-storage-dfs/12.9.0b2 Python/3.10.2 (Windows-10-10.0.19044-SP0)",
-        "x-ms-date": "Mon, 19 Sep 2022 23:31:13 GMT",
-        "x-ms-version": "2021-08-06"
+        "User-Agent": "azsdk-python-storage-dfs/12.11.0b1 Python/3.10.7 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Fri, 10 Mar 2023 20:17:37 GMT",
+        "x-ms-version": "2022-11-02"
       },
       "RequestBody": null,
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 19 Sep 2022 23:31:12 GMT",
-        "ETag": "\u00220x8DA9A970AAADE6C\u0022",
-        "Last-Modified": "Mon, 19 Sep 2022 23:31:13 GMT",
+        "Date": "Fri, 10 Mar 2023 20:17:37 GMT",
+        "ETag": "\u00220x8DB21A47DF5C65D\u0022",
+        "Last-Modified": "Fri, 10 Mar 2023 20:17:37 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-version": "2021-08-06"
+        "x-ms-version": "2022-11-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://storagesoftdelname.dfs.core.windows.net/fs2d3c7344f/dir10?resource=directory",
+      "RequestUri": "https://storagesoftdelname.dfs.core.windows.net/fs2e11a2e04/dir10%2Ffile%C5%87?resource=file",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip, deflate",
         "Content-Length": "0",
-        "User-Agent": "azsdk-python-storage-dfs/12.9.0b2 Python/3.10.2 (Windows-10-10.0.19044-SP0)",
-        "x-ms-date": "Mon, 19 Sep 2022 23:31:13 GMT",
-        "x-ms-version": "2021-08-06"
+        "User-Agent": "azsdk-python-storage-dfs/12.11.0b1 Python/3.10.7 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Fri, 10 Mar 2023 20:17:37 GMT",
+        "x-ms-version": "2022-11-02"
       },
       "RequestBody": null,
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 19 Sep 2022 23:31:13 GMT",
-        "ETag": "\u00220x8DA9A970AEB97D2\u0022",
-        "Last-Modified": "Mon, 19 Sep 2022 23:31:14 GMT",
+        "Date": "Fri, 10 Mar 2023 20:17:36 GMT",
+        "ETag": "\u00220x8DB21A47E1F4CBE\u0022",
+        "Last-Modified": "Fri, 10 Mar 2023 20:17:37 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-request-server-encrypted": "true",
-        "x-ms-version": "2021-08-06"
+        "x-ms-version": "2022-11-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://storagesoftdelname.dfs.core.windows.net/fs2d3c7344f/dir10?recursive=true",
+      "RequestUri": "https://storagesoftdelname.dfs.core.windows.net/fs2e11a2e04/dir10%2Ffile%C5%87",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip, deflate",
         "Content-Length": "0",
-        "User-Agent": "azsdk-python-storage-dfs/12.9.0b2 Python/3.10.2 (Windows-10-10.0.19044-SP0)",
-        "x-ms-date": "Mon, 19 Sep 2022 23:31:13 GMT",
-        "x-ms-version": "2021-08-06"
+        "User-Agent": "azsdk-python-storage-dfs/12.11.0b1 Python/3.10.7 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Fri, 10 Mar 2023 20:17:37 GMT",
+        "x-ms-version": "2022-11-02"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 19 Sep 2022 23:31:13 GMT",
+        "Date": "Fri, 10 Mar 2023 20:17:36 GMT",
         "Server": [
           "Windows-Azure-HDFS/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-delete-type-permanent": "false",
-        "x-ms-deletion-id": "133081038741428057",
-        "x-ms-version": "2021-08-06"
+        "x-ms-deletion-id": "133229530578116781",
+        "x-ms-version": "2022-11-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://storagesoftdelname.blob.core.windows.net/fs2d3c7344f/dir10",
+      "RequestUri": "https://storagesoftdelname.blob.core.windows.net/fs2e11a2e04/dir10/file%C5%87",
       "RequestMethod": "HEAD",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Accept-Encoding": "gzip, deflate",
-        "User-Agent": "azsdk-python-storage-dfs/12.9.0b2 Python/3.10.2 (Windows-10-10.0.19044-SP0)",
-        "x-ms-date": "Mon, 19 Sep 2022 23:31:14 GMT",
-        "x-ms-version": "2021-08-06"
+        "User-Agent": "azsdk-python-storage-dfs/12.11.0b1 Python/3.10.7 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Fri, 10 Mar 2023 20:17:37 GMT",
+        "x-ms-version": "2022-11-02"
       },
       "RequestBody": null,
       "StatusCode": 404,
       "ResponseHeaders": {
-        "Date": "Mon, 19 Sep 2022 23:31:13 GMT",
+        "Date": "Fri, 10 Mar 2023 20:17:37 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "Transfer-Encoding": "chunked",
         "x-ms-error-code": "BlobNotFound",
-        "x-ms-version": "2021-08-06"
+        "x-ms-version": "2022-11-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://storagesoftdelname.blob.core.windows.net/fs2d3c7344f/dir10?comp=undelete",
+      "RequestUri": "https://storagesoftdelname.blob.core.windows.net/fs2e11a2e04/dir10/file%C5%87?comp=undelete",
       "RequestMethod": "PUT",
       "RequestHeaders": {
         "Accept": "application/json",
         "Accept-Encoding": "gzip, deflate",
         "Content-Length": "0",
-        "User-Agent": "azsdk-python-storage-dfs/12.9.0b2 Python/3.10.2 (Windows-10-10.0.19044-SP0)",
-        "x-ms-date": "Mon, 19 Sep 2022 23:31:14 GMT",
-        "x-ms-undelete-source": "dir10?deletionid=133081038741428057",
+        "User-Agent": "azsdk-python-storage-dfs/12.11.0b1 Python/3.10.7 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Fri, 10 Mar 2023 20:17:37 GMT",
+        "x-ms-undelete-source": "dir10/file%C5%87?deletionid=133229530578116781",
         "x-ms-version": "2021-06-08"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Mon, 19 Sep 2022 23:31:13 GMT",
+        "Date": "Fri, 10 Mar 2023 20:17:37 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-creation-time": "Mon, 19 Sep 2022 23:31:14 GMT",
-        "x-ms-resource-type": "directory",
+        "x-ms-creation-time": "Fri, 10 Mar 2023 20:17:37 GMT",
+        "x-ms-resource-type": "file",
         "x-ms-version": "2021-06-08"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://storagesoftdelname.blob.core.windows.net/fs2d3c7344f/dir10",
+      "RequestUri": "https://storagesoftdelname.blob.core.windows.net/fs2e11a2e04/dir10/file%C5%87",
       "RequestMethod": "HEAD",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Accept-Encoding": "gzip, deflate",
-        "User-Agent": "azsdk-python-storage-dfs/12.9.0b2 Python/3.10.2 (Windows-10-10.0.19044-SP0)",
-        "x-ms-date": "Mon, 19 Sep 2022 23:31:14 GMT",
-        "x-ms-version": "2021-08-06"
+        "User-Agent": "azsdk-python-storage-dfs/12.11.0b1 Python/3.10.7 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Fri, 10 Mar 2023 20:17:38 GMT",
+        "x-ms-version": "2022-11-02"
       },
       "RequestBody": null,
       "StatusCode": 200,
@@ -146,9 +146,9 @@
         "Accept-Ranges": "bytes",
         "Content-Length": "0",
         "Content-Type": "application/octet-stream",
-        "Date": "Mon, 19 Sep 2022 23:31:13 GMT",
-        "ETag": "\u00220x8DA9A970AEB97D2\u0022",
-        "Last-Modified": "Mon, 19 Sep 2022 23:31:14 GMT",
+        "Date": "Fri, 10 Mar 2023 20:17:37 GMT",
+        "ETag": "\u00220x8DB21A47E1F4CBE\u0022",
+        "Last-Modified": "Fri, 10 Mar 2023 20:17:37 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
@@ -156,16 +156,15 @@
         "x-ms-access-tier": "Hot",
         "x-ms-access-tier-inferred": "true",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-creation-time": "Mon, 19 Sep 2022 23:31:14 GMT",
+        "x-ms-creation-time": "Fri, 10 Mar 2023 20:17:37 GMT",
         "x-ms-group": "$superuser",
         "x-ms-lease-state": "available",
         "x-ms-lease-status": "unlocked",
-        "x-ms-meta-hdi_isfolder": "true",
         "x-ms-owner": "$superuser",
-        "x-ms-permissions": "rwxr-x---",
-        "x-ms-resource-type": "directory",
+        "x-ms-permissions": "rw-r-----",
+        "x-ms-resource-type": "file",
         "x-ms-server-encrypted": "true",
-        "x-ms-version": "2021-08-06"
+        "x-ms-version": "2022-11-02"
       },
       "ResponseBody": null
     }

--- a/sdk/storage/azure-storage-file-datalake/tests/test_file_system.py
+++ b/sdk/storage/azure-storage-file-datalake/tests/test_file_system.py
@@ -1035,7 +1035,7 @@ class TestFileSystem(StorageRecordedTestCase):
 
     @DataLakePreparer()
     @recorded_by_proxy
-    def test_undelete_dir_with_version_id(self, **kwargs):
+    def test_undelete_dir(self, **kwargs):
         datalake_storage_account_name = kwargs.pop("storage_data_lake_soft_delete_account_name")
         datalake_storage_account_key = kwargs.pop("storage_data_lake_soft_delete_account_key")
 
@@ -1046,13 +1046,13 @@ class TestFileSystem(StorageRecordedTestCase):
         resp = dir_client.delete_directory()
         with pytest.raises(HttpResponseError):
             file_system_client.get_file_client(dir_path).get_file_properties()
-        restored_dir_client = file_system_client._undelete_path(dir_path, resp['deletion_id'])
+        restored_dir_client = file_system_client.undelete_path(dir_path, resp['deletion_id'])
         resp = restored_dir_client.get_directory_properties()
         assert resp is not None
 
     @DataLakePreparer()
     @recorded_by_proxy
-    def test_undelete_file_with_version_id(self, **kwargs):
+    def test_undelete_file(self, **kwargs):
         datalake_storage_account_name = kwargs.pop("storage_data_lake_soft_delete_account_name")
         datalake_storage_account_key = kwargs.pop("storage_data_lake_soft_delete_account_key")
 
@@ -1063,7 +1063,7 @@ class TestFileSystem(StorageRecordedTestCase):
         resp = dir_client.delete_file()
         with pytest.raises(HttpResponseError):
             file_system_client.get_file_client(file_path).get_file_properties()
-        restored_file_client = file_system_client._undelete_path(file_path, resp['deletion_id'])
+        restored_file_client = file_system_client.undelete_path(file_path, resp['deletion_id'])
         resp = restored_file_client.get_file_properties()
         assert resp is not None
 

--- a/sdk/storage/azure-storage-file-datalake/tests/test_file_system_async.py
+++ b/sdk/storage/azure-storage-file-datalake/tests/test_file_system_async.py
@@ -1169,7 +1169,7 @@ class TestFileSystemAsync(AsyncStorageRecordedTestCase):
 
     @DataLakePreparer()
     @recorded_by_proxy_async
-    async def test_undelete_dir_with_version_id(self, **kwargs):
+    async def test_undelete_dir(self, **kwargs):
         datalake_storage_account_name = kwargs.pop("storage_data_lake_soft_delete_account_name")
         datalake_storage_account_key = kwargs.pop("storage_data_lake_soft_delete_account_key")
 
@@ -1180,13 +1180,13 @@ class TestFileSystemAsync(AsyncStorageRecordedTestCase):
         resp = await dir_client.delete_directory()
         with pytest.raises(HttpResponseError):
             await file_system_client.get_file_client(dir_path).get_file_properties()
-        restored_dir_client = await file_system_client._undelete_path(dir_path, resp['deletion_id'])
+        restored_dir_client = await file_system_client.undelete_path(dir_path, resp['deletion_id'])
         resp = await restored_dir_client.get_directory_properties()
         assert resp is not None
 
     @DataLakePreparer()
     @recorded_by_proxy_async
-    async def test_undelete_file_with_version_id(self, **kwargs):
+    async def test_undelete_file(self, **kwargs):
         datalake_storage_account_name = kwargs.pop("storage_data_lake_soft_delete_account_name")
         datalake_storage_account_key = kwargs.pop("storage_data_lake_soft_delete_account_key")
 
@@ -1197,7 +1197,7 @@ class TestFileSystemAsync(AsyncStorageRecordedTestCase):
         resp = await dir_client.delete_file()
         with pytest.raises(HttpResponseError):
             await file_system_client.get_file_client(file_path).get_file_properties()
-        restored_file_client = await file_system_client._undelete_path(file_path, resp['deletion_id'])
+        restored_file_client = await file_system_client.undelete_path(file_path, resp['deletion_id'])
         resp = await restored_file_client.get_file_properties()
         assert resp is not None
 


### PR DESCRIPTION
Datalake `undelete_path` was previously added as a private method as it was still undergoing some design discussion. This PR aims to make `undelete_path` public. Client methods `is_file` and `is_directory` were added to help to be able to determine which resource type was returned by `undelete_path` to avoid having to type check the `Union` return type.

Additionally, existing tests were renamed/rerun and a sample was adding showing use of `is_file` with `undelete_path`.