### PR TITLE
Repair ci_tools installation

### DIFF
--- a/eng/pipelines/generate-all-docs.yml
+++ b/eng/pipelines/generate-all-docs.yml
@@ -21,7 +21,7 @@ jobs:
           versionSpec: '$(PythonVersion)'
 
       - script: |
-          python -m pip install setuptools==67.6.0
+          python -m pip install setuptools==58.3.0
           python -m pip install -r eng/ci_tools.txt
         displayName: 'Prep Environment'
 

--- a/eng/pipelines/generate-all-docs.yml
+++ b/eng/pipelines/generate-all-docs.yml
@@ -21,6 +21,7 @@ jobs:
           versionSpec: '$(PythonVersion)'
 
       - script: |
+          python -m pip install setuptools==67.6.0
           python -m pip install -r eng/ci_tools.txt
         displayName: 'Prep Environment'
 

--- a/eng/pipelines/templates/jobs/tests-nightly-python.yml
+++ b/eng/pipelines/templates/jobs/tests-nightly-python.yml
@@ -22,7 +22,7 @@ jobs:
       - script: |
           python -m pip freeze
           python -m pip --version
-          python -m pip install setuptools==67.6.0 wheel==0.37.0 tox==3.24.3 tox-monorepo==0.1.2 packaging==21.0 requests
+          python -m pip install setuptools==58.3.0 wheel==0.37.0 tox==3.24.3 tox-monorepo==0.1.2 packaging==21.0 requests
           python -m pip install $(Build.SourcesDirectory)/tools/azure-sdk-tools[build]
         displayName: Install Dependencies
 
@@ -67,7 +67,7 @@ jobs:
           sudo apt-get install build-essential -y
           python -m pip freeze
           python -m pip --version
-          python -m pip install setuptools==67.6.0 wheel==0.37.0 tox==3.24.3 tox-monorepo==0.1.2 packaging==21.0 requests
+          python -m pip install setuptools==58.3.0 wheel==0.37.0 tox==3.24.3 tox-monorepo==0.1.2 packaging==21.0 requests
           python -m pip install $(Build.SourcesDirectory)/tools/azure-sdk-tools[build]
         displayName: Install Dependencies
 

--- a/eng/pipelines/templates/jobs/trigger-ml-sample-pipeline.yml
+++ b/eng/pipelines/templates/jobs/trigger-ml-sample-pipeline.yml
@@ -39,7 +39,7 @@ jobs:
         versionSpec: $(PythonVersion)
 
     - script: |
-        python -m pip install setuptools==67.6.0
+        python -m pip install setuptools==58.3.0
         python -m pip install -r eng/ci_tools.txt
         python -m pip install -r eng/ml_sample_tools.txt
       displayName: 'Prep Environment'

--- a/eng/pipelines/templates/jobs/trigger-ml-sample-pipeline.yml
+++ b/eng/pipelines/templates/jobs/trigger-ml-sample-pipeline.yml
@@ -39,6 +39,7 @@ jobs:
         versionSpec: $(PythonVersion)
 
     - script: |
+        python -m pip install setuptools==67.6.0
         python -m pip install -r eng/ci_tools.txt
         python -m pip install -r eng/ml_sample_tools.txt
       displayName: 'Prep Environment'

--- a/eng/pipelines/templates/stages/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tests.yml
@@ -163,6 +163,7 @@ stages:
 
         steps:
           - pwsh: |
+              python -m pip install setuptools==67.6.0
               python -m pip install -r eng/ci_tools.txt 
             displayName: 'Install Necessary Dependencies'
           - task: PythonScript@0

--- a/eng/pipelines/templates/stages/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tests.yml
@@ -163,7 +163,7 @@ stages:
 
         steps:
           - pwsh: |
-              python -m pip install setuptools==67.6.0
+              python -m pip install setuptools==58.3.0
               python -m pip install -r eng/ci_tools.txt 
             displayName: 'Install Necessary Dependencies'
           - task: PythonScript@0

--- a/eng/pipelines/templates/steps/analyze.yml
+++ b/eng/pipelines/templates/steps/analyze.yml
@@ -39,12 +39,6 @@ steps:
           ServiceName: ${{parameters.ServiceDirectory}}
           ForRelease: false
 
-  - pwsh: |
-      python -m pip install setuptools==58.3.0
-      python -m pip install -r eng/ci_tools.txt $(if($IsWindows) {"--user" })
-    displayName: 'Install Necessary Dependencies'
-    condition: succeededOrFailed()
-
   - script: |
       python -m pip install "./tools/azure-sdk-tools[build]" -q -I
       sdk_find_invalid_versions --always-succeed --service=${{parameters.ServiceDirectory}}

--- a/eng/pipelines/templates/steps/analyze.yml
+++ b/eng/pipelines/templates/steps/analyze.yml
@@ -40,7 +40,8 @@ steps:
           ForRelease: false
 
   - pwsh: |
-     python -m pip install -r eng/ci_tools.txt $(if($IsWindows) {"--user" })
+      python -m pip install setuptools==67.6.0
+      python -m pip install -r eng/ci_tools.txt $(if($IsWindows) {"--user" })
     displayName: 'Install Necessary Dependencies'
     condition: succeededOrFailed()
 

--- a/eng/pipelines/templates/steps/analyze.yml
+++ b/eng/pipelines/templates/steps/analyze.yml
@@ -40,7 +40,7 @@ steps:
           ForRelease: false
 
   - pwsh: |
-      python -m pip install setuptools==67.6.0
+      python -m pip install setuptools==58.3.0
       python -m pip install -r eng/ci_tools.txt $(if($IsWindows) {"--user" })
     displayName: 'Install Necessary Dependencies'
     condition: succeededOrFailed()

--- a/eng/pipelines/templates/steps/analyze_dependency.yml
+++ b/eng/pipelines/templates/steps/analyze_dependency.yml
@@ -9,7 +9,7 @@ steps:
      versionSpec: '$(PythonVersion)'
 
   - pwsh: |
-      python -m pip install setuptools==67.6.0
+      python -m pip install setuptools==58.3.0
       python -m pip install -r eng/ci_tools.txt
     displayName: 'Install Python Tools'
     condition: succeededOrFailed()

--- a/eng/pipelines/templates/steps/analyze_dependency.yml
+++ b/eng/pipelines/templates/steps/analyze_dependency.yml
@@ -9,6 +9,7 @@ steps:
      versionSpec: '$(PythonVersion)'
 
   - pwsh: |
+      python -m pip install setuptools==67.6.0
       python -m pip install -r eng/ci_tools.txt
     displayName: 'Install Python Tools'
     condition: succeededOrFailed()

--- a/eng/pipelines/templates/steps/build-artifacts.yml
+++ b/eng/pipelines/templates/steps/build-artifacts.yml
@@ -43,6 +43,7 @@ steps:
       versionSpec: $(PythonVersion)
 
   - script: |
+      python -m pip install setuptools==67.6.0
       python -m pip install -r eng/ci_tools.txt
     displayName: 'Prep Environment'
 

--- a/eng/pipelines/templates/steps/build-artifacts.yml
+++ b/eng/pipelines/templates/steps/build-artifacts.yml
@@ -43,7 +43,7 @@ steps:
       versionSpec: $(PythonVersion)
 
   - script: |
-      python -m pip install setuptools==67.6.0
+      python -m pip install setuptools==58.3.0
       python -m pip install -r eng/ci_tools.txt
     displayName: 'Prep Environment'
 

--- a/eng/pipelines/templates/steps/build-conda-artifacts.yml
+++ b/eng/pipelines/templates/steps/build-conda-artifacts.yml
@@ -22,6 +22,7 @@ steps:
       versionSpec: $(PythonVersion)
 
   - script: |
+      python -m pip install setuptools==58.3.0
       python -m pip install -r eng/ci_tools.txt
     displayName: 'Prep Environment'
 

--- a/eng/pipelines/templates/steps/build-conda-artifacts.yml
+++ b/eng/pipelines/templates/steps/build-conda-artifacts.yml
@@ -21,11 +21,6 @@ steps:
     inputs:
       versionSpec: $(PythonVersion)
 
-  - script: |
-      python -m pip install setuptools==58.3.0
-      python -m pip install -r eng/ci_tools.txt
-    displayName: 'Prep Environment'
-
   - pwsh: |
       mkdir $(Agent.BuildDirectory)/conda/
       mkdir $(Agent.BuildDirectory)/conda/output

--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -34,6 +34,7 @@ steps:
   - script: |
       python -m pip install pip==20.3.3
       python -m pip install wheel==0.37.0
+      python -m pip install setuptools==67.6.0
       python -m pip install -r eng/ci_tools.txt
       pip --version
       pip freeze

--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -34,7 +34,7 @@ steps:
   - script: |
       python -m pip install pip==20.3.3
       python -m pip install wheel==0.37.0
-      python -m pip install setuptools==67.6.0
+      python -m pip install setuptools==58.3.0
       python -m pip install -r eng/ci_tools.txt
       pip --version
       pip freeze

--- a/eng/pipelines/templates/steps/run_apistub.yml
+++ b/eng/pipelines/templates/steps/run_apistub.yml
@@ -15,7 +15,7 @@ steps:
     condition: and(succeededOrFailed(), ne(variables['Skip.ApiStubGen'],'true'))
 
   - script: |
-      python -m pip install setuptools==67.6.0
+      python -m pip install setuptools==58.3.0
       python -m pip install -r eng/ci_tools.txt
     displayName: 'Prep Environment'
 

--- a/eng/pipelines/templates/steps/run_apistub.yml
+++ b/eng/pipelines/templates/steps/run_apistub.yml
@@ -15,6 +15,7 @@ steps:
     condition: and(succeededOrFailed(), ne(variables['Skip.ApiStubGen'],'true'))
 
   - script: |
+      python -m pip install setuptools==67.6.0
       python -m pip install -r eng/ci_tools.txt
     displayName: 'Prep Environment'
 

--- a/eng/pipelines/templates/steps/run_bandit.yml
+++ b/eng/pipelines/templates/steps/run_bandit.yml
@@ -11,6 +11,7 @@ parameters:
 # Please use `$(TargetingString)` to refer to the python packages glob string. This was previously `${{ parameters.BuildTargetingString }}`.
 steps:
   - script: |
+      python -m pip install setuptools==67.6.0
       python -m pip install -r eng/ci_tools.txt
     displayName: 'Prep Environment'
     condition: and(succeededOrFailed(), ne(variables['Skip.Bandit'],'true'))

--- a/eng/pipelines/templates/steps/run_bandit.yml
+++ b/eng/pipelines/templates/steps/run_bandit.yml
@@ -11,7 +11,7 @@ parameters:
 # Please use `$(TargetingString)` to refer to the python packages glob string. This was previously `${{ parameters.BuildTargetingString }}`.
 steps:
   - script: |
-      python -m pip install setuptools==67.6.0
+      python -m pip install setuptools==58.3.0
       python -m pip install -r eng/ci_tools.txt
     displayName: 'Prep Environment'
     condition: and(succeededOrFailed(), ne(variables['Skip.Bandit'],'true'))

--- a/eng/pipelines/templates/steps/run_breaking_changes.yml
+++ b/eng/pipelines/templates/steps/run_breaking_changes.yml
@@ -11,7 +11,7 @@ parameters:
 # Please use `$(TargetingString)` to refer to the python packages glob string. This was previously `${{ parameters.BuildTargetingString }}`.
 steps:
   - script: |
-      python -m pip install setuptools==67.6.0
+      python -m pip install setuptools==58.3.0
       pip install -r eng/ci_tools.txt
     displayName: 'Prep Environment'
     condition: and(succeededOrFailed(), ne(variables['Skip.BreakingChanges'],'true'))

--- a/eng/pipelines/templates/steps/run_breaking_changes.yml
+++ b/eng/pipelines/templates/steps/run_breaking_changes.yml
@@ -11,6 +11,7 @@ parameters:
 # Please use `$(TargetingString)` to refer to the python packages glob string. This was previously `${{ parameters.BuildTargetingString }}`.
 steps:
   - script: |
+      python -m pip install setuptools==67.6.0
       pip install -r eng/ci_tools.txt
     displayName: 'Prep Environment'
     condition: and(succeededOrFailed(), ne(variables['Skip.BreakingChanges'],'true'))

--- a/eng/pipelines/templates/steps/run_breaking_changes.yml
+++ b/eng/pipelines/templates/steps/run_breaking_changes.yml
@@ -10,12 +10,6 @@ parameters:
 
 # Please use `$(TargetingString)` to refer to the python packages glob string. This was previously `${{ parameters.BuildTargetingString }}`.
 steps:
-  - script: |
-      python -m pip install setuptools==58.3.0
-      pip install -r eng/ci_tools.txt
-    displayName: 'Prep Environment'
-    condition: and(succeededOrFailed(), ne(variables['Skip.BreakingChanges'],'true'))
-
   - task: PythonScript@0
     displayName: 'Run Breaking Changes'
     inputs:

--- a/eng/pipelines/templates/steps/run_mypy.yml
+++ b/eng/pipelines/templates/steps/run_mypy.yml
@@ -18,6 +18,7 @@ steps:
     condition: and(succeededOrFailed(), ne(variables['Skip.MyPy'],'true'))
 
   - script: |
+      python -m pip install setuptools==67.6.0
       pip install -r eng/ci_tools.txt
     displayName: 'Prep Environment'
     condition: and(succeededOrFailed(), ne(variables['Skip.MyPy'],'true'))

--- a/eng/pipelines/templates/steps/run_mypy.yml
+++ b/eng/pipelines/templates/steps/run_mypy.yml
@@ -18,7 +18,7 @@ steps:
     condition: and(succeededOrFailed(), ne(variables['Skip.MyPy'],'true'))
 
   - script: |
-      python -m pip install setuptools==67.6.0
+      python -m pip install setuptools==58.3.0
       pip install -r eng/ci_tools.txt
     displayName: 'Prep Environment'
     condition: and(succeededOrFailed(), ne(variables['Skip.MyPy'],'true'))

--- a/eng/pipelines/templates/steps/run_pylint.yml
+++ b/eng/pipelines/templates/steps/run_pylint.yml
@@ -17,6 +17,7 @@ steps:
     condition: and(succeededOrFailed(), ne(variables['Skip.Pylint'],'true'))    
 
   - script: |
+      python -m pip install setuptools==67.6.0
       python -m pip install -r eng/ci_tools.txt
     displayName: 'Prep Environment'
     condition: and(succeededOrFailed(), ne(variables['Skip.Pylint'],'true'))

--- a/eng/pipelines/templates/steps/run_pylint.yml
+++ b/eng/pipelines/templates/steps/run_pylint.yml
@@ -17,7 +17,7 @@ steps:
     condition: and(succeededOrFailed(), ne(variables['Skip.Pylint'],'true'))    
 
   - script: |
-      python -m pip install setuptools==67.6.0
+      python -m pip install setuptools==58.3.0
       python -m pip install -r eng/ci_tools.txt
     displayName: 'Prep Environment'
     condition: and(succeededOrFailed(), ne(variables['Skip.Pylint'],'true'))

--- a/eng/pipelines/templates/steps/run_pyright.yml
+++ b/eng/pipelines/templates/steps/run_pyright.yml
@@ -17,6 +17,7 @@ steps:
     condition: and(succeededOrFailed(), or(ne(variables['Skip.Pyright'],'true'), ne(variables['Skip.Verifytypes'],'true')))
 
   - script: |
+      python -m pip install setuptools==67.6.0
       python -m pip install -r eng/ci_tools.txt
     displayName: 'Prep Environment'
     condition: and(succeededOrFailed(), or(ne(variables['Skip.Pyright'],'true'), ne(variables['Skip.Verifytypes'],'true')))

--- a/eng/pipelines/templates/steps/run_pyright.yml
+++ b/eng/pipelines/templates/steps/run_pyright.yml
@@ -17,7 +17,7 @@ steps:
     condition: and(succeededOrFailed(), or(ne(variables['Skip.Pyright'],'true'), ne(variables['Skip.Verifytypes'],'true')))
 
   - script: |
-      python -m pip install setuptools==67.6.0
+      python -m pip install setuptools==58.3.0
       python -m pip install -r eng/ci_tools.txt
     displayName: 'Prep Environment'
     condition: and(succeededOrFailed(), or(ne(variables['Skip.Pyright'],'true'), ne(variables['Skip.Verifytypes'],'true')))


### PR DESCRIPTION
**tl;dr** the default install of `setuptools` has upgraded to the point where a deprecated function `use_2to3` is no longer present. `coverage==4.5.4` utilizes this function during installation.

Short, easy fix is to pin earlier setuptools that installs `ci_tools.txt`. This doesn't actually affect the version of `setuptools` that is installed while we actually build, test, etc.

The **actual** solution is to upgrade `coverage` and `pytest-cov`. Previously, we were precluded from doing this because coverage couldn't combine the resulting files. I'll file a followup issue with what history I have.
