### PR TITLE
[engsys] fix: Broken `next-pylint` tox environment

### DIFF
--- a/eng/tox/tox.ini
+++ b/eng/tox/tox.ini
@@ -106,7 +106,7 @@ setenv =
 deps =
   {[base]deps}
 commands =
-    python -m pip install {[testenv:next-pylint]pylint_version}
+    python -m pip install pylint=={[testenv:next-pylint]pylint_version}
     python -m pip install azure-pylint-guidelines-checker==0.0.8 --index-url="https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-python/pypi/simple/"
     python {repository_root}/eng/tox/create_package_and_install.py \
       -d {envtmpdir}/dist \


### PR DESCRIPTION
# Description

This PR is a follow up to #30159, and fixes the `next-pylint` tox environment which was broken by that PR

cc: @scbedd , @l0lawrence 


# Background

#30159 includes https://github.com/Azure/azure-sdk-for-python/pull/30159/commits/df6b4282331e7ee5742163c98b4e6bc49955f133 which was an attempt to better document the tox environments defined in tox.ini

The commit accidentally removed the `pylint==` from `pylint==2.15.8` 
(see https://github.com/Azure/azure-sdk-for-python/pull/30159/commits/df6b4282331e7ee5742163c98b4e6bc49955f133#diff-046db483898138bdccf106f32155fe12e3658ff0dd64ff0968507e3ffe15d09bL104-R107 ), which causes installation of pylint to fail.

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
