### PR TITLE
[ML][Pipelines] Add serverless in pipeline job default compute schema

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/pipeline/settings.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/pipeline/settings.py
@@ -6,10 +6,10 @@
 
 from marshmallow import INCLUDE, Schema, fields, post_dump, post_load
 
-from azure.ai.ml._schema.core.fields import ArmStr
+from azure.ai.ml._schema.core.fields import ArmStr, StringTransformedEnum, UnionField
 from azure.ai.ml._schema.pipeline.pipeline_component import NodeNameStr
 from azure.ai.ml._utils.utils import is_private_preview_enabled
-from azure.ai.ml.constants._common import AzureMLResourceType
+from azure.ai.ml.constants._common import AzureMLResourceType, SERVERLESS_COMPUTE
 
 
 class PipelineJobSettingsSchema(Schema):
@@ -17,7 +17,12 @@ class PipelineJobSettingsSchema(Schema):
         unknown = INCLUDE
 
     default_datastore = ArmStr(azureml_type=AzureMLResourceType.DATASTORE)
-    default_compute = ArmStr(azureml_type=AzureMLResourceType.COMPUTE)
+    default_compute = UnionField(
+        [
+            StringTransformedEnum(allowed_values=[SERVERLESS_COMPUTE]),
+            ArmStr(azureml_type=AzureMLResourceType.COMPUTE),
+        ]
+    )
     continue_on_step_failure = fields.Bool()
     force_rerun = fields.Bool()
 


### PR DESCRIPTION
# Description

Add serverless in pipeline job default compute schema, so that Azure ML extension can prompt users with value "severless".

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
