### PR TITLE
Update all usages of `pip` to `python -m pip`

### DIFF
--- a/eng/pipelines/autorest_checks.yml
+++ b/eng/pipelines/autorest_checks.yml
@@ -49,16 +49,16 @@ jobs:
 
       - script: |
           cd $(Build.SourcesDirectory)/autorest.python/packages/autorest.python/test/vanilla/legacy
-          pip install $(Build.SourcesDirectory)/$(source_path_azure_core)
-          pip install -r requirements.txt
+          python -m pip install $(Build.SourcesDirectory)/$(source_path_azure_core)
+          python -m pip install -r requirements.txt
           pip freeze
           pytest $(Build.SourcesDirectory)/autorest.python/packages/autorest.python/test/vanilla/legacy
         displayName: 'Install azure-core and Test Vanilla Legacy'
 
       - script: |
           cd $(Build.SourcesDirectory)/autorest.python/packages/autorest.python/test/azure/legacy
-          pip install $(Build.SourcesDirectory)/$(source_path_azure_mgmt_core)
-          pip install -r requirements.txt
+          python -m pip install $(Build.SourcesDirectory)/$(source_path_azure_mgmt_core)
+          python -m pip install -r requirements.txt
           pip freeze
           pytest $(Build.SourcesDirectory)/autorest.python/packages/autorest.python/test/azure/legacy
         displayName: 'Install azure-mgmt-core and Test Azure Legacy'

--- a/eng/pipelines/docindex.yml
+++ b/eng/pipelines/docindex.yml
@@ -21,7 +21,7 @@ jobs:
           versionSpec: '3.9.13'
 
       # Docs CI upgrades pip, wheel, and setuptools
-      - pwsh: pip install --upgrade pip wheel setuptools
+      - pwsh: python -m pip install --upgrade pip wheel setuptools
         displayName: Update python tools for package verification
 
       # Pull and build the docker image.

--- a/eng/pipelines/generate-all-docs.yml
+++ b/eng/pipelines/generate-all-docs.yml
@@ -21,7 +21,7 @@ jobs:
           versionSpec: '$(PythonVersion)'
 
       - script: |
-          pip install -r eng/ci_tools.txt
+          python -m pip install -r eng/ci_tools.txt
         displayName: 'Prep Environment'
 
       - task: PythonScript@0

--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -182,7 +182,7 @@ jobs:
             GenerateVMJobs: true
       PreGenerationSteps:
         - pwsh: |
-            pip install "./tools/azure-sdk-tools[build]"
+            python -m pip install "./tools/azure-sdk-tools[build]"
           displayName: 'Prep Environment'
         - template: /eng/pipelines/templates/steps/targeting-string-resolve.yml
           parameters:

--- a/eng/pipelines/templates/jobs/regression.yml
+++ b/eng/pipelines/templates/jobs/regression.yml
@@ -84,7 +84,7 @@ jobs:
 
       - pwsh: |
           mkdir -p $(TEST_PROXY_FOLDER)
-          pip install -r eng/regression_tools.txt
+          python -m pip install -r eng/regression_tools.txt
         displayName: 'Prep Environment'
 
       - template: /eng/common/testproxy/test-proxy-tool.yml

--- a/eng/pipelines/templates/jobs/run-cli-tests.yml
+++ b/eng/pipelines/templates/jobs/run-cli-tests.yml
@@ -67,14 +67,14 @@ jobs:
         - bash: |
             set -ev
             source env/bin/activate
-            pip install -e $(Build.SourcesDirectory)/${{ artifact }}
+            python -m pip install -e $(Build.SourcesDirectory)/${{ artifact }}
           displayName: Install ${{ artifact }} 
 
       - ${{ each package_spec in parameters.InjectedPackages }}:
         - bash: |
             set -ev
             source env/bin/activate
-            pip install -e ${{ package_spec }}
+            python -m pip install -e ${{ package_spec }}
           displayName: Install ${{ package_spec }} 
 
       - bash: |

--- a/eng/pipelines/templates/jobs/smoke.tests.yml
+++ b/eng/pipelines/templates/jobs/smoke.tests.yml
@@ -192,8 +192,8 @@ jobs:
         - pwsh: |
             $ErrorActionPreference = "Continue"
             while ($retries++ -lt 15) {
-              Write-Host "pip install -r $(requirements) --no-deps --upgrade --no-cache-dir"
-              pip install -r "$(requirements)" --no-deps --upgrade --no-cache-dir
+              Write-Host "python -m pip install -r $(requirements) --no-deps --upgrade --no-cache-dir"
+              python -m pip install -r "$(requirements)" --no-deps --upgrade --no-cache-dir
               if ($LASTEXITCODE) {
                 if ($retries -ge 15) {
                   exit $LASTEXITCODE
@@ -208,12 +208,12 @@ jobs:
 
       - ${{ if eq(parameters.Daily, true) }}:
         - pwsh: |
-            pip install -r "$(requirements)" --pre --no-deps --upgrade `
+            python -m pip install -r "$(requirements)" --pre --no-deps --upgrade `
               --index-url https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-python/pypi/simple
 
           displayName: Install requirements from dev feed without dependencies
 
-      - pwsh: pip install -r $(Build.SourcesDirectory)/common/smoketest/requirements_async.txt
+      - pwsh: python -m pip install -r $(Build.SourcesDirectory)/common/smoketest/requirements_async.txt
         displayName: "Install requirements_async.txt"
         condition: and(succeeded(), ne(variables['SkipAsyncInstall'], true))
 
@@ -222,10 +222,10 @@ jobs:
             | Out-File $(Build.SourcesDirectory)/common/smoketest/requirements_dependencies.txt
         displayName: Create dependency list from installed packages
 
-      - script: pip install -r $(Build.SourcesDirectory)/common/smoketest/requirements_dependencies.txt
+      - script: python -m pip install -r $(Build.SourcesDirectory)/common/smoketest/requirements_dependencies.txt
         displayName: Install package dependencies from PyPI
 
-      - script: pip freeze
+      - script: python -m pip freeze
         displayName: Show installed packages (pip freeze)
 
       - template: /eng/common/TestResources/deploy-test-resources.yml

--- a/eng/pipelines/templates/jobs/tests-nightly-python.yml
+++ b/eng/pipelines/templates/jobs/tests-nightly-python.yml
@@ -22,8 +22,8 @@ jobs:
       - script: |
           python -m pip freeze
           python -m pip --version
-          pip install setuptools==56.0.0 wheel==0.37.0 tox==3.24.3 tox-monorepo==0.1.2 packaging==21.0 requests
-          pip install $(Build.SourcesDirectory)/tools/azure-sdk-tools[build]
+          python -m pip install setuptools==56.0.0 wheel==0.37.0 tox==3.24.3 tox-monorepo==0.1.2 packaging==21.0 requests
+          python -m pip install $(Build.SourcesDirectory)/tools/azure-sdk-tools[build]
         displayName: Install Dependencies
 
       - template: /eng/common/testproxy/test-proxy-tool.yml
@@ -67,8 +67,8 @@ jobs:
           sudo apt-get install build-essential -y
           python -m pip freeze
           python -m pip --version
-          pip install setuptools==56.0.0 wheel==0.37.0 tox==3.24.3 tox-monorepo==0.1.2 packaging==21.0 requests
-          pip install $(Build.SourcesDirectory)/tools/azure-sdk-tools[build]
+          python -m pip install setuptools==56.0.0 wheel==0.37.0 tox==3.24.3 tox-monorepo==0.1.2 packaging==21.0 requests
+          python -m pip install $(Build.SourcesDirectory)/tools/azure-sdk-tools[build]
         displayName: Install Dependencies
 
       - template: /eng/common/testproxy/test-proxy-tool.yml

--- a/eng/pipelines/templates/jobs/trigger-ml-sample-pipeline.yml
+++ b/eng/pipelines/templates/jobs/trigger-ml-sample-pipeline.yml
@@ -39,8 +39,8 @@ jobs:
         versionSpec: $(PythonVersion)
 
     - script: |
-        pip install -r eng/ci_tools.txt
-        pip install -r eng/ml_sample_tools.txt
+        python -m pip install -r eng/ci_tools.txt
+        python -m pip install -r eng/ml_sample_tools.txt
       displayName: 'Prep Environment'
 
     - pwsh: |

--- a/eng/pipelines/templates/stages/archetype-python-release.yml
+++ b/eng/pipelines/templates/stages/archetype-python-release.yml
@@ -85,8 +85,8 @@ stages:
 
                       - script: |
                           set -e
-                          pip install -r eng/release_requirements.txt
-                          pip install tools/azure-sdk-tools
+                          python -m pip install -r eng/release_requirements.txt
+                          python -m pip install tools/azure-sdk-tools
                         displayName: Install Release Dependencies
 
                       - task: PythonScript@0
@@ -206,7 +206,7 @@ stages:
                       - checkout: self
                       - task: UsePythonVersion@0
                       - script: |
-                          pip install "./tools/azure-sdk-tools[build]"
+                          python -m pip install "./tools/azure-sdk-tools[build]"
                         displayName: Install versioning tool dependencies
                       - pwsh: |
                           sdk_increment_version --package-name ${{ artifact.name }} --service ${{ parameters.ServiceDirectory }}
@@ -245,7 +245,7 @@ stages:
       - task: UsePythonVersion@0
       - script: |
           set -e
-          pip install twine
+          python -m pip install twine
         displayName: Install Twine
 
       - template: ../steps/auth-dev-feed.yml

--- a/eng/pipelines/templates/steps/analyze.yml
+++ b/eng/pipelines/templates/steps/analyze.yml
@@ -40,12 +40,12 @@ steps:
           ForRelease: false
 
   - pwsh: |
-     pip install -r eng/ci_tools.txt $(if($IsWindows) {"--user" })
+     python -m pip install -r eng/ci_tools.txt $(if($IsWindows) {"--user" })
     displayName: 'Install Necessary Dependencies'
     condition: succeededOrFailed()
 
   - script: |
-      pip install "./tools/azure-sdk-tools[build]" -q -I
+      python -m pip install "./tools/azure-sdk-tools[build]" -q -I
       sdk_find_invalid_versions --always-succeed --service=${{parameters.ServiceDirectory}}
     displayName: Find Invalid Versions
     condition: succeededOrFailed()

--- a/eng/pipelines/templates/steps/build-artifacts.yml
+++ b/eng/pipelines/templates/steps/build-artifacts.yml
@@ -43,7 +43,7 @@ steps:
       versionSpec: $(PythonVersion)
 
   - script: |
-      pip install -r eng/ci_tools.txt
+      python -m pip install -r eng/ci_tools.txt
     displayName: 'Prep Environment'
 
   - template: ../steps/set-dev-build.yml

--- a/eng/pipelines/templates/steps/build-conda-artifacts.yml
+++ b/eng/pipelines/templates/steps/build-conda-artifacts.yml
@@ -22,7 +22,7 @@ steps:
       versionSpec: $(PythonVersion)
 
   - script: |
-      pip install -r eng/ci_tools.txt
+      python -m pip install -r eng/ci_tools.txt
     displayName: 'Prep Environment'
 
   - pwsh: |

--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -34,7 +34,7 @@ steps:
   - script: |
       python -m pip install pip==20.3.3
       python -m pip install wheel==0.37.0
-      pip install -r eng/ci_tools.txt
+      python -m pip install -r eng/ci_tools.txt
       pip --version
       pip freeze
     displayName: 'Prep Environment'

--- a/eng/pipelines/templates/steps/run_apistub.yml
+++ b/eng/pipelines/templates/steps/run_apistub.yml
@@ -15,7 +15,7 @@ steps:
     condition: and(succeededOrFailed(), ne(variables['Skip.ApiStubGen'],'true'))
 
   - script: |
-      pip install -r eng/ci_tools.txt
+      python -m pip install -r eng/ci_tools.txt
     displayName: 'Prep Environment'
 
   - task: PythonScript@0

--- a/eng/pipelines/templates/steps/run_bandit.yml
+++ b/eng/pipelines/templates/steps/run_bandit.yml
@@ -11,7 +11,7 @@ parameters:
 # Please use `$(TargetingString)` to refer to the python packages glob string. This was previously `${{ parameters.BuildTargetingString }}`.
 steps:
   - script: |
-      pip install -r eng/ci_tools.txt
+      python -m pip install -r eng/ci_tools.txt
     displayName: 'Prep Environment'
     condition: and(succeededOrFailed(), ne(variables['Skip.Bandit'],'true'))
 

--- a/eng/pipelines/templates/steps/run_black.yml
+++ b/eng/pipelines/templates/steps/run_black.yml
@@ -11,7 +11,7 @@ steps:
     condition: succeededOrFailed()
 
   - script: |
-      pip install black==22.3.0 tools/azure-sdk-tools["build"]
+      python -m pip install black==22.3.0 tools/azure-sdk-tools["build"]
     displayName: 'Prep Environment'
     condition: succeededOrFailed()
 

--- a/eng/pipelines/templates/steps/run_pylint.yml
+++ b/eng/pipelines/templates/steps/run_pylint.yml
@@ -17,7 +17,7 @@ steps:
     condition: and(succeededOrFailed(), ne(variables['Skip.Pylint'],'true'))    
 
   - script: |
-      pip install -r eng/ci_tools.txt
+      python -m pip install -r eng/ci_tools.txt
     displayName: 'Prep Environment'
     condition: and(succeededOrFailed(), ne(variables['Skip.Pylint'],'true'))
 

--- a/eng/pipelines/templates/steps/run_pyright.yml
+++ b/eng/pipelines/templates/steps/run_pyright.yml
@@ -17,7 +17,7 @@ steps:
     condition: and(succeededOrFailed(), or(ne(variables['Skip.Pyright'],'true'), ne(variables['Skip.Verifytypes'],'true')))
 
   - script: |
-      pip install -r eng/ci_tools.txt
+      python -m pip install -r eng/ci_tools.txt
     displayName: 'Prep Environment'
     condition: and(succeededOrFailed(), or(ne(variables['Skip.Pyright'],'true'), ne(variables['Skip.Verifytypes'],'true')))
 

--- a/eng/pipelines/templates/steps/seed-virtualenv-wheels.yml
+++ b/eng/pipelines/templates/steps/seed-virtualenv-wheels.yml
@@ -5,7 +5,7 @@ parameters:
 
 steps:
   - pwsh: |
-      pip install virtualenv
+      python -m pip install virtualenv
     displayName: Ensure virtualenv installed
 
   - pwsh: |

--- a/eng/pipelines/templates/steps/set-dev-build.yml
+++ b/eng/pipelines/templates/steps/set-dev-build.yml
@@ -13,7 +13,7 @@ steps:
       ServiceDirectory: ${{ parameters.ServiceDirectory }}
 
   - pwsh: |
-      pip install "tools/azure-sdk-tools[build]"
+      python -m pip install "tools/azure-sdk-tools[build]"
       sdk_set_dev_version "$(TargetingString)" --service="${{parameters.ServiceDirectory}}" --build-id="$(Build.BuildNumber)"
     displayName: "Update package versions for dev build"
     condition: and(succeededOrFailed(), eq(variables['SetDevVersion'],'true'))

--- a/eng/pipelines/templates/steps/use-python-version.yml
+++ b/eng/pipelines/templates/steps/use-python-version.yml
@@ -9,7 +9,7 @@ steps:
       versionSpec: 3.8
 
   - pwsh: |
-      pip install packaging==20.4
+      python -m pip install packaging==20.4
     displayName: Prep Environment
 
   # select the appropriate version from manifest if present

--- a/scripts/auto_release/PythonSdkLiveTest.yml
+++ b/scripts/auto_release/PythonSdkLiveTest.yml
@@ -71,7 +71,7 @@ jobs:
         # create virtual env
         python -m venv venv-sdk
         source venv-sdk/bin/activate
-        pip install -r $script_path/requirement.txt
+        python -m pip install -r $script_path/requirement.txt
 
         # import env variable
         export AZURE_TEST_RUN_LIVE=$(AZURE_TEST_RUN_LIVE)

--- a/scripts/collect_api_version_for_multi_api_sdk/collect_api_version.yml
+++ b/scripts/collect_api_version_for_multi_api_sdk/collect_api_version.yml
@@ -43,7 +43,7 @@ jobs:
         # create virtual env
         python -m venv venv-sdk
         source venv-sdk/bin/activate
-        pip install -r $script_path/requirement.txt
+        python -m pip install -r $script_path/requirement.txt
 
         # run
         cd file-storage

--- a/scripts/issue_helper/issue_helper.yml
+++ b/scripts/issue_helper/issue_helper.yml
@@ -55,7 +55,7 @@ jobs:
         # create virtual env
         python -m venv venv-sdk
         source venv-sdk/bin/activate
-        pip install -r $script_path/requirement.txt
+        python -m pip install -r $script_path/requirement.txt
 
         # checkout the target branch
         cd file-storage

--- a/scripts/release_helper/release_helper.yml
+++ b/scripts/release_helper/release_helper.yml
@@ -61,7 +61,7 @@ jobs:
         # create virtual env
         python -m venv venv-sdk
         source venv-sdk/bin/activate
-        pip install -r $script_path/requirement.txt
+        python -m pip install -r $script_path/requirement.txt
 
         # checkout the target branch
         cd file-storage

--- a/scripts/release_sdk_status/release_sdk_status.yml
+++ b/scripts/release_sdk_status/release_sdk_status.yml
@@ -65,7 +65,7 @@ jobs:
         # create virtual env
         python -m venv venv-sdk
         source venv-sdk/bin/activate
-        pip install -r $script_path/requirement.txt
+        python -m pip install -r $script_path/requirement.txt
 
         # checkout the target branch
         cd file-storage


### PR DESCRIPTION
@mikeharder 

@mccoyp context on this change is if we remove all remaining bare `pip install`, then we can unpin the agent image version and allow it to float forward. The python versions are only broken if you don't have the prefixed `python -m pip`, which all of our _tooling_ does. It's only the yml level install calls that have this issue.