### PR TITLE
[Cosmos] OpenTelemetry - repo sample, readme section on using telemetry

### DIFF
--- a/sdk/cosmos/azure-cosmos/README.md
+++ b/sdk/cosmos/azure-cosmos/README.md
@@ -672,7 +672,7 @@ pip install azure-core-tracing-opentelemetry
 pip install opentelemetry-sdk
 ```
 For more information on this, we recommend taking a look at this [document](https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/core/azure-core-tracing-opentelemetry/README.md) 
-from Azure Core describing how to set it up. We have also added a [sample file][telemetry_sync_sample] to show how it can
+from Azure Core describing how to set it up. We have also added a [sample file][telemetry_sample] to show how it can
 be used with our SDK. This works the same way regardless of the Cosmos client you are using.
 
 ## Next steps
@@ -715,7 +715,7 @@ For more extensive documentation on the Cosmos DB service, see the [Azure Cosmos
 [source_code]: https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/cosmos/azure-cosmos
 [venv]: https://docs.python.org/3/library/venv.html
 [virtualenv]: https://virtualenv.pypa.io
-[telemetry_sample]: https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/cosmos/azure-cosmos/samples/client_telemetry.py
+[telemetry_sample]: https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/cosmos/azure-cosmos/samples/tracing_open_telemetry.py
 
 ## Contributing
 

--- a/sdk/cosmos/azure-cosmos/README.md
+++ b/sdk/cosmos/azure-cosmos/README.md
@@ -664,6 +664,17 @@ client = CosmosClient(URL, credential=KEY, enable_diagnostics_logging=True)
 database = client.create_database(DATABASE_NAME, logger=logger)
 ```
 
+### Telemetry
+Azure Core provides the ability for our Python SDKs to use OpenTelemetry with them. The only packages that need to be installed
+to use this functionality are the following:
+```bash
+pip install azure-core-tracing-opentelemetry
+pip install opentelemetry-sdk
+```
+For more information on this, we recommend taking a look at this [document](https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/core/azure-core-tracing-opentelemetry/README.md) 
+from Azure Core describing how to set it up. We have also added a [sample file][telemetry_sync_sample] to show how it can
+be used with our SDK. This works the same way regardless of the Cosmos client you are using.
+
 ## Next steps
 
 For more extensive documentation on the Cosmos DB service, see the [Azure Cosmos DB documentation][cosmos_docs] on docs.microsoft.com.
@@ -704,6 +715,7 @@ For more extensive documentation on the Cosmos DB service, see the [Azure Cosmos
 [source_code]: https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/cosmos/azure-cosmos
 [venv]: https://docs.python.org/3/library/venv.html
 [virtualenv]: https://virtualenv.pypa.io
+[telemetry_sample]: https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/cosmos/azure-cosmos/samples/client_telemetry.py
 
 ## Contributing
 

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_container.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_container.py
@@ -805,7 +805,7 @@ class ContainerProxy(object):
         if response_hook:
             response_hook(self.client_connection.last_response_headers, result)
 
-    @distributed_trace
+    @distributed_trace_async
     async def delete_all_items_by_partition_key(
         self,
         partition_key: Union[str, int, float, bool],

--- a/sdk/cosmos/azure-cosmos/samples/README.md
+++ b/sdk/cosmos/azure-cosmos/samples/README.md
@@ -45,6 +45,8 @@ The following are code samples that show common scenario operations with the Azu
 
 * [multi-master operations](https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/cosmos/azure-cosmos/samples/MultiMasterOperations) - Example demonstrating multi-master operations.
 
+* [tracing-open-telemetry](https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/cosmos/azure-cosmos/samples/tracing_open_telemetry.py) - Example demonstrating how to use OpenTelemetry tracing with our SDK.
+
 ## Prerequisites
 * Python 3.6+
 * You must have an [Azure subscription](https://azure.microsoft.com/free/) and an

--- a/sdk/cosmos/azure-cosmos/samples/client_telemetry.py
+++ b/sdk/cosmos/azure-cosmos/samples/client_telemetry.py
@@ -1,0 +1,46 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE.txt in the project root for
+# license information.
+# -------------------------------------------------------------------------
+
+# Declare OpenTelemetry as enabled tracing plugin for Azure SDKs
+from azure.core.settings import settings
+from azure.core.tracing.ext.opentelemetry_span import OpenTelemetrySpan
+
+settings.tracing_implementation = OpenTelemetrySpan
+
+# In the below example, we use a simple console exporter, uncomment these lines to use
+# the OpenTelemetry exporter for Azure Monitor.
+# Example of a trace exporter for Azure Monitor, but you can use anything OpenTelemetry supports
+# from azure.monitor.opentelemetry.exporter import AzureMonitorTraceExporter
+# exporter = AzureMonitorTraceExporter(
+#     connection_string="the connection string used for your Application Insights resource"
+# )
+
+# Regular open telemetry usage from here, see https://github.com/open-telemetry/opentelemetry-python
+# for details
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor, ConsoleSpanExporter
+
+# Simple console exporter
+exporter = ConsoleSpanExporter()
+
+trace.set_tracer_provider(TracerProvider())
+tracer = trace.get_tracer(__name__)
+trace.get_tracer_provider().add_span_processor(
+    SimpleSpanProcessor(exporter)
+)
+
+# Example with Cosmos SDK
+import os
+from azure.cosmos.cosmos_client import CosmosClient
+
+account_url = os.environ["COSMOS_ACCOUNT_URL"]
+credential = os.environ["COSMOS_CREDENTIAL"]
+database_name = os.environ["DATABASE_NAME"]
+
+with tracer.start_as_current_span(name="MyApplication"):
+    client = CosmosClient(url=account_url, credential=credential)
+    client.create_database(database_name)  # Call will be traced

--- a/sdk/cosmos/azure-cosmos/samples/tracing_open_telemetry.py
+++ b/sdk/cosmos/azure-cosmos/samples/tracing_open_telemetry.py
@@ -1,8 +1,21 @@
-# -------------------------------------------------------------------------
+# ----------------------------------------------------------------------------------------------------------
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See LICENSE.txt in the project root for
 # license information.
-# -------------------------------------------------------------------------
+# ----------------------------------------------------------------------------------------------------------
+# Prerequisites -
+#
+# 1. An Azure Cosmos account -
+#    https://learn.microsoft.com/azure/cosmos-db/nosql/quickstart-python#create-an-azure-cosmos-db-account
+#
+# 2. Microsoft Azure Cosmos PyPI package -
+#    https://pypi.python.org/pypi/azure-cosmos/
+#
+# 3. Azure Core Tracing OpenTelemetry plugin and OpenTelemetry Python SDK
+#    pip install azure-core-tracing-opentelemetry opentelemetry-sdk
+# ----------------------------------------------------------------------------------------------------------
+# Sample - demonstrates tracing using OpenTelemetry
+# ----------------------------------------------------------------------------------------------------------
 
 # Declare OpenTelemetry as enabled tracing plugin for Azure SDKs
 from azure.core.settings import settings


### PR DESCRIPTION
The folks at Azure Core have worked on tools that allow our Python SDKs to leverage OpenTelemetry yet we had no information on how to use it within our repo. With this additional sample and information provided on the README, our users will now be aware of the fact that they can leverage these tools with our SDK as well.

PR also adds a small fix on adding the proper distributed tracing tag to the partition key delete method as well.