### PR TITLE
we should never use bare pip installs

### DIFF
--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -22,7 +22,7 @@ function Get-AllPackageInfoFromRepo ($serviceDirectory)
   try
   {
     Push-Location $RepoRoot
-    pip install "./tools/azure-sdk-tools[build]" -q -I
+    python -m pip install "./tools/azure-sdk-tools[build]" -q -I
     $allPkgPropLines = python (Join-path eng scripts get_package_properties.py) -s $searchPath
   }
   catch
@@ -252,8 +252,8 @@ function FallbackValidation
   try {
     $pipInstallOutput = ""
     if ($PackageSourceOverride) {
-      Write-Host "pip install $packageExpression --no-cache-dir --target $installTargetFolder --extra-index-url=$PackageSourceOverride"
-      $pipInstallOutput = pip `
+      Write-Host "python -m pip install $packageExpression --no-cache-dir --target $installTargetFolder --extra-index-url=$PackageSourceOverride"
+      $pipInstallOutput = python -m pip `
         install `
         $packageExpression `
         --no-cache-dir `
@@ -261,20 +261,20 @@ function FallbackValidation
         --extra-index-url=$PackageSourceOverride 2>&1
     }
     else {
-      Write-Host "pip install $packageExpression --no-cache-dir --target $installTargetFolder"
-      $pipInstallOutput = pip `
+      Write-Host "python -m pip install $packageExpression --no-cache-dir --target $installTargetFolder"
+      $pipInstallOutput = python -m pip `
         install `
         $packageExpression `
         --no-cache-dir `
         --target $installTargetFolder 2>&1
     }
     if ($LASTEXITCODE -ne 0) {
-      LogWarning "pip install failed for $packageExpression"
+      LogWarning "python -m pip install failed for $packageExpression"
       Write-Host $pipInstallOutput
       return $false
     }
   } catch {
-    LogWarning "pip install failed for $packageExpression with exception"
+    LogWarning "python -m pip install failed for $packageExpression with exception"
     LogWarning $_.Exception
     LogWarning $_.Exception.StackTrace
     return $false
@@ -522,7 +522,7 @@ function SetPackageVersion ($PackageName, $Version, $ServiceDirectory, $ReleaseD
   {
     $ReleaseDate = Get-Date -Format "yyyy-MM-dd"
   }
-  pip install "$RepoRoot/tools/azure-sdk-tools[build]" -q -I
+  python -m pip install "$RepoRoot/tools/azure-sdk-tools[build]" -q -I
   sdk_set_version --package-name $PackageName --new-version $Version `
   --service $ServiceDirectory --release-date $ReleaseDate --replace-latest-entry-title $ReplaceLatestEntryTitle
 }
@@ -573,7 +573,7 @@ function Import-Dev-Cert-python
   Write-Host "Python Trust Methodology"
 
   $pathToScript = Resolve-Path (Join-Path -Path $PSScriptRoot -ChildPath "../../scripts/devops_tasks/trust_proxy_cert.py")
-  python -m pip install requests
+  python -m python -m pip install requests
   python $pathToScript
 }
 


### PR DESCRIPTION
I obviously missed this when updating all the `yml` calls to `pip`. This should be an entirely safe and transient change for CI.

For local, this will resolve a couple bugs I'm encountering when attempting to repro a problem with `Verify-ChangelogEntry`