### PR TITLE
[ML-Pipelines] set user token for pipeline job

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_job_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_job_operations.py
@@ -539,8 +539,10 @@ class JobOperations(_ScopeDependentOperations):
 
             # Make a copy of self._kwargs instead of contaminate the original one
             kwargs = dict(**self._kwargs)
-            if hasattr(rest_job_resource.properties, "identity") and (
-                isinstance(rest_job_resource.properties.identity, UserIdentity)
+            # set headers with user aml token if job is a pipeline or has a user identity setting
+            if (rest_job_resource.properties.job_type == "Pipeline") or (
+                hasattr(rest_job_resource.properties, "identity")
+                and (isinstance(rest_job_resource.properties.identity, UserIdentity))
             ):
                 self._set_headers_with_user_aml_token(kwargs)
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_job_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_job_operations.py
@@ -540,7 +540,7 @@ class JobOperations(_ScopeDependentOperations):
             # Make a copy of self._kwargs instead of contaminate the original one
             kwargs = dict(**self._kwargs)
             # set headers with user aml token if job is a pipeline or has a user identity setting
-            if (rest_job_resource.properties.job_type == "Pipeline") or (
+            if (rest_job_resource.properties.job_type == RestJobType.PIPELINE) or (
                 hasattr(rest_job_resource.properties, "identity")
                 and (isinstance(rest_job_resource.properties.identity, UserIdentity))
             ):


### PR DESCRIPTION
# Description

Set user token for pipeline job. 
A spark step in pipeline may be set as UserIdentity, which could be in a nested layer of pipeline component, which we cannot tell from pipeline job root layer. 
Following UI practice always sending the request with user token when it is a pipeline job.

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
