### PR TITLE
[Test Proxy] Explicitly mark proxy executable as runnable by all users

### DIFF
--- a/tools/azure-sdk-tools/devtools_testutils/proxy_startup.py
+++ b/tools/azure-sdk-tools/devtools_testutils/proxy_startup.py
@@ -257,7 +257,9 @@ def prepare_local_tool(repo_root: str) -> str:
                     f.writelines([target_proxy_version])
 
             executable_path = os.path.join(download_folder, target_info["executable"])
-            os.chmod(executable_path, 0o755)  # Mark the executable file as executable by all users
+            # Mark the executable file as executable by all users; Mac drops these permissions during extraction
+            if system == "Darwin":
+                os.chmod(executable_path, 0o755)
             return os.path.abspath(executable_path).replace("\\", "/")
         else:
             _LOGGER.error(f'There are no available standalone proxy binaries for platform "{machine}".')

--- a/tools/azure-sdk-tools/devtools_testutils/proxy_startup.py
+++ b/tools/azure-sdk-tools/devtools_testutils/proxy_startup.py
@@ -256,7 +256,9 @@ def prepare_local_tool(repo_root: str) -> str:
                 with open(os.path.join(download_folder, "downloaded_version.txt"), "w") as f:
                     f.writelines([target_proxy_version])
 
-            return os.path.abspath(os.path.join(download_folder, target_info["executable"])).replace("\\", "/")
+            executable_path = os.path.join(download_folder, target_info["executable"])
+            os.chmod(executable_path, 0o755)  # Mark the executable file as executable by all users
+            return os.path.abspath(executable_path).replace("\\", "/")
         else:
             _LOGGER.error(f'There are no available standalone proxy binaries for platform "{machine}".')
             raise Exception(


### PR DESCRIPTION
# Description

Fixes the issue with the test proxy executable losing permissions during extraction on Mac, following the approach employed by JS: https://github.com/Azure/azure-sdk-for-js/blob/b0a286330a895b8e4273340ad3a67c0ca23c6f81/common/tools/dev-tool/src/util/testProxyUtils.ts#L132

The current workaround is to manually `chmod` the file; I'd like to leave this [section in the troubleshooting guide](https://github.com/Azure/azure-sdk-for-python/blob/main/doc/dev/test_proxy_troubleshooting.md#permissionerror-during-startup) in case someone uses a commit or has a file issue that reintroduces the problem.

@scbedd for notifications

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
