### PR TITLE
[ML] Fix isort pre-commit line length

### DIFF
--- a/sdk/ml/azure-ai-ml/pyproject.toml
+++ b/sdk/ml/azure-ai-ml/pyproject.toml
@@ -12,3 +12,4 @@ exclude = ["setup.py", "tests", "azure/ai/ml/_restclient"]
 
 [tool.isort]
 profile = "black"
+line_length = 120


### PR DESCRIPTION
# Description

This sets our isort config to a line length of 120 to match our black config

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
