### PR TITLE
[Core][OTel] Pass schema URL into tracer

### DIFF
--- a/sdk/core/azure-core-tracing-opentelemetry/CHANGELOG.md
+++ b/sdk/core/azure-core-tracing-opentelemetry/CHANGELOG.md
@@ -7,6 +7,9 @@
 - Python 2.7 is no longer supported. Please use Python version 3.7 or later.
 - Nested internal spans are now suppressed with just the outermost internal span being recorded. Nested client spans will be children of the outermost span. ([#29616](https://github.com/Azure/azure-sdk-for-python/pull/29616))
 - When client spans are created, a flag is set to indicate that automatic HTTP instrumentation should be suppressed. Since azure-core already instruments HTTP calls, this prevents duplicate spans from being produced. ([#29616](https://github.com/Azure/azure-sdk-for-python/pull/29616))
+- Schema URL is now set on the tracer's instrumentation scope. ([#30014](https://github.com/Azure/azure-sdk-for-python/pull/30014))
+- Minimum `opentelemetry-api` dependency bumped to `1.12.0`.
+- Minimum `azure-core` dependency bumped to `1.24.0`.
 
 ## 1.0.0b9 (2021-04-06)
 

--- a/sdk/core/azure-core-tracing-opentelemetry/azure/core/tracing/ext/opentelemetry_span/__init__.py
+++ b/sdk/core/azure-core-tracing-opentelemetry/azure/core/tracing/ext/opentelemetry_span/__init__.py
@@ -103,7 +103,11 @@ class OpenTelemetrySpan(HttpSpanMixin, object):
             # instrumentation libraries are being used.
             self._context_tokens.append(context.attach(context.set_value(_SUPPRESS_HTTP_INSTRUMENTATION_KEY, True)))
 
-        current_tracer = self.get_current_tracer()
+        current_tracer = trace.get_tracer(
+            __name__,
+            __version__,
+            schema_url=OpenTelemetrySchema.get_schema_url(self._schema_version),
+        )
 
         links = kwargs.pop("links", None)
         if links:

--- a/sdk/core/azure-core-tracing-opentelemetry/azure/core/tracing/ext/opentelemetry_span/_schema.py
+++ b/sdk/core/azure-core-tracing-opentelemetry/azure/core/tracing/ext/opentelemetry_span/_schema.py
@@ -17,9 +17,7 @@ class OpenTelemetrySchemaVersion(
 
 class OpenTelemetrySchema:
 
-    SUPPORTED_VERSIONS = [
-        OpenTelemetrySchemaVersion.V1_19_0,
-    ]
+    SUPPORTED_VERSIONS = (OpenTelemetrySchemaVersion.V1_19_0,)
 
     # Mappings of attributes potentially reported by Azure SDKs to corresponding ones that follow
     # OpenTelemetry semantic conventions.

--- a/sdk/core/azure-core-tracing-opentelemetry/azure/core/tracing/ext/opentelemetry_span/_schema.py
+++ b/sdk/core/azure-core-tracing-opentelemetry/azure/core/tracing/ext/opentelemetry_span/_schema.py
@@ -28,7 +28,7 @@ class OpenTelemetrySchema:
             "x-ms-client-request-id": "az.client_request_id",
             "x-ms-request-id": "az.service_request_id",
             "http.user_agent": "user_agent.original",
-            "messaging_bus.destination": "messaging.destination.name",
+            "message_bus.destination": "messaging.destination.name",
             "peer.address": "net.peer.name",
         }
     }
@@ -40,3 +40,7 @@ class OpenTelemetrySchema:
     @classmethod
     def get_attribute_mappings(cls, version: OpenTelemetrySchemaVersion) -> Dict[str, str]:
         return cls._ATTRIBUTE_MAPPINGS[version]
+
+    @classmethod
+    def get_schema_url(cls, version: OpenTelemetrySchemaVersion) -> str:
+        return f"https://opentelemetry.io/schemas/{version}"

--- a/sdk/core/azure-core-tracing-opentelemetry/dev_requirements.txt
+++ b/sdk/core/azure-core-tracing-opentelemetry/dev_requirements.txt
@@ -1,6 +1,6 @@
 -e ../../../tools/azure-sdk-tools
 ../azure-core
 -e ../../../tools/azure-devtools
-opentelemetry-sdk<2.0.0,>=1.0.0
+opentelemetry-sdk<2.0.0,>=1.11.1
 opentelemetry-instrumentation-requests
 requests

--- a/sdk/core/azure-core-tracing-opentelemetry/dev_requirements.txt
+++ b/sdk/core/azure-core-tracing-opentelemetry/dev_requirements.txt
@@ -1,6 +1,6 @@
 -e ../../../tools/azure-sdk-tools
 ../azure-core
 -e ../../../tools/azure-devtools
-opentelemetry-sdk<2.0.0,>=1.11.1
-opentelemetry-instrumentation-requests
+opentelemetry-sdk<2.0.0,>=1.12.0
+opentelemetry-instrumentation-requests>=0.32b0
 requests

--- a/sdk/core/azure-core-tracing-opentelemetry/setup.py
+++ b/sdk/core/azure-core-tracing-opentelemetry/setup.py
@@ -61,7 +61,7 @@ setup(
     },
     python_requires=">=3.7",
     install_requires=[
-        "opentelemetry-api<2.0.0,>=1.0.0",
+        "opentelemetry-api<2.0.0,>=1.11.1",
         "azure-core<2.0.0,>=1.13.0",
     ],
 )

--- a/sdk/core/azure-core-tracing-opentelemetry/setup.py
+++ b/sdk/core/azure-core-tracing-opentelemetry/setup.py
@@ -61,7 +61,7 @@ setup(
     },
     python_requires=">=3.7",
     install_requires=[
-        "opentelemetry-api<2.0.0,>=1.11.1",
-        "azure-core<2.0.0,>=1.13.0",
+        "opentelemetry-api<2.0.0,>=1.12.0",
+        "azure-core<2.0.0,>=1.24.0",
     ],
 )

--- a/sdk/core/azure-core-tracing-opentelemetry/tests/test_schema.py
+++ b/sdk/core/azure-core-tracing-opentelemetry/tests/test_schema.py
@@ -29,3 +29,19 @@ class TestOpenTelemetrySchema:
             for key in attribute_mappings:
                 # Check that original attribute is not present.
                 assert wrapped_class.span_instance.attributes.get(key) is None
+
+    def test_latest_schema_attributes_not_renamed(self, tracer):
+        with tracer.start_as_current_span("Root", kind=OpenTelemetrySpanKind.CLIENT) as parent:
+            wrapped_class = OpenTelemetrySpan(span=parent)
+
+            wrapped_class.add_attribute("foo", "bar")
+            wrapped_class.add_attribute("baz", "qux")
+
+            assert wrapped_class.span_instance.attributes.get("foo") == "bar"
+            assert wrapped_class.span_instance.attributes.get("baz") == "qux"
+
+    def test_schema_url_in_instrumentation_scope(self):
+        with OpenTelemetrySpan(name="span") as span:
+            schema_version = OpenTelemetrySchema.get_latest_version()
+            schema_url = OpenTelemetrySchema.get_schema_url(schema_version)
+            assert span.span_instance.instrumentation_scope.schema_url == schema_url


### PR DESCRIPTION
This provides more information as part of the tracer's instrumentation scope.

Also, fixed an attribute name in the rename dict (`messaging_bus.destination` should be `message_bus.destination` as that is what is actually being used by the amqp libraries.

Part of #25838
