### PR TITLE
[Monitor Query] Docstring updates

### DIFF
--- a/sdk/monitor/azure-monitor-query/azure/monitor/query/_helpers.py
+++ b/sdk/monitor/azure-monitor-query/azure/monitor/query/_helpers.py
@@ -15,7 +15,14 @@ from ._generated._serialization import Serializer, Deserializer
 
 
 def get_authentication_policy(credential: TokenCredential, audience: str) -> BearerTokenCredentialPolicy:
-    """Returns the correct authentication policy"""
+    """Returns the correct authentication policy.
+
+    :param credential: The credential to use for authentication with the service.
+    :type credential: ~azure.core.credentials.TokenCredential
+    :param str audience: The audience for the token.
+    :returns: The correct authentication policy.
+    :rtype: ~azure.core.pipeline.policies.BearerTokenCredentialPolicy
+    """
     if credential is None:
         raise ValueError("Parameter 'credential' must not be None.")
     scope = audience.rstrip("/") + "/.default"
@@ -66,8 +73,8 @@ def construct_iso8601(timespan=None) -> Optional[str]:
     if duration:
         try:
             duration_str = "PT{}S".format(duration.total_seconds())
-        except AttributeError:
-            raise ValueError("timespan must be a timedelta or a tuple.")
+        except AttributeError as e:
+            raise ValueError("timespan must be a timedelta or a tuple.") from e
     iso_str = None
     if start is not None:
         start = Serializer.serialize_iso(start)

--- a/sdk/monitor/azure-monitor-query/azure/monitor/query/_models.py
+++ b/sdk/monitor/azure-monitor-query/azure/monitor/query/_models.py
@@ -42,7 +42,11 @@ class LogsTableRow:
         self._row_dict = {_columns[i]: self._row[i] for i in range(len(self._row))}
 
     def __iter__(self) -> Iterator[Any]:
-        """This will iterate over the row directly."""
+        """This will iterate over the row directly.
+
+        :return: An iterator over the row.
+        :rtype: Iterator
+        """
         return iter(self._row)
 
     def __len__(self) -> int:
@@ -57,6 +61,8 @@ class LogsTableRow:
 
         :param column: The name of the column or the index of the element in a row.
         :type column: str or int
+        :return: The value of the column or the element in the row.
+        :rtype: Any
         """
         try:
             return self._row_dict[column]

--- a/sdk/monitor/azure-monitor-query/azure/monitor/query/aio/_helpers_async.py
+++ b/sdk/monitor/azure-monitor-query/azure/monitor/query/aio/_helpers_async.py
@@ -10,7 +10,14 @@ from azure.core.pipeline.policies import AsyncBearerTokenCredentialPolicy
 
 
 def get_authentication_policy(credential: AsyncTokenCredential, audience: str) -> AsyncBearerTokenCredentialPolicy:
-    """Returns the correct authentication policy"""
+    """Returns the correct authentication policy.
+
+    :param credential: The credential to use for authentication with the service.
+    :type credential: ~azure.core.credentials.TokenCredential
+    :param str audience: The audience for the token.
+    :returns: The correct authentication policy.
+    :rtype: ~azure.core.pipeline.policies.BearerTokenCredentialPolicy
+    """
     if credential is None:
         raise ValueError("Parameter 'credential' must not be None.")
     scope = audience.rstrip("/") + "/.default"

--- a/sdk/monitor/azure-monitor-query/azure/monitor/query/aio/_helpers_async.py
+++ b/sdk/monitor/azure-monitor-query/azure/monitor/query/aio/_helpers_async.py
@@ -13,10 +13,10 @@ def get_authentication_policy(credential: AsyncTokenCredential, audience: str) -
     """Returns the correct authentication policy.
 
     :param credential: The credential to use for authentication with the service.
-    :type credential: ~azure.core.credentials.TokenCredential
+    :type credential: ~azure.core.credentials.AsyncTokenCredential
     :param str audience: The audience for the token.
     :returns: The correct authentication policy.
-    :rtype: ~azure.core.pipeline.policies.BearerTokenCredentialPolicy
+    :rtype: ~azure.core.pipeline.policies.AsyncBearerTokenCredentialPolicy
     """
     if credential is None:
         raise ValueError("Parameter 'credential' must not be None.")


### PR DESCRIPTION
This is to enable a pass on pylint-next.

With this, monitor-query and monitor-ingestion should both pass pylint-next.