### PR TITLE
[Monitor] Fix CI latestdepedency check failure

### DIFF
--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/setup.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/setup.py
@@ -86,7 +86,7 @@ setup(
         "msrest>=0.6.10",
         "opentelemetry-api==1.17.0",
         "opentelemetry-sdk==1.17.0",
-        "importlib-metadata>=6.0.0; python_version < '3.8'"
+        "importlib-metadata~=6.0.0; python_version < '3.8'"
     ],
     entry_points={
         "opentelemetry_traces_exporter": [
@@ -103,4 +103,3 @@ setup(
         ]
     }
 )
-


### PR DESCRIPTION
The `python - monitor` automated runs have been failing recently due to a failure in the `latestdependency` check in `azure-monitor-opentelemetry-exporter`.

Error:
```
ERROR: Cannot install importlib-metadata==6.6.0 and opentelemetry-api==1.17.0 because these package versions have conflicting dependencies.

The conflict is caused by:
    The user requested importlib-metadata==6.6.0
    opentelemetry-api 1.17.0 depends on importlib-metadata~=6.0.0

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip attempt to solve the dependency conflict

ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/user_guide/#fixing-conflicting-dependencies
```
From [sample pipeline failure](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=2747375&view=logs&j=11a651e3-713b-5092-386c-1f3b6f7ebbbd&t=6fbf28f9-d2de-5c6e-ba72-80f998604aaa&l=2648).

This makes the versioning with the importlib-metadata package consistent with opentelemetry-api to avoid conflicts. Eventually, this dependency can  just be dropped after we drop support for Python 3.7 (which is EOL next month).

Ref: [OTel API dependency](https://github.com/open-telemetry/opentelemetry-python/blob/main/opentelemetry-api/pyproject.toml#L32)
