### PR TITLE
[ml] Fix registry bug causing notebook failures

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_registry/registry.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_registry/registry.py
@@ -150,7 +150,7 @@ class Registry(Resource):
 
         # Convert from api name region_details to user-shown name "replication locations"
         replication_locations = []
-        if real_registry.region_details:
+        if real_registry and real_registry.region_details:
             replication_locations = [
                 RegistryRegionDetails._from_rest_object(details)
                 for details in real_registry.region_details  # pylint: disable=protected-access


### PR DESCRIPTION
…ribute

# Description

sdk/resources/registry/registry-create notebook is failing and causing an IcM because an object's attribute is being called even though it's None. This is a quick PR to fix that.

https://github.com/Azure/azureml-examples/actions/workflows/sdk-resources-registry-registry-create.yml?query=branch%3Amain

![image](https://user-images.githubusercontent.com/16376603/231255602-2529258d-4ec1-4214-905a-af2a530cb7b1.png)

If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
