### PR TITLE
[Identity] Add code snippets to credential docstrings

### DIFF
--- a/sdk/identity/azure-identity/TOKEN_CACHING.md
+++ b/sdk/identity/azure-identity/TOKEN_CACHING.md
@@ -40,7 +40,7 @@ With persistent disk token caching enabled, the library first determines if a va
 
 The sample showcases how to activate persistence token caching in the credentials offered by the Azure Identity library. You need to specify `TokenCachePersistenceOptions` when creating the credential to activate persistent token caching.
 
-```python 
+```python
 ClientSecretCredential(
     "tenant", "client-id", "secret", cache_persistence_options=TokenCachePersistenceOptions()
 )
@@ -88,7 +88,7 @@ The following table indicates the state of in-memory and persistent caching in e
 | `AzureDeveloperCliCredential`  | Not Supported                                                          | Not Supported                 |
 | `AzurePowershellCredential`    | Not Supported                                                          | Not Supported                 |
 | `ClientAssertionCredential`    | Supported                                                              | Not Supported                 |
-| `ClientCertificateCredential`  | Supported                                                              | Supported                     |
+| `CertificateCredential`        | Supported                                                              | Supported                     |
 | `ClientSecretCredential`       | Supported                                                              | Supported                     |
 | `DefaultAzureCredential`       | Supported if the target credential in the credential chain supports it | Not Supported                 |
 | `DeviceCodeCredential`         | Supported                                                              | Supported                     |

--- a/sdk/identity/azure-identity/azure/identity/_credentials/authorization_code.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/authorization_code.py
@@ -29,6 +29,15 @@ class AuthorizationCodeCredential(GetTokenMixin):
     :keyword List[str] additionally_allowed_tenants: Specifies tenants in addition to the specified "tenant_id"
         for which the credential may acquire tokens. Add the wildcard value "*" to allow the credential to
         acquire tokens for any tenant the application can access.
+
+    .. admonition:: Example:
+
+        .. literalinclude:: ../samples/credential_creation_code_snippets.py
+            :start-after: [START create_authorization_code_credential]
+            :end-before: [END create_authorization_code_credential]
+            :language: python
+            :dedent: 4
+            :caption: Create an AuthorizationCodeCredential.
     """
 
     def __init__(

--- a/sdk/identity/azure-identity/azure/identity/_credentials/azure_cli.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/azure_cli.py
@@ -37,6 +37,15 @@ class AzureCliCredential:
         for which the credential may acquire tokens. Add the wildcard value "*" to allow the credential to
         acquire tokens for any tenant the application can access.
     :keyword int process_timeout: Seconds to wait for the Azure CLI process to respond. Defaults to 10 seconds.
+
+    .. admonition:: Example:
+
+        .. literalinclude:: ../samples/credential_creation_code_snippets.py
+            :start-after: [START create_azure_cli_credential]
+            :end-before: [END create_azure_cli_credential]
+            :language: python
+            :dedent: 4
+            :caption: Create an AzureCliCredential.
     """
     def __init__(
         self,

--- a/sdk/identity/azure-identity/azure/identity/_credentials/azure_powershell.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/azure_powershell.py
@@ -51,6 +51,15 @@ class AzurePowerShellCredential:
         for which the credential may acquire tokens. Add the wildcard value "*" to allow the credential to
         acquire tokens for any tenant the application can access.
     :keyword int process_timeout: Seconds to wait for the Azure PowerShell process to respond. Defaults to 10 seconds.
+
+    .. admonition:: Example:
+
+        .. literalinclude:: ../samples/credential_creation_code_snippets.py
+            :start-after: [START create_azure_power_shell_credential]
+            :end-before: [END create_azure_power_shell_credential]
+            :language: python
+            :dedent: 4
+            :caption: Create an AzurePowerShellCredential.
     """
     def __init__(
         self,

--- a/sdk/identity/azure-identity/azure/identity/_credentials/browser.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/browser.py
@@ -43,6 +43,15 @@ class InteractiveBrowserCredential(InteractiveCredential):
         is performed when attempting to authenticate. Setting this to true will completely disable instance discovery
         and authority validation.
     :raises ValueError: invalid **redirect_uri**
+
+    .. admonition:: Example:
+
+        .. literalinclude:: ../samples/credential_creation_code_snippets.py
+            :start-after: [START create_interactive_browser_credential]
+            :end-before: [END create_interactive_browser_credential]
+            :language: python
+            :dedent: 4
+            :caption: Create an InteractiveBrowserCredential.
     """
 
     def __init__(self, **kwargs: Any) -> None:

--- a/sdk/identity/azure-identity/azure/identity/_credentials/certificate.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/certificate.py
@@ -47,6 +47,15 @@ class CertificateCredential(ClientCredentialBase):
     :keyword List[str] additionally_allowed_tenants: Specifies tenants in addition to the specified "tenant_id"
         for which the credential may acquire tokens. Add the wildcard value "*" to allow the credential to
         acquire tokens for any tenant the application can access.
+
+    .. admonition:: Example:
+
+        .. literalinclude:: ../samples/credential_creation_code_snippets.py
+            :start-after: [START create_certificate_credential]
+            :end-before: [END create_certificate_credential]
+            :language: python
+            :dedent: 4
+            :caption: Create a CertificateCredential.
     """
 
     def __init__(

--- a/sdk/identity/azure-identity/azure/identity/_credentials/chained.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/chained.py
@@ -37,6 +37,15 @@ class ChainedTokenCredential:
 
     :param credentials: credential instances to form the chain
     :type credentials: :class:`azure.core.credentials.TokenCredential`
+
+    .. admonition:: Example:
+
+        .. literalinclude:: ../samples/credential_creation_code_snippets.py
+            :start-after: [START create_chained_token_credential]
+            :end-before: [END create_chained_token_credential]
+            :language: python
+            :dedent: 4
+            :caption: Create a ChainedTokenCredential.
     """
 
     def __init__(self, *credentials):

--- a/sdk/identity/azure-identity/azure/identity/_credentials/client_assertion.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/client_assertion.py
@@ -12,7 +12,7 @@ from .._internal.get_token_mixin import GetTokenMixin
 class ClientAssertionCredential(GetTokenMixin):
     """Authenticates a service principal with a JWT assertion.
 
-    This credential is for advanced scenarios. :class:`~azure.identity.ClientCertificateCredential` has a more
+    This credential is for advanced scenarios. :class:`~azure.identity.CertificateCredential` has a more
     convenient API for the most common assertion scenario, authenticating a service principal with a certificate.
 
     :param str tenant_id: ID of the principal's tenant. Also called its "directory" ID.
@@ -27,6 +27,15 @@ class ClientAssertionCredential(GetTokenMixin):
     :keyword List[str] additionally_allowed_tenants: Specifies tenants in addition to the specified "tenant_id"
         for which the credential may acquire tokens. Add the wildcard value "*" to allow the credential to
         acquire tokens for any tenant the application can access.
+
+    .. admonition:: Example:
+
+        .. literalinclude:: ../samples/credential_creation_code_snippets.py
+            :start-after: [START create_client_assertion_credential]
+            :end-before: [END create_client_assertion_credential]
+            :language: python
+            :dedent: 4
+            :caption: Create a ClientAssertionCredential.
     """
 
     def __init__(

--- a/sdk/identity/azure-identity/azure/identity/_credentials/client_secret.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/client_secret.py
@@ -25,6 +25,15 @@ class ClientSecretCredential(ClientCredentialBase):
     :keyword List[str] additionally_allowed_tenants: Specifies tenants in addition to the specified "tenant_id"
         for which the credential may acquire tokens. Add the wildcard value "*" to allow the credential to
         acquire tokens for any tenant the application can access.
+
+    .. admonition:: Example:
+
+        .. literalinclude:: ../samples/credential_creation_code_snippets.py
+            :start-after: [START create_client_secret_credential]
+            :end-before: [END create_client_secret_credential]
+            :language: python
+            :dedent: 4
+            :caption: Create a ClientSecretCredential.
     """
 
     def __init__(

--- a/sdk/identity/azure-identity/azure/identity/_credentials/default.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/default.py
@@ -84,6 +84,15 @@ class DefaultAzureCredential(ChainedTokenCredential):
         Directory work or school accounts.
     :keyword int developer_credential_timeout: The timeout in seconds to use for developer credentials that run
         subprocesses (e.g. AzureCliCredential, AzurePowerShellCredential). Defaults to **10** seconds.
+
+    .. admonition:: Example:
+
+        .. literalinclude:: ../samples/credential_creation_code_snippets.py
+            :start-after: [START create_default_credential]
+            :end-before: [END create_default_credential]
+            :language: python
+            :dedent: 4
+            :caption: Create a DefaultAzureCredential.
     """
 
     def __init__(self, **kwargs: Any) -> None:  # pylint: disable=too-many-statements

--- a/sdk/identity/azure-identity/azure/identity/_credentials/device_code.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/device_code.py
@@ -50,6 +50,15 @@ class DeviceCodeCredential(InteractiveCredential):
     :keyword bool disable_authority_validation_and_instance_discovery: Determines whether or not instance discovery
         is performed when attempting to authenticate. Setting this to true will completely disable instance discovery
         and authority validation.
+
+    .. admonition:: Example:
+
+        .. literalinclude:: ../samples/credential_creation_code_snippets.py
+            :start-after: [START create_device_code_credential]
+            :end-before: [END create_device_code_credential]
+            :language: python
+            :dedent: 4
+            :caption: Create a DeviceCodeCredential.
     """
 
     def __init__(

--- a/sdk/identity/azure-identity/azure/identity/_credentials/environment.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/environment.py
@@ -52,6 +52,15 @@ class EnvironmentCredential:
       - **AZURE_AUTHORITY_HOST**: authority of an Azure Active Directory endpoint, for example
         "login.microsoftonline.com", the authority for Azure Public Cloud, which is the default
         when no value is given.
+
+    .. admonition:: Example:
+
+        .. literalinclude:: ../samples/credential_creation_code_snippets.py
+            :start-after: [START create_environment_credential]
+            :end-before: [END create_environment_credential]
+            :language: python
+            :dedent: 4
+            :caption: Create an EnvironmentCredential.
     """
 
     def __init__(self, **kwargs: Any) -> None:

--- a/sdk/identity/azure-identity/azure/identity/_credentials/managed_identity.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/managed_identity.py
@@ -31,6 +31,15 @@ class ManagedIdentityCredential:
         or resource ID, for example ``{"object_id": "..."}``. Check the documentation for your hosting environment to
         learn what values it expects.
     :paramtype identity_config: Mapping[str, str]
+
+    .. admonition:: Example:
+
+        .. literalinclude:: ../samples/credential_creation_code_snippets.py
+            :start-after: [START create_managed_identity_credential]
+            :end-before: [END create_managed_identity_credential]
+            :language: python
+            :dedent: 4
+            :caption: Create a ManagedIdentityCredential.
     """
 
     def __init__(self, **kwargs: Any) -> None:

--- a/sdk/identity/azure-identity/azure/identity/_credentials/on_behalf_of.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/on_behalf_of.py
@@ -50,6 +50,15 @@ class OnBehalfOfCredential(MsalCredential, GetTokenMixin):
     :keyword List[str] additionally_allowed_tenants: Specifies tenants in addition to the specified "tenant_id"
         for which the credential may acquire tokens. Add the wildcard value "*" to allow the credential to
         acquire tokens for any tenant the application can access.
+
+    .. admonition:: Example:
+
+        .. literalinclude:: ../samples/credential_creation_code_snippets.py
+            :start-after: [START create_on_behalf_of_credential]
+            :end-before: [END create_on_behalf_of_credential]
+            :language: python
+            :dedent: 4
+            :caption: Create an OnBehalfOfCredential.
     """
 
     def __init__(

--- a/sdk/identity/azure-identity/azure/identity/_credentials/user_password.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/user_password.py
@@ -40,6 +40,15 @@ class UsernamePasswordCredential(InteractiveCredential):
     :keyword List[str] additionally_allowed_tenants: Specifies tenants in addition to the specified "tenant_id"
         for which the credential may acquire tokens. Add the wildcard value "*" to allow the credential to
         acquire tokens for any tenant the application can access.
+
+    .. admonition:: Example:
+
+        .. literalinclude:: ../samples/credential_creation_code_snippets.py
+            :start-after: [START create_username_password_credential]
+            :end-before: [END create_username_password_credential]
+            :language: python
+            :dedent: 4
+            :caption: Create a UsernamePasswordCredential.
     """
 
     def __init__(

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/authorization_code.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/authorization_code.py
@@ -29,6 +29,15 @@ class AuthorizationCodeCredential(AsyncContextManager, GetTokenMixin):
     :keyword List[str] additionally_allowed_tenants: Specifies tenants in addition to the specified "tenant_id"
         for which the credential may acquire tokens. Add the wildcard value "*" to allow the credential to
         acquire tokens for any tenant the application can access.
+
+    .. admonition:: Example:
+
+        .. literalinclude:: ../samples/credential_creation_code_snippets.py
+            :start-after: [START create_authorization_code_credential_async]
+            :end-before: [END create_authorization_code_credential_async]
+            :language: python
+            :dedent: 4
+            :caption: Create an AuthorizationCodeCredential.
     """
 
     async def __aenter__(self):

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/azure_cli.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/azure_cli.py
@@ -36,6 +36,15 @@ class AzureCliCredential(AsyncContextManager):
         for which the credential may acquire tokens. Add the wildcard value "*" to allow the credential to
         acquire tokens for any tenant the application can access.
     :keyword int process_timeout: Seconds to wait for the Azure CLI process to respond. Defaults to 10 seconds.
+
+    .. admonition:: Example:
+
+        .. literalinclude:: ../samples/credential_creation_code_snippets.py
+            :start-after: [START create_azure_cli_credential_async]
+            :end-before: [END create_azure_cli_credential_async]
+            :language: python
+            :dedent: 4
+            :caption: Create an AzureCliCredential.
     """
     def __init__(
         self,

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/azure_powershell.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/azure_powershell.py
@@ -30,6 +30,15 @@ class AzurePowerShellCredential(AsyncContextManager):
         for which the credential may acquire tokens. Add the wildcard value "*" to allow the credential to
         acquire tokens for any tenant the application can access.
     :keyword int process_timeout: Seconds to wait for the Azure PowerShell process to respond. Defaults to 10 seconds.
+
+    .. admonition:: Example:
+
+        .. literalinclude:: ../samples/credential_creation_code_snippets.py
+            :start-after: [START create_azure_power_shell_credential_async]
+            :end-before: [END create_azure_power_shell_credential_async]
+            :language: python
+            :dedent: 4
+            :caption: Create an AzurePowerShellCredential.
     """
 
     def __init__(

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/certificate.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/certificate.py
@@ -42,6 +42,15 @@ class CertificateCredential(AsyncContextManager, GetTokenMixin):
     :keyword List[str] additionally_allowed_tenants: Specifies tenants in addition to the specified "tenant_id"
         for which the credential may acquire tokens. Add the wildcard value "*" to allow the credential to
         acquire tokens for any tenant the application can access.
+
+    .. admonition:: Example:
+
+        .. literalinclude:: ../samples/credential_creation_code_snippets.py
+            :start-after: [START create_certificate_credential_async]
+            :end-before: [END create_certificate_credential_async]
+            :language: python
+            :dedent: 4
+            :caption: Create a CertificateCredential.
     """
 
     def __init__(

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/chained.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/chained.py
@@ -27,6 +27,15 @@ class ChainedTokenCredential(AsyncContextManager):
 
     :param credentials: credential instances to form the chain
     :type credentials: :class:`azure.core.credentials.AsyncTokenCredential`
+
+    .. admonition:: Example:
+
+        .. literalinclude:: ../samples/credential_creation_code_snippets.py
+            :start-after: [START create_chained_token_credential_async]
+            :end-before: [END create_chained_token_credential_async]
+            :language: python
+            :dedent: 4
+            :caption: Create a ChainedTokenCredential.
     """
 
     def __init__(self, *credentials: "AsyncTokenCredential") -> None:

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/client_assertion.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/client_assertion.py
@@ -12,7 +12,7 @@ from .._internal.get_token_mixin import GetTokenMixin
 class ClientAssertionCredential(AsyncContextManager, GetTokenMixin):
     """Authenticates a service principal with a JWT assertion.
 
-    This credential is for advanced scenarios. :class:`~azure.identity.ClientCertificateCredential` has a more
+    This credential is for advanced scenarios. :class:`~azure.identity.CertificateCredential` has a more
     convenient API for the most common assertion scenario, authenticating a service principal with a certificate.
 
     :param str tenant_id: ID of the principal's tenant. Also called its "directory" ID.
@@ -27,6 +27,15 @@ class ClientAssertionCredential(AsyncContextManager, GetTokenMixin):
     :keyword List[str] additionally_allowed_tenants: Specifies tenants in addition to the specified "tenant_id"
         for which the credential may acquire tokens. Add the wildcard value "*" to allow the credential to
         acquire tokens for any tenant the application can access.
+
+    .. admonition:: Example:
+
+        .. literalinclude:: ../samples/credential_creation_code_snippets.py
+            :start-after: [START create_client_assertion_credential_async]
+            :end-before: [END create_client_assertion_credential_async]
+            :language: python
+            :dedent: 4
+            :caption: Create a ClientAssertionCredential.
     """
 
     def __init__(self, tenant_id: str, client_id: str, func: Callable[[], str], **kwargs: Any) -> None:

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/client_secret.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/client_secret.py
@@ -31,6 +31,15 @@ class ClientSecretCredential(AsyncContextManager, GetTokenMixin):
     :keyword List[str] additionally_allowed_tenants: Specifies tenants in addition to the specified "tenant_id"
         for which the credential may acquire tokens. Add the wildcard value "*" to allow the credential to
         acquire tokens for any tenant the application can access.
+
+    .. admonition:: Example:
+
+        .. literalinclude:: ../samples/credential_creation_code_snippets.py
+            :start-after: [START create_client_secret_credential_async]
+            :end-before: [END create_client_secret_credential_async]
+            :language: python
+            :dedent: 4
+            :caption: Create a ClientSecretCredential.
     """
 
     def __init__(

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/default.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/default.py
@@ -76,6 +76,15 @@ class DefaultAzureCredential(ChainedTokenCredential):
         Directory work or school accounts.
     :keyword int developer_credential_timeout: The timeout in seconds to use for developer credentials that run
         subprocesses (e.g. AzureCliCredential, AzurePowerShellCredential). Defaults to **10** seconds.
+
+    .. admonition:: Example:
+
+        .. literalinclude:: ../samples/credential_creation_code_snippets.py
+            :start-after: [START create_default_credential_async]
+            :end-before: [END create_default_credential_async]
+            :language: python
+            :dedent: 4
+            :caption: Create a DefaultAzureCredential.
     """
 
     def __init__(self, **kwargs: Any) -> None:

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/environment.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/environment.py
@@ -39,6 +39,15 @@ class EnvironmentCredential(AsyncContextManager):
       - **AZURE_AUTHORITY_HOST**: authority of an Azure Active Directory endpoint, for example
         "login.microsoftonline.com", the authority for Azure Public Cloud, which is the default
         when no value is given.
+
+    .. admonition:: Example:
+
+        .. literalinclude:: ../samples/credential_creation_code_snippets.py
+            :start-after: [START create_environment_credential_async]
+            :end-before: [END create_environment_credential_async]
+            :language: python
+            :dedent: 4
+            :caption: Create an EnvironmentCredential.
     """
 
     def __init__(self, **kwargs: Any) -> None:

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/managed_identity.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/managed_identity.py
@@ -32,6 +32,15 @@ class ManagedIdentityCredential(AsyncContextManager):
         or resource ID, for example ``{"object_id": "..."}``. Check the documentation for your hosting environment to
         learn what values it expects.
     :paramtype identity_config: Mapping[str, str]
+
+    .. admonition:: Example:
+
+        .. literalinclude:: ../samples/credential_creation_code_snippets.py
+            :start-after: [START create_managed_identity_credential_async]
+            :end-before: [END create_managed_identity_credential_async]
+            :language: python
+            :dedent: 4
+            :caption: Create a ManagedIdentityCredential.
     """
 
     def __init__(self, **kwargs: Any) -> None:

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/on_behalf_of.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/on_behalf_of.py
@@ -44,6 +44,15 @@ class OnBehalfOfCredential(AsyncContextManager, GetTokenMixin):
     :keyword List[str] additionally_allowed_tenants: Specifies tenants in addition to the specified "tenant_id"
         for which the credential may acquire tokens. Add the wildcard value "*" to allow the credential to
         acquire tokens for any tenant the application can access.
+
+    .. admonition:: Example:
+
+        .. literalinclude:: ../samples/credential_creation_code_snippets.py
+            :start-after: [START create_on_behalf_of_credential_async]
+            :end-before: [END create_on_behalf_of_credential_async]
+            :language: python
+            :dedent: 4
+            :caption: Create an OnBehalfOfCredential.
     """
 
     def __init__(

--- a/sdk/identity/azure-identity/samples/credential_creation_code_snippets.py
+++ b/sdk/identity/azure-identity/samples/credential_creation_code_snippets.py
@@ -129,7 +129,7 @@ def create_chained_token_credential():
         # Fallback to Azure CLI if EnvironmentCredential fails
         AzureCliCredential(),
     )
-    credential = ChainedTokenCredential(credential_chain)
+    credential = ChainedTokenCredential(*credential_chain)
     # [END create_chained_token_credential]
 
 

--- a/sdk/identity/azure-identity/samples/credential_creation_code_snippets.py
+++ b/sdk/identity/azure-identity/samples/credential_creation_code_snippets.py
@@ -18,7 +18,7 @@ def create_authorization_code_credential():
     # [END create_authorization_code_credential]
 
 
-def create_authorization_code_credential_async():
+async def create_authorization_code_credential_async():
     # [START create_authorization_code_credential_async]
     from azure.identity.aio import AuthorizationCodeCredential
 
@@ -39,7 +39,7 @@ def create_azure_cli_credential():
     # [END create_azure_cli_credential]
 
 
-def create_azure_cli_credential_async():
+async def create_azure_cli_credential_async():
     # [START create_azure_cli_credential_async]
     from azure.identity.aio import AzureCliCredential
 
@@ -55,7 +55,7 @@ def create_azure_developer_cli_credential():
     # [END azure_developer_cli_credential]
 
 
-def create_azure_developer_cli_credential_async():
+async def create_azure_developer_cli_credential_async():
     # [START azure_developer_cli_credential_async]
     from azure.identity.aio import AzureDeveloperCliCredential
 
@@ -71,7 +71,7 @@ def create_azure_power_shell_credential():
     # [END create_azure_power_shell_credential]
 
 
-def create_azure_power_shell_credential_async():
+async def create_azure_power_shell_credential_async():
     # [START create_azure_power_shell_credential_async]
     from azure.identity.aio import AzurePowerShellCredential
 
@@ -99,7 +99,7 @@ def create_certificate_credential():
     # [END create_certificate_credential]
 
 
-def create_certificate_credential_async():
+async def create_certificate_credential_async():
     # [START create_certificate_credential_async]
     from azure.identity.aio import CertificateCredential
 
@@ -123,26 +123,26 @@ def create_chained_token_credential():
     # [START create_chained_token_credential]
     from azure.identity import ChainedTokenCredential, EnvironmentCredential, AzureCliCredential
 
-    credential_chain = [
+    credential_chain = (
         # Try EnvironmentCredential first
         EnvironmentCredential(),
         # Fallback to Azure CLI if EnvironmentCredential fails
         AzureCliCredential(),
-    ]
-    credential = ChainedTokenCredential(*credential_chain)
+    )
+    credential = ChainedTokenCredential(credential_chain)
     # [END create_chained_token_credential]
 
 
-def create_chained_token_credential_async():
+async def create_chained_token_credential_async():
     # [START create_chained_token_credential_async]
     from azure.identity.aio import ChainedTokenCredential, EnvironmentCredential, AzureCliCredential
 
-    credential_chain = [
+    credential_chain = (
         # Try EnvironmentCredential first
         EnvironmentCredential(),
         # Fallback to Azure CLI if EnvironmentCredential fails
         AzureCliCredential(),
-    ]
+    )
     credential = ChainedTokenCredential(*credential_chain)
     # [END create_chained_token_credential_async]
 
@@ -162,7 +162,7 @@ def create_client_assertion_credential():
     # [END create_client_assertion_credential]
 
 
-def create_client_assertion_credential_async():
+async def create_client_assertion_credential_async():
     # [START create_client_assertion_credential_async]
     from azure.identity.aio import ClientAssertionCredential
 
@@ -189,7 +189,7 @@ def create_client_secret_credential():
     # [END create_client_secret_credential]
 
 
-def create_client_secret_credential_async():
+async def create_client_secret_credential_async():
     # [START create_client_secret_credential_async]
     from azure.identity.aio import ClientSecretCredential
 
@@ -209,7 +209,7 @@ def create_default_credential():
     # [END create_default_credential]
 
 
-def create_default_credential_async():
+async def create_default_credential_async():
     # [START create_default_credential_async]
     from azure.identity.aio import DefaultAzureCredential
 
@@ -233,7 +233,7 @@ def create_environment_credential():
     # [END create_environment_credential]
 
 
-def create_environment_credential_async():
+async def create_environment_credential_async():
     # [START create_environment_credential_async]
     from azure.identity.aio import EnvironmentCredential
 
@@ -264,7 +264,7 @@ def create_managed_identity_credential():
     # [END create_managed_identity_credential]
 
 
-def create_managed_identity_credential_async():
+async def create_managed_identity_credential_async():
     # [START create_managed_identity_credential_async]
     from azure.identity.aio import ManagedIdentityCredential
 
@@ -290,20 +290,7 @@ def create_on_behalf_of_credential():
     # [END create_on_behalf_of_credential]
 
 
-def create_on_behalf_of_credential_async():
-    # [START create_on_behalf_of_credential_async]
-    from azure.identity.aio import OnBehalfOfCredential
-
-    credential = OnBehalfOfCredential(
-        tenant_id="<tenant_id>",
-        client_id="<client_id>",
-        client_secret="<client_secret>",
-        user_assertion="<access_token>",
-    )
-    # [END create_on_behalf_of_credential_async]
-
-
-def create_on_behalf_of_credential_async():
+async def create_on_behalf_of_credential_async():
     # [START create_on_behalf_of_credential_async]
     from azure.identity.aio import OnBehalfOfCredential
 
@@ -346,7 +333,7 @@ def create_workload_identity_credential():
     # [END workload_identity_credential]
 
 
-def create_workload_identity_credential_async():
+async def create_workload_identity_credential_async():
     # [START workload_identity_credential_async]
     from azure.identity.aio import WorkloadIdentityCredential
 

--- a/sdk/identity/azure-identity/samples/credential_creation_code_snippets.py
+++ b/sdk/identity/azure-identity/samples/credential_creation_code_snippets.py
@@ -5,6 +5,48 @@
 """Code snippets demonstrating how to create various credentials."""
 
 
+def create_authorization_code_credential():
+    # [START create_authorization_code_credential]
+    from azure.identity import AuthorizationCodeCredential
+
+    credential = AuthorizationCodeCredential(
+        tenant_id="<tenant_id>",
+        client_id="<client_id>",
+        authorization_code="<auth_code>",
+        redirect_uri="<redirect_uri>",
+    )
+    # [END create_authorization_code_credential]
+
+
+def create_authorization_code_credential_async():
+    # [START create_authorization_code_credential_async]
+    from azure.identity.aio import AuthorizationCodeCredential
+
+    credential = AuthorizationCodeCredential(
+        tenant_id="<tenant_id>",
+        client_id="<client_id>",
+        authorization_code="<auth_code>",
+        redirect_uri="<redirect_uri>",
+    )
+    # [END create_authorization_code_credential_async]
+
+
+def create_azure_cli_credential():
+    # [START create_azure_cli_credential]
+    from azure.identity import AzureCliCredential
+
+    credential = AzureCliCredential()
+    # [END create_azure_cli_credential]
+
+
+def create_azure_cli_credential_async():
+    # [START create_azure_cli_credential_async]
+    from azure.identity.aio import AzureCliCredential
+
+    credential = AzureCliCredential()
+    # [END create_azure_cli_credential_async]
+
+
 def create_azure_developer_cli_credential():
     # [START azure_developer_cli_credential]
     from azure.identity import AzureDeveloperCliCredential
@@ -21,6 +63,271 @@ def create_azure_developer_cli_credential_async():
     # [END azure_developer_cli_credential_async]
 
 
+def create_azure_power_shell_credential():
+    # [START create_azure_power_shell_credential]
+    from azure.identity import AzurePowerShellCredential
+
+    credential = AzurePowerShellCredential()
+    # [END create_azure_power_shell_credential]
+
+
+def create_azure_power_shell_credential_async():
+    # [START create_azure_power_shell_credential_async]
+    from azure.identity.aio import AzurePowerShellCredential
+
+    credential = AzurePowerShellCredential()
+    # [END create_azure_power_shell_credential_async]
+
+
+def create_certificate_credential():
+    # [START create_certificate_credential]
+    from azure.identity import CertificateCredential
+
+    credential = CertificateCredential(
+        tenant_id="<tenant_id>",
+        client_id="<client_id>",
+        certificate_path="<path to PEM/PKCS12 certificate>",
+        password="<certificate password if necessary>",
+    )
+
+    # Certificate/private key byte data can also be passed directly
+    credential = CertificateCredential(
+        tenant_id="<tenant_id>",
+        client_id="<client_id>",
+        certificate_data=b"<cert data>",
+    )
+    # [END create_certificate_credential]
+
+
+def create_certificate_credential_async():
+    # [START create_certificate_credential_async]
+    from azure.identity.aio import CertificateCredential
+
+    credential = CertificateCredential(
+        tenant_id="<tenant_id>",
+        client_id="<client_id>",
+        certificate_path="<path to PEM/PKCS12 certificate>",
+        password="<certificate password if necessary>",
+    )
+
+    # Certificate/private key byte data can also be passed directly
+    credential = CertificateCredential(
+        tenant_id="<tenant_id>",
+        client_id="<client_id>",
+        certificate_data=b"<cert data>",
+    )
+    # [END create_certificate_credential_async]
+
+
+def create_chained_token_credential():
+    # [START create_chained_token_credential]
+    from azure.identity import ChainedTokenCredential, EnvironmentCredential, AzureCliCredential
+
+    credential_chain = [
+        # Try EnvironmentCredential first
+        EnvironmentCredential(),
+        # Fallback to Azure CLI if EnvironmentCredential fails
+        AzureCliCredential(),
+    ]
+    credential = ChainedTokenCredential(*credential_chain)
+    # [END create_chained_token_credential]
+
+
+def create_chained_token_credential_async():
+    # [START create_chained_token_credential_async]
+    from azure.identity.aio import ChainedTokenCredential, EnvironmentCredential, AzureCliCredential
+
+    credential_chain = [
+        # Try EnvironmentCredential first
+        EnvironmentCredential(),
+        # Fallback to Azure CLI if EnvironmentCredential fails
+        AzureCliCredential(),
+    ]
+    credential = ChainedTokenCredential(*credential_chain)
+    # [END create_chained_token_credential_async]
+
+
+def create_client_assertion_credential():
+    # [START create_client_assertion_credential]
+    from azure.identity import ClientAssertionCredential
+
+    def get_assertion():
+        return "<client-assertion>"
+
+    credential = ClientAssertionCredential(
+        tenant_id="<tenant_id>",
+        client_id="<client_id>",
+        func=get_assertion,
+    )
+    # [END create_client_assertion_credential]
+
+
+def create_client_assertion_credential_async():
+    # [START create_client_assertion_credential_async]
+    from azure.identity.aio import ClientAssertionCredential
+
+    def get_assertion():
+        return "<client-assertion>"
+
+    credential = ClientAssertionCredential(
+        tenant_id="<tenant_id>",
+        client_id="<client_id>",
+        func=get_assertion,
+    )
+    # [END create_client_assertion_credential_async]
+
+
+def create_client_secret_credential():
+    # [START create_client_secret_credential]
+    from azure.identity import ClientSecretCredential
+
+    credential = ClientSecretCredential(
+        tenant_id="<tenant_id>",
+        client_id="<client_id>",
+        client_secret="<client_secret>",
+    )
+    # [END create_client_secret_credential]
+
+
+def create_client_secret_credential_async():
+    # [START create_client_secret_credential_async]
+    from azure.identity.aio import ClientSecretCredential
+
+    credential = ClientSecretCredential(
+        tenant_id="<tenant_id>",
+        client_id="<client_id>",
+        client_secret="<client_secret>",
+    )
+    # [END create_client_secret_credential_async]
+
+
+def create_default_credential():
+    # [START create_default_credential]
+    from azure.identity import DefaultAzureCredential
+
+    credential = DefaultAzureCredential()
+    # [END create_default_credential]
+
+
+def create_default_credential_async():
+    # [START create_default_credential_async]
+    from azure.identity.aio import DefaultAzureCredential
+
+    credential = DefaultAzureCredential()
+    # [END create_default_credential_async]
+
+
+def create_device_code_credential():
+    # [START create_device_code_credential]
+    from azure.identity import DeviceCodeCredential
+
+    credential = DeviceCodeCredential()
+    # [END create_device_code_credential]
+
+
+def create_environment_credential():
+    # [START create_environment_credential]
+    from azure.identity import EnvironmentCredential
+
+    credential = EnvironmentCredential()
+    # [END create_environment_credential]
+
+
+def create_environment_credential_async():
+    # [START create_environment_credential_async]
+    from azure.identity.aio import EnvironmentCredential
+
+    credential = EnvironmentCredential()
+    # [END create_environment_credential_async]
+
+
+def create_interactive_browser_credential():
+    # [START create_interactive_browser_credential]
+    from azure.identity import InteractiveBrowserCredential
+
+    credential = InteractiveBrowserCredential(
+        client_id="<client_id>",
+    )
+    # [END create_interactive_browser_credential]
+
+
+def create_managed_identity_credential():
+    # [START create_managed_identity_credential]
+    from azure.identity import ManagedIdentityCredential
+
+    credential = ManagedIdentityCredential()
+
+    # Can also specify a client ID of a user-assigned managed identity
+    credential = ManagedIdentityCredential(
+        client_id="<client_id>",
+    )
+    # [END create_managed_identity_credential]
+
+
+def create_managed_identity_credential_async():
+    # [START create_managed_identity_credential_async]
+    from azure.identity.aio import ManagedIdentityCredential
+
+    credential = ManagedIdentityCredential()
+
+    # Can also specify a client ID of a user-assigned managed identity
+    credential = ManagedIdentityCredential(
+        client_id="<client_id>",
+    )
+    # [END create_managed_identity_credential_async]
+
+
+def create_on_behalf_of_credential():
+    # [START create_on_behalf_of_credential]
+    from azure.identity import OnBehalfOfCredential
+
+    credential = OnBehalfOfCredential(
+        tenant_id="<tenant_id>",
+        client_id="<client_id>",
+        client_secret="<client_secret>",
+        user_assertion="<access_token>",
+    )
+    # [END create_on_behalf_of_credential]
+
+
+def create_on_behalf_of_credential_async():
+    # [START create_on_behalf_of_credential_async]
+    from azure.identity.aio import OnBehalfOfCredential
+
+    credential = OnBehalfOfCredential(
+        tenant_id="<tenant_id>",
+        client_id="<client_id>",
+        client_secret="<client_secret>",
+        user_assertion="<access_token>",
+    )
+    # [END create_on_behalf_of_credential_async]
+
+
+def create_on_behalf_of_credential_async():
+    # [START create_on_behalf_of_credential_async]
+    from azure.identity.aio import OnBehalfOfCredential
+
+    credential = OnBehalfOfCredential(
+        tenant_id="<tenant_id>",
+        client_id="<client_id>",
+        client_secret="<client_secret>",
+        user_assertion="<access_token>",
+    )
+    # [END create_on_behalf_of_credential_async]
+
+
+def create_username_password_credential():
+    # [START create_username_password_credential]
+    from azure.identity import UsernamePasswordCredential
+
+    credential = UsernamePasswordCredential(
+        client_id="<client_id>",
+        username="<username>",
+        password="<password>",
+    )
+    # [END create_username_password_credential]
+
+
 def create_workload_identity_credential():
     # [START workload_identity_credential]
     from azure.identity import WorkloadIdentityCredential
@@ -28,7 +335,7 @@ def create_workload_identity_credential():
     credential = WorkloadIdentityCredential(
         tenant_id="<tenant_id>",
         client_id="<client_id>",
-        file="<token_file_path>"
+        token_file_path="<token_file_path>",
     )
 
     # Parameters can be omitted if the following environment variables are set:
@@ -46,7 +353,7 @@ def create_workload_identity_credential_async():
     credential = WorkloadIdentityCredential(
         tenant_id="<tenant_id>",
         client_id="<client_id>",
-        file="<token_file_path>"
+        token_file_path="<token_file_path>",
     )
 
     # Parameters can be omitted if the following environment variables are set:


### PR DESCRIPTION
This adds code snippets to each credential's docstring to demonstrate how a credential is created, and provide copy-pasteable usage to users.