### PR TITLE
[Cosmos] samples fixes, updates multi-master  samples to use v4 client

### DIFF
--- a/sdk/cosmos/azure-cosmos/samples/MultiMasterOperations/MultiMasterScenario.py
+++ b/sdk/cosmos/azure-cosmos/samples/MultiMasterOperations/MultiMasterScenario.py
@@ -3,7 +3,7 @@ from ConflictWorker import ConflictWorker
 from Worker import Worker
 from multiprocessing.pool import ThreadPool
 import azure.cosmos.documents as documents
-import azure.cosmos._cosmos_client_connection as cosmos_client_connection
+from azure.cosmos import CosmosClient
 
 class MultiMasterScenario(object):
     def __init__(self):
@@ -27,12 +27,11 @@ class MultiMasterScenario(object):
             connection_policy.UseMultipleWriteLocations = True
             connection_policy.PreferredLocations = [region]
 
-            client = cosmos_client_connection.CosmosClientConnection(
-                self.account_endpoint,
-                {'masterKey': self.account_key},
-                connection_policy,
-                documents.ConsistencyLevel.Session
-            )
+            client = CosmosClient(
+                url=self.account_endpoint,
+                credential=self.account_key,
+                consistency_level=documents.ConsistencyLevel.Session,
+                connection_policy=connection_policy)
 
             self.workers.append(Worker(client, self.database_name, self.basic_collection_name))
 

--- a/sdk/cosmos/azure-cosmos/samples/database_management_async.py
+++ b/sdk/cosmos/azure-cosmos/samples/database_management_async.py
@@ -43,7 +43,7 @@ async def find_database(client, id):
     # return several databases using queries, we do not need to await the function. However, attempting
     # to cast this object into a list directly will throw an error; instead, iterate over the databases
     # to populate your list using an async for loop like shown here or in the list_databases() method
-    query_databases_response = client.query_databases({
+    query_databases_response = client.query_databases(query={
         "query": "SELECT * FROM r WHERE r.id=@id",
         "parameters": [
             { "name":"@id", "value": id }


### PR DESCRIPTION
Some errors we had in our samples reported in issue https://github.com/Azure/azure-sdk-for-python/issues/29455.

Fixed the one line missing in the query of the async database management tests, and updated our MultiMaster samples to utilize the v4 SDK client (which was released beginning of 2020). The fact we still had samples using the previous client is something we should've cleaned up earlier.

These samples might become affected by these changes, since I believe the code snippets were linked to the samples: https://learn.microsoft.com/azure/cosmos-db/nosql/how-to-manage-conflicts?tabs=dotnetv2%2Capi-async%2Casync#create-custom-conflict-resolution-policy-lww-python