### PR TITLE
[Key Vault] Move away from `TYPE_CHECKING`

### DIFF
--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_client.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_client.py
@@ -5,7 +5,9 @@
 # pylint:disable=too-many-lines,too-many-public-methods
 import base64
 from functools import partial
+from typing import Any, List, Optional, Union
 
+from azure.core.paging import ItemPaged
 from azure.core.polling import LROPoller
 from azure.core.tracing.decorator import distributed_trace
 
@@ -23,16 +25,6 @@ from ._models import (
     CertificateOperation,
 )
 from ._polling import CreateCertificatePoller
-
-try:
-    from typing import TYPE_CHECKING
-except ImportError:
-    TYPE_CHECKING = False
-
-if TYPE_CHECKING:
-    # pylint:disable=unused-import
-    from typing import Any, List, Optional, Union
-    from azure.core.paging import ItemPaged
 
 
 NO_SAN_OR_SUBJECT = "You need to set either subject or one of the subject alternative names parameters in the policy"
@@ -67,7 +59,7 @@ class CertificateClient(KeyVaultClientBase):
     @distributed_trace
     def begin_create_certificate(
         self, certificate_name: str, policy: CertificatePolicy, **kwargs
-    ) -> "LROPoller[Union[KeyVaultCertificate, CertificateOperation]]":
+    ) -> LROPoller[Union[KeyVaultCertificate, CertificateOperation]]:
         """Creates a new certificate.
 
         If this is the first version, the certificate resource is created. This operation requires the
@@ -453,7 +445,7 @@ class CertificateClient(KeyVaultClientBase):
 
     @distributed_trace
     def update_certificate_properties(
-        self, certificate_name: str, version: "Optional[str]" = None, **kwargs
+        self, certificate_name: str, version: Optional[str] = None, **kwargs
     ) -> KeyVaultCertificate:
         """Change a certificate's properties. Requires certificates/update permission.
 
@@ -562,7 +554,7 @@ class CertificateClient(KeyVaultClientBase):
         return KeyVaultCertificate._from_certificate_bundle(certificate_bundle=bundle)
 
     @distributed_trace
-    def list_deleted_certificates(self, **kwargs) -> "ItemPaged[DeletedCertificate]":
+    def list_deleted_certificates(self, **kwargs) -> ItemPaged[DeletedCertificate]:
         """Lists the currently-recoverable deleted certificates. Possible only if vault is soft-delete enabled.
 
         Requires certificates/get/list permission. Retrieves the certificates in the current vault which are in a
@@ -602,7 +594,7 @@ class CertificateClient(KeyVaultClientBase):
         )
 
     @distributed_trace
-    def list_properties_of_certificates(self, **kwargs) -> "ItemPaged[CertificateProperties]":
+    def list_properties_of_certificates(self, **kwargs) -> ItemPaged[CertificateProperties]:
         """List identifiers and properties of all certificates in the vault.
 
         Requires certificates/list permission.
@@ -642,7 +634,7 @@ class CertificateClient(KeyVaultClientBase):
     @distributed_trace
     def list_properties_of_certificate_versions(
         self, certificate_name: str, **kwargs
-    ) -> "ItemPaged[CertificateProperties]":
+    ) -> ItemPaged[CertificateProperties]:
         """List the identifiers and properties of a certificate's versions.
 
         Requires certificates/list permission.
@@ -673,7 +665,7 @@ class CertificateClient(KeyVaultClientBase):
         )
 
     @distributed_trace
-    def set_contacts(self, contacts: "List[CertificateContact]", **kwargs) -> "List[CertificateContact]":
+    def set_contacts(self, contacts: List[CertificateContact], **kwargs) -> List[CertificateContact]:
         """Sets the certificate contacts for the key vault. Requires certificates/managecontacts permission.
 
         :param contacts: The contact list for the vault certificates.
@@ -703,7 +695,7 @@ class CertificateClient(KeyVaultClientBase):
         ]
 
     @distributed_trace
-    def get_contacts(self, **kwargs) -> "List[CertificateContact]":
+    def get_contacts(self, **kwargs) -> List[CertificateContact]:
         """Gets the certificate contacts for the key vault. Requires the certificates/managecontacts permission.
 
         :return: The certificate contacts for the key vault.
@@ -723,7 +715,7 @@ class CertificateClient(KeyVaultClientBase):
         return [CertificateContact._from_certificate_contacts_item(contact_item=item) for item in contacts.contact_list]
 
     @distributed_trace
-    def delete_contacts(self, **kwargs) -> "List[CertificateContact]":
+    def delete_contacts(self, **kwargs) -> List[CertificateContact]:
         """Deletes the certificate contacts for the key vault. Requires the certificates/managecontacts permission.
 
         :return: The deleted contacts for the key vault.
@@ -803,7 +795,7 @@ class CertificateClient(KeyVaultClientBase):
 
     @distributed_trace
     def merge_certificate(
-        self, certificate_name: str, x509_certificates: "List[bytes]", **kwargs
+        self, certificate_name: str, x509_certificates: List[bytes], **kwargs
     ) -> KeyVaultCertificate:
         """Merges a certificate or a certificate chain with a key pair existing on the server.
 
@@ -913,7 +905,7 @@ class CertificateClient(KeyVaultClientBase):
         else:
             issuer_credentials = None
         if admin_contacts:
-            admin_details = [
+            admin_details: Optional[List[Any]] = [
                 self._models.AdministratorDetails(
                     first_name=contact.first_name,
                     last_name=contact.last_name,
@@ -921,7 +913,7 @@ class CertificateClient(KeyVaultClientBase):
                     phone=contact.phone,
                 )
                 for contact in admin_contacts
-            ]  # type: Optional[List[Any]]
+            ]
         else:
             admin_details = None
         if organization_id or admin_details:
@@ -976,7 +968,7 @@ class CertificateClient(KeyVaultClientBase):
         else:
             issuer_credentials = None
         if admin_contacts:
-            admin_details = [
+            admin_details: Optional[List[Any]] = [
                 self._models.AdministratorDetails(
                     first_name=contact.first_name,
                     last_name=contact.last_name,
@@ -984,7 +976,7 @@ class CertificateClient(KeyVaultClientBase):
                     phone=contact.phone,
                 )
                 for contact in admin_contacts
-            ]  # type: Optional[List[Any]]
+            ]
         else:
             admin_details = None
         if organization_id or admin_details:
@@ -1035,7 +1027,7 @@ class CertificateClient(KeyVaultClientBase):
         return CertificateIssuer._from_issuer_bundle(issuer_bundle=issuer_bundle)
 
     @distributed_trace
-    def list_properties_of_issuers(self, **kwargs) -> "ItemPaged[IssuerProperties]":
+    def list_properties_of_issuers(self, **kwargs) -> ItemPaged[IssuerProperties]:
         """Lists properties of the certificate issuers for the key vault.
 
         Requires the certificates/manageissuers/getissuers permission.

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_models.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_models.py
@@ -3,6 +3,9 @@
 # Licensed under the MIT License.
 # ------------------------------------
 # pylint: disable=too-many-lines,too-many-public-methods
+from datetime import datetime
+from typing import Dict, Optional, Union, List
+
 from . import _generated_models as models
 from ._shared import parse_key_vault_id
 from ._enums import(
@@ -13,15 +16,6 @@ from ._enums import(
     CertificateContentType,
     WellKnownIssuerNames
 )
-
-try:
-    from typing import TYPE_CHECKING
-except ImportError:
-    TYPE_CHECKING = False
-
-if TYPE_CHECKING:
-    from typing import Any, Dict, Optional, Union, List
-    from datetime import datetime
 
 
 class AdministratorContact(object):
@@ -39,10 +33,10 @@ class AdministratorContact(object):
 
     def __init__(
         self,
-        first_name: "Optional[str]" = None,
-        last_name: "Optional[str]" = None,
-        email: "Optional[str]" = None,
-        phone: "Optional[str]" = None,
+        first_name: Optional[str] = None,
+        last_name: Optional[str] = None,
+        email: Optional[str] = None,
+        phone: Optional[str] = None,
     ) -> None:
         self._first_name = first_name
         self._last_name = last_name
@@ -67,22 +61,22 @@ class AdministratorContact(object):
         )
 
     @property
-    def email(self) -> "Optional[str]":
+    def email(self) -> Optional[str]:
         """:rtype: str or None"""
         return self._email
 
     @property
-    def first_name(self) -> "Optional[str]":
+    def first_name(self) -> Optional[str]:
         """:rtype: str or None"""
         return self._first_name
 
     @property
-    def last_name(self) -> "Optional[str]":
+    def last_name(self) -> Optional[str]:
         """:rtype: str or None"""
         return self._last_name
 
     @property
-    def phone(self) -> "Optional[str]":
+    def phone(self) -> Optional[str]:
         """:rtype: str or None"""
         return self._phone
 
@@ -152,7 +146,7 @@ class CertificateProperties(object):
 
     @classmethod
     def _from_certificate_item(
-        cls, certificate_item: "Union[models.CertificateItem, models.CertificateBundle]"
+        cls, certificate_item: Union[models.CertificateItem, models.CertificateBundle]
     ) -> "CertificateProperties":
         """Construct a CertificateProperties from an autorest-generated CertificateItem"""
         return cls(
@@ -179,7 +173,7 @@ class CertificateProperties(object):
         return self._vault_id.name
 
     @property
-    def enabled(self) -> "Optional[bool]":
+    def enabled(self) -> Optional[bool]:
         """Whether the certificate is enabled or not.
 
         :rtype: bool or None
@@ -187,7 +181,7 @@ class CertificateProperties(object):
         return self._attributes.enabled if self._attributes else None
 
     @property
-    def not_before(self) -> "Optional[datetime]":
+    def not_before(self) -> Optional[datetime]:
         """The datetime before which the certificate is not valid.
 
         :rtype: ~datetime.datetime or None
@@ -195,7 +189,7 @@ class CertificateProperties(object):
         return self._attributes.not_before if self._attributes else None
 
     @property
-    def expires_on(self) -> "Optional[datetime]":
+    def expires_on(self) -> Optional[datetime]:
         """The datetime when the certificate expires.
 
         :rtype: ~datetime.datetime or None
@@ -203,7 +197,7 @@ class CertificateProperties(object):
         return self._attributes.expires if self._attributes else None
 
     @property
-    def created_on(self) -> "Optional[datetime]":
+    def created_on(self) -> Optional[datetime]:
         """The datetime when the certificate is created.
 
         :rtype: ~datetime.datetime or None
@@ -211,7 +205,7 @@ class CertificateProperties(object):
         return self._attributes.created if self._attributes else None
 
     @property
-    def updated_on(self) -> "Optional[datetime]":
+    def updated_on(self) -> Optional[datetime]:
         """The datetime when the certificate was last updated.
 
         :rtype: ~datetime.datetime or None
@@ -219,7 +213,7 @@ class CertificateProperties(object):
         return self._attributes.updated if self._attributes else None
 
     @property
-    def recoverable_days(self) -> "Optional[int]":
+    def recoverable_days(self) -> Optional[int]:
         """The number of days the certificate is retained before being deleted from a soft-delete enabled Key Vault.
 
         :rtype: int or None
@@ -230,7 +224,7 @@ class CertificateProperties(object):
         return None
 
     @property
-    def recovery_level(self) -> "Optional[models.DeletionRecoveryLevel]":
+    def recovery_level(self) -> Optional[models.DeletionRecoveryLevel]:
         """The deletion recovery level currently in effect for the certificate.
 
         :rtype: models.DeletionRecoveryLevel or None
@@ -254,7 +248,7 @@ class CertificateProperties(object):
         return self._x509_thumbprint
 
     @property
-    def tags(self) -> "Optional[Dict[str, str]]":
+    def tags(self) -> Optional[Dict[str, str]]:
         """Application specific metadata in the form of key-value pairs.
 
         :rtype: dict[str, str] or None
@@ -262,7 +256,7 @@ class CertificateProperties(object):
         return self._tags
 
     @property
-    def version(self) -> "Optional[str]":
+    def version(self) -> Optional[str]:
         """The version of the certificate
 
         :rtype: str or None
@@ -283,9 +277,9 @@ class KeyVaultCertificate(object):
 
     def __init__(
         self,
-        policy: "Optional[CertificatePolicy]" = None,
-        properties: "Optional[CertificateProperties]" = None,
-        cer: "Optional[bytearray]" = None,
+        policy: Optional["CertificatePolicy"] = None,
+        properties: Optional[CertificateProperties] = None,
+        cer: Optional[bytearray] = None,
         **kwargs,
     ) -> None:
         self._properties = properties
@@ -303,7 +297,7 @@ class KeyVaultCertificate(object):
         # pylint:disable=protected-access, line-too-long
 
         if certificate_bundle.policy:
-            policy = CertificatePolicy._from_certificate_policy_bundle(certificate_bundle.policy)  # type: Optional[CertificatePolicy]
+            policy: Optional[CertificatePolicy] = CertificatePolicy._from_certificate_policy_bundle(certificate_bundle.policy)
         else:
             policy = None
 
@@ -316,7 +310,7 @@ class KeyVaultCertificate(object):
         )
 
     @property
-    def id(self) -> "Optional[str]":
+    def id(self) -> Optional[str]:
         """Certificate identifier.
 
         :rtype: str or None
@@ -324,7 +318,7 @@ class KeyVaultCertificate(object):
         return self._properties.id if self._properties else None
 
     @property
-    def name(self) -> "Optional[str]":
+    def name(self) -> Optional[str]:
         """The name of the certificate.
 
         :rtype: str or None
@@ -332,7 +326,7 @@ class KeyVaultCertificate(object):
         return self._properties.name if self._properties else None
 
     @property
-    def properties(self) -> "Optional[CertificateProperties]":
+    def properties(self) -> Optional[CertificateProperties]:
         """The certificate's properties
 
         :rtype: ~azure.keyvault.certificates.CertificateProperties or None
@@ -340,7 +334,7 @@ class KeyVaultCertificate(object):
         return self._properties
 
     @property
-    def key_id(self) -> "Optional[str]":
+    def key_id(self) -> Optional[str]:
         """The ID of the key associated with the certificate.
 
         :rtype: str or None
@@ -348,7 +342,7 @@ class KeyVaultCertificate(object):
         return self._key_id
 
     @property
-    def secret_id(self) -> "Optional[str]":
+    def secret_id(self) -> Optional[str]:
         """The ID of the secret associated with the certificate.
 
         :rtype: str or None
@@ -356,7 +350,7 @@ class KeyVaultCertificate(object):
         return self._secret_id
 
     @property
-    def policy(self) -> "Optional[CertificatePolicy]":
+    def policy(self) -> Optional["CertificatePolicy"]:
         """The management policy of the certificate.
 
         :rtype: ~azure.keyvault.certificates.CertificatePolicy or None
@@ -364,7 +358,7 @@ class KeyVaultCertificate(object):
         return self._policy
 
     @property
-    def cer(self) -> "Optional[bytearray]":
+    def cer(self) -> Optional[bytearray]:
         """The CER contents of the certificate.
 
         :rtype: bytearray or None
@@ -404,7 +398,7 @@ class KeyVaultCertificateIdentifier(object):
         return self._resource_id.name
 
     @property
-    def version(self) -> "Optional[str]":
+    def version(self) -> Optional[str]:
         return self._resource_id.version
 
 
@@ -440,17 +434,17 @@ class CertificateOperation(object):
 
     def __init__(
         self,
-        cert_operation_id: "Optional[str]" = None,
-        issuer_name: "Optional[Union[str, WellKnownIssuerNames]]" = None,
-        certificate_type: "Optional[str]" = None,
-        certificate_transparency: "Optional[bool]" = False,
-        csr: "Optional[bytes]" = None,
-        cancellation_requested: "Optional[bool]" = False,
-        status: "Optional[str]" = None,
-        status_details: "Optional[str]" = None,
-        error: "Optional[CertificateOperationError]" = None,
-        target: "Optional[str]" = None,
-        request_id: "Optional[str]" = None,
+        cert_operation_id: Optional[str] = None,
+        issuer_name: Optional[Union[str, WellKnownIssuerNames]] = None,
+        certificate_type: Optional[str] = None,
+        certificate_transparency: Optional[bool] = False,
+        csr: Optional[bytes] = None,
+        cancellation_requested: Optional[bool] = False,
+        status: Optional[str] = None,
+        status_details: Optional[str] = None,
+        error: Optional[CertificateOperationError] = None,
+        target: Optional[str] = None,
+        request_id: Optional[str] = None,
     ) -> None:
         self._id = cert_operation_id
         self._vault_id = parse_key_vault_id(cert_operation_id) if cert_operation_id else None
@@ -496,17 +490,17 @@ class CertificateOperation(object):
         )
 
     @property
-    def id(self) -> "Optional[str]":
+    def id(self) -> Optional[str]:
         """:rtype: str or None"""
         return self._id
 
     @property
-    def name(self) -> "Optional[str]":
+    def name(self) -> Optional[str]:
         """:rtype: str or None"""
         return self._vault_id.name if self._vault_id else None
 
     @property
-    def vault_url(self) -> "Optional[str]":
+    def vault_url(self) -> Optional[str]:
         """URL of the vault containing the CertificateOperation
 
         :rtype: str or None
@@ -514,7 +508,7 @@ class CertificateOperation(object):
         return self._vault_id.vault_url if self._vault_id else None
 
     @property
-    def issuer_name(self) -> "Union[str, WellKnownIssuerNames, None]":
+    def issuer_name(self) -> Union[str, WellKnownIssuerNames, None]:
         """The name of the issuer of the certificate.
 
         :rtype: str or ~azure.keyvault.certificates.WellKnownIssuerNames or None
@@ -522,7 +516,7 @@ class CertificateOperation(object):
         return self._issuer_name
 
     @property
-    def certificate_type(self) -> "Optional[str]":
+    def certificate_type(self) -> Optional[str]:
         """Type of certificate to be requested from the issuer provider.
 
         :rtype: str or None
@@ -530,7 +524,7 @@ class CertificateOperation(object):
         return self._certificate_type
 
     @property
-    def certificate_transparency(self) -> "Optional[bool]":
+    def certificate_transparency(self) -> Optional[bool]:
         """Whether certificates generated under this policy should be published to certificate
         transparency logs.
 
@@ -539,7 +533,7 @@ class CertificateOperation(object):
         return self._certificate_transparency
 
     @property
-    def csr(self) -> "Optional[bytes]":
+    def csr(self) -> Optional[bytes]:
         """The certificate signing request that is being used in this certificate operation.
 
         :rtype: bytes or None
@@ -547,7 +541,7 @@ class CertificateOperation(object):
         return self._csr
 
     @property
-    def cancellation_requested(self) -> "Optional[bool]":
+    def cancellation_requested(self) -> Optional[bool]:
         """Whether cancellation was requested on the certificate operation.
 
         :rtype: bool or None
@@ -555,22 +549,22 @@ class CertificateOperation(object):
         return self._cancellation_requested
 
     @property
-    def status(self) -> "Optional[str]":
+    def status(self) -> Optional[str]:
         """:rtype: str or None"""
         return self._status
 
     @property
-    def status_details(self) -> "Optional[str]":
+    def status_details(self) -> Optional[str]:
         """:rtype: str or None"""
         return self._status_details
 
     @property
-    def error(self) -> "Optional[CertificateOperationError]":
+    def error(self) -> Optional[CertificateOperationError]:
         """:rtype: ~azure.keyvault.certificates.CertificateOperationError or None"""
         return self._error
 
     @property
-    def target(self) -> "Optional[str]":
+    def target(self) -> Optional[str]:
         """Location which contains the result of the certificate operation.
 
         :rtype: str or None
@@ -578,7 +572,7 @@ class CertificateOperation(object):
         return self._target
 
     @property
-    def request_id(self) -> "Optional[str]":
+    def request_id(self) -> Optional[str]:
         """Identifier for the certificate operation.
 
         :rtype: str or None
@@ -638,7 +632,7 @@ class CertificatePolicy(object):
     # pylint:disable=too-many-instance-attributes
     def __init__(
         self,
-        issuer_name: "Optional[str]" = None,
+        issuer_name: Optional[str] = None,
         **kwargs,
     ) -> None:
         self._issuer_name = issuer_name
@@ -670,11 +664,11 @@ class CertificatePolicy(object):
     def _to_certificate_policy_bundle(self) -> models.CertificatePolicy:
         """Construct a version emulating the generated CertificatePolicy from a wrapped CertificatePolicy"""
         if self.issuer_name or self.certificate_type or self.certificate_transparency:
-            issuer_parameters = models.IssuerParameters(
+            issuer_parameters: Optional[models.IssuerParameters] = models.IssuerParameters(
                 name=self.issuer_name,
                 certificate_type=self.certificate_type,
                 certificate_transparency=self.certificate_transparency,  # 2016-10-01 model will ignore this
-            )  # type: Optional[models.IssuerParameters]
+            )
         else:
             issuer_parameters = None
 
@@ -718,13 +712,13 @@ class CertificatePolicy(object):
             or self.validity_in_months
         ):
             if self.key_usage:
-                key_usage = [
+                key_usage: Optional[List[Union[str, KeyUsageType]]] = [
                     k.value if not isinstance(k, str) else k for k in self.key_usage
-                ]  # type: Optional[List[Union[str, KeyUsageType]]]
+                ]
             else:
                 key_usage = None
 
-            x509_certificate_properties = models.X509CertificateProperties(
+            x509_certificate_properties: Optional[models.X509CertificateProperties] = models.X509CertificateProperties(
                 subject=self.subject,
                 ekus=self.enhanced_key_usage,
                 subject_alternative_names=models.SubjectAlternativeNames(
@@ -732,25 +726,25 @@ class CertificatePolicy(object):
                 ),
                 key_usage=key_usage,
                 validity_in_months=self.validity_in_months,
-            )  # type: Optional[models.X509CertificateProperties]
+            )
         else:
             x509_certificate_properties = None
 
         if self.exportable or self.key_type or self.key_size or self.reuse_key or self.key_curve_name:
-            key_properties = models.KeyProperties(
+            key_properties: Optional[models.KeyProperties] = models.KeyProperties(
                 exportable=self.exportable,
                 key_type=self.key_type,
                 key_size=self.key_size,
                 reuse_key=self.reuse_key,
                 curve=self.key_curve_name,
-            )  # type: Optional[models.KeyProperties]
+            )
         else:
             key_properties = None
 
         if self.content_type:
-            secret_properties = models.SecretProperties(
+            secret_properties: Optional[models.SecretProperties] = models.SecretProperties(
                 content_type=self.content_type
-            )  # type: Optional[models.SecretProperties]
+            )
         else:
             secret_properties = None
 
@@ -766,28 +760,28 @@ class CertificatePolicy(object):
 
     @classmethod
     def _from_certificate_policy_bundle(
-        cls, certificate_policy_bundle: "Optional[models.CertificatePolicy]"
+        cls, certificate_policy_bundle: Optional[models.CertificatePolicy]
     ) -> "CertificatePolicy":
         """Construct a CertificatePolicy from an autorest-generated CertificatePolicy"""
         if certificate_policy_bundle is None:
             return cls()
 
         if certificate_policy_bundle.lifetime_actions:
-            lifetime_actions = [
+            lifetime_actions: Optional[List[LifetimeAction]] = [
                 LifetimeAction(
                     action=CertificatePolicyAction(item.action.action_type) if item.action else None,
                     lifetime_percentage=item.trigger.lifetime_percentage if item.trigger else None,
                     days_before_expiry=item.trigger.days_before_expiry if item.trigger else None,
                 )
                 for item in certificate_policy_bundle.lifetime_actions
-            ]  # type: Optional[List[LifetimeAction]]
+            ]
         else:
             lifetime_actions = None
         x509_certificate_properties = certificate_policy_bundle.x509_certificate_properties
         if x509_certificate_properties and x509_certificate_properties.key_usage:
-            key_usage = [
+            key_usage: Optional[List[KeyUsageType]] = [
                 KeyUsageType(k) for k in x509_certificate_properties.key_usage
-            ]  # type: Optional[List[KeyUsageType]]
+            ]
         else:
             key_usage = None
         key_properties = certificate_policy_bundle.key_properties
@@ -838,7 +832,7 @@ class CertificatePolicy(object):
         )
 
     @property
-    def exportable(self) -> "Optional[bool]":
+    def exportable(self) -> Optional[bool]:
         """Whether the private key can be exported.
 
         :rtype: bool or None
@@ -846,7 +840,7 @@ class CertificatePolicy(object):
         return self._exportable
 
     @property
-    def key_type(self) -> "Optional[KeyType]":
+    def key_type(self) -> Optional[KeyType]:
         """The type of key pair to be used for the certificate.
 
         :rtype: ~azure.keyvault.certificates.KeyType or None
@@ -854,7 +848,7 @@ class CertificatePolicy(object):
         return self._key_type
 
     @property
-    def key_size(self) -> "Optional[int]":
+    def key_size(self) -> Optional[int]:
         """The key size in bits.
 
         :rtype: int or None
@@ -862,7 +856,7 @@ class CertificatePolicy(object):
         return self._key_size
 
     @property
-    def reuse_key(self) -> "Optional[bool]":
+    def reuse_key(self) -> Optional[bool]:
         """Whether the same key pair will be used on certificate renewal.
 
         :rtype: bool or None
@@ -870,7 +864,7 @@ class CertificatePolicy(object):
         return self._reuse_key
 
     @property
-    def key_curve_name(self) -> "Optional[KeyCurveName]":
+    def key_curve_name(self) -> Optional[KeyCurveName]:
         """Elliptic curve name.
 
         :rtype: ~azure.keyvault.certificates.KeyCurveName or None
@@ -878,7 +872,7 @@ class CertificatePolicy(object):
         return self._key_curve_name
 
     @property
-    def enhanced_key_usage(self) -> "Optional[List[str]]":
+    def enhanced_key_usage(self) -> Optional[List[str]]:
         """The enhanced key usage.
 
         :rtype: list[str] or None
@@ -886,7 +880,7 @@ class CertificatePolicy(object):
         return self._enhanced_key_usage
 
     @property
-    def key_usage(self) -> "Optional[List[KeyUsageType]]":
+    def key_usage(self) -> Optional[List[KeyUsageType]]:
         """List of key usages.
 
         :rtype: list[~azure.keyvault.certificates.KeyUsageType] or None
@@ -894,7 +888,7 @@ class CertificatePolicy(object):
         return self._key_usage
 
     @property
-    def content_type(self) -> "Optional[CertificateContentType]":
+    def content_type(self) -> Optional[CertificateContentType]:
         """The media type (MIME type).
 
         :rtype: ~azure.keyvault.certificates.CertificateContentType or None
@@ -902,7 +896,7 @@ class CertificatePolicy(object):
         return self._content_type
 
     @property
-    def subject(self) -> "Optional[str]":
+    def subject(self) -> Optional[str]:
         """The subject name of the certificate.
 
         :rtype: str or None
@@ -910,7 +904,7 @@ class CertificatePolicy(object):
         return self._subject
 
     @property
-    def san_emails(self) -> "Optional[List[str]]":
+    def san_emails(self) -> Optional[List[str]]:
         """The subject alternative email addresses.
 
         :rtype: list[str] or None
@@ -918,7 +912,7 @@ class CertificatePolicy(object):
         return self._san_emails
 
     @property
-    def san_dns_names(self) -> "Optional[List[str]]":
+    def san_dns_names(self) -> Optional[List[str]]:
         """The subject alternative domain names.
 
         :rtype: list[str] or None
@@ -926,7 +920,7 @@ class CertificatePolicy(object):
         return self._san_dns_names
 
     @property
-    def san_user_principal_names(self) -> "Optional[List[str]]":
+    def san_user_principal_names(self) -> Optional[List[str]]:
         """The subject alternative user principal names.
 
         :rtype: list[str] or None
@@ -934,7 +928,7 @@ class CertificatePolicy(object):
         return self._san_user_principal_names
 
     @property
-    def validity_in_months(self) -> "Optional[int]":
+    def validity_in_months(self) -> Optional[int]:
         """The duration that the certificate is valid for in months.
 
         :rtype: int or None
@@ -942,7 +936,7 @@ class CertificatePolicy(object):
         return self._validity_in_months
 
     @property
-    def lifetime_actions(self) -> "Optional[List[LifetimeAction]]":
+    def lifetime_actions(self) -> Optional[List["LifetimeAction"]]:
         """Actions and their triggers that will be performed by Key Vault over
         the lifetime of the certificate.
 
@@ -951,7 +945,7 @@ class CertificatePolicy(object):
         return self._lifetime_actions
 
     @property
-    def issuer_name(self) -> "Optional[str]":
+    def issuer_name(self) -> Optional[str]:
         """Name of the referenced issuer object or reserved names for the issuer
         of the certificate.
 
@@ -960,7 +954,7 @@ class CertificatePolicy(object):
         return self._issuer_name
 
     @property
-    def certificate_type(self) -> "Optional[str]":
+    def certificate_type(self) -> Optional[str]:
         """Type of certificate requested from the issuer provider.
 
         :rtype: str or None
@@ -968,7 +962,7 @@ class CertificatePolicy(object):
         return self._certificate_type
 
     @property
-    def certificate_transparency(self) -> "Optional[bool]":
+    def certificate_transparency(self) -> Optional[bool]:
         """Whether the certificates generated under this policy should be published
         to certificate transparency logs.
 
@@ -977,7 +971,7 @@ class CertificatePolicy(object):
         return self._certificate_transparency
 
     @property
-    def enabled(self) -> "Optional[bool]":
+    def enabled(self) -> Optional[bool]:
         """Whether the certificate is enabled or not.
 
         :rtype: bool or None
@@ -985,7 +979,7 @@ class CertificatePolicy(object):
         return self._attributes.enabled if self._attributes else None
 
     @property
-    def created_on(self) -> "Optional[datetime]":
+    def created_on(self) -> Optional[datetime]:
         """The datetime when the certificate is created.
 
         :rtype: ~datetime.datetime or None
@@ -993,7 +987,7 @@ class CertificatePolicy(object):
         return self._attributes.created if self._attributes else None
 
     @property
-    def updated_on(self) -> "Optional[datetime]":
+    def updated_on(self) -> Optional[datetime]:
         """The datetime when the certificate was last updated.
 
         :rtype: ~datetime.datetime or None
@@ -1013,7 +1007,7 @@ class CertificateContact(object):
     """
 
     def __init__(
-        self, email: "Optional[str]" = None, name: "Optional[str]" = None, phone: "Optional[str]" = None
+        self, email: Optional[str] = None, name: Optional[str] = None, phone: Optional[str] = None
     ) -> None:
         self._email = email
         self._name = name
@@ -1031,17 +1025,17 @@ class CertificateContact(object):
         return cls(email=contact_item.email_address, name=contact_item.name, phone=contact_item.phone)
 
     @property
-    def email(self) -> "Optional[str]":
+    def email(self) -> Optional[str]:
         """:rtype: str or None"""
         return self._email
 
     @property
-    def name(self) -> "Optional[str]":
+    def name(self) -> Optional[str]:
         """:rtype: str or None"""
         return self._name
 
     @property
-    def phone(self) -> "Optional[str]":
+    def phone(self) -> Optional[str]:
         """:rtype: str or None"""
         return self._phone
 
@@ -1053,7 +1047,7 @@ class IssuerProperties(object):
     :type provider: str or None
     """
 
-    def __init__(self, provider: "Optional[str]" = None, **kwargs) -> None:
+    def __init__(self, provider: Optional[str] = None, **kwargs) -> None:
         self._id = kwargs.pop("issuer_id", None)
         self._vault_id = parse_key_vault_id(self._id)
         self._provider = provider
@@ -1063,24 +1057,24 @@ class IssuerProperties(object):
 
     @classmethod
     def _from_issuer_item(
-        cls, issuer_item: "Union[models.CertificateIssuerItem, models.IssuerBundle]"
+        cls, issuer_item: Union[models.CertificateIssuerItem, models.IssuerBundle]
     ) -> "IssuerProperties":
         """Construct a IssuerProperties from an autorest-generated CertificateIssuerItem"""
         return cls(issuer_id=issuer_item.id, provider=issuer_item.provider)
 
     @property
-    def id(self) -> "Optional[str]":
+    def id(self) -> Optional[str]:
         """:rtype: str or None"""
         return self._id
 
     @property
-    def name(self) -> "Optional[str]":
+    def name(self) -> Optional[str]:
         """:rtype: str or None"""
         # Issuer name is listed under version under vault_id
         return self._vault_id.version
 
     @property
-    def provider(self) -> "Optional[str]":
+    def provider(self) -> Optional[str]:
         """:rtype: str or None"""
         return self._provider
 
@@ -1102,12 +1096,12 @@ class CertificateIssuer(object):
 
     def __init__(
         self,
-        provider: "Optional[str]",
-        attributes: "Optional[models.IssuerAttributes]" = None,
-        account_id: "Optional[str]" = None,
-        password: "Optional[str]" = None,
-        organization_id: "Optional[str]" = None,
-        admin_contacts: "Optional[List[AdministratorContact]]" = None,
+        provider: Optional[str],
+        attributes: Optional[models.IssuerAttributes] = None,
+        account_id: Optional[str] = None,
+        password: Optional[str] = None,
+        organization_id: Optional[str] = None,
+        admin_contacts: Optional[List[AdministratorContact]] = None,
         **kwargs,
     ) -> None:
         self._provider = provider
@@ -1144,12 +1138,12 @@ class CertificateIssuer(object):
         )
 
     @property
-    def id(self) -> "Optional[str]":
+    def id(self) -> Optional[str]:
         """:rtype: str or None"""
         return self._id
 
     @property
-    def name(self) -> "Optional[str]":
+    def name(self) -> Optional[str]:
         """:rtype: str or None"""
         # Issuer name is listed under version under vault_id.
         # This is because the id we pass to parse_key_vault_id has an extra segment, so where most cases the version of
@@ -1158,7 +1152,7 @@ class CertificateIssuer(object):
         return self._vault_id.version
 
     @property
-    def provider(self) -> "Optional[str]":
+    def provider(self) -> Optional[str]:
         """The issuer provider.
 
         :rtype: str or None
@@ -1166,7 +1160,7 @@ class CertificateIssuer(object):
         return self._provider
 
     @property
-    def enabled(self) -> "Optional[bool]":
+    def enabled(self) -> Optional[bool]:
         """Whether the certificate is enabled or not.
 
         :rtype: bool or None
@@ -1174,7 +1168,7 @@ class CertificateIssuer(object):
         return self._attributes.enabled if self._attributes else None
 
     @property
-    def created_on(self) -> "Optional[datetime]":
+    def created_on(self) -> Optional[datetime]:
         """The datetime when the certificate is created.
 
         :rtype: ~datetime.datetime or None
@@ -1182,7 +1176,7 @@ class CertificateIssuer(object):
         return self._attributes.created if self._attributes else None
 
     @property
-    def updated_on(self) -> "Optional[datetime]":
+    def updated_on(self) -> Optional[datetime]:
         """The datetime when the certificate was last updated.
 
         :rtype: ~datetime.datetime or None
@@ -1190,7 +1184,7 @@ class CertificateIssuer(object):
         return self._attributes.updated if self._attributes else None
 
     @property
-    def account_id(self) -> "Optional[str]":
+    def account_id(self) -> Optional[str]:
         """The username/ account name/ account id.
 
         :rtype: str or None
@@ -1198,7 +1192,7 @@ class CertificateIssuer(object):
         return self._account_id
 
     @property
-    def password(self) -> "Optional[str]":
+    def password(self) -> Optional[str]:
         """The password / secret / account key.
 
         :rtype: str or None
@@ -1206,12 +1200,12 @@ class CertificateIssuer(object):
         return self._password
 
     @property
-    def organization_id(self) -> "Optional[str]":
+    def organization_id(self) -> Optional[str]:
         """:rtype: str or None"""
         return self._organization_id
 
     @property
-    def admin_contacts(self) -> "Optional[List[AdministratorContact]]":
+    def admin_contacts(self) -> Optional[List[AdministratorContact]]:
         """Contact details of the organization administrator of this issuer.
 
         :rtype: list[~azure.keyvault.certificates.AdministratorContact] or None
@@ -1234,9 +1228,9 @@ class LifetimeAction(object):
 
     def __init__(
         self,
-        action: "Union[str, CertificatePolicyAction, None]",
-        lifetime_percentage: "Optional[int]" = None,
-        days_before_expiry: "Optional[int]" = None,
+        action: Union[str, CertificatePolicyAction, None],
+        lifetime_percentage: Optional[int] = None,
+        days_before_expiry: Optional[int] = None,
     ) -> None:
         self._lifetime_percentage = lifetime_percentage
         self._days_before_expiry = days_before_expiry
@@ -1250,7 +1244,7 @@ class LifetimeAction(object):
         return result[:1024]
 
     @property
-    def lifetime_percentage(self) -> "Optional[int]":
+    def lifetime_percentage(self) -> Optional[int]:
         """Percentage of lifetime at which to trigger.
 
         :rtype: int or None
@@ -1258,7 +1252,7 @@ class LifetimeAction(object):
         return self._lifetime_percentage
 
     @property
-    def days_before_expiry(self) -> "Optional[int]":
+    def days_before_expiry(self) -> Optional[int]:
         """Days before expiry to attempt renewal.
 
         :rtype: int or None
@@ -1266,7 +1260,7 @@ class LifetimeAction(object):
         return self._days_before_expiry
 
     @property
-    def action(self) -> "Union[str, CertificatePolicyAction, None]":
+    def action(self) -> Union[str, CertificatePolicyAction, None]:
         """The type of the action that will be executed. Valid values are "EmailContacts" and "AutoRenew".
 
         :rtype: str or ~azure.keyvault.certificates.CertificatePolicyAction or None
@@ -1291,9 +1285,9 @@ class DeletedCertificate(KeyVaultCertificate):
 
     def __init__(
         self,
-        properties: "Optional[CertificateProperties]" = None,
-        policy: "Optional[CertificatePolicy]" = None,
-        cer: "Optional[bytearray]" = None,
+        properties: Optional[CertificateProperties] = None,
+        policy: Optional[CertificatePolicy] = None,
+        cer: Optional[bytearray] = None,
         **kwargs,
     ) -> None:
         super(DeletedCertificate, self).__init__(properties=properties, policy=policy, cer=cer, **kwargs)
@@ -1340,7 +1334,7 @@ class DeletedCertificate(KeyVaultCertificate):
         )
 
     @property
-    def deleted_on(self) -> "Optional[datetime]":
+    def deleted_on(self) -> Optional[datetime]:
         """The datetime that the certificate was deleted.
 
         :rtype: ~datetime.datetime or None
@@ -1348,7 +1342,7 @@ class DeletedCertificate(KeyVaultCertificate):
         return self._deleted_on
 
     @property
-    def recovery_id(self) -> "Optional[str]":
+    def recovery_id(self) -> Optional[str]:
         """The url of the recovery object, used to identify and recover the deleted certificate.
 
         :rtype: str or None
@@ -1356,7 +1350,7 @@ class DeletedCertificate(KeyVaultCertificate):
         return self._recovery_id
 
     @property
-    def scheduled_purge_date(self) -> "Optional[datetime]":
+    def scheduled_purge_date(self) -> Optional[datetime]:
         """The datetime when the certificate is scheduled to be purged.
 
         :rtype: ~datetime.datetime or None

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_polling.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_polling.py
@@ -4,34 +4,27 @@
 # ------------------------------------
 import logging
 import time
+from typing import Any, Callable, Optional, Union
 
 from azure.core.polling import PollingMethod
+from azure.keyvault.certificates import KeyVaultCertificate, CertificateOperation
 
-try:
-    from typing import TYPE_CHECKING
-except ImportError:
-    TYPE_CHECKING = False
-
-if TYPE_CHECKING:
-    # pylint: disable=ungrouped-imports
-    from typing import Any, Callable, Optional, Union
-    from azure.keyvault.certificates import KeyVaultCertificate, CertificateOperation
 
 logger = logging.getLogger(__name__)
 
 
 class CreateCertificatePoller(PollingMethod):
-    def __init__(self, get_certificate_command: "Callable", interval: int = 5) -> None:
-        self._command = None  # type: Optional[Callable]
-        self._resource = None  # type: Optional[Union[CertificateOperation, KeyVaultCertificate]]
-        self._pending_certificate_op = None  # type: Optional[CertificateOperation]
+    def __init__(self, get_certificate_command: Callable, interval: int = 5) -> None:
+        self._command: Optional[Callable] = None
+        self._resource: Optional[Union[CertificateOperation, KeyVaultCertificate]] = None
+        self._pending_certificate_op: Optional[CertificateOperation] = None
         self._get_certificate_command = get_certificate_command
         self._polling_interval = interval
 
     def _update_status(self) -> None:
         self._pending_certificate_op = self._command() if self._command else None
 
-    def initialize(self, client: "Any", initial_response: "Any", _: "Callable") -> None:
+    def initialize(self, client: Any, initial_response: Any, _: Callable) -> None:
         self._command = client
         self._pending_certificate_op = initial_response
 
@@ -56,7 +49,7 @@ class CreateCertificatePoller(PollingMethod):
             return True
         return self._pending_certificate_op.status.lower() != "inprogress"  # type: ignore
 
-    def resource(self) -> "Union[KeyVaultCertificate, CertificateOperation]":
+    def resource(self) -> Union[KeyVaultCertificate, CertificateOperation]:
         return self._resource  # type: ignore
 
     def status(self) -> str:

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/__init__.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/__init__.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
-from typing import TYPE_CHECKING
+from typing import Optional
 from urllib import parse
 
 from .challenge_auth_policy import ChallengeAuthPolicy
@@ -11,10 +11,6 @@ from .http_challenge import HttpChallenge
 from . import http_challenge_cache
 
 HttpChallengeCache = http_challenge_cache  # to avoid aliasing pylint error (C4745)
-
-if TYPE_CHECKING:
-    # pylint: disable=unused-import
-    from typing import Optional
 
 
 __all__ = [
@@ -30,7 +26,8 @@ class KeyVaultResourceId():
     :param str source_id: The complete identifier received from Key Vault
     :param str vault_url: The vault URL
     :param str name: The name extracted from the ID
-    :param str version: The version extracted from the ID
+    :param version: The version extracted from the ID
+    :type version: str or None
     """
 
     def __init__(
@@ -38,7 +35,7 @@ class KeyVaultResourceId():
         source_id: str,
         vault_url: str,
         name: str,
-        version: "Optional[str]" = None,
+        version: Optional[str] = None,
     ) -> None:
         self.source_id = source_id
         self.vault_url = vault_url

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/_polling.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/_polling.py
@@ -6,7 +6,7 @@ import logging
 import time
 import threading
 import uuid
-from typing import TYPE_CHECKING
+from typing import Any, Callable, Optional
 
 from azure.core.polling import PollingMethod, LROPoller, NoPolling
 from azure.core.exceptions import ResourceNotFoundError, HttpResponseError
@@ -14,9 +14,6 @@ from azure.core.exceptions import ResourceNotFoundError, HttpResponseError
 from azure.core.tracing.decorator import distributed_trace
 from azure.core.tracing.common import with_current_context
 
-if TYPE_CHECKING:
-    # pylint: disable=ungrouped-imports
-    from typing import Any, Callable, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -31,7 +28,7 @@ class KeyVaultOperationPoller(LROPoller):
         self._polling_method = polling_method
 
     # pylint: disable=arguments-differ
-    def result(self) -> "Any":  # type: ignore
+    def result(self) -> Any:  # type: ignore
         """Returns a representation of the final resource without waiting for the operation to complete.
 
         :returns: The deserialized resource of the long running operation
@@ -41,7 +38,7 @@ class KeyVaultOperationPoller(LROPoller):
         return self._polling_method.resource()
 
     @distributed_trace
-    def wait(self, timeout: "Optional[float]" = None) -> None:
+    def wait(self, timeout: Optional[float] = None) -> None:
         """Wait on the long running operation for a number of seconds.
 
         You can check if this call has ended with timeout with the "done()" method.
@@ -80,7 +77,7 @@ class DeleteRecoverPollingMethod(PollingMethod):
     Similarly, while recovering a deleted resource, Key Vault will respond 404 to GET requests for the non-deleted
     resource; when it responds 2xx, the resource exists in the non-deleted collection, i.e. its recovery is complete.
     """
-    def __init__(self, command: "Callable", final_resource: "Any", finished: bool, interval: int = 2) -> None:
+    def __init__(self, command: Callable, final_resource: Any, finished: bool, interval: int = 2) -> None:
         self._command = command
         self._resource = final_resource
         self._polling_interval = interval
@@ -100,7 +97,7 @@ class DeleteRecoverPollingMethod(PollingMethod):
             else:
                 raise
 
-    def initialize(self, client: "Any", initial_response: "Any", deserialization_callback: "Callable") -> None:
+    def initialize(self, client: Any, initial_response: Any, deserialization_callback: Callable) -> None:
         pass
 
     def run(self) -> None:
@@ -116,7 +113,7 @@ class DeleteRecoverPollingMethod(PollingMethod):
     def finished(self) -> bool:
         return self._finished
 
-    def resource(self) -> "Any":
+    def resource(self) -> Any:
         return self._resource
 
     def status(self) -> str:

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/_polling_async.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/_polling_async.py
@@ -5,14 +5,11 @@
 
 import asyncio
 import logging
-from typing import TYPE_CHECKING
+from typing import Any, Callable
 
 from azure.core.polling import AsyncPollingMethod
 from azure.core.exceptions import ResourceNotFoundError, HttpResponseError
 
-if TYPE_CHECKING:
-    # pylint:disable=ungrouped-imports
-    from typing import Any, Callable, Union
 
 logger = logging.getLogger(__name__)
 
@@ -29,13 +26,13 @@ class AsyncDeleteRecoverPollingMethod(AsyncPollingMethod):
     resource; when it responds 2xx, the resource exists in the non-deleted collection, i.e. its recovery is complete.
     """
 
-    def __init__(self, command, final_resource, finished, interval=2):
+    def __init__(self, command: Callable, final_resource: Any, finished: bool, interval: int = 2) -> None:
         self._command = command
         self._resource = final_resource
         self._polling_interval = interval
         self._finished = finished
 
-    def initialize(self, client, initial_response, deserialization_callback):
+    def initialize(self, client: Any, initial_response: Any, deserialization_callback: Callable) -> None:
         pass
 
     async def _update_status(self) -> None:
@@ -65,7 +62,7 @@ class AsyncDeleteRecoverPollingMethod(AsyncPollingMethod):
     def finished(self) -> bool:
         return self._finished
 
-    def resource(self) -> "Any":
+    def resource(self) -> Any:
         return self._resource
 
     def status(self) -> str:

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/async_client_base.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/async_client_base.py
@@ -2,9 +2,11 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
-from typing import TYPE_CHECKING
+from typing import Any, Awaitable
 
+from azure.core.credentials_async import AsyncTokenCredential
 from azure.core.pipeline.policies import HttpLoggingPolicy
+from azure.core.rest import AsyncHttpResponse, HttpRequest
 from azure.core.tracing.decorator_async import distributed_trace_async
 
 from . import AsyncChallengeAuthPolicy
@@ -12,16 +14,10 @@ from .client_base import ApiVersion, DEFAULT_VERSION, _format_api_version, _SERI
 from .._sdk_moniker import SDK_MONIKER
 from .._generated.aio import KeyVaultClient as _KeyVaultClient
 
-if TYPE_CHECKING:
-    # pylint:disable=unused-import
-    from typing import Any, Awaitable
-    from azure.core.credentials_async import AsyncTokenCredential
-    from azure.core.rest import AsyncHttpResponse, HttpRequest
-
 
 class AsyncKeyVaultClientBase(object):
     # pylint:disable=protected-access
-    def __init__(self, vault_url: str, credential: "AsyncTokenCredential", **kwargs) -> None:
+    def __init__(self, vault_url: str, credential: AsyncTokenCredential, **kwargs) -> None:
         if not credential:
             raise ValueError(
                 "credential should be an object supporting the AsyncTokenCredential protocol, "
@@ -73,7 +69,7 @@ class AsyncKeyVaultClientBase(object):
         await self._client.__aenter__()
         return self
 
-    async def __aexit__(self, *args: "Any") -> None:
+    async def __aexit__(self, *args: Any) -> None:
         await self._client.__aexit__(*args)
 
     async def close(self) -> None:
@@ -84,7 +80,7 @@ class AsyncKeyVaultClientBase(object):
         await self._client.close()
 
     @distributed_trace_async
-    def send_request(self, request: "HttpRequest", *, stream: bool = False, **kwargs) -> "Awaitable[AsyncHttpResponse]":
+    def send_request(self, request: HttpRequest, *, stream: bool = False, **kwargs) -> Awaitable[AsyncHttpResponse]:
         """Runs a network request using the client's existing pipeline.
 
         The request URL can be relative to the vault URL. The service API version used for the request is the same as

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/exceptions.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/exceptions.py
@@ -4,23 +4,19 @@
 # ------------------------------------
 from collections import defaultdict
 import functools
-from typing import TYPE_CHECKING
+from typing import Optional, Type
 
 from azure.core.exceptions import DecodeError, HttpResponseError, ResourceExistsError, ResourceNotFoundError
 from azure.core.pipeline.policies import ContentDecodePolicy
-
-if TYPE_CHECKING:
-    # pylint:disable=unused-import,ungrouped-imports
-    from typing import Optional, Type
-    from azure.core.rest import HttpResponse
+from azure.core.rest import HttpResponse
 
 
-def _get_exception_for_key_vault_error(cls: "Type[HttpResponseError]", response: "HttpResponse") -> HttpResponseError:
+def _get_exception_for_key_vault_error(cls: Type[HttpResponseError], response: HttpResponse) -> HttpResponseError:
     """Construct cls (HttpResponseError or subclass thereof) with Key Vault's error message."""
 
     try:
         body = ContentDecodePolicy.deserialize_from_http_generics(response)
-        message = f"({body['error']['code']}) {body['error']['message']}"  # type: Optional[str]
+        message: Optional[str] = f"({body['error']['code']}) {body['error']['message']}"
     except (DecodeError, KeyError):
         # Key Vault error response bodies should have the expected shape and be de-serializable.
         # If we somehow land here, we'll take HttpResponse's default message.

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/http_challenge.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/http_challenge.py
@@ -2,21 +2,18 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
-from typing import TYPE_CHECKING
+from typing import Dict, MutableMapping, Optional
 from urllib import parse
-
-if TYPE_CHECKING:
-    from typing import Dict, MutableMapping, Optional
 
 
 class HttpChallenge(object):
     def __init__(
-        self, request_uri: str, challenge: str, response_headers: "Optional[MutableMapping[str, str]]" = None
+        self, request_uri: str, challenge: str, response_headers: Optional[MutableMapping[str, str]] = None
     ) -> None:
         """Parses an HTTP WWW-Authentication Bearer challenge from a server."""
         self.source_authority = self._validate_request_uri(request_uri)
         self.source_uri = request_uri
-        self._parameters = {}  # type: Dict[str, str]
+        self._parameters: Dict[str, str] = {}
 
         # get the scheme of the challenge and remove from the challenge string
         trimmed_challenge = self._validate_challenge(challenge)
@@ -69,10 +66,10 @@ class HttpChallenge(object):
 
         return self.scheme.lower() == "pop"
 
-    def get_value(self, key: str) -> "Optional[str]":
+    def get_value(self, key: str) -> Optional[str]:
         return self._parameters.get(key)
 
-    def get_authorization_server(self) -> "Optional[str]":
+    def get_authorization_server(self) -> Optional[str]:
         """Returns the URI for the authorization server if present, otherwise empty string."""
         value = ""
         for key in ["authorization_uri", "authorization"]:

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/http_challenge_cache.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/http_challenge_cache.py
@@ -3,24 +3,17 @@
 # Licensed under the MIT License.
 # ------------------------------------
 import threading
+from typing import Dict, Optional
 from urllib import parse
 
-try:
-    from typing import TYPE_CHECKING
-except ImportError:
-    TYPE_CHECKING = False
-
-if TYPE_CHECKING:
-    # pylint: disable=unused-import
-    from typing import Dict, Optional
-    from .http_challenge import HttpChallenge
+from .http_challenge import HttpChallenge
 
 
-_cache = {}  # type: Dict[str, HttpChallenge]
+_cache: Dict[str, HttpChallenge] = {}
 _lock = threading.Lock()
 
 
-def get_challenge_for_url(url: str) -> "Optional[HttpChallenge]":
+def get_challenge_for_url(url: str) -> Optional[HttpChallenge]:
     """Gets the challenge for the cached URL.
 
     :param str url: the URL the challenge is cached for.
@@ -63,7 +56,7 @@ def remove_challenge_for_url(url: str) -> None:
         del _cache[parsed.netloc]
 
 
-def set_challenge_for_url(url: str, challenge: "HttpChallenge") -> None:
+def set_challenge_for_url(url: str, challenge: HttpChallenge) -> None:
     """Caches the challenge for the specified URL.
 
     :param str url: the URL for which to cache the challenge


### PR DESCRIPTION
# Description

CredScan raises a warning because the `password` argument is followed by a type hint that's assumed to be a secret value.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
