### PR TITLE
Fix job schema

### DIFF
--- a/sdk/ml/azure-ai-ml/CHANGELOG.md
+++ b/sdk/ml/azure-ai-ml/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features Added
 
 ### Bugs Fixed
+ - Fixed minor overlap bug in job schema that caused parsing issues.
 
 ### Breaking Changes
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/job/services.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/job/services.py
@@ -37,11 +37,10 @@ class JobServiceSchema(JobServiceBaseSchema):
     type = UnionField(
         [
             StringTransformedEnum(
-                allowed_values=JobServiceTypeNames.NAMES_ALLOWED_FOR_PUBLIC,
+                allowed_values=JobServiceTypeNames.NAMES_NOT_ALLOWED_FOR_PUBLIC,
                 pass_original=True,
             ),
-            fields.Str(),
-        ]
+        ], is_strict=True
     )
 
     @post_load

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/job/services.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/job/services.py
@@ -37,7 +37,7 @@ class JobServiceSchema(JobServiceBaseSchema):
     type = UnionField(
         [
             StringTransformedEnum(
-                allowed_values=JobServiceTypeNames.INERNAL_NAMES,
+                allowed_values=JobServiceTypeNames.INTERNAL_NAMES,
                 pass_original=True,
             ),
         ],

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/job/services.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/job/services.py
@@ -37,10 +37,11 @@ class JobServiceSchema(JobServiceBaseSchema):
     type = UnionField(
         [
             StringTransformedEnum(
-                allowed_values=JobServiceTypeNames.NAMES_NOT_ALLOWED_FOR_PUBLIC,
+                allowed_values=JobServiceTypeNames.INERNAL_NAMES,
                 pass_original=True,
             ),
-        ], is_strict=True
+        ],
+        is_strict=True,
     )
 
     @post_load

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/constants/_job/job.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/constants/_job/job.py
@@ -108,7 +108,7 @@ class JobServiceTypeNames:
     REST_TO_ENTITY = {v: k for k, v in ENTITY_TO_REST.items()}
 
     NAMES_ALLOWED_FOR_PUBLIC = [EntityNames.JUPYTER_LAB, EntityNames.SSH, EntityNames.STUDIO, EntityNames.VS_CODE]
-    INERNAL_NAMES = [EntityNames.CUSTOM, EntityNames.TRACKING, EntityNames.STUDIO]
+    INTERNAL_NAMES = [EntityNames.CUSTOM, EntityNames.TRACKING, EntityNames.STUDIO]
 
 
 class JobTierNames:

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/constants/_job/job.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/constants/_job/job.py
@@ -107,7 +107,7 @@ class JobServiceTypeNames:
 
     REST_TO_ENTITY = {v: k for k, v in ENTITY_TO_REST.items()}
 
-    NAMES_ALLOWED_FOR_PUBLIC = [EntityNames.JUPYTER_LAB, EntityNames.SSH, EntityNames.TENSOR_BOARD, EntityNames.VS_CODE]
+    NAMES_ALLOWED_FOR_PUBLIC = [EntityNames.CUSTOM, EntityNames.TRACKING, EntityNames.STUDIO]
 
 
 class JobTierNames:

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/constants/_job/job.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/constants/_job/job.py
@@ -107,7 +107,8 @@ class JobServiceTypeNames:
 
     REST_TO_ENTITY = {v: k for k, v in ENTITY_TO_REST.items()}
 
-    NAMES_NOT_ALLOWED_FOR_PUBLIC = [  EntityNames.CUSTOM, EntityNames.TRACKING, EntityNames.STUDIO]
+    NAMES_ALLOWED_FOR_PUBLIC = [EntityNames.JUPYTER_LAB, EntityNames.SSH, EntityNames.STUDIO, EntityNames.VS_CODE]
+    INERNAL_NAMES = [EntityNames.CUSTOM, EntityNames.TRACKING, EntityNames.STUDIO]
 
 
 class JobTierNames:

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/constants/_job/job.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/constants/_job/job.py
@@ -107,7 +107,7 @@ class JobServiceTypeNames:
 
     REST_TO_ENTITY = {v: k for k, v in ENTITY_TO_REST.items()}
 
-    NAMES_ALLOWED_FOR_PUBLIC = [EntityNames.CUSTOM, EntityNames.TRACKING, EntityNames.STUDIO]
+    NAMES_NOT_ALLOWED_FOR_PUBLIC = [  EntityNames.CUSTOM, EntityNames.TRACKING, EntityNames.STUDIO]
 
 
 class JobTierNames:

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/job_service.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/job_service.py
@@ -82,7 +82,7 @@ class JobServiceBase(RestTranslatableMixin, DictMixin):
     def _validate_type_name(self):
         if self.type and not self.type in JobServiceTypeNames.ENTITY_TO_REST.keys():
             msg = (
-                f"type should be one of " f"{JobServiceTypeNames.NAMES_ALLOWED_FOR_PUBLIC}, but received '{self.type}'."
+                f"type should be one of " f"{JobServiceTypeNames.ENTITY_TO_REST.keys()}, but received '{self.type}'."
             )
             raise ValidationException(
                 message=msg,

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/job_service.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/job_service.py
@@ -81,9 +81,7 @@ class JobServiceBase(RestTranslatableMixin, DictMixin):
 
     def _validate_type_name(self):
         if self.type and not self.type in JobServiceTypeNames.ENTITY_TO_REST.keys():
-            msg = (
-                f"type should be one of " f"{JobServiceTypeNames.ENTITY_TO_REST.keys()}, but received '{self.type}'."
-            )
+            msg = f"type should be one of " f"{JobServiceTypeNames.ENTITY_TO_REST.keys()}, but received '{self.type}'."
             raise ValidationException(
                 message=msg,
                 no_personal_data_message=msg,


### PR DESCRIPTION
# Description

Fixes a 3 month old bug in the job schema that caused parsing issues. The `NAMES_ALLOWED_FOR_PUBLIC` field was supposed to contain entity types that are NOT covered by other service types, instead of exactly what the other services cover. At least, that's what I gathered from the comment in base_job.py "JobServiceSchema [... supports] types not set by users like Custom, Tracking, Sudio"

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.


Behavior when looking at type options: 
![image](https://user-images.githubusercontent.com/108901744/235463571-315538d6-640f-4994-8ba4-7f9fa98c1c21.png)
