### PR TITLE
Fix KV Certificates types

### DIFF
--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_client.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_client.py
@@ -5,7 +5,7 @@
 # pylint:disable=too-many-lines,too-many-public-methods
 import base64
 from functools import partial
-from typing import TYPE_CHECKING, Any, List, Optional, Union, cast
+from typing import TYPE_CHECKING, Any, List, Optional, Union
 
 from azure.core.polling import LROPoller
 from azure.core.paging import ItemPaged

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_client.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_client.py
@@ -5,8 +5,10 @@
 # pylint:disable=too-many-lines,too-many-public-methods
 import base64
 from functools import partial
+from typing import TYPE_CHECKING, Any, List, Optional, Union, cast
 
 from azure.core.polling import LROPoller
+from azure.core.paging import ItemPaged
 from azure.core.tracing.decorator import distributed_trace
 
 from ._shared import KeyVaultClientBase
@@ -22,16 +24,6 @@ from ._models import (
     CertificateOperation,
 )
 from ._polling import CreateCertificatePoller
-
-try:
-    from typing import TYPE_CHECKING
-except ImportError:
-    TYPE_CHECKING = False
-
-if TYPE_CHECKING:
-    # pylint:disable=unused-import
-    from typing import Any, List, Optional, Union
-    from azure.core.paging import ItemPaged
 
 
 NO_SAN_OR_SUBJECT = "You need to set either subject or one of the subject alternative names parameters in the policy"
@@ -135,7 +127,8 @@ class CertificateClient(KeyVaultClientBase):
         create_certificate_polling = CreateCertificatePoller(
             get_certificate_command=get_certificate_command, interval=polling_interval
         )
-        return LROPoller(command, create_certificate_operation, lambda *_: None, create_certificate_polling)
+        def no_op(*_, **__) -> Any: pass  # The deserialization callback is ignored based on polling implementation
+        return LROPoller(command, create_certificate_operation, no_op, create_certificate_polling)
 
     @distributed_trace
     def get_certificate(self, certificate_name: str, **kwargs) -> KeyVaultCertificate:

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_client.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_client.py
@@ -5,7 +5,7 @@
 # pylint:disable=too-many-lines,too-many-public-methods
 import base64
 from functools import partial
-from typing import TYPE_CHECKING, Any, List, Optional, Union
+from typing import Any, List, Optional, Union
 
 from azure.core.polling import LROPoller
 from azure.core.paging import ItemPaged
@@ -127,7 +127,8 @@ class CertificateClient(KeyVaultClientBase):
         create_certificate_polling = CreateCertificatePoller(
             get_certificate_command=get_certificate_command, interval=polling_interval
         )
-        def no_op(*_, **__) -> Any: pass  # The deserialization callback is ignored based on polling implementation
+        def no_op(*_, **__) -> Any:  # The deserialization callback is ignored based on polling implementation
+            pass
         return LROPoller(command, create_certificate_operation, no_op, create_certificate_polling)
 
     @distributed_trace
@@ -547,7 +548,7 @@ class CertificateClient(KeyVaultClientBase):
         return KeyVaultCertificate._from_certificate_bundle(certificate_bundle=bundle)
 
     @distributed_trace
-    def list_deleted_certificates(self, **kwargs) -> "ItemPaged[DeletedCertificate]":
+    def list_deleted_certificates(self, **kwargs) -> ItemPaged[DeletedCertificate]:
         """Lists the currently-recoverable deleted certificates. Possible only if vault is soft-delete enabled.
 
         Requires certificates/get/list permission. Retrieves the certificates in the current vault which are in a
@@ -586,7 +587,7 @@ class CertificateClient(KeyVaultClientBase):
         )
 
     @distributed_trace
-    def list_properties_of_certificates(self, **kwargs) -> "ItemPaged[CertificateProperties]":
+    def list_properties_of_certificates(self, **kwargs) -> ItemPaged[CertificateProperties]:
         """List identifiers and properties of all certificates in the vault.
 
         Requires certificates/list permission.
@@ -625,7 +626,7 @@ class CertificateClient(KeyVaultClientBase):
     @distributed_trace
     def list_properties_of_certificate_versions(
         self, certificate_name: str, **kwargs
-    ) -> "ItemPaged[CertificateProperties]":
+    ) -> ItemPaged[CertificateProperties]:
         """List the identifiers and properties of a certificate's versions.
 
         Requires certificates/list permission.
@@ -1014,7 +1015,7 @@ class CertificateClient(KeyVaultClientBase):
         return CertificateIssuer._from_issuer_bundle(issuer_bundle=issuer_bundle)
 
     @distributed_trace
-    def list_properties_of_issuers(self, **kwargs) -> "ItemPaged[IssuerProperties]":
+    def list_properties_of_issuers(self, **kwargs) -> ItemPaged[IssuerProperties]:
         """Lists properties of the certificate issuers for the key vault.
 
         Requires the certificates/manageissuers/getissuers permission.

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_polling.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_polling.py
@@ -7,7 +7,7 @@ import time
 from typing import TYPE_CHECKING, Any, Callable, Optional, Union
 
 from azure.core.polling import PollingMethod
-from azure.keyvault.certificates import KeyVaultCertificate, CertificateOperation
+from azure.keyvault.certificates._models import KeyVaultCertificate, CertificateOperation
 
 logger = logging.getLogger(__name__)
 

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_polling.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_polling.py
@@ -4,7 +4,7 @@
 # ------------------------------------
 import logging
 import time
-from typing import TYPE_CHECKING, Any, Callable, Optional, Union
+from typing import Any, Callable, Optional, Union
 
 from azure.core.polling import PollingMethod
 from azure.keyvault.certificates._models import KeyVaultCertificate, CertificateOperation

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_polling.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_polling.py
@@ -4,34 +4,26 @@
 # ------------------------------------
 import logging
 import time
+from typing import TYPE_CHECKING, Any, Callable, Optional, Union
 
 from azure.core.polling import PollingMethod
-
-try:
-    from typing import TYPE_CHECKING
-except ImportError:
-    TYPE_CHECKING = False
-
-if TYPE_CHECKING:
-    # pylint: disable=ungrouped-imports
-    from typing import Any, Callable, Optional, Union
-    from azure.keyvault.certificates import KeyVaultCertificate, CertificateOperation
+from azure.keyvault.certificates import KeyVaultCertificate, CertificateOperation
 
 logger = logging.getLogger(__name__)
 
 
 class CreateCertificatePoller(PollingMethod):
-    def __init__(self, get_certificate_command: "Callable", interval: int = 5) -> None:
-        self._command = None  # type: Optional[Callable]
-        self._resource = None  # type: Optional[Union[CertificateOperation, KeyVaultCertificate]]
-        self._pending_certificate_op = None  # type: Optional[CertificateOperation]
+    def __init__(self, get_certificate_command: Callable, interval: int = 5) -> None:
+        self._command: Optional[Callable] = None
+        self._resource: Optional[Union[CertificateOperation, KeyVaultCertificate]] = None
+        self._pending_certificate_op: Optional[CertificateOperation] = None
         self._get_certificate_command = get_certificate_command
         self._polling_interval = interval
 
     def _update_status(self) -> None:
         self._pending_certificate_op = self._command() if self._command else None
 
-    def initialize(self, client: "Any", initial_response: "Any", _: "Callable") -> None:
+    def initialize(self, client: Any, initial_response: Any, _: Any) -> None:
         self._command = client
         self._pending_certificate_op = initial_response
 
@@ -56,7 +48,7 @@ class CreateCertificatePoller(PollingMethod):
             return True
         return self._pending_certificate_op.status.lower() != "inprogress"  # type: ignore
 
-    def resource(self) -> "Union[KeyVaultCertificate, CertificateOperation]":
+    def resource(self) -> Union[KeyVaultCertificate, CertificateOperation]:
         return self._resource  # type: ignore
 
     def status(self) -> str:

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/aio/_client.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/aio/_client.py
@@ -123,7 +123,8 @@ class CertificateClient(AsyncKeyVaultClientBase):
         create_certificate_polling = CreateCertificatePollerAsync(
             get_certificate_command=get_certificate_command, interval=polling_interval
         )
-        def no_op(*_, **__) -> Any: pass  # The deserialization callback is ignored based on polling implementation
+        def no_op(*_, **__) -> Any:  # The deserialization callback is ignored based on polling implementation
+            pass
         return await async_poller(command, create_certificate_operation, no_op, create_certificate_polling)
 
     @distributed_trace_async

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/aio/_client.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/aio/_client.py
@@ -123,7 +123,8 @@ class CertificateClient(AsyncKeyVaultClientBase):
         create_certificate_polling = CreateCertificatePollerAsync(
             get_certificate_command=get_certificate_command, interval=polling_interval
         )
-        return await async_poller(command, create_certificate_operation, None, create_certificate_polling)
+        def no_op(*_, **__) -> Any: pass  # The deserialization callback is ignored based on polling implementation
+        return await async_poller(command, create_certificate_operation, no_op, create_certificate_polling)
 
     @distributed_trace_async
     async def get_certificate(self, certificate_name: str, **kwargs) -> KeyVaultCertificate:


### PR DESCRIPTION
Type fixes, again for azure-core LRO types PR.

Rationale is that since the deserialization callback is ignored by the custom PollingMethod implementation, we should type the return as `Any` to not trigger a warning because the deserialization callback do not return the actual poller return type. Maybe this custom poller could have been designed differently, but that's a debate for another day :)