### PR TITLE
remove msrest dependency from mgmt template + add isodate

### DIFF
--- a/tools/azure-sdk-tools/packaging_tools/templates/packaging_files/setup.py
+++ b/tools/azure-sdk-tools/packaging_tools/templates/packaging_files/setup.py
@@ -71,7 +71,7 @@ setup(
         'pytyped': ['py.typed'],
     },
     install_requires=[
-        "msrest>=0.7.1",
+        "isodate>=0.6.0",
         {%- if need_msrestazure %}
         "msrestazure>=0.4.32,<2.0.0",
         {%- endif %}

--- a/tools/azure-sdk-tools/packaging_tools/templates/packaging_files/setup.py
+++ b/tools/azure-sdk-tools/packaging_tools/templates/packaging_files/setup.py
@@ -71,7 +71,7 @@ setup(
         'pytyped': ['py.typed'],
     },
     install_requires=[
-        "isodate>=0.6.0",
+        "isodate<1.0.0,>=0.6.1",
         {%- if need_msrestazure %}
         "msrestazure>=0.4.32,<2.0.0",
         {%- endif %}


### PR DESCRIPTION
@msyyc - Noticed that the azure-mgmt-* SDKs still take a dependency on `msrest`. I had a discussion with @lmazuel. Given that `msrest` has been deprecated, he mentioned that we should remove `msrest` here and add `isodate`.