### PR TITLE
[tooling] Fix: Rewrite pylintrc's `ignore` field as `ignore-paths`

### DIFF
--- a/eng/pylintrc
+++ b/eng/pylintrc
@@ -7,7 +7,7 @@ ignore-paths=
     azure\\mixedreality\\remoterendering\\_api_version.py,
     azure/mixedreality/remoterendering/_api_version.py,
     # Exclude any path that contains the following directory names
-    (?:.*[/\\]|^)(?:_vendor|_generated|_restclient|samples|examples|test|tests|doc|.tox)(?:[/\\]|$)
+    (?:.*[/\\]|^)(?:_vendor|_generated|_restclient|samples|examples|test|tests|doc|\.tox)(?:[/\\]|$)
 
 load-plugins=pylint_guidelines_checker
 

--- a/eng/pylintrc
+++ b/eng/pylintrc
@@ -3,8 +3,11 @@ ignore-patterns=test_*,conftest,setup
 reports=no
 
 # PYLINT DIRECTORY BLACKLIST.
-ignore=_vendor,_generated,_restclient,samples,examples,test,tests,doc,.tox
-ignore-paths=azure\\mixedreality\\remoterendering\\_api_version.py,azure/mixedreality/remoterendering/_api_version.py
+ignore-paths=
+    azure\\mixedreality\\remoterendering\\_api_version.py,
+    azure/mixedreality/remoterendering/_api_version.py,
+    # Exclude any path that contains the following directory names
+    (?:.*[/\\]|^)(?:_vendor|_generated|_restclient|samples|examples|test|tests|doc|.tox)(?:[/\\]|$)
 
 load-plugins=pylint_guidelines_checker
 

--- a/pylintrc
+++ b/pylintrc
@@ -7,7 +7,7 @@ ignore-paths=
     azure\\mixedreality\\remoterendering\\_api_version.py,
     azure/mixedreality/remoterendering/_api_version.py,
     # Exclude any path that contains the following directory names
-    (?:.*[/\\]|^)(?:_vendor|_generated|_restclient|samples|examples|test|tests|doc|.tox)(?:[/\\]|$)
+    (?:.*[/\\]|^)(?:_vendor|_generated|_restclient|samples|examples|test|tests|doc|\.tox)(?:[/\\]|$)
 
 load-plugins=pylint_guidelines_checker
 

--- a/pylintrc
+++ b/pylintrc
@@ -3,8 +3,11 @@ ignore-patterns=test_*,conftest,setup
 reports=no
 
 # PYLINT DIRECTORY BLACKLIST.
-ignore=_vendor,_generated,_restclient,samples,examples,test,tests,doc,.tox
-ignore-paths=azure\\mixedreality\\remoterendering\\_api_version.py,azure/mixedreality/remoterendering/_api_version.py
+ignore-paths=
+    azure\\mixedreality\\remoterendering\\_api_version.py,
+    azure/mixedreality/remoterendering/_api_version.py,
+    # Exclude any path that contains the following directory names
+    (?:.*[/\\]|^)(?:_vendor|_generated|_restclient|samples|examples|test|tests|doc|.tox)(?:[/\\]|$)
 
 load-plugins=pylint_guidelines_checker
 


### PR DESCRIPTION
# Description

Related to https://github.com/pylint-dev/pylint/issues/2686

This PR rewrites the `ignore` config field in `pylintrc` to the equivalent using `ignore-paths`.

# Background 

Pylint's `ignore` config field only matches against the basename of a path. This is fine if:
  * You only ever run pylint by giving it a parent directory of all the files you want to check (since it'll iteratively match the basename of a path of the files it discovers)
  * If you happen to provide a commandline argument whose basename matches a name you want to ignore

This doesn't work if the directory you want to ignore is a parent of the file you want to run pylint against (e.g. with `ignore=_vendor`, `pylint _vendor/file.py` won't ignore `file.py`)

Rewrote ignore config as `ignore-paths` which runs `re.match` against the entire path and ignores a file if a regex specified in `ignore-paths` matches the path.

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
