### PR TITLE
[Tables] Update isodate dependency

### DIFF
--- a/sdk/tables/azure-data-tables/CHANGELOG.md
+++ b/sdk/tables/azure-data-tables/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bugs Fixed
 
 ### Other Changes
+* Adjusted dependency on `isodate` to `<1.0.0,>=0.6.1`.
 
 ## 12.4.2 (2023-02-07)
 

--- a/sdk/tables/azure-data-tables/setup.py
+++ b/sdk/tables/azure-data-tables/setup.py
@@ -67,7 +67,7 @@ setup(
     install_requires=[
         "azure-core<2.0.0,>=1.24.0",
         "yarl<2.0,>=1.0",
-        "isodate>=0.6.0",
+        "isodate<1.0.0,>=0.6.1",
         "typing-extensions>=4.3.0"
     ],
 )


### PR DESCRIPTION
The mindependency CI check for Tables has been failing recent due to a recent minimum [version bump of isodate](https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/resources/azure-mgmt-resource/setup.py#L73) in `azure-mgmt-resource` which is something listed in the dev_requirements.txt file.

This change adjusts the isodate version range to match many of the other packages declaring this dependency.


Sample CI error:
```
ERROR: Cannot install -r .tox/mindependency/tmp/new_dev_requirements.txt (line 4) and isodate==0.6.0 because these package versions have conflicting dependencies.

The conflict is caused by:
    The user requested isodate==0.6.0
    azure-mgmt-resource 23.0.0 depends on isodate<1.0.0 and >=0.6.1
```
