### PR TITLE
[ML][Pipelines] Revert PR 28951 to improve CI performance

### DIFF
--- a/sdk/ml/azure-ai-ml/tests/conftest.py
+++ b/sdk/ml/azure-ai-ml/tests/conftest.py
@@ -100,6 +100,22 @@ def add_sanitizers(test_proxy, fake_datastore_key):
         group_for_replace="1",
     )
 
+    # identity_json_paths = [
+    #     ".systemData.createdBy",
+    #     ".systemData.lastModifiedBy",
+    #     ".createdBy.userName",
+    #     ".lastModifiedBy.userName",
+    #     ".runMetadata.createdBy.userName",
+    #     ".runMetadata.lastModifiedBy.userName",
+    # ]
+    # identity_replacements = [("Firstname Lastname", r".+\s.+"), ("alias@contoso.com", r".+@.+")]
+    #
+    # for path in identity_json_paths:
+    #     for replacement, regexp in identity_replacements:
+    #         add_body_key_sanitizer(json_path=path, value=replacement, regex=regexp)
+    #         # Try to match in arrays too
+    #         add_body_key_sanitizer(json_path=f".value[*]{path}", value=replacement, regex=regexp)
+
 
 def pytest_addoption(parser):
     parser.addoption("--location", action="store", default="eastus2euap")

--- a/sdk/ml/azure-ai-ml/tests/conftest.py
+++ b/sdk/ml/azure-ai-ml/tests/conftest.py
@@ -100,22 +100,6 @@ def add_sanitizers(test_proxy, fake_datastore_key):
         group_for_replace="1",
     )
 
-    # identity_json_paths = [
-    #     ".systemData.createdBy",
-    #     ".systemData.lastModifiedBy",
-    #     ".createdBy.userName",
-    #     ".lastModifiedBy.userName",
-    #     ".runMetadata.createdBy.userName",
-    #     ".runMetadata.lastModifiedBy.userName",
-    # ]
-    # identity_replacements = [("Firstname Lastname", r".+\s.+"), ("alias@contoso.com", r".+@.+")]
-    #
-    # for path in identity_json_paths:
-    #     for replacement, regexp in identity_replacements:
-    #         add_body_key_sanitizer(json_path=path, value=replacement, regex=regexp)
-    #         # Try to match in arrays too
-    #         add_body_key_sanitizer(json_path=f".value[*]{path}", value=replacement, regex=regexp)
-
 
 def pytest_addoption(parser):
     parser.addoption("--location", action="store", default="eastus2euap")

--- a/sdk/ml/azure-ai-ml/tests/conftest.py
+++ b/sdk/ml/azure-ai-ml/tests/conftest.py
@@ -100,21 +100,21 @@ def add_sanitizers(test_proxy, fake_datastore_key):
         group_for_replace="1",
     )
 
-    identity_json_paths = [
-        ".systemData.createdBy",
-        ".systemData.lastModifiedBy",
-        ".createdBy.userName",
-        ".lastModifiedBy.userName",
-        ".runMetadata.createdBy.userName",
-        ".runMetadata.lastModifiedBy.userName",
-    ]
-    identity_replacements = [("Firstname Lastname", r".+\s.+"), ("alias@contoso.com", r".+@.+")]
-
-    for path in identity_json_paths:
-        for replacement, regexp in identity_replacements:
-            add_body_key_sanitizer(json_path=path, value=replacement, regex=regexp)
-            # Try to match in arrays too
-            add_body_key_sanitizer(json_path=f".value[*]{path}", value=replacement, regex=regexp)
+    # identity_json_paths = [
+    #     ".systemData.createdBy",
+    #     ".systemData.lastModifiedBy",
+    #     ".createdBy.userName",
+    #     ".lastModifiedBy.userName",
+    #     ".runMetadata.createdBy.userName",
+    #     ".runMetadata.lastModifiedBy.userName",
+    # ]
+    # identity_replacements = [("Firstname Lastname", r".+\s.+"), ("alias@contoso.com", r".+@.+")]
+    #
+    # for path in identity_json_paths:
+    #     for replacement, regexp in identity_replacements:
+    #         add_body_key_sanitizer(json_path=path, value=replacement, regex=regexp)
+    #         # Try to match in arrays too
+    #         add_body_key_sanitizer(json_path=f".value[*]{path}", value=replacement, regex=regexp)
 
 
 def pytest_addoption(parser):

--- a/sdk/ml/azure-ai-ml/tests/conftest.py
+++ b/sdk/ml/azure-ai-ml/tests/conftest.py
@@ -100,6 +100,22 @@ def add_sanitizers(test_proxy, fake_datastore_key):
         group_for_replace="1",
     )
 
+    identity_json_paths = [
+        ".systemData.createdBy",
+        ".systemData.lastModifiedBy",
+        ".createdBy.userName",
+        ".lastModifiedBy.userName",
+        ".runMetadata.createdBy.userName",
+        ".runMetadata.lastModifiedBy.userName",
+    ]
+    identity_replacements = [("Firstname Lastname", r".+\s.+"), ("alias@contoso.com", r".+@.+")]
+
+    for path in identity_json_paths:
+        for replacement, regexp in identity_replacements:
+            add_body_key_sanitizer(json_path=path, value=replacement, regex=regexp)
+            # Try to match in arrays too
+            add_body_key_sanitizer(json_path=f".value[*]{path}", value=replacement, regex=regexp)
+
 
 def pytest_addoption(parser):
     parser.addoption("--location", action="store", default="eastus2euap")

--- a/sdk/ml/azure-ai-ml/tests/conftest.py
+++ b/sdk/ml/azure-ai-ml/tests/conftest.py
@@ -100,22 +100,6 @@ def add_sanitizers(test_proxy, fake_datastore_key):
         group_for_replace="1",
     )
 
-    identity_json_paths = [
-        ".systemData.createdBy",
-        ".systemData.lastModifiedBy",
-        ".createdBy.userName",
-        ".lastModifiedBy.userName",
-        ".runMetadata.createdBy.userName",
-        ".runMetadata.lastModifiedBy.userName",
-    ]
-    identity_replacements = [("Firstname Lastname", r".+\s.+"), ("alias@contoso.com", r".+@.+")]
-
-    for path in identity_json_paths:
-        for replacement, regexp in identity_replacements:
-            add_body_key_sanitizer(json_path=path, value=replacement, regex=regexp)
-            # Try to match in arrays too
-            add_body_key_sanitizer(json_path=f".value[*]{path}", value=replacement, regex=regexp)
-
 
 def pytest_addoption(parser):
     parser.addoption("--location", action="store", default="eastus2euap")


### PR DESCRIPTION
# Description

This PR targets to revert #28951 to improve CI performance.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
