### PR TITLE
[Core] Change order of default tracing check

### DIFF
--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features Added
 
-- Updated settings to include OpenTelemetry which is now the default tracer provider.  #29095
+- Updated settings to include OpenTelemetry as a tracer provider.  #29095
 
 ### Other Changes
 

--- a/sdk/core/azure-core/azure/core/settings.py
+++ b/sdk/core/azure-core/azure/core/settings.py
@@ -166,7 +166,7 @@ def convert_tracing_impl(value: Union[str, Type[AbstractSpan]]) -> Optional[Type
     """
     if value is None:
         return (
-            _get_opentelemetry_span_if_opentelemetry_is_imported() or _get_opencensus_span_if_opencensus_is_imported()
+            _get_opencensus_span_if_opencensus_is_imported() or _get_opentelemetry_span_if_opentelemetry_is_imported()
         )
 
     if not isinstance(value, str):


### PR DESCRIPTION
The Opencensus plugin should be checked for first since that was the previous default behavior. If the Opencensus plugin is not available, _then_ ht OpenTelemetry plugin is checked for.
