### PR TITLE
[ACR] Address apiview feedback

### DIFF
--- a/sdk/containerregistry/azure-containerregistry/azure/containerregistry/_models.py
+++ b/sdk/containerregistry/azure-containerregistry/azure/containerregistry/_models.py
@@ -308,7 +308,7 @@ class GetManifestResult(object):
     """The get manifest result.
 
     :ivar manifest: The manifest JSON.
-    :vartype manifest: MutableMapping[str, Any]
+    :vartype manifest: Mapping[str, Any]
     :ivar str media_type: The manifest's media type.
     :ivar str digest: The manifest's digest, calculated by the registry.
     """


### PR DESCRIPTION
Based on the feedback from [apiview](https://apiview.dev/Assemblies/Review/e77720207ba7448e84cb77859392731d?diffRevisionId=3e2025a817b74f259e1a4774481c43e3&diffOnly=False&revisionId=ffaa1c5fd7f84018ab8a88bcaa42fd8e&doc=False#), the manifest in download result should not expect to mutate and send it back. So change the manifest type in return result from `MutableMapping` to `Mapping`.