### PR TITLE
Fixing inexistent x-ms-request-quota

### DIFF
--- a/sdk/cosmos/azure-cosmos/azure/cosmos/diagnostics.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/diagnostics.py
@@ -48,7 +48,7 @@ class RecordDiagnostics(object):
         "x-ms-activity-id",
         "x-ms-session-token",
         "x-ms-item-count",
-        "x-ms-request-quota",
+        "x-ms-resource-quota",
         "x-ms-resource-usage",
         "x-ms-retry-after-ms",
     }


### PR DESCRIPTION
There was a typo where a key x-ms-request-quota was made available but did not exist.

The desired key x-ms-resource-quota did not exist (probably due to the typo).