### PR TITLE
[Core][OTel] Propagate library name/version/resource provider to tracing plugin

### DIFF
--- a/sdk/core/azure-core-tracing-opentelemetry/azure/core/tracing/ext/opentelemetry_span/__init__.py
+++ b/sdk/core/azure-core-tracing-opentelemetry/azure/core/tracing/ext/opentelemetry_span/__init__.py
@@ -58,6 +58,10 @@ class OpenTelemetrySpan(HttpSpanMixin, object):
     :paramtype kind: ~azure.core.tracing.SpanKind
     :keyword links: The list of links to be added to the span.
     :paramtype links: list[~azure.core.tracing.Link]
+    :keyword library_name: The name or identifier of the library that created the span.
+    :paramtype library_name: Optional[str]
+    :keyword library_version: The version of the library that created the span.
+    :paramtype library_version: Optional[str]
     """
 
     def __init__(self, span: Optional[Span] = None, name: str = "span", **kwargs: Any) -> None:
@@ -104,8 +108,8 @@ class OpenTelemetrySpan(HttpSpanMixin, object):
             self._context_tokens.append(context.attach(context.set_value(_SUPPRESS_HTTP_INSTRUMENTATION_KEY, True)))
 
         current_tracer = trace.get_tracer(
-            __name__,
-            __version__,
+            kwargs.pop("library_name", None) or __name__,
+            kwargs.pop("library_version", None),
             schema_url=OpenTelemetrySchema.get_schema_url(self._schema_version),
         )
 

--- a/sdk/core/azure-core-tracing-opentelemetry/tracing-details.md
+++ b/sdk/core/azure-core-tracing-opentelemetry/tracing-details.md
@@ -1,0 +1,120 @@
+# Propagating additional information to tracing spans
+
+Associated PR: https://github.com/Azure/azure-sdk-for-python/pull/29327
+
+## Problem
+
+Information needed in `distributed_trace` decorator:
+
+- SDK package name
+- SDK package version
+- SDK resource provider name
+
+This info is then passed to created span.
+
+## Solution
+
+Store these values as constants in some location where they can be accessed by the decorators.
+
+### Where to store resource provider constants?
+
+In base namespace. Options:
+
+`azure/storage/blob/`
+
+1. In `_version.py` as constants like `VERSION` already is:
+    ```python
+    VERSION = "12.16.0b1"
+    RESOURCE_PROVIDER = "Microsoft.Storage"
+    PACKAGE_NAME = "azure-storage-blob"
+    ```
+2. Or, in `__init__.py` as dunder variables:
+    ```python
+    __version__ = VERSION
+    __resource_provider__ = "Microsoft.Storage"
+    __package_name__ = "azure-storage-blob"
+    ```
+
+### How should `distributed_trace` decorators obtain these values?
+
+- **Option 1: Pass them in as arguments to the decorator**
+    - Pros: Simple to implement with no discernible perf overhead.
+    - Cons: Need to pass them in everywhere and repeatedly for each SDK method that uses the decorator.
+
+    ```python
+    @distributed_trace(resource_provider=resource_provider, package_name=package_name, package_version=package_version)
+    ```
+
+- **Option 2: Use `getattr` to get the values from the module**
+    - Pros:
+        - No need to pass arguments from decorator, so much less changes on SDK side.
+        - Even if SDK hasn't been update with values, the logic can still deduce at least the base module name and version which
+          can be used in the tracer instrumentation scope.
+    - Cons:
+        - Additional perf overhead on the core side. However, this is fairly
+        and only applicable when tracing is enabled. Repeated calls
+          are very fast with the lru_cache being used.
+
+    - Example implementations:
+
+        1. `_version` search implementation:
+
+            ```python
+            @lru_cache(maxsize=128)
+            def _get_module_info(func: Callable) -> Tuple[Optional[str], Optional[str], Optional[str]]:
+                module_parts = func.__module__.split(".")
+                # Traverse backwards through module name until we find a _version module.
+                for i in range(len(module_parts), 0, -1):
+                    try:
+                        module_name = ".".join(module_parts[:i])
+                        version_module = f"{module_name}._version"
+                        if version_module in sys.modules:
+                            module = sys.modules[version_module]
+
+                            version = getattr(module, "VERSION", None)
+                            package_name = getattr(module, "PACKAGE_NAME", module_name)
+                            resource_provider = getattr(module, "RESOURCE_PROVIDER", None)
+
+                            return package_name, version, resource_provider
+                    except Exception:  # pylint: disable=broad-except
+                        pass
+                return None, None, None
+            ```
+            This looks for `_version.py` in the module hierarchy, and if it finds it, it will use the values from there.
+
+            Sample input: func with module name = `azure.storage.blob._generated.operations._service_operations`
+
+            The function above would eventually find `azure.storage.blob._version` and will return the values from there.
+
+            This function adds, on average, 5-7% overhead to the decorator (about .000011 seconds on my system).
+
+        2. `__version__` search implementation:
+
+            ```python
+            @lru_cache(maxsize=128)
+            def _get_module_info_alt(func: Callable) -> Tuple[Optional[str], Optional[str], Optional[str]]:
+                print(func.__module__)
+                module_parts = func.__module__.split(".")
+                # Traverse backwards through module name until we find a _version module.
+                for i in range(len(module_parts), 0, -1):
+                    try:
+                        module_name = ".".join(module_parts[:i])
+                        module = sys.modules[module_name]
+                        if hasattr(module, "__version__"):
+                            version = module.__version__
+                            package_name = getattr(module, "__package_name__", module_name)
+                            resource_provider = getattr(module, "__resource_provider__", None)
+
+                            return package_name, version, resource_provider
+                    except Exception:  # pylint: disable=broad-except
+                        pass
+                return None, None, None
+            ```
+
+            Sample input: func with module name = `azure.storage.blob._generated.operations._service_operations`
+
+            The function above would eventually find `azure.storage.blob.__version__` and will make the assumption that the other dunder variables can be found where `__version__` was found.
+
+            This adds about a 15-20% overhead to the decorator (about .000035 seconds on my system)
+
+            When a decoratred operation call generally takes in the order of tenths of seconds (e.g., ~.15 seconds), both additional overheads are insignificant.

--- a/sdk/core/azure-core/azure/core/tracing/decorator_async.py
+++ b/sdk/core/azure-core/azure/core/tracing/decorator_async.py
@@ -29,7 +29,7 @@ import functools
 
 from typing import Awaitable, Callable, Any, TypeVar, overload, Optional
 from typing_extensions import ParamSpec
-from .common import change_context, get_function_and_class_name
+from .common import change_context, get_function_and_class_name, _get_module_info, _AZ_TRACING_NAMESPACE_KEY
 from . import SpanKind as _SpanKind
 from ..settings import settings
 
@@ -80,9 +80,15 @@ def distributed_trace_async(  # pylint:disable=function-redefined
             if merge_span and not passed_in_parent:
                 return await func(*args, **kwargs)
 
+            module_name, module_version, resource_provider = _get_module_info(func)
+
             with change_context(passed_in_parent):
                 name = name_of_span or get_function_and_class_name(func, *args)
-                with span_impl_type(name=name, kind=kind) as span:
+                with span_impl_type(
+                    name=name, kind=kind, library_name=module_name, library_version=module_version
+                ) as span:
+                    if resource_provider:
+                        span.add_attribute(_AZ_TRACING_NAMESPACE_KEY, resource_provider)
                     for key, value in tracing_attributes.items():
                         span.add_attribute(key, value)
                     return await func(*args, **kwargs)

--- a/sdk/core/azure-core/tests/test_tracing_decorator.py
+++ b/sdk/core/azure-core/tests/test_tracing_decorator.py
@@ -9,9 +9,11 @@ try:
 except ImportError:
     import mock
 
+import sys
 import time
 
 import pytest
+from azure.core import VERSION
 from azure.core.pipeline import Pipeline, PipelineResponse
 from azure.core.pipeline.policies import HTTPPolicy
 from azure.core.pipeline.transport import HttpTransport
@@ -97,6 +99,20 @@ def test_get_function_and_class_name(http_request):
     client = MockClient(http_request)
     assert common.get_function_and_class_name(client.get_foo, client) == "MockClient.get_foo"
     assert common.get_function_and_class_name(random_function) == "random_function"
+
+
+def test_get_module_info():
+    # Use arbitrary function in azure-core.
+    func = common.get_function_and_class_name
+    module_name, module_version, resource_provider = common._get_module_info(func)
+    assert module_name == "azure.core"
+    assert module_version == VERSION
+    assert resource_provider is None
+
+    module_name, module_version, resource_provider = common._get_module_info(random_function)
+    assert module_name is None
+    assert module_version is None
+    assert resource_provider is None
 
 
 @pytest.mark.usefixtures("fake_span")

--- a/sdk/core/azure-core/tests/tracing_common.py
+++ b/sdk/core/azure-core/tests/tracing_common.py
@@ -24,7 +24,7 @@ class FakeSpan(HttpSpanMixin, object):
     # Keep a fake context of the current one
     CONTEXT = []
 
-    def __init__(self, span=None, name="span", kind=None):
+    def __init__(self, span=None, name="span", kind=None, **kwargs):
         # type: (Optional[Span], Optional[str]) -> None
         """
         If a span is not passed in, creates a new tracer. If the instrumentation key for Azure Exporter is given, will


### PR DESCRIPTION
# Propagating SDK meta information for tracing

## Problem

For distributed tracing, there are a few pieces of information that we'd like to propagate to created spans:

- package name and version (for tracer instrumentation scope)
- associated resource provider (as `az.namespace` attribute) 
    - Examples from [this list](https://learn.microsoft.com/azure/azure-resource-manager/management/azure-services-resource-providers): Microsoft.Storage, Microsoft.Insights, etc.
    - See https://github.com/Azure/azure-sdk-for-python/issues/9256 for more information.

The primary entry point for span creation for most SDKs is through the `distributed_trace` and `distributed_trace_async` decorators which only get access to the function each decorator is wrapping. While package name and version (in most cases) can be determined heuristically, the resource provider value can not reliabily be determined. We need a way for all this information to be readily available.

## Proposed solution

1. Add a `RESOURCE_PROVIDER` constant to the base of all SDK packages inside `_version.py` or a new file like `_about.py`. This value will contain the corresponding value for each SDK.
2. Make the generation of this constant a part of the Python code generation process by adding some flag (like `--resource-provider`/`--provider`) when using autorest.
    - Can add these values to swagger files as a one-time effort for all relevant SDKs, so that resource provider will progressively be populated in each SDK.
3. Also, generate a `PACKAGE_NAME` constant (given by the `--package-name` flag) that has the pip-installable package name of the libary (i.e. `azure-storage-blob`). Since `package_name` is already an autorest argument, we can also propagate the value here to make determining the package name very straightforward.
4. Update guidelines that notes the existence and purpose of these constants.

## What this PR does

This PR makes the assumption that `VERSION`, `RESOURCE_PROVIDER`, and `PACKAGE_NAME` are in each SDK's `_version.py` file. These constants can be discovered and checked inside the `distributed_trace` and `distributed_trace_async` decorators by searching the decorated function module names until a `_version` module is found.  See PR code in `common.py`.

Sample `_version.py`:

```python
VERSION = "12.16.0b1"
RESOURCE_PROVIDER = "Microsoft.Storage"
PACKAGE_NAME = "azure-storage-blob"
```

This information is then extracted and passed to the created spans. The package name and version are passed to the the span constructor, while the resource provider value is added as an attribute with key `az.namespace`.

For the case of span creation inside `DistributedTracingPolicy`, we infer the values by checking the current span which will generally be a span created from inside one of the decorators. 

## Alternative solutions

1. Can also set dunder variables (e.g. `__resource_provider__`) defined in `__init__.py` at the base namespace. Would be similar logic to read these as reading constants from `_version.py`.
3. Another solution could be to make a "module/package name" -> "Resource provider" dictionary (e.g. `{ "azure.storage.blob": "Microsoft.Storage", "azure.ai.language.conversations": "Microsoft.CognitiveServices", ...}` in core that the decorators can check based on the function base modules, However, I'd rather we not have to maintain this dictionary, and we leave the responsibility of providing a resource provider to each SDK developer.

## Additional Context

1. The .NET SDK has a required `--provider` flag (see [here](https://github.com/Azure/azure-sdk-for-net/tree/main/eng/templates#list-help-and-toazureresourcemanagerxxx-creation-options-for--this-template)) where users are expected to pass in the project's associated resource provider. This info is then located in the `src/Properites/AssemblyInfo.cs` for each package ([example](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/monitor/Azure.Monitor.Query/src/Properties/AssemblyInfo.cs#L9)).

Ref: https://github.com/Azure/azure-sdk-for-python/issues/25838
