### PR TITLE
Make offline/online store mutable on feature store workspace update

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_feature_store_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_feature_store_operations.py
@@ -264,7 +264,9 @@ class _FeatureStoreOperations(WorkspaceOperationsBase):
                     not existing_offline_store_connection.properties
                     or existing_offline_store_connection.properties.target != offline_store.target
                 ):
-                    raise ValidationError("Cannot update the offline store target")
+                    module_logger.warning(
+                        "Warning: You have changed the offline store connection, any data that was materialized/backfilled earlier will not be available. You have to run backfill again."
+                    )
             else:
                 if not materialization_identity:
                     raise ValidationError("Materialization identity is required to setup offline store connection")
@@ -284,7 +286,9 @@ class _FeatureStoreOperations(WorkspaceOperationsBase):
                     not existing_online_store_connection.properties
                     or existing_online_store_connection.properties.target != online_store.target
                 ):
-                    raise ValidationError("Cannot update the online store target")
+                    module_logger.warning(
+                        "Warning: You have changed the online store connection, any data that was materialized/backfilled earlier will not be available. You have to run backfill again."
+                    )
             else:
                 if not materialization_identity:
                     raise ValidationError("Materialization identity is required to setup online store connection")
@@ -333,7 +337,7 @@ class _FeatureStoreOperations(WorkspaceOperationsBase):
             )
             feature_store_settings.online_store_connection_name = online_store_connection_name
 
-        identity = kwargs.get("identity", feature_store.identity)
+        identity = kwargs.pop("identity", feature_store.identity)
         if materialization_identity:
             identity = IdentityConfiguration(
                 type=camel_to_snake(ManagedServiceIdentityType.SYSTEM_ASSIGNED_USER_ASSIGNED),

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_feature_store_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_feature_store_operations.py
@@ -264,8 +264,10 @@ class _FeatureStoreOperations(WorkspaceOperationsBase):
                     not existing_offline_store_connection.properties
                     or existing_offline_store_connection.properties.target != offline_store.target
                 ):
-                    module_logger.warning(
-                        "Warning: You have changed the offline store connection, any data that was materialized/backfilled earlier will not be available. You have to run backfill again."
+                    module_logger.info(
+                        "Warning: You have changed the offline store connection, "
+                        "any data that was materialized/backfilled "
+                        "earlier will not be available. You have to run backfill again."
                     )
             else:
                 if not materialization_identity:
@@ -286,8 +288,10 @@ class _FeatureStoreOperations(WorkspaceOperationsBase):
                     not existing_online_store_connection.properties
                     or existing_online_store_connection.properties.target != online_store.target
                 ):
-                    module_logger.warning(
-                        "Warning: You have changed the online store connection, any data that was materialized/backfilled earlier will not be available. You have to run backfill again."
+                    module_logger.info(
+                        "Warning: You have changed the online store connection, "
+                        "any data that was materialized/backfilled earlier "
+                        "will not be available. You have to run backfill again."
                     )
             else:
                 if not materialization_identity:

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_feature_store_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_feature_store_operations.py
@@ -266,7 +266,7 @@ class _FeatureStoreOperations(WorkspaceOperationsBase):
                 ):
                     module_logger.info(
                         "Warning: You have changed the offline store connection, "
-                        "any data that was materialized/backfilled "
+                        "any data that was materialized "
                         "earlier will not be available. You have to run backfill again."
                     )
             else:
@@ -290,7 +290,7 @@ class _FeatureStoreOperations(WorkspaceOperationsBase):
                 ):
                     module_logger.info(
                         "Warning: You have changed the online store connection, "
-                        "any data that was materialized/backfilled earlier "
+                        "any data that was materialized earlier "
                         "will not be available. You have to run backfill again."
                     )
             else:


### PR DESCRIPTION
# Description

Make offline/online store mutable on feature store workspace update
Added the warning message when user will try to update target. 


If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
![image](https://user-images.githubusercontent.com/110191178/229234476-dae4579a-f208-4773-a489-2c48c2c86d18.png)

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
