### PR TITLE
[Storage] Fix `visibility_timeout` inaccuracy in `receive_message` API

### DIFF
--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_queue_client.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_queue_client.py
@@ -553,9 +553,9 @@ class QueueClient(StorageAccountHostsMixin, StorageEncryptionMixin):
         decrypted before being returned.
 
         :keyword int visibility_timeout:
-            If not specified, the default value is 0. Specifies the
+            If not specified, the default value is 30. Specifies the
             new visibility timeout value, in seconds, relative to server time.
-            The value must be larger than or equal to 0, and cannot be
+            The value must be larger than or equal to 1, and cannot be
             larger than 7 days. The visibility timeout of a message cannot be
             set to a value later than the expiry time. visibility_timeout
             should be set to a value smaller than the time-to-live value.

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/aio/_queue_client_async.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/aio/_queue_client_async.py
@@ -437,9 +437,9 @@ class QueueClient(AsyncStorageAccountHostsMixin, QueueClientBase, StorageEncrypt
         decrypted before being returned.
 
         :keyword int visibility_timeout:
-            If not specified, the default value is 0. Specifies the
+            If not specified, the default value is 30. Specifies the
             new visibility timeout value, in seconds, relative to server time.
-            The value must be larger than or equal to 0, and cannot be
+            The value must be larger than or equal to 1, and cannot be
             larger than 7 days. The visibility timeout of a message cannot be
             set to a value later than the expiry time. visibility_timeout
             should be set to a value smaller than the time-to-live value.


### PR DESCRIPTION
This PR addresses the inaccuracy was resolved in the `receive_messages` API (plural) but not the API for singular messages.