### PR TITLE
[ML][Pipelines] feat: add up thread number for concurrent artifact download

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_internal/entities/_additional_includes.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_internal/entities/_additional_includes.py
@@ -13,7 +13,6 @@ from typing import Union
 
 import yaml
 
-from ..._artifacts._constants import PROCESSES_PER_CORE
 from ..._utils._asset_utils import IgnoreFile, traverse_directory
 from ..._utils.utils import is_concurrent_component_registration_enabled, is_private_preview_enabled
 from ...entities._util import _general_copy
@@ -346,7 +345,10 @@ class _AdditionalIncludes:
             additional_includes_configs = additional_includes_configs.get(ADDITIONAL_INCLUDES_KEY, [])
 
         additional_includes, conflict_files = [], {}
-        num_threads = int(cpu_count()) * PROCESSES_PER_CORE
+        # Unlike component registration, artifact downloading is a pure download progress; so we can use
+        # more threads to speed up the downloading process.
+        # We use 5 threads per CPU core plus 5 extra threads, and the max number of threads is 64.
+        num_threads = min(64, (int(cpu_count()) * 5) + 5)
         if (
             len(additional_includes_configs) > 1
             and is_concurrent_component_registration_enabled()


### PR DESCRIPTION
# Description

Add up thread number used in concurrent artifact downloading given this is a pure downloading process. Accelerate it on machines with a small number of cpu cores.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
