### PR TITLE
[AppConfig] Fix flaky tests

### DIFF
--- a/sdk/appconfiguration/azure-appconfiguration/assets.json
+++ b/sdk/appconfiguration/azure-appconfiguration/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "python",
   "TagPrefix": "python/appconfiguration/azure-appconfiguration",
-  "Tag": "python/appconfiguration/azure-appconfiguration_ab4d812492"
+  "Tag": "python/appconfiguration/azure-appconfiguration_bbc12a70b5"
 }

--- a/sdk/appconfiguration/azure-appconfiguration/azure/appconfiguration/_azure_appconfiguration_client.py
+++ b/sdk/appconfiguration/azure-appconfiguration/azure/appconfiguration/_azure_appconfiguration_client.py
@@ -153,7 +153,7 @@ class AzureAppConfigurationClient:
         :param label_filter: filter results based on their label. '*' can be
          used as wildcard in the beginning or end of the filter
         :type label_filter: str
-        :keyword datetime accept_datetime: filter out ConfigurationSetting created after this datetime
+        :keyword datetime accept_datetime: retrieve ConfigurationSetting existed at this datetime
         :keyword List[str] fields: specify which fields to include in the results. Leave None to include all fields
         :return: An iterator of :class:`ConfigurationSetting`
         :rtype: ~azure.core.paging.ItemPaged[ConfigurationSetting]
@@ -165,7 +165,7 @@ class AzureAppConfigurationClient:
 
             from datetime import datetime, timedelta
 
-            accept_datetime = datetime.today() + timedelta(days=-1)
+            accept_datetime = datetime.utcnow() + timedelta(days=-1)
 
             all_listed = client.list_configuration_settings()
             for item in all_listed:
@@ -216,7 +216,7 @@ class AzureAppConfigurationClient:
         :type etag: str or None
         :param match_condition: The match condition to use upon the etag
         :type match_condition: :class:`~azure.core.MatchConditions`
-        :keyword datetime accept_datetime: the retrieved ConfigurationSetting that created no later than this datetime
+        :keyword datetime accept_datetime: retrieve ConfigurationSetting existed at this datetime
         :return: The matched ConfigurationSetting object
         :rtype: :class:`~azure.appconfiguration.ConfigurationSetting`
         :raises: :class:`HttpResponseError`, :class:`ClientAuthenticationError`, \
@@ -431,7 +431,7 @@ class AzureAppConfigurationClient:
         :param label_filter: filter results based on their label. '*' can be
          used as wildcard in the beginning or end of the filter
         :type label_filter: str
-        :keyword datetime accept_datetime: filter out ConfigurationSetting created after this datetime
+        :keyword datetime accept_datetime: retrieve ConfigurationSetting existed at this datetime
         :keyword List[str] fields: specify which fields to include in the results. Leave None to include all fields
         :return: An iterator of :class:`ConfigurationSetting`
         :rtype: ~azure.core.paging.ItemPaged[ConfigurationSetting]
@@ -443,7 +443,7 @@ class AzureAppConfigurationClient:
 
             from datetime import datetime, timedelta
 
-            accept_datetime = datetime.today() + timedelta(days=-1)
+            accept_datetime = datetime.utcnow() + timedelta(days=-1)
 
             all_revisions = client.list_revisions()
             for item in all_revisions:

--- a/sdk/appconfiguration/azure-appconfiguration/azure/appconfiguration/aio/_azure_configuration_client_async.py
+++ b/sdk/appconfiguration/azure-appconfiguration/azure/appconfiguration/aio/_azure_configuration_client_async.py
@@ -134,7 +134,7 @@ class AzureAppConfigurationClient:
         :param label_filter: filter results based on their label. '*' can be
          used as wildcard in the beginning or end of the filter
         :type label_filter: str
-        :keyword datetime accept_datetime: filter out ConfigurationSetting created after this datetime
+        :keyword datetime accept_datetime: retrieve ConfigurationSetting existed at this datetime
         :keyword List[str] fields: specify which fields to include in the results. Leave None to include all fields
         :return: An iterator of :class:`ConfigurationSetting`
         :rtype: ~azure.core.async_paging.AsyncItemPaged[ConfigurationSetting]
@@ -146,7 +146,7 @@ class AzureAppConfigurationClient:
 
             from datetime import datetime, timedelta
 
-            accept_datetime = datetime.today() + timedelta(days=-1)
+            accept_datetime = datetime.utcnow() + timedelta(days=-1)
 
             all_listed = async_client.list_configuration_settings()
             async for item in all_listed:
@@ -198,7 +198,7 @@ class AzureAppConfigurationClient:
         :type etag: str or None
         :param match_condition: The match condition to use upon the etag
         :type match_condition: :class:`~azure.core.MatchConditions`
-        :keyword datetime accept_datetime: the retrieved ConfigurationSetting that created no later than this datetime
+        :keyword datetime accept_datetime: retrieve ConfigurationSetting existed at this datetime
         :return: The matched ConfigurationSetting object
         :rtype: :class:`~azure.appconfiguration.ConfigurationSetting`
         :raises: :class:`HttpResponseError`, :class:`ClientAuthenticationError`, \
@@ -427,7 +427,7 @@ class AzureAppConfigurationClient:
         :param label_filter: filter results based on their label. '*' can be
          used as wildcard in the beginning or end of the filter
         :type label_filter: str
-        :keyword datetime accept_datetime: filter out ConfigurationSetting created after this datetime
+        :keyword datetime accept_datetime: retrieve ConfigurationSetting existed at this datetime
         :keyword List[str] fields: specify which fields to include in the results. Leave None to include all fields
         :return: An iterator of :class:`ConfigurationSetting`
         :rtype: ~azure.core.async_paging.AsyncItemPaged[ConfigurationSetting]
@@ -440,7 +440,7 @@ class AzureAppConfigurationClient:
             # in async function
             from datetime import datetime, timedelta
 
-            accept_datetime = datetime.today() + timedelta(days=-1)
+            accept_datetime = datetime.utcnow() + timedelta(days=-1)
 
             all_revisions = async_client.list_revisions()
             async for item in all_revisions:

--- a/sdk/appconfiguration/azure-appconfiguration/tests/asynctestcase.py
+++ b/sdk/appconfiguration/azure-appconfiguration/tests/asynctestcase.py
@@ -6,6 +6,7 @@
 # --------------------------------------------------------------------------
 from azure.appconfiguration.aio import AzureAppConfigurationClient
 from azure.core.async_paging import AsyncItemPaged
+from azure.core.exceptions import ResourceExistsError
 from testcase import AppConfigTestCase
 from typing import List
 
@@ -19,13 +20,10 @@ class AsyncAppConfigTestCase(AppConfigTestCase):
         return AzureAppConfigurationClient.from_connection_string(appconfiguration_connection_string)
 
     async def add_for_test(self, client, config_setting):
-        exist_list = await self.convert_to_list(
-            client.list_configuration_settings(key_filter=config_setting.key, label_filter=config_setting.label)
-        )
-        exist = bool(exist_list)
-        if exist:
-            await client.delete_configuration_setting(key=config_setting.key, label=config_setting.label)
-        return await client.add_configuration_setting(config_setting)
+        try:
+            await client.add_configuration_setting(config_setting)
+        except ResourceExistsError:
+            pass
 
     async def convert_to_list(self, config_settings: AsyncItemPaged) -> List:
         list = []

--- a/sdk/appconfiguration/azure-appconfiguration/tests/test_azure_appconfiguration_client.py
+++ b/sdk/appconfiguration/azure-appconfiguration/tests/test_azure_appconfiguration_client.py
@@ -8,6 +8,7 @@ import copy
 import datetime
 import json
 import re
+import time
 from azure.core import MatchConditions
 from azure.core.exceptions import (
     AzureError,
@@ -308,7 +309,7 @@ class TestAppConfigurationClient(AppConfigTestCase):
     def test_list_configuration_settings_correct_etag(self, appconfiguration_connection_string):
         client = self.create_client(appconfiguration_connection_string)
         to_list_kv = self.create_config_setting()
-        to_list_kv = self.add_for_test(client, to_list_kv)
+        self.add_for_test(client, to_list_kv)
         custom_headers = {"If-Match": to_list_kv.etag}
         items = list(
             client.list_configuration_settings(
@@ -361,15 +362,16 @@ class TestAppConfigurationClient(AppConfigTestCase):
     @recorded_by_proxy
     def test_list_configuration_settings_only_accepttime(self, appconfiguration_connection_string, **kwargs):
         recorded_variables = kwargs.pop("variables", {})
-        self.set_up(appconfiguration_connection_string)
-        exclude_today = self.client.list_configuration_settings(
-            accept_datetime=recorded_variables.setdefault(
-                "datetime", str(datetime.datetime.today() + datetime.timedelta(days=-1))
-            )
-        )
-        all_inclusive = self.client.list_configuration_settings()
-        assert len(list(all_inclusive)) > len(list(exclude_today))
-        self.tear_down()
+        recorded_variables.setdefault("timestamp", str(datetime.datetime.utcnow()))
+        
+        with AzureAppConfigurationClient.from_connection_string(appconfiguration_connection_string) as client:
+            # Confirm all configuration settings are cleaned up
+            current_config_settings = client.list_configuration_settings()
+            assert len(list(current_config_settings)) == 0
+        
+            revision = client.list_configuration_settings(accept_datetime=recorded_variables.get("timestamp"))
+            assert len(list(revision)) >= 0
+        
         return recorded_variables
 
     # method: list_revisions
@@ -414,7 +416,7 @@ class TestAppConfigurationClient(AppConfigTestCase):
     def test_list_revisions_correct_etag(self, appconfiguration_connection_string):
         client = self.create_client(appconfiguration_connection_string)
         to_list_kv = self.create_config_setting()
-        to_list_kv = self.add_for_test(client, to_list_kv)
+        self.add_for_test(client, to_list_kv)
         custom_headers = {"If-Match": to_list_kv.etag}
         items = list(
             client.list_revisions(key_filter=to_list_kv.key, label_filter=to_list_kv.label, headers=custom_headers)

--- a/sdk/appconfiguration/azure-appconfiguration/tests/test_azure_appconfiguration_client.py
+++ b/sdk/appconfiguration/azure-appconfiguration/tests/test_azure_appconfiguration_client.py
@@ -8,7 +8,6 @@ import copy
 import datetime
 import json
 import re
-import time
 from azure.core import MatchConditions
 from azure.core.exceptions import (
     AzureError,

--- a/sdk/appconfiguration/azure-appconfiguration/tests/test_azure_appconfiguration_client_aad.py
+++ b/sdk/appconfiguration/azure-appconfiguration/tests/test_azure_appconfiguration_client_aad.py
@@ -304,7 +304,7 @@ class TestAppConfigurationClientAAD(AppConfigTestCase):
     def test_list_configuration_settings_correct_etag(self, appconfiguration_endpoint_string):
         client = self.create_aad_client(appconfiguration_endpoint_string)
         to_list_kv = self.create_config_setting()
-        to_list_kv = self.add_for_test(client, to_list_kv)
+        self.add_for_test(client, to_list_kv)
         custom_headers = {"If-Match": to_list_kv.etag}
         items = list(
             client.list_configuration_settings(
@@ -410,7 +410,7 @@ class TestAppConfigurationClientAAD(AppConfigTestCase):
     def test_list_revisions_correct_etag(self, appconfiguration_endpoint_string):
         client = self.create_aad_client(appconfiguration_endpoint_string)
         to_list_kv = self.create_config_setting()
-        to_list_kv = self.add_for_test(client, to_list_kv)
+        self.add_for_test(client, to_list_kv)
         custom_headers = {"If-Match": to_list_kv.etag}
         items = list(
             client.list_revisions(key_filter=to_list_kv.key, label_filter=to_list_kv.label, headers=custom_headers)

--- a/sdk/appconfiguration/azure-appconfiguration/tests/test_azure_appconfiguration_client_async.py
+++ b/sdk/appconfiguration/azure-appconfiguration/tests/test_azure_appconfiguration_client_async.py
@@ -8,7 +8,6 @@ import copy
 import datetime
 import json
 import re
-import time
 from azure.core import MatchConditions
 from azure.core.exceptions import (
     ResourceModifiedError,

--- a/sdk/appconfiguration/azure-appconfiguration/tests/testcase.py
+++ b/sdk/appconfiguration/azure-appconfiguration/tests/testcase.py
@@ -11,6 +11,7 @@ from azure.appconfiguration import (
     FeatureFlagConfigurationSetting,
     SecretReferenceConfigurationSetting,
 )
+from azure.core.exceptions import ResourceExistsError
 from consts import (
     KEY,
     LABEL,
@@ -46,12 +47,10 @@ class AppConfigTestCase(AzureRecordedTestCase):
         )
 
     def add_for_test(self, client, config_setting):
-        key = config_setting.key
-        label = config_setting.label
-        exist = bool(list(client.list_configuration_settings(key_filter=key, label_filter=label)))
-        if exist:
-            client.delete_configuration_setting(key=config_setting.key, label=config_setting.label)
-        return client.add_configuration_setting(config_setting)
+        try:
+            client.add_configuration_setting(config_setting)
+        except ResourceExistsError:
+            pass
 
     def set_up(self, appconfiguration_string, is_aad=False):
         if is_aad:


### PR DESCRIPTION
- The test for `accept_time` is pretty flaky, it assumes the number of configuration settings on one day ago should be less than the number of configuration settings listing at current time(without passing parameter `accept_time`). The assumption is not always correct, for example, when there are some configuration settings created and deleted one day ago, we can still get the configuration settings in the list result with `accept_time` equals to one day ago, but it is no longer in the list result at current time. So it doesn't make sense to compare `all_inclusive` vs `exclude_today`. Also updated the sample test in docstring.
- Updated the description of parameter `accept_time` in docstring to be more clearer.
- Since the configuration setting's last updated time is saved in utc time, so changed to use utc time in docstring samples.