### PR TITLE
[ML] Fix mkdir in correct path during gen2 storage client download

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_artifacts/_gen2_storage_helper.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_artifacts/_gen2_storage_helper.py
@@ -175,12 +175,12 @@ class Gen2StorageClient:
             download_size_in_mb = 0
             for item in mylist:
                 file_name = item.name[len(starts_with) :].lstrip("/") or Path(starts_with).name
+                target_path = Path(destination, file_name)
 
                 if item.is_directory:
-                    os.makedirs(file_name)
+                    target_path.mkdir(parents=True, exist_ok=True)
                     continue
 
-                target_path = Path(destination, file_name)
                 file_client = self.file_system_client.get_file_client(item.name)
 
                 # check if total size of download has exceeded 100 MB


### PR DESCRIPTION
# Description

In `Gen2StorageClient` download, if one item is a directory, it will make directory from working directory, not honor destination. This PR updates this, refering the code in `BlobStorageClient`:

![image](https://user-images.githubusercontent.com/38847871/232691031-f5c15fea-03bd-4a15-ba6d-0f267afe1b6b.png)

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
