### PR TITLE
[Monitor][Query] Support non-public clouds

### DIFF
--- a/sdk/monitor/azure-monitor-query/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-query/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 ### Other Changes
 
+- Improved client configuration logic for non-public Azure clouds where credential scope will be determined based on the configured endpoint. ([#29602](https://github.com/Azure/azure-sdk-for-python/pull/29602))
+
 ## 1.1.1 (2023-02-13)
 
 ### Bugs Fixed

--- a/sdk/monitor/azure-monitor-query/README.md
+++ b/sdk/monitor/azure-monitor-query/README.md
@@ -63,6 +63,17 @@ async_logs_client = LogsQueryClient(credential)
 async_metrics_client = MetricsQueryClient(credential)
 ```
 
+#### Configure clients for non-public Azure clouds
+
+By default, `LogsQueryClient` and `MetricsQueryClient` are configured to connect to the public Azure cloud. These can be configured to connect to non-public Azure clouds by passing in the correct `endpoint` argument: For example:
+
+```python
+logs_client = LogsQueryClient(credential, endpoint="https://api.loganalytics.azure.cn/v1")
+metrics_client = MetricsQueryClient(credential, endpoint="https://management.chinacloudapi.cn")
+```
+
+**Note**: Currently, `MetricsQueryClient` uses the Azure Resource Manager (ARM) endpoint for querying metrics, so you will need the corresponding management endpoint for your cloud when using this client. This is subject to change in the future.
+
 ### Execute the query
 
 For examples of Logs and Metrics queries, see the [Examples](#examples) section.

--- a/sdk/monitor/azure-monitor-query/azure/monitor/query/_helpers.py
+++ b/sdk/monitor/azure-monitor-query/azure/monitor/query/_helpers.py
@@ -16,14 +16,12 @@ from ._generated._serialization import Serializer, Deserializer
 
 def get_authentication_policy(
     credential: TokenCredential,
-    audience: Optional[str] = None
+    audience: str
 ) -> BearerTokenCredentialPolicy:
     """Returns the correct authentication policy"""
-    if not audience:
-        audience = "https://api.loganalytics.io/"
-    scope = audience.rstrip('/') + "/.default"
     if credential is None:
         raise ValueError("Parameter 'credential' must not be None.")
+    scope = audience.rstrip('/') + "/.default"
     if hasattr(credential, "get_token"):
         return BearerTokenCredentialPolicy(
             credential, scope
@@ -34,14 +32,12 @@ def get_authentication_policy(
 
 def get_metrics_authentication_policy(
     credential: TokenCredential,
-    audience: Optional[str] = None
+    audience: str
 ) -> BearerTokenCredentialPolicy:
     """Returns the correct authentication policy"""
-    if not audience:
-        audience = "https://management.azure.com/"
-    scope = audience.rstrip('/') + "/.default"
     if credential is None:
         raise ValueError("Parameter 'credential' must not be None.")
+    scope = audience.rstrip('/') + "/.default"
     if hasattr(credential, "get_token"):
         return BearerTokenCredentialPolicy(
             credential, scope

--- a/sdk/monitor/azure-monitor-query/azure/monitor/query/_helpers.py
+++ b/sdk/monitor/azure-monitor-query/azure/monitor/query/_helpers.py
@@ -14,34 +14,13 @@ from azure.core.pipeline.policies import BearerTokenCredentialPolicy
 from ._generated._serialization import Serializer, Deserializer
 
 
-def get_authentication_policy(
-    credential: TokenCredential,
-    audience: str
-) -> BearerTokenCredentialPolicy:
+def get_authentication_policy(credential: TokenCredential, audience: str) -> BearerTokenCredentialPolicy:
     """Returns the correct authentication policy"""
     if credential is None:
         raise ValueError("Parameter 'credential' must not be None.")
-    scope = audience.rstrip('/') + "/.default"
+    scope = audience.rstrip("/") + "/.default"
     if hasattr(credential, "get_token"):
-        return BearerTokenCredentialPolicy(
-            credential, scope
-        )
-
-    raise TypeError("Unsupported credential")
-
-
-def get_metrics_authentication_policy(
-    credential: TokenCredential,
-    audience: str
-) -> BearerTokenCredentialPolicy:
-    """Returns the correct authentication policy"""
-    if credential is None:
-        raise ValueError("Parameter 'credential' must not be None.")
-    scope = audience.rstrip('/') + "/.default"
-    if hasattr(credential, "get_token"):
-        return BearerTokenCredentialPolicy(
-            credential, scope
-        )
+        return BearerTokenCredentialPolicy(credential, scope)
 
     raise TypeError("Unsupported credential")
 

--- a/sdk/monitor/azure-monitor-query/azure/monitor/query/_logs_query_client.py
+++ b/sdk/monitor/azure-monitor-query/azure/monitor/query/_logs_query_client.py
@@ -4,8 +4,9 @@
 # Licensed under the MIT License. See License.txt in the project root for
 # license information.
 # --------------------------------------------------------------------------
-from typing import Any, Union, Sequence, Dict, List, cast, Tuple, Optional
 from datetime import timedelta, datetime
+from typing import Any, Union, Sequence, Dict, List, cast, Tuple, Optional
+from urllib.parse import urlparse
 
 from azure.core.credentials import TokenCredential
 from azure.core.exceptions import HttpResponseError
@@ -43,20 +44,22 @@ class LogsQueryClient(object): # pylint: disable=client-accepts-api-version-keyw
 
     :param credential: The credential to authenticate the client.
     :type credential: ~azure.core.credentials.TokenCredential
-    :keyword endpoint: The endpoint to connect to. Defaults to 'https://api.loganalytics.io'.
+    :keyword endpoint: The endpoint to connect to. Defaults to 'https://api.loganalytics.io/v1'.
     :paramtype endpoint: Optional[str]
     """
 
     def __init__(self, credential: TokenCredential, **kwargs: Any) -> None:
-        endpoint = kwargs.pop("endpoint", "https://api.loganalytics.io")
+        endpoint = kwargs.pop("endpoint", "https://api.loganalytics.io/v1")
         if not endpoint.startswith("https://") and not endpoint.startswith("http://"):
             endpoint = "https://" + endpoint
+        parsed_endpoint = urlparse(endpoint)
+        audience = kwargs.pop("audience", f"{parsed_endpoint.scheme}://{parsed_endpoint.netloc}")
         self._endpoint = endpoint
         auth_policy = kwargs.pop("authentication_policy", None)
         self._client = MonitorQueryClient(
             credential=credential,
-            authentication_policy=auth_policy or get_authentication_policy(credential, endpoint),
-            endpoint=self._endpoint.rstrip('/') + "/v1",
+            authentication_policy=auth_policy or get_authentication_policy(credential, audience),
+            endpoint=self._endpoint,
             **kwargs
         )
         self._query_op = self._client.query

--- a/sdk/monitor/azure-monitor-query/azure/monitor/query/_metrics_query_client.py
+++ b/sdk/monitor/azure-monitor-query/azure/monitor/query/_metrics_query_client.py
@@ -40,8 +40,8 @@ class MetricsQueryClient(object): # pylint: disable=client-accepts-api-version-k
     """
 
     def __init__(self, credential: TokenCredential, **kwargs: Any) -> None:
-        audience = kwargs.pop("audience", None)
         endpoint = kwargs.pop("endpoint", "https://management.azure.com")
+        audience = kwargs.pop("audience", endpoint)
         if not endpoint.startswith("https://") and not endpoint.startswith("http://"):
             endpoint = "https://" + endpoint
         self._endpoint = endpoint

--- a/sdk/monitor/azure-monitor-query/azure/monitor/query/_metrics_query_client.py
+++ b/sdk/monitor/azure-monitor-query/azure/monitor/query/_metrics_query_client.py
@@ -14,7 +14,7 @@ from azure.core.tracing.decorator import distributed_trace
 from ._generated._serialization import Serializer
 from ._generated.metrics._client import MonitorMetricsClient
 from ._models import MetricsQueryResult, MetricDefinition, MetricNamespace
-from ._helpers import get_metrics_authentication_policy, construct_iso8601
+from ._helpers import get_authentication_policy, construct_iso8601
 
 
 class MetricsQueryClient(object): # pylint: disable=client-accepts-api-version-keyword
@@ -49,7 +49,7 @@ class MetricsQueryClient(object): # pylint: disable=client-accepts-api-version-k
         self._client = MonitorMetricsClient(
             credential=credential,
             endpoint=self._endpoint,
-            authentication_policy=auth_policy or get_metrics_authentication_policy(credential, audience),
+            authentication_policy=auth_policy or get_authentication_policy(credential, audience),
             **kwargs
         )
         self._metrics_op = self._client.metrics

--- a/sdk/monitor/azure-monitor-query/azure/monitor/query/aio/_helpers_async.py
+++ b/sdk/monitor/azure-monitor-query/azure/monitor/query/aio/_helpers_async.py
@@ -4,43 +4,17 @@
 # Licensed under the MIT License. See License.txt in the project root for
 # license information.
 # --------------------------------------------------------------------------
-from typing import Optional
 
 from azure.core.credentials_async import AsyncTokenCredential
 from azure.core.pipeline.policies import AsyncBearerTokenCredentialPolicy
 
 
-def get_authentication_policy(
-    credential: AsyncTokenCredential,
-    audience: Optional[str] = None
-) -> AsyncBearerTokenCredentialPolicy:
+def get_authentication_policy(credential: AsyncTokenCredential, audience: str) -> AsyncBearerTokenCredentialPolicy:
     """Returns the correct authentication policy"""
-    if not audience:
-        audience = "https://api.loganalytics.io/"
-    scope = audience.rstrip('/') + "/.default"
     if credential is None:
         raise ValueError("Parameter 'credential' must not be None.")
+    scope = audience.rstrip("/") + "/.default"
     if hasattr(credential, "get_token"):
-        return AsyncBearerTokenCredentialPolicy(
-            credential, scope
-        )
-
-    raise TypeError("Unsupported credential")
-
-
-def get_metrics_authentication_policy(
-    credential: AsyncTokenCredential,
-    audience: Optional[str] = None
-) -> AsyncBearerTokenCredentialPolicy:
-    """Returns the correct authentication policy"""
-    if not audience:
-        audience = "https://management.azure.com/"
-    scope = audience.rstrip('/') + "/.default"
-    if credential is None:
-        raise ValueError("Parameter 'credential' must not be None.")
-    if hasattr(credential, "get_token"):
-        return AsyncBearerTokenCredentialPolicy(
-            credential, scope
-        )
+        return AsyncBearerTokenCredentialPolicy(credential, scope)
 
     raise TypeError("Unsupported credential")

--- a/sdk/monitor/azure-monitor-query/azure/monitor/query/aio/_metrics_query_client_async.py
+++ b/sdk/monitor/azure-monitor-query/azure/monitor/query/aio/_metrics_query_client_async.py
@@ -16,7 +16,7 @@ from .._generated._serialization import Serializer
 from .._generated.metrics.aio._client import MonitorMetricsClient
 
 from .._models import MetricsQueryResult, MetricDefinition, MetricNamespace
-from ._helpers_async import get_metrics_authentication_policy
+from ._helpers_async import get_authentication_policy
 from .._helpers import construct_iso8601
 
 
@@ -39,7 +39,7 @@ class MetricsQueryClient(object): # pylint: disable=client-accepts-api-version-k
         self._client = MonitorMetricsClient(
             credential=credential,
             endpoint=self._endpoint,
-            authentication_policy=auth_policy or get_metrics_authentication_policy(credential, audience),
+            authentication_policy=auth_policy or get_authentication_policy(credential, audience),
             **kwargs
         )
         self._metrics_op = self._client.metrics

--- a/sdk/monitor/azure-monitor-query/azure/monitor/query/aio/_metrics_query_client_async.py
+++ b/sdk/monitor/azure-monitor-query/azure/monitor/query/aio/_metrics_query_client_async.py
@@ -30,8 +30,8 @@ class MetricsQueryClient(object): # pylint: disable=client-accepts-api-version-k
     """
 
     def __init__(self, credential: AsyncTokenCredential, **kwargs: Any) -> None:
-        audience = kwargs.pop("audience", None)
         endpoint = kwargs.pop("endpoint", "https://management.azure.com")
+        audience = kwargs.pop("audience", endpoint)
         if not endpoint.startswith("https://") and not endpoint.startswith("http://"):
             endpoint = "https://" + endpoint
         self._endpoint = endpoint

--- a/sdk/monitor/azure-monitor-query/tests/base_testcase.py
+++ b/sdk/monitor/azure-monitor-query/tests/base_testcase.py
@@ -1,0 +1,42 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE.txt in the project root for
+# license information.
+# -------------------------------------------------------------------------
+import os
+
+from devtools_testutils import AzureRecordedTestCase
+
+
+ENV_MONITOR_ENVIRONMENT = "MONITOR_ENVIRONMENT"
+ENV_MONITOR_RESOURCE_MANAGER_URL = "MONITOR_RESOURCE_MANAGER_URL"
+
+LOGS_ENVIRONMENT_ENDPOINT_MAP = {
+    "AzureCloud": "https://api.loganalytics.io/v1",
+    "AzureChinaCloud": "https://api.loganalytics.azure.cn/v1",
+    "AzureUSGovernment": "https://api.loganalytics.us/v1"
+}
+
+
+class AzureMonitorQueryLogsTestCase(AzureRecordedTestCase):
+
+    def get_client(self, client_class, credential):
+
+        kwargs = {}
+        environment = os.getenv(ENV_MONITOR_ENVIRONMENT)
+        if environment:
+            kwargs["endpoint"] = LOGS_ENVIRONMENT_ENDPOINT_MAP[environment]
+
+        return self.create_client_from_credential(client_class, credential, **kwargs)
+
+
+class AzureMonitorQueryMetricsTestCase(AzureRecordedTestCase):
+
+    def get_client(self, client_class, credential):
+
+        kwargs = {}
+        arm_url = os.getenv(ENV_MONITOR_RESOURCE_MANAGER_URL)
+        if arm_url:
+            kwargs["endpoint"] = arm_url
+
+        return self.create_client_from_credential(client_class, credential, **kwargs)

--- a/sdk/monitor/azure-monitor-query/tests/test_exceptions.py
+++ b/sdk/monitor/azure-monitor-query/tests/test_exceptions.py
@@ -10,18 +10,19 @@ import pytest
 from azure.identity import ClientSecretCredential
 from azure.core.exceptions import HttpResponseError
 from azure.monitor.query import LogsQueryClient, LogsBatchQuery, LogsQueryError, LogsQueryResult, LogsQueryPartialResult
-from devtools_testutils import AzureRecordedTestCase
+
+from base_testcase import AzureMonitorQueryLogsTestCase
 
 
-class TestQueryExceptions(AzureRecordedTestCase):
+class TestQueryExceptions(AzureMonitorQueryLogsTestCase):
 
     def test_logs_single_query_fatal_exception(self, recorded_test):
-        client = self.create_client_from_credential(LogsQueryClient, self.get_credential(LogsQueryClient))
+        client = self.get_client(LogsQueryClient, self.get_credential(LogsQueryClient))
         with pytest.raises(HttpResponseError):
             client.query_workspace('bad_workspace_id', 'AppRequests', timespan=None)
 
     def test_logs_single_query_partial_exception(self, recorded_test, monitor_info):
-        client = self.create_client_from_credential(LogsQueryClient, self.get_credential(LogsQueryClient))
+        client = self.get_client(LogsQueryClient, self.get_credential(LogsQueryClient))
         query = """let Weight = 92233720368547758;
         range x from 1 to 3 step 1
         | summarize percentilesw(x, Weight * 100, 50)"""
@@ -34,12 +35,12 @@ class TestQueryExceptions(AzureRecordedTestCase):
         assert response.partial_error.__class__ == LogsQueryError
 
     def test_logs_resource_query_fatal_exception(self, recorded_test):
-        client = self.create_client_from_credential(LogsQueryClient, self.get_credential(LogsQueryClient))
+        client = self.get_client(LogsQueryClient, self.get_credential(LogsQueryClient))
         with pytest.raises(HttpResponseError):
             client.query_resource('/bad/resource/id', 'AzureActivity', timespan=None)
 
     def test_logs_resource_query_partial_exception(self, recorded_test, monitor_info):
-        client = self.create_client_from_credential(LogsQueryClient, self.get_credential(LogsQueryClient))
+        client = self.get_client(LogsQueryClient, self.get_credential(LogsQueryClient))
         query = """let Weight = 92233720368547758;
         range x from 1 to 3 step 1
         | summarize percentilesw(x, Weight * 100, 50)"""
@@ -57,7 +58,7 @@ class TestQueryExceptions(AzureRecordedTestCase):
             client_secret = 'bad_secret',
             tenant_id = monitor_info['tenant_id']
         )
-        client = LogsQueryClient(credential)
+        client = self.get_client(LogsQueryClient, credential)
         requests = [
             LogsBatchQuery(
                 query="AzureActivity | summarize count()",
@@ -83,7 +84,7 @@ class TestQueryExceptions(AzureRecordedTestCase):
 
     @pytest.mark.live_test_only("Issues recording dynamic 'id' values in requests/responses")
     def test_logs_batch_query_partial_exception(self, monitor_info):
-        client = self.create_client_from_credential(LogsQueryClient, self.get_credential(LogsQueryClient))
+        client = self.get_client(LogsQueryClient, self.get_credential(LogsQueryClient))
         requests = [
             LogsBatchQuery(
                 query="AzureActivity | summarize count()",
@@ -112,7 +113,7 @@ class TestQueryExceptions(AzureRecordedTestCase):
 
     @pytest.mark.live_test_only("Issues recording dynamic 'id' values in requests/responses")
     def test_logs_batch_query_non_fatal_exception(self, monitor_info):
-        client = self.create_client_from_credential(LogsQueryClient, self.get_credential(LogsQueryClient))
+        client = self.get_client(LogsQueryClient, self.get_credential(LogsQueryClient))
         requests = [
             LogsBatchQuery(
                 query="AzureActivity | summarize count()",

--- a/sdk/monitor/azure-monitor-query/tests/test_exceptions_async.py
+++ b/sdk/monitor/azure-monitor-query/tests/test_exceptions_async.py
@@ -11,14 +11,15 @@ from azure.identity.aio import ClientSecretCredential
 from azure.core.exceptions import HttpResponseError
 from azure.monitor.query import LogsBatchQuery, LogsQueryError,LogsQueryResult, LogsQueryPartialResult
 from azure.monitor.query.aio import LogsQueryClient
-from devtools_testutils import AzureRecordedTestCase
+
+from base_testcase import AzureMonitorQueryLogsTestCase
 
 
-class TestQueryExceptionsAsync(AzureRecordedTestCase):
+class TestQueryExceptionsAsync(AzureMonitorQueryLogsTestCase):
 
     @pytest.mark.asyncio
     async def test_logs_single_query_fatal_exception(self, recorded_test):
-        client = self.create_client_from_credential(
+        client = self.get_client(
             LogsQueryClient, self.get_credential(LogsQueryClient, is_async=True))
         async with client:
             with pytest.raises(HttpResponseError):
@@ -26,7 +27,7 @@ class TestQueryExceptionsAsync(AzureRecordedTestCase):
 
     @pytest.mark.asyncio
     async def test_logs_single_query_partial_exception_not_allowed(self, recorded_test, monitor_info):
-        client = self.create_client_from_credential(
+        client = self.get_client(
             LogsQueryClient, self.get_credential(LogsQueryClient, is_async=True))
         async with client:
             query = """let Weight = 92233720368547758;
@@ -40,7 +41,7 @@ class TestQueryExceptionsAsync(AzureRecordedTestCase):
 
     @pytest.mark.asyncio
     async def test_logs_resource_query_fatal_exception(self, recorded_test):
-        client = self.create_client_from_credential(
+        client = self.get_client(
             LogsQueryClient, self.get_credential(LogsQueryClient, is_async=True))
         async with client:
             with pytest.raises(HttpResponseError):
@@ -48,7 +49,7 @@ class TestQueryExceptionsAsync(AzureRecordedTestCase):
 
     @pytest.mark.asyncio
     async def test_logs_resource_query_partial_exception(self, recorded_test, monitor_info):
-        client = self.create_client_from_credential(
+        client = self.get_client(
             LogsQueryClient, self.get_credential(LogsQueryClient, is_async=True))
         async with client:
             query = """let Weight = 92233720368547758;
@@ -67,7 +68,7 @@ class TestQueryExceptionsAsync(AzureRecordedTestCase):
             client_secret = 'bad_secret',
             tenant_id = monitor_info['tenant_id']
         )
-        client = LogsQueryClient(credential)
+        client = self.get_client(LogsQueryClient, credential)
         async with client:
             requests = [
                 LogsBatchQuery(
@@ -95,7 +96,7 @@ class TestQueryExceptionsAsync(AzureRecordedTestCase):
     @pytest.mark.live_test_only("Issues recording dynamic 'id' values in requests/responses")
     @pytest.mark.asyncio
     async def test_logs_batch_query_partial_exception_not_allowed(self, monitor_info):
-        client = self.create_client_from_credential(
+        client = self.get_client(
             LogsQueryClient, self.get_credential(LogsQueryClient, is_async=True))
         async with client:
             requests = [

--- a/sdk/monitor/azure-monitor-query/tests/test_logs_client.py
+++ b/sdk/monitor/azure-monitor-query/tests/test_logs_client.py
@@ -285,3 +285,10 @@ class TestLogsClient(AzureRecordedTestCase):
 
         assert response.visualization is not None
         assert response.statistics is not None
+    def test_client_different_endpoint(self):
+        credential = self.get_credential(LogsQueryClient)
+        endpoint = "https://api.loganalytics.azure.cn/v1"
+        client = LogsQueryClient(credential, endpoint=endpoint)
+
+        assert client._endpoint == endpoint
+        assert "https://api.loganalytics.azure.cn/.default" in client._client._config.authentication_policy._scopes

--- a/sdk/monitor/azure-monitor-query/tests/test_logs_client.py
+++ b/sdk/monitor/azure-monitor-query/tests/test_logs_client.py
@@ -10,13 +10,14 @@ import pytest
 from azure.core.exceptions import HttpResponseError
 from azure.monitor.query import LogsQueryClient, LogsBatchQuery, LogsQueryError, LogsTable, LogsQueryResult, LogsTableRow, LogsQueryPartialResult
 from azure.monitor.query._helpers import native_col_type
-from devtools_testutils import AzureRecordedTestCase
+
+from base_testcase import AzureMonitorQueryLogsTestCase
 
 
-class TestLogsClient(AzureRecordedTestCase):
+class TestLogsClient(AzureMonitorQueryLogsTestCase):
 
     def test_logs_single_query(self, recorded_test, monitor_info):
-        client = self.create_client_from_credential(LogsQueryClient, self.get_credential(LogsQueryClient))
+        client = self.get_client(LogsQueryClient, self.get_credential(LogsQueryClient))
         query = """AppRequests |
         where TimeGenerated > ago(12h) |
         summarize avgRequestDuration=avg(DurationMs) by bin(TimeGenerated, 10m), _ResourceId"""
@@ -28,7 +29,7 @@ class TestLogsClient(AzureRecordedTestCase):
         assert response.tables is not None
 
     def test_logs_single_query_raises_no_timespan(self, monitor_info):
-        client = self.create_client_from_credential(LogsQueryClient, self.get_credential(LogsQueryClient))
+        client = self.get_client(LogsQueryClient, self.get_credential(LogsQueryClient))
         query = """AppRequests |
         where TimeGenerated > ago(12h) |
         summarize avgRequestDuration=avg(DurationMs) by bin(TimeGenerated, 10m), _ResourceId"""
@@ -38,7 +39,7 @@ class TestLogsClient(AzureRecordedTestCase):
             client.query_workspace(monitor_info['workspace_id'], query)
 
     def test_logs_single_query_with_non_200(self, recorded_test, monitor_info):
-        client = self.create_client_from_credential(LogsQueryClient, self.get_credential(LogsQueryClient))
+        client = self.get_client(LogsQueryClient, self.get_credential(LogsQueryClient))
         query = """AppInsights |
         where TimeGenerated > ago(12h)"""
 
@@ -48,7 +49,7 @@ class TestLogsClient(AzureRecordedTestCase):
         assert "SemanticError" in e.value.message
 
     def test_logs_single_query_with_partial_success(self, recorded_test, monitor_info):
-        client = self.create_client_from_credential(LogsQueryClient, self.get_credential(LogsQueryClient))
+        client = self.get_client(LogsQueryClient, self.get_credential(LogsQueryClient))
         query = """let Weight = 92233720368547758;
         range x from 1 to 3 step 1
         | summarize percentilesw(x, Weight * 100, 50)"""
@@ -59,7 +60,7 @@ class TestLogsClient(AzureRecordedTestCase):
         assert response.__class__ == LogsQueryPartialResult
 
     def test_logs_server_timeout(self, recorded_test, monitor_info):
-        client = self.create_client_from_credential(LogsQueryClient, self.get_credential(LogsQueryClient))
+        client = self.get_client(LogsQueryClient, self.get_credential(LogsQueryClient))
 
         with pytest.raises(HttpResponseError) as e:
             response = client.query_workspace(
@@ -72,7 +73,7 @@ class TestLogsClient(AzureRecordedTestCase):
 
     @pytest.mark.live_test_only("Issues recording dynamic 'id' values in requests/responses")
     def test_logs_query_batch_default(self, monitor_info):
-        client = self.create_client_from_credential(LogsQueryClient, self.get_credential(LogsQueryClient))
+        client = self.get_client(LogsQueryClient, self.get_credential(LogsQueryClient))
 
         requests = [
             LogsBatchQuery(
@@ -106,7 +107,7 @@ class TestLogsClient(AzureRecordedTestCase):
         assert r2.__class__ == LogsQueryError
 
     def test_logs_single_query_with_statistics(self, recorded_test, monitor_info):
-        client = self.create_client_from_credential(LogsQueryClient, self.get_credential(LogsQueryClient))
+        client = self.get_client(LogsQueryClient, self.get_credential(LogsQueryClient))
         query = """AppRequests | take 10"""
 
         # returns LogsQueryResult
@@ -115,7 +116,7 @@ class TestLogsClient(AzureRecordedTestCase):
         assert response.statistics is not None
 
     def test_logs_single_query_with_visualization(self, recorded_test, monitor_info):
-        client = self.create_client_from_credential(LogsQueryClient, self.get_credential(LogsQueryClient))
+        client = self.get_client(LogsQueryClient, self.get_credential(LogsQueryClient))
         query = """AppRequests | take 10"""
 
         # returns LogsQueryResult
@@ -125,7 +126,7 @@ class TestLogsClient(AzureRecordedTestCase):
         assert response.visualization is not None
 
     def test_logs_single_query_with_visualization_and_stats(self, recorded_test, monitor_info):
-        client = self.create_client_from_credential(LogsQueryClient, self.get_credential(LogsQueryClient))
+        client = self.get_client(LogsQueryClient, self.get_credential(LogsQueryClient))
         query = """AppRequests | take 10"""
 
         # returns LogsQueryResult
@@ -137,7 +138,7 @@ class TestLogsClient(AzureRecordedTestCase):
 
     @pytest.mark.live_test_only("Issues recording dynamic 'id' values in requests/responses")
     def test_logs_query_batch_with_statistics_in_some(self, monitor_info):
-        client = self.create_client_from_credential(LogsQueryClient, self.get_credential(LogsQueryClient))
+        client = self.get_client(LogsQueryClient, self.get_credential(LogsQueryClient))
 
         requests = [
             LogsBatchQuery(
@@ -166,7 +167,7 @@ class TestLogsClient(AzureRecordedTestCase):
         assert response[2].statistics is not None
 
     def test_logs_single_query_additional_workspaces(self, recorded_test, monitor_info):
-        client = self.create_client_from_credential(LogsQueryClient, self.get_credential(LogsQueryClient))
+        client = self.get_client(LogsQueryClient, self.get_credential(LogsQueryClient))
         query = (
             f"{monitor_info['table_name']} | where TimeGenerated > ago(100d)"
             "| project TenantId | summarize count() by TenantId"
@@ -185,7 +186,7 @@ class TestLogsClient(AzureRecordedTestCase):
     @pytest.mark.skip("Flaky deserialization issues with msrest. Re-enable after removing msrest dependency.")
     @pytest.mark.live_test_only("Issues recording dynamic 'id' values in requests/responses")
     def test_logs_query_batch_additional_workspaces(self, monitor_info):
-        client = self.create_client_from_credential(LogsQueryClient, self.get_credential(LogsQueryClient))
+        client = self.get_client(LogsQueryClient, self.get_credential(LogsQueryClient))
         query = (
             f"{monitor_info['table_name']} | where TimeGenerated > ago(100d)"
             "| project TenantId | summarize count() by TenantId"
@@ -215,7 +216,7 @@ class TestLogsClient(AzureRecordedTestCase):
             assert len(resp.tables[0].rows) == 2
 
     def test_logs_query_result_iterate_over_tables(self, recorded_test, monitor_info):
-        client = self.create_client_from_credential(LogsQueryClient, self.get_credential(LogsQueryClient))
+        client = self.get_client(LogsQueryClient, self.get_credential(LogsQueryClient))
 
         query = "AppRequests | take 10; AppRequests | take 5"
 
@@ -237,7 +238,7 @@ class TestLogsClient(AzureRecordedTestCase):
         assert response.__class__ == LogsQueryResult
 
     def test_logs_query_result_row_type(self, recorded_test, monitor_info):
-        client = self.create_client_from_credential(LogsQueryClient, self.get_credential(LogsQueryClient))
+        client = self.get_client(LogsQueryClient, self.get_credential(LogsQueryClient))
 
         query = "AppRequests | take 5"
 
@@ -262,7 +263,7 @@ class TestLogsClient(AzureRecordedTestCase):
         assert val is not None
 
     def test_logs_resource_query(self, recorded_test, monitor_info):
-        client = self.create_client_from_credential(LogsQueryClient, self.get_credential(LogsQueryClient))
+        client = self.get_client(LogsQueryClient, self.get_credential(LogsQueryClient))
         query = "requests | summarize count()"
 
         response = client.query_resource(monitor_info['metrics_resource_id'], query, timespan=None)
@@ -272,7 +273,7 @@ class TestLogsClient(AzureRecordedTestCase):
         assert len(response.tables[0].rows) == 1
 
     def test_logs_resource_query_additional_options(self, recorded_test, monitor_info):
-        client = self.create_client_from_credential(LogsQueryClient, self.get_credential(LogsQueryClient))
+        client = self.get_client(LogsQueryClient, self.get_credential(LogsQueryClient))
         query = "requests | summarize count()"
 
         response = client.query_resource(
@@ -285,6 +286,7 @@ class TestLogsClient(AzureRecordedTestCase):
 
         assert response.visualization is not None
         assert response.statistics is not None
+
     def test_client_different_endpoint(self):
         credential = self.get_credential(LogsQueryClient)
         endpoint = "https://api.loganalytics.azure.cn/v1"

--- a/sdk/monitor/azure-monitor-query/tests/test_logs_client_async.py
+++ b/sdk/monitor/azure-monitor-query/tests/test_logs_client_async.py
@@ -261,6 +261,7 @@ class TestLogsClientAsync(AzureMonitorQueryLogsTestCase):
             assert response.visualization is not None
             assert response.statistics is not None
 
+    @pytest.mark.asyncio
     async def test_client_different_endpoint(self):
         credential = self.get_credential(LogsQueryClient, is_async=True)
         endpoint = "https://api.loganalytics.azure.cn/v1"

--- a/sdk/monitor/azure-monitor-query/tests/test_logs_client_async.py
+++ b/sdk/monitor/azure-monitor-query/tests/test_logs_client_async.py
@@ -259,3 +259,10 @@ class TestLogsClientAsync(AzureRecordedTestCase):
 
             assert response.visualization is not None
             assert response.statistics is not None
+    async def test_client_different_endpoint(self):
+        credential = self.get_credential(LogsQueryClient, is_async=True)
+        endpoint = "https://api.loganalytics.azure.cn/v1"
+        client = LogsQueryClient(credential, endpoint=endpoint)
+
+        assert client._endpoint == endpoint
+        assert "https://api.loganalytics.azure.cn/.default" in client._client._config.authentication_policy._scopes

--- a/sdk/monitor/azure-monitor-query/tests/test_logs_client_async.py
+++ b/sdk/monitor/azure-monitor-query/tests/test_logs_client_async.py
@@ -10,14 +10,15 @@ import pytest
 from azure.core.exceptions import HttpResponseError
 from azure.monitor.query import LogsBatchQuery, LogsQueryError, LogsTable, LogsQueryResult, LogsTableRow
 from azure.monitor.query.aio import LogsQueryClient
-from devtools_testutils import AzureRecordedTestCase
+
+from base_testcase import AzureMonitorQueryLogsTestCase
 
 
-class TestLogsClientAsync(AzureRecordedTestCase):
+class TestLogsClientAsync(AzureMonitorQueryLogsTestCase):
 
     @pytest.mark.asyncio
     async def test_logs_auth(self, recorded_test, monitor_info):
-        client = self.create_client_from_credential(
+        client = self.get_client(
             LogsQueryClient, self.get_credential(LogsQueryClient, is_async=True))
         async with client:
             query = """AppRequests |
@@ -32,7 +33,7 @@ class TestLogsClientAsync(AzureRecordedTestCase):
 
     @pytest.mark.asyncio
     async def test_logs_auth_no_timespan(self, monitor_info):
-        client = self.create_client_from_credential(
+        client = self.get_client(
             LogsQueryClient, self.get_credential(LogsQueryClient, is_async=True))
         async with client:
             query = """AppRequests |
@@ -45,7 +46,7 @@ class TestLogsClientAsync(AzureRecordedTestCase):
 
     @pytest.mark.asyncio
     async def test_logs_server_timeout(self, recorded_test, monitor_info):
-        client = self.create_client_from_credential(
+        client = self.get_client(
             LogsQueryClient, self.get_credential(LogsQueryClient, is_async=True))
 
         with pytest.raises(HttpResponseError) as e:
@@ -70,7 +71,7 @@ class TestLogsClientAsync(AzureRecordedTestCase):
     @pytest.mark.live_test_only("Issues recording dynamic 'id' values in requests/responses")
     @pytest.mark.asyncio
     async def test_logs_query_batch_default(self, monitor_info):
-        client = self.create_client_from_credential(
+        client = self.get_client(
             LogsQueryClient, self.get_credential(LogsQueryClient, is_async=True))
         async with client:
             requests = [
@@ -105,7 +106,7 @@ class TestLogsClientAsync(AzureRecordedTestCase):
 
     @pytest.mark.asyncio
     async def test_logs_single_query_additional_workspaces_async(self, recorded_test, monitor_info):
-        client = self.create_client_from_credential(
+        client = self.get_client(
             LogsQueryClient, self.get_credential(LogsQueryClient, is_async=True))
         async with client:
             query = (
@@ -128,7 +129,7 @@ class TestLogsClientAsync(AzureRecordedTestCase):
     @pytest.mark.live_test_only("Issues recording dynamic 'id' values in requests/responses")
     @pytest.mark.asyncio
     async def test_logs_query_batch_additional_workspaces(self, monitor_info):
-        client = self.create_client_from_credential(
+        client = self.get_client(
             LogsQueryClient, self.get_credential(LogsQueryClient, is_async=True))
         async with client:
             query = (
@@ -163,7 +164,7 @@ class TestLogsClientAsync(AzureRecordedTestCase):
 
     @pytest.mark.asyncio
     async def test_logs_single_query_with_visualization(self, recorded_test, monitor_info):
-        client = self.create_client_from_credential(
+        client = self.get_client(
             LogsQueryClient, self.get_credential(LogsQueryClient, is_async=True))
         async with client:
             query = """AppRequests | take 10"""
@@ -176,7 +177,7 @@ class TestLogsClientAsync(AzureRecordedTestCase):
 
     @pytest.mark.asyncio
     async def test_logs_single_query_with_visualization_and_stats(self, recorded_test, monitor_info):
-        client = self.create_client_from_credential(
+        client = self.get_client(
             LogsQueryClient, self.get_credential(LogsQueryClient, is_async=True))
         async with client:
             query = """AppRequests | take 10"""
@@ -189,7 +190,7 @@ class TestLogsClientAsync(AzureRecordedTestCase):
 
     @pytest.mark.asyncio
     async def test_logs_query_result_iterate_over_tables(self, recorded_test, monitor_info):
-        client = self.create_client_from_credential(
+        client = self.get_client(
             LogsQueryClient, self.get_credential(LogsQueryClient, is_async=True))
         async with client:
             query = "AppRequests | take 10; AppRequests | take 5"
@@ -212,7 +213,7 @@ class TestLogsClientAsync(AzureRecordedTestCase):
 
     @pytest.mark.asyncio
     async def test_logs_query_result_row_type(self, recorded_test, monitor_info):
-        client = self.create_client_from_credential(
+        client = self.get_client(
             LogsQueryClient, self.get_credential(LogsQueryClient, is_async=True))
         async with client:
             query = "AppRequests | take 5"
@@ -231,7 +232,7 @@ class TestLogsClientAsync(AzureRecordedTestCase):
 
     @pytest.mark.asyncio
     async def test_logs_resource_query(self, recorded_test, monitor_info):
-        client = self.create_client_from_credential(
+        client = self.get_client(
             LogsQueryClient, self.get_credential(LogsQueryClient, is_async=True))
         async with client:
             query = "requests | summarize count()"
@@ -244,7 +245,7 @@ class TestLogsClientAsync(AzureRecordedTestCase):
 
     @pytest.mark.asyncio
     async def test_logs_resource_query_additional_options(self, recorded_test, monitor_info):
-        client = self.create_client_from_credential(
+        client = self.get_client(
             LogsQueryClient, self.get_credential(LogsQueryClient, is_async=True))
         async with client:
             query = "requests | summarize count()"
@@ -259,6 +260,7 @@ class TestLogsClientAsync(AzureRecordedTestCase):
 
             assert response.visualization is not None
             assert response.statistics is not None
+
     async def test_client_different_endpoint(self):
         credential = self.get_credential(LogsQueryClient, is_async=True)
         endpoint = "https://api.loganalytics.azure.cn/v1"

--- a/sdk/monitor/azure-monitor-query/tests/test_logs_response.py
+++ b/sdk/monitor/azure-monitor-query/tests/test_logs_response.py
@@ -6,10 +6,11 @@
 from datetime import datetime, timezone
 
 from azure.monitor.query import LogsQueryClient
-from devtools_testutils import AzureRecordedTestCase
+
+from base_testcase import AzureMonitorQueryLogsTestCase
 
 
-class TestLogsResponse(AzureRecordedTestCase):
+class TestLogsResponse(AzureMonitorQueryLogsTestCase):
 
     def test_query_response_data(self, recorded_test, monitor_info):
         # Sample log entry that is populated in table before test.
@@ -19,7 +20,7 @@ class TestLogsResponse(AzureRecordedTestCase):
         #    "AdditionalContext": '{"testContextKey": 1, "CounterName": "AppMetric1"}}'
         # }
 
-        client = self.create_client_from_credential(LogsQueryClient, self.get_credential(LogsQueryClient))
+        client = self.get_client(LogsQueryClient, self.get_credential(LogsQueryClient))
         query = (
             f"{monitor_info['table_name']} | project TimeGenerated, Type, ExtendedColumn, AdditionalContext"
             f"| order by TimeGenerated desc | take 5")
@@ -39,7 +40,7 @@ class TestLogsResponse(AzureRecordedTestCase):
         assert "testContextKey" in result.tables[0].rows[0][3]
 
     def test_query_response_types(self, recorded_test, monitor_info):
-        client = self.create_client_from_credential(LogsQueryClient, self.get_credential(LogsQueryClient))
+        client = self.get_client(LogsQueryClient, self.get_credential(LogsQueryClient))
         query = """print "hello", true, make_datetime("2000-01-02 03:04:05Z"), toint(100), long(101), 102.1
             | project
                 stringcolumn=print_0,

--- a/sdk/monitor/azure-monitor-query/tests/test_logs_timespans.py
+++ b/sdk/monitor/azure-monitor-query/tests/test_logs_timespans.py
@@ -11,13 +11,14 @@ import pytest
 
 from azure.monitor.query import LogsQueryClient
 from azure.monitor.query._helpers import construct_iso8601
-from devtools_testutils import AzureRecordedTestCase
+
+from base_testcase import AzureMonitorQueryLogsTestCase
 
 
-class TestLogsTimespans(AzureRecordedTestCase):
+class TestLogsTimespans(AzureMonitorQueryLogsTestCase):
 
     def test_query_no_duration(self, recorded_test, monitor_info):
-        client = self.create_client_from_credential(LogsQueryClient, self.get_credential(LogsQueryClient))
+        client = self.get_client(LogsQueryClient, self.get_credential(LogsQueryClient))
         query = """AppRequests |
         where TimeGenerated > ago(12h) |
         summarize avgRequestDuration=avg(DurationMs) by bin(TimeGenerated, 10m), _ResourceId"""
@@ -29,7 +30,7 @@ class TestLogsTimespans(AzureRecordedTestCase):
         client.query_workspace(monitor_info['workspace_id'], query, timespan=None)
 
     def test_query_start_and_end_time(self, recorded_test, monitor_info):
-        client = self.create_client_from_credential(LogsQueryClient, self.get_credential(LogsQueryClient))
+        client = self.get_client(LogsQueryClient, self.get_credential(LogsQueryClient))
         query = "AppRequests | take 5"
 
         end_time = datetime(2022, 11, 8)
@@ -42,7 +43,7 @@ class TestLogsTimespans(AzureRecordedTestCase):
         client.query_workspace(monitor_info['workspace_id'], query, timespan=(start_time, end_time), raw_request_hook=callback)
 
     def test_query_duration_and_start_time(self, recorded_test, monitor_info):
-        client = self.create_client_from_credential(LogsQueryClient, self.get_credential(LogsQueryClient))
+        client = self.get_client(LogsQueryClient, self.get_credential(LogsQueryClient))
         query = "AppRequests | take 5"
 
         end_time = datetime(2022, 11, 8)
@@ -56,7 +57,7 @@ class TestLogsTimespans(AzureRecordedTestCase):
         client.query_workspace(monitor_info['workspace_id'], query, timespan=(start_time,duration), raw_request_hook=callback)
 
     def test_query_duration_only(self, recorded_test, monitor_info):
-        client = self.create_client_from_credential(LogsQueryClient, self.get_credential(LogsQueryClient))
+        client = self.get_client(LogsQueryClient, self.get_credential(LogsQueryClient))
         query = "AppRequests | take 5"
 
         duration = timedelta(days=3)

--- a/sdk/monitor/azure-monitor-query/tests/test_metrics_client.py
+++ b/sdk/monitor/azure-monitor-query/tests/test_metrics_client.py
@@ -7,17 +7,18 @@ from datetime import timedelta
 from unittest import mock
 
 from azure.monitor.query import MetricsQueryClient, MetricAggregationType, Metric
-from devtools_testutils import AzureRecordedTestCase
+
+from base_testcase import AzureMonitorQueryMetricsTestCase
 
 
 METRIC_NAME = "requests/count"
 METRIC_RESOURCE_PROVIDER = "Microsoft.Insights/components"
 
 
-class TestMetricsClient(AzureRecordedTestCase):
+class TestMetricsClient(AzureMonitorQueryMetricsTestCase):
 
     def test_metrics_auth(self, recorded_test, monitor_info):
-        client = self.create_client_from_credential(MetricsQueryClient, self.get_credential(MetricsQueryClient))
+        client = self.get_client(MetricsQueryClient, self.get_credential(MetricsQueryClient))
         response = client.query_resource(
             monitor_info['metrics_resource_id'],
             metric_names=[METRIC_NAME],
@@ -28,7 +29,7 @@ class TestMetricsClient(AzureRecordedTestCase):
         assert response.metrics
 
     def test_metrics_granularity(self, recorded_test, monitor_info):
-        client = self.create_client_from_credential(MetricsQueryClient, self.get_credential(MetricsQueryClient))
+        client = self.get_client(MetricsQueryClient, self.get_credential(MetricsQueryClient))
         response = client.query_resource(
             monitor_info['metrics_resource_id'],
             metric_names=[METRIC_NAME],
@@ -44,7 +45,7 @@ class TestMetricsClient(AzureRecordedTestCase):
             assert t.metadata_values is not None
 
     def test_metrics_filter(self, recorded_test, monitor_info):
-        client = self.create_client_from_credential(MetricsQueryClient, self.get_credential(MetricsQueryClient))
+        client = self.get_client(MetricsQueryClient, self.get_credential(MetricsQueryClient))
         response = client.query_resource(
             monitor_info['metrics_resource_id'],
             metric_names=[METRIC_NAME],
@@ -59,7 +60,7 @@ class TestMetricsClient(AzureRecordedTestCase):
             assert t.metadata_values is not None
 
     def test_metrics_list(self, recorded_test, monitor_info):
-        client = self.create_client_from_credential(MetricsQueryClient, self.get_credential(MetricsQueryClient))
+        client = self.get_client(MetricsQueryClient, self.get_credential(MetricsQueryClient))
         response = client.query_resource(
             monitor_info['metrics_resource_id'],
             metric_names=[METRIC_NAME],
@@ -79,7 +80,7 @@ class TestMetricsClient(AzureRecordedTestCase):
 
         with mock.patch("azure.monitor.query._generated.metrics.operations.MetricsOperations.list") as mock_list:
             mock_list.return_value = {"foo": "bar"}
-            client = self.create_client_from_credential(MetricsQueryClient, self.get_credential(MetricsQueryClient))
+            client = self.get_client(MetricsQueryClient, self.get_credential(MetricsQueryClient))
             client.query_resource(
                 "resource",
                 metric_names=["metric1,metric2", "foo,test,test"],
@@ -93,7 +94,7 @@ class TestMetricsClient(AzureRecordedTestCase):
 
 
     def test_metrics_namespaces(self, recorded_test, monitor_info):
-        client = self.create_client_from_credential(MetricsQueryClient, self.get_credential(MetricsQueryClient))
+        client = self.get_client(MetricsQueryClient, self.get_credential(MetricsQueryClient))
 
         response = client.list_metric_namespaces(monitor_info['metrics_resource_id'])
 
@@ -102,7 +103,7 @@ class TestMetricsClient(AzureRecordedTestCase):
             assert item
 
     def test_metrics_definitions(self, recorded_test, monitor_info):
-        client = self.create_client_from_credential(MetricsQueryClient, self.get_credential(MetricsQueryClient))
+        client = self.get_client(MetricsQueryClient, self.get_credential(MetricsQueryClient))
         response = client.list_metric_definitions(
             monitor_info['metrics_resource_id'], namespace=METRIC_RESOURCE_PROVIDER)
 

--- a/sdk/monitor/azure-monitor-query/tests/test_metrics_client.py
+++ b/sdk/monitor/azure-monitor-query/tests/test_metrics_client.py
@@ -109,3 +109,11 @@ class TestMetricsClient(AzureRecordedTestCase):
         assert response is not None
         for item in response:
             assert item
+
+    def test_client_different_endpoint(self):
+        credential = self.get_credential(MetricsQueryClient)
+        endpoint = "https://management.chinacloudapi.cn"
+        client = MetricsQueryClient(credential, endpoint=endpoint)
+
+        assert client._endpoint == endpoint
+        assert f"{endpoint}/.default" in client._client._config.authentication_policy._scopes

--- a/sdk/monitor/azure-monitor-query/tests/test_metrics_client_async.py
+++ b/sdk/monitor/azure-monitor-query/tests/test_metrics_client_async.py
@@ -11,18 +11,19 @@ import pytest
 
 from azure.monitor.query import MetricAggregationType, Metric
 from azure.monitor.query.aio import MetricsQueryClient
-from devtools_testutils import AzureRecordedTestCase
+
+from base_testcase import AzureMonitorQueryMetricsTestCase
 
 
 METRIC_NAME = "requests/count"
 METRIC_RESOURCE_PROVIDER = "Microsoft.Insights/components"
 
 
-class TestMetricsClientAsync(AzureRecordedTestCase):
+class TestMetricsClientAsync(AzureMonitorQueryMetricsTestCase):
 
     @pytest.mark.asyncio
     async def test_metrics_auth(self, recorded_test, monitor_info):
-        client = self.create_client_from_credential(
+        client = self.get_client(
             MetricsQueryClient, self.get_credential(MetricsQueryClient, is_async=True))
         async with client:
             response = await client.query_resource(
@@ -36,7 +37,7 @@ class TestMetricsClientAsync(AzureRecordedTestCase):
 
     @pytest.mark.asyncio
     async def test_metrics_granularity(self, recorded_test, monitor_info):
-        client = self.create_client_from_credential(
+        client = self.get_client(
             MetricsQueryClient, self.get_credential(MetricsQueryClient, is_async=True))
         async with client:
             response = await client.query_resource(
@@ -55,7 +56,7 @@ class TestMetricsClientAsync(AzureRecordedTestCase):
 
     @pytest.mark.asyncio
     async def test_metrics_filter(self, recorded_test, monitor_info):
-        client = self.create_client_from_credential(
+        client = self.get_client(
             MetricsQueryClient, self.get_credential(MetricsQueryClient, is_async=True))
         async with client:
             response = await client.query_resource(
@@ -73,7 +74,7 @@ class TestMetricsClientAsync(AzureRecordedTestCase):
 
     @pytest.mark.asyncio
     async def test_metrics_list(self, recorded_test, monitor_info):
-        client = self.create_client_from_credential(
+        client = self.get_client(
             MetricsQueryClient, self.get_credential(MetricsQueryClient, is_async=True))
         async with client:
             response = await client.query_resource(
@@ -97,7 +98,7 @@ class TestMetricsClientAsync(AzureRecordedTestCase):
 
         with mock.patch("azure.monitor.query._generated.metrics.aio.operations.MetricsOperations.list") as mock_list:
             mock_list.return_value = {"foo": "bar"}
-            client = self.create_client_from_credential(
+            client = self.get_client(
                 MetricsQueryClient, self.get_credential(MetricsQueryClient, is_async=True))
             async with client:
                 await client.query_resource(
@@ -113,7 +114,7 @@ class TestMetricsClientAsync(AzureRecordedTestCase):
 
     @pytest.mark.asyncio
     async def test_metrics_namespaces(self, recorded_test, monitor_info):
-        client = self.create_client_from_credential(
+        client = self.get_client(
             MetricsQueryClient, self.get_credential(MetricsQueryClient, is_async=True))
 
         async with client:
@@ -125,7 +126,7 @@ class TestMetricsClientAsync(AzureRecordedTestCase):
 
     @pytest.mark.asyncio
     async def test_metrics_definitions(self, recorded_test, monitor_info):
-        client = self.create_client_from_credential(
+        client = self.get_client(
             MetricsQueryClient, self.get_credential(MetricsQueryClient, is_async=True))
 
         async with client:

--- a/sdk/monitor/azure-monitor-query/tests/test_metrics_client_async.py
+++ b/sdk/monitor/azure-monitor-query/tests/test_metrics_client_async.py
@@ -135,3 +135,12 @@ class TestMetricsClientAsync(AzureRecordedTestCase):
             assert response is not None
             async for item in response:
                 assert item
+
+    @pytest.mark.asyncio
+    async def test_client_different_endpoint(self):
+        credential = self.get_credential(MetricsQueryClient)
+        endpoint = "https://management.chinacloudapi.cn"
+        client = MetricsQueryClient(credential, endpoint=endpoint)
+
+        assert client._endpoint == endpoint
+        assert f"{endpoint}/.default" in client._client._config.authentication_policy._scopes


### PR DESCRIPTION
This adds support and documents non-public cloud usage for LogsQueryClient and MetricsQueryClient.

There are two URIs we are concerned with: 

- the Log Analytics API endpoint (e.g., `https://api.loganalytics.io/v1`)
- the audience for determining the credential policy scope (`https://api.loganalytics.io`)

The endpoint passed in is expected to be the full endpoint including the `v1`, and the audience is expected to be the base URL of the endpoint. This logic is added to `LogsQueryClient`.


Also adjust tests to be able to accompany different cloud endpoints.
Verified on Azure China Cloud by running live tests there using the weekly pipeline.

Closes: https://github.com/Azure/azure-sdk-for-python/issues/27167

