### PR TITLE
{communication} Modified `attachmentType` to `contentType` to fix "Send Email with Attachments" example

### DIFF
--- a/sdk/communication/azure-communication-email/README.md
+++ b/sdk/communication/azure-communication-email/README.md
@@ -147,7 +147,7 @@ message = {
     "attachments": [
         {
             "name": "attachment.txt",
-            "attachmentType": "text/plain",
+            "contentType": "text/plain",
             "contentInBase64": file_bytes_b64.decode()
         }
     ]


### PR DESCRIPTION
# Description
Changed `attachmentType` to `contentType` to fix "Send Email with Attachments" example.
Fixes  [29696](https://github.com/Azure/azure-sdk-for-python/issues/29696)

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
