### PR TITLE
[ACR] Change exception type in manifest/blob digest validation

### DIFF
--- a/sdk/containerregistry/azure-containerregistry/CHANGELOG.md
+++ b/sdk/containerregistry/azure-containerregistry/CHANGELOG.md
@@ -5,11 +5,11 @@
 ### Features Added
 
 ### Breaking Changes
-- Changed the digest validation exception type to `ManifestDigestValidationException` in `set/get manifest` and `upload/download blob` operations.
 
 ### Bugs Fixed
 
 ### Other Changes
+- Changed the digest validation exception type to `ManifestDigestValidationError` in `set/get manifest` and `upload/download blob` operations.
 
 ## 1.1.0b4 (2023-04-25)
 

--- a/sdk/containerregistry/azure-containerregistry/CHANGELOG.md
+++ b/sdk/containerregistry/azure-containerregistry/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features Added
 
 ### Breaking Changes
+- Changed the digest validation exception type to `ManifestDigestValidationException` in `set/get manifest` and `upload/download blob` operations.
 
 ### Bugs Fixed
 

--- a/sdk/containerregistry/azure-containerregistry/azure/containerregistry/__init__.py
+++ b/sdk/containerregistry/azure-containerregistry/azure/containerregistry/__init__.py
@@ -18,7 +18,7 @@ from ._models import (
     RepositoryProperties,
     ArtifactTagProperties,
     GetManifestResult,
-    ManifestDigestValidationException,
+    ManifestDigestValidationError,
 )
 from ._download_stream import DownloadBlobStream
 from ._version import VERSION
@@ -36,5 +36,5 @@ __all__ = [
     "ArtifactTagProperties",
     "GetManifestResult",
     "DownloadBlobStream",
-    "ManifestDigestValidationException",
+    "ManifestDigestValidationError",
 ]

--- a/sdk/containerregistry/azure-containerregistry/azure/containerregistry/__init__.py
+++ b/sdk/containerregistry/azure-containerregistry/azure/containerregistry/__init__.py
@@ -18,6 +18,7 @@ from ._models import (
     RepositoryProperties,
     ArtifactTagProperties,
     GetManifestResult,
+    ManifestDigestValidationException,
 )
 from ._download_stream import DownloadBlobStream
 from ._version import VERSION
@@ -35,4 +36,5 @@ __all__ = [
     "ArtifactTagProperties",
     "GetManifestResult",
     "DownloadBlobStream",
+    "ManifestDigestValidationException",
 ]

--- a/sdk/containerregistry/azure-containerregistry/azure/containerregistry/_container_registry_client.py
+++ b/sdk/containerregistry/azure-containerregistry/azure/containerregistry/_container_registry_client.py
@@ -909,7 +909,9 @@ class ContainerRegistryClient(ContainerRegistryBaseClient):
             )
             digest = response_headers['Docker-Content-Digest']
             if not _validate_digest(data, digest):
-                raise ManifestDigestValidationException("The server-computed digest does not match the client-computed digest.")
+                raise ManifestDigestValidationException(
+                    "The server-computed digest does not match the client-computed digest."
+                )
         except Exception as e:
             if repository is None or manifest is None:
                 raise ValueError("The parameter repository and manifest cannot be None.") from e
@@ -946,11 +948,15 @@ class ContainerRegistryClient(ContainerRegistryBaseClient):
         if tag_or_digest.startswith("sha256:"):
             digest = tag_or_digest
             if not _validate_digest(manifest_bytes, digest):
-                raise ManifestDigestValidationException("The requested digest does not match the digest of the received manifest.")
+                raise ManifestDigestValidationException(
+                    "The requested digest does not match the digest of the received manifest."
+                )
         else:
             digest = response.http_response.headers['Docker-Content-Digest']
             if not _validate_digest(manifest_bytes, digest):
-                raise ManifestDigestValidationException("The server-computed digest does not match the client-computed digest.")
+                raise ManifestDigestValidationException(
+                    "The server-computed digest does not match the client-computed digest."
+                )
 
         return GetManifestResult(digest=digest, manifest=manifest_json, media_type=media_type)
 

--- a/sdk/containerregistry/azure-containerregistry/azure/containerregistry/_container_registry_client.py
+++ b/sdk/containerregistry/azure-containerregistry/azure/containerregistry/_container_registry_client.py
@@ -929,7 +929,7 @@ class ContainerRegistryClient(ContainerRegistryBaseClient):
         :returns: GetManifestResult
         :rtype: ~azure.containerregistry.GetManifestResult
         :raises ~azure.containerregistry.ManifestDigestValidationException:
-            If the requested digest does not match the digest of the received manifest, or
+            If the content of retrieved manifest digest does not match the requested digest, or
             the server-computed digest does not match the client-computed digest when tag is passing.
         """
         response = cast(
@@ -949,7 +949,7 @@ class ContainerRegistryClient(ContainerRegistryBaseClient):
             digest = tag_or_digest
             if not _validate_digest(manifest_bytes, digest):
                 raise ManifestDigestValidationException(
-                    "The requested digest does not match the digest of the received manifest."
+                    "The content of retrieved manifest digest does not match the requested digest."
                 )
         else:
             digest = response.http_response.headers['Docker-Content-Digest']
@@ -1025,7 +1025,7 @@ class ContainerRegistryClient(ContainerRegistryBaseClient):
         :returns: DownloadBlobStream
         :rtype: ~azure.containerregistry.DownloadBlobStream
         :raises ManifestDigestValidationException:
-            If the requested digest does not match the digest of the received blob.
+            If the content of retrieved blob digest does not match the requested digest.
         """
         end_range = DEFAULT_CHUNK_SIZE - 1
         first_chunk, headers = cast(

--- a/sdk/containerregistry/azure-containerregistry/azure/containerregistry/_container_registry_client.py
+++ b/sdk/containerregistry/azure-containerregistry/azure/containerregistry/_container_registry_client.py
@@ -41,7 +41,7 @@ from ._models import (
     ArtifactTagProperties,
     ArtifactManifestProperties,
     GetManifestResult,
-    ManifestDigestValidationException,
+    ManifestDigestValidationError,
 )
 
 JSON = MutableMapping[str, Any]
@@ -886,7 +886,7 @@ class ContainerRegistryClient(ContainerRegistryBaseClient):
         :returns: The digest of the set manifest, calculated by the registry.
         :rtype: str
         :raises ValueError: If the parameter repository or manifest is None.
-        :raises ~azure.containerregistry.ManifestDigestValidationException:
+        :raises ~azure.containerregistry.ManifestDigestValidationError:
             If the server-computed digest does not match the client-computed digest.
         """
         try:
@@ -909,7 +909,7 @@ class ContainerRegistryClient(ContainerRegistryBaseClient):
             )
             digest = response_headers['Docker-Content-Digest']
             if not _validate_digest(data, digest):
-                raise ManifestDigestValidationException(
+                raise ManifestDigestValidationError(
                     "The server-computed digest does not match the client-computed digest."
                 )
         except Exception as e:
@@ -928,7 +928,7 @@ class ContainerRegistryClient(ContainerRegistryBaseClient):
             When tag is provided, will use the digest in response headers to compare.
         :returns: GetManifestResult
         :rtype: ~azure.containerregistry.GetManifestResult
-        :raises ~azure.containerregistry.ManifestDigestValidationException:
+        :raises ~azure.containerregistry.ManifestDigestValidationError:
             If the content of retrieved manifest digest does not match the requested digest, or
             the server-computed digest does not match the client-computed digest when tag is passing.
         """
@@ -948,13 +948,13 @@ class ContainerRegistryClient(ContainerRegistryBaseClient):
         if tag_or_digest.startswith("sha256:"):
             digest = tag_or_digest
             if not _validate_digest(manifest_bytes, digest):
-                raise ManifestDigestValidationException(
+                raise ManifestDigestValidationError(
                     "The content of retrieved manifest digest does not match the requested digest."
                 )
         else:
             digest = response.http_response.headers['Docker-Content-Digest']
             if not _validate_digest(manifest_bytes, digest):
-                raise ManifestDigestValidationException(
+                raise ManifestDigestValidationError(
                     "The server-computed digest does not match the client-computed digest."
                 )
 
@@ -970,7 +970,7 @@ class ContainerRegistryClient(ContainerRegistryBaseClient):
         :returns: The digest and size in bytes of the uploaded blob.
         :rtype: Tuple[str, int]
         :raises ValueError: If the parameter repository or data is None.
-        :raises ~azure.containerregistry.ManifestDigestValidationException:
+        :raises ~azure.containerregistry.ManifestDigestValidationError:
             If the server-computed digest does not match the client-computed digest.
         """
         try:
@@ -990,7 +990,7 @@ class ContainerRegistryClient(ContainerRegistryBaseClient):
                 )
             )
             if digest != complete_upload_response_headers["Docker-Content-Digest"]:
-                raise ManifestDigestValidationException(
+                raise ManifestDigestValidationError(
                     "The server-computed digest does not match the client-computed digest."
                 )
         except Exception as e:
@@ -1024,7 +1024,7 @@ class ContainerRegistryClient(ContainerRegistryBaseClient):
         :param str digest: The digest of the blob to download.
         :returns: DownloadBlobStream
         :rtype: ~azure.containerregistry.DownloadBlobStream
-        :raises ManifestDigestValidationException:
+        :raises ManifestDigestValidationError:
             If the content of retrieved blob digest does not match the requested digest.
         """
         end_range = DEFAULT_CHUNK_SIZE - 1

--- a/sdk/containerregistry/azure-containerregistry/azure/containerregistry/_container_registry_client.py
+++ b/sdk/containerregistry/azure-containerregistry/azure/containerregistry/_container_registry_client.py
@@ -41,6 +41,7 @@ from ._models import (
     ArtifactTagProperties,
     ArtifactManifestProperties,
     GetManifestResult,
+    ManifestDigestValidationException,
 )
 
 JSON = MutableMapping[str, Any]
@@ -884,8 +885,9 @@ class ContainerRegistryClient(ContainerRegistryBaseClient):
         :paramtype media_type: str
         :returns: The digest of the set manifest, calculated by the registry.
         :rtype: str
-        :raises ValueError: If the parameter repository or manifest is None,
-            or the digest in the response does not match the digest of the set manifest.
+        :raises ValueError: If the parameter repository or manifest is None.
+        :raises ~azure.containerregistry.ManifestDigestValidationException:
+            If the server-computed digest does not match the client-computed digest.
         """
         try:
             data: IO[bytes]
@@ -907,7 +909,7 @@ class ContainerRegistryClient(ContainerRegistryBaseClient):
             )
             digest = response_headers['Docker-Content-Digest']
             if not _validate_digest(data, digest):
-                raise ValueError("The server-computed digest does not match the client-computed digest.")
+                raise ManifestDigestValidationException("The server-computed digest does not match the client-computed digest.")
         except Exception as e:
             if repository is None or manifest is None:
                 raise ValueError("The parameter repository and manifest cannot be None.") from e
@@ -924,7 +926,9 @@ class ContainerRegistryClient(ContainerRegistryBaseClient):
             When tag is provided, will use the digest in response headers to compare.
         :returns: GetManifestResult
         :rtype: ~azure.containerregistry.GetManifestResult
-        :raises ValueError: If the requested digest does not match the digest of the received manifest.
+        :raises ~azure.containerregistry.ManifestDigestValidationException:
+            If the requested digest does not match the digest of the received manifest, or
+            the server-computed digest does not match the client-computed digest when tag is passing.
         """
         response = cast(
             PipelineResponse,
@@ -942,11 +946,11 @@ class ContainerRegistryClient(ContainerRegistryBaseClient):
         if tag_or_digest.startswith("sha256:"):
             digest = tag_or_digest
             if not _validate_digest(manifest_bytes, digest):
-                raise ValueError("The requested digest does not match the digest of the received manifest.")
+                raise ManifestDigestValidationException("The requested digest does not match the digest of the received manifest.")
         else:
             digest = response.http_response.headers['Docker-Content-Digest']
             if not _validate_digest(manifest_bytes, digest):
-                raise ValueError("The server-computed digest does not match the client-computed digest.")
+                raise ManifestDigestValidationException("The server-computed digest does not match the client-computed digest.")
 
         return GetManifestResult(digest=digest, manifest=manifest_json, media_type=media_type)
 

--- a/sdk/containerregistry/azure-containerregistry/azure/containerregistry/_download_stream.py
+++ b/sdk/containerregistry/azure-containerregistry/azure/containerregistry/_download_stream.py
@@ -7,6 +7,7 @@ import hashlib
 from typing import Iterator, ContextManager, cast, Tuple, Dict, Any
 from typing_extensions import Protocol, Self
 from azure.core.pipeline import PipelineResponse
+from ._models import ManifestDigestValidationException
 
 
 class GetNext(Protocol):
@@ -70,7 +71,9 @@ class DownloadBlobStream(
             if self._downloaded >= self._blob_size:
                 computed_digest = "sha256:" + self._hasher.hexdigest()
                 if computed_digest != self._digest:
-                    raise ValueError("The requested digest does not match the digest of the received blob.")
+                    raise ManifestDigestValidationException(
+                        "The requested digest does not match the digest of the received blob."
+                    )
                 raise
             self._response = self._download_chunk()
             self._response_bytes = self._response.http_response.iter_bytes()

--- a/sdk/containerregistry/azure-containerregistry/azure/containerregistry/_download_stream.py
+++ b/sdk/containerregistry/azure-containerregistry/azure/containerregistry/_download_stream.py
@@ -72,7 +72,7 @@ class DownloadBlobStream(
                 computed_digest = "sha256:" + self._hasher.hexdigest()
                 if computed_digest != self._digest:
                     raise ManifestDigestValidationException(
-                        "The requested digest does not match the digest of the received blob."
+                        "The content of retrieved blob digest does not match the requested digest."
                     )
                 raise
             self._response = self._download_chunk()

--- a/sdk/containerregistry/azure-containerregistry/azure/containerregistry/_download_stream.py
+++ b/sdk/containerregistry/azure-containerregistry/azure/containerregistry/_download_stream.py
@@ -7,7 +7,7 @@ import hashlib
 from typing import Iterator, ContextManager, cast, Tuple, Dict, Any
 from typing_extensions import Protocol, Self
 from azure.core.pipeline import PipelineResponse
-from ._models import ManifestDigestValidationException
+from ._models import ManifestDigestValidationError
 
 
 class GetNext(Protocol):
@@ -71,7 +71,7 @@ class DownloadBlobStream(
             if self._downloaded >= self._blob_size:
                 computed_digest = "sha256:" + self._hasher.hexdigest()
                 if computed_digest != self._digest:
-                    raise ManifestDigestValidationException(
+                    raise ManifestDigestValidationError(
                         "The content of retrieved blob digest does not match the requested digest."
                     )
                 raise

--- a/sdk/containerregistry/azure-containerregistry/azure/containerregistry/_models.py
+++ b/sdk/containerregistry/azure-containerregistry/azure/containerregistry/_models.py
@@ -318,7 +318,7 @@ class GetManifestResult(object):
         self.digest = kwargs.get("digest")
 
 
-class ManifestDigestValidationException(ValueError):
+class ManifestDigestValidationError(ValueError):
     """Thrown when a manifest digest validation fails.
     :param str message: Message for caller describing the reason for the failure.
     """
@@ -326,5 +326,5 @@ class ManifestDigestValidationException(ValueError):
     def __init__(self, message):
         self.message = message
         super(  # pylint: disable=super-with-arguments
-            ManifestDigestValidationException, self
+            ManifestDigestValidationError, self
         ).__init__(self.message)

--- a/sdk/containerregistry/azure-containerregistry/azure/containerregistry/_models.py
+++ b/sdk/containerregistry/azure-containerregistry/azure/containerregistry/_models.py
@@ -316,3 +316,15 @@ class GetManifestResult(object):
         self.manifest = kwargs.get("manifest")
         self.media_type = kwargs.get("media_type")
         self.digest = kwargs.get("digest")
+
+
+class ManifestDigestValidationException(ValueError):
+    """Thrown when a manifest digest validation fails.
+    :param str message: Message for caller describing the reason for the failure.
+    """
+
+    def __init__(self, message):
+        self.message = message
+        super(  # pylint: disable=super-with-arguments
+            ManifestDigestValidationException, self
+        ).__init__(self.message)

--- a/sdk/containerregistry/azure-containerregistry/azure/containerregistry/aio/_async_container_registry_client.py
+++ b/sdk/containerregistry/azure-containerregistry/azure/containerregistry/aio/_async_container_registry_client.py
@@ -47,7 +47,7 @@ from .._models import (
     ArtifactManifestProperties,
     ArtifactTagProperties,
     GetManifestResult,
-    ManifestDigestValidationException,
+    ManifestDigestValidationError,
 )
 
 JSON = MutableMapping[str, Any]
@@ -901,7 +901,7 @@ class ContainerRegistryClient(ContainerRegistryBaseClient):
         :returns: The digest of the set manifest, calculated by the registry.
         :rtype: str
         :raises ValueError: If the parameter repository or manifest is None.
-        :raises ~azure.containerregistry.ManifestDigestValidationException:
+        :raises ~azure.containerregistry.ManifestDigestValidationError:
             If the server-computed digest does not match the client-computed digest.
         """
         try:
@@ -923,7 +923,7 @@ class ContainerRegistryClient(ContainerRegistryBaseClient):
             )
             digest = response_headers['Docker-Content-Digest']
             if not _validate_digest(data, digest):
-                raise ManifestDigestValidationException(
+                raise ManifestDigestValidationError(
                     "The server-computed digest does not match the client-computed digest."
                 )
         except Exception as e:
@@ -942,7 +942,7 @@ class ContainerRegistryClient(ContainerRegistryBaseClient):
             When tag is provided, will use the digest in response headers to compare.
         :returns: GetManifestResult
         :rtype: ~azure.containerregistry.GetManifestResult
-        :raises ~azure.containerregistry.ManifestDigestValidationException:
+        :raises ~azure.containerregistry.ManifestDigestValidationError:
             If the content of retrieved manifest digest does not match the requested digest, or
             the server-computed digest does not match the client-computed digest when tag is passing.
         """
@@ -962,13 +962,13 @@ class ContainerRegistryClient(ContainerRegistryBaseClient):
         if tag_or_digest.startswith("sha256:"):
             digest = tag_or_digest
             if not _validate_digest(manifest_bytes, digest):
-                raise ManifestDigestValidationException(
+                raise ManifestDigestValidationError(
                     "The content of retrieved manifest digest does not match the requested digest."
                 )
         else:
             digest = response.http_response.headers['Docker-Content-Digest']
             if not _validate_digest(manifest_bytes, digest):
-                raise ManifestDigestValidationException(
+                raise ManifestDigestValidationError(
                     "The server-computed digest does not match the client-computed digest."
                 )
 
@@ -984,7 +984,7 @@ class ContainerRegistryClient(ContainerRegistryBaseClient):
         :returns: The digest and size in bytes of the uploaded blob.
         :rtype: Tuple[str, int]
         :raises ValueError: If the parameter repository or data is None.
-        :raises ~azure.containerregistry.ManifestDigestValidationException:
+        :raises ~azure.containerregistry.ManifestDigestValidationError:
             If the server-computed digest does not match the client-computed digest.
         """
         try:
@@ -1007,7 +1007,7 @@ class ContainerRegistryClient(ContainerRegistryBaseClient):
                 )
             )
             if digest != complete_upload_response_headers["Docker-Content-Digest"]:
-                raise ManifestDigestValidationException(
+                raise ManifestDigestValidationError(
                     "The server-computed digest does not match the client-computed digest."
                 )
         except Exception as e:
@@ -1049,7 +1049,7 @@ class ContainerRegistryClient(ContainerRegistryBaseClient):
         :param str digest: The digest of the blob to download.
         :returns: AsyncDownloadBlobStream
         :rtype: ~azure.containerregistry.aio.AsyncDownloadBlobStream
-        :raises ManifestDigestValidationException:
+        :raises ManifestDigestValidationError:
             If the content of retrieved blob digest does not match the requested digest.
         """
         end_range = DEFAULT_CHUNK_SIZE - 1

--- a/sdk/containerregistry/azure-containerregistry/azure/containerregistry/aio/_async_container_registry_client.py
+++ b/sdk/containerregistry/azure-containerregistry/azure/containerregistry/aio/_async_container_registry_client.py
@@ -923,7 +923,9 @@ class ContainerRegistryClient(ContainerRegistryBaseClient):
             )
             digest = response_headers['Docker-Content-Digest']
             if not _validate_digest(data, digest):
-                raise ManifestDigestValidationException("The server-computed digest does not match the client-computed digest.")
+                raise ManifestDigestValidationException(
+                    "The server-computed digest does not match the client-computed digest."
+                )
         except Exception as e:
             if repository is None or manifest is None:
                 raise ValueError("The parameter repository and manifest cannot be None.") from e
@@ -960,11 +962,15 @@ class ContainerRegistryClient(ContainerRegistryBaseClient):
         if tag_or_digest.startswith("sha256:"):
             digest = tag_or_digest
             if not _validate_digest(manifest_bytes, digest):
-                raise ManifestDigestValidationException("The requested digest does not match the digest of the received manifest.")
+                raise ManifestDigestValidationException(
+                    "The requested digest does not match the digest of the received manifest."
+                )
         else:
             digest = response.http_response.headers['Docker-Content-Digest']
             if not _validate_digest(manifest_bytes, digest):
-                raise ManifestDigestValidationException("The server-computed digest does not match the client-computed digest.")
+                raise ManifestDigestValidationException(
+                    "The server-computed digest does not match the client-computed digest."
+                )
 
         return GetManifestResult(digest=digest, manifest=manifest_json, media_type=media_type)
 

--- a/sdk/containerregistry/azure-containerregistry/azure/containerregistry/aio/_async_container_registry_client.py
+++ b/sdk/containerregistry/azure-containerregistry/azure/containerregistry/aio/_async_container_registry_client.py
@@ -978,6 +978,8 @@ class ContainerRegistryClient(ContainerRegistryBaseClient):
         :returns: The digest and size in bytes of the uploaded blob.
         :rtype: Tuple[str, int]
         :raises ValueError: If the parameter repository or data is None.
+        :raises ~azure.containerregistry.ManifestDigestValidationException:
+            If the server-computed digest does not match the client-computed digest.
         """
         try:
             start_upload_response_headers = cast(
@@ -998,6 +1000,10 @@ class ContainerRegistryClient(ContainerRegistryBaseClient):
                     **kwargs
                 )
             )
+            if digest != complete_upload_response_headers["Docker-Content-Digest"]:
+                raise ManifestDigestValidationException(
+                    "The server-computed digest does not match the client-computed digest."
+                )
         except Exception as e:
             if repository is None or data is None:
                 raise ValueError("The parameter repository and data cannot be None.") from e
@@ -1037,7 +1043,8 @@ class ContainerRegistryClient(ContainerRegistryBaseClient):
         :param str digest: The digest of the blob to download.
         :returns: AsyncDownloadBlobStream
         :rtype: ~azure.containerregistry.aio.AsyncDownloadBlobStream
-        :raises ValueError: If the requested digest does not match the digest of the received blob.
+        :raises ManifestDigestValidationException:
+            If the requested digest does not match the digest of the received blob.
         """
         end_range = DEFAULT_CHUNK_SIZE - 1
         first_chunk, headers = cast(

--- a/sdk/containerregistry/azure-containerregistry/azure/containerregistry/aio/_async_container_registry_client.py
+++ b/sdk/containerregistry/azure-containerregistry/azure/containerregistry/aio/_async_container_registry_client.py
@@ -943,7 +943,7 @@ class ContainerRegistryClient(ContainerRegistryBaseClient):
         :returns: GetManifestResult
         :rtype: ~azure.containerregistry.GetManifestResult
         :raises ~azure.containerregistry.ManifestDigestValidationException:
-            If the requested digest does not match the digest of the received manifest, or
+            If the content of retrieved manifest digest does not match the requested digest, or
             the server-computed digest does not match the client-computed digest when tag is passing.
         """
         response = cast(
@@ -963,7 +963,7 @@ class ContainerRegistryClient(ContainerRegistryBaseClient):
             digest = tag_or_digest
             if not _validate_digest(manifest_bytes, digest):
                 raise ManifestDigestValidationException(
-                    "The requested digest does not match the digest of the received manifest."
+                    "The content of retrieved manifest digest does not match the requested digest."
                 )
         else:
             digest = response.http_response.headers['Docker-Content-Digest']
@@ -1050,7 +1050,7 @@ class ContainerRegistryClient(ContainerRegistryBaseClient):
         :returns: AsyncDownloadBlobStream
         :rtype: ~azure.containerregistry.aio.AsyncDownloadBlobStream
         :raises ManifestDigestValidationException:
-            If the requested digest does not match the digest of the received blob.
+            If the content of retrieved blob digest does not match the requested digest.
         """
         end_range = DEFAULT_CHUNK_SIZE - 1
         first_chunk, headers = cast(

--- a/sdk/containerregistry/azure-containerregistry/azure/containerregistry/aio/_async_download_stream.py
+++ b/sdk/containerregistry/azure-containerregistry/azure/containerregistry/aio/_async_download_stream.py
@@ -7,7 +7,7 @@ import hashlib
 from typing import AsyncIterator, AsyncContextManager, Awaitable, cast, Tuple, Dict, Any
 from typing_extensions import Protocol, Self
 from azure.core.pipeline import PipelineResponse
-from .._models import ManifestDigestValidationException
+from .._models import ManifestDigestValidationError
 
 
 class AsyncGetNext(Protocol):
@@ -71,7 +71,7 @@ class AsyncDownloadBlobStream(
             if self._downloaded >= self._blob_size:
                 computed_digest = "sha256:" + self._hasher.hexdigest()
                 if computed_digest != self._digest:
-                    raise ManifestDigestValidationException(
+                    raise ManifestDigestValidationError(
                         "The content of retrieved blob digest does not match the requested digest."
                     )
                 raise

--- a/sdk/containerregistry/azure-containerregistry/azure/containerregistry/aio/_async_download_stream.py
+++ b/sdk/containerregistry/azure-containerregistry/azure/containerregistry/aio/_async_download_stream.py
@@ -7,6 +7,7 @@ import hashlib
 from typing import AsyncIterator, AsyncContextManager, Awaitable, cast, Tuple, Dict, Any
 from typing_extensions import Protocol, Self
 from azure.core.pipeline import PipelineResponse
+from .._models import ManifestDigestValidationException
 
 
 class AsyncGetNext(Protocol):
@@ -70,7 +71,9 @@ class AsyncDownloadBlobStream(
             if self._downloaded >= self._blob_size:
                 computed_digest = "sha256:" + self._hasher.hexdigest()
                 if computed_digest != self._digest:
-                    raise ValueError("The requested digest does not match the digest of the received blob.")
+                    raise ManifestDigestValidationException(
+                        "The requested digest does not match the digest of the received blob."
+                    )
                 raise
             self._response = await self._download_chunk()
             self._response_bytes = self._response.http_response.iter_bytes()

--- a/sdk/containerregistry/azure-containerregistry/azure/containerregistry/aio/_async_download_stream.py
+++ b/sdk/containerregistry/azure-containerregistry/azure/containerregistry/aio/_async_download_stream.py
@@ -72,7 +72,7 @@ class AsyncDownloadBlobStream(
                 computed_digest = "sha256:" + self._hasher.hexdigest()
                 if computed_digest != self._digest:
                     raise ManifestDigestValidationException(
-                        "The requested digest does not match the digest of the received blob."
+                        "The content of retrieved blob digest does not match the requested digest."
                     )
                 raise
             self._response = await self._download_chunk()

--- a/sdk/containerregistry/azure-containerregistry/tests/test_container_registry_client.py
+++ b/sdk/containerregistry/azure-containerregistry/tests/test_container_registry_client.py
@@ -883,7 +883,7 @@ class TestContainerRegistryClient(ContainerRegistryTestClass):
                     pass
 
 
-class TestContainerRegistryClientUnitTests():
+class TestContainerRegistryClientUnitTests:
     containerregistry_endpoint="https://fake_url.azurecr.io"
     
     def text(self, encoding: Optional[str] = None) -> str:

--- a/sdk/containerregistry/azure-containerregistry/tests/test_container_registry_client.py
+++ b/sdk/containerregistry/azure-containerregistry/tests/test_container_registry_client.py
@@ -19,7 +19,7 @@ from azure.containerregistry import (
     ArtifactTagProperties,
     ArtifactTagOrder,
     ContainerRegistryClient,
-    ManifestDigestValidationException,
+    ManifestDigestValidationError,
 )
 from azure.containerregistry._helpers import DOCKER_MANIFEST, OCI_IMAGE_MANIFEST, DEFAULT_CHUNK_SIZE
 from azure.core.exceptions import ResourceNotFoundError, ClientAuthenticationError, HttpResponseError
@@ -920,7 +920,7 @@ class TestContainerRegistryClientUnitTests:
         with ContainerRegistryClient(
             endpoint=self.containerregistry_endpoint, transport = MagicMock(send=send_in_set_manifest)
         ) as client:
-            with pytest.raises(ManifestDigestValidationException) as exp:
+            with pytest.raises(ManifestDigestValidationError) as exp:
                 manifest = {"hello": "world"}
                 client.set_manifest("test-repo", manifest)
             assert str(exp.value) == "The server-computed digest does not match the client-computed digest."
@@ -929,12 +929,12 @@ class TestContainerRegistryClientUnitTests:
             endpoint=self.containerregistry_endpoint,
             transport = MagicMock(send=send_in_get_manifest)
         ) as client:
-            with pytest.raises(ManifestDigestValidationException) as exp:
+            with pytest.raises(ManifestDigestValidationError) as exp:
                 digest = hashlib.sha256(b"hello world").hexdigest()
                 client.get_manifest("test-repo", f"sha256:{digest}")
             assert str(exp.value) == "The content of retrieved manifest digest does not match the requested digest."
                 
-            with pytest.raises(ManifestDigestValidationException) as exp:
+            with pytest.raises(ManifestDigestValidationError) as exp:
                 client.get_manifest("test-repo", "test-tag")
             assert str(exp.value) == "The server-computed digest does not match the client-computed digest."
 
@@ -971,7 +971,7 @@ class TestContainerRegistryClientUnitTests:
         with ContainerRegistryClient(
             endpoint=self.containerregistry_endpoint, transport = MagicMock(send=send_in_upload_blob)
         ) as client:
-            with pytest.raises(ManifestDigestValidationException) as exp:
+            with pytest.raises(ManifestDigestValidationError) as exp:
                 client.upload_blob("test-repo", BytesIO(b'{"hello": "world"}'))
             assert str(exp.value) == "The server-computed digest does not match the client-computed digest."
             
@@ -980,7 +980,7 @@ class TestContainerRegistryClientUnitTests:
         ) as client:
             digest = hashlib.sha256(b"hello world").hexdigest()
             stream = client.download_blob("test-repo", f"sha256:{digest}")
-            with pytest.raises(ManifestDigestValidationException) as exp:
+            with pytest.raises(ManifestDigestValidationError) as exp:
                 for chunk in stream:
                     pass
             assert str(exp.value) == "The content of retrieved blob digest does not match the requested digest."

--- a/sdk/containerregistry/azure-containerregistry/tests/test_container_registry_client.py
+++ b/sdk/containerregistry/azure-containerregistry/tests/test_container_registry_client.py
@@ -885,13 +885,12 @@ class TestContainerRegistryClient(ContainerRegistryTestClass):
 
 class TestContainerRegistryClientUnitTests():
     containerregistry_endpoint="https://fake_url.azurecr.io"
-
-    def test_manifest_digest_validation(self):
-        
-        JSON = MutableMapping[str, Any]
-
-        def text(encoding: Optional[str] = None) -> str:
+    
+    def text(self, encoding: Optional[str] = None) -> str:
             return '{"hello": "world"}'
+
+    def test_manifest_digest_validation(self):        
+        JSON = MutableMapping[str, Any]
             
         def send_in_set_manifest(request: PipelineRequest, **kwargs) -> MagicMock:
             content_digest = hashlib.sha256(b"hello world").hexdigest()
@@ -899,7 +898,7 @@ class TestContainerRegistryClientUnitTests():
                 status_code=201,
                 headers={"Docker-Content-Digest": content_digest},
                 content_type="application/json; charset=utf-8",
-                text=text
+                text=self.text
         )
             
         def read() -> bytes:
@@ -933,16 +932,13 @@ class TestContainerRegistryClientUnitTests():
             with pytest.raises(ManifestDigestValidationException) as exp:
                 digest = hashlib.sha256(b"hello world").hexdigest()
                 client.get_manifest("test-repo", f"sha256:{digest}")
-            assert str(exp.value) == "The requested digest does not match the digest of the received manifest."
+            assert str(exp.value) == "The content of retrieved manifest digest does not match the requested digest."
                 
             with pytest.raises(ManifestDigestValidationException) as exp:
                 client.get_manifest("test-repo", "test-tag")
             assert str(exp.value) == "The server-computed digest does not match the client-computed digest."
 
-    def test_blob_digest_validation(self):        
-        def text(encoding: Optional[str] = None) -> str:
-            return '{"hello": "world"}'
-        
+    def test_blob_digest_validation(self):       
         def send_in_upload_blob(request: PipelineRequest, **kwargs) -> MagicMock:
             if request.method == "PUT":
                 content_digest = hashlib.sha256(b"hello world").hexdigest()
@@ -950,14 +946,14 @@ class TestContainerRegistryClientUnitTests():
                     status_code=201,
                     headers={"Docker-Content-Digest": content_digest},
                     content_type="application/json; charset=utf-8",
-                    text=text
+                    text=self.text
                 )
             else:
                 return MagicMock(
                     status_code=202,
-                    headers={"Location": "/v2/repo5b2f373f/blobs/uploads/fake_location"},
+                    headers={"Location": "/v2/test-repo/blobs/uploads/fake_location"},
                     content_type="application/json; charset=utf-8",
-                    text=text
+                    text=self.text
                 )
         
         def iter_bytes() -> Iterator[bytes]:
@@ -968,7 +964,7 @@ class TestContainerRegistryClientUnitTests():
                 status_code=206,
                 headers={"Content-Range": "bytes 0-27/28", "Content-Length": "28"},
                 content_type="application/json; charset=utf-8",
-                text=text,
+                text=self.text,
                 iter_bytes=iter_bytes
             )
             
@@ -987,4 +983,4 @@ class TestContainerRegistryClientUnitTests():
             with pytest.raises(ManifestDigestValidationException) as exp:
                 for chunk in stream:
                     pass
-            assert str(exp.value) == "The requested digest does not match the digest of the received blob."
+            assert str(exp.value) == "The content of retrieved blob digest does not match the requested digest."

--- a/sdk/containerregistry/azure-containerregistry/tests/test_container_registry_client_async.py
+++ b/sdk/containerregistry/azure-containerregistry/tests/test_container_registry_client_async.py
@@ -18,7 +18,7 @@ from azure.containerregistry import (
     ArtifactManifestOrder,
     ArtifactTagProperties,
     ArtifactTagOrder,
-    ManifestDigestValidationException,
+    ManifestDigestValidationError,
 )
 from azure.containerregistry.aio import ContainerRegistryClient
 from azure.containerregistry._helpers import DOCKER_MANIFEST, OCI_IMAGE_MANIFEST, DEFAULT_CHUNK_SIZE
@@ -940,7 +940,7 @@ class TestContainerRegistryClientAsyncUnitTests:
         async with ContainerRegistryClient(
             endpoint=self.containerregistry_endpoint, transport = MyMagicMock(send=send_in_set_manifest)
         ) as client:
-            with pytest.raises(ManifestDigestValidationException) as exp:
+            with pytest.raises(ManifestDigestValidationError) as exp:
                 manifest = {"hello": "world"}
                 await client.set_manifest("test-repo", manifest)
             assert str(exp.value) == "The server-computed digest does not match the client-computed digest."
@@ -948,12 +948,12 @@ class TestContainerRegistryClientAsyncUnitTests:
         async with ContainerRegistryClient(
             endpoint=self.containerregistry_endpoint, transport = MyMagicMock(send=send_in_get_manifest)
         ) as client:
-            with pytest.raises(ManifestDigestValidationException) as exp:
+            with pytest.raises(ManifestDigestValidationError) as exp:
                 digest = hashlib.sha256(b"hello world").hexdigest()
                 await client.get_manifest("test-repo", f"sha256:{digest}")
             assert str(exp.value) == "The content of retrieved manifest digest does not match the requested digest."
                 
-            with pytest.raises(ManifestDigestValidationException) as exp:
+            with pytest.raises(ManifestDigestValidationError) as exp:
                 await client.get_manifest("test-repo", "test-tag")
             assert str(exp.value) == "The server-computed digest does not match the client-computed digest."
 
@@ -991,7 +991,7 @@ class TestContainerRegistryClientAsyncUnitTests:
         async with ContainerRegistryClient(
             endpoint=self.containerregistry_endpoint, transport = MyMagicMock(send=send_in_upload_blob)
         ) as client:
-            with pytest.raises(ManifestDigestValidationException) as exp:
+            with pytest.raises(ManifestDigestValidationError) as exp:
                 await client.upload_blob("test-repo", BytesIO(b'{"hello": "world"}'))
             assert str(exp.value) == "The server-computed digest does not match the client-computed digest."
             
@@ -1000,7 +1000,7 @@ class TestContainerRegistryClientAsyncUnitTests:
         ) as client:
             digest = hashlib.sha256(b"hello world").hexdigest()
             stream = await client.download_blob("test-repo", f"sha256:{digest}")
-            with pytest.raises(ManifestDigestValidationException) as exp:
+            with pytest.raises(ManifestDigestValidationError) as exp:
                 async for chunk in stream:
                     pass
             assert str(exp.value) == "The content of retrieved blob digest does not match the requested digest."

--- a/sdk/containerregistry/azure-containerregistry/tests/test_container_registry_client_async.py
+++ b/sdk/containerregistry/azure-containerregistry/tests/test_container_registry_client_async.py
@@ -891,109 +891,109 @@ class TestContainerRegistryClientAsync(AsyncContainerRegistryTestClass):
                     pass
 
 
-@pytest.mark.asyncio
-async def test_manifest_digest_validation():
+class TestContainerRegistryClientAsyncUnitTests():
     containerregistry_endpoint="https://fake_url.azurecr.io"
-    JSON = MutableMapping[str, Any]
-    
-    def text(encoding: Optional[str] = None) -> str:
-        return '{"hello": "world"}'
-        
-    async def send_in_set_manifest(request: PipelineRequest, **kwargs) -> MagicMock:
-        content_digest = hashlib.sha256(b"hello world").hexdigest()
-        return MagicMock(
-            status_code=201,
-            headers={"Docker-Content-Digest": content_digest},
-            content_type="application/json; charset=utf-8",
-            text=text
-    )
-        
-    async def read() -> bytes:
-        return b'{"hello": "world"}'
-    
-    def json() -> JSON:
-        return {"hello": "world"}
-    
-    async def send_in_get_manifest(request: PipelineRequest, **kwargs) -> MagicMock:
-        content_digest = hashlib.sha256(b"hello world").hexdigest()
-        content_type = "application/vnd.oci.image.manifest.v1+json"
-        return MagicMock(
-            status_code=200,
-            headers={"Docker-Content-Digest": content_digest, "Content-Type": content_type},
-            read=read,
-            json=json
-    )
-        
-    async with ContainerRegistryClient(
-        endpoint=containerregistry_endpoint, transport = MagicMock(send=send_in_set_manifest)
-    ) as client:
-        with pytest.raises(ManifestDigestValidationException) as exp:
-            manifest = {"hello": "world"}
-            await client.set_manifest("test-repo", manifest)
-        assert str(exp.value) == "The server-computed digest does not match the client-computed digest."
-        
-    async with ContainerRegistryClient(
-        endpoint=containerregistry_endpoint,
-        transport = MagicMock(send=send_in_get_manifest)
-    ) as client:
-        with pytest.raises(ManifestDigestValidationException) as exp:
-            digest = hashlib.sha256(b"hello world").hexdigest()
-            await client.get_manifest("test-repo", f"sha256:{digest}")
-        assert str(exp.value) == "The requested digest does not match the digest of the received manifest."
-            
-        with pytest.raises(ManifestDigestValidationException) as exp:
-            await client.get_manifest("test-repo", "test-tag")
-        assert str(exp.value) == "The server-computed digest does not match the client-computed digest."
 
-@pytest.mark.asyncio
-async def test_blob_digest_validation():
-    containerregistry_endpoint="https://fake_url.azurecr.io"
-    
-    def text(encoding: Optional[str] = None) -> str:
-        return '{"hello": "world"}'
-    
-    async def send_in_upload_blob(request: PipelineRequest, **kwargs) -> MagicMock:
-        if request.method == "PUT":
+    @pytest.mark.asyncio
+    async def test_manifest_digest_validation(self):
+        JSON = MutableMapping[str, Any]
+        
+        def text(encoding: Optional[str] = None) -> str:
+            return '{"hello": "world"}'
+            
+        async def send_in_set_manifest(request: PipelineRequest, **kwargs) -> MagicMock:
             content_digest = hashlib.sha256(b"hello world").hexdigest()
             return MagicMock(
                 status_code=201,
                 headers={"Docker-Content-Digest": content_digest},
                 content_type="application/json; charset=utf-8",
                 text=text
-            )
-        else:
-            return MagicMock(
-                status_code=202,
-                headers={"Location": "/v2/repo5b2f373f/blobs/uploads/fake_location"},
-                content_type="application/json; charset=utf-8",
-                text=text
-            )
-    
-    async def iter_bytes() -> AsyncIterator[bytes]:
-        yield b'{"hello": "world"}'
-    
-    async def send_in_download_blob(request: PipelineRequest, **kwargs) -> MagicMock:
-        return MagicMock(
-            status_code=206,
-            headers={"Content-Range": "bytes 0-27/28", "Content-Length": "28"},
-            content_type="application/octet-stream",
-            text=text,
-            iter_bytes=iter_bytes
         )
+            
+        async def read() -> bytes:
+            return b'{"hello": "world"}'
         
-    async with ContainerRegistryClient(
-        endpoint=containerregistry_endpoint, transport = MagicMock(send=send_in_upload_blob)
-    ) as client:
-        with pytest.raises(ManifestDigestValidationException) as exp:
-            await client.upload_blob("test-repo", BytesIO(b'{"hello": "world"}'))
-        assert str(exp.value) == "The server-computed digest does not match the client-computed digest."
+        def json() -> JSON:
+            return {"hello": "world"}
         
-    async with ContainerRegistryClient(
-        endpoint=containerregistry_endpoint, transport = MagicMock(send=send_in_download_blob)
-    ) as client:
-        digest = hashlib.sha256(b"hello world").hexdigest()
-        stream = await client.download_blob("test-repo", f"sha256:{digest}")
-        with pytest.raises(ManifestDigestValidationException) as exp:
-            async for chunk in stream:
-                pass
-        assert str(exp.value) == "The requested digest does not match the digest of the received blob."
+        async def send_in_get_manifest(request: PipelineRequest, **kwargs) -> MagicMock:
+            content_digest = hashlib.sha256(b"hello world").hexdigest()
+            content_type = "application/vnd.oci.image.manifest.v1+json"
+            return MagicMock(
+                status_code=200,
+                headers={"Docker-Content-Digest": content_digest, "Content-Type": content_type},
+                read=read,
+                json=json
+        )
+            
+        async with ContainerRegistryClient(
+            endpoint=self.containerregistry_endpoint, transport = MagicMock(send=send_in_set_manifest)
+        ) as client:
+            with pytest.raises(ManifestDigestValidationException) as exp:
+                manifest = {"hello": "world"}
+                await client.set_manifest("test-repo", manifest)
+            assert str(exp.value) == "The server-computed digest does not match the client-computed digest."
+            
+        async with ContainerRegistryClient(
+            endpoint=self.containerregistry_endpoint,
+            transport = MagicMock(send=send_in_get_manifest)
+        ) as client:
+            with pytest.raises(ManifestDigestValidationException) as exp:
+                digest = hashlib.sha256(b"hello world").hexdigest()
+                await client.get_manifest("test-repo", f"sha256:{digest}")
+            assert str(exp.value) == "The requested digest does not match the digest of the received manifest."
+                
+            with pytest.raises(ManifestDigestValidationException) as exp:
+                await client.get_manifest("test-repo", "test-tag")
+            assert str(exp.value) == "The server-computed digest does not match the client-computed digest."
+
+    @pytest.mark.asyncio
+    async def test_blob_digest_validation(self):        
+        def text(encoding: Optional[str] = None) -> str:
+            return '{"hello": "world"}'
+        
+        async def send_in_upload_blob(request: PipelineRequest, **kwargs) -> MagicMock:
+            if request.method == "PUT":
+                content_digest = hashlib.sha256(b"hello world").hexdigest()
+                return MagicMock(
+                    status_code=201,
+                    headers={"Docker-Content-Digest": content_digest},
+                    content_type="application/json; charset=utf-8",
+                    text=text
+                )
+            else:
+                return MagicMock(
+                    status_code=202,
+                    headers={"Location": "/v2/repo5b2f373f/blobs/uploads/fake_location"},
+                    content_type="application/json; charset=utf-8",
+                    text=text
+                )
+        
+        async def iter_bytes() -> AsyncIterator[bytes]:
+            yield b'{"hello": "world"}'
+        
+        async def send_in_download_blob(request: PipelineRequest, **kwargs) -> MagicMock:
+            return MagicMock(
+                status_code=206,
+                headers={"Content-Range": "bytes 0-27/28", "Content-Length": "28"},
+                content_type="application/octet-stream",
+                text=text,
+                iter_bytes=iter_bytes
+            )
+            
+        async with ContainerRegistryClient(
+            endpoint=self.containerregistry_endpoint, transport = MagicMock(send=send_in_upload_blob)
+        ) as client:
+            with pytest.raises(ManifestDigestValidationException) as exp:
+                await client.upload_blob("test-repo", BytesIO(b'{"hello": "world"}'))
+            assert str(exp.value) == "The server-computed digest does not match the client-computed digest."
+            
+        async with ContainerRegistryClient(
+            endpoint=self.containerregistry_endpoint, transport = MagicMock(send=send_in_download_blob)
+        ) as client:
+            digest = hashlib.sha256(b"hello world").hexdigest()
+            stream = await client.download_blob("test-repo", f"sha256:{digest}")
+            with pytest.raises(ManifestDigestValidationException) as exp:
+                async for chunk in stream:
+                    pass
+            assert str(exp.value) == "The requested digest does not match the digest of the received blob."

--- a/sdk/containerregistry/azure-containerregistry/tests/test_container_registry_client_async.py
+++ b/sdk/containerregistry/azure-containerregistry/tests/test_container_registry_client_async.py
@@ -10,17 +10,21 @@ import hashlib
 import json
 from datetime import datetime
 from io import BytesIO
+from unittest.mock import MagicMock
+from typing import Optional
 from azure.containerregistry import (
     RepositoryProperties,
     ArtifactManifestProperties,
     ArtifactManifestOrder,
     ArtifactTagProperties,
     ArtifactTagOrder,
+    ManifestDigestValidationException,
 )
 from azure.containerregistry.aio import ContainerRegistryClient
 from azure.containerregistry._helpers import DOCKER_MANIFEST, OCI_IMAGE_MANIFEST, DEFAULT_CHUNK_SIZE
 from azure.core.exceptions import ResourceNotFoundError, ClientAuthenticationError, HttpResponseError
 from azure.core.async_paging import AsyncItemPaged
+from azure.core.pipeline import PipelineRequest
 from azure.identity import AzureAuthorityHosts
 from asynctestcase import AsyncContainerRegistryTestClass, get_authority, get_audience
 from constants import HELLO_WORLD, ALPINE, BUSYBOX, DOES_NOT_EXIST
@@ -885,3 +889,57 @@ class TestContainerRegistryClientAsync(AsyncContainerRegistryTestClass):
             if response is not None:
                 async for manifest in response:
                     pass
+
+
+@pytest.mark.asyncio
+async def test_manifest_digest_validation():
+    containerregistry_endpoint="https://fake_url.azurecr.io"
+    
+    def text(encoding: Optional[str] = None) -> str:
+        return '{"hello": "world"}'
+        
+    async def send_in_set_manifest(request: PipelineRequest, **kwargs) -> MagicMock:
+        content_digest = hashlib.sha256(b"hello world").hexdigest()
+        return MagicMock(
+            status_code=201,
+            headers={"Docker-Content-Digest": content_digest},
+            content_type="application/json; charset=utf-8",
+            text=text
+    )
+        
+    async def read():
+        return b'{"hello": "world"}'
+    
+    def json():
+        return {"hello": "world"}
+    
+    async def send_in_get_manifest(request: PipelineRequest, **kwargs) -> MagicMock:
+        content_digest = hashlib.sha256(b"hello world").hexdigest()
+        content_type = "application/vnd.oci.image.manifest.v1+json"
+        return MagicMock(
+            status_code=200,
+            headers={"Docker-Content-Digest": content_digest, "Content-Type": content_type},
+            read=read,
+            json=json
+    )
+        
+    async with ContainerRegistryClient(
+        endpoint=containerregistry_endpoint, transport = MagicMock(send=send_in_set_manifest)
+    ) as client:
+        with pytest.raises(ManifestDigestValidationException) as exp:
+            manifest = {"hello": "world"}
+            await client.set_manifest("test-repo", manifest)
+            assert str(exp.value) == "The digest in the response does not match the digest of the uploaded manifest."
+        
+    async with ContainerRegistryClient(
+        endpoint=containerregistry_endpoint,
+        transport = MagicMock(send=send_in_get_manifest)
+    ) as client:
+        with pytest.raises(ManifestDigestValidationException) as exp:
+            digest = hashlib.sha256(b'{"hello": "world"}').hexdigest()
+            await client.get_manifest("test-repo", digest)
+            assert str(exp.value) == "The requested digest does not match the digest of the received manifest."
+            
+        with pytest.raises(ManifestDigestValidationException) as exp:
+            await client.get_manifest("test-repo", "test-tag")
+            assert str(exp.value) == "The server-computed digest does not match the client-computed digest."

--- a/sdk/containerregistry/azure-containerregistry/tests/test_container_registry_client_async.py
+++ b/sdk/containerregistry/azure-containerregistry/tests/test_container_registry_client_async.py
@@ -11,7 +11,7 @@ import json
 from datetime import datetime
 from io import BytesIO
 from unittest.mock import MagicMock
-from typing import Optional
+from typing import Optional, AsyncIterator, Any, MutableMapping
 from azure.containerregistry import (
     RepositoryProperties,
     ArtifactManifestProperties,
@@ -894,6 +894,7 @@ class TestContainerRegistryClientAsync(AsyncContainerRegistryTestClass):
 @pytest.mark.asyncio
 async def test_manifest_digest_validation():
     containerregistry_endpoint="https://fake_url.azurecr.io"
+    JSON = MutableMapping[str, Any]
     
     def text(encoding: Optional[str] = None) -> str:
         return '{"hello": "world"}'
@@ -907,10 +908,10 @@ async def test_manifest_digest_validation():
             text=text
     )
         
-    async def read():
+    async def read() -> bytes:
         return b'{"hello": "world"}'
     
-    def json():
+    def json() -> JSON:
         return {"hello": "world"}
     
     async def send_in_get_manifest(request: PipelineRequest, **kwargs) -> MagicMock:
@@ -929,17 +930,70 @@ async def test_manifest_digest_validation():
         with pytest.raises(ManifestDigestValidationException) as exp:
             manifest = {"hello": "world"}
             await client.set_manifest("test-repo", manifest)
-            assert str(exp.value) == "The digest in the response does not match the digest of the uploaded manifest."
+        assert str(exp.value) == "The server-computed digest does not match the client-computed digest."
         
     async with ContainerRegistryClient(
         endpoint=containerregistry_endpoint,
         transport = MagicMock(send=send_in_get_manifest)
     ) as client:
         with pytest.raises(ManifestDigestValidationException) as exp:
-            digest = hashlib.sha256(b'{"hello": "world"}').hexdigest()
-            await client.get_manifest("test-repo", digest)
-            assert str(exp.value) == "The requested digest does not match the digest of the received manifest."
+            digest = hashlib.sha256(b"hello world").hexdigest()
+            await client.get_manifest("test-repo", f"sha256:{digest}")
+        assert str(exp.value) == "The requested digest does not match the digest of the received manifest."
             
         with pytest.raises(ManifestDigestValidationException) as exp:
             await client.get_manifest("test-repo", "test-tag")
-            assert str(exp.value) == "The server-computed digest does not match the client-computed digest."
+        assert str(exp.value) == "The server-computed digest does not match the client-computed digest."
+
+@pytest.mark.asyncio
+async def test_blob_digest_validation():
+    containerregistry_endpoint="https://fake_url.azurecr.io"
+    
+    def text(encoding: Optional[str] = None) -> str:
+        return '{"hello": "world"}'
+    
+    async def send_in_upload_blob(request: PipelineRequest, **kwargs) -> MagicMock:
+        if request.method == "PUT":
+            content_digest = hashlib.sha256(b"hello world").hexdigest()
+            return MagicMock(
+                status_code=201,
+                headers={"Docker-Content-Digest": content_digest},
+                content_type="application/json; charset=utf-8",
+                text=text
+            )
+        else:
+            return MagicMock(
+                status_code=202,
+                headers={"Location": "/v2/repo5b2f373f/blobs/uploads/fake_location"},
+                content_type="application/json; charset=utf-8",
+                text=text
+            )
+    
+    async def iter_bytes() -> AsyncIterator[bytes]:
+        yield b'{"hello": "world"}'
+    
+    async def send_in_download_blob(request: PipelineRequest, **kwargs) -> MagicMock:
+        return MagicMock(
+            status_code=206,
+            headers={"Content-Range": "bytes 0-27/28", "Content-Length": "28"},
+            content_type="application/octet-stream",
+            text=text,
+            iter_bytes=iter_bytes
+        )
+        
+    async with ContainerRegistryClient(
+        endpoint=containerregistry_endpoint, transport = MagicMock(send=send_in_upload_blob)
+    ) as client:
+        with pytest.raises(ManifestDigestValidationException) as exp:
+            await client.upload_blob("test-repo", BytesIO(b'{"hello": "world"}'))
+        assert str(exp.value) == "The server-computed digest does not match the client-computed digest."
+        
+    async with ContainerRegistryClient(
+        endpoint=containerregistry_endpoint, transport = MagicMock(send=send_in_download_blob)
+    ) as client:
+        digest = hashlib.sha256(b"hello world").hexdigest()
+        stream = await client.download_blob("test-repo", f"sha256:{digest}")
+        with pytest.raises(ManifestDigestValidationException) as exp:
+            async for chunk in stream:
+                pass
+        assert str(exp.value) == "The requested digest does not match the digest of the received blob."


### PR DESCRIPTION
This PR includes updates in:
- use a custom exception type when validating digests
- add digest validation in `upload_blob()`