### PR TITLE
[FR] rerecord and make sure we catch non-flaky tests

### DIFF
--- a/sdk/formrecognizer/azure-ai-formrecognizer/assets.json
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "python",
   "TagPrefix": "python/formrecognizer/azure-ai-formrecognizer",
-  "Tag": "python/formrecognizer/azure-ai-formrecognizer_2e1ce3f599"
+  "Tag": "python/formrecognizer/azure-ai-formrecognizer_8c256f5277"
 }

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/conftest.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/conftest.py
@@ -66,21 +66,21 @@ def add_sanitizers(test_proxy):
 def skip_flaky_test(f):
     @wraps(f)
     def wrapper(*args, **kwargs):
-        try:
-            return f(*args, **kwargs)
-        except HttpResponseError as error:
-            logger = logging.getLogger("azure")
-            if "Invalid request".casefold() in error.message.casefold():
-                pytest.mark.skip("flaky service response: {}".format(error))
-                logger.debug("flaky service response: {}".format(error))
-            elif "Generic error".casefold() in error.message.casefold():
-                pytest.mark.skip("flaky service response: {}".format(error))
-                logger.debug("flaky service response: {}".format(error))
-            elif "Timeout" in error.message.casefold():
-                pytest.mark.skip("flaky service response: {}".format(error))
-                logger.debug("flaky service response: {}".format(error))
-            elif "InvalidImage" in error.message.casefold():
-                pytest.mark.skip("flaky service response: {}".format(error))
-                logger.debug("flaky service response: {}".format(error))
+        # try:
+        return f(*args, **kwargs)
+        # except HttpResponseError as error:
+        #     logger = logging.getLogger("azure")
+        #     if "Invalid request".casefold() in error.message.casefold():
+        #         pytest.mark.skip("flaky service response: {}".format(error))
+        #         logger.debug("flaky service response: {}".format(error))
+        #     elif "Generic error".casefold() in error.message.casefold():
+        #         pytest.mark.skip("flaky service response: {}".format(error))
+        #         logger.debug("flaky service response: {}".format(error))
+        #     elif "Timeout" in error.message.casefold():
+        #         pytest.mark.skip("flaky service response: {}".format(error))
+        #         logger.debug("flaky service response: {}".format(error))
+        #     elif "InvalidImage" in error.message.casefold():
+        #         pytest.mark.skip("flaky service response: {}".format(error))
+        #         logger.debug("flaky service response: {}".format(error))
 
     return wrapper

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/conftest.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/conftest.py
@@ -66,21 +66,22 @@ def add_sanitizers(test_proxy):
 def skip_flaky_test(f):
     @wraps(f)
     def wrapper(*args, **kwargs):
-        # try:
-        return f(*args, **kwargs)
-        # except HttpResponseError as error:
-        #     logger = logging.getLogger("azure")
-        #     if "Invalid request".casefold() in error.message.casefold():
-        #         pytest.mark.skip("flaky service response: {}".format(error))
-        #         logger.debug("flaky service response: {}".format(error))
-        #     elif "Generic error".casefold() in error.message.casefold():
-        #         pytest.mark.skip("flaky service response: {}".format(error))
-        #         logger.debug("flaky service response: {}".format(error))
-        #     elif "Timeout" in error.message.casefold():
-        #         pytest.mark.skip("flaky service response: {}".format(error))
-        #         logger.debug("flaky service response: {}".format(error))
-        #     elif "InvalidImage" in error.message.casefold():
-        #         pytest.mark.skip("flaky service response: {}".format(error))
-        #         logger.debug("flaky service response: {}".format(error))
+        try:
+            return f(*args, **kwargs)
+        except HttpResponseError as error:
+            logger = logging.getLogger("azure")
+            if "Invalid request".casefold() in error.message.casefold():
+                pytest.mark.skip("flaky service response: {}".format(error))
+                logger.debug("flaky service response: {}".format(error))
+            elif "Generic error".casefold() in error.message.casefold():
+                pytest.mark.skip("flaky service response: {}".format(error))
+                logger.debug("flaky service response: {}".format(error))
+            elif "Timeout" in error.message.casefold():
+                pytest.mark.skip("flaky service response: {}".format(error))
+                logger.debug("flaky service response: {}".format(error))
+            elif "InvalidImage" in error.message.casefold():
+                pytest.mark.skip("flaky service response: {}".format(error))
+                logger.debug("flaky service response: {}".format(error))
+            raise  # not a flaky test
 
     return wrapper


### PR DESCRIPTION
Makes sure all recordings point to 2023-02-28-preview and that we raise if a test fails due to a non-flaky reason.