### PR TITLE
[devcenter] pass mypy 1.0.0

### DIFF
--- a/sdk/devcenter/azure-developer-devcenter/azure/developer/devcenter/_client.py
+++ b/sdk/devcenter/azure-developer-devcenter/azure/developer/devcenter/_client.py
@@ -44,7 +44,7 @@ class DevCenterClient:  # pylint: disable=client-accepts-api-version-keyword
     def __init__(self, endpoint: str, credential: "TokenCredential", **kwargs: Any) -> None:
         _endpoint = "{endpoint}"
         self._config = DevCenterClientConfiguration(endpoint=endpoint, credential=credential, **kwargs)
-        self._client = PipelineClient(base_url=_endpoint, config=self._config, **kwargs)
+        self._client: PipelineClient = PipelineClient(base_url=_endpoint, config=self._config, **kwargs)
 
         self._serialize = Serializer()
         self._deserialize = Deserializer()

--- a/sdk/devcenter/azure-developer-devcenter/azure/developer/devcenter/aio/_client.py
+++ b/sdk/devcenter/azure-developer-devcenter/azure/developer/devcenter/aio/_client.py
@@ -44,7 +44,7 @@ class DevCenterClient:  # pylint: disable=client-accepts-api-version-keyword
     def __init__(self, endpoint: str, credential: "AsyncTokenCredential", **kwargs: Any) -> None:
         _endpoint = "{endpoint}"
         self._config = DevCenterClientConfiguration(endpoint=endpoint, credential=credential, **kwargs)
-        self._client = AsyncPipelineClient(base_url=_endpoint, config=self._config, **kwargs)
+        self._client: AsyncPipelineClient = AsyncPipelineClient(base_url=_endpoint, config=self._config, **kwargs)
 
         self._serialize = Serializer()
         self._deserialize = Deserializer()


### PR DESCRIPTION
Adding type hints where mypy asks for them so devcenter can pass with mypy==1.0.0. This is already fixed in the python generator (https://github.com/Azure/autorest.python/issues/1764) and will include hints upon next generation.