### PR TITLE
[typespec] package json with just emitter dependency

### DIFF
--- a/eng/emitter-package.json
+++ b/eng/emitter-package.json
@@ -1,16 +1,6 @@
 {
   "main": "dist/src/index.js",
   "dependencies": {
-    "@azure-tools/cadl-python": "0.4.25",
-    "@autorest/python": "6.4.0",
-    "@azure-tools/cadl-autorest": "0.26.0",
-    "@azure-tools/cadl-azure-core": "0.26.0",
-    "@azure-tools/cadl-dpg": "0.26.0",
-    "@azure-tools/cadl-azure-resource-manager": "0.26.0",
-    "@cadl-lang/compiler": "0.40.0",
-    "@cadl-lang/eslint-config-cadl": "0.5.0",
-    "@cadl-lang/openapi": "0.40.0",
-    "@cadl-lang/rest": "0.40.0",
-    "@cadl-lang/versioning": "0.40.0"
+    "@azure-tools/typespec-python": "0.7.0"
   }
 }


### PR DESCRIPTION
as part of our efforts to only install emitter / typespec packages once, we can't pin the typespec package dependencies in `emitter-package.json`