### PR TITLE
fix policy bug

### DIFF
--- a/sdk/communication/azure-communication-callautomation/azure/communication/callautomation/_shared/policy.py
+++ b/sdk/communication/azure-communication-callautomation/azure/communication/callautomation/_shared/policy.py
@@ -8,6 +8,7 @@ import hashlib
 import urllib
 import base64
 import hmac
+from  urllib.parse import ParseResult, urlparse
 from azure.core.credentials import AzureKeyCredential
 from azure.core.pipeline.policies import SansIOHTTPPolicy
 from .utils import get_current_utc_time
@@ -51,7 +52,11 @@ class HMACCredentialsPolicy(SansIOHTTPPolicy):
         verb = request.http_request.method.upper()
 
         # Get the path and query from url, which looks like https://host/path/query
-        query_url = str(request.http_request.url[len(self._host) + 8:])
+        parsedUrl:ParseResult = urlparse(request.http_request.url)
+        query_url = parsedUrl.path
+
+        if parsedUrl.query:
+            query_url += "?" + parsedUrl.query
 
         if self._decode_url:
             query_url = urllib.parse.unquote(query_url)

--- a/sdk/communication/azure-communication-callautomation/tests/test_hmac.py
+++ b/sdk/communication/azure-communication-callautomation/tests/test_hmac.py
@@ -5,9 +5,9 @@
 # license information.
 # --------------------------------------------------------------------------
 import unittest
-from azure.communication.rooms._shared.policy import HMACCredentialsPolicy
+from azure.communication.callautomation._shared.policy import HMACCredentialsPolicy
 from devtools_testutils import AzureTestCase
-from azure.communication.rooms._shared.utils import get_current_utc_time
+from azure.communication.callautomation._shared.utils import get_current_utc_time
 from azure.core.pipeline import PipelineRequest, PipelineContext
 from azure.core.rest import HttpRequest
 
@@ -32,7 +32,7 @@ class HMACTest(AzureTestCase):
     def mocked_get_current_utc_time():
         return "Wed, 13 Apr 2022 18:09:12 GMT"
 
-    @unittest.mock.patch('azure.communication.rooms._shared.policy.get_current_utc_time', mocked_get_current_utc_time)
+    @unittest.mock.patch('azure.communication.callautomation._shared.policy.get_current_utc_time', mocked_get_current_utc_time)
     def test_correct_signature(self):
         auth_policy = HMACCredentialsPolicy("https://contoso.communicationservices.azure.com", "pw==")
 
@@ -42,7 +42,7 @@ class HMACTest(AzureTestCase):
 
         assert "HMAC-SHA256 SignedHeaders=x-ms-date;host;x-ms-content-sha256&Signature=88MDmJhUR3m5QhFxb8ztShsSwlGrg7g/6XPnWf7QEO4=" == signature
 
-    @unittest.mock.patch('azure.communication.rooms._shared.policy.get_current_utc_time', mocked_get_current_utc_time)
+    @unittest.mock.patch('azure.communication.callautomation._shared.policy.get_current_utc_time', mocked_get_current_utc_time)
     def test_correct_signature_with_path(self):
         auth_policy = HMACCredentialsPolicy("https://contoso.communicationservices.azure.com", "pw==")
 
@@ -52,7 +52,7 @@ class HMACTest(AzureTestCase):
 
         assert "HMAC-SHA256 SignedHeaders=x-ms-date;host;x-ms-content-sha256&Signature=RoCrHjw7fb9fpHSbqvRUY2xa8RBS0YvI1cxI1x8AS38=" == signature
 
-    @unittest.mock.patch('azure.communication.rooms._shared.policy.get_current_utc_time', mocked_get_current_utc_time)
+    @unittest.mock.patch('azure.communication.callautomation._shared.policy.get_current_utc_time', mocked_get_current_utc_time)
     def test_correct_signature_with_path_and_host(self):
         auth_policy = HMACCredentialsPolicy("https://contoso.communicationservices.azure.com", "pw==")
 

--- a/sdk/communication/azure-communication-chat/azure/communication/chat/_shared/policy.py
+++ b/sdk/communication/azure-communication-chat/azure/communication/chat/_shared/policy.py
@@ -8,6 +8,7 @@ import hashlib
 import urllib
 import base64
 import hmac
+from  urllib.parse import ParseResult, urlparse
 from azure.core.credentials import AzureKeyCredential
 from azure.core.pipeline.policies import SansIOHTTPPolicy
 from .utils import get_current_utc_time
@@ -51,7 +52,11 @@ class HMACCredentialsPolicy(SansIOHTTPPolicy):
         verb = request.http_request.method.upper()
 
         # Get the path and query from url, which looks like https://host/path/query
-        query_url = str(request.http_request.url[len(self._host) + 8:])
+        parsedUrl:ParseResult = urlparse(request.http_request.url)
+        query_url = parsedUrl.path
+
+        if parsedUrl.query:
+            query_url += "?" + parsedUrl.query
 
         if self._decode_url:
             query_url = urllib.parse.unquote(query_url)

--- a/sdk/communication/azure-communication-chat/tests/test_hmac.py
+++ b/sdk/communication/azure-communication-chat/tests/test_hmac.py
@@ -5,9 +5,9 @@
 # license information.
 # --------------------------------------------------------------------------
 import unittest
-from azure.communication.rooms._shared.policy import HMACCredentialsPolicy
+from azure.communication.chat._shared.policy import HMACCredentialsPolicy
 from devtools_testutils import AzureTestCase
-from azure.communication.rooms._shared.utils import get_current_utc_time
+from azure.communication.chat._shared.utils import get_current_utc_time
 from azure.core.pipeline import PipelineRequest, PipelineContext
 from azure.core.rest import HttpRequest
 
@@ -32,7 +32,7 @@ class HMACTest(AzureTestCase):
     def mocked_get_current_utc_time():
         return "Wed, 13 Apr 2022 18:09:12 GMT"
 
-    @unittest.mock.patch('azure.communication.rooms._shared.policy.get_current_utc_time', mocked_get_current_utc_time)
+    @unittest.mock.patch('azure.communication.chat._shared.policy.get_current_utc_time', mocked_get_current_utc_time)
     def test_correct_signature(self):
         auth_policy = HMACCredentialsPolicy("https://contoso.communicationservices.azure.com", "pw==")
 
@@ -42,7 +42,7 @@ class HMACTest(AzureTestCase):
 
         assert "HMAC-SHA256 SignedHeaders=x-ms-date;host;x-ms-content-sha256&Signature=88MDmJhUR3m5QhFxb8ztShsSwlGrg7g/6XPnWf7QEO4=" == signature
 
-    @unittest.mock.patch('azure.communication.rooms._shared.policy.get_current_utc_time', mocked_get_current_utc_time)
+    @unittest.mock.patch('azure.communication.chat._shared.policy.get_current_utc_time', mocked_get_current_utc_time)
     def test_correct_signature_with_path(self):
         auth_policy = HMACCredentialsPolicy("https://contoso.communicationservices.azure.com", "pw==")
 
@@ -52,7 +52,7 @@ class HMACTest(AzureTestCase):
 
         assert "HMAC-SHA256 SignedHeaders=x-ms-date;host;x-ms-content-sha256&Signature=RoCrHjw7fb9fpHSbqvRUY2xa8RBS0YvI1cxI1x8AS38=" == signature
 
-    @unittest.mock.patch('azure.communication.rooms._shared.policy.get_current_utc_time', mocked_get_current_utc_time)
+    @unittest.mock.patch('azure.communication.chat._shared.policy.get_current_utc_time', mocked_get_current_utc_time)
     def test_correct_signature_with_path_and_host(self):
         auth_policy = HMACCredentialsPolicy("https://contoso.communicationservices.azure.com", "pw==")
 

--- a/sdk/communication/azure-communication-email/azure/communication/email/_shared/policy.py
+++ b/sdk/communication/azure-communication-email/azure/communication/email/_shared/policy.py
@@ -8,6 +8,7 @@ import hashlib
 import urllib
 import base64
 import hmac
+from  urllib.parse import ParseResult, urlparse
 from azure.core.credentials import AzureKeyCredential
 from azure.core.pipeline.policies import SansIOHTTPPolicy
 from .utils import get_current_utc_time
@@ -51,7 +52,11 @@ class HMACCredentialsPolicy(SansIOHTTPPolicy):
         verb = request.http_request.method.upper()
 
         # Get the path and query from url, which looks like https://host/path/query
-        query_url = str(request.http_request.url[len(self._host) + 8:])
+        parsedUrl:ParseResult = urlparse(request.http_request.url)
+        query_url = parsedUrl.path
+
+        if parsedUrl.query:
+            query_url += "?" + parsedUrl.query
 
         if self._decode_url:
             query_url = urllib.parse.unquote(query_url)

--- a/sdk/communication/azure-communication-email/tests/test_hmac.py
+++ b/sdk/communication/azure-communication-email/tests/test_hmac.py
@@ -5,9 +5,9 @@
 # license information.
 # --------------------------------------------------------------------------
 import unittest
-from azure.communication.rooms._shared.policy import HMACCredentialsPolicy
+from azure.communication.email._shared.policy import HMACCredentialsPolicy
 from devtools_testutils import AzureTestCase
-from azure.communication.rooms._shared.utils import get_current_utc_time
+from azure.communication.email._shared.utils import get_current_utc_time
 from azure.core.pipeline import PipelineRequest, PipelineContext
 from azure.core.rest import HttpRequest
 
@@ -32,7 +32,7 @@ class HMACTest(AzureTestCase):
     def mocked_get_current_utc_time():
         return "Wed, 13 Apr 2022 18:09:12 GMT"
 
-    @unittest.mock.patch('azure.communication.rooms._shared.policy.get_current_utc_time', mocked_get_current_utc_time)
+    @unittest.mock.patch('azure.communication.email._shared.policy.get_current_utc_time', mocked_get_current_utc_time)
     def test_correct_signature(self):
         auth_policy = HMACCredentialsPolicy("https://contoso.communicationservices.azure.com", "pw==")
 
@@ -42,7 +42,7 @@ class HMACTest(AzureTestCase):
 
         assert "HMAC-SHA256 SignedHeaders=x-ms-date;host;x-ms-content-sha256&Signature=88MDmJhUR3m5QhFxb8ztShsSwlGrg7g/6XPnWf7QEO4=" == signature
 
-    @unittest.mock.patch('azure.communication.rooms._shared.policy.get_current_utc_time', mocked_get_current_utc_time)
+    @unittest.mock.patch('azure.communication.email._shared.policy.get_current_utc_time', mocked_get_current_utc_time)
     def test_correct_signature_with_path(self):
         auth_policy = HMACCredentialsPolicy("https://contoso.communicationservices.azure.com", "pw==")
 
@@ -52,7 +52,7 @@ class HMACTest(AzureTestCase):
 
         assert "HMAC-SHA256 SignedHeaders=x-ms-date;host;x-ms-content-sha256&Signature=RoCrHjw7fb9fpHSbqvRUY2xa8RBS0YvI1cxI1x8AS38=" == signature
 
-    @unittest.mock.patch('azure.communication.rooms._shared.policy.get_current_utc_time', mocked_get_current_utc_time)
+    @unittest.mock.patch('azure.communication.email._shared.policy.get_current_utc_time', mocked_get_current_utc_time)
     def test_correct_signature_with_path_and_host(self):
         auth_policy = HMACCredentialsPolicy("https://contoso.communicationservices.azure.com", "pw==")
 

--- a/sdk/communication/azure-communication-identity/azure/communication/identity/_shared/policy.py
+++ b/sdk/communication/azure-communication-identity/azure/communication/identity/_shared/policy.py
@@ -8,6 +8,7 @@ import hashlib
 import urllib
 import base64
 import hmac
+from  urllib.parse import ParseResult, urlparse
 from azure.core.credentials import AzureKeyCredential
 from azure.core.pipeline.policies import SansIOHTTPPolicy
 from .utils import get_current_utc_time
@@ -51,7 +52,11 @@ class HMACCredentialsPolicy(SansIOHTTPPolicy):
         verb = request.http_request.method.upper()
 
         # Get the path and query from url, which looks like https://host/path/query
-        query_url = str(request.http_request.url[len(self._host) + 8:])
+        parsedUrl:ParseResult = urlparse(request.http_request.url)
+        query_url = parsedUrl.path
+
+        if parsedUrl.query:
+            query_url += "?" + parsedUrl.query
 
         if self._decode_url:
             query_url = urllib.parse.unquote(query_url)

--- a/sdk/communication/azure-communication-identity/tests/test_hmac.py
+++ b/sdk/communication/azure-communication-identity/tests/test_hmac.py
@@ -5,9 +5,9 @@
 # license information.
 # --------------------------------------------------------------------------
 import unittest
-from azure.communication.rooms._shared.policy import HMACCredentialsPolicy
+from azure.communication.identity._shared.policy import HMACCredentialsPolicy
 from devtools_testutils import AzureTestCase
-from azure.communication.rooms._shared.utils import get_current_utc_time
+from azure.communication.identity._shared.utils import get_current_utc_time
 from azure.core.pipeline import PipelineRequest, PipelineContext
 from azure.core.rest import HttpRequest
 
@@ -32,7 +32,7 @@ class HMACTest(AzureTestCase):
     def mocked_get_current_utc_time():
         return "Wed, 13 Apr 2022 18:09:12 GMT"
 
-    @unittest.mock.patch('azure.communication.rooms._shared.policy.get_current_utc_time', mocked_get_current_utc_time)
+    @unittest.mock.patch('azure.communication.identity._shared.policy.get_current_utc_time', mocked_get_current_utc_time)
     def test_correct_signature(self):
         auth_policy = HMACCredentialsPolicy("https://contoso.communicationservices.azure.com", "pw==")
 
@@ -42,7 +42,7 @@ class HMACTest(AzureTestCase):
 
         assert "HMAC-SHA256 SignedHeaders=x-ms-date;host;x-ms-content-sha256&Signature=88MDmJhUR3m5QhFxb8ztShsSwlGrg7g/6XPnWf7QEO4=" == signature
 
-    @unittest.mock.patch('azure.communication.rooms._shared.policy.get_current_utc_time', mocked_get_current_utc_time)
+    @unittest.mock.patch('azure.communication.identity._shared.policy.get_current_utc_time', mocked_get_current_utc_time)
     def test_correct_signature_with_path(self):
         auth_policy = HMACCredentialsPolicy("https://contoso.communicationservices.azure.com", "pw==")
 
@@ -52,7 +52,7 @@ class HMACTest(AzureTestCase):
 
         assert "HMAC-SHA256 SignedHeaders=x-ms-date;host;x-ms-content-sha256&Signature=RoCrHjw7fb9fpHSbqvRUY2xa8RBS0YvI1cxI1x8AS38=" == signature
 
-    @unittest.mock.patch('azure.communication.rooms._shared.policy.get_current_utc_time', mocked_get_current_utc_time)
+    @unittest.mock.patch('azure.communication.identity._shared.policy.get_current_utc_time', mocked_get_current_utc_time)
     def test_correct_signature_with_path_and_host(self):
         auth_policy = HMACCredentialsPolicy("https://contoso.communicationservices.azure.com", "pw==")
 

--- a/sdk/communication/azure-communication-jobrouter/azure/communication/jobrouter/_shared/policy.py
+++ b/sdk/communication/azure-communication-jobrouter/azure/communication/jobrouter/_shared/policy.py
@@ -8,6 +8,7 @@ import hashlib
 import urllib
 import base64
 import hmac
+from  urllib.parse import ParseResult, urlparse
 from azure.core.credentials import AzureKeyCredential
 from azure.core.pipeline.policies import SansIOHTTPPolicy
 from .utils import get_current_utc_time
@@ -51,7 +52,11 @@ class HMACCredentialsPolicy(SansIOHTTPPolicy):
         verb = request.http_request.method.upper()
 
         # Get the path and query from url, which looks like https://host/path/query
-        query_url = str(request.http_request.url[len(self._host) + 8:])
+        parsedUrl:ParseResult = urlparse(request.http_request.url)
+        query_url = parsedUrl.path
+
+        if parsedUrl.query:
+            query_url += "?" + parsedUrl.query
 
         if self._decode_url:
             query_url = urllib.parse.unquote(query_url)

--- a/sdk/communication/azure-communication-jobrouter/tests/test_hmac.py
+++ b/sdk/communication/azure-communication-jobrouter/tests/test_hmac.py
@@ -5,9 +5,9 @@
 # license information.
 # --------------------------------------------------------------------------
 import unittest
-from azure.communication.rooms._shared.policy import HMACCredentialsPolicy
+from azure.communication.jobrouter._shared.policy import HMACCredentialsPolicy
 from devtools_testutils import AzureTestCase
-from azure.communication.rooms._shared.utils import get_current_utc_time
+from azure.communication.jobrouter._shared.utils import get_current_utc_time
 from azure.core.pipeline import PipelineRequest, PipelineContext
 from azure.core.rest import HttpRequest
 
@@ -32,7 +32,7 @@ class HMACTest(AzureTestCase):
     def mocked_get_current_utc_time():
         return "Wed, 13 Apr 2022 18:09:12 GMT"
 
-    @unittest.mock.patch('azure.communication.rooms._shared.policy.get_current_utc_time', mocked_get_current_utc_time)
+    @unittest.mock.patch('azure.communication.jobrouter._shared.policy.get_current_utc_time', mocked_get_current_utc_time)
     def test_correct_signature(self):
         auth_policy = HMACCredentialsPolicy("https://contoso.communicationservices.azure.com", "pw==")
 
@@ -42,7 +42,7 @@ class HMACTest(AzureTestCase):
 
         assert "HMAC-SHA256 SignedHeaders=x-ms-date;host;x-ms-content-sha256&Signature=88MDmJhUR3m5QhFxb8ztShsSwlGrg7g/6XPnWf7QEO4=" == signature
 
-    @unittest.mock.patch('azure.communication.rooms._shared.policy.get_current_utc_time', mocked_get_current_utc_time)
+    @unittest.mock.patch('azure.communication.jobrouter._shared.policy.get_current_utc_time', mocked_get_current_utc_time)
     def test_correct_signature_with_path(self):
         auth_policy = HMACCredentialsPolicy("https://contoso.communicationservices.azure.com", "pw==")
 
@@ -52,7 +52,7 @@ class HMACTest(AzureTestCase):
 
         assert "HMAC-SHA256 SignedHeaders=x-ms-date;host;x-ms-content-sha256&Signature=RoCrHjw7fb9fpHSbqvRUY2xa8RBS0YvI1cxI1x8AS38=" == signature
 
-    @unittest.mock.patch('azure.communication.rooms._shared.policy.get_current_utc_time', mocked_get_current_utc_time)
+    @unittest.mock.patch('azure.communication.jobrouter._shared.policy.get_current_utc_time', mocked_get_current_utc_time)
     def test_correct_signature_with_path_and_host(self):
         auth_policy = HMACCredentialsPolicy("https://contoso.communicationservices.azure.com", "pw==")
 

--- a/sdk/communication/azure-communication-networktraversal/azure/communication/networktraversal/_shared/policy.py
+++ b/sdk/communication/azure-communication-networktraversal/azure/communication/networktraversal/_shared/policy.py
@@ -8,6 +8,7 @@ import hashlib
 import urllib
 import base64
 import hmac
+from  urllib.parse import ParseResult, urlparse
 from azure.core.credentials import AzureKeyCredential
 from azure.core.pipeline.policies import SansIOHTTPPolicy
 from .utils import get_current_utc_time
@@ -51,7 +52,11 @@ class HMACCredentialsPolicy(SansIOHTTPPolicy):
         verb = request.http_request.method.upper()
 
         # Get the path and query from url, which looks like https://host/path/query
-        query_url = str(request.http_request.url[len(self._host) + 8:])
+        parsedUrl:ParseResult = urlparse(request.http_request.url)
+        query_url = parsedUrl.path
+
+        if parsedUrl.query:
+            query_url += "?" + parsedUrl.query
 
         if self._decode_url:
             query_url = urllib.parse.unquote(query_url)

--- a/sdk/communication/azure-communication-networktraversal/tests/test_hmac.py
+++ b/sdk/communication/azure-communication-networktraversal/tests/test_hmac.py
@@ -5,9 +5,9 @@
 # license information.
 # --------------------------------------------------------------------------
 import unittest
-from azure.communication.rooms._shared.policy import HMACCredentialsPolicy
+from azure.communication.networktraversal._shared.policy import HMACCredentialsPolicy
 from devtools_testutils import AzureTestCase
-from azure.communication.rooms._shared.utils import get_current_utc_time
+from azure.communication.networktraversal._shared.utils import get_current_utc_time
 from azure.core.pipeline import PipelineRequest, PipelineContext
 from azure.core.rest import HttpRequest
 
@@ -32,7 +32,7 @@ class HMACTest(AzureTestCase):
     def mocked_get_current_utc_time():
         return "Wed, 13 Apr 2022 18:09:12 GMT"
 
-    @unittest.mock.patch('azure.communication.rooms._shared.policy.get_current_utc_time', mocked_get_current_utc_time)
+    @unittest.mock.patch('azure.communication.networktraversal._shared.policy.get_current_utc_time', mocked_get_current_utc_time)
     def test_correct_signature(self):
         auth_policy = HMACCredentialsPolicy("https://contoso.communicationservices.azure.com", "pw==")
 
@@ -42,7 +42,7 @@ class HMACTest(AzureTestCase):
 
         assert "HMAC-SHA256 SignedHeaders=x-ms-date;host;x-ms-content-sha256&Signature=88MDmJhUR3m5QhFxb8ztShsSwlGrg7g/6XPnWf7QEO4=" == signature
 
-    @unittest.mock.patch('azure.communication.rooms._shared.policy.get_current_utc_time', mocked_get_current_utc_time)
+    @unittest.mock.patch('azure.communication.networktraversal._shared.policy.get_current_utc_time', mocked_get_current_utc_time)
     def test_correct_signature_with_path(self):
         auth_policy = HMACCredentialsPolicy("https://contoso.communicationservices.azure.com", "pw==")
 
@@ -52,7 +52,7 @@ class HMACTest(AzureTestCase):
 
         assert "HMAC-SHA256 SignedHeaders=x-ms-date;host;x-ms-content-sha256&Signature=RoCrHjw7fb9fpHSbqvRUY2xa8RBS0YvI1cxI1x8AS38=" == signature
 
-    @unittest.mock.patch('azure.communication.rooms._shared.policy.get_current_utc_time', mocked_get_current_utc_time)
+    @unittest.mock.patch('azure.communication.networktraversal._shared.policy.get_current_utc_time', mocked_get_current_utc_time)
     def test_correct_signature_with_path_and_host(self):
         auth_policy = HMACCredentialsPolicy("https://contoso.communicationservices.azure.com", "pw==")
 

--- a/sdk/communication/azure-communication-phonenumbers/azure/communication/phonenumbers/_shared/policy.py
+++ b/sdk/communication/azure-communication-phonenumbers/azure/communication/phonenumbers/_shared/policy.py
@@ -8,6 +8,7 @@ import hashlib
 import urllib
 import base64
 import hmac
+from  urllib.parse import ParseResult, urlparse
 from azure.core.credentials import AzureKeyCredential
 from azure.core.pipeline.policies import SansIOHTTPPolicy
 from .utils import get_current_utc_time
@@ -51,7 +52,11 @@ class HMACCredentialsPolicy(SansIOHTTPPolicy):
         verb = request.http_request.method.upper()
 
         # Get the path and query from url, which looks like https://host/path/query
-        query_url = str(request.http_request.url[len(self._host) + 8:])
+        parsedUrl:ParseResult = urlparse(request.http_request.url)
+        query_url = parsedUrl.path
+
+        if parsedUrl.query:
+            query_url += "?" + parsedUrl.query
 
         if self._decode_url:
             query_url = urllib.parse.unquote(query_url)

--- a/sdk/communication/azure-communication-phonenumbers/test/test_hmac.py
+++ b/sdk/communication/azure-communication-phonenumbers/test/test_hmac.py
@@ -5,9 +5,9 @@
 # license information.
 # --------------------------------------------------------------------------
 import unittest
-from azure.communication.rooms._shared.policy import HMACCredentialsPolicy
+from azure.communication.phonenumbers._shared.policy import HMACCredentialsPolicy
 from devtools_testutils import AzureTestCase
-from azure.communication.rooms._shared.utils import get_current_utc_time
+from azure.communication.phonenumbers._shared.utils import get_current_utc_time
 from azure.core.pipeline import PipelineRequest, PipelineContext
 from azure.core.rest import HttpRequest
 
@@ -32,7 +32,7 @@ class HMACTest(AzureTestCase):
     def mocked_get_current_utc_time():
         return "Wed, 13 Apr 2022 18:09:12 GMT"
 
-    @unittest.mock.patch('azure.communication.rooms._shared.policy.get_current_utc_time', mocked_get_current_utc_time)
+    @unittest.mock.patch('azure.communication.phonenumbers._shared.policy.get_current_utc_time', mocked_get_current_utc_time)
     def test_correct_signature(self):
         auth_policy = HMACCredentialsPolicy("https://contoso.communicationservices.azure.com", "pw==")
 
@@ -42,7 +42,7 @@ class HMACTest(AzureTestCase):
 
         assert "HMAC-SHA256 SignedHeaders=x-ms-date;host;x-ms-content-sha256&Signature=88MDmJhUR3m5QhFxb8ztShsSwlGrg7g/6XPnWf7QEO4=" == signature
 
-    @unittest.mock.patch('azure.communication.rooms._shared.policy.get_current_utc_time', mocked_get_current_utc_time)
+    @unittest.mock.patch('azure.communication.phonenumbers._shared.policy.get_current_utc_time', mocked_get_current_utc_time)
     def test_correct_signature_with_path(self):
         auth_policy = HMACCredentialsPolicy("https://contoso.communicationservices.azure.com", "pw==")
 
@@ -52,7 +52,7 @@ class HMACTest(AzureTestCase):
 
         assert "HMAC-SHA256 SignedHeaders=x-ms-date;host;x-ms-content-sha256&Signature=RoCrHjw7fb9fpHSbqvRUY2xa8RBS0YvI1cxI1x8AS38=" == signature
 
-    @unittest.mock.patch('azure.communication.rooms._shared.policy.get_current_utc_time', mocked_get_current_utc_time)
+    @unittest.mock.patch('azure.communication.phonenumbers._shared.policy.get_current_utc_time', mocked_get_current_utc_time)
     def test_correct_signature_with_path_and_host(self):
         auth_policy = HMACCredentialsPolicy("https://contoso.communicationservices.azure.com", "pw==")
 

--- a/sdk/communication/azure-communication-rooms/azure/communication/rooms/_shared/policy.py
+++ b/sdk/communication/azure-communication-rooms/azure/communication/rooms/_shared/policy.py
@@ -8,6 +8,7 @@ import hashlib
 import urllib
 import base64
 import hmac
+from  urllib.parse import ParseResult, urlparse
 from azure.core.credentials import AzureKeyCredential
 from azure.core.pipeline.policies import SansIOHTTPPolicy
 from .utils import get_current_utc_time
@@ -51,7 +52,11 @@ class HMACCredentialsPolicy(SansIOHTTPPolicy):
         verb = request.http_request.method.upper()
 
         # Get the path and query from url, which looks like https://host/path/query
-        query_url = str(request.http_request.url[len(self._host) + 8:])
+        parsedUrl:ParseResult = urlparse(request.http_request.url)
+        query_url = parsedUrl.path
+
+        if parsedUrl.query:
+            query_url += "?" + parsedUrl.query
 
         if self._decode_url:
             query_url = urllib.parse.unquote(query_url)

--- a/sdk/communication/azure-communication-sms/azure/communication/sms/_shared/policy.py
+++ b/sdk/communication/azure-communication-sms/azure/communication/sms/_shared/policy.py
@@ -8,6 +8,7 @@ import hashlib
 import urllib
 import base64
 import hmac
+from  urllib.parse import ParseResult, urlparse
 from azure.core.credentials import AzureKeyCredential
 from azure.core.pipeline.policies import SansIOHTTPPolicy
 from .utils import get_current_utc_time
@@ -51,7 +52,11 @@ class HMACCredentialsPolicy(SansIOHTTPPolicy):
         verb = request.http_request.method.upper()
 
         # Get the path and query from url, which looks like https://host/path/query
-        query_url = str(request.http_request.url[len(self._host) + 8:])
+        parsedUrl:ParseResult = urlparse(request.http_request.url)
+        query_url = parsedUrl.path
+
+        if parsedUrl.query:
+            query_url += "?" + parsedUrl.query
 
         if self._decode_url:
             query_url = urllib.parse.unquote(query_url)

--- a/sdk/communication/azure-communication-sms/tests/test_hmac.py
+++ b/sdk/communication/azure-communication-sms/tests/test_hmac.py
@@ -4,24 +4,60 @@
 # Licensed under the MIT License. See License.txt in the project root for
 # license information.
 # --------------------------------------------------------------------------
-
 import unittest
 from azure.communication.sms._shared.policy import HMACCredentialsPolicy
 from devtools_testutils import AzureTestCase
+from azure.communication.sms._shared.utils import get_current_utc_time
+from azure.core.pipeline import PipelineRequest, PipelineContext
+from azure.core.rest import HttpRequest
 
 class HMACTest(AzureTestCase):
     def setUp(self):
         super(HMACTest, self).setUp()
 
     def test_correct_hmac(self):
-        auth_policy = HMACCredentialsPolicy("contoso.communicationservices.azure.com", "pw==")
+        auth_policy = HMACCredentialsPolicy("https://contoso.communicationservices.azure.com", "pw==")
 
         sha_val = auth_policy._compute_hmac("banana")
+        #[SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="unit test with fake keys")]
         assert sha_val == "88EC05aAS9iXnaimtNO78JLjiPtfWryQB/5QYEzEsu8="
 
     def test_correct_utf16_hmac(self):
-        auth_policy = HMACCredentialsPolicy("contoso.communicationservices.azure.com", "pw==")
+        auth_policy = HMACCredentialsPolicy("https://contoso.communicationservices.azure.com", "pw==")
 
         sha_val = auth_policy._compute_hmac(u"😀")
-
+        #[SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="unit test with fake keys")]
         assert sha_val == "1rudJKjn2Zi+3hRrBG29wIF6pD6YyAeQR1ZcFtXoKAU=" 
+
+    def mocked_get_current_utc_time():
+        return "Wed, 13 Apr 2022 18:09:12 GMT"
+
+    @unittest.mock.patch('azure.communication.sms._shared.policy.get_current_utc_time', mocked_get_current_utc_time)
+    def test_correct_signature(self):
+        auth_policy = HMACCredentialsPolicy("https://contoso.communicationservices.azure.com", "pw==")
+
+        test_request = HttpRequest(method = "GET", url = "https://contoso.communicationservices.azure.com/")
+        request = PipelineRequest(test_request, PipelineContext(None))
+        signature = auth_policy._sign_request(request).http_request.headers['Authorization']
+
+        assert "HMAC-SHA256 SignedHeaders=x-ms-date;host;x-ms-content-sha256&Signature=88MDmJhUR3m5QhFxb8ztShsSwlGrg7g/6XPnWf7QEO4=" == signature
+
+    @unittest.mock.patch('azure.communication.sms._shared.policy.get_current_utc_time', mocked_get_current_utc_time)
+    def test_correct_signature_with_path(self):
+        auth_policy = HMACCredentialsPolicy("https://contoso.communicationservices.azure.com", "pw==")
+
+        test_request = HttpRequest(method = "GET", url = "https://contoso.communicationservices.azure.com/testPath")
+        request = PipelineRequest(test_request, PipelineContext(None))
+        signature = auth_policy._sign_request(request).http_request.headers['Authorization']
+
+        assert "HMAC-SHA256 SignedHeaders=x-ms-date;host;x-ms-content-sha256&Signature=RoCrHjw7fb9fpHSbqvRUY2xa8RBS0YvI1cxI1x8AS38=" == signature
+
+    @unittest.mock.patch('azure.communication.sms._shared.policy.get_current_utc_time', mocked_get_current_utc_time)
+    def test_correct_signature_with_path_and_host(self):
+        auth_policy = HMACCredentialsPolicy("https://contoso.communicationservices.azure.com", "pw==")
+
+        test_request = HttpRequest(method = "GET", url = "https://contoso.communicationservices.azure.com/testPath?testQuery=yes")
+        request = PipelineRequest(test_request, PipelineContext(None))
+        signature = auth_policy._sign_request(request).http_request.headers['Authorization']
+
+        assert "HMAC-SHA256 SignedHeaders=x-ms-date;host;x-ms-content-sha256&Signature=il99+rd6V5O136roX/zVePCNle78HmvC4B7tu9zRH3I=" == signature


### PR DESCRIPTION
### Packages impacted by this PR
communication-common

### Describe the problem that is addressed by this PR
When running the policy, a query param is always being detected as the URLSearchParams object exists, even if it is empty.

This is causing a "?" to be appended to the pathAndQuery while no query is present. This leads to a incorrect signature being generated if the url has no query. 

### Are there test cases added in this PR? _(If not, why?)_
Yes, one to test correct signature is generated when query parameter and path are both present
one to test correct signature is generated when only path is present


