### PR TITLE
Split `Build` job into two separate jobs

### DIFF
--- a/eng/pipelines/templates/steps/update_snippet.yml
+++ b/eng/pipelines/templates/steps/update_snippet.yml
@@ -7,7 +7,7 @@ steps:
   - task: UsePythonVersion@0
     displayName: 'Use Python 3.9'
     inputs:
-     versionSpec: '3.9'
+     versionSpec: '$(PythonVersion)'
     condition: succeededOrFailed()
 
   - task: PythonScript@0

--- a/eng/pipelines/templates/variables/globals.yml
+++ b/eng/pipelines/templates/variables/globals.yml
@@ -1,5 +1,5 @@
 variables:
-  PythonVersion: '3.9'
+  PythonVersion: '3.10'
   skipComponentGovernanceDetection: true
   AzureSDKCondaChannel: https://azuresdkconda.blob.core.windows.net/channel1/
   Package.EnableSBOMSigning: true


### PR DESCRIPTION
Resolves #30038 

**Job layout before this change**

```text
Build
  -> Analyze
  -> PythonVersionX+PlatformY
  -> PythonVersionX+PlatformY
  -> ..
```

Where `Build` contains `Create wheel/sdist`, `Create APIStub`, `Create docs`.

**Job layout after this change**

```
Build Extended (Docs, APIStubGen)
Build (wheel/sdist)
  -> Analyze
  -> PythonVersionX+PlatformY
  -> PythonVersionX+PlatformY
  -> ..
```

Two primary benefits after this change:

1. **Tests will start faster** as we won't be waiting for more than what is actually necessary to properly invoke those jobs.
2. This also really simplifies implementation of #28211 as we no longer need to condition the `apistubgen` and `docs` steps to only run on the `ubuntu` agent! 

CC @kdestin for visibility




