### PR TITLE
[OTel] Enable span suppression

### DIFF
--- a/sdk/core/azure-core-tracing-opentelemetry/CHANGELOG.md
+++ b/sdk/core/azure-core-tracing-opentelemetry/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Other Changes
 
-- Python 2.7 is no longer supported. Please use Python version 3.6 or later.
+- Python 2.7 is no longer supported. Please use Python version 3.7 or later.
 - Nested internal spans are now suppressed with just the outermost internal span being recorded. Nested client spans will be children of the outermost span. ([#29616](https://github.com/Azure/azure-sdk-for-python/pull/29616))
 - When client spans are created, a flag is set to indicate that automatic HTTP instrumentation should be suppressed. Since azure-core already instruments HTTP calls, this prevents duplicate spans from being produced. ([#29616](https://github.com/Azure/azure-sdk-for-python/pull/29616))
 

--- a/sdk/core/azure-core-tracing-opentelemetry/CHANGELOG.md
+++ b/sdk/core/azure-core-tracing-opentelemetry/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Other Changes
 
 - Python 2.7 is no longer supported. Please use Python version 3.6 or later.
+- Nested internal spans are now suppressed with just the outermost internal span being recorded. Nested client spans will be children of the outermost span. ([#29616](https://github.com/Azure/azure-sdk-for-python/pull/29616))
+- When client spans are created, a flag is set to indicate that automatic HTTP instrumentation should be suppressed. Since azure-core already instruments HTTP calls, this prevents duplicate spans from being produced. ([#29616](https://github.com/Azure/azure-sdk-for-python/pull/29616))
 
 ## 1.0.0b9 (2021-04-06)
 
@@ -44,7 +46,7 @@
 
 - Pinned opentelemetry-api to version 0.4a0
 
-## 1.0.0b1 
+## 1.0.0b1
 
 ### Features
 

--- a/sdk/core/azure-core-tracing-opentelemetry/azure/core/tracing/ext/opentelemetry_span/__init__.py
+++ b/sdk/core/azure-core-tracing-opentelemetry/azure/core/tracing/ext/opentelemetry_span/__init__.py
@@ -3,14 +3,25 @@
 # Licensed under the MIT License.
 # ------------------------------------
 """Implements azure.core.tracing.AbstractSpan to wrap OpenTelemetry spans."""
-from typing import Any, ContextManager, Dict, Optional, Union, Callable, Sequence
+from typing import Any, ContextManager, Dict, Optional, Union, Callable, Sequence, cast
 import warnings
 
-from opentelemetry import trace
-from opentelemetry.trace import Span, Tracer, SpanKind as OpenTelemetrySpanKind, Link as OpenTelemetryLink
-from opentelemetry.context import attach, detach, get_current  # type: ignore[attr-defined]
+from opentelemetry import context, trace
+from opentelemetry.trace import (
+    Span,
+    Tracer,
+    NonRecordingSpan,
+    SpanKind as OpenTelemetrySpanKind,
+    Link as OpenTelemetryLink,
+)  # type: ignore[attr-defined]
 from opentelemetry.propagate import extract, inject  # type: ignore[attr-defined]
 from opentelemetry.trace.propagation import get_current_span as get_span_from_context  # type: ignore[attr-defined]
+
+# TODO: Fix import of this private attribute once the location of the suppress instrumentation key is defined.
+try:
+    from opentelemetry.context import _SUPPRESS_HTTP_INSTRUMENTATION_KEY  # type: ignore[attr-defined]
+except ImportError:
+    _SUPPRESS_HTTP_INSTRUMENTATION_KEY = "suppress_http_instrumentation"
 
 from azure.core.tracing import SpanKind, HttpSpanMixin  # type: ignore[attr-defined] # pylint: disable=no-name-in-module
 
@@ -32,6 +43,9 @@ Attributes = Optional[Dict[str, AttributeValue]]
 
 __version__ = VERSION
 
+_SUPPRESSED_SPAN_FLAG = "SUPPRESSED_SPAN_FLAG"
+_LAST_UNSUPPRESSED_SPAN = "LAST_UNSUPPRESSED_SPAN"
+
 
 class OpenTelemetrySpan(HttpSpanMixin, object):
     """OpenTelemetry plugin for Azure client libraries.
@@ -47,31 +61,49 @@ class OpenTelemetrySpan(HttpSpanMixin, object):
     """
 
     def __init__(self, span: Optional[Span] = None, name: str = "span", **kwargs: Any) -> None:
-        current_tracer = self.get_current_tracer()
+        self._name = name
+        self._context_tokens = []
+        self._current_ctxt_manager: Optional[ContextManager[Span]] = None
 
         # TODO: Once we have additional supported versions, we should add a way to specify the version.
         self._schema_version = OpenTelemetrySchema.get_latest_version()
         self._attribute_mappings = OpenTelemetrySchema.get_attribute_mappings(self._schema_version)
 
+        if span:
+            self._span_instance = span
+            return
+
         ## kind
-        value = kwargs.pop("kind", None)
-        kind = (
+        span_kind = kwargs.pop("kind", None)
+        otel_kind = (
             OpenTelemetrySpanKind.CLIENT
-            if value == SpanKind.CLIENT
+            if span_kind == SpanKind.CLIENT
             else OpenTelemetrySpanKind.PRODUCER
-            if value == SpanKind.PRODUCER
+            if span_kind == SpanKind.PRODUCER
             else OpenTelemetrySpanKind.SERVER
-            if value == SpanKind.SERVER
+            if span_kind == SpanKind.SERVER
             else OpenTelemetrySpanKind.CONSUMER
-            if value == SpanKind.CONSUMER
+            if span_kind == SpanKind.CONSUMER
             else OpenTelemetrySpanKind.INTERNAL
-            if value == SpanKind.INTERNAL
+            if span_kind == SpanKind.INTERNAL
             else OpenTelemetrySpanKind.INTERNAL
-            if value == SpanKind.UNSPECIFIED
+            if span_kind == SpanKind.UNSPECIFIED
             else None
         )
-        if value and kind is None:
-            raise ValueError("Kind {} is not supported in OpenTelemetry".format(value))
+        if span_kind and otel_kind is None:
+            raise ValueError("Kind {} is not supported in OpenTelemetry".format(span_kind))
+
+        if otel_kind == OpenTelemetrySpanKind.INTERNAL and context.get_value(_SUPPRESSED_SPAN_FLAG):
+            # Nested internal calls should be suppressed per the Azure SDK guidelines.
+            self._span_instance = NonRecordingSpan(context=self.get_current_span().get_span_context())
+            return
+
+        if otel_kind == OpenTelemetrySpanKind.CLIENT:
+            # Since core instruments HTTP calls, we need to suppress any automatic HTTP instrumentation provided by
+            # other libraries to prevent duplicate spans.
+            self._context_tokens.append(context.attach(context.set_value(_SUPPRESS_HTTP_INSTRUMENTATION_KEY, True)))
+
+        current_tracer = self.get_current_tracer()
 
         links = kwargs.pop("links", None)
         if links:
@@ -86,8 +118,7 @@ class OpenTelemetrySpan(HttpSpanMixin, object):
                 # We will just send the links as is if it's not ~azure.core.tracing.Link without any validation
                 # assuming user knows what they are doing.
                 kwargs.setdefault("links", links)
-        self._span_instance = span or current_tracer.start_span(name=name, kind=kind, **kwargs)  # type: ignore
-        self._current_ctxt_manager: Optional[ContextManager[Span]] = None
+        self._span_instance = current_tracer.start_span(name=name, kind=otel_kind, **kwargs)  # type: ignore
 
     @property
     def span_instance(self) -> Span:
@@ -98,7 +129,7 @@ class OpenTelemetrySpan(HttpSpanMixin, object):
 
     def span(self, name: str = "span", **kwargs: Any) -> "OpenTelemetrySpan":
         """
-        Create a child span for the current span and append it to the child spans list in the span instance.
+        Create a child span for the current span and return it.
         :param name: Name of the child span
         :type name: str
         :keyword kind: The span kind of this span.
@@ -112,7 +143,10 @@ class OpenTelemetrySpan(HttpSpanMixin, object):
     @property
     def kind(self) -> Optional[SpanKind]:
         """Get the span kind of this span."""
-        value = self.span_instance.kind  # type: ignore[attr-defined]
+        try:
+            value = self.span_instance.kind  # type: ignore[attr-defined]
+        except AttributeError:
+            return None
         return (
             SpanKind.CLIENT
             if value == OpenTelemetrySpanKind.CLIENT
@@ -158,6 +192,15 @@ class OpenTelemetrySpan(HttpSpanMixin, object):
 
     def __enter__(self) -> "OpenTelemetrySpan":
         """Start a span."""
+        if not isinstance(self.span_instance, NonRecordingSpan):
+            if self.kind == SpanKind.INTERNAL:
+                # Suppress INTERNAL spans within this context.
+                self._context_tokens.append(context.attach(context.set_value(_SUPPRESSED_SPAN_FLAG, True)))
+
+            # Since the span is not suppressed, let's keep a reference to it in the context so that children spans
+            # always have access to the last non-suppressed parent span.
+            self._context_tokens.append(context.attach(context.set_value(_LAST_UNSUPPRESSED_SPAN, self)))
+
         self._current_ctxt_manager = trace.use_span(self._span_instance, end_on_exit=True)
         if self._current_ctxt_manager:
             self._current_ctxt_manager.__enter__()  # pylint: disable=no-member
@@ -168,6 +211,9 @@ class OpenTelemetrySpan(HttpSpanMixin, object):
         if self._current_ctxt_manager:
             self._current_ctxt_manager.__exit__(exception_type, exception_value, traceback)  # pylint: disable=no-member
             self._current_ctxt_manager = None
+        for token in self._context_tokens:
+            context.detach(token)
+            self._context_tokens.remove(token)
 
     def start(self) -> None:
         # Spans are automatically started at their creation with OpenTelemetry.
@@ -176,6 +222,9 @@ class OpenTelemetrySpan(HttpSpanMixin, object):
     def finish(self) -> None:
         """Set the end time for a span."""
         self.span_instance.end()
+        for token in self._context_tokens:
+            context.detach(token)
+            self._context_tokens.remove(token)
 
     def to_header(self) -> Dict[str, str]:  # pylint: disable=no-self-use
         """
@@ -249,7 +298,11 @@ class OpenTelemetrySpan(HttpSpanMixin, object):
         """
         Get the current span from the execution context.
         """
-        return get_span_from_context()
+        span = get_span_from_context()
+        last_unsuppressed_parent = context.get_value(_LAST_UNSUPPRESSED_SPAN)
+        if isinstance(span, NonRecordingSpan) and last_unsuppressed_parent:
+            return cast(OpenTelemetrySpan, last_unsuppressed_parent).span_instance
+        return span
 
     @classmethod
     def get_current_tracer(cls) -> Tracer:
@@ -287,13 +340,13 @@ class OpenTelemetrySpan(HttpSpanMixin, object):
         :return: The target the pass in instead of the function
         """
         # returns the current Context object
-        context = get_current()
+        current_context = context.get_current()
 
         def call_with_current_context(*args, **kwargs):
             try:
-                token = attach(context)
+                token = context.attach(current_context)
                 return func(*args, **kwargs)
             finally:
-                detach(token)
+                context.detach(token)
 
         return call_with_current_context

--- a/sdk/core/azure-core-tracing-opentelemetry/azure/core/tracing/ext/opentelemetry_span/__init__.py
+++ b/sdk/core/azure-core-tracing-opentelemetry/azure/core/tracing/ext/opentelemetry_span/__init__.py
@@ -61,7 +61,6 @@ class OpenTelemetrySpan(HttpSpanMixin, object):
     """
 
     def __init__(self, span: Optional[Span] = None, name: str = "span", **kwargs: Any) -> None:
-        self._name = name
         self._context_tokens = []
         self._current_ctxt_manager: Optional[ContextManager[Span]] = None
 

--- a/sdk/core/azure-core-tracing-opentelemetry/azure/core/tracing/ext/opentelemetry_span/__init__.py
+++ b/sdk/core/azure-core-tracing-opentelemetry/azure/core/tracing/ext/opentelemetry_span/__init__.py
@@ -99,8 +99,9 @@ class OpenTelemetrySpan(HttpSpanMixin, object):
             return
 
         if otel_kind == OpenTelemetrySpanKind.CLIENT:
-            # Since core instruments HTTP calls, we need to suppress any automatic HTTP instrumentation provided by
-            # other libraries to prevent duplicate spans.
+            # Since core already instruments HTTP calls, we need to suppress any automatic HTTP instrumentation
+            # provided by other libraries to prevent duplicate spans. This has no effect if no automatic HTTP
+            # instrumentation libraries are being used.
             self._context_tokens.append(context.attach(context.set_value(_SUPPRESS_HTTP_INSTRUMENTATION_KEY, True)))
 
         current_tracer = self.get_current_tracer()

--- a/sdk/core/azure-core-tracing-opentelemetry/dev_requirements.txt
+++ b/sdk/core/azure-core-tracing-opentelemetry/dev_requirements.txt
@@ -2,3 +2,5 @@
 ../azure-core
 -e ../../../tools/azure-devtools
 opentelemetry-sdk<2.0.0,>=1.0.0
+opentelemetry-instrumentation-requests
+requests

--- a/sdk/core/azure-core-tracing-opentelemetry/tests/conftest.py
+++ b/sdk/core/azure-core-tracing-opentelemetry/tests/conftest.py
@@ -4,12 +4,26 @@
 # ------------------------------------
 from opentelemetry import trace
 from opentelemetry.sdk.trace import TracerProvider
-import sys
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 
 import pytest
 
 
+span_exporter = InMemorySpanExporter()
+
+
 @pytest.fixture(scope="session")
 def tracer():
-    trace.set_tracer_provider(TracerProvider())
-    return trace.get_tracer(__name__)
+    processor = SimpleSpanProcessor(span_exporter)
+    provider = TracerProvider()
+    provider.add_span_processor(processor)
+    trace.set_tracer_provider(provider)
+
+    return provider.get_tracer(__name__)
+
+
+@pytest.fixture(scope="function")
+def exporter():
+    span_exporter.clear()
+    return span_exporter

--- a/sdk/core/azure-core-tracing-opentelemetry/tests/test_threading.py
+++ b/sdk/core/azure-core-tracing-opentelemetry/tests/test_threading.py
@@ -2,9 +2,13 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
+from concurrent.futures import ThreadPoolExecutor, wait
 import threading
 
+from opentelemetry.trace import NonRecordingSpan
+
 from azure.core.tracing.ext.opentelemetry_span import OpenTelemetrySpan
+from azure.core.tracing import SpanKind
 
 
 def test_get_span_from_thread(tracer):
@@ -22,3 +26,22 @@ def test_get_span_from_thread(tracer):
         thread.join()
 
         assert span is result[0]
+
+
+def test_nest_span_with_thread_pool_executor(tracer, exporter):
+
+    def nest_spans():
+        with OpenTelemetrySpan(name="outer-span", kind=SpanKind.INTERNAL) as outer_span:
+            with outer_span.span(name="inner-span", kind=SpanKind.INTERNAL) as inner_span:
+                assert isinstance(inner_span.span_instance, NonRecordingSpan)
+                assert inner_span.get_current_span() == outer_span
+
+    futures = []
+    with tracer.start_as_current_span(name="TestSpan"):
+        with ThreadPoolExecutor() as executor:
+            for _ in range(3):
+                futures.append(executor.submit(OpenTelemetrySpan.with_current_context(nest_spans)))
+        wait(futures)
+
+    # Each thread should produce 1 span, so we should have 3 spans plus the parent span.
+    assert len(exporter.get_finished_spans()) == 4

--- a/sdk/core/azure-core-tracing-opentelemetry/tests/test_threading.py
+++ b/sdk/core/azure-core-tracing-opentelemetry/tests/test_threading.py
@@ -29,7 +29,6 @@ def test_get_span_from_thread(tracer):
 
 
 def test_nest_span_with_thread_pool_executor(tracer, exporter):
-
     def nest_spans():
         with OpenTelemetrySpan(name="outer-span", kind=SpanKind.INTERNAL) as outer_span:
             with outer_span.span(name="inner-span", kind=SpanKind.INTERNAL) as inner_span:


### PR DESCRIPTION
With the Core OTel tracing plugin, there are two levels of suppression that are enabled by this change:

1. Nested logical span suppression. Nested INTERNAL calls are now suppressed by default. HTTP calls will now be children of the outer span that was not suppressed.
2. If HTTP auto-instrumentation is enabled, these are now suppressed if the OTel tracing plugin is being used since HTTP calls are traced by the plugin. This prevents duplicate HTTP spans from being produced.

Ref: https://github.com/Azure/azure-sdk-for-python/issues/25838
Closes: https://github.com/Azure/azure-sdk-for-python/issues/19573
