### PR TITLE
Stabilize PhoneNumbers SIP Routing samples

### DIFF
--- a/sdk/communication/azure-communication-phonenumbers/samples/siprouting/set_sip_routes_sample.py
+++ b/sdk/communication/azure-communication-phonenumbers/samples/siprouting/set_sip_routes_sample.py
@@ -19,7 +19,7 @@ USAGE:
 import os
 from azure.communication.phonenumbers.siprouting import SipRoutingClient, SipTrunkRoute
 
-ROUTES = [SipTrunkRoute(name="First rule", description="Handle numbers starting with '+123'", number_pattern="\+123[0-9]+", trunks=["sbs1.sipsampletest.com"])]
+ROUTES = [SipTrunkRoute(name="First rule", description="Handle numbers starting with '+123'", number_pattern="\+123[0-9]+", trunks=[])]
 connection_string = os.getenv("COMMUNICATION_SAMPLES_CONNECTION_STRING")
 client = SipRoutingClient.from_connection_string(connection_string)
 

--- a/sdk/communication/azure-communication-phonenumbers/samples/siprouting/set_sip_routes_sample_async.py
+++ b/sdk/communication/azure-communication-phonenumbers/samples/siprouting/set_sip_routes_sample_async.py
@@ -21,7 +21,7 @@ import asyncio
 from azure.communication.phonenumbers.siprouting.aio import SipRoutingClient
 from azure.communication.phonenumbers.siprouting import SipTrunkRoute
 
-ROUTES = [SipTrunkRoute(name="First rule", description="Handle numbers starting with '+123'", number_pattern="\+123[0-9]+", trunks=["sbs1.sipsampletest.com"])]
+ROUTES = [SipTrunkRoute(name="First rule", description="Handle numbers starting with '+123'", number_pattern="\+123[0-9]+", trunks=[])]
 connection_string = os.getenv("COMMUNICATION_SAMPLES_CONNECTION_STRING")
 client = SipRoutingClient.from_connection_string(connection_string)
 


### PR DESCRIPTION
# Description

The SIP Routing samples were recently fixed.
Occasionally the setRoutes samples can run before setTrunks ones. That will result in UnprocessableConfiguration - MissingTrunk. 

A route without trunk reference is also possible configuration and it removes this problem.
Another posssibility would be to add the trunk setting before setRoute call.
But we probably dont want to complicate the sample. 

- [x] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
