### PR TITLE
[Storage] Adjust timing for soft delete test flakiness

### DIFF
--- a/sdk/storage/azure-storage-blob/tests/recordings/test_common_blob.pyTestStorageCommonBlobtest_soft_delete_blob_without_snapshots.json
+++ b/sdk/storage/azure-storage-blob/tests/recordings/test_common_blob.pyTestStorageCommonBlobtest_soft_delete_blob_without_snapshots.json
@@ -8,22 +8,22 @@
         "Accept-Encoding": "gzip, deflate",
         "Connection": "keep-alive",
         "Content-Length": "0",
-        "User-Agent": "azsdk-python-storage-blob/12.14.0b1 Python/3.10.5 (Windows-10-10.0.22000-SP0)",
-        "x-ms-date": "Fri, 12 Aug 2022 20:50:01 GMT",
-        "x-ms-version": "2021-08-06"
+        "User-Agent": "azsdk-python-storage-blob/12.16.0b1 Python/3.11.1 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Mon, 13 Mar 2023 23:48:35 GMT",
+        "x-ms-version": "2022-11-02"
       },
       "RequestBody": null,
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 12 Aug 2022 20:50:00 GMT",
-        "ETag": "\u00220x8DA7CA439B910A2\u0022",
-        "Last-Modified": "Fri, 12 Aug 2022 20:50:01 GMT",
+        "Date": "Mon, 13 Mar 2023 23:48:31 GMT",
+        "ETag": "\u00220x8DB241D741FD222\u0022",
+        "Last-Modified": "Mon, 13 Mar 2023 23:48:32 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-version": "2021-08-06"
+        "x-ms-version": "2022-11-02"
       },
       "ResponseBody": null
     },
@@ -35,22 +35,22 @@
         "Accept-Encoding": "gzip, deflate",
         "Connection": "keep-alive",
         "Content-Length": "0",
-        "User-Agent": "azsdk-python-storage-blob/12.14.0b1 Python/3.10.5 (Windows-10-10.0.22000-SP0)",
-        "x-ms-date": "Fri, 12 Aug 2022 20:50:01 GMT",
-        "x-ms-version": "2021-08-06"
+        "User-Agent": "azsdk-python-storage-blob/12.16.0b1 Python/3.11.1 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Mon, 13 Mar 2023 23:48:36 GMT",
+        "x-ms-version": "2022-11-02"
       },
       "RequestBody": null,
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 12 Aug 2022 20:50:00 GMT",
-        "ETag": "\u00220x8DA7CA439C4F5C6\u0022",
-        "Last-Modified": "Fri, 12 Aug 2022 20:50:01 GMT",
+        "Date": "Mon, 13 Mar 2023 23:48:32 GMT",
+        "ETag": "\u00220x8DB241D742B4226\u0022",
+        "Last-Modified": "Mon, 13 Mar 2023 23:48:32 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-version": "2021-08-06"
+        "x-ms-version": "2022-11-02"
       },
       "ResponseBody": null
     },
@@ -63,9 +63,9 @@
         "Connection": "keep-alive",
         "Content-Length": "176",
         "Content-Type": "application/xml",
-        "User-Agent": "azsdk-python-storage-blob/12.14.0b1 Python/3.10.5 (Windows-10-10.0.22000-SP0)",
-        "x-ms-date": "Fri, 12 Aug 2022 20:50:01 GMT",
-        "x-ms-version": "2021-08-06"
+        "User-Agent": "azsdk-python-storage-blob/12.16.0b1 Python/3.11.1 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Mon, 13 Mar 2023 23:48:36 GMT",
+        "x-ms-version": "2022-11-02"
       },
       "RequestBody": [
         "\u003C?xml version=\u00271.0\u0027 encoding=\u0027utf-8\u0027?\u003E\n",
@@ -74,12 +74,12 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 12 Aug 2022 20:50:01 GMT",
+        "Date": "Mon, 13 Mar 2023 23:48:32 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-version": "2021-08-06"
+        "x-ms-version": "2022-11-02"
       },
       "ResponseBody": null
     },
@@ -93,26 +93,26 @@
         "Content-Length": "1024",
         "Content-Type": "application/octet-stream",
         "If-None-Match": "*",
-        "User-Agent": "azsdk-python-storage-blob/12.14.0b1 Python/3.10.5 (Windows-10-10.0.22000-SP0)",
+        "User-Agent": "azsdk-python-storage-blob/12.16.0b1 Python/3.11.1 (Windows-10-10.0.22621-SP0)",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-date": "Fri, 12 Aug 2022 20:50:41 GMT",
-        "x-ms-version": "2021-08-06"
+        "x-ms-date": "Mon, 13 Mar 2023 23:49:17 GMT",
+        "x-ms-version": "2022-11-02"
       },
       "RequestBody": "YWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYQ==",
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "yaNM/IXZgmmMasifdgcavQ==",
-        "Date": "Fri, 12 Aug 2022 20:50:41 GMT",
-        "ETag": "\u00220x8DA7CA45204FADE\u0022",
-        "Last-Modified": "Fri, 12 Aug 2022 20:50:41 GMT",
+        "Date": "Mon, 13 Mar 2023 23:49:12 GMT",
+        "ETag": "\u00220x8DB241D8C79AE26\u0022",
+        "Last-Modified": "Mon, 13 Mar 2023 23:49:13 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-content-crc64": "ov8U1LLnyKc=",
         "x-ms-request-server-encrypted": "true",
-        "x-ms-version": "2021-08-06"
+        "x-ms-version": "2022-11-02"
       },
       "ResponseBody": null
     },
@@ -124,21 +124,21 @@
         "Accept-Encoding": "gzip, deflate",
         "Connection": "keep-alive",
         "Content-Length": "0",
-        "User-Agent": "azsdk-python-storage-blob/12.14.0b1 Python/3.10.5 (Windows-10-10.0.22000-SP0)",
-        "x-ms-date": "Fri, 12 Aug 2022 20:50:41 GMT",
-        "x-ms-version": "2021-08-06"
+        "User-Agent": "azsdk-python-storage-blob/12.16.0b1 Python/3.11.1 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Mon, 13 Mar 2023 23:49:17 GMT",
+        "x-ms-version": "2022-11-02"
       },
       "RequestBody": null,
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 12 Aug 2022 20:50:41 GMT",
+        "Date": "Mon, 13 Mar 2023 23:49:12 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-delete-type-permanent": "false",
-        "x-ms-version": "2021-08-06"
+        "x-ms-version": "2022-11-02"
       },
       "ResponseBody": null
     },
@@ -149,24 +149,23 @@
         "Accept": "application/xml",
         "Accept-Encoding": "gzip, deflate",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-python-storage-blob/12.14.0b1 Python/3.10.5 (Windows-10-10.0.22000-SP0)",
-        "x-ms-date": "Fri, 12 Aug 2022 20:50:42 GMT",
-        "x-ms-version": "2021-08-06"
+        "User-Agent": "azsdk-python-storage-blob/12.16.0b1 Python/3.11.1 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Mon, 13 Mar 2023 23:49:17 GMT",
+        "x-ms-version": "2022-11-02"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Type": "application/xml",
-        "Date": "Fri, 12 Aug 2022 20:50:41 GMT",
+        "Date": "Mon, 13 Mar 2023 23:49:12 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "Transfer-Encoding": "chunked",
-        "Vary": "Origin",
-        "x-ms-version": "2021-08-06"
+        "x-ms-version": "2022-11-02"
       },
-      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CEnumerationResults ServiceEndpoint=\u0022https://storagename.blob.core.windows.net/\u0022 ContainerName=\u0022utcontainer6acf31ab\u0022\u003E\u003CBlobs\u003E\u003CBlob\u003E\u003CName\u003Eblob6acf31ab\u003C/Name\u003E\u003CDeleted\u003Etrue\u003C/Deleted\u003E\u003CProperties\u003E\u003CCreation-Time\u003EFri, 12 Aug 2022 20:50:41 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EFri, 12 Aug 2022 20:50:41 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8DA7CA45204FADE\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EyaNM/IXZgmmMasifdgcavQ==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003CDeletedTime\u003EFri, 12 Aug 2022 20:50:41 GMT\u003C/DeletedTime\u003E\u003CRemainingRetentionDays\u003E1\u003C/RemainingRetentionDays\u003E\u003C/Properties\u003E\u003COrMetadata /\u003E\u003C/Blob\u003E\u003C/Blobs\u003E\u003CNextMarker /\u003E\u003C/EnumerationResults\u003E"
+      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CEnumerationResults ServiceEndpoint=\u0022https://storagename.blob.core.windows.net/\u0022 ContainerName=\u0022utcontainer6acf31ab\u0022\u003E\u003CBlobs\u003E\u003CBlob\u003E\u003CName\u003Eblob6acf31ab\u003C/Name\u003E\u003CDeleted\u003Etrue\u003C/Deleted\u003E\u003CProperties\u003E\u003CCreation-Time\u003EMon, 13 Mar 2023 23:49:13 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EMon, 13 Mar 2023 23:49:13 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8DB241D8C79AE26\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EyaNM/IXZgmmMasifdgcavQ==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003CDeletedTime\u003EMon, 13 Mar 2023 23:49:13 GMT\u003C/DeletedTime\u003E\u003CRemainingRetentionDays\u003E1\u003C/RemainingRetentionDays\u003E\u003C/Properties\u003E\u003COrMetadata /\u003E\u003C/Blob\u003E\u003C/Blobs\u003E\u003CNextMarker /\u003E\u003C/EnumerationResults\u003E"
     },
     {
       "RequestUri": "https://storagename.blob.core.windows.net/utcontainer6acf31ab?restype=container\u0026comp=list",
@@ -175,22 +174,21 @@
         "Accept": "application/xml",
         "Accept-Encoding": "gzip, deflate",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-python-storage-blob/12.14.0b1 Python/3.10.5 (Windows-10-10.0.22000-SP0)",
-        "x-ms-date": "Fri, 12 Aug 2022 20:50:42 GMT",
-        "x-ms-version": "2021-08-06"
+        "User-Agent": "azsdk-python-storage-blob/12.16.0b1 Python/3.11.1 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Mon, 13 Mar 2023 23:49:17 GMT",
+        "x-ms-version": "2022-11-02"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Type": "application/xml",
-        "Date": "Fri, 12 Aug 2022 20:50:41 GMT",
+        "Date": "Mon, 13 Mar 2023 23:49:13 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "Transfer-Encoding": "chunked",
-        "Vary": "Origin",
-        "x-ms-version": "2021-08-06"
+        "x-ms-version": "2022-11-02"
       },
       "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CEnumerationResults ServiceEndpoint=\u0022https://storagename.blob.core.windows.net/\u0022 ContainerName=\u0022utcontainer6acf31ab\u0022\u003E\u003CBlobs /\u003E\u003CNextMarker /\u003E\u003C/EnumerationResults\u003E"
     },
@@ -202,20 +200,20 @@
         "Accept-Encoding": "gzip, deflate",
         "Connection": "keep-alive",
         "Content-Length": "0",
-        "User-Agent": "azsdk-python-storage-blob/12.14.0b1 Python/3.10.5 (Windows-10-10.0.22000-SP0)",
-        "x-ms-date": "Fri, 12 Aug 2022 20:50:42 GMT",
-        "x-ms-version": "2021-08-06"
+        "User-Agent": "azsdk-python-storage-blob/12.16.0b1 Python/3.11.1 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Mon, 13 Mar 2023 23:49:17 GMT",
+        "x-ms-version": "2022-11-02"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 12 Aug 2022 20:50:41 GMT",
+        "Date": "Mon, 13 Mar 2023 23:49:13 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-version": "2021-08-06"
+        "x-ms-version": "2022-11-02"
       },
       "ResponseBody": null
     },
@@ -226,24 +224,23 @@
         "Accept": "application/xml",
         "Accept-Encoding": "gzip, deflate",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-python-storage-blob/12.14.0b1 Python/3.10.5 (Windows-10-10.0.22000-SP0)",
-        "x-ms-date": "Fri, 12 Aug 2022 20:50:42 GMT",
-        "x-ms-version": "2021-08-06"
+        "User-Agent": "azsdk-python-storage-blob/12.16.0b1 Python/3.11.1 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Mon, 13 Mar 2023 23:49:17 GMT",
+        "x-ms-version": "2022-11-02"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Type": "application/xml",
-        "Date": "Fri, 12 Aug 2022 20:50:41 GMT",
+        "Date": "Mon, 13 Mar 2023 23:49:13 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "Transfer-Encoding": "chunked",
-        "Vary": "Origin",
-        "x-ms-version": "2021-08-06"
+        "x-ms-version": "2022-11-02"
       },
-      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CEnumerationResults ServiceEndpoint=\u0022https://storagename.blob.core.windows.net/\u0022 ContainerName=\u0022utcontainer6acf31ab\u0022\u003E\u003CBlobs\u003E\u003CBlob\u003E\u003CName\u003Eblob6acf31ab\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EFri, 12 Aug 2022 20:50:41 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EFri, 12 Aug 2022 20:50:41 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8DA7CA45204FADE\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EyaNM/IXZgmmMasifdgcavQ==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003COrMetadata /\u003E\u003C/Blob\u003E\u003C/Blobs\u003E\u003CNextMarker /\u003E\u003C/EnumerationResults\u003E"
+      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CEnumerationResults ServiceEndpoint=\u0022https://storagename.blob.core.windows.net/\u0022 ContainerName=\u0022utcontainer6acf31ab\u0022\u003E\u003CBlobs\u003E\u003CBlob\u003E\u003CName\u003Eblob6acf31ab\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EMon, 13 Mar 2023 23:49:13 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EMon, 13 Mar 2023 23:49:13 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8DB241D8C79AE26\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EyaNM/IXZgmmMasifdgcavQ==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003COrMetadata /\u003E\u003C/Blob\u003E\u003C/Blobs\u003E\u003CNextMarker /\u003E\u003C/EnumerationResults\u003E"
     },
     {
       "RequestUri": "https://storagename.blob.core.windows.net/?restype=service\u0026comp=properties",
@@ -254,9 +251,9 @@
         "Connection": "keep-alive",
         "Content-Length": "163",
         "Content-Type": "application/xml",
-        "User-Agent": "azsdk-python-storage-blob/12.14.0b1 Python/3.10.5 (Windows-10-10.0.22000-SP0)",
-        "x-ms-date": "Fri, 12 Aug 2022 20:50:42 GMT",
-        "x-ms-version": "2021-08-06"
+        "User-Agent": "azsdk-python-storage-blob/12.16.0b1 Python/3.11.1 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Mon, 13 Mar 2023 23:49:17 GMT",
+        "x-ms-version": "2022-11-02"
       },
       "RequestBody": [
         "\u003C?xml version=\u00271.0\u0027 encoding=\u0027utf-8\u0027?\u003E\n",
@@ -265,12 +262,12 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 12 Aug 2022 20:50:42 GMT",
+        "Date": "Mon, 13 Mar 2023 23:49:13 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-version": "2021-08-06"
+        "x-ms-version": "2022-11-02"
       },
       "ResponseBody": null
     }

--- a/sdk/storage/azure-storage-blob/tests/recordings/test_common_blob.pyTestStorageCommonBlobtest_soft_delete_only_snapshots_of_blob.json
+++ b/sdk/storage/azure-storage-blob/tests/recordings/test_common_blob.pyTestStorageCommonBlobtest_soft_delete_only_snapshots_of_blob.json
@@ -8,22 +8,22 @@
         "Accept-Encoding": "gzip, deflate",
         "Connection": "keep-alive",
         "Content-Length": "0",
-        "User-Agent": "azsdk-python-storage-blob/12.14.0b1 Python/3.10.5 (Windows-10-10.0.22000-SP0)",
-        "x-ms-date": "Fri, 12 Aug 2022 20:51:26 GMT",
-        "x-ms-version": "2021-08-06"
+        "User-Agent": "azsdk-python-storage-blob/12.16.0b1 Python/3.11.1 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Mon, 13 Mar 2023 23:47:38 GMT",
+        "x-ms-version": "2022-11-02"
       },
       "RequestBody": null,
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 12 Aug 2022 20:51:25 GMT",
-        "ETag": "\u00220x8DA7CA46C6203D1\u0022",
-        "Last-Modified": "Fri, 12 Aug 2022 20:51:26 GMT",
+        "Date": "Mon, 13 Mar 2023 23:47:34 GMT",
+        "ETag": "\u00220x8DB241D51F37ECB\u0022",
+        "Last-Modified": "Mon, 13 Mar 2023 23:47:35 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-version": "2021-08-06"
+        "x-ms-version": "2022-11-02"
       },
       "ResponseBody": null
     },
@@ -35,22 +35,22 @@
         "Accept-Encoding": "gzip, deflate",
         "Connection": "keep-alive",
         "Content-Length": "0",
-        "User-Agent": "azsdk-python-storage-blob/12.14.0b1 Python/3.10.5 (Windows-10-10.0.22000-SP0)",
-        "x-ms-date": "Fri, 12 Aug 2022 20:51:26 GMT",
-        "x-ms-version": "2021-08-06"
+        "User-Agent": "azsdk-python-storage-blob/12.16.0b1 Python/3.11.1 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Mon, 13 Mar 2023 23:47:39 GMT",
+        "x-ms-version": "2022-11-02"
       },
       "RequestBody": null,
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 12 Aug 2022 20:51:25 GMT",
-        "ETag": "\u00220x8DA7CA46C6ED334\u0022",
-        "Last-Modified": "Fri, 12 Aug 2022 20:51:26 GMT",
+        "Date": "Mon, 13 Mar 2023 23:47:34 GMT",
+        "ETag": "\u00220x8DB241D5201FB6F\u0022",
+        "Last-Modified": "Mon, 13 Mar 2023 23:47:35 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-version": "2021-08-06"
+        "x-ms-version": "2022-11-02"
       },
       "ResponseBody": null
     },
@@ -63,9 +63,9 @@
         "Connection": "keep-alive",
         "Content-Length": "176",
         "Content-Type": "application/xml",
-        "User-Agent": "azsdk-python-storage-blob/12.14.0b1 Python/3.10.5 (Windows-10-10.0.22000-SP0)",
-        "x-ms-date": "Fri, 12 Aug 2022 20:51:26 GMT",
-        "x-ms-version": "2021-08-06"
+        "User-Agent": "azsdk-python-storage-blob/12.16.0b1 Python/3.11.1 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Mon, 13 Mar 2023 23:47:39 GMT",
+        "x-ms-version": "2022-11-02"
       },
       "RequestBody": [
         "\u003C?xml version=\u00271.0\u0027 encoding=\u0027utf-8\u0027?\u003E\n",
@@ -74,12 +74,12 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 12 Aug 2022 20:51:25 GMT",
+        "Date": "Mon, 13 Mar 2023 23:47:35 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-version": "2021-08-06"
+        "x-ms-version": "2022-11-02"
       },
       "ResponseBody": null
     },
@@ -93,26 +93,26 @@
         "Content-Length": "1024",
         "Content-Type": "application/octet-stream",
         "If-None-Match": "*",
-        "User-Agent": "azsdk-python-storage-blob/12.14.0b1 Python/3.10.5 (Windows-10-10.0.22000-SP0)",
+        "User-Agent": "azsdk-python-storage-blob/12.16.0b1 Python/3.11.1 (Windows-10-10.0.22621-SP0)",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-date": "Fri, 12 Aug 2022 20:52:06 GMT",
-        "x-ms-version": "2021-08-06"
+        "x-ms-date": "Mon, 13 Mar 2023 23:48:20 GMT",
+        "x-ms-version": "2022-11-02"
       },
       "RequestBody": "YWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYQ==",
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "yaNM/IXZgmmMasifdgcavQ==",
-        "Date": "Fri, 12 Aug 2022 20:52:05 GMT",
-        "ETag": "\u00220x8DA7CA4846626E9\u0022",
-        "Last-Modified": "Fri, 12 Aug 2022 20:52:06 GMT",
+        "Date": "Mon, 13 Mar 2023 23:48:15 GMT",
+        "ETag": "\u00220x8DB241D6A4EFD5C\u0022",
+        "Last-Modified": "Mon, 13 Mar 2023 23:48:15 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-content-crc64": "ov8U1LLnyKc=",
         "x-ms-request-server-encrypted": "true",
-        "x-ms-version": "2021-08-06"
+        "x-ms-version": "2022-11-02"
       },
       "ResponseBody": null
     },
@@ -124,24 +124,24 @@
         "Accept-Encoding": "gzip, deflate",
         "Connection": "keep-alive",
         "Content-Length": "0",
-        "User-Agent": "azsdk-python-storage-blob/12.14.0b1 Python/3.10.5 (Windows-10-10.0.22000-SP0)",
-        "x-ms-date": "Fri, 12 Aug 2022 20:52:06 GMT",
-        "x-ms-version": "2021-08-06"
+        "User-Agent": "azsdk-python-storage-blob/12.16.0b1 Python/3.11.1 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Mon, 13 Mar 2023 23:48:20 GMT",
+        "x-ms-version": "2022-11-02"
       },
       "RequestBody": null,
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 12 Aug 2022 20:52:05 GMT",
-        "ETag": "\u00220x8DA7CA4846626E9\u0022",
-        "Last-Modified": "Fri, 12 Aug 2022 20:52:06 GMT",
+        "Date": "Mon, 13 Mar 2023 23:48:15 GMT",
+        "ETag": "\u00220x8DB241D6A4EFD5C\u0022",
+        "Last-Modified": "Mon, 13 Mar 2023 23:48:15 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-request-server-encrypted": "false",
-        "x-ms-snapshot": "2022-08-12T20:52:06.5003907Z",
-        "x-ms-version": "2021-08-06"
+        "x-ms-snapshot": "2023-03-13T23:48:15.9899879Z",
+        "x-ms-version": "2022-11-02"
       },
       "ResponseBody": null
     },
@@ -153,24 +153,24 @@
         "Accept-Encoding": "gzip, deflate",
         "Connection": "keep-alive",
         "Content-Length": "0",
-        "User-Agent": "azsdk-python-storage-blob/12.14.0b1 Python/3.10.5 (Windows-10-10.0.22000-SP0)",
-        "x-ms-date": "Fri, 12 Aug 2022 20:52:06 GMT",
-        "x-ms-version": "2021-08-06"
+        "User-Agent": "azsdk-python-storage-blob/12.16.0b1 Python/3.11.1 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Mon, 13 Mar 2023 23:48:20 GMT",
+        "x-ms-version": "2022-11-02"
       },
       "RequestBody": null,
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 12 Aug 2022 20:52:06 GMT",
-        "ETag": "\u00220x8DA7CA4846626E9\u0022",
-        "Last-Modified": "Fri, 12 Aug 2022 20:52:06 GMT",
+        "Date": "Mon, 13 Mar 2023 23:48:15 GMT",
+        "ETag": "\u00220x8DB241D6A4EFD5C\u0022",
+        "Last-Modified": "Mon, 13 Mar 2023 23:48:15 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-request-server-encrypted": "false",
-        "x-ms-snapshot": "2022-08-12T20:52:06.6253200Z",
-        "x-ms-version": "2021-08-06"
+        "x-ms-snapshot": "2023-03-13T23:48:16.0509543Z",
+        "x-ms-version": "2022-11-02"
       },
       "ResponseBody": null
     },
@@ -182,22 +182,22 @@
         "Accept-Encoding": "gzip, deflate",
         "Connection": "keep-alive",
         "Content-Length": "0",
-        "User-Agent": "azsdk-python-storage-blob/12.14.0b1 Python/3.10.5 (Windows-10-10.0.22000-SP0)",
-        "x-ms-date": "Fri, 12 Aug 2022 20:52:06 GMT",
+        "User-Agent": "azsdk-python-storage-blob/12.16.0b1 Python/3.11.1 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Mon, 13 Mar 2023 23:48:20 GMT",
         "x-ms-delete-snapshots": "only",
-        "x-ms-version": "2021-08-06"
+        "x-ms-version": "2022-11-02"
       },
       "RequestBody": null,
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 12 Aug 2022 20:52:06 GMT",
+        "Date": "Mon, 13 Mar 2023 23:48:15 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-delete-type-permanent": "false",
-        "x-ms-version": "2021-08-06"
+        "x-ms-version": "2022-11-02"
       },
       "ResponseBody": null
     },
@@ -208,24 +208,23 @@
         "Accept": "application/xml",
         "Accept-Encoding": "gzip, deflate",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-python-storage-blob/12.14.0b1 Python/3.10.5 (Windows-10-10.0.22000-SP0)",
-        "x-ms-date": "Fri, 12 Aug 2022 20:52:06 GMT",
-        "x-ms-version": "2021-08-06"
+        "User-Agent": "azsdk-python-storage-blob/12.16.0b1 Python/3.11.1 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Mon, 13 Mar 2023 23:48:20 GMT",
+        "x-ms-version": "2022-11-02"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Type": "application/xml",
-        "Date": "Fri, 12 Aug 2022 20:52:06 GMT",
+        "Date": "Mon, 13 Mar 2023 23:48:15 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "Transfer-Encoding": "chunked",
-        "Vary": "Origin",
-        "x-ms-version": "2021-08-06"
+        "x-ms-version": "2022-11-02"
       },
-      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CEnumerationResults ServiceEndpoint=\u0022https://storagename.blob.core.windows.net/\u0022 ContainerName=\u0022utcontainer6b5e318d\u0022\u003E\u003CBlobs\u003E\u003CBlob\u003E\u003CName\u003Eblob6b5e318d\u003C/Name\u003E\u003CSnapshot\u003E2022-08-12T20:52:06.5003907Z\u003C/Snapshot\u003E\u003CDeleted\u003Etrue\u003C/Deleted\u003E\u003CProperties\u003E\u003CCreation-Time\u003EFri, 12 Aug 2022 20:52:06 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EFri, 12 Aug 2022 20:52:06 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8DA7CA4846626E9\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EyaNM/IXZgmmMasifdgcavQ==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003CDeletedTime\u003EFri, 12 Aug 2022 20:52:06 GMT\u003C/DeletedTime\u003E\u003CRemainingRetentionDays\u003E1\u003C/RemainingRetentionDays\u003E\u003C/Properties\u003E\u003COrMetadata /\u003E\u003C/Blob\u003E\u003CBlob\u003E\u003CName\u003Eblob6b5e318d\u003C/Name\u003E\u003CSnapshot\u003E2022-08-12T20:52:06.6253200Z\u003C/Snapshot\u003E\u003CDeleted\u003Etrue\u003C/Deleted\u003E\u003CProperties\u003E\u003CCreation-Time\u003EFri, 12 Aug 2022 20:52:06 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EFri, 12 Aug 2022 20:52:06 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8DA7CA4846626E9\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EyaNM/IXZgmmMasifdgcavQ==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003CDeletedTime\u003EFri, 12 Aug 2022 20:52:06 GMT\u003C/DeletedTime\u003E\u003CRemainingRetentionDays\u003E1\u003C/RemainingRetentionDays\u003E\u003C/Properties\u003E\u003COrMetadata /\u003E\u003C/Blob\u003E\u003CBlob\u003E\u003CName\u003Eblob6b5e318d\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EFri, 12 Aug 2022 20:52:06 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EFri, 12 Aug 2022 20:52:06 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8DA7CA4846626E9\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EyaNM/IXZgmmMasifdgcavQ==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003COrMetadata /\u003E\u003C/Blob\u003E\u003C/Blobs\u003E\u003CNextMarker /\u003E\u003C/EnumerationResults\u003E"
+      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CEnumerationResults ServiceEndpoint=\u0022https://storagename.blob.core.windows.net/\u0022 ContainerName=\u0022utcontainer6b5e318d\u0022\u003E\u003CBlobs\u003E\u003CBlob\u003E\u003CName\u003Eblob6b5e318d\u003C/Name\u003E\u003CSnapshot\u003E2023-03-13T23:48:15.9899879Z\u003C/Snapshot\u003E\u003CDeleted\u003Etrue\u003C/Deleted\u003E\u003CProperties\u003E\u003CCreation-Time\u003EMon, 13 Mar 2023 23:48:15 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EMon, 13 Mar 2023 23:48:15 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8DB241D6A4EFD5C\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EyaNM/IXZgmmMasifdgcavQ==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003CDeletedTime\u003EMon, 13 Mar 2023 23:48:16 GMT\u003C/DeletedTime\u003E\u003CRemainingRetentionDays\u003E1\u003C/RemainingRetentionDays\u003E\u003C/Properties\u003E\u003COrMetadata /\u003E\u003C/Blob\u003E\u003CBlob\u003E\u003CName\u003Eblob6b5e318d\u003C/Name\u003E\u003CSnapshot\u003E2023-03-13T23:48:16.0509543Z\u003C/Snapshot\u003E\u003CDeleted\u003Etrue\u003C/Deleted\u003E\u003CProperties\u003E\u003CCreation-Time\u003EMon, 13 Mar 2023 23:48:15 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EMon, 13 Mar 2023 23:48:15 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8DB241D6A4EFD5C\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EyaNM/IXZgmmMasifdgcavQ==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003CDeletedTime\u003EMon, 13 Mar 2023 23:48:16 GMT\u003C/DeletedTime\u003E\u003CRemainingRetentionDays\u003E1\u003C/RemainingRetentionDays\u003E\u003C/Properties\u003E\u003COrMetadata /\u003E\u003C/Blob\u003E\u003CBlob\u003E\u003CName\u003Eblob6b5e318d\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EMon, 13 Mar 2023 23:48:15 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EMon, 13 Mar 2023 23:48:15 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8DB241D6A4EFD5C\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EyaNM/IXZgmmMasifdgcavQ==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003COrMetadata /\u003E\u003C/Blob\u003E\u003C/Blobs\u003E\u003CNextMarker /\u003E\u003C/EnumerationResults\u003E"
     },
     {
       "RequestUri": "https://storagename.blob.core.windows.net/utcontainer6b5e318d?restype=container\u0026comp=list\u0026include=snapshots",
@@ -234,24 +233,23 @@
         "Accept": "application/xml",
         "Accept-Encoding": "gzip, deflate",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-python-storage-blob/12.14.0b1 Python/3.10.5 (Windows-10-10.0.22000-SP0)",
-        "x-ms-date": "Fri, 12 Aug 2022 20:52:06 GMT",
-        "x-ms-version": "2021-08-06"
+        "User-Agent": "azsdk-python-storage-blob/12.16.0b1 Python/3.11.1 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Mon, 13 Mar 2023 23:48:20 GMT",
+        "x-ms-version": "2022-11-02"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Type": "application/xml",
-        "Date": "Fri, 12 Aug 2022 20:52:06 GMT",
+        "Date": "Mon, 13 Mar 2023 23:48:15 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "Transfer-Encoding": "chunked",
-        "Vary": "Origin",
-        "x-ms-version": "2021-08-06"
+        "x-ms-version": "2022-11-02"
       },
-      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CEnumerationResults ServiceEndpoint=\u0022https://storagename.blob.core.windows.net/\u0022 ContainerName=\u0022utcontainer6b5e318d\u0022\u003E\u003CBlobs\u003E\u003CBlob\u003E\u003CName\u003Eblob6b5e318d\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EFri, 12 Aug 2022 20:52:06 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EFri, 12 Aug 2022 20:52:06 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8DA7CA4846626E9\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EyaNM/IXZgmmMasifdgcavQ==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003COrMetadata /\u003E\u003C/Blob\u003E\u003C/Blobs\u003E\u003CNextMarker /\u003E\u003C/EnumerationResults\u003E"
+      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CEnumerationResults ServiceEndpoint=\u0022https://storagename.blob.core.windows.net/\u0022 ContainerName=\u0022utcontainer6b5e318d\u0022\u003E\u003CBlobs\u003E\u003CBlob\u003E\u003CName\u003Eblob6b5e318d\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EMon, 13 Mar 2023 23:48:15 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EMon, 13 Mar 2023 23:48:15 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8DB241D6A4EFD5C\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EyaNM/IXZgmmMasifdgcavQ==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003COrMetadata /\u003E\u003C/Blob\u003E\u003C/Blobs\u003E\u003CNextMarker /\u003E\u003C/EnumerationResults\u003E"
     },
     {
       "RequestUri": "https://storagename.blob.core.windows.net/utcontainer6b5e318d/blob6b5e318d?comp=undelete",
@@ -261,20 +259,20 @@
         "Accept-Encoding": "gzip, deflate",
         "Connection": "keep-alive",
         "Content-Length": "0",
-        "User-Agent": "azsdk-python-storage-blob/12.14.0b1 Python/3.10.5 (Windows-10-10.0.22000-SP0)",
-        "x-ms-date": "Fri, 12 Aug 2022 20:52:07 GMT",
-        "x-ms-version": "2021-08-06"
+        "User-Agent": "azsdk-python-storage-blob/12.16.0b1 Python/3.11.1 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Mon, 13 Mar 2023 23:48:20 GMT",
+        "x-ms-version": "2022-11-02"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 12 Aug 2022 20:52:06 GMT",
+        "Date": "Mon, 13 Mar 2023 23:48:15 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-version": "2021-08-06"
+        "x-ms-version": "2022-11-02"
       },
       "ResponseBody": null
     },
@@ -285,24 +283,23 @@
         "Accept": "application/xml",
         "Accept-Encoding": "gzip, deflate",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-python-storage-blob/12.14.0b1 Python/3.10.5 (Windows-10-10.0.22000-SP0)",
-        "x-ms-date": "Fri, 12 Aug 2022 20:52:07 GMT",
-        "x-ms-version": "2021-08-06"
+        "User-Agent": "azsdk-python-storage-blob/12.16.0b1 Python/3.11.1 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Mon, 13 Mar 2023 23:48:20 GMT",
+        "x-ms-version": "2022-11-02"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Type": "application/xml",
-        "Date": "Fri, 12 Aug 2022 20:52:06 GMT",
+        "Date": "Mon, 13 Mar 2023 23:48:15 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "Transfer-Encoding": "chunked",
-        "Vary": "Origin",
-        "x-ms-version": "2021-08-06"
+        "x-ms-version": "2022-11-02"
       },
-      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CEnumerationResults ServiceEndpoint=\u0022https://storagename.blob.core.windows.net/\u0022 ContainerName=\u0022utcontainer6b5e318d\u0022\u003E\u003CBlobs\u003E\u003CBlob\u003E\u003CName\u003Eblob6b5e318d\u003C/Name\u003E\u003CSnapshot\u003E2022-08-12T20:52:06.5003907Z\u003C/Snapshot\u003E\u003CProperties\u003E\u003CCreation-Time\u003EFri, 12 Aug 2022 20:52:06 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EFri, 12 Aug 2022 20:52:06 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8DA7CA4846626E9\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EyaNM/IXZgmmMasifdgcavQ==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003COrMetadata /\u003E\u003C/Blob\u003E\u003CBlob\u003E\u003CName\u003Eblob6b5e318d\u003C/Name\u003E\u003CSnapshot\u003E2022-08-12T20:52:06.6253200Z\u003C/Snapshot\u003E\u003CProperties\u003E\u003CCreation-Time\u003EFri, 12 Aug 2022 20:52:06 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EFri, 12 Aug 2022 20:52:06 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8DA7CA4846626E9\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EyaNM/IXZgmmMasifdgcavQ==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003COrMetadata /\u003E\u003C/Blob\u003E\u003CBlob\u003E\u003CName\u003Eblob6b5e318d\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EFri, 12 Aug 2022 20:52:06 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EFri, 12 Aug 2022 20:52:06 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8DA7CA4846626E9\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EyaNM/IXZgmmMasifdgcavQ==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003COrMetadata /\u003E\u003C/Blob\u003E\u003C/Blobs\u003E\u003CNextMarker /\u003E\u003C/EnumerationResults\u003E"
+      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CEnumerationResults ServiceEndpoint=\u0022https://storagename.blob.core.windows.net/\u0022 ContainerName=\u0022utcontainer6b5e318d\u0022\u003E\u003CBlobs\u003E\u003CBlob\u003E\u003CName\u003Eblob6b5e318d\u003C/Name\u003E\u003CSnapshot\u003E2023-03-13T23:48:15.9899879Z\u003C/Snapshot\u003E\u003CProperties\u003E\u003CCreation-Time\u003EMon, 13 Mar 2023 23:48:15 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EMon, 13 Mar 2023 23:48:15 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8DB241D6A4EFD5C\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EyaNM/IXZgmmMasifdgcavQ==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003COrMetadata /\u003E\u003C/Blob\u003E\u003CBlob\u003E\u003CName\u003Eblob6b5e318d\u003C/Name\u003E\u003CSnapshot\u003E2023-03-13T23:48:16.0509543Z\u003C/Snapshot\u003E\u003CProperties\u003E\u003CCreation-Time\u003EMon, 13 Mar 2023 23:48:15 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EMon, 13 Mar 2023 23:48:15 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8DB241D6A4EFD5C\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EyaNM/IXZgmmMasifdgcavQ==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003COrMetadata /\u003E\u003C/Blob\u003E\u003CBlob\u003E\u003CName\u003Eblob6b5e318d\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EMon, 13 Mar 2023 23:48:15 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EMon, 13 Mar 2023 23:48:15 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8DB241D6A4EFD5C\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EyaNM/IXZgmmMasifdgcavQ==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003COrMetadata /\u003E\u003C/Blob\u003E\u003C/Blobs\u003E\u003CNextMarker /\u003E\u003C/EnumerationResults\u003E"
     },
     {
       "RequestUri": "https://storagename.blob.core.windows.net/?restype=service\u0026comp=properties",
@@ -313,9 +310,9 @@
         "Connection": "keep-alive",
         "Content-Length": "163",
         "Content-Type": "application/xml",
-        "User-Agent": "azsdk-python-storage-blob/12.14.0b1 Python/3.10.5 (Windows-10-10.0.22000-SP0)",
-        "x-ms-date": "Fri, 12 Aug 2022 20:52:07 GMT",
-        "x-ms-version": "2021-08-06"
+        "User-Agent": "azsdk-python-storage-blob/12.16.0b1 Python/3.11.1 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Mon, 13 Mar 2023 23:48:20 GMT",
+        "x-ms-version": "2022-11-02"
       },
       "RequestBody": [
         "\u003C?xml version=\u00271.0\u0027 encoding=\u0027utf-8\u0027?\u003E\n",
@@ -324,12 +321,12 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 12 Aug 2022 20:52:06 GMT",
+        "Date": "Mon, 13 Mar 2023 23:48:15 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-version": "2021-08-06"
+        "x-ms-version": "2022-11-02"
       },
       "ResponseBody": null
     }

--- a/sdk/storage/azure-storage-blob/tests/recordings/test_common_blob.pyTestStorageCommonBlobtest_soft_delete_single_blob_snapshot.json
+++ b/sdk/storage/azure-storage-blob/tests/recordings/test_common_blob.pyTestStorageCommonBlobtest_soft_delete_single_blob_snapshot.json
@@ -8,22 +8,22 @@
         "Accept-Encoding": "gzip, deflate",
         "Connection": "keep-alive",
         "Content-Length": "0",
-        "User-Agent": "azsdk-python-storage-blob/12.14.0b1 Python/3.10.5 (Windows-10-10.0.22000-SP0)",
-        "x-ms-date": "Fri, 12 Aug 2022 20:50:43 GMT",
-        "x-ms-version": "2021-08-06"
+        "User-Agent": "azsdk-python-storage-blob/12.16.0b1 Python/3.11.1 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Mon, 13 Mar 2023 23:46:36 GMT",
+        "x-ms-version": "2022-11-02"
       },
       "RequestBody": null,
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 12 Aug 2022 20:50:43 GMT",
-        "ETag": "\u00220x8DA7CA453185E2E\u0022",
-        "Last-Modified": "Fri, 12 Aug 2022 20:50:43 GMT",
+        "Date": "Mon, 13 Mar 2023 23:46:33 GMT",
+        "ETag": "\u00220x8DB241D2D130C50\u0022",
+        "Last-Modified": "Mon, 13 Mar 2023 23:46:33 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-version": "2021-08-06"
+        "x-ms-version": "2022-11-02"
       },
       "ResponseBody": null
     },
@@ -35,22 +35,22 @@
         "Accept-Encoding": "gzip, deflate",
         "Connection": "keep-alive",
         "Content-Length": "0",
-        "User-Agent": "azsdk-python-storage-blob/12.14.0b1 Python/3.10.5 (Windows-10-10.0.22000-SP0)",
-        "x-ms-date": "Fri, 12 Aug 2022 20:50:43 GMT",
-        "x-ms-version": "2021-08-06"
+        "User-Agent": "azsdk-python-storage-blob/12.16.0b1 Python/3.11.1 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Mon, 13 Mar 2023 23:46:37 GMT",
+        "x-ms-version": "2022-11-02"
       },
       "RequestBody": null,
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 12 Aug 2022 20:50:43 GMT",
-        "ETag": "\u00220x8DA7CA45327501A\u0022",
-        "Last-Modified": "Fri, 12 Aug 2022 20:50:43 GMT",
+        "Date": "Mon, 13 Mar 2023 23:46:33 GMT",
+        "ETag": "\u00220x8DB241D2D1DDFED\u0022",
+        "Last-Modified": "Mon, 13 Mar 2023 23:46:33 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-version": "2021-08-06"
+        "x-ms-version": "2022-11-02"
       },
       "ResponseBody": null
     },
@@ -63,9 +63,9 @@
         "Connection": "keep-alive",
         "Content-Length": "176",
         "Content-Type": "application/xml",
-        "User-Agent": "azsdk-python-storage-blob/12.14.0b1 Python/3.10.5 (Windows-10-10.0.22000-SP0)",
-        "x-ms-date": "Fri, 12 Aug 2022 20:50:43 GMT",
-        "x-ms-version": "2021-08-06"
+        "User-Agent": "azsdk-python-storage-blob/12.16.0b1 Python/3.11.1 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Mon, 13 Mar 2023 23:46:37 GMT",
+        "x-ms-version": "2022-11-02"
       },
       "RequestBody": [
         "\u003C?xml version=\u00271.0\u0027 encoding=\u0027utf-8\u0027?\u003E\n",
@@ -74,12 +74,12 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 12 Aug 2022 20:50:43 GMT",
+        "Date": "Mon, 13 Mar 2023 23:46:33 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-version": "2021-08-06"
+        "x-ms-version": "2022-11-02"
       },
       "ResponseBody": null
     },
@@ -93,26 +93,26 @@
         "Content-Length": "1024",
         "Content-Type": "application/octet-stream",
         "If-None-Match": "*",
-        "User-Agent": "azsdk-python-storage-blob/12.14.0b1 Python/3.10.5 (Windows-10-10.0.22000-SP0)",
+        "User-Agent": "azsdk-python-storage-blob/12.16.0b1 Python/3.11.1 (Windows-10-10.0.22621-SP0)",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-date": "Fri, 12 Aug 2022 20:51:24 GMT",
-        "x-ms-version": "2021-08-06"
+        "x-ms-date": "Mon, 13 Mar 2023 23:47:17 GMT",
+        "x-ms-version": "2022-11-02"
       },
       "RequestBody": "YWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYQ==",
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
         "Content-MD5": "yaNM/IXZgmmMasifdgcavQ==",
-        "Date": "Fri, 12 Aug 2022 20:51:23 GMT",
-        "ETag": "\u00220x8DA7CA46B29E470\u0022",
-        "Last-Modified": "Fri, 12 Aug 2022 20:51:24 GMT",
+        "Date": "Mon, 13 Mar 2023 23:47:13 GMT",
+        "ETag": "\u00220x8DB241D4553947C\u0022",
+        "Last-Modified": "Mon, 13 Mar 2023 23:47:13 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-content-crc64": "ov8U1LLnyKc=",
         "x-ms-request-server-encrypted": "true",
-        "x-ms-version": "2021-08-06"
+        "x-ms-version": "2022-11-02"
       },
       "ResponseBody": null
     },
@@ -124,24 +124,24 @@
         "Accept-Encoding": "gzip, deflate",
         "Connection": "keep-alive",
         "Content-Length": "0",
-        "User-Agent": "azsdk-python-storage-blob/12.14.0b1 Python/3.10.5 (Windows-10-10.0.22000-SP0)",
-        "x-ms-date": "Fri, 12 Aug 2022 20:51:24 GMT",
-        "x-ms-version": "2021-08-06"
+        "User-Agent": "azsdk-python-storage-blob/12.16.0b1 Python/3.11.1 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Mon, 13 Mar 2023 23:47:18 GMT",
+        "x-ms-version": "2022-11-02"
       },
       "RequestBody": null,
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 12 Aug 2022 20:51:23 GMT",
-        "ETag": "\u00220x8DA7CA46B29E470\u0022",
-        "Last-Modified": "Fri, 12 Aug 2022 20:51:24 GMT",
+        "Date": "Mon, 13 Mar 2023 23:47:13 GMT",
+        "ETag": "\u00220x8DB241D4553947C\u0022",
+        "Last-Modified": "Mon, 13 Mar 2023 23:47:13 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-request-server-encrypted": "false",
-        "x-ms-snapshot": "2022-08-12T20:51:24.1604344Z",
-        "x-ms-version": "2021-08-06"
+        "x-ms-snapshot": "2023-03-13T23:47:13.9453704Z",
+        "x-ms-version": "2022-11-02"
       },
       "ResponseBody": null
     },
@@ -153,50 +153,50 @@
         "Accept-Encoding": "gzip, deflate",
         "Connection": "keep-alive",
         "Content-Length": "0",
-        "User-Agent": "azsdk-python-storage-blob/12.14.0b1 Python/3.10.5 (Windows-10-10.0.22000-SP0)",
-        "x-ms-date": "Fri, 12 Aug 2022 20:51:24 GMT",
-        "x-ms-version": "2021-08-06"
+        "User-Agent": "azsdk-python-storage-blob/12.16.0b1 Python/3.11.1 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Mon, 13 Mar 2023 23:47:18 GMT",
+        "x-ms-version": "2022-11-02"
       },
       "RequestBody": null,
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 12 Aug 2022 20:51:23 GMT",
-        "ETag": "\u00220x8DA7CA46B29E470\u0022",
-        "Last-Modified": "Fri, 12 Aug 2022 20:51:24 GMT",
+        "Date": "Mon, 13 Mar 2023 23:47:13 GMT",
+        "ETag": "\u00220x8DB241D4553947C\u0022",
+        "Last-Modified": "Mon, 13 Mar 2023 23:47:13 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-request-server-encrypted": "false",
-        "x-ms-snapshot": "2022-08-12T20:51:24.2293944Z",
-        "x-ms-version": "2021-08-06"
+        "x-ms-snapshot": "2023-03-13T23:47:14.0123322Z",
+        "x-ms-version": "2022-11-02"
       },
       "ResponseBody": null
     },
     {
-      "RequestUri": "https://storagename.blob.core.windows.net/utcontainer3ba30a6/blob3ba30a6?snapshot=2022-08-12T20:51:24.1604344Z",
+      "RequestUri": "https://storagename.blob.core.windows.net/utcontainer3ba30a6/blob3ba30a6?snapshot=2023-03-13T23:47:13.9453704Z",
       "RequestMethod": "DELETE",
       "RequestHeaders": {
         "Accept": "application/xml",
         "Accept-Encoding": "gzip, deflate",
         "Connection": "keep-alive",
         "Content-Length": "0",
-        "User-Agent": "azsdk-python-storage-blob/12.14.0b1 Python/3.10.5 (Windows-10-10.0.22000-SP0)",
-        "x-ms-date": "Fri, 12 Aug 2022 20:51:24 GMT",
-        "x-ms-version": "2021-08-06"
+        "User-Agent": "azsdk-python-storage-blob/12.16.0b1 Python/3.11.1 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Mon, 13 Mar 2023 23:47:18 GMT",
+        "x-ms-version": "2022-11-02"
       },
       "RequestBody": null,
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 12 Aug 2022 20:51:23 GMT",
+        "Date": "Mon, 13 Mar 2023 23:47:13 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "x-ms-delete-type-permanent": "false",
-        "x-ms-version": "2021-08-06"
+        "x-ms-version": "2022-11-02"
       },
       "ResponseBody": null
     },
@@ -207,24 +207,23 @@
         "Accept": "application/xml",
         "Accept-Encoding": "gzip, deflate",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-python-storage-blob/12.14.0b1 Python/3.10.5 (Windows-10-10.0.22000-SP0)",
-        "x-ms-date": "Fri, 12 Aug 2022 20:51:24 GMT",
-        "x-ms-version": "2021-08-06"
+        "User-Agent": "azsdk-python-storage-blob/12.16.0b1 Python/3.11.1 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Mon, 13 Mar 2023 23:47:18 GMT",
+        "x-ms-version": "2022-11-02"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Type": "application/xml",
-        "Date": "Fri, 12 Aug 2022 20:51:23 GMT",
+        "Date": "Mon, 13 Mar 2023 23:47:13 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "Transfer-Encoding": "chunked",
-        "Vary": "Origin",
-        "x-ms-version": "2021-08-06"
+        "x-ms-version": "2022-11-02"
       },
-      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CEnumerationResults ServiceEndpoint=\u0022https://storagename.blob.core.windows.net/\u0022 ContainerName=\u0022utcontainer3ba30a6\u0022\u003E\u003CBlobs\u003E\u003CBlob\u003E\u003CName\u003Eblob3ba30a6\u003C/Name\u003E\u003CSnapshot\u003E2022-08-12T20:51:24.1604344Z\u003C/Snapshot\u003E\u003CDeleted\u003Etrue\u003C/Deleted\u003E\u003CProperties\u003E\u003CCreation-Time\u003EFri, 12 Aug 2022 20:51:24 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EFri, 12 Aug 2022 20:51:24 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8DA7CA46B29E470\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EyaNM/IXZgmmMasifdgcavQ==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003CDeletedTime\u003EFri, 12 Aug 2022 20:51:24 GMT\u003C/DeletedTime\u003E\u003CRemainingRetentionDays\u003E1\u003C/RemainingRetentionDays\u003E\u003C/Properties\u003E\u003COrMetadata /\u003E\u003C/Blob\u003E\u003CBlob\u003E\u003CName\u003Eblob3ba30a6\u003C/Name\u003E\u003CSnapshot\u003E2022-08-12T20:51:24.2293944Z\u003C/Snapshot\u003E\u003CProperties\u003E\u003CCreation-Time\u003EFri, 12 Aug 2022 20:51:24 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EFri, 12 Aug 2022 20:51:24 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8DA7CA46B29E470\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EyaNM/IXZgmmMasifdgcavQ==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003COrMetadata /\u003E\u003C/Blob\u003E\u003CBlob\u003E\u003CName\u003Eblob3ba30a6\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EFri, 12 Aug 2022 20:51:24 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EFri, 12 Aug 2022 20:51:24 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8DA7CA46B29E470\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EyaNM/IXZgmmMasifdgcavQ==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003COrMetadata /\u003E\u003C/Blob\u003E\u003C/Blobs\u003E\u003CNextMarker /\u003E\u003C/EnumerationResults\u003E"
+      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CEnumerationResults ServiceEndpoint=\u0022https://storagename.blob.core.windows.net/\u0022 ContainerName=\u0022utcontainer3ba30a6\u0022\u003E\u003CBlobs\u003E\u003CBlob\u003E\u003CName\u003Eblob3ba30a6\u003C/Name\u003E\u003CSnapshot\u003E2023-03-13T23:47:13.9453704Z\u003C/Snapshot\u003E\u003CDeleted\u003Etrue\u003C/Deleted\u003E\u003CProperties\u003E\u003CCreation-Time\u003EMon, 13 Mar 2023 23:47:13 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EMon, 13 Mar 2023 23:47:13 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8DB241D4553947C\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EyaNM/IXZgmmMasifdgcavQ==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003CDeletedTime\u003EMon, 13 Mar 2023 23:47:14 GMT\u003C/DeletedTime\u003E\u003CRemainingRetentionDays\u003E1\u003C/RemainingRetentionDays\u003E\u003C/Properties\u003E\u003COrMetadata /\u003E\u003C/Blob\u003E\u003CBlob\u003E\u003CName\u003Eblob3ba30a6\u003C/Name\u003E\u003CSnapshot\u003E2023-03-13T23:47:14.0123322Z\u003C/Snapshot\u003E\u003CProperties\u003E\u003CCreation-Time\u003EMon, 13 Mar 2023 23:47:13 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EMon, 13 Mar 2023 23:47:13 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8DB241D4553947C\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EyaNM/IXZgmmMasifdgcavQ==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003COrMetadata /\u003E\u003C/Blob\u003E\u003CBlob\u003E\u003CName\u003Eblob3ba30a6\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EMon, 13 Mar 2023 23:47:13 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EMon, 13 Mar 2023 23:47:13 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8DB241D4553947C\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EyaNM/IXZgmmMasifdgcavQ==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003COrMetadata /\u003E\u003C/Blob\u003E\u003C/Blobs\u003E\u003CNextMarker /\u003E\u003C/EnumerationResults\u003E"
     },
     {
       "RequestUri": "https://storagename.blob.core.windows.net/utcontainer3ba30a6?restype=container\u0026comp=list\u0026include=snapshots",
@@ -233,24 +232,23 @@
         "Accept": "application/xml",
         "Accept-Encoding": "gzip, deflate",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-python-storage-blob/12.14.0b1 Python/3.10.5 (Windows-10-10.0.22000-SP0)",
-        "x-ms-date": "Fri, 12 Aug 2022 20:51:24 GMT",
-        "x-ms-version": "2021-08-06"
+        "User-Agent": "azsdk-python-storage-blob/12.16.0b1 Python/3.11.1 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Mon, 13 Mar 2023 23:47:18 GMT",
+        "x-ms-version": "2022-11-02"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Type": "application/xml",
-        "Date": "Fri, 12 Aug 2022 20:51:24 GMT",
+        "Date": "Mon, 13 Mar 2023 23:47:14 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "Transfer-Encoding": "chunked",
-        "Vary": "Origin",
-        "x-ms-version": "2021-08-06"
+        "x-ms-version": "2022-11-02"
       },
-      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CEnumerationResults ServiceEndpoint=\u0022https://storagename.blob.core.windows.net/\u0022 ContainerName=\u0022utcontainer3ba30a6\u0022\u003E\u003CBlobs\u003E\u003CBlob\u003E\u003CName\u003Eblob3ba30a6\u003C/Name\u003E\u003CSnapshot\u003E2022-08-12T20:51:24.2293944Z\u003C/Snapshot\u003E\u003CProperties\u003E\u003CCreation-Time\u003EFri, 12 Aug 2022 20:51:24 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EFri, 12 Aug 2022 20:51:24 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8DA7CA46B29E470\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EyaNM/IXZgmmMasifdgcavQ==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003COrMetadata /\u003E\u003C/Blob\u003E\u003CBlob\u003E\u003CName\u003Eblob3ba30a6\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EFri, 12 Aug 2022 20:51:24 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EFri, 12 Aug 2022 20:51:24 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8DA7CA46B29E470\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EyaNM/IXZgmmMasifdgcavQ==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003COrMetadata /\u003E\u003C/Blob\u003E\u003C/Blobs\u003E\u003CNextMarker /\u003E\u003C/EnumerationResults\u003E"
+      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CEnumerationResults ServiceEndpoint=\u0022https://storagename.blob.core.windows.net/\u0022 ContainerName=\u0022utcontainer3ba30a6\u0022\u003E\u003CBlobs\u003E\u003CBlob\u003E\u003CName\u003Eblob3ba30a6\u003C/Name\u003E\u003CSnapshot\u003E2023-03-13T23:47:14.0123322Z\u003C/Snapshot\u003E\u003CProperties\u003E\u003CCreation-Time\u003EMon, 13 Mar 2023 23:47:13 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EMon, 13 Mar 2023 23:47:13 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8DB241D4553947C\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EyaNM/IXZgmmMasifdgcavQ==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003COrMetadata /\u003E\u003C/Blob\u003E\u003CBlob\u003E\u003CName\u003Eblob3ba30a6\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EMon, 13 Mar 2023 23:47:13 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EMon, 13 Mar 2023 23:47:13 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8DB241D4553947C\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EyaNM/IXZgmmMasifdgcavQ==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003COrMetadata /\u003E\u003C/Blob\u003E\u003C/Blobs\u003E\u003CNextMarker /\u003E\u003C/EnumerationResults\u003E"
     },
     {
       "RequestUri": "https://storagename.blob.core.windows.net/utcontainer3ba30a6/blob3ba30a6?comp=undelete",
@@ -260,20 +258,20 @@
         "Accept-Encoding": "gzip, deflate",
         "Connection": "keep-alive",
         "Content-Length": "0",
-        "User-Agent": "azsdk-python-storage-blob/12.14.0b1 Python/3.10.5 (Windows-10-10.0.22000-SP0)",
-        "x-ms-date": "Fri, 12 Aug 2022 20:51:24 GMT",
-        "x-ms-version": "2021-08-06"
+        "User-Agent": "azsdk-python-storage-blob/12.16.0b1 Python/3.11.1 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Mon, 13 Mar 2023 23:47:18 GMT",
+        "x-ms-version": "2022-11-02"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 12 Aug 2022 20:51:24 GMT",
+        "Date": "Mon, 13 Mar 2023 23:47:14 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-version": "2021-08-06"
+        "x-ms-version": "2022-11-02"
       },
       "ResponseBody": null
     },
@@ -284,24 +282,23 @@
         "Accept": "application/xml",
         "Accept-Encoding": "gzip, deflate",
         "Connection": "keep-alive",
-        "User-Agent": "azsdk-python-storage-blob/12.14.0b1 Python/3.10.5 (Windows-10-10.0.22000-SP0)",
-        "x-ms-date": "Fri, 12 Aug 2022 20:51:24 GMT",
-        "x-ms-version": "2021-08-06"
+        "User-Agent": "azsdk-python-storage-blob/12.16.0b1 Python/3.11.1 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Mon, 13 Mar 2023 23:47:18 GMT",
+        "x-ms-version": "2022-11-02"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Type": "application/xml",
-        "Date": "Fri, 12 Aug 2022 20:51:24 GMT",
+        "Date": "Mon, 13 Mar 2023 23:47:14 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "Transfer-Encoding": "chunked",
-        "Vary": "Origin",
-        "x-ms-version": "2021-08-06"
+        "x-ms-version": "2022-11-02"
       },
-      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CEnumerationResults ServiceEndpoint=\u0022https://storagename.blob.core.windows.net/\u0022 ContainerName=\u0022utcontainer3ba30a6\u0022\u003E\u003CBlobs\u003E\u003CBlob\u003E\u003CName\u003Eblob3ba30a6\u003C/Name\u003E\u003CSnapshot\u003E2022-08-12T20:51:24.1604344Z\u003C/Snapshot\u003E\u003CProperties\u003E\u003CCreation-Time\u003EFri, 12 Aug 2022 20:51:24 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EFri, 12 Aug 2022 20:51:24 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8DA7CA46B29E470\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EyaNM/IXZgmmMasifdgcavQ==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003COrMetadata /\u003E\u003C/Blob\u003E\u003CBlob\u003E\u003CName\u003Eblob3ba30a6\u003C/Name\u003E\u003CSnapshot\u003E2022-08-12T20:51:24.2293944Z\u003C/Snapshot\u003E\u003CProperties\u003E\u003CCreation-Time\u003EFri, 12 Aug 2022 20:51:24 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EFri, 12 Aug 2022 20:51:24 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8DA7CA46B29E470\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EyaNM/IXZgmmMasifdgcavQ==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003COrMetadata /\u003E\u003C/Blob\u003E\u003CBlob\u003E\u003CName\u003Eblob3ba30a6\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EFri, 12 Aug 2022 20:51:24 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EFri, 12 Aug 2022 20:51:24 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8DA7CA46B29E470\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EyaNM/IXZgmmMasifdgcavQ==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003COrMetadata /\u003E\u003C/Blob\u003E\u003C/Blobs\u003E\u003CNextMarker /\u003E\u003C/EnumerationResults\u003E"
+      "ResponseBody": "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CEnumerationResults ServiceEndpoint=\u0022https://storagename.blob.core.windows.net/\u0022 ContainerName=\u0022utcontainer3ba30a6\u0022\u003E\u003CBlobs\u003E\u003CBlob\u003E\u003CName\u003Eblob3ba30a6\u003C/Name\u003E\u003CSnapshot\u003E2023-03-13T23:47:13.9453704Z\u003C/Snapshot\u003E\u003CProperties\u003E\u003CCreation-Time\u003EMon, 13 Mar 2023 23:47:13 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EMon, 13 Mar 2023 23:47:13 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8DB241D4553947C\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EyaNM/IXZgmmMasifdgcavQ==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003COrMetadata /\u003E\u003C/Blob\u003E\u003CBlob\u003E\u003CName\u003Eblob3ba30a6\u003C/Name\u003E\u003CSnapshot\u003E2023-03-13T23:47:14.0123322Z\u003C/Snapshot\u003E\u003CProperties\u003E\u003CCreation-Time\u003EMon, 13 Mar 2023 23:47:13 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EMon, 13 Mar 2023 23:47:13 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8DB241D4553947C\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EyaNM/IXZgmmMasifdgcavQ==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003COrMetadata /\u003E\u003C/Blob\u003E\u003CBlob\u003E\u003CName\u003Eblob3ba30a6\u003C/Name\u003E\u003CProperties\u003E\u003CCreation-Time\u003EMon, 13 Mar 2023 23:47:13 GMT\u003C/Creation-Time\u003E\u003CLast-Modified\u003EMon, 13 Mar 2023 23:47:13 GMT\u003C/Last-Modified\u003E\u003CEtag\u003E0x8DB241D4553947C\u003C/Etag\u003E\u003CContent-Length\u003E1024\u003C/Content-Length\u003E\u003CContent-Type\u003Eapplication/octet-stream\u003C/Content-Type\u003E\u003CContent-Encoding /\u003E\u003CContent-Language /\u003E\u003CContent-CRC64 /\u003E\u003CContent-MD5\u003EyaNM/IXZgmmMasifdgcavQ==\u003C/Content-MD5\u003E\u003CCache-Control /\u003E\u003CContent-Disposition /\u003E\u003CBlobType\u003EBlockBlob\u003C/BlobType\u003E\u003CAccessTier\u003EHot\u003C/AccessTier\u003E\u003CAccessTierInferred\u003Etrue\u003C/AccessTierInferred\u003E\u003CLeaseStatus\u003Eunlocked\u003C/LeaseStatus\u003E\u003CLeaseState\u003Eavailable\u003C/LeaseState\u003E\u003CServerEncrypted\u003Etrue\u003C/ServerEncrypted\u003E\u003C/Properties\u003E\u003COrMetadata /\u003E\u003C/Blob\u003E\u003C/Blobs\u003E\u003CNextMarker /\u003E\u003C/EnumerationResults\u003E"
     },
     {
       "RequestUri": "https://storagename.blob.core.windows.net/?restype=service\u0026comp=properties",
@@ -312,9 +309,9 @@
         "Connection": "keep-alive",
         "Content-Length": "163",
         "Content-Type": "application/xml",
-        "User-Agent": "azsdk-python-storage-blob/12.14.0b1 Python/3.10.5 (Windows-10-10.0.22000-SP0)",
-        "x-ms-date": "Fri, 12 Aug 2022 20:51:24 GMT",
-        "x-ms-version": "2021-08-06"
+        "User-Agent": "azsdk-python-storage-blob/12.16.0b1 Python/3.11.1 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Mon, 13 Mar 2023 23:47:18 GMT",
+        "x-ms-version": "2022-11-02"
       },
       "RequestBody": [
         "\u003C?xml version=\u00271.0\u0027 encoding=\u0027utf-8\u0027?\u003E\n",
@@ -323,12 +320,12 @@
       "StatusCode": 202,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Fri, 12 Aug 2022 20:51:24 GMT",
+        "Date": "Mon, 13 Mar 2023 23:47:14 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-version": "2021-08-06"
+        "x-ms-version": "2022-11-02"
       },
       "ResponseBody": null
     }

--- a/sdk/storage/azure-storage-blob/tests/test_common_blob.py
+++ b/sdk/storage/azure-storage-blob/tests/test_common_blob.py
@@ -1184,6 +1184,7 @@ class TestStorageCommonBlob(StorageRecordedTestCase):
 
             # Soft delete the blob
             blob.delete_blob()
+            self.sleep(5)
             blob_list = list(container.list_blobs(include='deleted'))
 
             # Assert
@@ -1225,6 +1226,7 @@ class TestStorageCommonBlob(StorageRecordedTestCase):
             snapshot_1 = self.bsc.get_blob_client(
                 self.container_name, blob_name, snapshot=blob_snapshot_1)
             snapshot_1.delete_blob()
+            self.sleep(5)
 
             with pytest.raises(ValueError):
                 snapshot_1.delete_blob(delete_snapshots='only')
@@ -1248,6 +1250,7 @@ class TestStorageCommonBlob(StorageRecordedTestCase):
 
             # Restore snapshot with undelete
             blob.undelete_blob()
+            self.sleep(5)
             blob_list = list(container.list_blobs(include=["snapshots", "deleted"]))
 
             # Assert
@@ -1273,6 +1276,7 @@ class TestStorageCommonBlob(StorageRecordedTestCase):
 
             # Soft delete all snapshots
             blob.delete_blob(delete_snapshots='only')
+            self.sleep(5)
             container = self.bsc.get_container_client(self.container_name)
             blob_list = list(container.list_blobs(include=["snapshots", "deleted"]))
 

--- a/sdk/storage/azure-storage-blob/tests/test_common_blob.py
+++ b/sdk/storage/azure-storage-blob/tests/test_common_blob.py
@@ -1184,7 +1184,6 @@ class TestStorageCommonBlob(StorageRecordedTestCase):
 
             # Soft delete the blob
             blob.delete_blob()
-            self.sleep(5)
             blob_list = list(container.list_blobs(include='deleted'))
 
             # Assert
@@ -1199,7 +1198,6 @@ class TestStorageCommonBlob(StorageRecordedTestCase):
 
             # Restore blob with undelete
             blob.undelete_blob()
-            self.sleep(5)
             blob_list = list(container.list_blobs(include='deleted'))
 
             # Assert
@@ -1208,6 +1206,7 @@ class TestStorageCommonBlob(StorageRecordedTestCase):
 
         finally:
             self._disable_soft_delete()
+            time.sleep(40)
 
     @BlobPreparer()
     @recorded_by_proxy
@@ -1227,7 +1226,6 @@ class TestStorageCommonBlob(StorageRecordedTestCase):
             snapshot_1 = self.bsc.get_blob_client(
                 self.container_name, blob_name, snapshot=blob_snapshot_1)
             snapshot_1.delete_blob()
-            self.sleep(5)
 
             with pytest.raises(ValueError):
                 snapshot_1.delete_blob(delete_snapshots='only')
@@ -1251,7 +1249,6 @@ class TestStorageCommonBlob(StorageRecordedTestCase):
 
             # Restore snapshot with undelete
             blob.undelete_blob()
-            self.sleep(5)
             blob_list = list(container.list_blobs(include=["snapshots", "deleted"]))
 
             # Assert
@@ -1260,6 +1257,7 @@ class TestStorageCommonBlob(StorageRecordedTestCase):
                 self._assert_blob_not_soft_deleted(blob)
         finally:
             self._disable_soft_delete()
+            time.sleep(40)
 
     @BlobPreparer()
     @recorded_by_proxy
@@ -1277,7 +1275,6 @@ class TestStorageCommonBlob(StorageRecordedTestCase):
 
             # Soft delete all snapshots
             blob.delete_blob(delete_snapshots='only')
-            self.sleep(5)
             container = self.bsc.get_container_client(self.container_name)
             blob_list = list(container.list_blobs(include=["snapshots", "deleted"]))
 
@@ -1299,7 +1296,6 @@ class TestStorageCommonBlob(StorageRecordedTestCase):
 
             # Restore snapshots with undelete
             blob.undelete_blob()
-            self.sleep(5)
             blob_list = list(container.list_blobs(include=["snapshots", "deleted"]))
 
             # Assert
@@ -1309,6 +1305,7 @@ class TestStorageCommonBlob(StorageRecordedTestCase):
 
         finally:
             self._disable_soft_delete()
+            time.sleep(40)
 
     @BlobPreparer()
     @recorded_by_proxy

--- a/sdk/storage/azure-storage-blob/tests/test_common_blob.py
+++ b/sdk/storage/azure-storage-blob/tests/test_common_blob.py
@@ -1199,6 +1199,7 @@ class TestStorageCommonBlob(StorageRecordedTestCase):
 
             # Restore blob with undelete
             blob.undelete_blob()
+            self.sleep(5)
             blob_list = list(container.list_blobs(include='deleted'))
 
             # Assert
@@ -1298,6 +1299,7 @@ class TestStorageCommonBlob(StorageRecordedTestCase):
 
             # Restore snapshots with undelete
             blob.undelete_blob()
+            self.sleep(5)
             blob_list = list(container.list_blobs(include=["snapshots", "deleted"]))
 
             # Assert

--- a/sdk/storage/azure-storage-blob/tests/test_common_blob.py
+++ b/sdk/storage/azure-storage-blob/tests/test_common_blob.py
@@ -150,7 +150,7 @@ class TestStorageCommonBlob(StorageRecordedTestCase):
         # wait until the policy has gone into effect
         if self.is_live:
             self.bsc.set_service_properties(delete_retention_policy=delete_retention_policy)
-            time.sleep(40)
+            time.sleep(60)
 
     def _disable_soft_delete(self):
         delete_retention_policy = RetentionPolicy(enabled=False)
@@ -1206,7 +1206,6 @@ class TestStorageCommonBlob(StorageRecordedTestCase):
 
         finally:
             self._disable_soft_delete()
-            time.sleep(40)
 
     @BlobPreparer()
     @recorded_by_proxy
@@ -1257,7 +1256,6 @@ class TestStorageCommonBlob(StorageRecordedTestCase):
                 self._assert_blob_not_soft_deleted(blob)
         finally:
             self._disable_soft_delete()
-            time.sleep(40)
 
     @BlobPreparer()
     @recorded_by_proxy
@@ -1305,7 +1303,6 @@ class TestStorageCommonBlob(StorageRecordedTestCase):
 
         finally:
             self._disable_soft_delete()
-            time.sleep(40)
 
     @BlobPreparer()
     @recorded_by_proxy

--- a/sdk/storage/azure-storage-blob/tests/test_common_blob_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_common_blob_async.py
@@ -151,7 +151,7 @@ class TestStorageCommonBlobAsync(AsyncStorageRecordedTestCase):
 
         # wait until the policy has gone into effect
         if self.is_live:
-            time.sleep(40)
+            time.sleep(60)
 
     async def _disable_soft_delete(self):
         delete_retention_policy = RetentionPolicy(enabled=False)


### PR DESCRIPTION
The tests are passing locally just fine without the sleep -- but my theory is that the delete happens and then querying for listing the blobs is occasionally happening before the state of the blobs is updated. Hoping that a small sleep will ensure this doesn't happen 😄 