### PR TITLE
[ML][Pipelines] fix: support data binding expression for limits.timeout

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_internal/entities/command.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_internal/entities/command.py
@@ -7,7 +7,6 @@ from typing import Dict, List, Union
 from marshmallow import INCLUDE, Schema
 
 from ... import MpiDistribution, PyTorchDistribution, TensorFlowDistribution
-from ..._restclient.v2023_02_01_preview.models import CommandJobLimits as RestCommandJobLimits
 from ..._restclient.v2023_02_01_preview.models import JobResourceConfiguration as RestJobResourceConfiguration
 from ..._schema import PathAwareSchema
 from ..._schema.core.fields import DistributionField
@@ -112,8 +111,7 @@ class Command(InternalBaseNode):
 
         # handle limits
         if "limits" in obj and obj["limits"]:
-            rest_limits = RestCommandJobLimits.from_dict(obj["limits"])
-            obj["limits"] = CommandJobLimits()._from_rest_object(rest_limits)
+            obj["limits"] = CommandJobLimits()._from_rest_object(obj["limits"])
         return obj
 
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/job_limits.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/job_limits.py
@@ -8,10 +8,10 @@ from typing import Optional, Union
 
 from azure.ai.ml._restclient.v2022_12_01_preview.models import CommandJobLimits as RestCommandJobLimits
 from azure.ai.ml._restclient.v2022_12_01_preview.models import SweepJobLimits as RestSweepJobLimits
-from azure.ai.ml._utils.utils import from_iso_duration_format, to_iso_duration_format, is_data_binding_expression
+from azure.ai.ml._utils.utils import from_iso_duration_format, is_data_binding_expression, to_iso_duration_format
 from azure.ai.ml.constants import JobType
-from azure.ai.ml.entities._mixins import RestTranslatableMixin
 from azure.ai.ml.entities._job.pipeline._io import PipelineInput
+from azure.ai.ml.entities._mixins import RestTranslatableMixin
 
 module_logger = logging.getLogger(__name__)
 
@@ -49,11 +49,11 @@ class CommandJobLimits(JobLimits):
         return RestCommandJobLimits(timeout=to_iso_duration_format(self.timeout))
 
     @classmethod
-    def _from_rest_object(cls, obj: Union[RestCommandJobLimits, dict]) -> "CommandJobLimits":
+    def _from_rest_object(cls, obj: Union[RestCommandJobLimits, dict]) -> Optional["CommandJobLimits"]:
         if not obj:
             return None
         if isinstance(obj, dict):
-            timeout_value = obj["timeout"]
+            timeout_value = obj.get("timeout", None)
             # if timeout value is a binding string
             if is_data_binding_expression(timeout_value):
                 return cls(timeout=timeout_value)


### PR DESCRIPTION
# Description

1. handle the case that timeout is not provided
2. handle the case to load data-binding expression in timeout by removing redundant `RestCommandJobLimits.from_dict`, which will fail when trying to load data-binding expression as iso time

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
