### PR TITLE
[ServiceBus] Tracing updates

### DIFF
--- a/sdk/servicebus/azure-servicebus/CHANGELOG.md
+++ b/sdk/servicebus/azure-servicebus/CHANGELOG.md
@@ -10,7 +10,11 @@
 
 ### Other Changes
 
-- Tracing: span links on receive/send spans now fall back to using `Diagnostic-Id` if the `traceparent` message application property is not found.
+- Tracing updates:
+  - Span links on receive/send spans now fall back to using `Diagnostic-Id` if the `traceparent` message application property is not found.
+  - Span links will now still be created for receive/send spans even if no context propagation headers are found in message application properties.
+  - The `component` attribute was removed from all spans.
+
 
 ## 7.10.0 (2023-05-09)
 

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_common/tracing.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_common/tracing.py
@@ -83,7 +83,6 @@ class TraceAttributes:
     TRACE_MESSAGING_OPERATION_ATTRIBUTE = "messaging.operation"
     TRACE_MESSAGING_BATCH_COUNT_ATTRIBUTE = "messaging.batch.message_count"
 
-    LEGACY_TRACE_COMPONENT_ATTRIBUTE = "component"
     LEGACY_TRACE_MESSAGE_BUS_DESTINATION_ATTRIBUTE = "message_bus.destination"
     LEGACY_TRACE_PEER_ADDRESS_ATTRIBUTE = "peer.address"
 
@@ -216,8 +215,8 @@ def get_receive_links(messages: Union[ReceiveMessageTypes, Iterable[ReceiveMessa
     links = []
     try:
         for message in trace_messages:
+            headers = {}
             if message.application_properties:
-                headers = {}
                 traceparent = (message.application_properties.get(TRACE_PARENT_PROPERTY, b"") or
                                message.application_properties.get(TRACE_DIAGNOSTIC_ID_PROPERTY, b""))
                 if hasattr(traceparent, "decode"):
@@ -231,11 +230,9 @@ def get_receive_links(messages: Union[ReceiveMessageTypes, Iterable[ReceiveMessa
                 if tracestate:
                     headers["tracestate"] = cast(str, tracestate)
 
-                enqueued_time = message.raw_amqp_message.annotations.get(TRACE_ENQUEUED_TIME_PROPERTY)
-                attributes = {SPAN_ENQUEUED_TIME_PROPERTY: enqueued_time} if enqueued_time else None
-
-                if headers:
-                    links.append(Link(headers, attributes=attributes))
+            enqueued_time = message.raw_amqp_message.annotations.get(TRACE_ENQUEUED_TIME_PROPERTY)
+            attributes = {SPAN_ENQUEUED_TIME_PROPERTY: enqueued_time} if enqueued_time else None
+            links.append(Link(headers, attributes=attributes))
     except AttributeError:
         pass
     return links
@@ -274,7 +271,7 @@ def get_span_link_from_message(message: Union[uamqp_Message, pyamqp_Message, Ser
                 headers["tracestate"] = cast(str, tracestate)
     except AttributeError :
         return None
-    return Link(headers) if headers else None
+    return Link(headers)
 
 
 def add_span_attributes(
@@ -294,7 +291,6 @@ def add_span_attributes(
 
     if operation_type in (TraceOperationTypes.PUBLISH, TraceOperationTypes.RECEIVE):
         # Maintain legacy attributes for backwards compatibility.
-        span.add_attribute(TraceAttributes.LEGACY_TRACE_COMPONENT_ATTRIBUTE, TraceAttributes.TRACE_MESSAGING_SYSTEM)
         span.add_attribute(TraceAttributes.LEGACY_TRACE_MESSAGE_BUS_DESTINATION_ATTRIBUTE, handler._entity_name)  # pylint: disable=protected-access
         span.add_attribute(TraceAttributes.LEGACY_TRACE_PEER_ADDRESS_ATTRIBUTE, handler.fully_qualified_namespace)
 


### PR DESCRIPTION
- Remove unused component attribute.
- Create span links even if no headers/properties in message.

This aligns with EventHubs tracing behavior.