### PR TITLE
Update `azsdk-pool-mms-ubuntu-1804-general` to `azsdk-pool-mms-ubuntu-2004-general`

### DIFF
--- a/sdk/keyvault/azure-keyvault-keys/platform-matrix.json
+++ b/sdk/keyvault/azure-keyvault-keys/platform-matrix.json
@@ -2,9 +2,9 @@
   "include": [
     {
       "Agent": {
-        "ubuntu-18.04_ManagedHSM": {
-          "OSVmImage": "MMSUbuntu18.04",
-          "Pool": "azsdk-pool-mms-ubuntu-1804-general",
+        "ubuntu-20.04_ManagedHSM": {
+          "OSVmImage": "MMSUbuntu20.04",
+          "Pool": "azsdk-pool-mms-ubuntu-2004-general",
           "ArmTemplateParameters": "@{ enableHsm = $true }"
         }
       },

--- a/sdk/storage/platform-matrix-all-versions.json
+++ b/sdk/storage/platform-matrix-all-versions.json
@@ -6,7 +6,7 @@
     },
     "matrix": {
         "Agent": {
-          "ubuntu-18.04": { "OSVmImage": "MMSUbuntu20.04", "Pool": "azsdk-pool-mms-ubuntu-2004-general" },
+          "Ubuntu-20.04": { "OSVmImage": "MMSUbuntu20.04", "Pool": "azsdk-pool-mms-ubuntu-2004-general" },
           "windows-2022": { "OSVmImage": "MMS2022", "Pool": "azsdk-pool-mms-win-2022-general" },
           "macos-11": { "OSVmImage": "macos-11", "Pool": "Azure Pipelines" }
         },


### PR DESCRIPTION
Internal Azure SDK Engineering System update of the used Ubuntu image per
- https://github.com/Azure/azure-sdk-tools/issues/5472

There are more occurrences of Ubuntu 18 but I am not updating them because:
- they appear to me to denote past test recording config, e.g. `"environmentId": "azureml:AzureML-sklearn-0.24-ubuntu18.04-py37-cpu:1",` ([permalink](https://github.com/Azure/azure-sdk-for-python/blob/964dcc172aeb7c9e18fb147b9e6c212b4f6226b7/sdk/ml/azure-ai-ml/tests/recordings/command_job/e2etests/test_command_job.pyTestCommandJobtest_command_job_builder.json#L546))
- they refer to an image from a container registry, e.g. `image: mcr.microsoft.com/azureml/openmpi3.1.2-ubuntu18.04` ([permalink](https://github.com/Azure/azure-sdk-for-python/blob/964dcc172aeb7c9e18fb147b9e6c212b4f6226b7/sdk/ml/azure-ai-ml/tests/test_configs/dsl_pipeline/do_while/basic_component/component.yml#L39))