### PR TITLE
Azure.monitor.opentelemetry.exporter replace pkg_resources with importlib.metadata

### DIFF
--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_utils.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_utils.py
@@ -8,7 +8,11 @@ import platform
 import threading
 import time
 
-import pkg_resources
+try:
+    from importlib.metadata import version
+except ImportError:
+    # fallback for python 3.7
+    from importlib_metadata import version
 
 from opentelemetry.semconv.resource import ResourceAttributes
 from opentelemetry.sdk.util import ns_to_iso_str
@@ -19,9 +23,7 @@ from azure.monitor.opentelemetry.exporter._constants import _INSTRUMENTATIONS_BI
 
 
 # Workaround for missing version file
-opentelemetry_version = pkg_resources.get_distribution(
-    "opentelemetry-sdk"
-).version
+opentelemetry_version = version("opentelemetry-sdk")
 
 
 def _get_sdk_version_prefix():

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/setup.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/setup.py
@@ -86,6 +86,7 @@ setup(
         "msrest>=0.6.10",
         "opentelemetry-api==1.17.0",
         "opentelemetry-sdk==1.17.0",
+        "importlib-metadata>=1.4.0; python_version < '3.8'"
     ],
     entry_points={
         "opentelemetry_traces_exporter": [

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/setup.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/setup.py
@@ -86,7 +86,7 @@ setup(
         "msrest>=0.6.10",
         "opentelemetry-api==1.17.0",
         "opentelemetry-sdk==1.17.0",
-        "importlib-metadata>=1.4.0; python_version < '3.8'"
+        "importlib-metadata>=6.0.0; python_version < '3.8'"
     ],
     entry_points={
         "opentelemetry_traces_exporter": [

--- a/shared_requirements.txt
+++ b/shared_requirements.txt
@@ -45,3 +45,4 @@ azure-schemaregistry
 avro
 uamqp
 yarl
+importlib-metadata


### PR DESCRIPTION
# Description

Azure.monitor.opentelemetry.exporter is currently using pkg_resources to find the version of opentelemetry sdk. 
Usage pkg_resources is [discouraged](https://setuptools.pypa.io/en/latest/pkg_resources.html) and the same functionality is available in importlib.metadata in the std lib. 

The main problem with pkg_resources is that import is very slow since it scans all installed packages at import. Opentelemetry it self dropped the usage of it in [1.17](https://github.com/open-telemetry/opentelemetry-python/issues/2927) this means that is a Azure exported telemetry config this package is now the only one that imports pkg_resources.

Since this functionality was added to the std lib in 3.8 we use the official backported package for 3.7. Note that opentelemetry already depends on this package in a similar way. 

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.** n/a
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes. (n/a)
