### PR TITLE
[Key Vault] Support AD FS authentication

### DIFF
--- a/sdk/keyvault/azure-keyvault-administration/CHANGELOG.md
+++ b/sdk/keyvault/azure-keyvault-administration/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 4.4.0b1 (2023-05-10)
+## 4.4.0b1 (2023-05-11)
 
 ### Bugs Fixed
 - Token requests made during AD FS authentication no longer specify an erroneous "adfs" tenant ID

--- a/sdk/keyvault/azure-keyvault-administration/CHANGELOG.md
+++ b/sdk/keyvault/azure-keyvault-administration/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 4.3.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 4.4.0b1 (2023-05-10)
 
 ### Bugs Fixed
-
-### Other Changes
+- Token requests made during AD FS authentication no longer specify an erroneous "adfs" tenant ID
+  ([#29888](https://github.com/Azure/azure-sdk-for-python/issues/29888))
 
 ## 4.3.0 (2023-03-16)
 

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/async_challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/async_challenge_auth_policy.py
@@ -86,7 +86,13 @@ class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
 
         body = request.context.pop("key_vault_request_data", None)
         request.http_request.set_text_body(body)  # no-op when text is None
-        await self.authorize_request(request, scope, tenant_id=challenge.tenant_id)
+
+        # The tenant parsed from AD FS challenges is "adfs"; we don't actually need a tenant for AD FS authentication
+        # For AD FS we skip cross-tenant authentication per https://github.com/Azure/azure-sdk-for-python/issues/28648
+        if challenge.tenant_id.lower().endswith("adfs"):
+            await self.authorize_request(request, scope)
+        else:
+            await self.authorize_request(request, scope, tenant_id=challenge.tenant_id)
 
         return True
 

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/async_challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/async_challenge_auth_policy.py
@@ -89,7 +89,7 @@ class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
 
         # The tenant parsed from AD FS challenges is "adfs"; we don't actually need a tenant for AD FS authentication
         # For AD FS we skip cross-tenant authentication per https://github.com/Azure/azure-sdk-for-python/issues/28648
-        if challenge.tenant_id.lower().endswith("adfs"):
+        if challenge.tenant_id and challenge.tenant_id.lower().endswith("adfs"):
             await self.authorize_request(request, scope)
         else:
             await self.authorize_request(request, scope, tenant_id=challenge.tenant_id)

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/challenge_auth_policy.py
@@ -109,7 +109,13 @@ class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
 
         body = request.context.pop("key_vault_request_data", None)
         request.http_request.set_text_body(body)  # no-op when text is None
-        self.authorize_request(request, scope, tenant_id=challenge.tenant_id)
+
+        # The tenant parsed from AD FS challenges is "adfs"; we don't actually need a tenant for AD FS authentication
+        # For AD FS we skip cross-tenant authentication per https://github.com/Azure/azure-sdk-for-python/issues/28648
+        if challenge.tenant_id.lower().endswith("adfs"):
+            self.authorize_request(request, scope)
+        else:
+            self.authorize_request(request, scope, tenant_id=challenge.tenant_id)
 
         return True
 

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/challenge_auth_policy.py
@@ -112,7 +112,7 @@ class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
 
         # The tenant parsed from AD FS challenges is "adfs"; we don't actually need a tenant for AD FS authentication
         # For AD FS we skip cross-tenant authentication per https://github.com/Azure/azure-sdk-for-python/issues/28648
-        if challenge.tenant_id.lower().endswith("adfs"):
+        if challenge.tenant_id and challenge.tenant_id.lower().endswith("adfs"):
             self.authorize_request(request, scope)
         else:
             self.authorize_request(request, scope, tenant_id=challenge.tenant_id)

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_version.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_version.py
@@ -3,4 +3,4 @@
 # Licensed under the MIT License.
 # ------------------------------------
 
-VERSION = "4.3.1"
+VERSION = "4.4.0b1"

--- a/sdk/keyvault/azure-keyvault-administration/setup.py
+++ b/sdk/keyvault/azure-keyvault-administration/setup.py
@@ -44,7 +44,7 @@ setup(
     author_email="azurekeyvault@microsoft.com",
     url="https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/keyvault/azure-keyvault-administration",
     classifiers=[
-        "Development Status :: 5 - Production/Stable",
+        "Development Status :: 4 - Beta",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3 :: Only",
         "Programming Language :: Python :: 3",

--- a/sdk/keyvault/azure-keyvault-certificates/CHANGELOG.md
+++ b/sdk/keyvault/azure-keyvault-certificates/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 4.8.0b1 (2023-05-10)
+## 4.8.0b1 (2023-05-11)
 
 ### Bugs Fixed
 - Token requests made during AD FS authentication no longer specify an erroneous "adfs" tenant ID

--- a/sdk/keyvault/azure-keyvault-certificates/CHANGELOG.md
+++ b/sdk/keyvault/azure-keyvault-certificates/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 4.7.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 4.8.0b1 (2023-05-10)
 
 ### Bugs Fixed
-
-### Other Changes
+- Token requests made during AD FS authentication no longer specify an erroneous "adfs" tenant ID
+  ([#29888](https://github.com/Azure/azure-sdk-for-python/issues/29888))
 
 ## 4.7.0 (2023-03-16)
 

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/async_challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/async_challenge_auth_policy.py
@@ -86,7 +86,13 @@ class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
 
         body = request.context.pop("key_vault_request_data", None)
         request.http_request.set_text_body(body)  # no-op when text is None
-        await self.authorize_request(request, scope, tenant_id=challenge.tenant_id)
+
+        # The tenant parsed from AD FS challenges is "adfs"; we don't actually need a tenant for AD FS authentication
+        # For AD FS we skip cross-tenant authentication per https://github.com/Azure/azure-sdk-for-python/issues/28648
+        if challenge.tenant_id.lower().endswith("adfs"):
+            await self.authorize_request(request, scope)
+        else:
+            await self.authorize_request(request, scope, tenant_id=challenge.tenant_id)
 
         return True
 

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/async_challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/async_challenge_auth_policy.py
@@ -89,7 +89,7 @@ class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
 
         # The tenant parsed from AD FS challenges is "adfs"; we don't actually need a tenant for AD FS authentication
         # For AD FS we skip cross-tenant authentication per https://github.com/Azure/azure-sdk-for-python/issues/28648
-        if challenge.tenant_id.lower().endswith("adfs"):
+        if challenge.tenant_id and challenge.tenant_id.lower().endswith("adfs"):
             await self.authorize_request(request, scope)
         else:
             await self.authorize_request(request, scope, tenant_id=challenge.tenant_id)

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/challenge_auth_policy.py
@@ -109,7 +109,13 @@ class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
 
         body = request.context.pop("key_vault_request_data", None)
         request.http_request.set_text_body(body)  # no-op when text is None
-        self.authorize_request(request, scope, tenant_id=challenge.tenant_id)
+
+        # The tenant parsed from AD FS challenges is "adfs"; we don't actually need a tenant for AD FS authentication
+        # For AD FS we skip cross-tenant authentication per https://github.com/Azure/azure-sdk-for-python/issues/28648
+        if challenge.tenant_id.lower().endswith("adfs"):
+            self.authorize_request(request, scope)
+        else:
+            self.authorize_request(request, scope, tenant_id=challenge.tenant_id)
 
         return True
 

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/challenge_auth_policy.py
@@ -112,7 +112,7 @@ class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
 
         # The tenant parsed from AD FS challenges is "adfs"; we don't actually need a tenant for AD FS authentication
         # For AD FS we skip cross-tenant authentication per https://github.com/Azure/azure-sdk-for-python/issues/28648
-        if challenge.tenant_id.lower().endswith("adfs"):
+        if challenge.tenant_id and challenge.tenant_id.lower().endswith("adfs"):
             self.authorize_request(request, scope)
         else:
             self.authorize_request(request, scope, tenant_id=challenge.tenant_id)

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_version.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_version.py
@@ -3,4 +3,4 @@
 # Licensed under the MIT License.
 # ------------------------------------
 
-VERSION = "4.7.1"
+VERSION = "4.8.0b1"

--- a/sdk/keyvault/azure-keyvault-certificates/setup.py
+++ b/sdk/keyvault/azure-keyvault-certificates/setup.py
@@ -44,7 +44,7 @@ setup(
     author_email="azurekeyvault@microsoft.com",
     url="https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/keyvault/azure-keyvault-certificates",
     classifiers=[
-        "Development Status :: 5 - Production/Stable",
+        "Development Status :: 4 - Beta",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3 :: Only",
         "Programming Language :: Python :: 3",

--- a/sdk/keyvault/azure-keyvault-keys/CHANGELOG.md
+++ b/sdk/keyvault/azure-keyvault-keys/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 4.8.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 4.9.0b1 (2023-05-10)
 
 ### Bugs Fixed
-
-### Other Changes
+- Token requests made during AD FS authentication no longer specify an erroneous "adfs" tenant ID
+  ([#29888](https://github.com/Azure/azure-sdk-for-python/issues/29888))
 
 ## 4.8.0 (2023-03-16)
 

--- a/sdk/keyvault/azure-keyvault-keys/CHANGELOG.md
+++ b/sdk/keyvault/azure-keyvault-keys/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 4.9.0b1 (2023-05-10)
+## 4.9.0b1 (2023-05-11)
 
 ### Bugs Fixed
 - Token requests made during AD FS authentication no longer specify an erroneous "adfs" tenant ID

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/async_challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/async_challenge_auth_policy.py
@@ -86,7 +86,13 @@ class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
 
         body = request.context.pop("key_vault_request_data", None)
         request.http_request.set_text_body(body)  # no-op when text is None
-        await self.authorize_request(request, scope, tenant_id=challenge.tenant_id)
+
+        # The tenant parsed from AD FS challenges is "adfs"; we don't actually need a tenant for AD FS authentication
+        # For AD FS we skip cross-tenant authentication per https://github.com/Azure/azure-sdk-for-python/issues/28648
+        if challenge.tenant_id.lower().endswith("adfs"):
+            await self.authorize_request(request, scope)
+        else:
+            await self.authorize_request(request, scope, tenant_id=challenge.tenant_id)
 
         return True
 

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/async_challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/async_challenge_auth_policy.py
@@ -89,7 +89,7 @@ class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
 
         # The tenant parsed from AD FS challenges is "adfs"; we don't actually need a tenant for AD FS authentication
         # For AD FS we skip cross-tenant authentication per https://github.com/Azure/azure-sdk-for-python/issues/28648
-        if challenge.tenant_id.lower().endswith("adfs"):
+        if challenge.tenant_id and challenge.tenant_id.lower().endswith("adfs"):
             await self.authorize_request(request, scope)
         else:
             await self.authorize_request(request, scope, tenant_id=challenge.tenant_id)

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/challenge_auth_policy.py
@@ -109,7 +109,13 @@ class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
 
         body = request.context.pop("key_vault_request_data", None)
         request.http_request.set_text_body(body)  # no-op when text is None
-        self.authorize_request(request, scope, tenant_id=challenge.tenant_id)
+
+        # The tenant parsed from AD FS challenges is "adfs"; we don't actually need a tenant for AD FS authentication
+        # For AD FS we skip cross-tenant authentication per https://github.com/Azure/azure-sdk-for-python/issues/28648
+        if challenge.tenant_id.lower().endswith("adfs"):
+            self.authorize_request(request, scope)
+        else:
+            self.authorize_request(request, scope, tenant_id=challenge.tenant_id)
 
         return True
 

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/challenge_auth_policy.py
@@ -112,7 +112,7 @@ class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
 
         # The tenant parsed from AD FS challenges is "adfs"; we don't actually need a tenant for AD FS authentication
         # For AD FS we skip cross-tenant authentication per https://github.com/Azure/azure-sdk-for-python/issues/28648
-        if challenge.tenant_id.lower().endswith("adfs"):
+        if challenge.tenant_id and challenge.tenant_id.lower().endswith("adfs"):
             self.authorize_request(request, scope)
         else:
             self.authorize_request(request, scope, tenant_id=challenge.tenant_id)

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_version.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_version.py
@@ -3,4 +3,4 @@
 # Licensed under the MIT License.
 # ------------------------------------
 
-VERSION = "4.8.1"
+VERSION = "4.9.0b1"

--- a/sdk/keyvault/azure-keyvault-keys/setup.py
+++ b/sdk/keyvault/azure-keyvault-keys/setup.py
@@ -44,7 +44,7 @@ setup(
     author_email="azurekeyvault@microsoft.com",
     url="https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/keyvault/azure-keyvault-keys",
     classifiers=[
-        "Development Status :: 5 - Production/Stable",
+        "Development Status :: 4 - Beta",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3 :: Only",
         "Programming Language :: Python :: 3",

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_challenge_auth_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_challenge_auth_async.py
@@ -200,6 +200,62 @@ async def test_tenant():
 
 @pytest.mark.asyncio
 @empty_challenge_cache
+async def test_adfs():
+    """The policy should handle AD FS challenges as a special case and omit the tenant ID from token requests"""
+
+    expected_content = b"a duck"
+
+    async def test_with_challenge(challenge, expected_tenant):
+        expected_token = "expected_token"
+
+        class Requests:
+            count = 0
+
+        async def send(request):
+            Requests.count += 1
+            if Requests.count == 1:
+                # first request should be unauthorized and have no content
+                assert not request.body
+                assert request.headers["Content-Length"] == "0"
+                return challenge
+            elif Requests.count == 2:
+                # second request should be authorized according to challenge and have the expected content
+                assert request.headers["Content-Length"]
+                assert request.body == expected_content
+                assert expected_token in request.headers["Authorization"]
+                return Mock(status_code=200)
+            raise ValueError("unexpected request")
+
+        async def get_token(*_, **kwargs):
+            # we shouldn't provide a tenant ID during AD FS authentication
+            assert "tenant_id" not in kwargs
+            return AccessToken(expected_token, 0)
+
+        credential = Mock(get_token=Mock(wraps=get_token))
+        pipeline = AsyncPipeline(
+            policies=[AsyncChallengeAuthPolicy(credential=credential)], transport=Mock(send=send)
+        )
+        request = HttpRequest("POST", get_random_url())
+        request.set_bytes_body(expected_content)
+        await pipeline.run(request)
+
+        assert credential.get_token.call_count == 1
+
+    tenant = "tenant-id"
+    # AD FS challenges have an unusual authority format; see https://github.com/Azure/azure-sdk-for-python/issues/28648
+    endpoint = f"https://adfs.redmond.azurestack.corp.microsoft.com/adfs/{tenant}"
+    resource = "https://vault.azure.net"
+
+    challenge = Mock(
+        status_code=401,
+        headers={"WWW-Authenticate": f'Bearer authorization="{endpoint}", resource={resource}'},
+    )
+
+    await test_with_challenge(challenge, tenant)
+
+
+@pytest.mark.asyncio
+@empty_challenge_cache
 async def test_policy_updates_cache():
     """
     It's possible for the challenge returned for a request to change, e.g. when a vault is moved to a new tenant.

--- a/sdk/keyvault/azure-keyvault-secrets/CHANGELOG.md
+++ b/sdk/keyvault/azure-keyvault-secrets/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 4.8.0b1 (2023-05-10)
+## 4.8.0b1 (2023-05-11)
 
 ### Bugs Fixed
 - Token requests made during AD FS authentication no longer specify an erroneous "adfs" tenant ID

--- a/sdk/keyvault/azure-keyvault-secrets/CHANGELOG.md
+++ b/sdk/keyvault/azure-keyvault-secrets/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 4.7.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 4.8.0b1 (2023-05-10)
 
 ### Bugs Fixed
-
-### Other Changes
+- Token requests made during AD FS authentication no longer specify an erroneous "adfs" tenant ID
+  ([#29888](https://github.com/Azure/azure-sdk-for-python/issues/29888))
 
 ## 4.7.0 (2023-03-16)
 

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/async_challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/async_challenge_auth_policy.py
@@ -86,7 +86,13 @@ class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
 
         body = request.context.pop("key_vault_request_data", None)
         request.http_request.set_text_body(body)  # no-op when text is None
-        await self.authorize_request(request, scope, tenant_id=challenge.tenant_id)
+
+        # The tenant parsed from AD FS challenges is "adfs"; we don't actually need a tenant for AD FS authentication
+        # For AD FS we skip cross-tenant authentication per https://github.com/Azure/azure-sdk-for-python/issues/28648
+        if challenge.tenant_id.lower().endswith("adfs"):
+            await self.authorize_request(request, scope)
+        else:
+            await self.authorize_request(request, scope, tenant_id=challenge.tenant_id)
 
         return True
 

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/async_challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/async_challenge_auth_policy.py
@@ -89,7 +89,7 @@ class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
 
         # The tenant parsed from AD FS challenges is "adfs"; we don't actually need a tenant for AD FS authentication
         # For AD FS we skip cross-tenant authentication per https://github.com/Azure/azure-sdk-for-python/issues/28648
-        if challenge.tenant_id.lower().endswith("adfs"):
+        if challenge.tenant_id and challenge.tenant_id.lower().endswith("adfs"):
             await self.authorize_request(request, scope)
         else:
             await self.authorize_request(request, scope, tenant_id=challenge.tenant_id)

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/challenge_auth_policy.py
@@ -109,7 +109,13 @@ class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
 
         body = request.context.pop("key_vault_request_data", None)
         request.http_request.set_text_body(body)  # no-op when text is None
-        self.authorize_request(request, scope, tenant_id=challenge.tenant_id)
+
+        # The tenant parsed from AD FS challenges is "adfs"; we don't actually need a tenant for AD FS authentication
+        # For AD FS we skip cross-tenant authentication per https://github.com/Azure/azure-sdk-for-python/issues/28648
+        if challenge.tenant_id.lower().endswith("adfs"):
+            self.authorize_request(request, scope)
+        else:
+            self.authorize_request(request, scope, tenant_id=challenge.tenant_id)
 
         return True
 

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/challenge_auth_policy.py
@@ -112,7 +112,7 @@ class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
 
         # The tenant parsed from AD FS challenges is "adfs"; we don't actually need a tenant for AD FS authentication
         # For AD FS we skip cross-tenant authentication per https://github.com/Azure/azure-sdk-for-python/issues/28648
-        if challenge.tenant_id.lower().endswith("adfs"):
+        if challenge.tenant_id and challenge.tenant_id.lower().endswith("adfs"):
             self.authorize_request(request, scope)
         else:
             self.authorize_request(request, scope, tenant_id=challenge.tenant_id)

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_version.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_version.py
@@ -3,4 +3,4 @@
 # Licensed under the MIT License.
 # ------------------------------------
 
-VERSION = "4.7.1"
+VERSION = "4.8.0b1"

--- a/sdk/keyvault/azure-keyvault-secrets/setup.py
+++ b/sdk/keyvault/azure-keyvault-secrets/setup.py
@@ -44,7 +44,7 @@ setup(
     author_email="azurekeyvault@microsoft.com",
     url="https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/keyvault/azure-keyvault-secrets",
     classifiers=[
-        "Development Status :: 5 - Production/Stable",
+        "Development Status :: 4 - Beta",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3 :: Only",
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
# Description

Resolves https://github.com/Azure/azure-sdk-for-python/issues/29888. This PR takes the CLI team's approach to handling AD FS challenge responses as a special case. When we parse "adfs" as the tenant in a challenge response (as is the case for AD FS interactions, per https://github.com/Azure/azure-sdk-for-python/issues/28648), we now send token requests that omit a `tenant_id` kwarg since AD FS authentication doesn't involve tenant IDs.

This also updates version metadata for the upcoming beta releases that will include this behavior fix 🙂

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
