### PR TITLE
[Key Vault] Update unnecessary version-specific testing decorators

### DIFF
--- a/sdk/keyvault/azure-keyvault-administration/tests/test_settings_client.py
+++ b/sdk/keyvault/azure-keyvault-administration/tests/test_settings_client.py
@@ -4,18 +4,19 @@
 # ------------------------------------
 import pytest
 
-from azure.keyvault.administration import ApiVersion, KeyVaultSetting, KeyVaultSettingsClient, KeyVaultSettingType
+from azure.keyvault.administration import KeyVaultSetting, KeyVaultSettingsClient, KeyVaultSettingType
+from azure.keyvault.administration._internal.client_base import DEFAULT_VERSION
 
 from devtools_testutils import recorded_by_proxy
 
 from _shared.test_case import KeyVaultTestCase
 from _test_case import KeyVaultSettingsClientPreparer, get_decorator
 
-only_7_4 = get_decorator(api_versions=[ApiVersion.V7_4])
+only_latest = get_decorator(api_versions=[DEFAULT_VERSION])
 
 
 class TestSettings(KeyVaultTestCase):
-    @pytest.mark.parametrize("api_version", only_7_4)
+    @pytest.mark.parametrize("api_version", only_latest)
     @KeyVaultSettingsClientPreparer()
     @recorded_by_proxy
     def test_list_settings(self, client: KeyVaultSettingsClient, **kwargs):
@@ -24,7 +25,7 @@ class TestSettings(KeyVaultTestCase):
         for setting in default_settings:
             assert setting.name and setting.setting_type and setting.value is not None
 
-    @pytest.mark.parametrize("api_version", only_7_4)
+    @pytest.mark.parametrize("api_version", only_latest)
     @KeyVaultSettingsClientPreparer()
     @recorded_by_proxy
     def test_update_settings(self, client: KeyVaultSettingsClient, **kwargs):

--- a/sdk/keyvault/azure-keyvault-administration/tests/test_settings_client_async.py
+++ b/sdk/keyvault/azure-keyvault-administration/tests/test_settings_client_async.py
@@ -3,19 +3,20 @@
 # Licensed under the MIT License.
 # ------------------------------------
 import pytest
-from azure.keyvault.administration import ApiVersion, KeyVaultSetting, KeyVaultSettingType
+from azure.keyvault.administration import KeyVaultSetting, KeyVaultSettingType
 from azure.keyvault.administration.aio import KeyVaultSettingsClient
+from azure.keyvault.administration._internal.client_base import DEFAULT_VERSION
 from devtools_testutils.aio import recorded_by_proxy_async
 
 from _async_test_case import KeyVaultSettingsClientPreparer, get_decorator
 from _shared.test_case_async import KeyVaultTestCase
 
-only_7_4 = get_decorator(api_versions=[ApiVersion.V7_4])
+only_latest = get_decorator(api_versions=[DEFAULT_VERSION])
 
 
 class TestSettings(KeyVaultTestCase):
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("api_version", only_7_4)
+    @pytest.mark.parametrize("api_version", only_latest)
     @KeyVaultSettingsClientPreparer()
     @recorded_by_proxy_async
     async def test_list_settings(self, client: KeyVaultSettingsClient, **kwargs):
@@ -28,7 +29,7 @@ class TestSettings(KeyVaultTestCase):
             assert setting.name and setting.setting_type and setting.value is not None
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("api_version", only_7_4)
+    @pytest.mark.parametrize("api_version", only_latest)
     @KeyVaultSettingsClientPreparer()
     @recorded_by_proxy_async
     async def test_update_settings(self, client: KeyVaultSettingsClient, **kwargs):

--- a/sdk/keyvault/azure-keyvault-keys/assets.json
+++ b/sdk/keyvault/azure-keyvault-keys/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "python",
   "TagPrefix": "python/keyvault/azure-keyvault-keys",
-  "Tag": "python/keyvault/azure-keyvault-keys_c6e71da583"
+  "Tag": "python/keyvault/azure-keyvault-keys_19356f3a5b"
 }

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client.py
@@ -19,13 +19,7 @@ import pytest
 from azure.core.exceptions import AzureError, HttpResponseError
 from azure.core.pipeline.policies import SansIOHTTPPolicy
 from azure.core.rest import HttpRequest
-from azure.keyvault.keys import (
-    ApiVersion,
-    JsonWebKey,
-    KeyCurveName,
-    KeyOperation,
-    KeyVaultKey,
-)
+from azure.keyvault.keys import JsonWebKey, KeyCurveName, KeyOperation, KeyVaultKey
 from azure.keyvault.keys.crypto import (
     CryptographyClient,
     EncryptionAlgorithm,
@@ -46,7 +40,6 @@ from _keys_test_case import KeysTestCase
 NO_GET = Permissions(keys=[p.value for p in KeyPermissions if p.value != "get"])
 
 all_api_versions = get_decorator()
-only_7_4_hsm = get_decorator(only_hsm=True, api_versions=[ApiVersion.V7_4])
 only_hsm = get_decorator(only_hsm=True)
 only_vault_latest = get_decorator(only_vault=True, api_versions=[DEFAULT_VERSION])
 no_get = get_decorator(permissions=NO_GET)

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client_async.py
@@ -13,13 +13,7 @@ import pytest
 from azure.core.exceptions import AzureError, HttpResponseError
 from azure.core.pipeline.policies import SansIOHTTPPolicy
 from azure.core.rest import HttpRequest
-from azure.keyvault.keys import (
-    ApiVersion,
-    JsonWebKey,
-    KeyCurveName,
-    KeyOperation,
-    KeyVaultKey,
-)
+from azure.keyvault.keys import JsonWebKey, KeyCurveName, KeyOperation, KeyVaultKey
 from azure.keyvault.keys.crypto._providers import NoLocalCryptography, get_local_cryptography_provider
 from azure.keyvault.keys.crypto.aio import (
     CryptographyClient,
@@ -43,7 +37,6 @@ from _keys_test_case import KeysTestCase
 NO_GET = Permissions(keys=[p.value for p in KeyPermissions if p.value != "get"])
 
 all_api_versions = get_decorator(is_async=True)
-only_7_4_hsm = get_decorator(only_hsm=True, api_versions=[ApiVersion.V7_4])
 only_hsm = get_decorator(only_hsm=True, is_async=True)
 only_vault_latest = get_decorator(only_vault=True, is_async=True, api_versions=[DEFAULT_VERSION])
 no_get = get_decorator(is_async=True, permissions=NO_GET)

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_key_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_key_client.py
@@ -14,7 +14,6 @@ from azure.core.exceptions import HttpResponseError, ResourceExistsError, Resour
 from azure.core.pipeline.policies import SansIOHTTPPolicy
 from azure.core.rest import HttpRequest
 from azure.keyvault.keys import (
-    ApiVersion,
     JsonWebKey,
     KeyClient,
     KeyReleasePolicy,
@@ -35,10 +34,9 @@ from _keys_test_case import KeysTestCase
 
 all_api_versions = get_decorator()
 only_hsm = get_decorator(only_hsm=True)
-only_hsm_7_3 = get_decorator(only_hsm=True, api_versions=[ApiVersion.V7_3])
+only_hsm_latest = get_decorator(only_hsm=True, api_versions=[DEFAULT_VERSION])
 only_vault_latest = get_decorator(only_vault=True, api_versions=[DEFAULT_VERSION])
-only_vault_7_3 = get_decorator(only_vault=True, api_versions=[ApiVersion.V7_3])
-only_7_3 = get_decorator(api_versions=[ApiVersion.V7_3])
+only_latest = get_decorator(api_versions=[DEFAULT_VERSION])
 logging_enabled = get_decorator(logging_enable=True)
 logging_disabled = get_decorator(logging_enable=False)
 
@@ -496,7 +494,7 @@ class TestKeyClient(KeyVaultTestCase, KeysTestCase):
 
         mock_handler.close()
 
-    @pytest.mark.parametrize("api_version,is_hsm",only_hsm_7_3)
+    @pytest.mark.parametrize("api_version,is_hsm",only_hsm_latest)
     @KeysClientPreparer()
     @recorded_by_proxy
     def test_get_random_bytes(self, client, **kwargs):
@@ -512,7 +510,7 @@ class TestKeyClient(KeyVaultTestCase, KeysTestCase):
             assert all(random_bytes != rb for rb in generated_random_bytes)
             generated_random_bytes.append(random_bytes)
 
-    @pytest.mark.parametrize("api_version,is_hsm",only_7_3)
+    @pytest.mark.parametrize("api_version,is_hsm",only_latest)
     @KeysClientPreparer()
     @recorded_by_proxy
     def test_key_release(self, client, **kwargs):
@@ -535,7 +533,7 @@ class TestKeyClient(KeyVaultTestCase, KeysTestCase):
         release_result = client.release_key(rsa_key_name, attestation)
         assert release_result.value
 
-    @pytest.mark.parametrize("api_version,is_hsm",only_hsm_7_3)
+    @pytest.mark.parametrize("api_version,is_hsm",only_hsm_latest)
     @KeysClientPreparer()
     @recorded_by_proxy
     def test_imported_key_release(self, client, **kwargs):
@@ -555,7 +553,7 @@ class TestKeyClient(KeyVaultTestCase, KeysTestCase):
         release_result = client.release_key(imported_key_name, attestation)
         assert release_result.value
 
-    @pytest.mark.parametrize("api_version,is_hsm",only_7_3)
+    @pytest.mark.parametrize("api_version,is_hsm",only_latest)
     @KeysClientPreparer()
     @recorded_by_proxy
     def test_update_release_policy(self, client, **kwargs):
@@ -600,7 +598,7 @@ class TestKeyClient(KeyVaultTestCase, KeysTestCase):
         assert claim_condition is False
 
     #Immutable policies aren't currently supported on Managed HSM
-    @pytest.mark.parametrize("api_version,is_hsm",only_vault_7_3)
+    @pytest.mark.parametrize("api_version,is_hsm",only_vault_latest)
     @KeysClientPreparer()
     @recorded_by_proxy
     def test_immutable_release_policy(self, client, **kwargs):
@@ -637,7 +635,7 @@ class TestKeyClient(KeyVaultTestCase, KeysTestCase):
         with pytest.raises(HttpResponseError):
             self._update_key_properties(client, key, new_release_policy)
 
-    @pytest.mark.parametrize("api_version,is_hsm",only_vault_7_3)
+    @pytest.mark.parametrize("api_version,is_hsm",only_vault_latest)
     @KeysClientPreparer()
     @recorded_by_proxy
     def test_key_rotation(self, client, **kwargs):
@@ -655,7 +653,7 @@ class TestKeyClient(KeyVaultTestCase, KeysTestCase):
         assert key.key.n != rotated_key.key.n
 
     @pytest.mark.playback_test_only("Currently fails in live mode because of service regression; will be fixed soon.")
-    @pytest.mark.parametrize("api_version,is_hsm",only_vault_7_3)
+    @pytest.mark.parametrize("api_version,is_hsm",only_vault_latest)
     @KeysClientPreparer()
     @recorded_by_proxy
     def test_key_rotation_policy(self, client, **kwargs):

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_keys_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_keys_async.py
@@ -14,7 +14,6 @@ from azure.core.exceptions import HttpResponseError, ResourceExistsError, Resour
 from azure.core.pipeline.policies import SansIOHTTPPolicy
 from azure.core.rest import HttpRequest
 from azure.keyvault.keys import (
-    ApiVersion,
     JsonWebKey,
     KeyReleasePolicy,
     KeyRotationLifetimeAction,
@@ -35,10 +34,9 @@ from _keys_test_case import KeysTestCase
 
 all_api_versions = get_decorator(is_async=True)
 only_hsm = get_decorator(only_hsm=True, is_async=True)
-only_hsm_7_3 = get_decorator(only_hsm=True, is_async=True, api_versions=[ApiVersion.V7_3])
+only_hsm_latest = get_decorator(only_hsm=True, is_async=True, api_versions=[DEFAULT_VERSION])
 only_vault_latest = get_decorator(only_vault=True, is_async=True, api_versions=[DEFAULT_VERSION])
-only_vault_7_3 = get_decorator(only_vault=True, is_async=True, api_versions=[ApiVersion.V7_3])
-only_7_3 = get_decorator(is_async=True, api_versions=[ApiVersion.V7_3])
+only_latest = get_decorator(is_async=True, api_versions=[DEFAULT_VERSION])
 logging_enabled = get_decorator(is_async=True, logging_enable=True)
 logging_disabled = get_decorator(is_async=True, logging_enable=False)
 
@@ -497,7 +495,7 @@ class TestKeyVaultKey(KeyVaultTestCase, KeysTestCase):
         mock_handler.close()
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("api_version,is_hsm",only_hsm_7_3)
+    @pytest.mark.parametrize("api_version,is_hsm",only_hsm_latest)
     @AsyncKeysClientPreparer()
     @recorded_by_proxy_async
     async def test_get_random_bytes(self, client, **kwargs):
@@ -514,7 +512,7 @@ class TestKeyVaultKey(KeyVaultTestCase, KeysTestCase):
             generated_random_bytes.append(random_bytes)
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("api_version,is_hsm",only_7_3)
+    @pytest.mark.parametrize("api_version,is_hsm",only_latest)
     @AsyncKeysClientPreparer()
     @recorded_by_proxy_async
     async def test_key_release(self, client, **kwargs):
@@ -538,7 +536,7 @@ class TestKeyVaultKey(KeyVaultTestCase, KeysTestCase):
         assert release_result.value
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("api_version,is_hsm",only_hsm_7_3)
+    @pytest.mark.parametrize("api_version,is_hsm",only_hsm_latest)
     @AsyncKeysClientPreparer()
     @recorded_by_proxy_async
     async def test_imported_key_release(self, client, **kwargs):
@@ -559,7 +557,7 @@ class TestKeyVaultKey(KeyVaultTestCase, KeysTestCase):
         assert release_result.value
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("api_version,is_hsm",only_7_3)
+    @pytest.mark.parametrize("api_version,is_hsm",only_latest)
     @AsyncKeysClientPreparer()
     @recorded_by_proxy_async
     async def test_update_release_policy(self, client, **kwargs):
@@ -605,7 +603,7 @@ class TestKeyVaultKey(KeyVaultTestCase, KeysTestCase):
 
     # Immutable policies aren't currently supported on Managed HSM
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("api_version,is_hsm",only_vault_7_3)
+    @pytest.mark.parametrize("api_version,is_hsm",only_vault_latest)
     @AsyncKeysClientPreparer()
     @recorded_by_proxy_async
     async def test_immutable_release_policy(self, client, **kwargs):
@@ -643,7 +641,7 @@ class TestKeyVaultKey(KeyVaultTestCase, KeysTestCase):
             await self._update_key_properties(client, key, new_release_policy)
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("api_version,is_hsm",only_vault_7_3)
+    @pytest.mark.parametrize("api_version,is_hsm",only_vault_latest)
     @AsyncKeysClientPreparer()
     @recorded_by_proxy_async
     async def test_key_rotation(self, client, **kwargs):
@@ -662,7 +660,7 @@ class TestKeyVaultKey(KeyVaultTestCase, KeysTestCase):
 
     @pytest.mark.playback_test_only("Currently fails in live mode because of service regression; will be fixed soon.")
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("api_version,is_hsm",only_vault_7_3)
+    @pytest.mark.parametrize("api_version,is_hsm",only_vault_latest)
     @AsyncKeysClientPreparer()
     @recorded_by_proxy_async
     async def test_key_rotation_policy(self, client, **kwargs):

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_samples_keys.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_samples_keys.py
@@ -8,7 +8,7 @@ import os
 import time
 
 import pytest
-from azure.keyvault.keys import ApiVersion, KeyCurveName, KeyType
+from azure.keyvault.keys import KeyType
 from devtools_testutils import recorded_by_proxy
 
 from _shared.test_case import KeyVaultTestCase
@@ -16,7 +16,6 @@ from _test_case import KeysClientPreparer, get_decorator
 from _keys_test_case import KeysTestCase
 
 all_api_versions = get_decorator(only_vault=True)
-only_7_4_hsm = get_decorator(only_hsm=True, api_versions=[ApiVersion.V7_4])
 only_hsm = get_decorator(only_hsm=True)
 
 

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_samples_keys_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_samples_keys_async.py
@@ -6,14 +6,13 @@ import asyncio
 import os
 
 import pytest
-from azure.keyvault.keys import ApiVersion, KeyCurveName, KeyType
+from azure.keyvault.keys import KeyType
 from devtools_testutils.aio import recorded_by_proxy_async
 
 from _async_test_case import AsyncKeysClientPreparer, get_decorator
 from _shared.test_case_async import KeyVaultTestCase
 
 all_api_versions = get_decorator(is_async=True, only_vault=True)
-only_7_4_hsm = get_decorator(only_hsm=True, api_versions=[ApiVersion.V7_4])
 only_hsm = get_decorator(only_hsm=True, is_async=True)
 
 


### PR DESCRIPTION
# Description

Some tests have been targeting specific service API versions, such as 7.3 or 7.4, when we can instead target the default API version generally. This makes sure we're still testing the latest API version when the service has updates.

(Note: most tests run against all API versions; tests that target the latest version(s) do so to account for features that were previously unavailable.)

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
