### PR TITLE
[ML] fix: Use repo's cspell config in pre-commit hook

### DIFF
--- a/sdk/ml/azure-ai-ml/.pre-commit-config.yaml
+++ b/sdk/ml/azure-ai-ml/.pre-commit-config.yaml
@@ -16,6 +16,7 @@ repos:
   rev: v6.31.0
   hooks:
   - id: cspell
+    args: ['--config', '.vscode/cspell.json']
 - repo: https://github.com/pre-commit/mirrors-isort
   rev: v5.8.0
   hooks:


### PR DESCRIPTION
# Description

This PR fixes an issue with `azure-ai-ml`'s pre-commit config where the cspell step wasn't using the repository's cspell config.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
