### PR TITLE
Adding _workspace_id in feature store and bug fixes

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_feature_store/feature_store.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_feature_store/feature_store.py
@@ -117,6 +117,7 @@ class _FeatureStore(Workspace):
                 OFFLINE_STORE_CONNECTION_NAME if materialization_identity and offline_store else None
             ),
         )
+        self._workspace_id = kwargs.pop("workspace_id", "")
         super().__init__(
             name=name,
             description=description,
@@ -171,6 +172,7 @@ class _FeatureStore(Workspace):
             public_network_access=workspace_object.public_network_access,
             identity=workspace_object.identity,
             primary_user_assigned_identity=workspace_object.primary_user_assigned_identity,
+            workspace_id=rest_obj.workspace_id,
         )
 
     @classmethod

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_feature_set_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_feature_set_operations.py
@@ -204,7 +204,7 @@ class _FeatureSetOperations(_ScopeDependentOperations):
         compute_resource: Optional[_MaterializationComputeResource] = None,
         spark_configuration: Optional[Dict[str, str]] = None,
         **kwargs,  # pylint: disable=unused-argument
-    ) -> LROPoller[_FeatureSetMaterializationResponse]:
+    ) -> LROPoller[_FeatureSetBackfillResponse]:
         """Backfill.
 
         :param name: Feature set name. This is case-sensitive.

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_feature_store_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_feature_store_operations.py
@@ -15,6 +15,7 @@ from azure.ai.ml._scope_dependent_operations import OperationsContainer, Operati
 from azure.core.credentials import TokenCredential
 from azure.core.polling import LROPoller
 from azure.core.tracing.decorator import distributed_trace
+from azure.core.exceptions import ResourceNotFoundError
 from azure.ai.ml._utils._logger_utils import OpsLogger
 from azure.ai.ml.entities._feature_store.feature_store import _FeatureStore
 from azure.ai.ml.entities._workspace.feature_store_settings import _FeatureStoreSettings
@@ -115,9 +116,12 @@ class _FeatureStoreOperations(WorkspaceOperationsBase):
                 rest_workspace_obj.feature_store_settings
                 and rest_workspace_obj.feature_store_settings.offline_store_connection_name
             ):
-                offline_Store_connection = self._workspace_connection_operation.get(
-                    resource_group, name, rest_workspace_obj.feature_store_settings.offline_store_connection_name
-                )
+                try:
+                    offline_Store_connection = self._workspace_connection_operation.get(
+                        resource_group, name, rest_workspace_obj.feature_store_settings.offline_store_connection_name
+                    )
+                except ResourceNotFoundError:
+                    pass
 
             if offline_Store_connection:
                 if (


### PR DESCRIPTION
# Description

1. Adding _workspace_id in feature store
2. Fix response type for backfill
3. Get feature store without offline store information when connection is not found

If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
