### PR TITLE
[Identity] Disable added CAE support for release

### DIFF
--- a/sdk/identity/azure-identity/CHANGELOG.md
+++ b/sdk/identity/azure-identity/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.13.0 (2023-04-11)
+## 1.13.0 (Unreleased)
 
 ### Features Added
 
@@ -11,6 +11,7 @@
 > These changes do not impact the API of stable versions such as 1.12.0.
 > Only code written against a beta version such as 1.13.0b3 may be affected.
 - Windows Web Account Manager (WAM) Brokered Authentication is still in preview and not available in this release. It will be available in the next beta release.
+- Additional Continuous Access Evaluation (CAE) support for service principal credentials is still in preview and not available in this release. It will be available in the next beta release.
 
 ## 1.13.0b3 (2023-03-07)
 

--- a/sdk/identity/azure-identity/azure/identity/_internal/aad_client_base.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/aad_client_base.py
@@ -5,7 +5,6 @@
 import abc
 import base64
 import json
-import os
 import time
 from uuid import uuid4
 from typing import TYPE_CHECKING, List, Any, Iterable, Optional, Union, Dict
@@ -18,7 +17,6 @@ from azure.core.pipeline.policies import ContentDecodePolicy
 from azure.core.pipeline.transport import HttpRequest
 from azure.core.credentials import AccessToken
 from azure.core.exceptions import ClientAuthenticationError
-from .._constants import EnvironmentVariables
 from .utils import get_default_authority, normalize_authority, resolve_tenant
 from .aadclient_certificate import AadClientCertificate
 
@@ -54,8 +52,7 @@ class AadClientBase(abc.ABC):
 
         self._cache = cache or TokenCache()
         self._client_id = client_id
-        # CP1 = can handle claims challenges (CAE)
-        self._capabilities = None if EnvironmentVariables.AZURE_IDENTITY_DISABLE_CP1 in os.environ else ["CP1"]
+        self._capabilities = None
         self._additionally_allowed_tenants = additionally_allowed_tenants or []
         self._pipeline = self._build_pipeline(**kwargs)
 

--- a/sdk/identity/azure-identity/tests/test_aad_client.py
+++ b/sdk/identity/azure-identity/tests/test_aad_client.py
@@ -328,39 +328,39 @@ def test_multitenant_cache():
         client_d.get_cached_access_token([scope], tenant_id=tenant_a)
 
 
-@pytest.mark.parametrize("method,args", BASE_CLASS_METHODS)
-def test_claims(method, args):
+# @pytest.mark.parametrize("method,args", BASE_CLASS_METHODS)
+# def test_claims(method, args):
 
-    scopes = ["scope"]
-    claims = '{"access_token": {"essential": "true"}}'
+#     scopes = ["scope"]
+#     claims = '{"access_token": {"essential": "true"}}'
 
-    client = AadClient("tenant_id", "client_id")
+#     client = AadClient("tenant_id", "client_id")
 
-    expected_merged_claims = '{"access_token": {"essential": "true", "xms_cc": {"values": ["CP1"]}}}'
+#     expected_merged_claims = '{"access_token": {"essential": "true", "xms_cc": {"values": ["CP1"]}}}'
 
-    with patch.object(AadClient, "_post") as post_mock:
-        func = getattr(client, method)
-        func(scopes, *args, claims=claims)
+#     with patch.object(AadClient, "_post") as post_mock:
+#         func = getattr(client, method)
+#         func(scopes, *args, claims=claims)
 
-        assert post_mock.call_count == 1
-        data, _ = post_mock.call_args
-        assert len(data) == 1
-        assert data[0]["claims"] == expected_merged_claims
+#         assert post_mock.call_count == 1
+#         data, _ = post_mock.call_args
+#         assert len(data) == 1
+#         assert data[0]["claims"] == expected_merged_claims
 
 
-@pytest.mark.parametrize("method,args", BASE_CLASS_METHODS)
-def test_claims_disable_capabilities(method, args):
-    scopes = ["scope"]
-    claims = '{"access_token": {"essential": "true"}}'
+# @pytest.mark.parametrize("method,args", BASE_CLASS_METHODS)
+# def test_claims_disable_capabilities(method, args):
+#     scopes = ["scope"]
+#     claims = '{"access_token": {"essential": "true"}}'
 
-    with patch.dict("os.environ", {"AZURE_IDENTITY_DISABLE_CP1": "true"}):
-        client = AadClient("tenant_id", "client_id")
+#     with patch.dict("os.environ", {"AZURE_IDENTITY_DISABLE_CP1": "true"}):
+#         client = AadClient("tenant_id", "client_id")
 
-        with patch.object(AadClient, "_post") as post_mock:
-            func = getattr(client, method)
-            func(scopes, *args, claims=claims)
+#         with patch.object(AadClient, "_post") as post_mock:
+#             func = getattr(client, method)
+#             func(scopes, *args, claims=claims)
 
-            assert post_mock.call_count == 1
-            data, _ = post_mock.call_args
-            assert len(data) == 1
-            assert data[0]["claims"] == claims
+#             assert post_mock.call_count == 1
+#             data, _ = post_mock.call_args
+#             assert len(data) == 1
+#             assert data[0]["claims"] == claims

--- a/sdk/identity/azure-identity/tests/test_live.py
+++ b/sdk/identity/azure-identity/tests/test_live.py
@@ -46,8 +46,8 @@ def test_certificate_credential(certificate_fixture, request):
         tenant_id, client_id, certificate_data=cert["cert_with_password_bytes"], password=cert["password"]
     )
     token = get_token(credential)
-    parsed_payload = get_token_payload_contents(token.token)
-    assert "xms_cc" in parsed_payload and "CP1" in parsed_payload["xms_cc"]
+    # parsed_payload = get_token_payload_contents(token.token)
+    # assert "xms_cc" in parsed_payload and "CP1" in parsed_payload["xms_cc"]
 
 
 def test_client_secret_credential(live_service_principal):
@@ -57,8 +57,8 @@ def test_client_secret_credential(live_service_principal):
         live_service_principal["client_secret"],
     )
     token = get_token(credential)
-    parsed_payload = get_token_payload_contents(token.token)
-    assert "xms_cc" in parsed_payload and "CP1" in parsed_payload["xms_cc"]
+    # parsed_payload = get_token_payload_contents(token.token)
+    # assert "xms_cc" in parsed_payload and "CP1" in parsed_payload["xms_cc"]
 
 
 def test_default_credential(live_service_principal):

--- a/sdk/identity/azure-identity/tests/test_live_async.py
+++ b/sdk/identity/azure-identity/tests/test_live_async.py
@@ -40,8 +40,8 @@ async def test_certificate_credential(certificate_fixture, request):
         tenant_id, client_id, certificate_data=cert["cert_with_password_bytes"], password=cert["password"]
     )
     token = await get_token(credential)
-    parsed_payload = get_token_payload_contents(token.token)
-    assert "xms_cc" in parsed_payload and "CP1" in parsed_payload["xms_cc"]
+    # parsed_payload = get_token_payload_contents(token.token)
+    # assert "xms_cc" in parsed_payload and "CP1" in parsed_payload["xms_cc"]
 
 
 
@@ -53,8 +53,8 @@ async def test_client_secret_credential(live_service_principal):
         live_service_principal["client_secret"],
     )
     token = await get_token(credential)
-    parsed_payload = get_token_payload_contents(token.token)
-    assert "xms_cc" in parsed_payload and "CP1" in parsed_payload["xms_cc"]
+    # parsed_payload = get_token_payload_contents(token.token)
+    # assert "xms_cc" in parsed_payload and "CP1" in parsed_payload["xms_cc"]
 
 
 


### PR DESCRIPTION
This support should stay in beta for now.

Closes https://github.com/Azure/azure-sdk-for-python/issues/29473
