### PR TITLE
[Storage] Improve `generate_blob_sas` version_id documentation

### DIFF
--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared_access_signature.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared_access_signature.py
@@ -561,7 +561,10 @@ def generate_blob_sas(
         For example, specifying ip=168.1.5.65 or ip=168.1.5.60-168.1.5.70 on the SAS
         restricts the request to those IP addresses.
     :keyword str version_id:
-        An optional blob version ID. This parameter is only for versioning enabled account
+        An optional blob version ID. This parameter is only applicable for versioning-enabled
+        Storage accounts. Note that the 'versionid' query parameter is not included in the output
+        SAS. Therefore, please provide the 'version_id' parameter to any APIs when using the output
+        SAS to operate on a specific version.
 
         .. versionadded:: 12.4.0
             This keyword argument was introduced in API version '2019-12-12'.

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared_access_signature.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared_access_signature.py
@@ -561,10 +561,7 @@ def generate_blob_sas(
         For example, specifying ip=168.1.5.65 or ip=168.1.5.60-168.1.5.70 on the SAS
         restricts the request to those IP addresses.
     :keyword str version_id:
-        An optional blob version ID. This parameter is only applicable for versioning-enabled
-        Storage accounts. Note that the 'versionid' query parameter is not included in the output
-        SAS. Therefore, please provide the 'version_id' parameter to any APIs when using the output
-        SAS to operate on a specific version.
+        An optional blob version ID. This parameter is only for versioning enabled account
 
         .. versionadded:: 12.4.0
             This keyword argument was introduced in API version '2019-12-12'.


### PR DESCRIPTION
As raised in #28545, this PR aims to clarify any confusion about the mechanics of using the blob SAS against versioned blobs.

In short, the SAS does not automatically append the `versionid` query parameter to the SAS as any API calls that will utilize the SAS and target a specific version will do that append. This PR aims to clarify this behavior to avoid customers from believing that the `versionid` query parameter will be inferred from the SAS on their other API calls.