### PR TITLE
[multiapi combiner] add `_api_version` function for mixin operation group

### DIFF
--- a/tools/azure-sdk-tools/packaging_tools/templates/multiapi_combiner/operation_group.py.jinja2
+++ b/tools/azure-sdk-tools/packaging_tools/templates/multiapi_combiner/operation_group.py.jinja2
@@ -17,6 +17,10 @@ class {{ operation_group.name }}{{ "(" + operation_group.name.replace("Operation
         self._serialize = input_args.pop(0) if input_args else kwargs.pop("serializer")
         self._deserialize = input_args.pop(0) if input_args else kwargs.pop("deserializer")
         self._api_version = input_args.pop(0) if input_args else kwargs.pop("api_version")
+{% else %}
+    @property
+    def _api_version(self)-> str:
+        return self._get_api_version(None)
 
 {% endif %}
     {% for operation in operation_group.operations %}


### PR DESCRIPTION
use databox as test package: https://github.com/msyyc/azure-sdk-for-python/commit/78ae5a64653237e269e45e6f36ec555fcf2e6fcf