### PR TITLE
Only deploy HSMs in weekly tests

### DIFF
--- a/sdk/keyvault/tests.yml
+++ b/sdk/keyvault/tests.yml
@@ -16,7 +16,6 @@ stages:
         ServiceDirectory: keyvault
         BuildTargetingString: ${{ service }}
         JobName: ${{ replace(service, '-', '_') }}
-        TestTimeoutInMinutes: 240
         SupportedClouds: 'Public,UsGov,China'
         CloudConfig:
           Public:

--- a/sdk/keyvault/tests.yml
+++ b/sdk/keyvault/tests.yml
@@ -30,11 +30,12 @@ stages:
             MatrixFilters:
               - ArmTemplateParameters=^(?!.*enableHsm.*true)
         ${{ if or(eq(service, 'azure-keyvault-keys'), eq(service, 'azure-keyvault-administration')) }}:
-          AdditionalMatrixConfigs:
-            - Name: keyvault_test_matrix_addons
-              Path: sdk/keyvault/azure-keyvault-keys/platform-matrix.json
-              Selection: sparse
-              GenerateVMJobs: true
+          ${{ if contains(variables['Build.DefinitionName'], 'tests-weekly')  }}:
+            AdditionalMatrixConfigs:
+              - Name: keyvault_test_matrix_addons
+                Path: sdk/keyvault/azure-keyvault-keys/platform-matrix.json
+                Selection: sparse
+                GenerateVMJobs: true
         EnvVars:
           AZURE_TEST_RUN_LIVE: true
           AZURE_SKIP_LIVE_RECORDING: 'True'


### PR DESCRIPTION
# Description

Using the logic from `archetype-sdk-tests.yml` to apply behavior to weekly test pipelines only: https://github.com/Azure/azure-sdk-for-python/blob/aec6d92587c63e76468527246013f0728b6a5f32/eng/pipelines/templates/stages/archetype-sdk-tests.yml#L149
This PR changes Key Vault's live test pipelines to no longer deploy Managed HSMs for nightly tests; instead, they're only used in weekly test pipelines (and only for Public cloud, since the resource is unavailable in USGov and China). This is to save on resource costs and reduce the number of false flags from failed HSM deployments in nightly runs.

Also, this removes a pipeline timeout override that had previously been set to debug HSM deployment issues. The four hour timeout we had set was excessive and the default value should be sufficient now.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
