### PR TITLE
[Autorest][CI] Bump Node version and pin pnpm

### DIFF
--- a/eng/pipelines/autorest_checks.yml
+++ b/eng/pipelines/autorest_checks.yml
@@ -14,7 +14,7 @@ pr:
     - sdk/core/
 
 variables:
-  NodeVersion: '14.x'
+  NodeVersion: '18.x'
   PythonVersion: '3.7'
   auto_rest_clone_url: 'https://github.com/Azure/autorest.python.git'
   repo_branch: 'autorestv3'
@@ -40,7 +40,7 @@ jobs:
           versionSpec: $(PythonVersion)
 
       - script: |
-          npm install -g pnpm
+          npm install -g pnpm@7.27.1
           git clone $(auto_rest_clone_url)
           cd autorest.python
           git checkout $(repo_branch)


### PR DESCRIPTION
The latest version of pnpm doesn't support Node 14.x anymore, and
always installing the latest has resulted in CI pipeline failures.
This pins pnpm to a 7.x version that remains compatible with the current
pnpm-lock.yaml file for autorest.python.

Since Node 14.x is EOL very soon, this also updates to Node 18.x which is
good for the next two years.