### PR TITLE
[ML][Pipelines]Fail when configured upper case node name instead of silently change it to lower case

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/dsl/_pipeline_component_builder.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/dsl/_pipeline_component_builder.py
@@ -351,8 +351,6 @@ class PipelineComponentBuilder:
             # for node name _, treat it as anonymous node with name unset
             if name == "_":
                 continue
-            if name is not None:
-                name = name.lower()
 
             # User defined name must be valid python identifier
             if not is_valid_node_name(name):

--- a/sdk/ml/azure-ai-ml/tests/dsl/unittests/test_dsl_pipeline.py
+++ b/sdk/ml/azure-ai-ml/tests/dsl/unittests/test_dsl_pipeline.py
@@ -572,6 +572,20 @@ class TestDSLPipeline:
         with pytest.raises(UserErrorException, match="Invalid node name found"):
             pipeline_with_invalid_user_defined_nodes_3()
 
+    def test_pipeline_variable_name_uppercase(self):
+        component_yaml = "./tests/test_configs/components/helloworld_component_no_paths.yml"
+        component_func1 = load_component(source=component_yaml)
+
+        @dsl.pipeline(name="pipeline_with_uppercase_node_names")
+        def pipeline_with_user_defined_nodes_1():
+            for i in range(2):
+                for_loop_node = component_func1()
+                for_loop_node.name = f"Dummy_{i}"
+
+        # raise clear exception instead of silently lower it
+        with pytest.raises(UserErrorException, match="Invalid node name found: 'Dummy_1'"):
+            pipeline_with_user_defined_nodes_1()
+
     def test_connect_components_in_pipeline(self):
         hello_world_component_yaml = "./tests/test_configs/components/helloworld_component_with_input_and_output.yml"
         hello_world_component_func = load_component(source=hello_world_component_yaml)

--- a/sdk/ml/azure-ai-ml/tests/internal/e2etests/test_pipeline_job.py
+++ b/sdk/ml/azure-ai-ml/tests/internal/e2etests/test_pipeline_job.py
@@ -318,7 +318,7 @@ class TestPipelineJob(AzureRecordedTestCase):
         @pipeline
         def pipeline_func():
             node = component_func()
-            # node level should not have output type when type not configured
+            # node level should have correct output type when type not configured
             node.outputs.output.mode = "mount"
 
         pipeline_job = pipeline_func()

--- a/sdk/ml/azure-ai-ml/tests/internal/unittests/test_pipeline_job.py
+++ b/sdk/ml/azure-ai-ml/tests/internal/unittests/test_pipeline_job.py
@@ -216,7 +216,7 @@ class TestPipelineJob:
         @pipeline
         def pipeline_func():
             node = component_func()
-            # node level should not have output type when type not configured
+            # node level should have correct output type when type not configured
             node.outputs.data_any_file.mode = "mount"
 
         pipeline_job = pipeline_func()


### PR DESCRIPTION
# Description

Please add an informative description that covers that changes made by the pull request and link all relevant issues.

When node name in @pipeline configured to illegal python identifier, raise clear exception instead of silently make it lower

![image](https://user-images.githubusercontent.com/7776147/229721421-622f8934-cbdb-4e16-bc1d-712871bd8c22.png)



If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
