### PR TITLE
[Core][OpenCensus] Fix bug with unexpected kwargs

### DIFF
--- a/sdk/core/azure-core-tracing-opencensus/CHANGELOG.md
+++ b/sdk/core/azure-core-tracing-opencensus/CHANGELOG.md
@@ -6,13 +6,13 @@
 
 ### Breaking Changes
 
-### Key Bugs Fixed
+### Bugs Fixed
 
-### Fixed
+- Fixed a bug where starting a span would fail if an unexpected keyword argument was passed in to `OpenCensusSpan`.
 
 ### Other Changes
 
-- Python 2.7 is no longer supported. Please use Python version 3.6 or later.
+- Python 2.7 is no longer supported. Please use Python version 3.7 or later.
 
 ## 1.0.0b8 (2021-07-01)
 

--- a/sdk/core/azure-core-tracing-opencensus/azure/core/tracing/ext/opencensus_span/__init__.py
+++ b/sdk/core/azure-core-tracing-opencensus/azure/core/tracing/ext/opencensus_span/__init__.py
@@ -82,7 +82,7 @@ class OpenCensusSpan(HttpSpanMixin, object):
             raise ValueError("Kind {} is not supported in OpenCensus".format(value))
 
         links = kwargs.pop("links", None)
-        self._span_instance = span or tracer.start_span(name=name, **kwargs)
+        self._span_instance = span or tracer.start_span(name=name)
         if kind is not None:
             self._span_instance.span_kind = kind
 

--- a/sdk/core/azure-core-tracing-opencensus/setup.py
+++ b/sdk/core/azure-core-tracing-opencensus/setup.py
@@ -44,7 +44,6 @@ setup(
         "Programming Language :: Python",
         "Programming Language :: Python :: 3 :: Only",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
@@ -59,7 +58,7 @@ setup(
     package_data={
         "pytyped": ["py.typed"],
     },
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     install_requires=[
         "opencensus>=0.6.0",
         "opencensus-ext-azure>=0.3.1",

--- a/sdk/core/azure-core-tracing-opencensus/setup.py
+++ b/sdk/core/azure-core-tracing-opencensus/setup.py
@@ -48,6 +48,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "License :: OSI Approved :: MIT License",
     ],
     zip_safe=False,


### PR DESCRIPTION
In OpenCensus, the `start_span` method only accepts a name argument. This fixes cases where a user might pass in additional arbitrary kwargs to `OpenCensusSpan` that are then passed to the `start_span` method, yielding an unexpected keyword error.

Also bump minimum Python version to 3.7.
