### PR TITLE
[formrecognizer] Fix formula tests

### DIFF
--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_prebuilt_read.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_prebuilt_read.py
@@ -35,12 +35,12 @@ class TestDACAnalyzeRead(FormRecognizerTest):
         assert result.pages[0].formulas[0].value
         assert result.pages[0].formulas[0].polygon
         assert result.pages[0].formulas[0].span
-        assert result.pages[0].formulas[0].confidence > 0.8
+        assert result.pages[0].formulas[0].confidence
         assert result.pages[0].formulas[1].kind == "display"
         assert result.pages[0].formulas[1].value
         assert result.pages[0].formulas[1].polygon
         assert result.pages[0].formulas[1].span
-        assert result.pages[0].formulas[1].confidence > 0.8
+        assert result.pages[0].formulas[1].confidence
 
     @skip_flaky_test
     @FormRecognizerPreparer()

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_prebuilt_read.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_prebuilt_read.py
@@ -35,12 +35,12 @@ class TestDACAnalyzeRead(FormRecognizerTest):
         assert result.pages[0].formulas[0].value
         assert result.pages[0].formulas[0].polygon
         assert result.pages[0].formulas[0].span
-        assert result.pages[0].formulas[0].confidence
+        assert result.pages[0].formulas[0].confidence is not None
         assert result.pages[0].formulas[1].kind == "display"
         assert result.pages[0].formulas[1].value
         assert result.pages[0].formulas[1].polygon
         assert result.pages[0].formulas[1].span
-        assert result.pages[0].formulas[1].confidence
+        assert result.pages[0].formulas[1].confidence is not None
 
     @skip_flaky_test
     @FormRecognizerPreparer()

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_prebuilt_read_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_prebuilt_read_async.py
@@ -36,12 +36,12 @@ class TestDACAnalyzeReadAsync(AsyncFormRecognizerTest):
         assert result.pages[0].formulas[0].value
         assert result.pages[0].formulas[0].polygon
         assert result.pages[0].formulas[0].span
-        assert result.pages[0].formulas[0].confidence
+        assert result.pages[0].formulas[0].confidence is not None
         assert result.pages[0].formulas[1].kind == "display"
         assert result.pages[0].formulas[1].value
         assert result.pages[0].formulas[1].polygon
         assert result.pages[0].formulas[1].span
-        assert result.pages[0].formulas[1].confidence
+        assert result.pages[0].formulas[1].confidence is not None
 
     @skip_flaky_test
     @FormRecognizerPreparer()

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_prebuilt_read_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dac_analyze_prebuilt_read_async.py
@@ -36,12 +36,12 @@ class TestDACAnalyzeReadAsync(AsyncFormRecognizerTest):
         assert result.pages[0].formulas[0].value
         assert result.pages[0].formulas[0].polygon
         assert result.pages[0].formulas[0].span
-        assert result.pages[0].formulas[0].confidence > 0.8
+        assert result.pages[0].formulas[0].confidence
         assert result.pages[0].formulas[1].kind == "display"
         assert result.pages[0].formulas[1].value
         assert result.pages[0].formulas[1].polygon
         assert result.pages[0].formulas[1].span
-        assert result.pages[0].formulas[1].confidence > 0.8
+        assert result.pages[0].formulas[1].confidence
 
     @skip_flaky_test
     @FormRecognizerPreparer()


### PR DESCRIPTION
The confidence for formula tests is not steady and causes an issue with the confidence check. Switching to only checking that there is a confidence to improve live tests.