### PR TITLE
[Identity] Check for AADSTS error in CLI-based credentials

### DIFF
--- a/sdk/identity/azure-identity/CHANGELOG.md
+++ b/sdk/identity/azure-identity/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 - Update typing of async credentials to match the `AsyncTokenCredential` protocol.
 - If within `DefaultAzureCredential`, `EnvironmentCredential` will now use log level INFO instead of WARNING to inform users of an incomplete environment configuration.  ([#31814](https://github.com/Azure/azure-sdk-for-python/pull/31814))
+- Strengthened `AzureCliCredential` and `AzureDeveloperCliCredential` error checking when determining if a user is logged in or not. Now, if an AADSTS error exists in the error, the full error message is propagated instead of a canned error message. ([#30047](https://github.com/Azure/azure-sdk-for-python/pull/30047))
 
 ## 1.14.0 (2023-08-08)
 

--- a/sdk/identity/azure-identity/azure/identity/_credentials/azd_cli.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/azd_cli.py
@@ -224,7 +224,7 @@ def _run_command(command: str, timeout: int) -> str:
         # Fallback check in case the executable is not found while executing subprocess.
         if ex.returncode == 127 or ex.stderr.startswith("'azd' is not recognized"):
             raise CredentialUnavailableError(message=CLI_NOT_FOUND) from ex
-        if "not logged in, run `azd auth login` to login" in ex.stderr:
+        if "not logged in, run `azd auth login` to login" in ex.stderr and "AADSTS" not in ex.stderr:
             raise CredentialUnavailableError(message=NOT_LOGGED_IN) from ex
 
         # return code is from the CLI -> propagate its output

--- a/sdk/identity/azure-identity/azure/identity/_credentials/azure_cli.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/azure_cli.py
@@ -199,7 +199,7 @@ def _run_command(command: str, timeout: int) -> str:
         # Fallback check in case the executable is not found while executing subprocess.
         if ex.returncode == 127 or ex.stderr.startswith("'az' is not recognized"):
             raise CredentialUnavailableError(message=CLI_NOT_FOUND) from ex
-        if "az login" in ex.stderr or "az account set" in ex.stderr:
+        if ("az login" in ex.stderr or "az account set" in ex.stderr) and "AADSTS" not in ex.stderr:
             raise CredentialUnavailableError(message=NOT_LOGGED_IN) from ex
 
         # return code is from the CLI -> propagate its output

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/azd_cli.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/azd_cli.py
@@ -180,7 +180,7 @@ async def _run_command(command: str, timeout: int) -> str:
     if proc.returncode == 127 or stderr.startswith("'azd' is not recognized"):
         raise CredentialUnavailableError(CLI_NOT_FOUND)
 
-    if "not logged in, run `azd auth login` to login" in stderr:
+    if "not logged in, run `azd auth login` to login" in stderr and "AADSTS" not in stderr:
         raise CredentialUnavailableError(message=NOT_LOGGED_IN)
 
     message = sanitize_output(stderr) if stderr else "Failed to invoke Azure Developer CLI"

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/azure_cli.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/azure_cli.py
@@ -158,7 +158,7 @@ async def _run_command(command: str, timeout: int) -> str:
     if proc.returncode == 127 or stderr.startswith("'az' is not recognized"):
         raise CredentialUnavailableError(CLI_NOT_FOUND)
 
-    if "az login" in stderr or "az account set" in stderr:
+    if ("az login" in stderr or "az account set" in stderr) and "AADSTS" not in stderr:
         raise CredentialUnavailableError(message=NOT_LOGGED_IN)
 
     message = sanitize_output(stderr) if stderr else "Failed to invoke Azure CLI"

--- a/sdk/identity/azure-identity/tests/test_azd_cli_credential.py
+++ b/sdk/identity/azure-identity/tests/test_azd_cli_credential.py
@@ -92,6 +92,17 @@ def test_not_logged_in():
                 AzureDeveloperCliCredential().get_token("scope")
 
 
+def test_aadsts_error():
+    """When there is an AADSTS error, the credential should raise an error containing the CLI's output even if the
+    error also contains the 'not logged in' string."""
+
+    stderr = "ERROR: AADSTS70043: The refresh token has expired, not logged in, run `azd auth login` to login"
+    with mock.patch("shutil.which", return_value="azd"):
+        with mock.patch(CHECK_OUTPUT, raise_called_process_error(1, stderr=stderr)):
+            with pytest.raises(ClientAuthenticationError, match=stderr):
+                AzureDeveloperCliCredential().get_token("scope")
+
+
 def test_unexpected_error():
     """When the CLI returns an unexpected error, the credential should raise an error containing the CLI's output"""
 

--- a/sdk/identity/azure-identity/tests/test_azd_cli_credential_async.py
+++ b/sdk/identity/azure-identity/tests/test_azd_cli_credential_async.py
@@ -122,6 +122,18 @@ async def test_not_logged_in():
                 await credential.get_token("scope")
 
 
+async def test_aadsts_error():
+    """When there is an AADSTS error, the credential should raise an error containing the CLI's output even if the
+    error also contains the 'not logged in' string."""
+
+    stderr = "ERROR: AADSTS70043: The refresh token has expired, not logged in, run `azd auth login` to login"
+    with mock.patch("shutil.which", return_value="azd"):
+        with mock.patch(SUBPROCESS_EXEC, mock_exec("", stderr, return_code=1)):
+            with pytest.raises(ClientAuthenticationError, match=stderr):
+                credential = AzureDeveloperCliCredential()
+                await credential.get_token("scope")
+
+
 async def test_unexpected_error():
     """When the CLI returns an unexpected error, the credential should raise an error containing the CLI's output"""
 

--- a/sdk/identity/azure-identity/tests/test_cli_credential.py
+++ b/sdk/identity/azure-identity/tests/test_cli_credential.py
@@ -99,6 +99,16 @@ def test_not_logged_in():
                 AzureCliCredential().get_token("scope")
 
 
+def test_aadsts_error():
+    """When the CLI isn't logged in, the credential should raise CredentialUnavailableError"""
+
+    stderr = "ERROR: AADSTS70043: The refresh token has expired, Please run 'az login' to setup account."
+    with mock.patch("shutil.which", return_value="az"):
+        with mock.patch(CHECK_OUTPUT, raise_called_process_error(1, stderr=stderr)):
+            with pytest.raises(ClientAuthenticationError, match=stderr):
+                AzureCliCredential().get_token("scope")
+
+
 def test_unexpected_error():
     """When the CLI returns an unexpected error, the credential should raise an error containing the CLI's output"""
 

--- a/sdk/identity/azure-identity/tests/test_cli_credential_async.py
+++ b/sdk/identity/azure-identity/tests/test_cli_credential_async.py
@@ -129,6 +129,17 @@ async def test_not_logged_in():
                 await credential.get_token("scope")
 
 
+async def test_aadsts_error():
+    """When the CLI isn't logged in, the credential should raise CredentialUnavailableError"""
+
+    stderr = "ERROR: AADSTS70043: The refresh token has expired, Please run 'az login' to setup account."
+    with mock.patch("shutil.which", return_value="az"):
+        with mock.patch(SUBPROCESS_EXEC, mock_exec("", stderr, return_code=1)):
+            with pytest.raises(ClientAuthenticationError, match=stderr):
+                credential = AzureCliCredential()
+                await credential.get_token("scope")
+
+
 async def test_unexpected_error():
     """When the CLI returns an unexpected error, the credential should raise an error containing the CLI's output"""
 


### PR DESCRIPTION
In some cases, when using the CLI credentials, the error message might contain the "az login" substring, but not really be an error about the user not being logged in. This changes adds a check for "AADSTS" in stderr before giving users the NOT_LOGGED_IN error message. .NET does something [similar ](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/identity/Azure.Identity/src/Credentials/AzureCliCredential.cs#L148)already.

Closes: #29649
