### PR TITLE
[Communication][Email] Adding PPE Only Parameter to Email Live Tests

### DIFF
--- a/sdk/communication/azure-communication-email/tests.yml
+++ b/sdk/communication/azure-communication-email/tests.yml
@@ -8,7 +8,6 @@ trigger: none
 
 variables:
 - name: stagesToRun
-  value: 'Int,PPE'
 
 stages:
   - template: /eng/pipelines/templates/stages/archetype-sdk-tests.yml

--- a/sdk/communication/azure-communication-email/tests.yml
+++ b/sdk/communication/azure-communication-email/tests.yml
@@ -3,7 +3,7 @@ trigger: none
 parameters:
 - name: runOnlyPPE
   displayName: "Run only the PPE stage"
-  type: boolean,
+  type: boolean
   default: false
 
 stages:

--- a/sdk/communication/azure-communication-email/tests.yml
+++ b/sdk/communication/azure-communication-email/tests.yml
@@ -32,7 +32,7 @@ stages:
           SubscriptionConfigurations:
             - $(sub-config-communication-int-test-resources-common)
             - $(sub-config-communication-int-test-resources-python)
-      Clouds: ${{ variables.stagesToRun }}
+      Clouds: $(stagesToRun)
       EnvVars:
         AZURE_SKIP_LIVE_RECORDING: 'True'
         AZURE_TEST_RUN_LIVE: 'true'

--- a/sdk/communication/azure-communication-email/tests.yml
+++ b/sdk/communication/azure-communication-email/tests.yml
@@ -1,5 +1,10 @@
 trigger: none
 
+parameters:
+- name: runOnlyPPEStage
+  type: boolean
+  default: false
+
 stages:
   - template: /eng/pipelines/templates/stages/archetype-sdk-tests.yml
     parameters:
@@ -13,7 +18,20 @@ stages:
             - $(sub-config-communication-ppe-test-resources-python)
           MatrixReplace:
             - TestSamples=.*/true
+      ${{ if eq(parameters.runOnlyPPEStage, false) }}:
+        Public:
+          SubscriptionConfigurations:
+            - $(sub-config-azure-cloud-test-resources)
+            - $(sub-config-communication-services-cloud-test-resources-common)
+            - $(sub-config-communication-services-cloud-test-resources-python)
+        Int:
+          SubscriptionConfigurations:
+            - $(sub-config-communication-int-test-resources-common)
+            - $(sub-config-communication-int-test-resources-python)
+    ${{ if eq(parameters.runOnlyPPEStage, true) }}:
       Clouds: 'PPE'
+    ${{ if eq(parameters.runOnlyPPEStage, false) }}:
+      Clouds: 'Public,PPE,Int'
       EnvVars:
         AZURE_SKIP_LIVE_RECORDING: 'True'
         AZURE_TEST_RUN_LIVE: 'true'

--- a/sdk/communication/azure-communication-email/tests.yml
+++ b/sdk/communication/azure-communication-email/tests.yml
@@ -1,9 +1,14 @@
 trigger: none
 
-parameters:
+# parameters:
+# - name: stagesToRun
+#   displayName: "Stages To Run"
+#   type: string
+#   default: 'Int,PPE,Public'
+
+variables:
 - name: stagesToRun
-  type: string
-  default: 'Int,PPE,Public'
+  value: 'Int,PPE,Public'
 
 stages:
   - template: /eng/pipelines/templates/stages/archetype-sdk-tests.yml
@@ -27,7 +32,7 @@ stages:
           SubscriptionConfigurations:
             - $(sub-config-communication-int-test-resources-common)
             - $(sub-config-communication-int-test-resources-python)
-      Clouds: ${{ parameters.stagesToRun }}
+      Clouds: ${{ variables.stagesToRun }}
       EnvVars:
         AZURE_SKIP_LIVE_RECORDING: 'True'
         AZURE_TEST_RUN_LIVE: 'true'

--- a/sdk/communication/azure-communication-email/tests.yml
+++ b/sdk/communication/azure-communication-email/tests.yml
@@ -18,15 +18,16 @@ stages:
             - $(sub-config-communication-ppe-test-resources-python)
           MatrixReplace:
             - TestSamples=.*/true
-        Public:
-          SubscriptionConfigurations:
-            - $(sub-config-azure-cloud-test-resources)
-            - $(sub-config-communication-services-cloud-test-resources-common)
-            - $(sub-config-communication-services-cloud-test-resources-python)
-        Int:
-          SubscriptionConfigurations:
-            - $(sub-config-communication-int-test-resources-common)
-            - $(sub-config-communication-int-test-resources-python)
+        ${{ if eq(parameters.runOnlyPPEStage, false) }}:
+          Public:
+            SubscriptionConfigurations:
+              - $(sub-config-azure-cloud-test-resources)
+              - $(sub-config-communication-services-cloud-test-resources-common)
+              - $(sub-config-communication-services-cloud-test-resources-python)
+          Int:
+            SubscriptionConfigurations:
+              - $(sub-config-communication-int-test-resources-common)
+              - $(sub-config-communication-int-test-resources-python)
       ${{ if eq(parameters.runOnlyPPEStage, true) }}:
         Clouds: 'PPE'
       ${{ if eq(parameters.runOnlyPPEStage, false) }}:

--- a/sdk/communication/azure-communication-email/tests.yml
+++ b/sdk/communication/azure-communication-email/tests.yml
@@ -1,9 +1,9 @@
 trigger: none
 
 parameters:
-- name: runOnlyPPEStage
-  type: boolean
-  default: false
+- name: stagesToRun
+  type: string
+  default: 'Int,PPE,Public'
 
 stages:
   - template: /eng/pipelines/templates/stages/archetype-sdk-tests.yml
@@ -27,10 +27,7 @@ stages:
           SubscriptionConfigurations:
             - $(sub-config-communication-int-test-resources-common)
             - $(sub-config-communication-int-test-resources-python)
-      ${{ if eq(parameters.runOnlyPPEStage, true) }}:
-        Clouds: 'PPE'
-      ${{ if eq(parameters.runOnlyPPEStage, false) }}:
-        Clouds: 'Public,PPE,Int'
+      Clouds: ${{ parameters.stagesToRun }}
       EnvVars:
         AZURE_SKIP_LIVE_RECORDING: 'True'
         AZURE_TEST_RUN_LIVE: 'true'

--- a/sdk/communication/azure-communication-email/tests.yml
+++ b/sdk/communication/azure-communication-email/tests.yml
@@ -32,7 +32,7 @@ stages:
           SubscriptionConfigurations:
             - $(sub-config-communication-int-test-resources-common)
             - $(sub-config-communication-int-test-resources-python)
-      Clouds: $(stagesToRun)
+      Clouds: $[variables.stagesToRun]
       EnvVars:
         AZURE_SKIP_LIVE_RECORDING: 'True'
         AZURE_TEST_RUN_LIVE: 'true'

--- a/sdk/communication/azure-communication-email/tests.yml
+++ b/sdk/communication/azure-communication-email/tests.yml
@@ -7,22 +7,13 @@ stages:
       JobName: email
       ServiceDirectory: communication
       CloudConfig:
-        Public:
-          SubscriptionConfigurations:
-            - $(sub-config-azure-cloud-test-resources)
-            - $(sub-config-communication-services-cloud-test-resources-common)
-            - $(sub-config-communication-services-cloud-test-resources-python)
-        Int:
-          SubscriptionConfigurations:
-            - $(sub-config-communication-int-test-resources-common)
-            - $(sub-config-communication-int-test-resources-python)
         PPE:
           SubscriptionConfigurations:
             - $(sub-config-communication-ppe-test-resources-common)
             - $(sub-config-communication-ppe-test-resources-python)
           MatrixReplace:
             - TestSamples=.*/true
-      Clouds: 'Public,PPE,Int'
+      Clouds: 'PPE'
       EnvVars:
         AZURE_SKIP_LIVE_RECORDING: 'True'
         AZURE_TEST_RUN_LIVE: 'true'

--- a/sdk/communication/azure-communication-email/tests.yml
+++ b/sdk/communication/azure-communication-email/tests.yml
@@ -18,16 +18,15 @@ stages:
             - $(sub-config-communication-ppe-test-resources-python)
           MatrixReplace:
             - TestSamples=.*/true
-        ${{ if eq(parameters.runOnlyPPEStage, false) }}:
-          Public:
-            SubscriptionConfigurations:
-              - $(sub-config-azure-cloud-test-resources)
-              - $(sub-config-communication-services-cloud-test-resources-common)
-              - $(sub-config-communication-services-cloud-test-resources-python)
-          Int:
-            SubscriptionConfigurations:
-              - $(sub-config-communication-int-test-resources-common)
-              - $(sub-config-communication-int-test-resources-python)
+        Public:
+          SubscriptionConfigurations:
+            - $(sub-config-azure-cloud-test-resources)
+            - $(sub-config-communication-services-cloud-test-resources-common)
+            - $(sub-config-communication-services-cloud-test-resources-python)
+        Int:
+          SubscriptionConfigurations:
+            - $(sub-config-communication-int-test-resources-common)
+            - $(sub-config-communication-int-test-resources-python)
       ${{ if eq(parameters.runOnlyPPEStage, true) }}:
         Clouds: 'PPE'
       ${{ if eq(parameters.runOnlyPPEStage, false) }}:

--- a/sdk/communication/azure-communication-email/tests.yml
+++ b/sdk/communication/azure-communication-email/tests.yml
@@ -18,7 +18,6 @@ stages:
             - $(sub-config-communication-ppe-test-resources-python)
           MatrixReplace:
             - TestSamples=.*/true
-      ${{ if eq(parameters.runOnlyPPEStage, false) }}:
         Public:
           SubscriptionConfigurations:
             - $(sub-config-azure-cloud-test-resources)
@@ -28,10 +27,10 @@ stages:
           SubscriptionConfigurations:
             - $(sub-config-communication-int-test-resources-common)
             - $(sub-config-communication-int-test-resources-python)
-    ${{ if eq(parameters.runOnlyPPEStage, true) }}:
-      Clouds: 'PPE'
-    ${{ if eq(parameters.runOnlyPPEStage, false) }}:
-      Clouds: 'Public,PPE,Int'
+      ${{ if eq(parameters.runOnlyPPEStage, true) }}:
+        Clouds: 'PPE'
+      ${{ if eq(parameters.runOnlyPPEStage, false) }}:
+        Clouds: 'Public,PPE,Int'
       EnvVars:
         AZURE_SKIP_LIVE_RECORDING: 'True'
         AZURE_TEST_RUN_LIVE: 'true'

--- a/sdk/communication/azure-communication-email/tests.yml
+++ b/sdk/communication/azure-communication-email/tests.yml
@@ -1,13 +1,10 @@
 trigger: none
 
-# parameters:
-# - name: stagesToRun
-#   displayName: "Stages To Run"
-#   type: string
-#   default: 'Int,PPE,Public'
-
-variables:
-- name: stagesToRun
+parameters:
+- name: runOnlyPPE
+  displayName: "Run only the PPE stage"
+  type: boolean,
+  default: false
 
 stages:
   - template: /eng/pipelines/templates/stages/archetype-sdk-tests.yml
@@ -31,7 +28,10 @@ stages:
           SubscriptionConfigurations:
             - $(sub-config-communication-int-test-resources-common)
             - $(sub-config-communication-int-test-resources-python)
-      Clouds: ${{ variables.stagesToRun }}
+      ${{ if eq(parameters.runOnlyPPE, true) }}:
+        Clouds: 'PPE'
+      ${{ if eq(parameters.runOnlyPPE, false) }}:
+        Clouds: 'Public,Int,PPE'
       EnvVars:
         AZURE_SKIP_LIVE_RECORDING: 'True'
         AZURE_TEST_RUN_LIVE: 'true'

--- a/sdk/communication/azure-communication-email/tests.yml
+++ b/sdk/communication/azure-communication-email/tests.yml
@@ -8,7 +8,7 @@ trigger: none
 
 variables:
 - name: stagesToRun
-  value: 'Int,PPE,Public'
+  value: 'Int,PPE'
 
 stages:
   - template: /eng/pipelines/templates/stages/archetype-sdk-tests.yml
@@ -32,7 +32,7 @@ stages:
           SubscriptionConfigurations:
             - $(sub-config-communication-int-test-resources-common)
             - $(sub-config-communication-int-test-resources-python)
-      Clouds: $[variables.stagesToRun]
+      Clouds: ${{ variables.stagesToRun }}
       EnvVars:
         AZURE_SKIP_LIVE_RECORDING: 'True'
         AZURE_TEST_RUN_LIVE: 'true'


### PR DESCRIPTION
I've added a parameter to the email live test pipelines that allows only the PPE stage to be run. This allows us to start a build on this pipeline from our service deployment pipeline.