### PR TITLE
Add guidance for PermissionError during tool execution

### DIFF
--- a/doc/dev/test_proxy_troubleshooting.md
+++ b/doc/dev/test_proxy_troubleshooting.md
@@ -20,6 +20,7 @@ GitHub repository, and documentation of how to set up and use the proxy can be f
     - [Different error than expected when using proxy](#different-error-than-expected-when-using-proxy)
     - [Test setup failure in test pipeline](#test-setup-failure-in-test-pipeline)
     - [Fixture not found error](#fixture-not-found-error)
+    - [PermissionError during startup](#permissionerror-during-startup)
 
 ## Debugging tip
 
@@ -151,6 +152,20 @@ a test with the `recorded_by_proxy` decorator will permit using named parameters
 As noted in the [Fetch environment variables][env_var_section] section of the [migration guide][migration_guide],
 reading expected variables from an accepted `**kwargs` parameter is recommended instead so that tests will run as
 expected in either case.
+
+## PermissionError during startup
+
+While the test proxy is being invoked during the start of a test run, you may see an error such as
+```
+PermissionError: [Errno 13] Permission denied: '.../azure-sdk-for-python/.proxy/Azure.Sdk.Tools.TestProxy'
+```
+
+This means that the test proxy tool was successfully installed at the location in the error message, but we don't have
+sufficient permissions to run it with the tool startup script. We can set the correct permissions on the file by using
+`chmod`. Using the tool path that was provided in the `PermissionError` message, run the following command:
+```
+chmod +x .../azure-sdk-for-python/.proxy/Azure.Sdk.Tools.TestProxy
+```
 
 
 [detailed_docs]: https://github.com/Azure/azure-sdk-tools/tree/main/tools/test-proxy/Azure.Sdk.Tools.TestProxy/README.md


### PR DESCRIPTION
# Description

@swathipil saw a `PermissionError` when attempting to run recorded tests (without Docker, for the first time) on Mac. Using `chmod +x` on the test proxy executable resolved the issue.

@scbedd this just adds advice for manually resolving this, but is an automatic `chmod` something we may want to do? I remember `chmod` being mentioned in the past in the context of standalone executables, but can't remember all the details.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
