### PR TITLE
Fix samples invocation to ignore nonstandard python versions

### DIFF
--- a/eng/tox/tox.ini
+++ b/eng/tox/tox.ini
@@ -281,7 +281,7 @@ commands =
 
 
 [testenv:sphinx]
-description=Builds a package's documentation with sphinx
+description="Builds a package's documentation with sphinx"
 skipsdist = true
 skip_install = true
 passenv = *
@@ -452,7 +452,7 @@ commands =
 
 
 [testenv:samples]
-description=Runs a package's samples
+description="Runs a package's samples"
 skipsdist = false
 skip_install = false
 usedevelop = false


### PR DESCRIPTION
The devops team needs to custom assemble some older python versions for windows. As a result of that, sometimes we get some values that would gently call "non-standard."

For example we see [3.7.16bp1](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=2798627&view=logs&j=00d488d8-0928-537b-2837-a217e71ffc55&s=5b3e9ae3-cd92-570a-9aaf-e9389c3d395d&t=00f8a32b-867a-5915-1684-2a6d3a96272e&l=123) pop up sometimes.

Rather than sob about this, let's just eliminate the source of the problem, as this check doesn't need fidelity of preview versus not anyway.
