### PR TITLE
[Key Vault] Prevent errors caused by setting update challenge authentication bug

### DIFF
--- a/sdk/keyvault/azure-keyvault-administration/CHANGELOG.md
+++ b/sdk/keyvault/azure-keyvault-administration/CHANGELOG.md
@@ -1,10 +1,12 @@
 # Release History
 
-## 4.4.0b1 (2023-05-11)
+## 4.4.0b1 (2023-05-15)
 
 ### Bugs Fixed
 - Token requests made during AD FS authentication no longer specify an erroneous "adfs" tenant ID
   ([#29888](https://github.com/Azure/azure-sdk-for-python/issues/29888))
+- Newly-created `KeyVaultSettingsClient`s that call `update_setting` no longer cause erroneous "No content provided"
+  errors ([#30382](https://github.com/Azure/azure-sdk-for-python/issues/30382))
 
 ## 4.3.0 (2023-03-16)
 

--- a/sdk/keyvault/azure-keyvault-administration/assets.json
+++ b/sdk/keyvault/azure-keyvault-administration/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "python",
   "TagPrefix": "python/keyvault/azure-keyvault-administration",
-  "Tag": "python/keyvault/azure-keyvault-administration_f6e776f55f"
+  "Tag": "python/keyvault/azure-keyvault-administration_0e9a37d41c"
 }

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_settings_client.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_settings_client.py
@@ -80,7 +80,7 @@ class KeyVaultSettingsClient(KeyVaultClientBase):
             # `get_setting` is just used to prompt a challenge; we don't want to stop on any errors it may raise
             try:
                 self._client.get_setting(vault_base_url=self._vault_url, setting_name=setting.name, **kwargs)
-            except:
+            except Exception:  # pylint:disable=broad-except
                 pass
 
         parameters = UpdateSettingRequest(value=setting.value)

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_settings_client.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_settings_client.py
@@ -77,11 +77,7 @@ class KeyVaultSettingsClient(KeyVaultClientBase):
         # (Note: we prompt a challenge instead of fetching a token directly so the token has correct permissions)
         challenge_cached = HttpChallengeCache.get_challenge_for_url(self._vault_url)
         if not challenge_cached:
-            # `get_setting` is just used to prompt a challenge; we don't want to stop on any errors it may raise
-            try:
-                self._client.get_setting(vault_base_url=self._vault_url, setting_name=setting.name, **kwargs)
-            except Exception:  # pylint:disable=broad-except
-                pass
+            self._client.get_setting(vault_base_url=self._vault_url, setting_name=setting.name, **kwargs)
 
         parameters = UpdateSettingRequest(value=setting.value)
         result = self._client.update_setting(

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_settings_client.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_settings_client.py
@@ -6,7 +6,7 @@ from azure.core.paging import ItemPaged
 from azure.core.tracing.decorator import distributed_trace
 
 from ._generated_models import UpdateSettingRequest
-from ._internal import KeyVaultClientBase
+from ._internal import HttpChallengeCache, KeyVaultClientBase
 from ._models import KeyVaultSetting
 
 
@@ -72,6 +72,17 @@ class KeyVaultSettingsClient(KeyVaultClientBase):
         :rtype: ~azure.keyvault.administration.KeyVaultSetting
         :raises: :class:`~azure.core.exceptions.HttpResponseError`
         """
+        # Challenge authentication doesn't work as expected with this method's request endpoint
+        # If we need to prompt an auth challenge, do so using `get_setting` instead
+        # (Note: we prompt a challenge instead of fetching a token directly so the token has correct permissions)
+        challenge_cached = HttpChallengeCache.get_challenge_for_url(self._vault_url)
+        if not challenge_cached:
+            # `get_setting` is just used to prompt a challenge; we don't want to stop on any errors it may raise
+            try:
+                self._client.get_setting(vault_base_url=self._vault_url, setting_name=setting.name, **kwargs)
+            except:
+                pass
+
         parameters = UpdateSettingRequest(value=setting.value)
         result = self._client.update_setting(
             vault_base_url=self._vault_url,

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/aio/_settings_client.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/aio/_settings_client.py
@@ -83,7 +83,7 @@ class KeyVaultSettingsClient(AsyncKeyVaultClientBase):
             # `get_setting` is just used to prompt a challenge; we don't want to stop on any errors it may raise
             try:
                 await self._client.get_setting(vault_base_url=self._vault_url, setting_name=setting.name, **kwargs)
-            except:
+            except Exception:  # pylint:disable=broad-except
                 pass
 
         parameters = UpdateSettingRequest(value=setting.value)

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/aio/_settings_client.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/aio/_settings_client.py
@@ -80,11 +80,7 @@ class KeyVaultSettingsClient(AsyncKeyVaultClientBase):
         # (Note: we prompt a challenge instead of fetching a token directly so the token has correct permissions)
         challenge_cached = HttpChallengeCache.get_challenge_for_url(self._vault_url)
         if not challenge_cached:
-            # `get_setting` is just used to prompt a challenge; we don't want to stop on any errors it may raise
-            try:
-                await self._client.get_setting(vault_base_url=self._vault_url, setting_name=setting.name, **kwargs)
-            except Exception:  # pylint:disable=broad-except
-                pass
+            await self._client.get_setting(vault_base_url=self._vault_url, setting_name=setting.name, **kwargs)
 
         parameters = UpdateSettingRequest(value=setting.value)
         result = await self._client.update_setting(

--- a/sdk/keyvault/azure-keyvault-administration/tests/test_settings_client.py
+++ b/sdk/keyvault/azure-keyvault-administration/tests/test_settings_client.py
@@ -5,8 +5,8 @@
 import pytest
 
 from azure.keyvault.administration import KeyVaultSetting, KeyVaultSettingsClient, KeyVaultSettingType
-from azure.keyvault.administration._internal.client_base import DEFAULT_VERSION
 from azure.keyvault.administration._internal import HttpChallengeCache
+from azure.keyvault.administration._internal.client_base import DEFAULT_VERSION
 
 from devtools_testutils import recorded_by_proxy
 
@@ -34,7 +34,7 @@ class TestSettings(KeyVaultTestCase):
         assert setting.name and setting.setting_type and setting.value
 
         # Clear the credential's token and challenge cache to force a new auth interaction upon calling `update_setting`
-        # This tests for a bug in 4.3.0 where `update_setting` doesn't trigger correct authentication
+        # This tests for a bug in 4.3.0 (or the service) where `update_setting` doesn't trigger correct authentication
         client._client._config.authentication_policy._token = None
         HttpChallengeCache.clear()
 

--- a/sdk/keyvault/azure-keyvault-administration/tests/test_settings_client_async.py
+++ b/sdk/keyvault/azure-keyvault-administration/tests/test_settings_client_async.py
@@ -5,6 +5,7 @@
 import pytest
 from azure.keyvault.administration import KeyVaultSetting, KeyVaultSettingType
 from azure.keyvault.administration.aio import KeyVaultSettingsClient
+from azure.keyvault.administration._internal import HttpChallengeCache
 from azure.keyvault.administration._internal.client_base import DEFAULT_VERSION
 from devtools_testutils.aio import recorded_by_proxy_async
 
@@ -35,6 +36,11 @@ class TestSettings(KeyVaultTestCase):
     async def test_update_settings(self, client: KeyVaultSettingsClient, **kwargs):
         setting = await client.get_setting("AllowKeyManagementOperationsThroughARM")
         assert setting.name and setting.setting_type and setting.value
+
+        # Clear the credential's token and challenge cache to force a new auth interaction upon calling `update_setting`
+        # This tests for a bug in 4.3.0 (or the service) where `update_setting` doesn't trigger correct authentication
+        client._client._config.authentication_policy._token = None
+        HttpChallengeCache.clear()
 
         # Set value by using a bool
         opposite_value = KeyVaultSetting(

--- a/sdk/keyvault/azure-keyvault-certificates/CHANGELOG.md
+++ b/sdk/keyvault/azure-keyvault-certificates/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 4.8.0b1 (2023-05-11)
+## 4.8.0b1 (2023-05-15)
 
 ### Bugs Fixed
 - Token requests made during AD FS authentication no longer specify an erroneous "adfs" tenant ID

--- a/sdk/keyvault/azure-keyvault-keys/CHANGELOG.md
+++ b/sdk/keyvault/azure-keyvault-keys/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 4.9.0b1 (2023-05-11)
+## 4.9.0b1 (2023-05-15)
 
 ### Bugs Fixed
 - Token requests made during AD FS authentication no longer specify an erroneous "adfs" tenant ID

--- a/sdk/keyvault/azure-keyvault-secrets/CHANGELOG.md
+++ b/sdk/keyvault/azure-keyvault-secrets/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 4.8.0b1 (2023-05-11)
+## 4.8.0b1 (2023-05-15)
 
 ### Bugs Fixed
 - Token requests made during AD FS authentication no longer specify an erroneous "adfs" tenant ID


### PR DESCRIPTION
# Description

An at-least-temporary fix for https://github.com/Azure/azure-sdk-for-python/issues/30382. Since triggering an authentication challenge at the `update_setting` endpoint doesn't work with our standard flow, this PR updates the method to trigger auth challenges using `get_setting` if necessary (i.e. if we don't have a cached challenge for the user's vault URL).

I opted to use a real service request instead of a direct token request so that we can still use any auth parameters that would only be discovered with a challenge from the service. `get_setting` was chosen because:

1. It's a quick, inexpensive operation.
2. We already have the information necessary to make a successful request (a setting name).

Any error raised by this additional `get_setting` call is tossed. If the error is from failing to authenticate, then this error would have been raised when calling `update_setting` anyway. If the error is specific to the GET request -- e.g. the setting doesn't exist -- we will still have triggered an auth challenge from the service. The error from the GET request wouldn't be relevant to the `update_setting` call (the user didn't explicitly request the `get_setting` call in the first place), so there's no compelling reason I can think of to expose an error that comes up.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
