### PR TITLE
Updating feature set properties casing based on change in service

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_feature_set_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_feature_set_operations.py
@@ -171,8 +171,8 @@ class _FeatureSetOperations(_ScopeDependentOperations):
         """
 
         featureset_spec = validate_and_get_feature_set_spec(featureset)
-        featureset.properties["featureset_properties_version"] = "1"
-        featureset.properties["featureset_properties"] = json.dumps(featureset_spec._to_dict())
+        featureset.properties["featuresetPropertiesVersion"] = "1"
+        featureset.properties["featuresetProperties"] = json.dumps(featureset_spec._to_dict())
 
         sas_uri = None
         featureset, _ = _check_and_upload_path(


### PR DESCRIPTION
# Description

Updating feature set properties casing based on change in service

If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
