### PR TITLE
[Pipeline] Support pipeline binding for node resource.instance_count

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_internal/entities/command.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_internal/entities/command.py
@@ -7,7 +7,6 @@ from typing import Dict, List, Union
 from marshmallow import INCLUDE, Schema
 
 from ... import MpiDistribution, PyTorchDistribution, TensorFlowDistribution
-from ..._restclient.v2023_02_01_preview.models import JobResourceConfiguration as RestJobResourceConfiguration
 from ..._schema import PathAwareSchema
 from ..._schema.core.fields import DistributionField
 from ...entities import CommandJobLimits, JobResourceConfiguration
@@ -106,8 +105,7 @@ class Command(InternalBaseNode):
         obj = InternalBaseNode._from_rest_object_to_init_params(obj)
 
         if "resources" in obj and obj["resources"]:
-            resources = RestJobResourceConfiguration.from_dict(obj["resources"])
-            obj["resources"] = JobResourceConfiguration._from_rest_object(resources)
+            obj["resources"] = JobResourceConfiguration._from_rest_object(obj["resources"])
 
         # handle limits
         if "limits" in obj and obj["limits"]:

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_builders/command.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_builders/command.py
@@ -591,8 +591,7 @@ class Command(BaseNode):
         obj = BaseNode._from_rest_object_to_init_params(obj)
 
         if "resources" in obj and obj["resources"]:
-            resources = RestJobResourceConfiguration.from_dict(obj["resources"])
-            obj["resources"] = JobResourceConfiguration._from_rest_object(resources)
+            obj["resources"] = JobResourceConfiguration._from_rest_object(obj["resources"])
 
         # services, sweep won't have services
         if "services" in obj and obj["services"]:

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_builders/command.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_builders/command.py
@@ -15,7 +15,6 @@ from marshmallow import INCLUDE, Schema
 
 from azure.ai.ml._restclient.v2023_02_01_preview.models import CommandJob as RestCommandJob
 from azure.ai.ml._restclient.v2023_02_01_preview.models import JobBase
-from azure.ai.ml._restclient.v2023_02_01_preview.models import JobResourceConfiguration as RestJobResourceConfiguration
 from azure.ai.ml._restclient.v2023_02_01_preview.models import QueueSettings as RestQueueSettings
 from azure.ai.ml._schema.core.fields import NestedField, UnionField
 from azure.ai.ml._schema.job.command_job import CommandJobSchema

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/job_resource_configuration.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/job_resource_configuration.py
@@ -10,7 +10,6 @@ from azure.ai.ml._restclient.v2023_02_01_preview.models import JobResourceConfig
 from azure.ai.ml.constants._job.job import JobComputePropertyFields
 from azure.ai.ml.entities._mixins import DictMixin, RestTranslatableMixin
 from azure.ai.ml.entities._util import convert_ordered_dict_to_dict
-from azure.ai.ml._utils.utils import is_data_binding_expression
 
 module_logger = logging.getLogger(__name__)
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/job_resource_configuration.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/job_resource_configuration.py
@@ -4,12 +4,13 @@
 
 import json
 import logging
-from typing import Any, Dict, Optional, List
+from typing import Any, Dict, Optional, List, Union
 
 from azure.ai.ml._restclient.v2023_02_01_preview.models import JobResourceConfiguration as RestJobResourceConfiguration
 from azure.ai.ml.constants._job.job import JobComputePropertyFields
 from azure.ai.ml.entities._mixins import DictMixin, RestTranslatableMixin
 from azure.ai.ml.entities._util import convert_ordered_dict_to_dict
+from azure.ai.ml._utils.utils import is_data_binding_expression
 
 module_logger = logging.getLogger(__name__)
 
@@ -108,7 +109,7 @@ class JobResourceConfiguration(RestTranslatableMixin, DictMixin):
         self,
         *,
         locations: Optional[List[str]] = None,
-        instance_count: Optional[int] = None,
+        instance_count: Union[int, str, None] = None,
         instance_type: Optional[str] = None,
         properties: Optional[Dict[str, Any]] = None,
         docker_args: Optional[str] = None,
@@ -153,9 +154,19 @@ class JobResourceConfiguration(RestTranslatableMixin, DictMixin):
         return obj
 
     @classmethod
-    def _from_rest_object(cls, obj: Optional[RestJobResourceConfiguration]) -> Optional["JobResourceConfiguration"]:
+    def _from_rest_object(cls, obj: Union[RestJobResourceConfiguration, dict]) -> Optional["JobResourceConfiguration"]:
         if obj is None:
             return None
+        if isinstance(obj, dict):
+            return JobResourceConfiguration(
+                locations=obj.get("locations", None),
+                instance_count=obj.get("instance_count", None),
+                instance_type=obj.get("instance_type", None),
+                properties=obj.get("properties", None),
+                docker_args=obj.get("docker_args", None),
+                shm_size=obj.get("shm_size", None),
+                deserialize_properties=True,
+            )
         return JobResourceConfiguration(
             locations=obj.locations,
             instance_count=obj.instance_count,

--- a/sdk/ml/azure-ai-ml/tests/component/unittests/test_pipeline_component_entity.py
+++ b/sdk/ml/azure-ai-ml/tests/component/unittests/test_pipeline_component_entity.py
@@ -423,7 +423,7 @@ class TestPipelineComponentEntity:
             "literal_input2": {"job_input_type": "literal", "value": "12"},
         }
         assert node_dict["resources"] == {
-            "instance_count": 1,
+            "instance_count": "1",
             "properties": {"target_selector": {"my_resource_only": "false", "allow_spot_vm": "true"}},
             "shm_size": "2g",
         }

--- a/sdk/ml/azure-ai-ml/tests/dsl/unittests/test_dsl_pipeline.py
+++ b/sdk/ml/azure-ai-ml/tests/dsl/unittests/test_dsl_pipeline.py
@@ -10,6 +10,7 @@ import pydash
 import pytest
 
 from azure.ai.ml.constants._job import PipelineConstants
+from azure.ai.ml.dsl import pipeline
 from test_configs.dsl_pipeline import data_binding_expression
 from test_utilities.utils import omit_with_wildcard, prepare_dsl_curated, assert_job_cancel
 

--- a/sdk/ml/azure-ai-ml/tests/dsl/unittests/test_dsl_pipeline.py
+++ b/sdk/ml/azure-ai-ml/tests/dsl/unittests/test_dsl_pipeline.py
@@ -3113,21 +3113,26 @@ class TestDSLPipeline:
         assert pipeline_dict["properties"]["jobs"]["node_0"]["limits"]["timeout"] == "${{parent.inputs.timeout}}"
         assert pipeline_dict["properties"]["jobs"]["node_1"]["limits"]["timeout"] == "PT1S"
 
-    def test_pipeline_input_binding_limits_timeout(self):
+    def test_pipeline_input_binding_instance_count(self):
         component_yaml = r"./tests/test_configs/components/helloworld_component_no_paths.yml"
         component_func = load_component(source=component_yaml)
 
         @dsl.pipeline
         def my_pipeline(instance_count) -> PipelineJob:
-            # case 1: if timeout is PipelineInput
+            # case 1: if instance_count is PipelineInput
             node_0 = component_func(component_in_number=1)
+            node_0.resources = JobResourceConfiguration()
             node_0.resources.instance_count = instance_count
-            # case 2: if timeout is not PipelineInput
+            # case 2: if instance_count is not PipelineInput
             node_1 = component_func(component_in_number=1)
+            node_1.resources = JobResourceConfiguration()
             node_1.resources.instance_count = 2
 
         pipeline = my_pipeline(2)
         pipeline.settings.default_compute = "cpu-cluster"
         pipeline_dict = pipeline._to_rest_object().as_dict()
-        assert pipeline_dict["properties"]["jobs"]["node_0"]["resources"]["instance_count"] == "${{parent.inputs.instance_count}}"
-        assert pipeline_dict["properties"]["jobs"]["node_1"]["resources"]["instance_count"] == "2"
+        assert (
+            pipeline_dict["properties"]["jobs"]["node_0"]["resources"]["instance_count"]
+            == "${{parent.inputs.instance_count}}"
+        )
+        assert pipeline_dict["properties"]["jobs"]["node_1"]["resources"]["instance_count"] == 2


### PR DESCRIPTION
# Description
Support pipeline binding for node resources.instance_count
```python
@dsl.pipeline
def my_pipeline(instance_count):
    node = component_func(component_in_number=1)
    # bind PipelineInput to node's resources.instance_count
    assert isinstance(instance_count, PipelineInput)
    node.resources.instance_count = instance_count
```

Error msg:
```
Exception: Unable to deserialize response data. Data: ${{parent.inputs.instance_count}}, int, ValueError: invalid literal for int() with base 10: '${{parent.inputs.instance_count}}'.
Traceback (most recent call last):
  File "D:\conda_env\smile\lib\site-packages\msrest\serialization.py", line 1605, in deserialize_data
    return self.deserialize_basic(data, data_type)
  File "D:\conda_env\smile\lib\site-packages\msrest\serialization.py", line 1748, in deserialize_basic
    return eval(data_type)(attr)
ValueError: invalid literal for int() with base 10: '${{parent.inputs.instance_count}}'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "d:\project\azure-sdk-for-python\sdk\ml\azure-ai-ml\azure\ai\ml\entities\_job\job.py", line 309, in _from_rest_object
    return PipelineJob._load_from_rest(obj)
  File "d:\project\azure-sdk-for-python\sdk\ml\azure-ai-ml\azure\ai\ml\entities\_job\pipeline\pipeline_job.py", line 526, in _load_from_rest
    sub_nodes = PipelineComponent._resolve_sub_nodes(properties.jobs) if properties.jobs else {}
  File "d:\project\azure-sdk-for-python\sdk\ml\azure-ai-ml\azure\ai\ml\entities\_component\pipeline_component.py", line 359, in _resolve_sub_nodes
    sub_nodes[node_name] = pipeline_node_factory.load_from_rest_object(obj=node)
  File "d:\project\azure-sdk-for-python\sdk\ml\azure-ai-ml\azure\ai\ml\entities\_job\pipeline\_load_component.py", line 252, in load_from_rest_object
    return self.get_load_from_rest_object_func(_type)(obj, **kwargs)
  File "d:\project\azure-sdk-for-python\sdk\ml\azure-ai-ml\azure\ai\ml\entities\_builders\base_node.py", line 369, in _from_rest_object
    init_kwargs = instance._from_rest_object_to_init_params(obj)
  File "d:\project\azure-sdk-for-python\sdk\ml\azure-ai-ml\azure\ai\ml\_internal\entities\command.py", line 110, in _from_rest_object_to_init_params
    resources = RestJobResourceConfiguration.from_dict(obj["resources"])
  File "D:\conda_env\smile\lib\site-packages\msrest\serialization.py", line 349, in from_dict
    return deserializer(cls.__name__, data, content_type=content_type)
  File "D:\conda_env\smile\lib\site-packages\msrest\serialization.py", line 1368, in __call__
    return self._deserialize(target_obj, data)
  File "D:\conda_env\smile\lib\site-packages\msrest\serialization.py", line 1442, in _deserialize
    value = self.deserialize_data(raw_value, attr_desc['type'])
  File "D:\conda_env\smile\lib\site-packages\msrest\serialization.py", line 1629, in deserialize_data
    raise_with_traceback(DeserializationError, msg, err)
  File "D:\conda_env\smile\lib\site-packages\msrest\exceptions.py", line 51, in raise_with_traceback
    raise error.with_traceback(exc_traceback)
  File "D:\conda_env\smile\lib\site-packages\msrest\serialization.py", line 1605, in deserialize_data
    return self.deserialize_basic(data, data_type)
  File "D:\conda_env\smile\lib\site-packages\msrest\serialization.py", line 1748, in deserialize_basic
    return eval(data_type)(attr)
msrest.exceptions.DeserializationError: Unable to deserialize response data. Data: ${{parent.inputs.instance_count}}, int, ValueError: invalid literal for int() with base 10: '${{parent.inputs.instance_count}}'
```
Please add an informative description that covers that changes made by the pull request and link all relevant issues.

If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
