### PR TITLE
[EventHubs] Update process span tracing logic

### DIFF
--- a/sdk/eventhub/azure-eventhub/CHANGELOG.md
+++ b/sdk/eventhub/azure-eventhub/CHANGELOG.md
@@ -23,6 +23,7 @@
    - The `component` attribute was removed from all spans.
    - All `send` spans now contain links to `message` spans. Now, `message` spans will no longer contain a link to the `send` span.
    - Message application properties will now contain values for `traceparent` (and `tracestate` if applicable)
+   - Process spans will now be a direct children of message span contexts in when event handling on a per-message basis. ([#30537](https://github.com/Azure/azure-sdk-for-python/pull/30537))
 
 ## 5.11.2 (2023-03-20)
 

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_eventprocessor/event_processor.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_eventprocessor/event_processor.py
@@ -243,13 +243,16 @@ class EventProcessor(
                 partition_context._last_received_event = event  # type: ignore  #pylint:disable=protected-access
 
             links = []
+            is_batch = False
             if is_tracing_enabled():
                 links = get_span_links_from_received_events(event)
+                if isinstance(event, list):
+                    is_batch = True
 
             with receive_context_manager(self._eventhub_client, links=links, start_time=self._last_received_time):  # pylint:disable=protected-access
                 self._last_received_time = time.time_ns()
 
-            with process_context_manager(self._eventhub_client, links=links):
+            with process_context_manager(self._eventhub_client, links=links, is_batch=is_batch):
                 self._event_handler(partition_context, event)
         else:
             self._event_handler(partition_context, event)

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_tracing.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_tracing.py
@@ -105,12 +105,21 @@ def receive_context_manager(
 
 
 @contextmanager
-def process_context_manager(client: Optional[ClientBase], links: Optional[List[Link]] = None) -> Iterator[None]:
+def process_context_manager(
+    client: Optional[ClientBase], links: Optional[List[Link]] = None, is_batch: bool = False
+) -> Iterator[None]:
     """Tracing for message processing."""
     span_impl_type: Type[AbstractSpan] = settings.tracing_implementation()
     if span_impl_type is not None:
+        context = None
         links = links or []
-        with span_impl_type(name="EventHubs.process", kind=SpanKind.CONSUMER, links=links) as span:
+
+        # If the processing callback is called per single message, the processing span should be a child of the
+        # context of the message (as opposed to messages being links in the processing span).
+        if not is_batch and links:
+            context = links[0].headers
+            links = []
+        with span_impl_type(name="EventHubs.process", kind=SpanKind.CONSUMER, links=links, context=context) as span:
             add_span_attributes(span, TraceOperationTypes.PROCESS, client, message_count=len(links))
             yield
     else:

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_eventprocessor/event_processor.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_eventprocessor/event_processor.py
@@ -241,14 +241,18 @@ class EventProcessor(
                 partition_context._last_received_event = event[-1]  # type: ignore  #pylint:disable=protected-access
             except TypeError:
                 partition_context._last_received_event = event  # type: ignore  # pylint:disable=protected-access
+
             links = []
+            is_batch = False
             if is_tracing_enabled():
                 links = get_span_links_from_received_events(event)
+                if isinstance(event, list):
+                    is_batch = True
 
             with receive_context_manager(self._eventhub_client, links=links, start_time=self._last_received_time):
                 self._last_received_time = time.time_ns()
 
-            with process_context_manager(self._eventhub_client, links=links):
+            with process_context_manager(self._eventhub_client, links=links, is_batch=is_batch):
                 await self._event_handler(partition_context, event)
         else:
             await self._event_handler(partition_context, event)

--- a/sdk/eventhub/azure-eventhub/tests/livetest/synctests/test_consumer_client.py
+++ b/sdk/eventhub/azure-eventhub/tests/livetest/synctests/test_consumer_client.py
@@ -2,6 +2,9 @@ import time
 import pytest
 import threading
 import sys
+
+from azure.core.settings import settings
+from azure.core.tracing import SpanKind
 from azure.eventhub import EventData
 from azure.eventhub import EventHubConsumerClient
 from azure.eventhub._eventprocessor.in_memory_checkpoint_store import InMemoryCheckpointStore
@@ -202,3 +205,62 @@ def test_receive_batch_early_callback(connstr_senders, uamqp_transport):
         time.sleep(10)
         assert on_event_batch.received == 10
     worker.join()
+
+
+@pytest.mark.liveTest
+def test_receive_batch_tracing(connstr_senders, uamqp_transport, fake_span):
+    """Test that that receive and process spans are properly created and linked."""
+    settings.tracing_implementation.set_value(fake_span)
+    connection_str, senders = connstr_senders
+
+    with fake_span(name="SendSpan") as root_send:
+        senders[0].send([EventData(b"Data"), EventData(b"Data")])
+
+    assert len(root_send.children) == 3
+    assert root_send.children[0].name == "EventHubs.message"
+    assert root_send.children[1].name == "EventHubs.message"
+    assert root_send.children[2].name == "EventHubs.send"
+    assert len(root_send.children[2].links) == 2
+
+    traceparent1 = root_send.children[2].links[0].headers['traceparent']
+    traceparent2 = root_send.children[2].links[1].headers['traceparent']
+
+    def on_event_batch(partition_context, event_batch):
+        on_event_batch.received += len(event_batch)
+
+    on_event_batch.received = 0
+
+    client = EventHubConsumerClient.from_connection_string(
+        connection_str, consumer_group='$default', uamqp_transport=uamqp_transport
+    )
+
+    with fake_span(name="ReceiveSpan") as root_receive:
+        with client:
+            worker = threading.Thread(target=client.receive_batch, args=(on_event_batch,),
+                                    kwargs={"starting_position": "-1"})
+            worker.start()
+            time.sleep(20)
+            assert on_event_batch.received == 2
+
+    worker.join()
+
+    assert root_receive.name == "ReceiveSpan"
+    # One receive span and one process span.
+    assert len(root_receive.children) == 2
+
+    assert root_receive.children[0].name == "EventHubs.receive"
+    assert root_receive.children[0].kind == SpanKind.CLIENT
+
+    # One link for each message in the batch.
+    assert len(root_receive.children[0].links) == 2
+    assert root_receive.children[0].links[0].headers['traceparent'] == traceparent1
+    assert root_receive.children[0].links[1].headers['traceparent'] == traceparent2
+
+    assert root_receive.children[1].name == "EventHubs.process"
+    assert root_receive.children[1].kind == SpanKind.CONSUMER
+
+    assert len(root_receive.children[1].links) == 2
+    assert root_receive.children[1].links[0].headers['traceparent'] == traceparent1
+    assert root_receive.children[1].links[1].headers['traceparent'] == traceparent2
+
+    settings.tracing_implementation.set_value(None)


### PR DESCRIPTION
In the case of event handling on a per-message basis, the process span should be a direct child of the message context. This change adds the logic to do so.

Additional context: https://gist.github.com/lmolkova/e4215c0f44a49ef824983382762e6b92#processing-messages