### PR TITLE
[Core][OTel] Add parent context param

### DIFF
--- a/sdk/core/azure-core-tracing-opentelemetry/CHANGELOG.md
+++ b/sdk/core/azure-core-tracing-opentelemetry/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 1.0.0b10 (Unreleased)
 
+### Features Added
+
+- Enabled the use of the `context` keyword argument for passing in context headers of a parent span. This will be the parent context used when creating the span. ([#30411](https://github.com/Azure/azure-sdk-for-python/pull/30411))
+
 ### Other Changes
 
 - Python 2.7 is no longer supported. Please use Python version 3.7 or later.

--- a/sdk/core/azure-core-tracing-opentelemetry/azure/core/tracing/ext/opentelemetry_span/__init__.py
+++ b/sdk/core/azure-core-tracing-opentelemetry/azure/core/tracing/ext/opentelemetry_span/__init__.py
@@ -58,6 +58,8 @@ class OpenTelemetrySpan(HttpSpanMixin, object):
     :paramtype kind: ~azure.core.tracing.SpanKind
     :keyword links: The list of links to be added to the span.
     :paramtype links: list[~azure.core.tracing.Link]
+    :keyword context: Context headers of parent span that should be used when creating a new span.
+    :paramtype context: Dict[str, str]
     """
 
     def __init__(self, span: Optional[Span] = None, name: str = "span", **kwargs: Any) -> None:
@@ -122,6 +124,12 @@ class OpenTelemetrySpan(HttpSpanMixin, object):
                 # We will just send the links as is if it's not ~azure.core.tracing.Link without any validation
                 # assuming user knows what they are doing.
                 kwargs.setdefault("links", links)
+
+        parent_context = kwargs.pop("context", None)
+        if parent_context:
+            # Create OpenTelemetry Context object from dict.
+            kwargs["context"] = extract(parent_context)
+
         self._span_instance = current_tracer.start_span(name=name, kind=otel_kind, **kwargs)  # type: ignore
 
     @property


### PR DESCRIPTION
This enables passing in a context of the span's parent. In some cases, it is desirable to make a span a child of some other span not in the current scope. For example, in EventHubs, when processing a single message, the "process" span should be a direct child of the "message" span which is generally part of a different trace.

