### PR TITLE
[ML][Pipelines] fix: extra kwargs in loading component

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_component/component.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_component/component.py
@@ -323,20 +323,25 @@ class Component(
             for_load=True,
         )
         new_instance = create_instance_func()
-        init_kwargs = new_instance._load_with_schema(  # pylint: disable=protected-access
-            data,
-            context={
-                BASE_PATH_CONTEXT_KEY: base_path,
-                SOURCE_PATH_CONTEXT_KEY: yaml_path,
-                PARAMS_OVERRIDE_KEY: params_override,
-            },
-            unknown=INCLUDE,
-            raise_original_exception=True,
-            **kwargs,
+        # specific keys must be popped before loading with schema using kwargs
+        init_kwargs = {
+            "yaml_str": kwargs.pop("yaml_str", None),
+            "_source": kwargs.pop("_source", ComponentSource.YAML_COMPONENT),
+        }
+        init_kwargs.update(
+            new_instance._load_with_schema(  # pylint: disable=protected-access
+                data,
+                context={
+                    BASE_PATH_CONTEXT_KEY: base_path,
+                    SOURCE_PATH_CONTEXT_KEY: yaml_path,
+                    PARAMS_OVERRIDE_KEY: params_override,
+                },
+                unknown=INCLUDE,
+                raise_original_exception=True,
+                **kwargs,
+            )
         )
         new_instance.__init__(
-            yaml_str=kwargs.pop("yaml_str", None),
-            _source=kwargs.pop("_source", ComponentSource.YAML_COMPONENT),
             **init_kwargs,
         )
         # Set base path separately to avoid doing this in post load, as return types of post load are not unified,

--- a/sdk/ml/azure-ai-ml/tests/component/unittests/test_component_schema.py
+++ b/sdk/ml/azure-ai-ml/tests/component/unittests/test_component_schema.py
@@ -7,11 +7,11 @@ from unittest import mock
 import pydash
 import pytest
 import yaml
-
 from azure.ai.ml import MLClient, load_component
 from azure.ai.ml._restclient.v2022_05_01.models import ComponentVersionData
 from azure.ai.ml._utils._arm_id_utils import PROVIDER_RESOURCE_ID_WITH_VERSION
 from azure.ai.ml.constants._common import BASE_PATH_CONTEXT_KEY, PARAMS_OVERRIDE_KEY, AssetTypes, LegacyAssetTypes
+from azure.ai.ml.constants._component import ComponentSource
 from azure.ai.ml.entities import CommandComponent, Component, PipelineComponent
 from azure.ai.ml.entities._assets import Code
 from azure.ai.ml.entities._component.component import COMPONENT_CODE_PLACEHOLDER, COMPONENT_PLACEHOLDER
@@ -316,6 +316,7 @@ class TestCommandComponent:
             context={
                 "source_path": test_path,
             },
+            _source=ComponentSource.YAML_COMPONENT,
         )
         assert recreated_component._to_dict() == component_entity._to_dict()
 


### PR DESCRIPTION
# Description

Initial code:
```python
result = func(
  kwargs.pop("_source", xxx),
  ** schema.load(xxx, **kwargs)
)
```

Refactored code:
```python
# _source hasn't been popped yet
args = schema.load(xxx, **kwargs)
result = func(
  _source=kwargs.pop("_source", xxx),
  **args
)
```
fixed code:
```python
args = {
  "_source": kwargs.pop("_source", xxx),
}
args.update(schema.load(xxx, **kwargs))
result = func(**args)
```

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
