### PR TITLE
fix case change blob_prefix not coherent other sdk

### DIFF
--- a/sdk/eventhub/azure-eventhub-checkpointstoreblob-aio/azure/eventhub/extensions/checkpointstoreblobaio/_blobstoragecsaio.py
+++ b/sdk/eventhub/azure-eventhub-checkpointstoreblob-aio/azure/eventhub/extensions/checkpointstoreblobaio/_blobstoragecsaio.py
@@ -189,7 +189,7 @@ class BlobCheckpointStore(CheckpointStore):
                 fully_qualified_namespace, eventhub_name, consumer_group
             )
             blobs = self._container_client.list_blobs(
-                name_starts_with=blob_prefix.lower(), include=["metadata"], **kwargs
+                name_starts_with=blob_prefix, include=["metadata"], **kwargs
             )
             result = []
             async for blob in blobs:
@@ -312,7 +312,7 @@ class BlobCheckpointStore(CheckpointStore):
             fully_qualified_namespace, eventhub_name, consumer_group
         )
         blobs = self._container_client.list_blobs(
-            name_starts_with=blob_prefix.lower(), include=["metadata"], **kwargs
+            name_starts_with=blob_prefix, include=["metadata"], **kwargs
         )
         result = []
         async for blob in blobs:

--- a/sdk/eventhub/azure-eventhub-checkpointstoreblob/azure/eventhub/extensions/checkpointstoreblob/_blobstoragecs.py
+++ b/sdk/eventhub/azure-eventhub-checkpointstoreblob/azure/eventhub/extensions/checkpointstoreblob/_blobstoragecs.py
@@ -209,7 +209,7 @@ class BlobCheckpointStore(CheckpointStore):
                 fully_qualified_namespace, eventhub_name, consumer_group
             )
             blobs = self._container_client.list_blobs(
-                name_starts_with=blob_prefix.lower(), include=["metadata"], **kwargs
+                name_starts_with=blob_prefix, include=["metadata"], **kwargs
             )
             result = []
             for blob in blobs:
@@ -331,7 +331,7 @@ class BlobCheckpointStore(CheckpointStore):
             fully_qualified_namespace, eventhub_name, consumer_group
         )
         blobs = self._container_client.list_blobs(
-            name_starts_with=blob_prefix.lower(), include=["metadata"], **kwargs
+            name_starts_with=blob_prefix, include=["metadata"], **kwargs
         )
         result = []
         for b in blobs:


### PR DESCRIPTION
# Description

The BlobCheckpointStore class in the Python Azure SDK uses the lower() method to transform the blob prefix for the checkpoint path, which can cause problems when working with other languages that do not use the same transformation.

Specifically, when the consumer group name includes uppercase letters (like $Default), the lower() method in the Python SDK transforms the consumer group name to lowercase, resulting in a different prefix that may not be found when the checkpoint was created using azure sdk with other languages.

This issue does not occur in the Java, JavaScript, or Go SDKs because these SDKs do not transform the prefix.



