### PR TITLE
refactor(azure-eventhub): add defensive assert

### DIFF
--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_eventprocessor/ownership_manager.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_eventprocessor/ownership_manager.py
@@ -96,6 +96,7 @@ class OwnershipManager(object):  # pylint:disable=too-many-instance-attributes
         ]
         if not partition_ownership:
             return
+        assert len(partition_ownership) == 1
         partition_ownership[0]["owner_id"] = ""
         self.checkpoint_store.claim_ownership(partition_ownership)
 


### PR DESCRIPTION
# Description

It should never happen that there is more than one partition that satisfies the filters. If it does happens for some reason (manual modification of ownership information, bug in code, etc.) this assert will reveal it and stops the code that might otherwise lead to undeterministic and unexpected behaviour.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
