### PR TITLE
[ML] [Pipelines] perf optimization: resolve all leaf node concurrently

### DIFF
--- a/sdk/ml/azure-ai-ml/tests/test_configs/components/helloworld_multi_layer_pipeline_component.yml
+++ b/sdk/ml/azure-ai-ml/tests/test_configs/components/helloworld_multi_layer_pipeline_component.yml
@@ -1,0 +1,51 @@
+$schema: https://azuremlschemas.azureedge.net/development/pipelineComponent.schema.json
+type: pipeline
+
+name: helloworld_pipeline_component
+display_name: Hello World Pipeline Component
+description: This is the basic pipeline component
+tags:
+  tag: tagvalue
+  owner: sdkteam
+
+version: 1
+
+inputs:
+  component_in_number:
+    description: A number for pipeline component
+    type: number
+    default: 10.99
+    optional: True
+  component_in_path:
+    description: A path for pipeline component
+    type: uri_folder
+outputs:
+  nested_output:
+    type: uri_folder
+  nested_output2:
+    type: uri_folder
+
+
+jobs:
+  pipeline_component_1:
+    type: pipeline
+    component: ./helloworld_nested_pipeline_component.yml
+    inputs:
+      component_in_path: ${{parent.inputs.component_in_path}}
+    outputs:
+      component_out_path: ${{parent.outputs.nested_output}}
+
+  pipeline_component_2:
+    type: pipeline
+    component: ./helloworld_pipeline_component.yml
+    inputs:
+      component_in_path: ${{parent.inputs.component_in_path}}
+    outputs:
+      output_path: ${{parent.outputs.nested_output2}}
+
+  command_component:
+    type: command
+    component: ./helloworld_component.yml
+    inputs:
+      component_in_number: ${{parent.inputs.component_in_number}}
+      component_in_path: ${{parent.inputs.component_in_path}}


### PR DESCRIPTION
# Description

update the function to divide nodes in a pipeline component into layers and put all leaf nodes (potentially involve slow operations like IO, file uploading and artifact downloading) at the last layer.

In this way, all slow operations can be done concurrently so improve the overall performance.

L2 first submission perf: 446s =>320s

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
