### PR TITLE
[ml] Fix pylint issue when pylint run on python3.10

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_utils/_endpoint_utils.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_utils/_endpoint_utils.py
@@ -180,7 +180,7 @@ def validate_scoring_script(deployment):
             contents = script.read()
             try:
                 ast.parse(contents, score_script_path)
-            except Exception as err:  # pylint: disable=broad-except
+            except SyntaxError as err:
                 err.filename = err.filename.split("/")[-1]
                 msg = (
                     f"Failed to submit deployment {deployment.name} due to syntax errors "  # pylint: disable=no-member
@@ -203,9 +203,7 @@ def validate_scoring_script(deployment):
                     error_category=ErrorCategory.USER_ERROR,
                     error_type=ValidationErrorType.CANNOT_PARSE,
                 )
-    except Exception as err:
-        if isinstance(err, ValidationException):
-            raise err
+    except OSError as err:
         raise MlException(
             message=f"Failed to open scoring script {err.filename}.",
             no_personal_data_message="Failed to open scoring script.",


### PR DESCRIPTION
# Description

`pylint` would report some issues related to missing members of `Exception` when pylint was run on python3.10 using `tox -e pylint -c ../../../eng/tox/tox.ini` (but curiously, these pylint results didn't show up in python3.7, python3.8 or python3.9).

This PR resolves those pylint issues by narrowing the exception types caught by the try catch blocks.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
