### PR TITLE
[Servicebus] Improve span context propagation

### DIFF
--- a/sdk/servicebus/azure-servicebus/CHANGELOG.md
+++ b/sdk/servicebus/azure-servicebus/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+- Tracing: span links on receive/send spans now fall back to using `Diagnostic-Id` if the `traceparent` message application property is not found.
+
 ## 7.10.0 (2023-05-09)
 
 Version 7.10.0 is our first stable release of the Azure Service Bus client library based on a pure Python implemented AMQP stack.

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_common/tracing.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_common/tracing.py
@@ -218,8 +218,8 @@ def get_receive_links(messages: Union[ReceiveMessageTypes, Iterable[ReceiveMessa
         for message in trace_messages:
             if message.application_properties:
                 headers = {}
-
-                traceparent = message.application_properties.get(TRACE_PARENT_PROPERTY, b"")
+                traceparent = (message.application_properties.get(TRACE_PARENT_PROPERTY, b"") or
+                               message.application_properties.get(TRACE_DIAGNOSTIC_ID_PROPERTY, b""))
                 if hasattr(traceparent, "decode"):
                     traceparent = traceparent.decode(TRACE_PROPERTY_ENCODING)
                 if traceparent:
@@ -260,7 +260,8 @@ def get_span_link_from_message(message: Union[uamqp_Message, pyamqp_Message, Ser
     headers = {}
     try:
         if message.application_properties:
-            traceparent = message.application_properties.get(TRACE_PARENT_PROPERTY, b"")
+            traceparent = (message.application_properties.get(TRACE_PARENT_PROPERTY, b"") or
+                           message.application_properties.get(TRACE_DIAGNOSTIC_ID_PROPERTY, b""))
             if hasattr(traceparent, "decode"):
                 traceparent = traceparent.decode(TRACE_PROPERTY_ENCODING)
             if traceparent:


### PR DESCRIPTION
When creating span links, this adds a fallback to check for `Diagnostic-Id` if for some reason `traceparent` doesn't exist when extracting trace context in message application properties. Potentially useful when the messages are sent using an older client that doesn't yet populate the `traceparent` application properties.
