### PR TITLE
[Identity] Rename arguments

### DIFF
--- a/sdk/identity/azure-identity/CHANGELOG.md
+++ b/sdk/identity/azure-identity/CHANGELOG.md
@@ -4,14 +4,13 @@
 
 ### Features Added
 
-- Changed parameter from `disable_instance_discovery` to `disable_authority_validation_and_instance_discovery` to make it more explicit.
-
 ### Breaking Changes
 
 > These changes do not impact the API of stable versions such as 1.12.0.
 > Only code written against a beta version such as 1.13.0b4 may be affected.
 - Windows Web Account Manager (WAM) Brokered Authentication is still in preview and not available in this release. It will be available in the next beta release.
 - Additional Continuous Access Evaluation (CAE) support for service principal credentials is still in preview and not available in this release. It will be available in the next beta release.
+- Renamed keyword argument `developer_credential_timeout` to `process_timeout` in `DefaultAzureCredential` to remain consistent with the other credentials that launch a subprocess to acquire tokens.
 
 
 ### Bugs Fixed

--- a/sdk/identity/azure-identity/azure/identity/_credentials/browser.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/browser.py
@@ -39,9 +39,13 @@ class InteractiveBrowserCredential(InteractiveCredential):
         will cache tokens in memory.
     :paramtype cache_persistence_options: ~azure.identity.TokenCachePersistenceOptions
     :keyword int timeout: seconds to wait for the user to complete authentication. Defaults to 300 (5 minutes).
-    :keyword bool disable_authority_validation_and_instance_discovery: Determines whether or not instance discovery
-        is performed when attempting to authenticate. Setting this to true will completely disable instance discovery
-        and authority validation.
+    :keyword bool disable_instance_discovery: Determines whether or not instance discovery is performed when attempting
+        to authenticate. Setting this to true will completely disable both instance discovery and authority validation.
+        This functionality is intended for use in scenarios where the metadata endpoint cannot be reached, such as in
+        private clouds or Azure Stack. The process of instance discovery entails retrieving authority metadata from
+        https://login.microsoft.com/ to validate the authority. By setting this to **True**, the validation of the
+        authority is disabled. As a result, it is crucial to ensure that the configured authority host is valid and
+        trustworthy.
     :raises ValueError: invalid **redirect_uri**
 
     .. admonition:: Example:

--- a/sdk/identity/azure-identity/azure/identity/_credentials/certificate.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/certificate.py
@@ -41,9 +41,13 @@ class CertificateCredential(ClientCredentialBase):
     :keyword cache_persistence_options: Configuration for persistent token caching. If unspecified, the credential
         will cache tokens in memory.
     :paramtype cache_persistence_options: ~azure.identity.TokenCachePersistenceOptions
-    :keyword bool disable_authority_validation_and_instance_discovery: Determines whether or not instance discovery
-        is performed when attempting to authenticate. Setting this to true will completely disable instance discovery
-        and authority validation.
+    :keyword bool disable_instance_discovery: Determines whether or not instance discovery is performed when attempting
+        to authenticate. Setting this to true will completely disable both instance discovery and authority validation.
+        This functionality is intended for use in scenarios where the metadata endpoint cannot be reached, such as in
+        private clouds or Azure Stack. The process of instance discovery entails retrieving authority metadata from
+        https://login.microsoft.com/ to validate the authority. By setting this to **True**, the validation of the
+        authority is disabled. As a result, it is crucial to ensure that the configured authority host is valid and
+        trustworthy.
     :keyword List[str] additionally_allowed_tenants: Specifies tenants in addition to the specified "tenant_id"
         for which the credential may acquire tokens. Add the wildcard value "*" to allow the credential to
         acquire tokens for any tenant the application can access.

--- a/sdk/identity/azure-identity/azure/identity/_credentials/client_secret.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/client_secret.py
@@ -19,9 +19,13 @@ class ClientSecretCredential(ClientCredentialBase):
     :keyword cache_persistence_options: Configuration for persistent token caching. If unspecified, the credential
         will cache tokens in memory.
     :paramtype cache_persistence_options: ~azure.identity.TokenCachePersistenceOptions
-    :keyword bool disable_authority_validation_and_instance_discovery: Determines whether or not instance discovery
-        is performed when attempting to authenticate. Setting this to true will completely disable instance discovery
-        and authority validation.
+    :keyword bool disable_instance_discovery: Determines whether or not instance discovery is performed when attempting
+        to authenticate. Setting this to true will completely disable both instance discovery and authority validation.
+        This functionality is intended for use in scenarios where the metadata endpoint cannot be reached, such as in
+        private clouds or Azure Stack. The process of instance discovery entails retrieving authority metadata from
+        https://login.microsoft.com/ to validate the authority. By setting this to **True**, the validation of the
+        authority is disabled. As a result, it is crucial to ensure that the configured authority host is valid and
+        trustworthy.
     :keyword List[str] additionally_allowed_tenants: Specifies tenants in addition to the specified "tenant_id"
         for which the credential may acquire tokens. Add the wildcard value "*" to allow the credential to
         acquire tokens for any tenant the application can access.

--- a/sdk/identity/azure-identity/azure/identity/_credentials/device_code.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/device_code.py
@@ -47,9 +47,13 @@ class DeviceCodeCredential(InteractiveCredential):
     :keyword cache_persistence_options: configuration for persistent token caching. If unspecified, the credential
         will cache tokens in memory.
     :paramtype cache_persistence_options: ~azure.identity.TokenCachePersistenceOptions
-    :keyword bool disable_authority_validation_and_instance_discovery: Determines whether or not instance discovery
-        is performed when attempting to authenticate. Setting this to true will completely disable instance discovery
-        and authority validation.
+    :keyword bool disable_instance_discovery: Determines whether or not instance discovery is performed when attempting
+        to authenticate. Setting this to true will completely disable both instance discovery and authority validation.
+        This functionality is intended for use in scenarios where the metadata endpoint cannot be reached, such as in
+        private clouds or Azure Stack. The process of instance discovery entails retrieving authority metadata from
+        https://login.microsoft.com/ to validate the authority. By setting this to **True**, the validation of the
+        authority is disabled. As a result, it is crucial to ensure that the configured authority host is valid and
+        trustworthy.
 
     .. admonition:: Example:
 

--- a/sdk/identity/azure-identity/azure/identity/_credentials/on_behalf_of.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/on_behalf_of.py
@@ -44,9 +44,13 @@ class OnBehalfOfCredential(MsalCredential, GetTokenMixin):
         is a unicode string, it will be encoded as UTF-8. If the certificate requires a different encoding, pass
         appropriately encoded bytes instead.
     :paramtype password: str or bytes
-    :keyword bool disable_authority_validation_and_instance_discovery: Determines whether or not instance discovery
-        is performed when attempting to authenticate. Setting this to true will completely disable instance discovery
-        and authority validation.
+    :keyword bool disable_instance_discovery: Determines whether or not instance discovery is performed when attempting
+        to authenticate. Setting this to true will completely disable both instance discovery and authority validation.
+        This functionality is intended for use in scenarios where the metadata endpoint cannot be reached, such as in
+        private clouds or Azure Stack. The process of instance discovery entails retrieving authority metadata from
+        https://login.microsoft.com/ to validate the authority. By setting this to **True**, the validation of the
+        authority is disabled. As a result, it is crucial to ensure that the configured authority host is valid and
+        trustworthy.
     :keyword List[str] additionally_allowed_tenants: Specifies tenants in addition to the specified "tenant_id"
         for which the credential may acquire tokens. Add the wildcard value "*" to allow the credential to
         acquire tokens for any tenant the application can access.

--- a/sdk/identity/azure-identity/azure/identity/_credentials/user_password.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/user_password.py
@@ -34,9 +34,13 @@ class UsernamePasswordCredential(InteractiveCredential):
     :keyword cache_persistence_options: Configuration for persistent token caching. If unspecified, the credential
         will cache tokens in memory.
     :paramtype cache_persistence_options: ~azure.identity.TokenCachePersistenceOptions
-    :keyword bool disable_authority_validation_and_instance_discovery: Determines whether or not instance discovery
-        is performed when attempting to authenticate. Setting this to true will completely disable instance discovery
-        and authority validation.
+    :keyword bool disable_instance_discovery: Determines whether or not instance discovery is performed when attempting
+        to authenticate. Setting this to true will completely disable both instance discovery and authority validation.
+        This functionality is intended for use in scenarios where the metadata endpoint cannot be reached, such as in
+        private clouds or Azure Stack. The process of instance discovery entails retrieving authority metadata from
+        https://login.microsoft.com/ to validate the authority. By setting this to **True**, the validation of the
+        authority is disabled. As a result, it is crucial to ensure that the configured authority host is valid and
+        trustworthy.
     :keyword List[str] additionally_allowed_tenants: Specifies tenants in addition to the specified "tenant_id"
         for which the credential may acquire tokens. Add the wildcard value "*" to allow the credential to
         acquire tokens for any tenant the application can access.

--- a/sdk/identity/azure-identity/azure/identity/_internal/msal_credentials.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/msal_credentials.py
@@ -24,12 +24,12 @@ class MsalCredential:   # pylint: disable=too-many-instance-attributes
             additionally_allowed_tenants: Optional[List[str]] = None,
             # allow_broker: Optional[bool] = None,
             authority: Optional[str] = None,
-            disable_authority_validation_and_instance_discovery: Optional[bool] = None,
+            disable_instance_discovery: Optional[bool] = None,
             tenant_id: Optional[str] = None,
             **kwargs
     ) -> None:
-        self._instance_discovery = None if disable_authority_validation_and_instance_discovery is None\
-            else not disable_authority_validation_and_instance_discovery
+        self._instance_discovery = None if disable_instance_discovery is None\
+            else not disable_instance_discovery
         self._authority = normalize_authority(authority) if authority else get_default_authority()
         self._regional_authority = os.environ.get(EnvironmentVariables.AZURE_REGIONAL_AUTHORITY_NAME)
         if self._regional_authority and self._regional_authority.lower() in ["tryautodetect", "true"]:

--- a/sdk/identity/azure-identity/tests/test_device_code_credential.py
+++ b/sdk/identity/azure-identity/tests/test_device_code_credential.py
@@ -203,7 +203,7 @@ def test_device_code_credential():
 
     callback = Mock()
     credential = DeviceCodeCredential(
-        client_id=client_id, prompt_callback=callback, transport=transport, disable_authority_validation_and_instance_discovery=True,
+        client_id=client_id, prompt_callback=callback, transport=transport, disable_instance_discovery=True,
     )
 
     now = datetime.datetime.utcnow()
@@ -259,7 +259,7 @@ def test_tenant_id():
 
     callback = Mock()
     credential = DeviceCodeCredential(
-        client_id=client_id, prompt_callback=callback, transport=transport, disable_authority_validation_and_instance_discovery=True, additionally_allowed_tenants=['*']
+        client_id=client_id, prompt_callback=callback, transport=transport, disable_instance_discovery=True, additionally_allowed_tenants=['*']
     )
 
     now = datetime.datetime.utcnow()
@@ -274,7 +274,7 @@ def test_timeout():
         msal_app.initiate_device_flow.return_value = flow
         msal_app.acquire_token_by_device_flow.return_value = {"error": "authorization_pending"}
 
-        credential = DeviceCodeCredential(client_id="_", timeout=1, disable_authority_validation_and_instance_discovery=True)
+        credential = DeviceCodeCredential(client_id="_", timeout=1, disable_instance_discovery=True)
         with pytest.raises(ClientAuthenticationError) as ex:
             credential.get_token("scope")
         assert "timed out" in ex.value.message.lower()

--- a/sdk/identity/azure-identity/tests/test_instance_discovery.py
+++ b/sdk/identity/azure-identity/tests/test_instance_discovery.py
@@ -8,14 +8,14 @@ from azure.identity._internal.msal_credentials import MsalCredential
 def test_instance_discovery():
     credential = MsalCredential(
         client_id="CLIENT_ID",
-        disable_authority_validation_and_instance_discovery=True,
+        disable_instance_discovery=True,
     )
     app = credential._get_app()
     assert not app._instance_discovery
 
     credential = MsalCredential(
         client_id="CLIENT_ID",
-        disable_authority_validation_and_instance_discovery=False,
+        disable_instance_discovery=False,
     )
     app = credential._get_app()
     assert app._instance_discovery

--- a/sdk/identity/azure-identity/tests/test_username_password_credential.py
+++ b/sdk/identity/azure-identity/tests/test_username_password_credential.py
@@ -111,7 +111,7 @@ def test_username_password_credential():
         username="user@azure",
         password="secret_password",
         transport=transport,
-        disable_authority_validation_and_instance_discovery=True,  # kwargs are passed to MSAL; this one prevents an AAD verification request
+        disable_instance_discovery=True,  # kwargs are passed to MSAL; this one prevents an AAD verification request
     )
 
     token = credential.get_token("scope")


### PR DESCRIPTION
Based on archboard discussion, `developer_credential_timeout` is renamed to `process_timeout` and
`disable_authority_validation_and_instance_discovery` is renamed back to `disable_instance_discovery`.

Docstring for `disable_instance_discovery` was also updated to  be more informative and consistent with .NET.
