### PR TITLE
Remove special case for azure-mgmt-containerregistry in Docs-ToC.ps1 

### DIFF
--- a/eng/scripts/docs/Docs-ToC.ps1
+++ b/eng/scripts/docs/Docs-ToC.ps1
@@ -124,11 +124,6 @@ function Get-python-UpdatedDocsMsToc($toc) {
     if ($services[$i].name -eq 'Mixed Reality') {
       $services[$i] = addManagementPackage $services[$i] 'azure-mgmt-mixedreality'
     }
-
-    # Retired package
-    if ($services[$i].name -eq 'Container Registry') {
-      $services[$i] = addManagementPackage $services[$i] 'azure-mgmt-containerregistry'
-    }
   }
 
   $functionService =  [PSCustomObject]@{


### PR DESCRIPTION
This package is now properly tracked

Example fixed build: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=2697301&view=logs&j=dc056dfc-c0cf-5958-c8c4-8da4f91a3739&t=ea7ab532-38c0-5179-8da8-db428ade1489

*Why did we have a special case like this?* 

Special cases emerged as we were cleaning up the onboarding CSV file and didn't have direct knowledge of certain specific deviations. It appears that at least one such case has been addressed. 