### PR TITLE
fix: Support `unknown` artifiact OS and arch in container manifests

### DIFF
--- a/sdk/containerregistry/azure-containerregistry/azure/containerregistry/_models.py
+++ b/sdk/containerregistry/azure-containerregistry/azure/containerregistry/_models.py
@@ -34,6 +34,7 @@ class ArtifactArchitecture(str, Enum, metaclass=CaseInsensitiveEnumMeta):
     RISCV64 = "riscv64"
     S390X = "s390x"
     WASM = "wasm"
+    UNKNOWN = "unknown"
 
 
 class ArtifactOperatingSystem(str, Enum, metaclass=CaseInsensitiveEnumMeta):
@@ -51,6 +52,7 @@ class ArtifactOperatingSystem(str, Enum, metaclass=CaseInsensitiveEnumMeta):
     PLAN9 = "plan9"
     SOLARIS = "solaris"
     WINDOWS = "windows"
+    UNKNOWN = "unknown"
 
 
 class ArtifactManifestProperties(object):  # pylint: disable=too-many-instance-attributes


### PR DESCRIPTION
# Description

This new value for artifact OS and architecture were introduced with buildX v0.10.0 when attestations were added to the manifests.

# All SDK Contribution checklist:
- [X] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
