### PR TITLE
[ML] Fix auto delete setting comparison bug in Asset

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_assets/asset.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_assets/asset.py
@@ -120,7 +120,7 @@ class Asset(Resource):
             and self.base_path == other.base_path
             and self._is_anonymous == other._is_anonymous
             and self._auto_increment_version == other._auto_increment_version
-            and self.auto_delete_setting == other._auto_delete_setting
+            and self.auto_delete_setting == other.auto_delete_setting
         )
 
     def __ne__(self, other) -> bool:

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_assets/auto_delete_setting.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_assets/auto_delete_setting.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-from typing import Any
+from typing import Any, Union
 from azure.ai.ml._utils._experimental import experimental
 from azure.ai.ml.constants._common import AutoDeleteCondition
 from azure.ai.ml.entities._mixins import DictMixin
@@ -19,7 +19,12 @@ class AutoDeleteSetting(DictMixin):
     :type value: str
     """
 
-    def __init__(self, *, condition: AutoDeleteCondition = AutoDeleteCondition.CREATED_GREATER_THAN, value: str = None):
+    def __init__(
+        self,
+        *,
+        condition: AutoDeleteCondition = AutoDeleteCondition.CREATED_GREATER_THAN,
+        value: Union[str, None] = None
+    ):
         self.condition = condition
         self.value = value
 

--- a/sdk/ml/azure-ai-ml/tests/test_configs/dataset/data_with_auto_delete_setting.yml
+++ b/sdk/ml/azure-ai-ml/tests/test_configs/dataset/data_with_auto_delete_setting.yml
@@ -1,0 +1,8 @@
+name: testDataAssetfolder
+version: 1
+description: "this is a test data asset with auto delete setting"
+path: azureml://datastores/workspacemanageddatastore/
+
+auto_delete_setting:
+  condition: created_greater_than
+  value: 30d

--- a/sdk/ml/azure-ai-ml/tests/test_configs/dataset/data_without_auto_delete_setting.yml
+++ b/sdk/ml/azure-ai-ml/tests/test_configs/dataset/data_without_auto_delete_setting.yml
@@ -1,0 +1,4 @@
+name: testDataAssetfolder
+version: 1
+description: "this is a test data asset without auto delete setting"
+path: azureml://datastores/workspacemanageddatastore/


### PR DESCRIPTION
# Description

- Fix auto delete setting comparison in Asset.
- Add a unit test for it.

Please add an informative description that covers that changes made by the pull request and link all relevant issues.

If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
