### PR TITLE
[ServiceBus] move UamqpTransport imports into client constructor

### DIFF
--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_servicebus_client.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_servicebus_client.py
@@ -28,11 +28,6 @@ from ._common.constants import (
     ServiceBusSessionFilter,
 )
 
-try:
-    from ._transport._uamqp_transport import UamqpTransport
-except ImportError:
-    UamqpTransport = None   # type: ignore
-
 from ._transport._pyamqp_transport import PyamqpTransport
 
 if TYPE_CHECKING:
@@ -119,8 +114,11 @@ class ServiceBusClient(object): # pylint: disable=client-accepts-api-version-key
         **kwargs: Any
     ) -> None:
         uamqp_transport = kwargs.pop("uamqp_transport", False)
-        if uamqp_transport and UamqpTransport is None:
-            raise ValueError("To use the uAMQP transport, please install `uamqp>=1.6.3,<2.0.0`.")
+        if uamqp_transport:
+            try:
+                from ._transport._uamqp_transport import UamqpTransport
+            except ImportError:
+                raise ValueError("To use the uAMQP transport, please install `uamqp>=1.6.3,<2.0.0`.")
         self._amqp_transport = UamqpTransport if uamqp_transport else PyamqpTransport
 
         # If the user provided http:// or sb://, let's be polite and strip that.

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_servicebus_client_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_servicebus_client_async.py
@@ -10,10 +10,6 @@ import certifi
 
 from azure.core.credentials import AzureSasCredential, AzureNamedKeyCredential
 
-try:
-    from ._transport._uamqp_transport_async import UamqpTransportAsync
-except ImportError:
-    UamqpTransportAsync = None  # type: ignore
 from ._transport._pyamqp_transport_async import PyamqpTransportAsync
 from .._base_handler import _parse_conn_str
 from ._base_handler_async import (
@@ -111,8 +107,11 @@ class ServiceBusClient(object): # pylint: disable=client-accepts-api-version-key
         **kwargs: Any
     ) -> None:
         uamqp_transport = kwargs.pop("uamqp_transport", False)
-        if uamqp_transport and UamqpTransportAsync is None:
-            raise ValueError("To use the uAMQP transport, please install `uamqp>=1.6.3,<2.0.0`.")
+        if uamqp_transport:
+            try:
+                from ._transport._uamqp_transport_async import UamqpTransportAsync
+            except ImportError:
+                raise ValueError("To use the uAMQP transport, please install `uamqp>=1.6.3,<2.0.0`.")
         self._amqp_transport = UamqpTransportAsync if uamqp_transport else PyamqpTransportAsync
         # If the user provided http:// or sb://, let's be polite and strip that.
         self.fully_qualified_namespace = strip_protocol_from_uri(


### PR DESCRIPTION
Currently, uamqp is being imported by default when installed, even when pyamqp is being used. This is resulting in a memory bump, since uamqp takes memory when imported. Moving the uamqp imports into the client constructor `uamqp_transport=True` check.