### PR TITLE
Set up base path for feature set in load function

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_assets/_artifacts/feature_set.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_assets/_artifacts/feature_set.py
@@ -139,12 +139,14 @@ class _FeatureSet(Artifact):
     ) -> "_FeatureSet":
         data = data or {}
         params_override = params_override or []
+        base_path = Path(yaml_path).parent if yaml_path else Path("./")
         context = {
-            BASE_PATH_CONTEXT_KEY: Path(yaml_path).parent if yaml_path else Path("./"),
+            BASE_PATH_CONTEXT_KEY: base_path,
             PARAMS_OVERRIDE_KEY: params_override,
         }
         loaded_schema = load_from_dict(FeatureSetSchema, data, context, **kwargs)
-        return _FeatureSet(**loaded_schema)
+        feature_set = _FeatureSet(base_path=base_path, **loaded_schema)
+        return feature_set
 
     def _to_dict(self) -> Dict:
         # pylint: disable=no-member


### PR DESCRIPTION
# Description

1. Set up base path for feature set in load function
2. Bug fix for featureset spec yaml file is not taking the relative path

If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
