### PR TITLE
[ML] [Cherry-Pick] Fix `ml_client.jobs.download` for BatchJob (#29316)

### DIFF
--- a/sdk/ml/azure-ai-ml/CHANGELOG.md
+++ b/sdk/ml/azure-ai-ml/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Error message improvement when a local path fails to match with data asset type.
 - Error message improvement when an asset does not exist in a registry
 - Fix an issue when submit spark pipeline job with referring a registered component
+- Fix an issue that prevented Job.download from downloading the output of a BatchJob
 
 ### Other Changes
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/constants/_common.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/constants/_common.py
@@ -115,7 +115,6 @@ EXPERIMENTAL_LINK_MESSAGE = (
 REF_DOC_YAML_SCHEMA_ERROR_MSG_FORMAT = "\nVisit this link to refer to the {} schema if needed: {}."
 STORAGE_AUTH_MISMATCH_ERROR = "AuthorizationPermissionMismatch"
 SWEEP_JOB_BEST_CHILD_RUN_ID_PROPERTY_NAME = "best_child_run_id"
-BATCH_JOB_CHILD_RUN_NAME = "batchscoring"
 BATCH_JOB_CHILD_RUN_OUTPUT_NAME = "score"
 DEFAULT_ARTIFACT_STORE_OUTPUT_NAME = "default"
 DEFAULT_EXPERIMENT_NAME = "Default"

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_job_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_job_operations.py
@@ -50,7 +50,6 @@ from azure.ai.ml._utils.utils import (
 from azure.ai.ml.constants._common import (
     API_URL_KEY,
     AZUREML_RESOURCE_PROVIDER,
-    BATCH_JOB_CHILD_RUN_NAME,
     BATCH_JOB_CHILD_RUN_OUTPUT_NAME,
     COMMON_RUNTIME_ENV_VAR,
     DEFAULT_ARTIFACT_STORE_OUTPUT_NAME,
@@ -831,12 +830,13 @@ class JobOperations(_ScopeDependentOperations):
     def _get_batch_job_scoring_output_uri(self, job_name: str) -> Optional[str]:
         uri = None
         # Download scoring output, which is the "score" output of the child job named "batchscoring"
+        # Batch Jobs are pipeline jobs with only one child, so this should terminate after an iteration
         for child in self._runs_operations.get_run_children(job_name):
-            if child.properties.get("azureml.moduleName", None) == BATCH_JOB_CHILD_RUN_NAME:
-                uri = self._get_named_output_uri(child.name, BATCH_JOB_CHILD_RUN_OUTPUT_NAME).get(
-                    BATCH_JOB_CHILD_RUN_OUTPUT_NAME, None
-                )
-                # After the correct child is found, break to prevent unnecessary looping
+            uri = self._get_named_output_uri(child.name, BATCH_JOB_CHILD_RUN_OUTPUT_NAME).get(
+                BATCH_JOB_CHILD_RUN_OUTPUT_NAME, None
+            )
+            # After the correct child is found, break to prevent unnecessary looping
+            if uri is not None:
                 break
         return uri
 

--- a/sdk/ml/ci.yml
+++ b/sdk/ml/ci.yml
@@ -29,6 +29,7 @@ extends:
   parameters:
     ServiceDirectory: ml
     ValidateFormatting: true
+    TestTimeoutInMinutes: 75
     TestProxy: true
     Artifacts:
     - name: azure-ai-ml


### PR DESCRIPTION
* fix: Avoid matching BatchJob child by name during Job.downlaod

    When downloading a BatchJob, the SDK needed to do a manual search
    through the BatchJob's children to find the output.

    The SDK attempted to make the child by name, but a recent service
    change caused that search to fail.

    BatchJobs only have one child, so matching by name is largely
    unnecessary anyway.

* Update CHANGELOG.md

# Description

Please add an informative description that covers that changes made by the pull request and link all relevant issues.

If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
