### PR TITLE
fix: add type hint for public property name

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_builders/base_node.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_builders/base_node.py
@@ -187,7 +187,7 @@ class BaseNode(Job, PipelineNodeIOMixin, YamlTranslatableMixin, _AttrDict, Schem
         self._init = False
 
     @property
-    def name(self):
+    def name(self) -> str:
         """Name of the node."""
         return self._name
 


### PR DESCRIPTION
# Description

1. add type hint for public property `name`

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
