### PR TITLE
[AppConfig] Address link

### DIFF
--- a/sdk/appconfiguration/azure-appconfiguration/README.md
+++ b/sdk/appconfiguration/azure-appconfiguration/README.md
@@ -9,7 +9,7 @@ Use the client library for App Configuration to create and manage application co
 [Source code](https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/appconfiguration/azure-appconfiguration)
 | [Package (Pypi)][package]
 | [Package (Conda)](https://anaconda.org/microsoft/azure-appconfiguration/)
-| [API reference documentation](https://learn.microsoft.com/python/api/overview/azure/appconfiguration-readme?view=azure-python)
+| [API reference documentation](https://learn.microsoft.com/python/api/azure-appconfiguration/azure.appconfiguration?view=azure-python)
 | [Product documentation][appconfig_docs]
 
 ## _Disclaimer_
@@ -333,4 +333,4 @@ additional questions or comments.
 [code_of_conduct]: https://opensource.microsoft.com/codeofconduct/
 [coc_faq]: https://opensource.microsoft.com/codeofconduct/faq/
 [coc_contact]: mailto:opencode@microsoft.com
-[troubleshooting_guide]: https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/identity/azure-identity/TROUBLESHOOTING.md
+[troubleshooting_guide]: https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/appconfiguration/azure-appconfiguration/TROUBLESHOOTING.md

--- a/sdk/appconfiguration/azure-appconfiguration/README.md
+++ b/sdk/appconfiguration/azure-appconfiguration/README.md
@@ -333,4 +333,4 @@ additional questions or comments.
 [code_of_conduct]: https://opensource.microsoft.com/codeofconduct/
 [coc_faq]: https://opensource.microsoft.com/codeofconduct/faq/
 [coc_contact]: mailto:opencode@microsoft.com
-[troubleshooting_guide]: https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/appconfiguration/azure-appconfiguration/TROUBLESHOOTING.md
+[troubleshooting_guide]: https://aka.ms/azsdk/python/appconfiguration/troubleshoot

--- a/sdk/appconfiguration/azure-appconfiguration/README.md
+++ b/sdk/appconfiguration/azure-appconfiguration/README.md
@@ -9,7 +9,7 @@ Use the client library for App Configuration to create and manage application co
 [Source code](https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/appconfiguration/azure-appconfiguration)
 | [Package (Pypi)][package]
 | [Package (Conda)](https://anaconda.org/microsoft/azure-appconfiguration/)
-| [API reference documentation](https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/appconfiguration/azure-appconfiguration)
+| [API reference documentation](https://learn.microsoft.com/python/api/overview/azure/appconfiguration-readme?view=azure-python)
 | [Product documentation][appconfig_docs]
 
 ## _Disclaimer_


### PR DESCRIPTION
This PR addressed links below:
- The `API reference documentation` link was pointing to the readme in GitHub. 
- The tsg file link was pointing to the one in `azure-identity`.