### PR TITLE
[ml] Add none as name in deployment template for when existing app insights 

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_arm_deployments/arm_templates/workspace_param.json
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_arm_deployments/arm_templates/workspace_param.json
@@ -45,7 +45,7 @@
         "value": ""
     },
     "logAnalyticsName": {
-        "value": ""
+        "value": "none"
     },
     "logAnalyticsArmId": {
         "value": ""


### PR DESCRIPTION
# Description

When user specify existing app insights resource to use the log analytics template not having name was causing an issue. Set the default to none for when we will not be provisioning that resource. 

manually confirmed
<img width="411" alt="image" src="https://user-images.githubusercontent.com/53531213/233739768-07a77251-b0b8-4dde-8d46-3562de1f1ecd.png">


Work item to make workspace tests more robust. https://dev.azure.com/msdata/Vienna/_workitems/edit/2365020

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
