### PR TITLE
Omit `_serialization.py` from code coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -5,6 +5,7 @@ include =
 omit =
 	*/test*
 	env*
+	*/_serialization.py
 
 [paths]
 source =

--- a/.coveragerc
+++ b/.coveragerc
@@ -20,3 +20,7 @@ exclude_lines =
 	if headers:
 	if response.status_code not in
 	if TYPE_CHECKING:
+omit =
+	*/test*
+	env*
+	*/_serialization.py

--- a/scripts/devops_tasks/create_coverage.py
+++ b/scripts/devops_tasks/create_coverage.py
@@ -53,7 +53,7 @@ def collect_tox_coverage_files():
 def generate_coverage_xml():
     if os.path.exists(coverage_dir):
         logging.info("Generating coverage XML")
-        commands = ["coverage", "xml", "-i", "--omit", '"*test*,*example*"']
+        commands = ["coverage", "xml", "-i", "--omit", '"*test*,*example*,*/_serialization.py"']
         run_check_call(commands, root_dir, always_exit = False)
     else:
         logging.error("Coverage file is not available in {} to generate coverage XML".format(coverage_dir))

--- a/scripts/devops_tasks/create_coverage.py
+++ b/scripts/devops_tasks/create_coverage.py
@@ -53,7 +53,7 @@ def collect_tox_coverage_files():
 def generate_coverage_xml():
     if os.path.exists(coverage_dir):
         logging.info("Generating coverage XML")
-        commands = ["coverage", "xml", "-i", "--omit", '"*test*,*example*,*/_serialization.py"']
+        commands = ["coverage", "xml", "-i"]
         run_check_call(commands, root_dir, always_exit = False)
     else:
         logging.error("Coverage file is not available in {} to generate coverage XML".format(coverage_dir))


### PR DESCRIPTION
# Description

`_serialization.py` is a common, generated file that has a good amount of unused code in most applications.

This PR removes the `--omit` flag from the `coverage xml` command that's used to generate our code coverage reports, and instead uses only the `.coveragerc` file at the root of the repository. Using the command flag overrides options in the configuration file, which is confusing and led to prior efforts to omit `_serialization.py`.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
