### PR TITLE
Remove `codecov`

### DIFF
--- a/eng/ci_tools.txt
+++ b/eng/ci_tools.txt
@@ -13,7 +13,6 @@ pathlib2==2.3.5
 doc-warden==0.7.2
 # we pin coverage to 4.5.4 because there is an bug with `pytest-cov`. the generated coverage files cannot be `coverage combine`ed
 coverage==4.5.4
-codecov==2.1.0
 beautifulsoup4==4.9.1
 pkginfo==1.5.0.1
 pip==20.3.3

--- a/eng/pipelines/templates/jobs/tests-nightly-python.yml
+++ b/eng/pipelines/templates/jobs/tests-nightly-python.yml
@@ -131,7 +131,7 @@ jobs:
           curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
           python3 get-pip.py
           python3 -m pip install setuptools==67.6.0 wheel
-          python3 -m pip install tox tox-monorepo packaging twine codecov beautifulsoup4
+          python3 -m pip install tox tox-monorepo packaging twine beautifulsoup4
           python3 --version
           cd $(Build.SourcesDirectory)
           python3 ./scripts/devops_tasks/setup_execute_tests.py "$(BuildTargetingString)" --junitxml="junit/test_results_38.xml" --toxenv="whl" --filter-type="None"

--- a/eng/regression_tools.txt
+++ b/eng/regression_tools.txt
@@ -15,7 +15,6 @@ readme-renderer[md]==25.0
 doc-warden==0.7.1
 # we pin coverage to 4.5.4 because there is an bug with `pytest-cov`. the generated coverage files cannot be `coverage combine`ed
 coverage==4.5.4
-codecov==2.1.0
 beautifulsoup4==4.9.1
 pkginfo==1.5.0.1
 pip==20.2


### PR DESCRIPTION
Due to broken pypi dependency.

FYI @pvaneck 

I think I was confusing `codecov` as a required dependency. Famous last words. `pytest-cov` and `coverage` are what we actually use. I think `codecov` was used to publish to a different target, and we don't even do that anymore. We'll see how this pans out.

