### PR TITLE
Require `urllib3` version less than 2

### DIFF
--- a/eng/ci_tools.txt
+++ b/eng/ci_tools.txt
@@ -35,7 +35,6 @@ pytest==4.6.9; python_version == '2.7'
 pytest==5.4.2; python_version >= '3.5' and python_version <= '3.9'
 pytest==6.2.4; python_version >= '3.10'
 pytest-cov==2.8.1
-urllib3<2[build]
 
 # local dev packages
 ./tools/azure-devtools

--- a/eng/ci_tools.txt
+++ b/eng/ci_tools.txt
@@ -35,6 +35,7 @@ pytest==4.6.9; python_version == '2.7'
 pytest==5.4.2; python_version >= '3.5' and python_version <= '3.9'
 pytest==6.2.4; python_version >= '3.10'
 pytest-cov==2.8.1
+urllib3<2[build]
 
 # local dev packages
 ./tools/azure-devtools

--- a/tools/azure-sdk-tools/setup.py
+++ b/tools/azure-sdk-tools/setup.py
@@ -20,7 +20,7 @@ DEPENDENCIES = [
     "pyopenssl",
     "python-dotenv",
     "PyYAML",
-    "urllib3",
+    "urllib3<2",
     "tomli"
 ]
 


### PR DESCRIPTION
# Description

See pipeline errors such as https://dev.azure.com/azure-sdk/internal/_build/results?buildId=2745719&view=logs&j=b5f0e079-ce2f-544d-69c8-a3e3e98b9869&t=62526f2c-1909-51fc-76d2-35eacb7ec40e&l=177, caused by using `urllib3` 2.0.1

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
