### PR TITLE
CodeCov uses package namespace

### DIFF
--- a/scripts/devops_tasks/common_tasks.py
+++ b/scripts/devops_tasks/common_tasks.py
@@ -9,19 +9,14 @@
 # package targeting during release.
 
 import glob
-from subprocess import check_call, CalledProcessError, Popen
 import os
 import errno
-import shutil
 import sys
 import logging
-import ast
-import textwrap
-import io
-import re
-import fnmatch
-import platform
-from typing import Tuple, Iterable
+
+from subprocess import check_call, CalledProcessError, Popen
+from argparse import Namespace
+from typing import Iterable
 
 # Assumes the presence of setuptools
 from pkg_resources import parse_version, parse_requirements, Requirement, WorkingSet, working_set
@@ -36,7 +31,6 @@ from ci_tools.parsing import parse_require, ParsedSetup
 
 DEV_REQ_FILE = "dev_requirements.txt"
 NEW_DEV_REQ_FILE = "new_dev_requirements.txt"
-
 
 logging.getLogger().setLevel(logging.INFO)
 
@@ -105,18 +99,18 @@ def run_check_call(
 
 
 # This function generates code coverage parameters
-def create_code_coverage_params(parsed_args, package_name):
+def create_code_coverage_params(parsed_args: Namespace, package_path: str):
     coverage_args = []
     if parsed_args.disablecov:
         logging.info("Code coverage disabled as per the flag(--disablecov)")
         coverage_args.append("--no-cov")
     else:
-        current_package_name = package_name.replace("-", ".")
-        coverage_args.append("--cov={}".format(current_package_name))
+        namespace = ParsedSetup.from_path(package_path).namespace
+        coverage_args.append("--cov={}".format(namespace))
         coverage_args.append("--cov-append")
         logging.info(
             "Code coverage is enabled for package {0}, pytest arguements: {1}".format(
-                current_package_name, coverage_args
+                namespace, coverage_args
             )
         )
     return coverage_args

--- a/scripts/devops_tasks/setup_execute_tests.py
+++ b/scripts/devops_tasks/setup_execute_tests.py
@@ -121,7 +121,7 @@ def run_tests(targeted_packages, test_output_location, test_res, parsed_args):
         local_command_array = command_array[:]
 
         # Get code coverage params for current package
-        coverage_commands = create_code_coverage_params(parsed_args, package_name)
+        coverage_commands = create_code_coverage_params(parsed_args, target_package)
         # Create local copy of params to pass to execute
         local_command_array.extend(coverage_commands)
 

--- a/scripts/devops_tasks/tox_harness.py
+++ b/scripts/devops_tasks/tox_harness.py
@@ -264,7 +264,7 @@ def prep_and_run_tox(targeted_packages: List[str], parsed_args: Namespace, optio
 
         # Get code coverage params for current package
         package_name = os.path.basename(package_dir)
-        coverage_commands = create_code_coverage_params(parsed_args, package_name)
+        coverage_commands = create_code_coverage_params(parsed_args, package_dir)
         local_options_array.extend(coverage_commands)
 
         pkg_egg_info_name = "{}.egg-info".format(package_name.replace("-", "_"))


### PR DESCRIPTION
For `azure-storage-file-share` and `azure-storage-file-datalake`

The reason for the missing modules was because we were not using a well-founded `namespace` from our package metadata function. 

```python
# BEFORE
argument_to_pytest="--cov=azure.storage.file.share"

# AFTER
argument_to_pytest="--cov=azure.storage.fileshare"
```

Telling coverage to watch module X and then testing against module Y is a good way to get 0 coverage data 👍 

Resolves #30295
