### PR TITLE
[Test Proxy] Account for unexpected TypeErrors during tests

### DIFF
--- a/tools/azure-sdk-tools/devtools_testutils/proxy_testcase.py
+++ b/tools/azure-sdk-tools/devtools_testutils/proxy_testcase.py
@@ -220,21 +220,32 @@ def recorded_by_proxy(test_func: "Callable") -> None:
         # call the modified function
         # we define test_variables before invoking the test so the variable is defined in case of an exception
         test_variables = None
+        # this tracks whether the test has been run yet; used when calling the test function with/without `variables`
+        # running without `variables` in the `except` block leads to unnecessary exceptions in test execution output
+        test_run = False
         try:
             try:
                 test_variables = test_func(*args, variables=variables, **trimmed_kwargs)
-            except TypeError:
-                logger = logging.getLogger()
-                logger.info(
-                    "This test can't accept variables as input. The test method should accept `**kwargs` and/or a "
-                    "`variables` parameter to make use of recorded test variables."
-                )
+                test_run = True
+            except TypeError as error:
+                if "unexpected keyword argument" in str(error) and "variables" in str(error):
+                    logger = logging.getLogger()
+                    logger.info(
+                        "This test can't accept variables as input. The test method should accept `**kwargs` and/or a "
+                        "`variables` parameter to make use of recorded test variables."
+                    )
+                else:
+                    raise error
+            # if the test couldn't accept `variables`, run the test without passing them
+            if not test_run:
                 test_variables = test_func(*args, **trimmed_kwargs)
+
         except ResourceNotFoundError as error:
             error_body = ContentDecodePolicy.deserialize_from_http_generics(error.response)
             message = error_body.get("message") or error_body.get("Message")
             error_with_message = ResourceNotFoundError(message=message, response=error.response)
             six.raise_from(error_with_message, error)
+
         finally:
             RequestsTransport.send = original_transport_func
             stop_record_or_playback(test_id, recording_id, test_variables)


### PR DESCRIPTION
# Description

This resolves an issue that was reported by @jalauzon-msft: when TypeErrors are raised during a recorded test, the test proxy swallows this error and re-executes the test. This makes the test re-send interactions that were already processed, leading to erroneous errors that hide the actual problem.

The error swallowing comes from the test proxy's attempt to conditionally invoke tests with or without passing in pre-recorded test variables. If a test can't accept a `variables` kwarg, we swallow the TypeError and re-invoke the test without the argument. This error handling wasn't specific enough though, so all TypeErrors were assumed to be related to `variables`.

This PR reads into the exception message when we get a TypeError during a test, and if it's not related to `variables`, raises the error correctly. Also, this moves the second test invocation -- the one that doesn't pass `variables` -- out of the `except TypeError` block. This is to prevent the `try/except` from appearing in stack traces; I've been told before that it's confusing when a test fails and the test proxy's failed `variables`-passing attempt is included as an error in the stack trace.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
