### PR TITLE
[Test Proxy] Restore `PROXY_URL` setting functionality via `.env`

### DIFF
--- a/tools/azure-sdk-tools/devtools_testutils/config.py
+++ b/tools/azure-sdk-tools/devtools_testutils/config.py
@@ -5,5 +5,9 @@
 # --------------------------------------------------------------------------
 import os
 
+from dotenv import load_dotenv, find_dotenv
+
+load_dotenv(find_dotenv())
+
 PROXY_URL = os.getenv("PROXY_URL", "https://localhost:5001").rstrip("/")
 TEST_SETTING_FILENAME = "testsettings_local.cfg"

--- a/tools/azure-sdk-tools/devtools_testutils/proxy_startup.py
+++ b/tools/azure-sdk-tools/devtools_testutils/proxy_startup.py
@@ -16,6 +16,7 @@ from typing import Optional
 import zipfile
 
 import certifi
+from dotenv import load_dotenv, find_dotenv
 import pytest
 import subprocess
 from urllib3 import PoolManager, Retry
@@ -27,6 +28,8 @@ from .config import PROXY_URL
 from .helpers import is_live_and_not_recording
 from .sanitizers import add_remove_header_sanitizer, set_custom_default_matcher
 
+
+load_dotenv(find_dotenv())
 
 _LOGGER = logging.getLogger()
 


### PR DESCRIPTION
# Description

After moving away from Docker, the test proxy's startup tooling stopped using the `PROXY_URL` environment variable correctly when it's set with a `.env` file. Debugging revealed that an apparent change in setup execution must have deferred `.env` loading until after `PROXY_URL`'s value is read.

This PR adds `.env` file loading to `proxy_startup.py` to ensure we read variables during setup, and to `config.py` since it's the file that actually loads `PROXY_URL`'s value. This is technically redundant since the latter change (the only explicitly necessary one) will ensure `.env` is read before `proxy_startup.py` is run -- but loading the `.env` file as part of setup seems like it would help preserve behavior if there's future refactoring.

(@scbedd for notifications)

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
