### PR TITLE
[ACR] Resolve failing weekly pipeline

### DIFF
--- a/eng/tox/tox.ini
+++ b/eng/tox/tox.ini
@@ -48,7 +48,7 @@ pkgs =
 
 [pytest]
 ignore_args=--ignore=.tox --ignore=build --ignore=.eggs
-default_args = --junitxml={tox_root}/test-junit-{envname}.xml --verbose -s --durations=10 --ignore=azure {[pytest]ignore_args}
+default_args = --junitxml={tox_root}/test-junit-{envname}.xml --verbose -s -o log_cli=true -o log_cli_level="DEBUG" --durations=10 --ignore=azure {[pytest]ignore_args}
 
 [testenv]
 parallel_show_output =True

--- a/eng/tox/tox.ini
+++ b/eng/tox/tox.ini
@@ -48,7 +48,7 @@ pkgs =
 
 [pytest]
 ignore_args=--ignore=.tox --ignore=build --ignore=.eggs
-default_args = --junitxml={tox_root}/test-junit-{envname}.xml --verbose --durations=10 --ignore=azure {[pytest]ignore_args}
+default_args = --junitxml={tox_root}/test-junit-{envname}.xml --verbose -s -o log_cli=true -o log_cli_level="DEBUG" --durations=10 --ignore=azure {[pytest]ignore_args}
 
 [testenv]
 parallel_show_output =True

--- a/eng/tox/tox.ini
+++ b/eng/tox/tox.ini
@@ -48,7 +48,7 @@ pkgs =
 
 [pytest]
 ignore_args=--ignore=.tox --ignore=build --ignore=.eggs
-default_args = --junitxml={tox_root}/test-junit-{envname}.xml --verbose --durations=10 --ignore=azure {[pytest]ignore_args}
+default_args = --junitxml={tox_root}/test-junit-{envname}.xml --verbose -s --durations=10 --ignore=azure {[pytest]ignore_args}
 
 [testenv]
 parallel_show_output =True

--- a/eng/tox/tox.ini
+++ b/eng/tox/tox.ini
@@ -48,7 +48,7 @@ pkgs =
 
 [pytest]
 ignore_args=--ignore=.tox --ignore=build --ignore=.eggs
-default_args = --junitxml={tox_root}/test-junit-{envname}.xml --verbose -s -o log_cli=true -o log_cli_level="DEBUG" --durations=10 --ignore=azure {[pytest]ignore_args}
+default_args = --junitxml={tox_root}/test-junit-{envname}.xml --verbose --durations=10 --ignore=azure {[pytest]ignore_args}
 
 [testenv]
 parallel_show_output =True

--- a/sdk/containerregistry/azure-containerregistry/README.md
+++ b/sdk/containerregistry/azure-containerregistry/README.md
@@ -104,13 +104,12 @@ Iterate through the collection of tags in the repository with anonymous access.
 <!-- SNIPPET:sample_list_tags.list_tags_anonymous -->
 
 ```python
-endpoint = os.environ.get("CONTAINERREGISTRY_ANONREGISTRY_ENDPOINT")
 with ContainerRegistryClient(endpoint) as anon_client:
     manifest = anon_client.get_manifest_properties("library/hello-world", "latest")
     print(f"Tags of {manifest.repository_name}: ")
     # Iterate through all the tags
     for tag in manifest.tags:
-        print(f"{tag}\n")
+        print(tag)
 ```
 
 <!-- END SNIPPET -->

--- a/sdk/containerregistry/azure-containerregistry/dev_requirements.txt
+++ b/sdk/containerregistry/azure-containerregistry/dev_requirements.txt
@@ -1,6 +1,5 @@
 -e ../../../tools/azure-sdk-tools
 -e ../../../tools/azure-devtools
 ../../core/azure-core
-../azure-mgmt-containerregistry
 aiohttp>=3.0
 azure-identity

--- a/sdk/containerregistry/azure-containerregistry/samples/sample_delete_images.py
+++ b/sdk/containerregistry/azure-containerregistry/samples/sample_delete_images.py
@@ -25,8 +25,6 @@ USAGE:
     2) CONTAINERREGISTRY_TENANT_ID - The service principal's tenant ID
     3) CONTAINERREGISTRY_CLIENT_ID - The service principal's client ID
     4) CONTAINERREGISTRY_CLIENT_SECRET - The service principal's client secret
-    5) CONTAINERREGISTRY_RESOURCE_GROUP - The resource group name
-    6) CONTAINERREGISTRY_REGISTRY_NAME - The registry name
 """
 import os
 from dotenv import find_dotenv, load_dotenv
@@ -42,7 +40,7 @@ class DeleteImages(object):
         self.credential = get_credential(self.authority)
 
     def delete_images(self):
-        load_registry()
+        load_registry(self.endpoint)
         # Instantiate an instance of ContainerRegistryClient
         # [START delete_manifests]
         with ContainerRegistryClient(self.endpoint, self.credential) as client:

--- a/sdk/containerregistry/azure-containerregistry/samples/sample_delete_images_async.py
+++ b/sdk/containerregistry/azure-containerregistry/samples/sample_delete_images_async.py
@@ -25,8 +25,6 @@ USAGE:
     2) CONTAINERREGISTRY_TENANT_ID - The service principal's tenant ID
     3) CONTAINERREGISTRY_CLIENT_ID - The service principal's client ID
     4) CONTAINERREGISTRY_CLIENT_SECRET - The service principal's client secret
-    5) CONTAINERREGISTRY_RESOURCE_GROUP - The resource group name
-    6) CONTAINERREGISTRY_REGISTRY_NAME - The registry name
 """
 import asyncio
 import os
@@ -44,7 +42,7 @@ class DeleteImagesAsync(object):
         self.credential = get_credential(self.authority, is_async=True)
 
     async def delete_images(self):
-        load_registry()
+        load_registry(self.endpoint)
         # Instantiate an instance of ContainerRegistryClient
         async with ContainerRegistryClient(self.endpoint, self.credential) as client:
             async for repository in client.list_repository_names():

--- a/sdk/containerregistry/azure-containerregistry/samples/sample_delete_tags.py
+++ b/sdk/containerregistry/azure-containerregistry/samples/sample_delete_tags.py
@@ -25,8 +25,6 @@ USAGE:
     2) CONTAINERREGISTRY_TENANT_ID - The service principal's tenant ID
     3) CONTAINERREGISTRY_CLIENT_ID - The service principal's client ID
     4) CONTAINERREGISTRY_CLIENT_SECRET - The service principal's client secret
-    5) CONTAINERREGISTRY_RESOURCE_GROUP - The resource group name
-    6) CONTAINERREGISTRY_REGISTRY_NAME - The registry name
 """
 import os
 from dotenv import find_dotenv, load_dotenv
@@ -42,7 +40,7 @@ class DeleteTags(object):
         self.credential = get_credential(self.authority)
 
     def delete_tags(self):
-        load_registry()
+        load_registry(self.endpoint)
         # [START list_repository_names]
         with ContainerRegistryClient(self.endpoint, self.credential) as client:
             # Iterate through all the repositories

--- a/sdk/containerregistry/azure-containerregistry/samples/sample_delete_tags_async.py
+++ b/sdk/containerregistry/azure-containerregistry/samples/sample_delete_tags_async.py
@@ -25,8 +25,6 @@ USAGE:
     2) CONTAINERREGISTRY_TENANT_ID - The service principal's tenant ID
     3) CONTAINERREGISTRY_CLIENT_ID - The service principal's client ID
     4) CONTAINERREGISTRY_CLIENT_SECRET - The service principal's client secret
-    5) CONTAINERREGISTRY_RESOURCE_GROUP - The resource group name
-    6) CONTAINERREGISTRY_REGISTRY_NAME - The registry name
 """
 import asyncio
 import os
@@ -44,7 +42,7 @@ class DeleteTagsAsync(object):
         self.credential = get_credential(self.authority, is_async=True)
 
     async def delete_tags(self):
-        load_registry()
+        load_registry(self.endpoint)
         # [START list_repository_names]
         async with ContainerRegistryClient(self.endpoint, self.credential) as client:
             # Iterate through all the repositories

--- a/sdk/containerregistry/azure-containerregistry/samples/sample_hello_world.py
+++ b/sdk/containerregistry/azure-containerregistry/samples/sample_hello_world.py
@@ -25,8 +25,6 @@ USAGE:
     2) CONTAINERREGISTRY_TENANT_ID - The service principal's tenant ID
     3) CONTAINERREGISTRY_CLIENT_ID - The service principal's client ID
     4) CONTAINERREGISTRY_CLIENT_SECRET - The service principal's client secret
-    5) CONTAINERREGISTRY_RESOURCE_GROUP - The resource group name
-    6) CONTAINERREGISTRY_REGISTRY_NAME - The registry name
 """
 import os
 from dotenv import find_dotenv, load_dotenv
@@ -42,7 +40,7 @@ class HelloWorld(object):
         self.credential = get_credential(self.authority)
 
     def basic_sample(self):
-        load_registry()
+        load_registry(self.endpoint)
         # Instantiate an instance of ContainerRegistryClient
         # [START create_registry_client]
         with ContainerRegistryClient(self.endpoint, self.credential) as client:

--- a/sdk/containerregistry/azure-containerregistry/samples/sample_hello_world_async.py
+++ b/sdk/containerregistry/azure-containerregistry/samples/sample_hello_world_async.py
@@ -25,8 +25,6 @@ USAGE:
     2) CONTAINERREGISTRY_TENANT_ID - The service principal's tenant ID
     3) CONTAINERREGISTRY_CLIENT_ID - The service principal's client ID
     4) CONTAINERREGISTRY_CLIENT_SECRET - The service principal's client secret
-    5) CONTAINERREGISTRY_RESOURCE_GROUP - The resource group name
-    6) CONTAINERREGISTRY_REGISTRY_NAME - The registry name
 """
 import asyncio
 import os
@@ -43,7 +41,7 @@ class HelloWorldAsync(object):
         self.credential = get_credential(self.authority, is_async=True)
 
     async def basic_sample(self):
-        load_registry()
+        load_registry(self.endpoint)
         # Instantiate an instance of ContainerRegistryClient
         # [START create_registry_client]
         async with ContainerRegistryClient(self.endpoint, self.credential) as client:

--- a/sdk/containerregistry/azure-containerregistry/samples/sample_list_tags.py
+++ b/sdk/containerregistry/azure-containerregistry/samples/sample_list_tags.py
@@ -49,7 +49,7 @@ class ListTags(object):
             print(f"Tags of {manifest.repository_name}: ")
             # Iterate through all the tags
             for tag in manifest.tags:
-                print(f"{tag}\n")
+                print(tag)
         # [END list_tags_anonymous]
 
 

--- a/sdk/containerregistry/azure-containerregistry/samples/sample_list_tags.py
+++ b/sdk/containerregistry/azure-containerregistry/samples/sample_list_tags.py
@@ -27,8 +27,6 @@ USAGE:
     2) CONTAINERREGISTRY_TENANT_ID - The service principal's tenant ID
     3) CONTAINERREGISTRY_CLIENT_ID - The service principal's client ID
     4) CONTAINERREGISTRY_CLIENT_SECRET - The service principal's client secret
-    5) CONTAINERREGISTRY_RESOURCE_GROUP - The resource group name
-    6) CONTAINERREGISTRY_REGISTRY_NAME - The registry name
 """
 import os
 from dotenv import find_dotenv, load_dotenv
@@ -41,9 +39,9 @@ class ListTags(object):
         load_dotenv(find_dotenv())
 
     def list_tags(self):
-        load_registry()
-        # [START list_tags_anonymous]
         endpoint = os.environ.get("CONTAINERREGISTRY_ANONREGISTRY_ENDPOINT")
+        load_registry(endpoint)
+        # [START list_tags_anonymous]
         with ContainerRegistryClient(endpoint) as anon_client:
             manifest = anon_client.get_manifest_properties("library/hello-world", "latest")
             print(f"Tags of {manifest.repository_name}: ")

--- a/sdk/containerregistry/azure-containerregistry/samples/sample_list_tags_async.py
+++ b/sdk/containerregistry/azure-containerregistry/samples/sample_list_tags_async.py
@@ -50,7 +50,7 @@ class ListTagsAsync(object):
             print(f"Tags of {manifest.repository_name}: ")
             # Iterate through all the tags
             for tag in manifest.tags:
-                print(f"{tag}\n")
+                print(tag)
         # [END list_tags_anonymous]
 
 

--- a/sdk/containerregistry/azure-containerregistry/samples/sample_list_tags_async.py
+++ b/sdk/containerregistry/azure-containerregistry/samples/sample_list_tags_async.py
@@ -27,8 +27,6 @@ USAGE:
     2) CONTAINERREGISTRY_TENANT_ID - The service principal's tenant ID
     3) CONTAINERREGISTRY_CLIENT_ID - The service principal's client ID
     4) CONTAINERREGISTRY_CLIENT_SECRET - The service principal's client secret
-    5) CONTAINERREGISTRY_RESOURCE_GROUP - The resource group name
-    6) CONTAINERREGISTRY_REGISTRY_NAME - The registry name
 """
 import asyncio
 import os
@@ -42,9 +40,9 @@ class ListTagsAsync(object):
         load_dotenv(find_dotenv())
 
     async def list_tags(self):
-        load_registry()
-        # [START list_tags_anonymous]
         endpoint = os.environ.get("CONTAINERREGISTRY_ANONREGISTRY_ENDPOINT")
+        load_registry(endpoint)
+        # [START list_tags_anonymous]
         async with ContainerRegistryClient(endpoint) as anon_client:
             manifest = await anon_client.get_manifest_properties("library/hello-world", "latest")
             print(f"Tags of {manifest.repository_name}: ")

--- a/sdk/containerregistry/azure-containerregistry/samples/sample_set_get_image.py
+++ b/sdk/containerregistry/azure-containerregistry/samples/sample_set_get_image.py
@@ -17,15 +17,6 @@ USAGE:
 
     Set the environment variables with your own values before running the sample:
     1) CONTAINERREGISTRY_ENDPOINT - The URL of your Container Registry account
-
-    This sample assumes your registry has a repository "library/hello-world", run load_registry() if you don't have.
-    Set the environment variables with your own values before running load_registry():
-    1) CONTAINERREGISTRY_ENDPOINT - The URL of your Container Registry account
-    2) CONTAINERREGISTRY_TENANT_ID - The service principal's tenant ID
-    3) CONTAINERREGISTRY_CLIENT_ID - The service principal's client ID
-    4) CONTAINERREGISTRY_CLIENT_SECRET - The service principal's client secret
-    5) CONTAINERREGISTRY_RESOURCE_GROUP - The resource group name
-    6) CONTAINERREGISTRY_REGISTRY_NAME - The registry name
 """
 import os
 import json
@@ -33,11 +24,9 @@ from io import BytesIO
 from dotenv import find_dotenv, load_dotenv
 from azure.containerregistry import (
     ContainerRegistryClient,
-    ArtifactArchitecture,
-    ArtifactOperatingSystem,
     DigestValidationError,
 )
-from utilities import load_registry, get_authority, get_credential
+from utilities import get_authority, get_credential
 
 
 class SetGetImage(object):
@@ -147,27 +136,35 @@ class SetGetImage(object):
         self.delete_oci_image()
     
     def set_get_docker_image(self):
-        load_registry()
-        repository_name = "library/hello-world"
-        # create a Docker image object in Docker v2 Manifest List format
-        manifest_list = {
-            "schemaVersion": 2,
-            "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
-            "manifests": [
-                {
-                    "digest": "sha256:7e9b6e7ba2842c91cf49f3e214d04a7a496f8214356f41d81a6e6dcad11f11e3",
-                    "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
-                    "platform": {
-                        "architecture": ArtifactArchitecture.AMD64,
-                        "os": ArtifactOperatingSystem.LINUX
-                    },
-                    "size": 525
-                }
-            ]
-        }
+        repository_name = "sample-docker-image"
         with ContainerRegistryClient(self.endpoint, self.credential) as client:
+            # Upload a layer
+            layer = BytesIO(b"Sample layer")
+            layer_digest, layer_size = client.upload_blob(repository_name, layer)
+            print(f"Uploaded layer: digest - {layer_digest}, size - {layer_size}")
+            # Upload a config
+            config = BytesIO(json.dumps({"sample config": "content"}).encode())
+            config_digest, config_size = client.upload_blob(repository_name, config)
+            print(f"Uploaded config: digest - {config_digest}, size - {config_size}")
+            # create a Docker image object in Docker v2 Manifest format
+            docker_manifest = {
+                "config": {
+                    "digest": config_digest,
+                    "mediaType": "application/vnd.docker.container.image.v1+json",
+                    "size": config_size
+                },
+                "layers": [
+                    {
+                        "digest": layer_digest,
+                        "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+                        "size": layer_size
+                    }
+                ],
+                "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+                "schemaVersion": 2
+            }
             # Set the image with one custom media type
-            client.set_manifest(repository_name, manifest_list, tag="sample", media_type=manifest_list["mediaType"])
+            client.set_manifest(repository_name, docker_manifest, tag="sample", media_type=docker_manifest["mediaType"])
 
             # Get the image
             get_manifest_result = client.get_manifest(repository_name, "sample")
@@ -175,6 +172,9 @@ class SetGetImage(object):
             print(received_manifest)
             received_manifest_media_type = get_manifest_result.media_type
             print(received_manifest_media_type)
+            
+            # Delete the image
+            client.delete_manifest(repository_name, get_manifest_result.digest)
 
 
 if __name__ == "__main__":

--- a/sdk/containerregistry/azure-containerregistry/samples/sample_set_get_image_async.py
+++ b/sdk/containerregistry/azure-containerregistry/samples/sample_set_get_image_async.py
@@ -17,24 +17,15 @@ USAGE:
 
     Set the environment variables with your own values before running the sample:
     1) CONTAINERREGISTRY_ANONREGISTRY_ENDPOINT - The URL of your Container Registry account for anonymous access
-
-    This sample assumes your registry has a repository "library/hello-world", run load_registry() if you don't have.
-    Set the environment variables with your own values before running load_registry():
-    1) CONTAINERREGISTRY_ANONREGISTRY_ENDPOINT - The URL of your Container Registry account for anonymous access
-    2) CONTAINERREGISTRY_TENANT_ID - The service principal's tenant ID
-    3) CONTAINERREGISTRY_CLIENT_ID - The service principal's client ID
-    4) CONTAINERREGISTRY_CLIENT_SECRET - The service principal's client secret
-    5) CONTAINERREGISTRY_RESOURCE_GROUP - The resource group name
-    6) CONTAINERREGISTRY_REGISTRY_NAME - The registry name
 """
 import asyncio
 import os
 import json
 from io import BytesIO
 from dotenv import find_dotenv, load_dotenv
-from azure.containerregistry import ArtifactArchitecture, ArtifactOperatingSystem, DigestValidationError
+from azure.containerregistry import DigestValidationError
 from azure.containerregistry.aio import ContainerRegistryClient
-from utilities import load_registry, get_authority, get_credential
+from utilities import get_authority, get_credential
 
 
 class SetGetImageAsync(object):
@@ -124,27 +115,35 @@ class SetGetImageAsync(object):
             await client.delete_manifest(repository_name, get_manifest_result.digest)
 
     async def set_get_docker_image(self):
-        load_registry()
-        repository_name = "library/hello-world"
-        # create a Docker image object in Docker v2 Manifest List format
-        manifest_list = {
-            "schemaVersion": 2,
-            "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
-            "manifests": [
-                {
-                    "digest": "sha256:7e9b6e7ba2842c91cf49f3e214d04a7a496f8214356f41d81a6e6dcad11f11e3",
-                    "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
-                    "platform": {
-                        "architecture": ArtifactArchitecture.AMD64,
-                        "os": ArtifactOperatingSystem.LINUX
-                    },
-                    "size": 525
-                }
-            ]
-        }
+        repository_name = "sample-docker-image"
         async with ContainerRegistryClient(self.endpoint, self.credential) as client:
+            # Upload a layer
+            layer = BytesIO(b"Sample layer")
+            layer_digest, layer_size = await client.upload_blob(repository_name, layer)
+            print(f"Uploaded layer: digest - {layer_digest}, size - {layer_size}")
+            # Upload a config
+            config = BytesIO(json.dumps({"sample config": "content"}).encode())
+            config_digest, config_size = await client.upload_blob(repository_name, config)
+            print(f"Uploaded config: digest - {config_digest}, size - {config_size}")
+            # create a Docker image object in Docker v2 Manifest format
+            docker_manifest = {
+                "config": {
+                    "digest": config_digest,
+                    "mediaType": "application/vnd.docker.container.image.v1+json",
+                    "size": config_size
+                },
+                "layers": [
+                    {
+                        "digest": layer_digest,
+                        "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+                        "size": layer_size
+                    }
+                ],
+                "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+                "schemaVersion": 2
+            }
             # Set the image with one custom media type
-            await client.set_manifest(repository_name, manifest_list, tag="sample", media_type=manifest_list["mediaType"])
+            await client.set_manifest(repository_name, docker_manifest, tag="sample", media_type=docker_manifest["mediaType"])
 
             # Get the image
             get_manifest_result = await client.get_manifest(repository_name, "sample")
@@ -152,6 +151,9 @@ class SetGetImageAsync(object):
             print(received_manifest)
             received_manifest_media_type = get_manifest_result.media_type
             print(received_manifest_media_type)
+            
+            # Delete the image
+            client.delete_manifest(repository_name, get_manifest_result.digest)
 
 
 async def main():

--- a/sdk/containerregistry/azure-containerregistry/samples/sample_set_image_properties.py
+++ b/sdk/containerregistry/azure-containerregistry/samples/sample_set_image_properties.py
@@ -26,8 +26,6 @@ USAGE:
     2) CONTAINERREGISTRY_TENANT_ID - The service principal's tenant ID
     3) CONTAINERREGISTRY_CLIENT_ID - The service principal's client ID
     4) CONTAINERREGISTRY_CLIENT_SECRET - The service principal's client secret
-    5) CONTAINERREGISTRY_RESOURCE_GROUP - The resource group name
-    6) CONTAINERREGISTRY_REGISTRY_NAME - The registry name
 """
 import os
 from dotenv import find_dotenv, load_dotenv
@@ -43,7 +41,7 @@ class SetImageProperties(object):
         self.credential = get_credential(self.authority)
 
     def set_image_properties(self):
-        load_registry()
+        load_registry(self.endpoint)
         # [START update_manifest_properties]
         with ContainerRegistryClient(self.endpoint, self.credential) as client:
             # Set permissions on image "library/hello-world:v1"

--- a/sdk/containerregistry/azure-containerregistry/samples/sample_set_image_properties_async.py
+++ b/sdk/containerregistry/azure-containerregistry/samples/sample_set_image_properties_async.py
@@ -26,8 +26,6 @@ USAGE:
     2) CONTAINERREGISTRY_TENANT_ID - The service principal's tenant ID
     3) CONTAINERREGISTRY_CLIENT_ID - The service principal's client ID
     4) CONTAINERREGISTRY_CLIENT_SECRET - The service principal's client secret
-    5) CONTAINERREGISTRY_RESOURCE_GROUP - The resource group name
-    6) CONTAINERREGISTRY_REGISTRY_NAME - The registry name
 """
 import asyncio
 import os
@@ -44,7 +42,7 @@ class SetImagePropertiesAsync(object):
         self.credential = get_credential(self.authority, is_async=True)
 
     async def set_image_properties(self):
-        load_registry()
+        load_registry(self.endpoint)
         # Instantiate an instance of ContainerRegistryClient
         async with ContainerRegistryClient(self.endpoint, self.credential) as client:
             # Set permissions on image "library/hello-world:v1"

--- a/sdk/containerregistry/azure-containerregistry/samples/utilities.py
+++ b/sdk/containerregistry/azure-containerregistry/samples/utilities.py
@@ -29,14 +29,6 @@ def load_registry():
     endpoint = os.environ.get("CONTAINERREGISTRY_ENDPOINT")
     repo = "library/hello-world"
     tags = ["latest", "v1", "v2", "v3"]
-    # tags = [
-    #     [
-    #         "library/hello-world:latest",
-    #         "library/hello-world:v1",
-    #         "library/hello-world:v2",
-    #         "library/hello-world:v3"
-    #     ]
-    # ]
     try:
         _import_images(endpoint, repo, tags)
     except Exception as e:
@@ -75,31 +67,7 @@ def _import_images(endpoint, repository, tags):
         }
         for tag in tags:
             client.set_manifest(repository, docker_manifest, tag=tag, media_type="application/vnd.docker.distribution.manifest.v2+json")
-    # sub_id = os.environ.get("CONTAINERREGISTRY_SUBSCRIPTION_ID")
-    # audience = get_audience(authority)
-    # scope = [audience + "/.default"]
-    # mgmt_client = ContainerRegistryManagementClient(
-    #     credential,
-    #     sub_id,
-    #     api_version="2019-05-01",
-    #     base_url=audience,
-    #     credential_scopes=scope
-    # )
-    # registry_uri = "registry.hub.docker.com"
-    # rg_name = os.environ.get("CONTAINERREGISTRY_RESOURCE_GROUP")
-    # registry_name = os.environ.get("CONTAINERREGISTRY_REGISTRY_NAME")
 
-    # import_source = ImportSource(source_image=repository, registry_uri=registry_uri)
-
-    # import_params = ImportImageParameters(mode=ImportMode.Force, source=import_source, target_tags=tags)
-
-    # result = mgmt_client.registries.begin_import_image(
-    #     rg_name,
-    #     registry_name,
-    #     parameters=import_params,
-    # )
-    
-    # result.wait()
 
 def get_authority(endpoint):
     if ".azurecr.io" in endpoint:

--- a/sdk/containerregistry/azure-containerregistry/samples/utilities.py
+++ b/sdk/containerregistry/azure-containerregistry/samples/utilities.py
@@ -11,7 +11,7 @@ FILE: utilities.py
 
 DESCRIPTION:
     This file include some utility functions for samples to use:
-    - load_registry(): to create some repositories and import images with different tags in each repository.
+    - load_registry(): to create repository "library/hello-world" and import images with different tags.
     - get_authority(): get authority of the ContainerRegistryClient
     - get_audience(): get audience of the ContainerRegistryClient
     - get_credential(): get credential of the ContainerRegistryClient
@@ -24,9 +24,8 @@ from azure.containerregistry import ContainerRegistryClient
 from azure.identity import AzureAuthorityHosts, ClientSecretCredential
 from azure.identity.aio import ClientSecretCredential as AsyncClientSecretCredential
 
-def load_registry():
+def load_registry(endpoint):
     print("loading registry...")
-    endpoint = os.environ.get("CONTAINERREGISTRY_ENDPOINT")
     repo = "library/hello-world"
     tags = ["latest", "v1", "v2", "v3"]
     try:
@@ -101,6 +100,3 @@ def get_credential(authority, **kwargs):
         client_secret=os.environ.get("CONTAINERREGISTRY_CLIENT_SECRET"),
         authority=authority
     )
-
-def get_data_path():
-    return os.path.join(os.getcwd(), "samples", "data", "docker_artifact")

--- a/sdk/containerregistry/azure-containerregistry/tests/conftest.py
+++ b/sdk/containerregistry/azure-containerregistry/tests/conftest.py
@@ -23,7 +23,7 @@ logger = logging.getLogger()
 def load_registry():
     if not is_live():
         return
-    logger.warning("loading registry")
+    logger.info("loading registry")
     endpoint = os.environ.get("CONTAINERREGISTRY_ENDPOINT")
     endpoint_anon = os.environ.get("CONTAINERREGISTRY_ANONREGISTRY_ENDPOINT")
     repo = HELLO_WORLD

--- a/sdk/containerregistry/azure-containerregistry/tests/conftest.py
+++ b/sdk/containerregistry/azure-containerregistry/tests/conftest.py
@@ -14,7 +14,7 @@ from devtools_testutils import (
     test_proxy,
     is_live,
 )
-from testcase import import_image
+from testcase import import_image, is_public_endpoint
 from constants import HELLO_WORLD
 
 logger = logging.getLogger()
@@ -30,7 +30,8 @@ def load_registry():
     tags = ["latest", "v1"]
     try:
         import_image(endpoint, repo, tags)
-        import_image(endpoint_anon, repo, tags)
+        if is_public_endpoint(endpoint_anon):
+            import_image(endpoint_anon, repo, tags)
     except Exception as e:
         logger.exception(e)
         raise

--- a/sdk/containerregistry/azure-containerregistry/tests/conftest.py
+++ b/sdk/containerregistry/azure-containerregistry/tests/conftest.py
@@ -4,6 +4,7 @@
 # Licensed under the MIT License. See License.txt in the project root for
 # license information.
 # --------------------------------------------------------------------------
+import logging
 import os
 import pytest
 from devtools_testutils import (
@@ -15,8 +16,11 @@ from devtools_testutils import (
 )
 from testcase import get_authority, import_image
 
+logger = logging.getLogger()
+
 @pytest.fixture(scope="session", autouse=True)
 def load_registry():
+    logger.warning("loading registry")
     if not is_live():
         return
     authority = get_authority(os.environ.get("CONTAINERREGISTRY_ENDPOINT"))

--- a/sdk/containerregistry/azure-containerregistry/tests/conftest.py
+++ b/sdk/containerregistry/azure-containerregistry/tests/conftest.py
@@ -14,27 +14,26 @@ from devtools_testutils import (
     test_proxy,
     is_live,
 )
-from testcase import get_authority, import_image
+from testcase import import_image
+from constants import HELLO_WORLD
 
 logger = logging.getLogger()
 
 @pytest.fixture(scope="session", autouse=True)
 def load_registry():
-    logger.warning("loading registry")
     if not is_live():
         return
-    authority = get_authority(os.environ.get("CONTAINERREGISTRY_ENDPOINT"))
-    authority_anon = get_authority(os.environ.get("CONTAINERREGISTRY_ANONREGISTRY_ENDPOINT"))
-    repo = "library/hello-world"
-    tags = [
-        "library/hello-world:latest",
-        "library/hello-world:v1"
-    ]
+    logger.warning("loading registry")
+    endpoint = os.environ.get("CONTAINERREGISTRY_ENDPOINT")
+    endpoint_anon = os.environ.get("CONTAINERREGISTRY_ANONREGISTRY_ENDPOINT")
+    repo = HELLO_WORLD
+    tags = ["latest", "v1"]
     try:
-        import_image(authority, repo, tags)
-        import_image(authority_anon, repo, tags, is_anonymous=True)
+        import_image(endpoint, repo, tags)
+        import_image(endpoint_anon, repo, tags)
     except Exception as e:
-        print(e)
+        logger.exception(e)
+        raise
 
 @pytest.fixture(scope="session", autouse=True)
 def add_sanitizers(test_proxy):

--- a/sdk/containerregistry/azure-containerregistry/tests/test_anon_access.py
+++ b/sdk/containerregistry/azure-containerregistry/tests/test_anon_access.py
@@ -15,7 +15,7 @@ from azure.containerregistry import (
     ContainerRegistryClient,
 )
 
-from testcase import ContainerRegistryTestClass
+from testcase import ContainerRegistryTestClass, is_public_endpoint
 from constants import HELLO_WORLD
 from preparer import acr_preparer
 from devtools_testutils import recorded_by_proxy
@@ -25,7 +25,7 @@ class TestContainerRegistryClient(ContainerRegistryTestClass):
     @acr_preparer()
     @recorded_by_proxy
     def test_list_repository_names(self, containerregistry_anonregistry_endpoint):
-        if not self.is_public_endpoint(containerregistry_anonregistry_endpoint):
+        if not is_public_endpoint(containerregistry_anonregistry_endpoint):
             pytest.skip("Not a public endpoint")
 
         with self.create_anon_client(containerregistry_anonregistry_endpoint) as client:
@@ -47,7 +47,7 @@ class TestContainerRegistryClient(ContainerRegistryTestClass):
     @acr_preparer()
     @recorded_by_proxy
     def test_list_repository_names_by_page(self, containerregistry_anonregistry_endpoint):
-        if not self.is_public_endpoint(containerregistry_anonregistry_endpoint):
+        if not is_public_endpoint(containerregistry_anonregistry_endpoint):
             pytest.skip("Not a public endpoint")
 
         with self.create_anon_client(containerregistry_anonregistry_endpoint) as client:
@@ -74,7 +74,7 @@ class TestContainerRegistryClient(ContainerRegistryTestClass):
     @acr_preparer()
     @recorded_by_proxy
     def test_get_repository_properties(self, containerregistry_anonregistry_endpoint):
-        if not self.is_public_endpoint(containerregistry_anonregistry_endpoint):
+        if not is_public_endpoint(containerregistry_anonregistry_endpoint):
             pytest.skip("Not a public endpoint")
 
         with self.create_anon_client(containerregistry_anonregistry_endpoint) as client:
@@ -88,7 +88,7 @@ class TestContainerRegistryClient(ContainerRegistryTestClass):
     @acr_preparer()
     @recorded_by_proxy
     def test_list_manifest_properties(self, containerregistry_anonregistry_endpoint):
-        if not self.is_public_endpoint(containerregistry_anonregistry_endpoint):
+        if not is_public_endpoint(containerregistry_anonregistry_endpoint):
             pytest.skip("Not a public endpoint")
 
         with self.create_anon_client(containerregistry_anonregistry_endpoint) as client:
@@ -103,7 +103,7 @@ class TestContainerRegistryClient(ContainerRegistryTestClass):
     @acr_preparer()
     @recorded_by_proxy
     def test_get_manifest_properties(self, containerregistry_anonregistry_endpoint):
-        if not self.is_public_endpoint(containerregistry_anonregistry_endpoint):
+        if not is_public_endpoint(containerregistry_anonregistry_endpoint):
             pytest.skip("Not a public endpoint")
 
         with self.create_anon_client(containerregistry_anonregistry_endpoint) as client:
@@ -118,7 +118,7 @@ class TestContainerRegistryClient(ContainerRegistryTestClass):
     @acr_preparer()
     @recorded_by_proxy
     def test_list_tag_properties(self, containerregistry_anonregistry_endpoint):
-        if not self.is_public_endpoint(containerregistry_anonregistry_endpoint):
+        if not is_public_endpoint(containerregistry_anonregistry_endpoint):
             pytest.skip("Not a public endpoint")
 
         with self.create_anon_client(containerregistry_anonregistry_endpoint) as client:
@@ -133,7 +133,7 @@ class TestContainerRegistryClient(ContainerRegistryTestClass):
     @acr_preparer()
     @recorded_by_proxy
     def test_delete_repository(self, containerregistry_anonregistry_endpoint):
-        if not self.is_public_endpoint(containerregistry_anonregistry_endpoint):
+        if not is_public_endpoint(containerregistry_anonregistry_endpoint):
             pytest.skip("Not a public endpoint")
 
         with self.create_anon_client(containerregistry_anonregistry_endpoint) as client:
@@ -145,7 +145,7 @@ class TestContainerRegistryClient(ContainerRegistryTestClass):
     @acr_preparer()
     @recorded_by_proxy
     def test_delete_tag(self, containerregistry_anonregistry_endpoint):
-        if not self.is_public_endpoint(containerregistry_anonregistry_endpoint):
+        if not is_public_endpoint(containerregistry_anonregistry_endpoint):
             pytest.skip("Not a public endpoint")
 
         with self.create_anon_client(containerregistry_anonregistry_endpoint) as client:
@@ -157,7 +157,7 @@ class TestContainerRegistryClient(ContainerRegistryTestClass):
     @acr_preparer()
     @recorded_by_proxy
     def test_delete_manifest(self, containerregistry_anonregistry_endpoint):
-        if not self.is_public_endpoint(containerregistry_anonregistry_endpoint):
+        if not is_public_endpoint(containerregistry_anonregistry_endpoint):
             pytest.skip("Not a public endpoint")
 
         with self.create_anon_client(containerregistry_anonregistry_endpoint) as client:
@@ -169,7 +169,7 @@ class TestContainerRegistryClient(ContainerRegistryTestClass):
     @acr_preparer()
     @recorded_by_proxy
     def test_update_repository_properties(self, containerregistry_anonregistry_endpoint):
-        if not self.is_public_endpoint(containerregistry_anonregistry_endpoint):
+        if not is_public_endpoint(containerregistry_anonregistry_endpoint):
             pytest.skip("Not a public endpoint")
 
         with self.create_anon_client(containerregistry_anonregistry_endpoint) as client:
@@ -181,7 +181,7 @@ class TestContainerRegistryClient(ContainerRegistryTestClass):
     @acr_preparer()
     @recorded_by_proxy
     def test_update_tag_properties(self, containerregistry_anonregistry_endpoint):
-        if not self.is_public_endpoint(containerregistry_anonregistry_endpoint):
+        if not is_public_endpoint(containerregistry_anonregistry_endpoint):
             pytest.skip("Not a public endpoint")
 
         with self.create_anon_client(containerregistry_anonregistry_endpoint) as client:
@@ -193,7 +193,7 @@ class TestContainerRegistryClient(ContainerRegistryTestClass):
     @acr_preparer()
     @recorded_by_proxy
     def test_update_manifest_properties(self, containerregistry_anonregistry_endpoint):
-        if not self.is_public_endpoint(containerregistry_anonregistry_endpoint):
+        if not is_public_endpoint(containerregistry_anonregistry_endpoint):
             pytest.skip("Not a public endpoint")
 
         with self.create_anon_client(containerregistry_anonregistry_endpoint) as client:

--- a/sdk/containerregistry/azure-containerregistry/tests/test_anon_access_async.py
+++ b/sdk/containerregistry/azure-containerregistry/tests/test_anon_access_async.py
@@ -16,6 +16,7 @@ from azure.core.async_paging import AsyncItemPaged
 from azure.core.exceptions import ClientAuthenticationError
 
 from asynctestcase import AsyncContainerRegistryTestClass
+from testcase import is_public_endpoint
 from constants import HELLO_WORLD
 from preparer import acr_preparer
 from devtools_testutils.aio import recorded_by_proxy_async
@@ -25,7 +26,7 @@ class TestContainerRegistryClientAsync(AsyncContainerRegistryTestClass):
     @acr_preparer()
     @recorded_by_proxy_async
     async def test_list_repository_names(self, containerregistry_anonregistry_endpoint):
-        if not self.is_public_endpoint(containerregistry_anonregistry_endpoint):
+        if not is_public_endpoint(containerregistry_anonregistry_endpoint):
             pytest.skip("Not a public endpoint")
 
         async with self.create_anon_client(containerregistry_anonregistry_endpoint) as client:
@@ -47,7 +48,7 @@ class TestContainerRegistryClientAsync(AsyncContainerRegistryTestClass):
     @acr_preparer()
     @recorded_by_proxy_async
     async def test_list_repository_names_by_page(self, containerregistry_anonregistry_endpoint):
-        if not self.is_public_endpoint(containerregistry_anonregistry_endpoint):
+        if not is_public_endpoint(containerregistry_anonregistry_endpoint):
             pytest.skip("Not a public endpoint")
 
         async with self.create_anon_client(containerregistry_anonregistry_endpoint) as client:
@@ -74,7 +75,7 @@ class TestContainerRegistryClientAsync(AsyncContainerRegistryTestClass):
     @acr_preparer()
     @recorded_by_proxy_async
     async def test_get_repository_properties(self, containerregistry_anonregistry_endpoint):
-        if not self.is_public_endpoint(containerregistry_anonregistry_endpoint):
+        if not is_public_endpoint(containerregistry_anonregistry_endpoint):
             pytest.skip("Not a public endpoint")
 
         async with self.create_anon_client(containerregistry_anonregistry_endpoint) as client:
@@ -88,7 +89,7 @@ class TestContainerRegistryClientAsync(AsyncContainerRegistryTestClass):
     @acr_preparer()
     @recorded_by_proxy_async
     async def test_list_manifest_properties(self, containerregistry_anonregistry_endpoint):
-        if not self.is_public_endpoint(containerregistry_anonregistry_endpoint):
+        if not is_public_endpoint(containerregistry_anonregistry_endpoint):
             pytest.skip("Not a public endpoint")
 
         async with self.create_anon_client(containerregistry_anonregistry_endpoint) as client:
@@ -103,7 +104,7 @@ class TestContainerRegistryClientAsync(AsyncContainerRegistryTestClass):
     @acr_preparer()
     @recorded_by_proxy_async
     async def test_get_manifest_properties(self, containerregistry_anonregistry_endpoint):
-        if not self.is_public_endpoint(containerregistry_anonregistry_endpoint):
+        if not is_public_endpoint(containerregistry_anonregistry_endpoint):
             pytest.skip("Not a public endpoint")
 
         async with self.create_anon_client(containerregistry_anonregistry_endpoint) as client:
@@ -118,7 +119,7 @@ class TestContainerRegistryClientAsync(AsyncContainerRegistryTestClass):
     @acr_preparer()
     @recorded_by_proxy_async
     async def test_list_tag_properties(self, containerregistry_anonregistry_endpoint):
-        if not self.is_public_endpoint(containerregistry_anonregistry_endpoint):
+        if not is_public_endpoint(containerregistry_anonregistry_endpoint):
             pytest.skip("Not a public endpoint")
 
         async with self.create_anon_client(containerregistry_anonregistry_endpoint) as client:
@@ -133,7 +134,7 @@ class TestContainerRegistryClientAsync(AsyncContainerRegistryTestClass):
     @acr_preparer()
     @recorded_by_proxy_async
     async def test_delete_repository(self, containerregistry_anonregistry_endpoint):
-        if not self.is_public_endpoint(containerregistry_anonregistry_endpoint):
+        if not is_public_endpoint(containerregistry_anonregistry_endpoint):
             pytest.skip("Not a public endpoint")
 
         async with self.create_anon_client(containerregistry_anonregistry_endpoint) as client:
@@ -145,7 +146,7 @@ class TestContainerRegistryClientAsync(AsyncContainerRegistryTestClass):
     @acr_preparer()
     @recorded_by_proxy_async
     async def test_delete_tag(self, containerregistry_anonregistry_endpoint):
-        if not self.is_public_endpoint(containerregistry_anonregistry_endpoint):
+        if not is_public_endpoint(containerregistry_anonregistry_endpoint):
             pytest.skip("Not a public endpoint")
 
         async with self.create_anon_client(containerregistry_anonregistry_endpoint) as client:
@@ -157,7 +158,7 @@ class TestContainerRegistryClientAsync(AsyncContainerRegistryTestClass):
     @acr_preparer()
     @recorded_by_proxy_async
     async def test_delete_manifest(self, containerregistry_anonregistry_endpoint):
-        if not self.is_public_endpoint(containerregistry_anonregistry_endpoint):
+        if not is_public_endpoint(containerregistry_anonregistry_endpoint):
             pytest.skip("Not a public endpoint")
 
         async with self.create_anon_client(containerregistry_anonregistry_endpoint) as client:
@@ -169,7 +170,7 @@ class TestContainerRegistryClientAsync(AsyncContainerRegistryTestClass):
     @acr_preparer()
     @recorded_by_proxy_async
     async def test_update_repository_properties(self, containerregistry_anonregistry_endpoint):
-        if not self.is_public_endpoint(containerregistry_anonregistry_endpoint):
+        if not is_public_endpoint(containerregistry_anonregistry_endpoint):
             pytest.skip("Not a public endpoint")
 
         async with self.create_anon_client(containerregistry_anonregistry_endpoint) as client:
@@ -181,7 +182,7 @@ class TestContainerRegistryClientAsync(AsyncContainerRegistryTestClass):
     @acr_preparer()
     @recorded_by_proxy_async
     async def test_update_tag_properties(self, containerregistry_anonregistry_endpoint):
-        if not self.is_public_endpoint(containerregistry_anonregistry_endpoint):
+        if not is_public_endpoint(containerregistry_anonregistry_endpoint):
             pytest.skip("Not a public endpoint")
 
         async with self.create_anon_client(containerregistry_anonregistry_endpoint) as client:
@@ -193,7 +194,7 @@ class TestContainerRegistryClientAsync(AsyncContainerRegistryTestClass):
     @acr_preparer()
     @recorded_by_proxy_async
     async def test_update_manifest_properties(self, containerregistry_anonregistry_endpoint):
-        if not self.is_public_endpoint(containerregistry_anonregistry_endpoint):
+        if not is_public_endpoint(containerregistry_anonregistry_endpoint):
             pytest.skip("Not a public endpoint")
 
         async with self.create_anon_client(containerregistry_anonregistry_endpoint) as client:

--- a/sdk/containerregistry/azure-containerregistry/tests/test_container_registry_client.py
+++ b/sdk/containerregistry/azure-containerregistry/tests/test_container_registry_client.py
@@ -32,7 +32,7 @@ from azure.core.exceptions import (
 from azure.core.paging import ItemPaged
 from azure.core.pipeline import PipelineRequest
 from azure.identity import AzureAuthorityHosts
-from testcase import ContainerRegistryTestClass, get_authority, get_audience, is_public_endpoint, is_china_endpoint
+from testcase import ContainerRegistryTestClass, get_authority, get_audience, is_public_endpoint
 from constants import HELLO_WORLD, DOES_NOT_EXIST
 from preparer import acr_preparer
 from devtools_testutils import recorded_by_proxy
@@ -502,8 +502,8 @@ class TestContainerRegistryClient(ContainerRegistryTestClass):
     @acr_preparer()
     @recorded_by_proxy
     def test_set_oci_manifest_without_spaces(self, containerregistry_endpoint):
-        if is_china_endpoint(containerregistry_endpoint):
-            pytest.skip("Running in china cloud may cause all tests finishing longer than the max time of 120 mins.")
+        if not is_public_endpoint(containerregistry_endpoint):
+            pytest.skip("This test is for testing test_set_docker_manifest in playback.")
         
         repo = self.get_resource_name("repo")
         path = os.path.join(self.get_test_directory(), "data", "oci_artifact", "manifest_without_spaces.json")
@@ -575,8 +575,8 @@ class TestContainerRegistryClient(ContainerRegistryTestClass):
     @acr_preparer()
     @recorded_by_proxy
     def test_set_docker_manifest_without_spaces(self, containerregistry_endpoint):
-        if is_china_endpoint(containerregistry_endpoint):
-            pytest.skip("Running in china cloud may cause all tests finishing longer than the max time of 120 mins.")
+        if not is_public_endpoint(containerregistry_endpoint):
+            pytest.skip("This test is for testing test_set_docker_manifest in playback.")
         
         repo = self.get_resource_name("repo")
         path = os.path.join(self.get_test_directory(), "data", "docker_artifact", "manifest_without_spaces.json")
@@ -626,6 +626,9 @@ class TestContainerRegistryClient(ContainerRegistryTestClass):
     @acr_preparer()
     def upload_large_blob_in_chunk(self, **kwargs):
         containerregistry_endpoint = kwargs.pop("containerregistry_endpoint")
+        if not is_public_endpoint(containerregistry_endpoint):
+            pytest.skip("Running on non-public cloud may cause all tests finishing longer than the max time of 120 mins.")
+        
         repo = self.get_resource_name("repo")
         with self.create_registry_client(containerregistry_endpoint) as client:
             # Test blob upload and download in equal size chunks

--- a/sdk/containerregistry/azure-containerregistry/tests/test_container_registry_client.py
+++ b/sdk/containerregistry/azure-containerregistry/tests/test_container_registry_client.py
@@ -457,243 +457,243 @@ class TestContainerRegistryClient(ContainerRegistryTestClass):
 
     # Live only, as test proxy now cannot handle spaces correctly
     # issue: https://github.com/Azure/azure-sdk-tools/issues/5968
-    @pytest.mark.live_test_only
-    @acr_preparer()
-    def test_set_oci_manifest(self, **kwargs):
-        containerregistry_endpoint = kwargs.pop("containerregistry_endpoint")
-        repo = self.get_resource_name("repo")
-        path = os.path.join(self.get_test_directory(), "data", "oci_artifact", "manifest.json")
-        with self.create_registry_client(containerregistry_endpoint) as client:
-            self.upload_oci_manifest_prerequisites(repo, client)
+    # @pytest.mark.live_test_only
+    # @acr_preparer()
+    # def test_set_oci_manifest(self, **kwargs):
+    #     containerregistry_endpoint = kwargs.pop("containerregistry_endpoint")
+    #     repo = self.get_resource_name("repo")
+    #     path = os.path.join(self.get_test_directory(), "data", "oci_artifact", "manifest.json")
+    #     with self.create_registry_client(containerregistry_endpoint) as client:
+    #         self.upload_oci_manifest_prerequisites(repo, client)
             
-            with open(path, "rb") as manifest_stream:
-                # test set oci manifest in stream format
-                with pytest.raises(HttpResponseError):
-                    client.set_manifest(repo, manifest_stream, tag="v1", media_type=DOCKER_MANIFEST)
-                manifest_stream.seek(0)
-                digest1 = client.set_manifest(repo, manifest_stream, tag="v1")
-                manifest_stream.seek(0)
+    #         with open(path, "rb") as manifest_stream:
+    #             # test set oci manifest in stream format
+    #             with pytest.raises(HttpResponseError):
+    #                 client.set_manifest(repo, manifest_stream, tag="v1", media_type=DOCKER_MANIFEST)
+    #             manifest_stream.seek(0)
+    #             digest1 = client.set_manifest(repo, manifest_stream, tag="v1")
+    #             manifest_stream.seek(0)
                 
-                # test set oci manifest in JSON format
-                manifest_json = json.loads(manifest_stream.read().decode())
-                with pytest.raises(HttpResponseError):
-                    client.set_manifest(repo, manifest_json, tag="v2", media_type=DOCKER_MANIFEST)
-                digest2 = client.set_manifest(repo, manifest_json, tag="v2")
+    #             # test set oci manifest in JSON format
+    #             manifest_json = json.loads(manifest_stream.read().decode())
+    #             with pytest.raises(HttpResponseError):
+    #                 client.set_manifest(repo, manifest_json, tag="v2", media_type=DOCKER_MANIFEST)
+    #             digest2 = client.set_manifest(repo, manifest_json, tag="v2")
             
-            assert digest1 == digest2
+    #         assert digest1 == digest2
             
-            # test get oci manifest by digest
-            response = client.get_manifest(repo, digest1)
-            assert response.media_type == OCI_IMAGE_MANIFEST
+    #         # test get oci manifest by digest
+    #         response = client.get_manifest(repo, digest1)
+    #         assert response.media_type == OCI_IMAGE_MANIFEST
             
-            # test get oci manifest by tag
-            response = client.get_manifest(repo, "v1")
-            assert response.media_type == OCI_IMAGE_MANIFEST
-            response = client.get_manifest(repo, "v2")
-            assert response.media_type == OCI_IMAGE_MANIFEST
+    #         # test get oci manifest by tag
+    #         response = client.get_manifest(repo, "v1")
+    #         assert response.media_type == OCI_IMAGE_MANIFEST
+    #         response = client.get_manifest(repo, "v2")
+    #         assert response.media_type == OCI_IMAGE_MANIFEST
 
-            client.delete_manifest(repo, digest1)
-            client.delete_repository(repo)
+    #         client.delete_manifest(repo, digest1)
+    #         client.delete_repository(repo)
 
     # Reading data from a no space file to make this test pass in playback as test proxy cannot handle spaces correctly.
     # issue: https://github.com/Azure/azure-sdk-tools/issues/5968
-    @acr_preparer()
-    @recorded_by_proxy
-    def test_set_oci_manifest_without_spaces(self, containerregistry_endpoint):
-        if self.is_china_endpoint(containerregistry_endpoint):
-            pytest.skip("Running in china cloud may cause all tests finishing longer than the max time of 120 mins.")
+    # @acr_preparer()
+    # @recorded_by_proxy
+    # def test_set_oci_manifest_without_spaces(self, containerregistry_endpoint):
+    #     if self.is_china_endpoint(containerregistry_endpoint):
+    #         pytest.skip("Running in china cloud may cause all tests finishing longer than the max time of 120 mins.")
         
-        repo = self.get_resource_name("repo")
-        path = os.path.join(self.get_test_directory(), "data", "oci_artifact", "manifest_without_spaces.json")
-        with self.create_registry_client(containerregistry_endpoint) as client:
-            self.upload_oci_manifest_prerequisites(repo, client)
+    #     repo = self.get_resource_name("repo")
+    #     path = os.path.join(self.get_test_directory(), "data", "oci_artifact", "manifest_without_spaces.json")
+    #     with self.create_registry_client(containerregistry_endpoint) as client:
+    #         self.upload_oci_manifest_prerequisites(repo, client)
 
-            with open(path, "rb") as manifest_stream:
-                # test set oci manifest in stream format
-                with pytest.raises(HttpResponseError):
-                    client.set_manifest(repo, manifest_stream, tag="v1", media_type=DOCKER_MANIFEST)
-                manifest_stream.seek(0)
-                digest = client.set_manifest(repo, manifest_stream, tag="v1")
+    #         with open(path, "rb") as manifest_stream:
+    #             # test set oci manifest in stream format
+    #             with pytest.raises(HttpResponseError):
+    #                 client.set_manifest(repo, manifest_stream, tag="v1", media_type=DOCKER_MANIFEST)
+    #             manifest_stream.seek(0)
+    #             digest = client.set_manifest(repo, manifest_stream, tag="v1")
                         
-            # test get oci manifest by digest
-            response = client.get_manifest(repo, digest)
-            assert response.media_type == OCI_IMAGE_MANIFEST
+    #         # test get oci manifest by digest
+    #         response = client.get_manifest(repo, digest)
+    #         assert response.media_type == OCI_IMAGE_MANIFEST
             
-            # test get oci manifest by tag
-            response = client.get_manifest(repo, "v1")
-            assert response.media_type == OCI_IMAGE_MANIFEST
+    #         # test get oci manifest by tag
+    #         response = client.get_manifest(repo, "v1")
+    #         assert response.media_type == OCI_IMAGE_MANIFEST
 
-            client.delete_manifest(repo, digest)
-            client.delete_repository(repo)
+    #         client.delete_manifest(repo, digest)
+    #         client.delete_repository(repo)
     
     # Live only, as test proxy now cannot handle spaces correctly
     # issue: https://github.com/Azure/azure-sdk-tools/issues/5968
-    @pytest.mark.live_test_only
-    @acr_preparer()
-    def test_set_docker_manifest(self, **kwargs):
-        containerregistry_endpoint = kwargs.pop("containerregistry_endpoint")
-        if self.is_china_endpoint(containerregistry_endpoint):
-            pytest.skip("Not run in China cloud")
-        repo = self.get_resource_name("repo")
-        path = os.path.join(self.get_test_directory(), "data", "docker_artifact", "manifest.json")
-        with self.create_registry_client(containerregistry_endpoint) as client:
-            self.upload_docker_manifest_prerequisites(repo, client)
+    # @pytest.mark.live_test_only
+    # @acr_preparer()
+    # def test_set_docker_manifest(self, **kwargs):
+    #     containerregistry_endpoint = kwargs.pop("containerregistry_endpoint")
+    #     if self.is_china_endpoint(containerregistry_endpoint):
+    #         pytest.skip("Not run in China cloud")
+    #     repo = self.get_resource_name("repo")
+    #     path = os.path.join(self.get_test_directory(), "data", "docker_artifact", "manifest.json")
+    #     with self.create_registry_client(containerregistry_endpoint) as client:
+    #         self.upload_docker_manifest_prerequisites(repo, client)
 
-            with open(path, "rb") as manifest_stream:
-                # test set Docker manifest in stream format
-                with pytest.raises(HttpResponseError):
-                    # It fails as the default media type is oci image manifest media type
-                    client.set_manifest(repo, manifest_stream, tag="v1")
-                manifest_stream.seek(0)
-                digest1 = client.set_manifest(repo, manifest_stream, tag="v1", media_type=DOCKER_MANIFEST)
-                manifest_stream.seek(0)
+    #         with open(path, "rb") as manifest_stream:
+    #             # test set Docker manifest in stream format
+    #             with pytest.raises(HttpResponseError):
+    #                 # It fails as the default media type is oci image manifest media type
+    #                 client.set_manifest(repo, manifest_stream, tag="v1")
+    #             manifest_stream.seek(0)
+    #             digest1 = client.set_manifest(repo, manifest_stream, tag="v1", media_type=DOCKER_MANIFEST)
+    #             manifest_stream.seek(0)
                 
-                # test set Docker manifest in JSON format
-                manifest_json = json.loads(manifest_stream.read().decode())
-                with pytest.raises(HttpResponseError):
-                    # It fails as the default media type is oci image manifest media type
-                    client.set_manifest(repo, manifest_json, tag="v2")
-                digest2 = client.set_manifest(repo, manifest_json, tag="v2", media_type=DOCKER_MANIFEST)
+    #             # test set Docker manifest in JSON format
+    #             manifest_json = json.loads(manifest_stream.read().decode())
+    #             with pytest.raises(HttpResponseError):
+    #                 # It fails as the default media type is oci image manifest media type
+    #                 client.set_manifest(repo, manifest_json, tag="v2")
+    #             digest2 = client.set_manifest(repo, manifest_json, tag="v2", media_type=DOCKER_MANIFEST)
             
-            assert digest1 == digest2
+    #         assert digest1 == digest2
                 
-            # test get Docker manifest by digest
-            response = client.get_manifest(repo, digest1)
-            assert response.media_type == DOCKER_MANIFEST
+    #         # test get Docker manifest by digest
+    #         response = client.get_manifest(repo, digest1)
+    #         assert response.media_type == DOCKER_MANIFEST
             
-            # test get Docker manifest by tag
-            response = client.get_manifest(repo, "v1")
-            assert response.media_type == DOCKER_MANIFEST
-            response = client.get_manifest(repo, "v2")
-            assert response.media_type == DOCKER_MANIFEST
+    #         # test get Docker manifest by tag
+    #         response = client.get_manifest(repo, "v1")
+    #         assert response.media_type == DOCKER_MANIFEST
+    #         response = client.get_manifest(repo, "v2")
+    #         assert response.media_type == DOCKER_MANIFEST
 
-            client.delete_manifest(repo, digest1)
-            client.delete_repository(repo)
+    #         client.delete_manifest(repo, digest1)
+    #         client.delete_repository(repo)
     
     # Reading data from a no space file to make this test pass in playback as test proxy cannot handle spaces correctly.
     # issue: https://github.com/Azure/azure-sdk-tools/issues/5968
-    @acr_preparer()
-    @recorded_by_proxy
-    def test_set_docker_manifest_without_spaces(self, containerregistry_endpoint):
-        if self.is_china_endpoint(containerregistry_endpoint):
-            pytest.skip("Running in china cloud may cause all tests finishing longer than the max time of 120 mins.")
+    # @acr_preparer()
+    # @recorded_by_proxy
+    # def test_set_docker_manifest_without_spaces(self, containerregistry_endpoint):
+    #     if self.is_china_endpoint(containerregistry_endpoint):
+    #         pytest.skip("Running in china cloud may cause all tests finishing longer than the max time of 120 mins.")
         
-        repo = self.get_resource_name("repo")
-        path = os.path.join(self.get_test_directory(), "data", "docker_artifact", "manifest_without_spaces.json")
-        with self.create_registry_client(containerregistry_endpoint) as client:
-            self.upload_docker_manifest_prerequisites(repo, client)
+    #     repo = self.get_resource_name("repo")
+    #     path = os.path.join(self.get_test_directory(), "data", "docker_artifact", "manifest_without_spaces.json")
+    #     with self.create_registry_client(containerregistry_endpoint) as client:
+    #         self.upload_docker_manifest_prerequisites(repo, client)
 
-            with open(path, "rb") as manifest_stream:
-                # test set Docker manifest in stream format
-                with pytest.raises(HttpResponseError):
-                    # It fails as the default media type is oci image manifest media type
-                    client.set_manifest(repo, manifest_stream, tag="v1")
-                manifest_stream.seek(0)
-                digest = client.set_manifest(repo, manifest_stream, tag="v1", media_type=DOCKER_MANIFEST)
+    #         with open(path, "rb") as manifest_stream:
+    #             # test set Docker manifest in stream format
+    #             with pytest.raises(HttpResponseError):
+    #                 # It fails as the default media type is oci image manifest media type
+    #                 client.set_manifest(repo, manifest_stream, tag="v1")
+    #             manifest_stream.seek(0)
+    #             digest = client.set_manifest(repo, manifest_stream, tag="v1", media_type=DOCKER_MANIFEST)
                 
-            # test get Docker manifest by digest
-            response = client.get_manifest(repo, digest)
-            assert response.media_type == DOCKER_MANIFEST
+    #         # test get Docker manifest by digest
+    #         response = client.get_manifest(repo, digest)
+    #         assert response.media_type == DOCKER_MANIFEST
             
-            # test get Docker manifest by tag
-            response = client.get_manifest(repo, "v1")
-            assert response.media_type == DOCKER_MANIFEST
+    #         # test get Docker manifest by tag
+    #         response = client.get_manifest(repo, "v1")
+    #         assert response.media_type == DOCKER_MANIFEST
 
-            client.delete_manifest(repo, digest)
-            client.delete_repository(repo)
+    #         client.delete_manifest(repo, digest)
+    #         client.delete_repository(repo)
 
-    @acr_preparer()
-    @recorded_by_proxy
-    def test_upload_blob(self, containerregistry_endpoint):
-        repo = self.get_resource_name("repo")
-        blob = BytesIO(b"hello world")
+    # @acr_preparer()
+    # @recorded_by_proxy
+    # def test_upload_blob(self, containerregistry_endpoint):
+    #     repo = self.get_resource_name("repo")
+    #     blob = BytesIO(b"hello world")
 
-        with self.create_registry_client(containerregistry_endpoint) as client:
-            # Act
-            digest, blob_size = client.upload_blob(repo, blob)
+    #     with self.create_registry_client(containerregistry_endpoint) as client:
+    #         # Act
+    #         digest, blob_size = client.upload_blob(repo, blob)
 
-            # Assert
-            blob_content = b""
-            stream = client.download_blob(repo, digest)
-            for chunk in stream:
-                blob_content += chunk
-            assert len(blob_content) == blob_size
+    #         # Assert
+    #         blob_content = b""
+    #         stream = client.download_blob(repo, digest)
+    #         for chunk in stream:
+    #             blob_content += chunk
+    #         assert len(blob_content) == blob_size
 
-            client.delete_blob(repo, digest)
-            client.delete_repository(repo)
+    #         client.delete_blob(repo, digest)
+    #         client.delete_repository(repo)
 
-    @pytest.mark.live_test_only
-    @acr_preparer()
-    def upload_large_blob_in_chunk(self, **kwargs):
-        containerregistry_endpoint = kwargs.pop("containerregistry_endpoint")
-        if not self.is_public_endpoint(containerregistry_endpoint):
-            pytest.skip("Running in non-public cloud may cause all tests finishing longer than the max time of 120 mins.")
+    # @pytest.mark.live_test_only
+    # @acr_preparer()
+    # def upload_large_blob_in_chunk(self, **kwargs):
+    #     containerregistry_endpoint = kwargs.pop("containerregistry_endpoint")
+    #     if not self.is_public_endpoint(containerregistry_endpoint):
+    #         pytest.skip("Running in non-public cloud may cause all tests finishing longer than the max time of 120 mins.")
         
-        repo = self.get_resource_name("repo")
-        with self.create_registry_client(containerregistry_endpoint) as client:
-            # Test blob upload and download in equal size chunks
-            try:
-                blob_size = DEFAULT_CHUNK_SIZE * 1024 # 4GB
-                data = b'\x00' * int(blob_size)
-                digest, size = client.upload_blob(repo, BytesIO(data))
-                assert size == blob_size
+    #     repo = self.get_resource_name("repo")
+    #     with self.create_registry_client(containerregistry_endpoint) as client:
+    #         # Test blob upload and download in equal size chunks
+    #         try:
+    #             blob_size = DEFAULT_CHUNK_SIZE * 1024 # 4GB
+    #             data = b'\x00' * int(blob_size)
+    #             digest, size = client.upload_blob(repo, BytesIO(data))
+    #             assert size == blob_size
 
-                stream = client.download_blob(repo, digest)
-                size = 0
-                with open("text1.txt", "wb") as file:
-                    for chunk in stream:
-                        size += file.write(chunk)
-                assert size == blob_size
+    #             stream = client.download_blob(repo, digest)
+    #             size = 0
+    #             with open("text1.txt", "wb") as file:
+    #                 for chunk in stream:
+    #                     size += file.write(chunk)
+    #             assert size == blob_size
 
-                client.delete_blob(repo, digest)
-            except (ServiceRequestError, ServiceResponseError) as err:
-                # Service does not support resumable upload when get transient error while uploading
-                # issue: https://github.com/Azure/azure-sdk-for-python/issues/29738
-                print(f"Failed to upload blob: {err.message}")
-            except ResourceNotFoundError as err:
-                # Service does not support resumable upload when get transient error while uploading
-                # issue: https://github.com/Azure/azure-sdk-for-python/issues/29738
-                assert err.status_code == 404
-                assert err.response.request.method == "PATCH"
-                assert err.response.text() == '{"errors":[{"code":"BLOB_UPLOAD_INVALID","message":"blob upload invalid"}]}\n'
+    #             client.delete_blob(repo, digest)
+    #         except (ServiceRequestError, ServiceResponseError) as err:
+    #             # Service does not support resumable upload when get transient error while uploading
+    #             # issue: https://github.com/Azure/azure-sdk-for-python/issues/29738
+    #             print(f"Failed to upload blob: {err.message}")
+    #         except ResourceNotFoundError as err:
+    #             # Service does not support resumable upload when get transient error while uploading
+    #             # issue: https://github.com/Azure/azure-sdk-for-python/issues/29738
+    #             assert err.status_code == 404
+    #             assert err.response.request.method == "PATCH"
+    #             assert err.response.text() == '{"errors":[{"code":"BLOB_UPLOAD_INVALID","message":"blob upload invalid"}]}\n'
 
-            # Test blob upload and download in unequal size chunks
-            try:
-                blob_size = DEFAULT_CHUNK_SIZE * 1024 + 20
-                data = b'\x00' * int(blob_size)
-                digest, size = client.upload_blob(repo, BytesIO(data))
-                assert size == blob_size
+    #         # Test blob upload and download in unequal size chunks
+    #         try:
+    #             blob_size = DEFAULT_CHUNK_SIZE * 1024 + 20
+    #             data = b'\x00' * int(blob_size)
+    #             digest, size = client.upload_blob(repo, BytesIO(data))
+    #             assert size == blob_size
 
-                stream = client.download_blob(repo, digest)
-                size = 0
-                with open("text2.txt", "wb") as file:
-                    for chunk in stream:
-                        size += file.write(chunk)
-                assert size == blob_size
+    #             stream = client.download_blob(repo, digest)
+    #             size = 0
+    #             with open("text2.txt", "wb") as file:
+    #                 for chunk in stream:
+    #                     size += file.write(chunk)
+    #             assert size == blob_size
 
-                client.delete_blob(repo, digest)
-            except (ServiceRequestError, ServiceResponseError) as err:
-                # Service does not support resumable upload when get transient error while uploading
-                # issue: https://github.com/Azure/azure-sdk-for-python/issues/29738
-                print(f"Failed to upload blob: {err.message}")
-            except ResourceNotFoundError as err:
-                # Service does not support resumable upload when get transient error while uploading
-                # issue: https://github.com/Azure/azure-sdk-for-python/issues/29738
-                assert err.status_code == 404
-                assert err.response.request.method == "PATCH"
-                assert err.response.text() == '{"errors":[{"code":"BLOB_UPLOAD_INVALID","message":"blob upload invalid"}]}\n'
+    #             client.delete_blob(repo, digest)
+    #         except (ServiceRequestError, ServiceResponseError) as err:
+    #             # Service does not support resumable upload when get transient error while uploading
+    #             # issue: https://github.com/Azure/azure-sdk-for-python/issues/29738
+    #             print(f"Failed to upload blob: {err.message}")
+    #         except ResourceNotFoundError as err:
+    #             # Service does not support resumable upload when get transient error while uploading
+    #             # issue: https://github.com/Azure/azure-sdk-for-python/issues/29738
+    #             assert err.status_code == 404
+    #             assert err.response.request.method == "PATCH"
+    #             assert err.response.text() == '{"errors":[{"code":"BLOB_UPLOAD_INVALID","message":"blob upload invalid"}]}\n'
 
-            # Cleanup
-            client.delete_repository(repo)
+    #         # Cleanup
+    #         client.delete_repository(repo)
     
-    @acr_preparer()
-    @recorded_by_proxy
-    def test_delete_blob_does_not_exist(self, containerregistry_endpoint):
-        repo = self.get_resource_name("repo")
-        hash_value = hashlib.sha256(b"test").hexdigest()
-        digest = f"sha256:{hash_value}"
-        with self.create_registry_client(containerregistry_endpoint) as client:
-            client.delete_blob(repo, digest)
+    # @acr_preparer()
+    # @recorded_by_proxy
+    # def test_delete_blob_does_not_exist(self, containerregistry_endpoint):
+    #     repo = self.get_resource_name("repo")
+    #     hash_value = hashlib.sha256(b"test").hexdigest()
+    #     digest = f"sha256:{hash_value}"
+    #     with self.create_registry_client(containerregistry_endpoint) as client:
+    #         client.delete_blob(repo, digest)
 
     @acr_preparer()
     @recorded_by_proxy

--- a/sdk/containerregistry/azure-containerregistry/tests/test_container_registry_client.py
+++ b/sdk/containerregistry/azure-containerregistry/tests/test_container_registry_client.py
@@ -626,9 +626,6 @@ class TestContainerRegistryClient(ContainerRegistryTestClass):
     @acr_preparer()
     def upload_large_blob_in_chunk(self, **kwargs):
         containerregistry_endpoint = kwargs.pop("containerregistry_endpoint")
-        if not is_public_endpoint(containerregistry_endpoint):
-            pytest.skip("Running in non-public cloud may cause all tests finishing longer than the max time of 120 mins.")
-        
         repo = self.get_resource_name("repo")
         with self.create_registry_client(containerregistry_endpoint) as client:
             # Test blob upload and download in equal size chunks

--- a/sdk/containerregistry/azure-containerregistry/tests/test_container_registry_client.py
+++ b/sdk/containerregistry/azure-containerregistry/tests/test_container_registry_client.py
@@ -83,6 +83,7 @@ class TestContainerRegistryClient(ContainerRegistryTestClass):
     def test_delete_repository(self, containerregistry_endpoint):
         repo = self.get_resource_name("repo")
         self.import_image(containerregistry_endpoint, repo, ["test"])
+        self.sleep(5)
         with self.create_registry_client(containerregistry_endpoint) as client:
             client.delete_repository(repo)
 
@@ -109,6 +110,7 @@ class TestContainerRegistryClient(ContainerRegistryTestClass):
     def test_update_repository_properties(self, containerregistry_endpoint):
         repo = self.get_resource_name("repo")
         self.import_image(containerregistry_endpoint, repo, ["test"])
+        self.sleep(5)
         with self.create_registry_client(containerregistry_endpoint) as client:
             properties = self.set_all_properties(RepositoryProperties(), False)
             received = client.update_repository_properties(repo, properties)
@@ -126,7 +128,7 @@ class TestContainerRegistryClient(ContainerRegistryTestClass):
     def test_update_repository_properties_kwargs(self, containerregistry_endpoint):
         repo = self.get_resource_name("repo")
         self.import_image(containerregistry_endpoint, repo, ["test"])
-
+        self.sleep(5)
         with self.create_registry_client(containerregistry_endpoint) as client:
             received = client.update_repository_properties(
                 repo, can_delete=False, can_read=False, can_write=False, can_list=False
@@ -228,7 +230,7 @@ class TestContainerRegistryClient(ContainerRegistryTestClass):
         repo = self.get_resource_name("repo")
         tag = "test"
         self.import_image(containerregistry_endpoint, repo, [tag])
-
+        self.sleep(5)
         with self.create_registry_client(containerregistry_endpoint) as client:
             properties = self.set_all_properties(ArtifactManifestProperties(), False)
             received = client.update_manifest_properties(repo, tag, properties)
@@ -247,7 +249,7 @@ class TestContainerRegistryClient(ContainerRegistryTestClass):
         repo = self.get_resource_name("repo")
         tag = "test"
         self.import_image(containerregistry_endpoint, repo, [tag])
-
+        self.sleep(5)
         with self.create_registry_client(containerregistry_endpoint) as client:
             received = client.update_manifest_properties(
                 repo, tag, can_delete=False, can_read=False, can_write=False, can_list=False
@@ -285,7 +287,7 @@ class TestContainerRegistryClient(ContainerRegistryTestClass):
         repo = self.get_resource_name("repo")
         tag = "test"
         self.import_image(containerregistry_endpoint, repo, [tag])
-
+        self.sleep(5)
         with self.create_registry_client(containerregistry_endpoint) as client:
             properties = self.set_all_properties(ArtifactTagProperties(), False)
             received = client.update_tag_properties(repo, tag, properties)
@@ -304,7 +306,7 @@ class TestContainerRegistryClient(ContainerRegistryTestClass):
         repo = self.get_resource_name("repo")
         tag = "test"
         self.import_image(containerregistry_endpoint, repo, [tag])
-
+        self.sleep(5)
         with self.create_registry_client(containerregistry_endpoint) as client:
             received = client.update_tag_properties(
                 repo, tag, can_delete=False, can_read=False, can_write=False, can_list=False
@@ -362,7 +364,7 @@ class TestContainerRegistryClient(ContainerRegistryTestClass):
         repo = self.get_resource_name("repo")
         tag = "test"
         self.import_image(containerregistry_endpoint, repo, [tag])
-
+        self.sleep(5)
         with self.create_registry_client(containerregistry_endpoint) as client:
             client.delete_tag(repo, tag)
 
@@ -386,7 +388,7 @@ class TestContainerRegistryClient(ContainerRegistryTestClass):
         repo = self.get_resource_name("repo")
         tag = "test"
         self.import_image(containerregistry_endpoint, repo, [tag])
-
+        self.sleep(5)
         with self.create_registry_client(containerregistry_endpoint) as client:
             client.delete_manifest(repo, tag)
 
@@ -726,6 +728,7 @@ class TestContainerRegistryClient(ContainerRegistryTestClass):
     def test_list_in_empty_repo(self, containerregistry_endpoint):
         repo = self.get_resource_name("repo")
         self.import_image(containerregistry_endpoint, repo, ["test"])
+        self.sleep(5)
         with self.create_registry_client(containerregistry_endpoint) as client:
             # cleanup tags in repo
             for tag in client.list_tag_properties(repo):

--- a/sdk/containerregistry/azure-containerregistry/tests/test_container_registry_client.py
+++ b/sdk/containerregistry/azure-containerregistry/tests/test_container_registry_client.py
@@ -82,11 +82,11 @@ class TestContainerRegistryClient(ContainerRegistryTestClass):
     @recorded_by_proxy
     def test_delete_repository(self, containerregistry_endpoint):
         repo = self.get_resource_name("repo")
-        self.import_image(containerregistry_endpoint, HELLO_WORLD, [repo])
+        self.import_image(containerregistry_endpoint, repo, ["test"])
         with self.create_registry_client(containerregistry_endpoint) as client:
             client.delete_repository(repo)
 
-            self.sleep(10)
+            self.sleep(5)
             with pytest.raises(ResourceNotFoundError):
                 client.get_repository_properties(repo)
 
@@ -108,7 +108,7 @@ class TestContainerRegistryClient(ContainerRegistryTestClass):
     @recorded_by_proxy
     def test_update_repository_properties(self, containerregistry_endpoint):
         repo = self.get_resource_name("repo")
-        self.import_image(containerregistry_endpoint, HELLO_WORLD, [f"{repo}:test"])
+        self.import_image(containerregistry_endpoint, repo, ["test"])
         with self.create_registry_client(containerregistry_endpoint) as client:
             properties = self.set_all_properties(RepositoryProperties(), False)
             received = client.update_repository_properties(repo, properties)
@@ -125,7 +125,7 @@ class TestContainerRegistryClient(ContainerRegistryTestClass):
     @recorded_by_proxy
     def test_update_repository_properties_kwargs(self, containerregistry_endpoint):
         repo = self.get_resource_name("repo")
-        self.import_image(containerregistry_endpoint, HELLO_WORLD, [f"{repo}:test"])
+        self.import_image(containerregistry_endpoint, repo, ["test"])
 
         with self.create_registry_client(containerregistry_endpoint) as client:
             received = client.update_repository_properties(
@@ -227,7 +227,7 @@ class TestContainerRegistryClient(ContainerRegistryTestClass):
     def test_update_manifest_properties(self, containerregistry_endpoint):
         repo = self.get_resource_name("repo")
         tag = "test"
-        self.import_image(containerregistry_endpoint, HELLO_WORLD, [f"{repo}:{tag}"])
+        self.import_image(containerregistry_endpoint, repo, [tag])
 
         with self.create_registry_client(containerregistry_endpoint) as client:
             properties = self.set_all_properties(ArtifactManifestProperties(), False)
@@ -246,7 +246,7 @@ class TestContainerRegistryClient(ContainerRegistryTestClass):
     def test_update_manifest_properties_kwargs(self, containerregistry_endpoint):
         repo = self.get_resource_name("repo")
         tag = "test"
-        self.import_image(containerregistry_endpoint, HELLO_WORLD, [f"{repo}:{tag}"])
+        self.import_image(containerregistry_endpoint, repo, [tag])
 
         with self.create_registry_client(containerregistry_endpoint) as client:
             received = client.update_manifest_properties(
@@ -284,7 +284,7 @@ class TestContainerRegistryClient(ContainerRegistryTestClass):
     def test_update_tag_properties(self, containerregistry_endpoint):
         repo = self.get_resource_name("repo")
         tag = "test"
-        self.import_image(containerregistry_endpoint, HELLO_WORLD, [f"{repo}:{tag}"])
+        self.import_image(containerregistry_endpoint, repo, [tag])
 
         with self.create_registry_client(containerregistry_endpoint) as client:
             properties = self.set_all_properties(ArtifactTagProperties(), False)
@@ -303,7 +303,7 @@ class TestContainerRegistryClient(ContainerRegistryTestClass):
     def test_update_tag_properties_kwargs(self, containerregistry_endpoint):
         repo = self.get_resource_name("repo")
         tag = "test"
-        self.import_image(containerregistry_endpoint, HELLO_WORLD, [f"{repo}:{tag}"])
+        self.import_image(containerregistry_endpoint, repo, [tag])
 
         with self.create_registry_client(containerregistry_endpoint) as client:
             received = client.update_tag_properties(
@@ -361,7 +361,7 @@ class TestContainerRegistryClient(ContainerRegistryTestClass):
     def test_delete_tag(self, containerregistry_endpoint):
         repo = self.get_resource_name("repo")
         tag = "test"
-        self.import_image(containerregistry_endpoint, HELLO_WORLD, [f"{repo}:{tag}"])
+        self.import_image(containerregistry_endpoint, repo, [tag])
 
         with self.create_registry_client(containerregistry_endpoint) as client:
             client.delete_tag(repo, tag)
@@ -385,7 +385,7 @@ class TestContainerRegistryClient(ContainerRegistryTestClass):
     def test_delete_manifest(self, containerregistry_endpoint):
         repo = self.get_resource_name("repo")
         tag = "test"
-        self.import_image(containerregistry_endpoint, HELLO_WORLD, [f"{repo}:{tag}"])
+        self.import_image(containerregistry_endpoint, repo, [tag])
 
         with self.create_registry_client(containerregistry_endpoint) as client:
             client.delete_manifest(repo, tag)
@@ -457,243 +457,243 @@ class TestContainerRegistryClient(ContainerRegistryTestClass):
 
     # Live only, as test proxy now cannot handle spaces correctly
     # issue: https://github.com/Azure/azure-sdk-tools/issues/5968
-    # @pytest.mark.live_test_only
-    # @acr_preparer()
-    # def test_set_oci_manifest(self, **kwargs):
-    #     containerregistry_endpoint = kwargs.pop("containerregistry_endpoint")
-    #     repo = self.get_resource_name("repo")
-    #     path = os.path.join(self.get_test_directory(), "data", "oci_artifact", "manifest.json")
-    #     with self.create_registry_client(containerregistry_endpoint) as client:
-    #         self.upload_oci_manifest_prerequisites(repo, client)
+    @pytest.mark.live_test_only
+    @acr_preparer()
+    def test_set_oci_manifest(self, **kwargs):
+        containerregistry_endpoint = kwargs.pop("containerregistry_endpoint")
+        repo = self.get_resource_name("repo")
+        path = os.path.join(self.get_test_directory(), "data", "oci_artifact", "manifest.json")
+        with self.create_registry_client(containerregistry_endpoint) as client:
+            self.upload_oci_manifest_prerequisites(repo, client)
             
-    #         with open(path, "rb") as manifest_stream:
-    #             # test set oci manifest in stream format
-    #             with pytest.raises(HttpResponseError):
-    #                 client.set_manifest(repo, manifest_stream, tag="v1", media_type=DOCKER_MANIFEST)
-    #             manifest_stream.seek(0)
-    #             digest1 = client.set_manifest(repo, manifest_stream, tag="v1")
-    #             manifest_stream.seek(0)
+            with open(path, "rb") as manifest_stream:
+                # test set oci manifest in stream format
+                with pytest.raises(HttpResponseError):
+                    client.set_manifest(repo, manifest_stream, tag="v1", media_type=DOCKER_MANIFEST)
+                manifest_stream.seek(0)
+                digest1 = client.set_manifest(repo, manifest_stream, tag="v1")
+                manifest_stream.seek(0)
                 
-    #             # test set oci manifest in JSON format
-    #             manifest_json = json.loads(manifest_stream.read().decode())
-    #             with pytest.raises(HttpResponseError):
-    #                 client.set_manifest(repo, manifest_json, tag="v2", media_type=DOCKER_MANIFEST)
-    #             digest2 = client.set_manifest(repo, manifest_json, tag="v2")
+                # test set oci manifest in JSON format
+                manifest_json = json.loads(manifest_stream.read().decode())
+                with pytest.raises(HttpResponseError):
+                    client.set_manifest(repo, manifest_json, tag="v2", media_type=DOCKER_MANIFEST)
+                digest2 = client.set_manifest(repo, manifest_json, tag="v2")
             
-    #         assert digest1 == digest2
+            assert digest1 == digest2
             
-    #         # test get oci manifest by digest
-    #         response = client.get_manifest(repo, digest1)
-    #         assert response.media_type == OCI_IMAGE_MANIFEST
+            # test get oci manifest by digest
+            response = client.get_manifest(repo, digest1)
+            assert response.media_type == OCI_IMAGE_MANIFEST
             
-    #         # test get oci manifest by tag
-    #         response = client.get_manifest(repo, "v1")
-    #         assert response.media_type == OCI_IMAGE_MANIFEST
-    #         response = client.get_manifest(repo, "v2")
-    #         assert response.media_type == OCI_IMAGE_MANIFEST
+            # test get oci manifest by tag
+            response = client.get_manifest(repo, "v1")
+            assert response.media_type == OCI_IMAGE_MANIFEST
+            response = client.get_manifest(repo, "v2")
+            assert response.media_type == OCI_IMAGE_MANIFEST
 
-    #         client.delete_manifest(repo, digest1)
-    #         client.delete_repository(repo)
+            client.delete_manifest(repo, digest1)
+            client.delete_repository(repo)
 
     # Reading data from a no space file to make this test pass in playback as test proxy cannot handle spaces correctly.
     # issue: https://github.com/Azure/azure-sdk-tools/issues/5968
-    # @acr_preparer()
-    # @recorded_by_proxy
-    # def test_set_oci_manifest_without_spaces(self, containerregistry_endpoint):
-    #     if self.is_china_endpoint(containerregistry_endpoint):
-    #         pytest.skip("Running in china cloud may cause all tests finishing longer than the max time of 120 mins.")
+    @acr_preparer()
+    @recorded_by_proxy
+    def test_set_oci_manifest_without_spaces(self, containerregistry_endpoint):
+        if self.is_china_endpoint(containerregistry_endpoint):
+            pytest.skip("Running in china cloud may cause all tests finishing longer than the max time of 120 mins.")
         
-    #     repo = self.get_resource_name("repo")
-    #     path = os.path.join(self.get_test_directory(), "data", "oci_artifact", "manifest_without_spaces.json")
-    #     with self.create_registry_client(containerregistry_endpoint) as client:
-    #         self.upload_oci_manifest_prerequisites(repo, client)
+        repo = self.get_resource_name("repo")
+        path = os.path.join(self.get_test_directory(), "data", "oci_artifact", "manifest_without_spaces.json")
+        with self.create_registry_client(containerregistry_endpoint) as client:
+            self.upload_oci_manifest_prerequisites(repo, client)
 
-    #         with open(path, "rb") as manifest_stream:
-    #             # test set oci manifest in stream format
-    #             with pytest.raises(HttpResponseError):
-    #                 client.set_manifest(repo, manifest_stream, tag="v1", media_type=DOCKER_MANIFEST)
-    #             manifest_stream.seek(0)
-    #             digest = client.set_manifest(repo, manifest_stream, tag="v1")
+            with open(path, "rb") as manifest_stream:
+                # test set oci manifest in stream format
+                with pytest.raises(HttpResponseError):
+                    client.set_manifest(repo, manifest_stream, tag="v1", media_type=DOCKER_MANIFEST)
+                manifest_stream.seek(0)
+                digest = client.set_manifest(repo, manifest_stream, tag="v1")
                         
-    #         # test get oci manifest by digest
-    #         response = client.get_manifest(repo, digest)
-    #         assert response.media_type == OCI_IMAGE_MANIFEST
+            # test get oci manifest by digest
+            response = client.get_manifest(repo, digest)
+            assert response.media_type == OCI_IMAGE_MANIFEST
             
-    #         # test get oci manifest by tag
-    #         response = client.get_manifest(repo, "v1")
-    #         assert response.media_type == OCI_IMAGE_MANIFEST
+            # test get oci manifest by tag
+            response = client.get_manifest(repo, "v1")
+            assert response.media_type == OCI_IMAGE_MANIFEST
 
-    #         client.delete_manifest(repo, digest)
-    #         client.delete_repository(repo)
+            client.delete_manifest(repo, digest)
+            client.delete_repository(repo)
     
     # Live only, as test proxy now cannot handle spaces correctly
     # issue: https://github.com/Azure/azure-sdk-tools/issues/5968
-    # @pytest.mark.live_test_only
-    # @acr_preparer()
-    # def test_set_docker_manifest(self, **kwargs):
-    #     containerregistry_endpoint = kwargs.pop("containerregistry_endpoint")
-    #     if self.is_china_endpoint(containerregistry_endpoint):
-    #         pytest.skip("Not run in China cloud")
-    #     repo = self.get_resource_name("repo")
-    #     path = os.path.join(self.get_test_directory(), "data", "docker_artifact", "manifest.json")
-    #     with self.create_registry_client(containerregistry_endpoint) as client:
-    #         self.upload_docker_manifest_prerequisites(repo, client)
+    @pytest.mark.live_test_only
+    @acr_preparer()
+    def test_set_docker_manifest(self, **kwargs):
+        containerregistry_endpoint = kwargs.pop("containerregistry_endpoint")
+        if self.is_china_endpoint(containerregistry_endpoint):
+            pytest.skip("Not run in China cloud")
+        repo = self.get_resource_name("repo")
+        path = os.path.join(self.get_test_directory(), "data", "docker_artifact", "manifest.json")
+        with self.create_registry_client(containerregistry_endpoint) as client:
+            self.upload_docker_manifest_prerequisites(repo, client)
 
-    #         with open(path, "rb") as manifest_stream:
-    #             # test set Docker manifest in stream format
-    #             with pytest.raises(HttpResponseError):
-    #                 # It fails as the default media type is oci image manifest media type
-    #                 client.set_manifest(repo, manifest_stream, tag="v1")
-    #             manifest_stream.seek(0)
-    #             digest1 = client.set_manifest(repo, manifest_stream, tag="v1", media_type=DOCKER_MANIFEST)
-    #             manifest_stream.seek(0)
+            with open(path, "rb") as manifest_stream:
+                # test set Docker manifest in stream format
+                with pytest.raises(HttpResponseError):
+                    # It fails as the default media type is oci image manifest media type
+                    client.set_manifest(repo, manifest_stream, tag="v1")
+                manifest_stream.seek(0)
+                digest1 = client.set_manifest(repo, manifest_stream, tag="v1", media_type=DOCKER_MANIFEST)
+                manifest_stream.seek(0)
                 
-    #             # test set Docker manifest in JSON format
-    #             manifest_json = json.loads(manifest_stream.read().decode())
-    #             with pytest.raises(HttpResponseError):
-    #                 # It fails as the default media type is oci image manifest media type
-    #                 client.set_manifest(repo, manifest_json, tag="v2")
-    #             digest2 = client.set_manifest(repo, manifest_json, tag="v2", media_type=DOCKER_MANIFEST)
+                # test set Docker manifest in JSON format
+                manifest_json = json.loads(manifest_stream.read().decode())
+                with pytest.raises(HttpResponseError):
+                    # It fails as the default media type is oci image manifest media type
+                    client.set_manifest(repo, manifest_json, tag="v2")
+                digest2 = client.set_manifest(repo, manifest_json, tag="v2", media_type=DOCKER_MANIFEST)
             
-    #         assert digest1 == digest2
+            assert digest1 == digest2
                 
-    #         # test get Docker manifest by digest
-    #         response = client.get_manifest(repo, digest1)
-    #         assert response.media_type == DOCKER_MANIFEST
+            # test get Docker manifest by digest
+            response = client.get_manifest(repo, digest1)
+            assert response.media_type == DOCKER_MANIFEST
             
-    #         # test get Docker manifest by tag
-    #         response = client.get_manifest(repo, "v1")
-    #         assert response.media_type == DOCKER_MANIFEST
-    #         response = client.get_manifest(repo, "v2")
-    #         assert response.media_type == DOCKER_MANIFEST
+            # test get Docker manifest by tag
+            response = client.get_manifest(repo, "v1")
+            assert response.media_type == DOCKER_MANIFEST
+            response = client.get_manifest(repo, "v2")
+            assert response.media_type == DOCKER_MANIFEST
 
-    #         client.delete_manifest(repo, digest1)
-    #         client.delete_repository(repo)
+            client.delete_manifest(repo, digest1)
+            client.delete_repository(repo)
     
     # Reading data from a no space file to make this test pass in playback as test proxy cannot handle spaces correctly.
     # issue: https://github.com/Azure/azure-sdk-tools/issues/5968
-    # @acr_preparer()
-    # @recorded_by_proxy
-    # def test_set_docker_manifest_without_spaces(self, containerregistry_endpoint):
-    #     if self.is_china_endpoint(containerregistry_endpoint):
-    #         pytest.skip("Running in china cloud may cause all tests finishing longer than the max time of 120 mins.")
+    @acr_preparer()
+    @recorded_by_proxy
+    def test_set_docker_manifest_without_spaces(self, containerregistry_endpoint):
+        if self.is_china_endpoint(containerregistry_endpoint):
+            pytest.skip("Running in china cloud may cause all tests finishing longer than the max time of 120 mins.")
         
-    #     repo = self.get_resource_name("repo")
-    #     path = os.path.join(self.get_test_directory(), "data", "docker_artifact", "manifest_without_spaces.json")
-    #     with self.create_registry_client(containerregistry_endpoint) as client:
-    #         self.upload_docker_manifest_prerequisites(repo, client)
+        repo = self.get_resource_name("repo")
+        path = os.path.join(self.get_test_directory(), "data", "docker_artifact", "manifest_without_spaces.json")
+        with self.create_registry_client(containerregistry_endpoint) as client:
+            self.upload_docker_manifest_prerequisites(repo, client)
 
-    #         with open(path, "rb") as manifest_stream:
-    #             # test set Docker manifest in stream format
-    #             with pytest.raises(HttpResponseError):
-    #                 # It fails as the default media type is oci image manifest media type
-    #                 client.set_manifest(repo, manifest_stream, tag="v1")
-    #             manifest_stream.seek(0)
-    #             digest = client.set_manifest(repo, manifest_stream, tag="v1", media_type=DOCKER_MANIFEST)
+            with open(path, "rb") as manifest_stream:
+                # test set Docker manifest in stream format
+                with pytest.raises(HttpResponseError):
+                    # It fails as the default media type is oci image manifest media type
+                    client.set_manifest(repo, manifest_stream, tag="v1")
+                manifest_stream.seek(0)
+                digest = client.set_manifest(repo, manifest_stream, tag="v1", media_type=DOCKER_MANIFEST)
                 
-    #         # test get Docker manifest by digest
-    #         response = client.get_manifest(repo, digest)
-    #         assert response.media_type == DOCKER_MANIFEST
+            # test get Docker manifest by digest
+            response = client.get_manifest(repo, digest)
+            assert response.media_type == DOCKER_MANIFEST
             
-    #         # test get Docker manifest by tag
-    #         response = client.get_manifest(repo, "v1")
-    #         assert response.media_type == DOCKER_MANIFEST
+            # test get Docker manifest by tag
+            response = client.get_manifest(repo, "v1")
+            assert response.media_type == DOCKER_MANIFEST
 
-    #         client.delete_manifest(repo, digest)
-    #         client.delete_repository(repo)
+            client.delete_manifest(repo, digest)
+            client.delete_repository(repo)
 
-    # @acr_preparer()
-    # @recorded_by_proxy
-    # def test_upload_blob(self, containerregistry_endpoint):
-    #     repo = self.get_resource_name("repo")
-    #     blob = BytesIO(b"hello world")
+    @acr_preparer()
+    @recorded_by_proxy
+    def test_upload_blob(self, containerregistry_endpoint):
+        repo = self.get_resource_name("repo")
+        blob = BytesIO(b"hello world")
 
-    #     with self.create_registry_client(containerregistry_endpoint) as client:
-    #         # Act
-    #         digest, blob_size = client.upload_blob(repo, blob)
+        with self.create_registry_client(containerregistry_endpoint) as client:
+            # Act
+            digest, blob_size = client.upload_blob(repo, blob)
 
-    #         # Assert
-    #         blob_content = b""
-    #         stream = client.download_blob(repo, digest)
-    #         for chunk in stream:
-    #             blob_content += chunk
-    #         assert len(blob_content) == blob_size
+            # Assert
+            blob_content = b""
+            stream = client.download_blob(repo, digest)
+            for chunk in stream:
+                blob_content += chunk
+            assert len(blob_content) == blob_size
 
-    #         client.delete_blob(repo, digest)
-    #         client.delete_repository(repo)
+            client.delete_blob(repo, digest)
+            client.delete_repository(repo)
 
     # @pytest.mark.live_test_only
     # @acr_preparer()
-    # def upload_large_blob_in_chunk(self, **kwargs):
-    #     containerregistry_endpoint = kwargs.pop("containerregistry_endpoint")
-    #     if not self.is_public_endpoint(containerregistry_endpoint):
-    #         pytest.skip("Running in non-public cloud may cause all tests finishing longer than the max time of 120 mins.")
+    def upload_large_blob_in_chunk(self, **kwargs):
+        containerregistry_endpoint = kwargs.pop("containerregistry_endpoint")
+        if not self.is_public_endpoint(containerregistry_endpoint):
+            pytest.skip("Running in non-public cloud may cause all tests finishing longer than the max time of 120 mins.")
         
-    #     repo = self.get_resource_name("repo")
-    #     with self.create_registry_client(containerregistry_endpoint) as client:
-    #         # Test blob upload and download in equal size chunks
-    #         try:
-    #             blob_size = DEFAULT_CHUNK_SIZE * 1024 # 4GB
-    #             data = b'\x00' * int(blob_size)
-    #             digest, size = client.upload_blob(repo, BytesIO(data))
-    #             assert size == blob_size
+        repo = self.get_resource_name("repo")
+        with self.create_registry_client(containerregistry_endpoint) as client:
+            # Test blob upload and download in equal size chunks
+            try:
+                blob_size = DEFAULT_CHUNK_SIZE * 1024 # 4GB
+                data = b'\x00' * int(blob_size)
+                digest, size = client.upload_blob(repo, BytesIO(data))
+                assert size == blob_size
 
-    #             stream = client.download_blob(repo, digest)
-    #             size = 0
-    #             with open("text1.txt", "wb") as file:
-    #                 for chunk in stream:
-    #                     size += file.write(chunk)
-    #             assert size == blob_size
+                stream = client.download_blob(repo, digest)
+                size = 0
+                with open("text1.txt", "wb") as file:
+                    for chunk in stream:
+                        size += file.write(chunk)
+                assert size == blob_size
 
-    #             client.delete_blob(repo, digest)
-    #         except (ServiceRequestError, ServiceResponseError) as err:
-    #             # Service does not support resumable upload when get transient error while uploading
-    #             # issue: https://github.com/Azure/azure-sdk-for-python/issues/29738
-    #             print(f"Failed to upload blob: {err.message}")
-    #         except ResourceNotFoundError as err:
-    #             # Service does not support resumable upload when get transient error while uploading
-    #             # issue: https://github.com/Azure/azure-sdk-for-python/issues/29738
-    #             assert err.status_code == 404
-    #             assert err.response.request.method == "PATCH"
-    #             assert err.response.text() == '{"errors":[{"code":"BLOB_UPLOAD_INVALID","message":"blob upload invalid"}]}\n'
+                client.delete_blob(repo, digest)
+            except (ServiceRequestError, ServiceResponseError) as err:
+                # Service does not support resumable upload when get transient error while uploading
+                # issue: https://github.com/Azure/azure-sdk-for-python/issues/29738
+                print(f"Failed to upload blob: {err.message}")
+            except ResourceNotFoundError as err:
+                # Service does not support resumable upload when get transient error while uploading
+                # issue: https://github.com/Azure/azure-sdk-for-python/issues/29738
+                assert err.status_code == 404
+                assert err.response.request.method == "PATCH"
+                assert err.response.text() == '{"errors":[{"code":"BLOB_UPLOAD_INVALID","message":"blob upload invalid"}]}\n'
 
-    #         # Test blob upload and download in unequal size chunks
-    #         try:
-    #             blob_size = DEFAULT_CHUNK_SIZE * 1024 + 20
-    #             data = b'\x00' * int(blob_size)
-    #             digest, size = client.upload_blob(repo, BytesIO(data))
-    #             assert size == blob_size
+            # Test blob upload and download in unequal size chunks
+            try:
+                blob_size = DEFAULT_CHUNK_SIZE * 1024 + 20
+                data = b'\x00' * int(blob_size)
+                digest, size = client.upload_blob(repo, BytesIO(data))
+                assert size == blob_size
 
-    #             stream = client.download_blob(repo, digest)
-    #             size = 0
-    #             with open("text2.txt", "wb") as file:
-    #                 for chunk in stream:
-    #                     size += file.write(chunk)
-    #             assert size == blob_size
+                stream = client.download_blob(repo, digest)
+                size = 0
+                with open("text2.txt", "wb") as file:
+                    for chunk in stream:
+                        size += file.write(chunk)
+                assert size == blob_size
 
-    #             client.delete_blob(repo, digest)
-    #         except (ServiceRequestError, ServiceResponseError) as err:
-    #             # Service does not support resumable upload when get transient error while uploading
-    #             # issue: https://github.com/Azure/azure-sdk-for-python/issues/29738
-    #             print(f"Failed to upload blob: {err.message}")
-    #         except ResourceNotFoundError as err:
-    #             # Service does not support resumable upload when get transient error while uploading
-    #             # issue: https://github.com/Azure/azure-sdk-for-python/issues/29738
-    #             assert err.status_code == 404
-    #             assert err.response.request.method == "PATCH"
-    #             assert err.response.text() == '{"errors":[{"code":"BLOB_UPLOAD_INVALID","message":"blob upload invalid"}]}\n'
+                client.delete_blob(repo, digest)
+            except (ServiceRequestError, ServiceResponseError) as err:
+                # Service does not support resumable upload when get transient error while uploading
+                # issue: https://github.com/Azure/azure-sdk-for-python/issues/29738
+                print(f"Failed to upload blob: {err.message}")
+            except ResourceNotFoundError as err:
+                # Service does not support resumable upload when get transient error while uploading
+                # issue: https://github.com/Azure/azure-sdk-for-python/issues/29738
+                assert err.status_code == 404
+                assert err.response.request.method == "PATCH"
+                assert err.response.text() == '{"errors":[{"code":"BLOB_UPLOAD_INVALID","message":"blob upload invalid"}]}\n'
 
-    #         # Cleanup
-    #         client.delete_repository(repo)
+            # Cleanup
+            client.delete_repository(repo)
     
-    # @acr_preparer()
-    # @recorded_by_proxy
-    # def test_delete_blob_does_not_exist(self, containerregistry_endpoint):
-    #     repo = self.get_resource_name("repo")
-    #     hash_value = hashlib.sha256(b"test").hexdigest()
-    #     digest = f"sha256:{hash_value}"
-    #     with self.create_registry_client(containerregistry_endpoint) as client:
-    #         client.delete_blob(repo, digest)
+    @acr_preparer()
+    @recorded_by_proxy
+    def test_delete_blob_does_not_exist(self, containerregistry_endpoint):
+        repo = self.get_resource_name("repo")
+        hash_value = hashlib.sha256(b"test").hexdigest()
+        digest = f"sha256:{hash_value}"
+        with self.create_registry_client(containerregistry_endpoint) as client:
+            client.delete_blob(repo, digest)
 
     @acr_preparer()
     @recorded_by_proxy
@@ -725,7 +725,7 @@ class TestContainerRegistryClient(ContainerRegistryTestClass):
     @recorded_by_proxy
     def test_list_in_empty_repo(self, containerregistry_endpoint):
         repo = self.get_resource_name("repo")
-        self.import_image(containerregistry_endpoint, HELLO_WORLD, [repo])
+        self.import_image(containerregistry_endpoint, repo, ["test"])
         with self.create_registry_client(containerregistry_endpoint) as client:
             # cleanup tags in repo
             for tag in client.list_tag_properties(repo):

--- a/sdk/containerregistry/azure-containerregistry/tests/test_container_registry_client.py
+++ b/sdk/containerregistry/azure-containerregistry/tests/test_container_registry_client.py
@@ -32,7 +32,7 @@ from azure.core.exceptions import (
 from azure.core.paging import ItemPaged
 from azure.core.pipeline import PipelineRequest
 from azure.identity import AzureAuthorityHosts
-from testcase import ContainerRegistryTestClass, get_authority, get_audience
+from testcase import ContainerRegistryTestClass, get_authority, get_audience, is_public_endpoint, is_china_endpoint
 from constants import HELLO_WORLD, DOES_NOT_EXIST
 from preparer import acr_preparer
 from devtools_testutils import recorded_by_proxy
@@ -500,7 +500,7 @@ class TestContainerRegistryClient(ContainerRegistryTestClass):
     @acr_preparer()
     @recorded_by_proxy
     def test_set_oci_manifest_without_spaces(self, containerregistry_endpoint):
-        if self.is_china_endpoint(containerregistry_endpoint):
+        if is_china_endpoint(containerregistry_endpoint):
             pytest.skip("Running in china cloud may cause all tests finishing longer than the max time of 120 mins.")
         
         repo = self.get_resource_name("repo")
@@ -532,7 +532,7 @@ class TestContainerRegistryClient(ContainerRegistryTestClass):
     @acr_preparer()
     def test_set_docker_manifest(self, **kwargs):
         containerregistry_endpoint = kwargs.pop("containerregistry_endpoint")
-        if self.is_china_endpoint(containerregistry_endpoint):
+        if is_china_endpoint(containerregistry_endpoint):
             pytest.skip("Not run in China cloud")
         repo = self.get_resource_name("repo")
         path = os.path.join(self.get_test_directory(), "data", "docker_artifact", "manifest.json")
@@ -575,7 +575,7 @@ class TestContainerRegistryClient(ContainerRegistryTestClass):
     @acr_preparer()
     @recorded_by_proxy
     def test_set_docker_manifest_without_spaces(self, containerregistry_endpoint):
-        if self.is_china_endpoint(containerregistry_endpoint):
+        if is_china_endpoint(containerregistry_endpoint):
             pytest.skip("Running in china cloud may cause all tests finishing longer than the max time of 120 mins.")
         
         repo = self.get_resource_name("repo")
@@ -626,7 +626,7 @@ class TestContainerRegistryClient(ContainerRegistryTestClass):
     # @acr_preparer()
     def upload_large_blob_in_chunk(self, **kwargs):
         containerregistry_endpoint = kwargs.pop("containerregistry_endpoint")
-        if not self.is_public_endpoint(containerregistry_endpoint):
+        if not is_public_endpoint(containerregistry_endpoint):
             pytest.skip("Running in non-public cloud may cause all tests finishing longer than the max time of 120 mins.")
         
         repo = self.get_resource_name("repo")

--- a/sdk/containerregistry/azure-containerregistry/tests/test_container_registry_client.py
+++ b/sdk/containerregistry/azure-containerregistry/tests/test_container_registry_client.py
@@ -532,6 +532,8 @@ class TestContainerRegistryClient(ContainerRegistryTestClass):
     @acr_preparer()
     def test_set_docker_manifest(self, **kwargs):
         containerregistry_endpoint = kwargs.pop("containerregistry_endpoint")
+        if self.is_china_endpoint(containerregistry_endpoint):
+            pytest.skip("Not run in China cloud")
         repo = self.get_resource_name("repo")
         path = os.path.join(self.get_test_directory(), "data", "docker_artifact", "manifest.json")
         with self.create_registry_client(containerregistry_endpoint) as client:

--- a/sdk/containerregistry/azure-containerregistry/tests/test_container_registry_client.py
+++ b/sdk/containerregistry/azure-containerregistry/tests/test_container_registry_client.py
@@ -534,8 +534,6 @@ class TestContainerRegistryClient(ContainerRegistryTestClass):
     @acr_preparer()
     def test_set_docker_manifest(self, **kwargs):
         containerregistry_endpoint = kwargs.pop("containerregistry_endpoint")
-        if is_china_endpoint(containerregistry_endpoint):
-            pytest.skip("Not run in China cloud")
         repo = self.get_resource_name("repo")
         path = os.path.join(self.get_test_directory(), "data", "docker_artifact", "manifest.json")
         with self.create_registry_client(containerregistry_endpoint) as client:
@@ -624,8 +622,8 @@ class TestContainerRegistryClient(ContainerRegistryTestClass):
             client.delete_blob(repo, digest)
             client.delete_repository(repo)
 
-    # @pytest.mark.live_test_only
-    # @acr_preparer()
+    @pytest.mark.live_test_only
+    @acr_preparer()
     def upload_large_blob_in_chunk(self, **kwargs):
         containerregistry_endpoint = kwargs.pop("containerregistry_endpoint")
         if not is_public_endpoint(containerregistry_endpoint):

--- a/sdk/containerregistry/azure-containerregistry/tests/test_container_registry_client_async.py
+++ b/sdk/containerregistry/azure-containerregistry/tests/test_container_registry_client_async.py
@@ -630,9 +630,6 @@ class TestContainerRegistryClientAsync(AsyncContainerRegistryTestClass):
     @acr_preparer()
     async def test_upload_large_blob_in_chunk(self, **kwargs):
         containerregistry_endpoint = kwargs.pop("containerregistry_endpoint")
-        if not is_public_endpoint(containerregistry_endpoint):
-            pytest.skip("Running in non-public cloud may cause all tests finishing longer than the max time of 120 mins.")
-        
         repo = self.get_resource_name("repo")
         async with self.create_registry_client(containerregistry_endpoint) as client:
             # Test blob upload and download in equal size chunks

--- a/sdk/containerregistry/azure-containerregistry/tests/test_container_registry_client_async.py
+++ b/sdk/containerregistry/azure-containerregistry/tests/test_container_registry_client_async.py
@@ -461,243 +461,243 @@ class TestContainerRegistryClientAsync(AsyncContainerRegistryTestClass):
     
     # Live only, as test proxy now cannot handle spaces correctly
     # issue: https://github.com/Azure/azure-sdk-tools/issues/5968
-    @pytest.mark.live_test_only
-    @acr_preparer()
-    async def test_set_oci_manifest(self, **kwargs):
-        containerregistry_endpoint = kwargs.pop("containerregistry_endpoint")
-        repo = self.get_resource_name("repo")
-        path = os.path.join(self.get_test_directory(), "data", "oci_artifact", "manifest.json")
-        async with self.create_registry_client(containerregistry_endpoint) as client:
-            await self.upload_oci_manifest_prerequisites(repo, client)
+    # @pytest.mark.live_test_only
+    # @acr_preparer()
+    # async def test_set_oci_manifest(self, **kwargs):
+    #     containerregistry_endpoint = kwargs.pop("containerregistry_endpoint")
+    #     repo = self.get_resource_name("repo")
+    #     path = os.path.join(self.get_test_directory(), "data", "oci_artifact", "manifest.json")
+    #     async with self.create_registry_client(containerregistry_endpoint) as client:
+    #         await self.upload_oci_manifest_prerequisites(repo, client)
             
-            with open(path, "rb") as manifest_stream:
-                # test set oci manifest in stream format
-                with pytest.raises(HttpResponseError):
-                    await client.set_manifest(repo, manifest_stream, tag="v1", media_type=DOCKER_MANIFEST)
-                manifest_stream.seek(0)
-                digest1 = await client.set_manifest(repo, manifest_stream, tag="v1")
-                manifest_stream.seek(0)
+    #         with open(path, "rb") as manifest_stream:
+    #             # test set oci manifest in stream format
+    #             with pytest.raises(HttpResponseError):
+    #                 await client.set_manifest(repo, manifest_stream, tag="v1", media_type=DOCKER_MANIFEST)
+    #             manifest_stream.seek(0)
+    #             digest1 = await client.set_manifest(repo, manifest_stream, tag="v1")
+    #             manifest_stream.seek(0)
                 
-                # test set oci manifest in JSON format
-                manifest_json = json.loads(manifest_stream.read().decode())
-                with pytest.raises(HttpResponseError):
-                    await client.set_manifest(repo, manifest_json, tag="v2", media_type=DOCKER_MANIFEST)
-                digest2 = await client.set_manifest(repo, manifest_json, tag="v2")
+    #             # test set oci manifest in JSON format
+    #             manifest_json = json.loads(manifest_stream.read().decode())
+    #             with pytest.raises(HttpResponseError):
+    #                 await client.set_manifest(repo, manifest_json, tag="v2", media_type=DOCKER_MANIFEST)
+    #             digest2 = await client.set_manifest(repo, manifest_json, tag="v2")
                 
-            assert digest1 == digest2
+    #         assert digest1 == digest2
             
-            # test get oci manifest by digest
-            response = await client.get_manifest(repo, digest1)
-            assert response.media_type == OCI_IMAGE_MANIFEST
+    #         # test get oci manifest by digest
+    #         response = await client.get_manifest(repo, digest1)
+    #         assert response.media_type == OCI_IMAGE_MANIFEST
             
-            # test get oci manifest by tag
-            response = await client.get_manifest(repo, "v1")
-            assert response.media_type == OCI_IMAGE_MANIFEST
-            response = await client.get_manifest(repo, "v2")
-            assert response.media_type == OCI_IMAGE_MANIFEST
+    #         # test get oci manifest by tag
+    #         response = await client.get_manifest(repo, "v1")
+    #         assert response.media_type == OCI_IMAGE_MANIFEST
+    #         response = await client.get_manifest(repo, "v2")
+    #         assert response.media_type == OCI_IMAGE_MANIFEST
 
-            await client.delete_manifest(repo, digest1)
-            await client.delete_repository(repo)
+    #         await client.delete_manifest(repo, digest1)
+    #         await client.delete_repository(repo)
     
     # Reading data from a no space file to make this test pass in playback as test proxy cannot handle spaces correctly.
     # issue: https://github.com/Azure/azure-sdk-tools/issues/5968
-    @acr_preparer()
-    @recorded_by_proxy_async
-    async def test_set_oci_manifest_without_spaces(self, containerregistry_endpoint):
-        if self.is_china_endpoint(containerregistry_endpoint):
-            pytest.skip("Running in china cloud may cause all tests finishing longer than the max time of 120 mins.")
+    # @acr_preparer()
+    # @recorded_by_proxy_async
+    # async def test_set_oci_manifest_without_spaces(self, containerregistry_endpoint):
+    #     if self.is_china_endpoint(containerregistry_endpoint):
+    #         pytest.skip("Running in china cloud may cause all tests finishing longer than the max time of 120 mins.")
         
-        repo = self.get_resource_name("repo")
-        path = os.path.join(self.get_test_directory(), "data", "oci_artifact", "manifest_without_spaces.json")
-        async with self.create_registry_client(containerregistry_endpoint) as client:
-            await self.upload_oci_manifest_prerequisites(repo, client)
+    #     repo = self.get_resource_name("repo")
+    #     path = os.path.join(self.get_test_directory(), "data", "oci_artifact", "manifest_without_spaces.json")
+    #     async with self.create_registry_client(containerregistry_endpoint) as client:
+    #         await self.upload_oci_manifest_prerequisites(repo, client)
 
-            with open(path, "rb") as manifest_stream:
-                # test set oci manifest in stream format
-                with pytest.raises(HttpResponseError):
-                    await client.set_manifest(repo, manifest_stream, tag="v1", media_type=DOCKER_MANIFEST)
-                manifest_stream.seek(0)
-                digest = await client.set_manifest(repo, manifest_stream, tag="v1")
+    #         with open(path, "rb") as manifest_stream:
+    #             # test set oci manifest in stream format
+    #             with pytest.raises(HttpResponseError):
+    #                 await client.set_manifest(repo, manifest_stream, tag="v1", media_type=DOCKER_MANIFEST)
+    #             manifest_stream.seek(0)
+    #             digest = await client.set_manifest(repo, manifest_stream, tag="v1")
                 
-            # test get oci manifest by digest
-            response = await client.get_manifest(repo, digest)
-            assert response.media_type == OCI_IMAGE_MANIFEST
+    #         # test get oci manifest by digest
+    #         response = await client.get_manifest(repo, digest)
+    #         assert response.media_type == OCI_IMAGE_MANIFEST
             
-            # test get oci manifest by tag
-            response = await client.get_manifest(repo, "v1")
-            assert response.media_type == OCI_IMAGE_MANIFEST
+    #         # test get oci manifest by tag
+    #         response = await client.get_manifest(repo, "v1")
+    #         assert response.media_type == OCI_IMAGE_MANIFEST
 
-            await client.delete_manifest(repo, digest)
-            await client.delete_repository(repo)
+    #         await client.delete_manifest(repo, digest)
+    #         await client.delete_repository(repo)
 
     # Live only, as test proxy now cannot handle spaces correctly
     # issue: https://github.com/Azure/azure-sdk-tools/issues/5968
-    @pytest.mark.live_test_only
-    @acr_preparer()
-    async def test_set_docker_manifest(self, **kwargs):
-        containerregistry_endpoint = kwargs.pop("containerregistry_endpoint")
-        if self.is_china_endpoint(containerregistry_endpoint):
-            pytest.skip("Not run in China cloud")
-        repo = self.get_resource_name("repo")
-        path = os.path.join(self.get_test_directory(), "data", "docker_artifact", "manifest.json")
-        async with self.create_registry_client(containerregistry_endpoint) as client:
-            await self.upload_docker_manifest_prerequisites(repo, client)
+    # @pytest.mark.live_test_only
+    # @acr_preparer()
+    # async def test_set_docker_manifest(self, **kwargs):
+    #     containerregistry_endpoint = kwargs.pop("containerregistry_endpoint")
+    #     if self.is_china_endpoint(containerregistry_endpoint):
+    #         pytest.skip("Not run in China cloud")
+    #     repo = self.get_resource_name("repo")
+    #     path = os.path.join(self.get_test_directory(), "data", "docker_artifact", "manifest.json")
+    #     async with self.create_registry_client(containerregistry_endpoint) as client:
+    #         await self.upload_docker_manifest_prerequisites(repo, client)
             
-            with open(path, "rb") as manifest_stream:
-                # test set Docker manifest in stream format
-                with pytest.raises(HttpResponseError):
-                    # It fails as the default media type is oci image manifest media type
-                    await client.set_manifest(repo, manifest_stream, tag="v1")
-                manifest_stream.seek(0)
-                digest1 = await client.set_manifest(repo, manifest_stream, tag="v1", media_type=DOCKER_MANIFEST)
-                manifest_stream.seek(0)
+    #         with open(path, "rb") as manifest_stream:
+    #             # test set Docker manifest in stream format
+    #             with pytest.raises(HttpResponseError):
+    #                 # It fails as the default media type is oci image manifest media type
+    #                 await client.set_manifest(repo, manifest_stream, tag="v1")
+    #             manifest_stream.seek(0)
+    #             digest1 = await client.set_manifest(repo, manifest_stream, tag="v1", media_type=DOCKER_MANIFEST)
+    #             manifest_stream.seek(0)
                 
-                # test set Docker manifest in JSON format
-                manifest_json = json.loads(manifest_stream.read().decode())
-                with pytest.raises(HttpResponseError):
-                    # It fails as the default media type is oci image manifest media type
-                    await client.set_manifest(repo, manifest_json, tag="v2")
-                digest2 = await client.set_manifest(repo, manifest_json, tag="v2", media_type=DOCKER_MANIFEST)
+    #             # test set Docker manifest in JSON format
+    #             manifest_json = json.loads(manifest_stream.read().decode())
+    #             with pytest.raises(HttpResponseError):
+    #                 # It fails as the default media type is oci image manifest media type
+    #                 await client.set_manifest(repo, manifest_json, tag="v2")
+    #             digest2 = await client.set_manifest(repo, manifest_json, tag="v2", media_type=DOCKER_MANIFEST)
             
-            assert digest1 == digest2
+    #         assert digest1 == digest2
                 
-            # test get Docker manifest by digest
-            response = await client.get_manifest(repo, digest1)
-            assert response.media_type == DOCKER_MANIFEST
+    #         # test get Docker manifest by digest
+    #         response = await client.get_manifest(repo, digest1)
+    #         assert response.media_type == DOCKER_MANIFEST
             
-            # test get Docker manifest by tag
-            response = await client.get_manifest(repo, "v1")
-            assert response.media_type == DOCKER_MANIFEST
-            response = await client.get_manifest(repo, "v2")
-            assert response.media_type == DOCKER_MANIFEST
+    #         # test get Docker manifest by tag
+    #         response = await client.get_manifest(repo, "v1")
+    #         assert response.media_type == DOCKER_MANIFEST
+    #         response = await client.get_manifest(repo, "v2")
+    #         assert response.media_type == DOCKER_MANIFEST
 
-            await client.delete_manifest(repo, digest1)
-            await client.delete_repository(repo)
+    #         await client.delete_manifest(repo, digest1)
+    #         await client.delete_repository(repo)
     
     # Reading data from a no space file to make this test pass in playback as test proxy cannot handle spaces correctly.
     # issue: https://github.com/Azure/azure-sdk-tools/issues/5968
-    @acr_preparer()
-    @recorded_by_proxy_async
-    async def test_set_docker_manifest_without_spaces(self, containerregistry_endpoint):
-        if self.is_china_endpoint(containerregistry_endpoint):
-            pytest.skip("Running in china cloud may cause all tests finishing longer than the max time of 120 mins.")
+    # @acr_preparer()
+    # @recorded_by_proxy_async
+    # async def test_set_docker_manifest_without_spaces(self, containerregistry_endpoint):
+    #     if self.is_china_endpoint(containerregistry_endpoint):
+    #         pytest.skip("Running in china cloud may cause all tests finishing longer than the max time of 120 mins.")
         
-        repo = self.get_resource_name("repo")
-        path = os.path.join(self.get_test_directory(), "data", "docker_artifact", "manifest_without_spaces.json")
-        async with self.create_registry_client(containerregistry_endpoint) as client:
-            await self.upload_docker_manifest_prerequisites(repo, client)
+    #     repo = self.get_resource_name("repo")
+    #     path = os.path.join(self.get_test_directory(), "data", "docker_artifact", "manifest_without_spaces.json")
+    #     async with self.create_registry_client(containerregistry_endpoint) as client:
+    #         await self.upload_docker_manifest_prerequisites(repo, client)
             
-            with open(path, "rb") as manifest_stream:
-                # test set Docker manifest in stream format
-                with pytest.raises(HttpResponseError):
-                    # It fails as the default media type is oci image manifest media type
-                    await client.set_manifest(repo, manifest_stream, tag="v1")
-                manifest_stream.seek(0)
-                digest = await client.set_manifest(repo, manifest_stream, tag="v1", media_type=DOCKER_MANIFEST)
+    #         with open(path, "rb") as manifest_stream:
+    #             # test set Docker manifest in stream format
+    #             with pytest.raises(HttpResponseError):
+    #                 # It fails as the default media type is oci image manifest media type
+    #                 await client.set_manifest(repo, manifest_stream, tag="v1")
+    #             manifest_stream.seek(0)
+    #             digest = await client.set_manifest(repo, manifest_stream, tag="v1", media_type=DOCKER_MANIFEST)
                 
-            # test get Docker manifest by digest
-            response = await client.get_manifest(repo, digest)
-            assert response.media_type == DOCKER_MANIFEST
+    #         # test get Docker manifest by digest
+    #         response = await client.get_manifest(repo, digest)
+    #         assert response.media_type == DOCKER_MANIFEST
             
-            # test get Docker manifest by tag
-            response = await client.get_manifest(repo, "v1")
-            assert response.media_type == DOCKER_MANIFEST
+    #         # test get Docker manifest by tag
+    #         response = await client.get_manifest(repo, "v1")
+    #         assert response.media_type == DOCKER_MANIFEST
 
-            await client.delete_manifest(repo, digest)
-            await client.delete_repository(repo)
+    #         await client.delete_manifest(repo, digest)
+    #         await client.delete_repository(repo)
 
-    @acr_preparer()
-    @recorded_by_proxy_async
-    async def test_upload_blob(self, containerregistry_endpoint):
-        repo = self.get_resource_name("repo")
-        blob = BytesIO(b"hello world")
+    # @acr_preparer()
+    # @recorded_by_proxy_async
+    # async def test_upload_blob(self, containerregistry_endpoint):
+    #     repo = self.get_resource_name("repo")
+    #     blob = BytesIO(b"hello world")
 
-        async with self.create_registry_client(containerregistry_endpoint) as client:
-            # Act
-            digest, blob_size = await client.upload_blob(repo, blob)
+    #     async with self.create_registry_client(containerregistry_endpoint) as client:
+    #         # Act
+    #         digest, blob_size = await client.upload_blob(repo, blob)
 
-            # Assert
-            blob_content = b""
-            stream = await client.download_blob(repo, digest)
-            async for chunk in stream:
-                blob_content += chunk
-            assert len(blob_content) == blob_size
+    #         # Assert
+    #         blob_content = b""
+    #         stream = await client.download_blob(repo, digest)
+    #         async for chunk in stream:
+    #             blob_content += chunk
+    #         assert len(blob_content) == blob_size
 
-            await client.delete_blob(repo, digest)
-            await client.delete_repository(repo)
+    #         await client.delete_blob(repo, digest)
+    #         await client.delete_repository(repo)
 
-    @pytest.mark.live_test_only
-    @acr_preparer()
-    async def test_upload_large_blob_in_chunk(self, **kwargs):
-        containerregistry_endpoint = kwargs.pop("containerregistry_endpoint")
-        if not self.is_public_endpoint(containerregistry_endpoint):
-            pytest.skip("Running in non-public cloud may cause all tests finishing longer than the max time of 120 mins.")
+    # @pytest.mark.live_test_only
+    # @acr_preparer()
+    # async def test_upload_large_blob_in_chunk(self, **kwargs):
+    #     containerregistry_endpoint = kwargs.pop("containerregistry_endpoint")
+    #     if not self.is_public_endpoint(containerregistry_endpoint):
+    #         pytest.skip("Running in non-public cloud may cause all tests finishing longer than the max time of 120 mins.")
         
-        repo = self.get_resource_name("repo")
-        async with self.create_registry_client(containerregistry_endpoint) as client:
-            # Test blob upload and download in equal size chunks
-            try:
-                blob_size = DEFAULT_CHUNK_SIZE * 1024 # 4GB
-                data = b'\x00' * int(blob_size)
-                digest, size = await client.upload_blob(repo, BytesIO(data))
-                assert size == blob_size
+    #     repo = self.get_resource_name("repo")
+    #     async with self.create_registry_client(containerregistry_endpoint) as client:
+    #         # Test blob upload and download in equal size chunks
+    #         try:
+    #             blob_size = DEFAULT_CHUNK_SIZE * 1024 # 4GB
+    #             data = b'\x00' * int(blob_size)
+    #             digest, size = await client.upload_blob(repo, BytesIO(data))
+    #             assert size == blob_size
 
-                stream = await client.download_blob(repo, digest)
-                size = 0
-                with open("text1.txt", "wb") as file:
-                    async for chunk in stream:
-                        size += file.write(chunk)
-                assert size == blob_size
+    #             stream = await client.download_blob(repo, digest)
+    #             size = 0
+    #             with open("text1.txt", "wb") as file:
+    #                 async for chunk in stream:
+    #                     size += file.write(chunk)
+    #             assert size == blob_size
 
-                await client.delete_blob(repo, digest)
-            except (ServiceRequestError, ServiceResponseError) as err:
-                # Service does not support resumable upload when get transient error while uploading
-                # issue: https://github.com/Azure/azure-sdk-for-python/issues/29738
-                print(f"Failed to upload blob: {err.message}")
-            except ResourceNotFoundError as err:
-                # Service does not support resumable upload when get transient error while uploading
-                # issue: https://github.com/Azure/azure-sdk-for-python/issues/29738
-                assert err.status_code == 404
-                assert err.response.request.method == "PATCH"
-                assert err.response.text() == '{"errors":[{"code":"BLOB_UPLOAD_INVALID","message":"blob upload invalid"}]}\n'
+    #             await client.delete_blob(repo, digest)
+    #         except (ServiceRequestError, ServiceResponseError) as err:
+    #             # Service does not support resumable upload when get transient error while uploading
+    #             # issue: https://github.com/Azure/azure-sdk-for-python/issues/29738
+    #             print(f"Failed to upload blob: {err.message}")
+    #         except ResourceNotFoundError as err:
+    #             # Service does not support resumable upload when get transient error while uploading
+    #             # issue: https://github.com/Azure/azure-sdk-for-python/issues/29738
+    #             assert err.status_code == 404
+    #             assert err.response.request.method == "PATCH"
+    #             assert err.response.text() == '{"errors":[{"code":"BLOB_UPLOAD_INVALID","message":"blob upload invalid"}]}\n'
 
-            # Test blob upload and download in unequal size chunks
-            try:
-                blob_size = DEFAULT_CHUNK_SIZE * 1024 + 20
-                data = b'\x00' * int(blob_size)
-                digest, size = await client.upload_blob(repo, BytesIO(data))
-                assert size == blob_size
+    #         # Test blob upload and download in unequal size chunks
+    #         try:
+    #             blob_size = DEFAULT_CHUNK_SIZE * 1024 + 20
+    #             data = b'\x00' * int(blob_size)
+    #             digest, size = await client.upload_blob(repo, BytesIO(data))
+    #             assert size == blob_size
 
-                stream = await client.download_blob(repo, digest)
-                size = 0
-                with open("text2.txt", "wb") as file:
-                    async for chunk in stream:
-                        size += file.write(chunk)
-                assert size == blob_size
+    #             stream = await client.download_blob(repo, digest)
+    #             size = 0
+    #             with open("text2.txt", "wb") as file:
+    #                 async for chunk in stream:
+    #                     size += file.write(chunk)
+    #             assert size == blob_size
 
-                await client.delete_blob(repo, digest)
-            except (ServiceRequestError, ServiceResponseError) as err:
-                # Service does not support resumable upload when get transient error while uploading
-                # issue: https://github.com/Azure/azure-sdk-for-python/issues/29738
-                print(f"Failed to upload blob: {err.message}")
-            except ResourceNotFoundError as err:
-                # Service does not support resumable upload when get transient error while uploading
-                # issue: https://github.com/Azure/azure-sdk-for-python/issues/29738
-                assert err.status_code == 404
-                assert err.response.request.method == "PATCH"
-                assert err.response.text() == '{"errors":[{"code":"BLOB_UPLOAD_INVALID","message":"blob upload invalid"}]}\n'
+    #             await client.delete_blob(repo, digest)
+    #         except (ServiceRequestError, ServiceResponseError) as err:
+    #             # Service does not support resumable upload when get transient error while uploading
+    #             # issue: https://github.com/Azure/azure-sdk-for-python/issues/29738
+    #             print(f"Failed to upload blob: {err.message}")
+    #         except ResourceNotFoundError as err:
+    #             # Service does not support resumable upload when get transient error while uploading
+    #             # issue: https://github.com/Azure/azure-sdk-for-python/issues/29738
+    #             assert err.status_code == 404
+    #             assert err.response.request.method == "PATCH"
+    #             assert err.response.text() == '{"errors":[{"code":"BLOB_UPLOAD_INVALID","message":"blob upload invalid"}]}\n'
 
-            # Cleanup
-            await client.delete_repository(repo)
+    #         # Cleanup
+    #         await client.delete_repository(repo)
 
-    @acr_preparer()
-    @recorded_by_proxy_async
-    async def test_delete_blob_does_not_exist(self, containerregistry_endpoint):
-        repo = self.get_resource_name("repo")
-        hash_value = hashlib.sha256(b"test").hexdigest()
-        digest = f"sha256:{hash_value}"
-        async with self.create_registry_client(containerregistry_endpoint) as client:
-            await client.delete_blob(repo, digest)
+    # @acr_preparer()
+    # @recorded_by_proxy_async
+    # async def test_delete_blob_does_not_exist(self, containerregistry_endpoint):
+    #     repo = self.get_resource_name("repo")
+    #     hash_value = hashlib.sha256(b"test").hexdigest()
+    #     digest = f"sha256:{hash_value}"
+    #     async with self.create_registry_client(containerregistry_endpoint) as client:
+    #         await client.delete_blob(repo, digest)
 
     @acr_preparer()
     @recorded_by_proxy_async

--- a/sdk/containerregistry/azure-containerregistry/tests/test_container_registry_client_async.py
+++ b/sdk/containerregistry/azure-containerregistry/tests/test_container_registry_client_async.py
@@ -82,11 +82,11 @@ class TestContainerRegistryClientAsync(AsyncContainerRegistryTestClass):
     @recorded_by_proxy_async
     async def test_delete_repository(self, containerregistry_endpoint):
         repo = self.get_resource_name("repo")
-        self.import_image(containerregistry_endpoint, HELLO_WORLD, [repo])
+        self.import_image(containerregistry_endpoint, repo, ["test"])
         async with self.create_registry_client(containerregistry_endpoint) as client:
             await client.delete_repository(repo)
 
-            self.sleep(10)
+            self.sleep(5)
             with pytest.raises(ResourceNotFoundError):
                 await client.get_repository_properties(repo)
 
@@ -108,7 +108,7 @@ class TestContainerRegistryClientAsync(AsyncContainerRegistryTestClass):
     @recorded_by_proxy_async
     async def test_update_repository_properties(self, containerregistry_endpoint):
         repo = self.get_resource_name("repo")
-        self.import_image(containerregistry_endpoint, HELLO_WORLD, [f"{repo}:test"])
+        self.import_image(containerregistry_endpoint, repo, ["test"])
 
         async with self.create_registry_client(containerregistry_endpoint) as client:
             properties = self.set_all_properties(RepositoryProperties(), False)
@@ -126,7 +126,7 @@ class TestContainerRegistryClientAsync(AsyncContainerRegistryTestClass):
     @recorded_by_proxy_async
     async def test_update_repository_properties_kwargs(self, containerregistry_endpoint):
         repo = self.get_resource_name("repo")
-        self.import_image(containerregistry_endpoint, HELLO_WORLD, [f"{repo}:test"])
+        self.import_image(containerregistry_endpoint, repo, ["test"])
 
         async with self.create_registry_client(containerregistry_endpoint) as client:
             received = await client.update_repository_properties(
@@ -232,7 +232,7 @@ class TestContainerRegistryClientAsync(AsyncContainerRegistryTestClass):
     async def test_update_manifest_properties(self, containerregistry_endpoint):
         repo = self.get_resource_name("repo")
         tag = "test"
-        self.import_image(containerregistry_endpoint, HELLO_WORLD, [f"{repo}:{tag}"])
+        self.import_image(containerregistry_endpoint, repo, [tag])
 
         async with self.create_registry_client(containerregistry_endpoint) as client: 
             properties = self.set_all_properties(ArtifactManifestProperties(), False)
@@ -251,7 +251,7 @@ class TestContainerRegistryClientAsync(AsyncContainerRegistryTestClass):
     async def test_update_manifest_properties_kwargs(self, containerregistry_endpoint):
         repo = self.get_resource_name("repo")
         tag = "test"
-        self.import_image(containerregistry_endpoint, HELLO_WORLD, [f"{repo}:{tag}"])
+        self.import_image(containerregistry_endpoint, repo, [tag])
 
         async with self.create_registry_client(containerregistry_endpoint) as client:
             received = await client.update_manifest_properties(
@@ -289,7 +289,7 @@ class TestContainerRegistryClientAsync(AsyncContainerRegistryTestClass):
     async def test_update_tag_properties(self, containerregistry_endpoint):
         repo = self.get_resource_name("repo")
         tag = "test"
-        self.import_image(containerregistry_endpoint, HELLO_WORLD, [f"{repo}:{tag}"])
+        self.import_image(containerregistry_endpoint, repo, [tag])
 
         async with self.create_registry_client(containerregistry_endpoint) as client:
             properties = self.set_all_properties(ArtifactTagProperties(), False)
@@ -308,7 +308,7 @@ class TestContainerRegistryClientAsync(AsyncContainerRegistryTestClass):
     async def test_update_tag_properties_kwargs(self, containerregistry_endpoint):
         repo = self.get_resource_name("repo")
         tag = "test"
-        self.import_image(containerregistry_endpoint, HELLO_WORLD, [f"{repo}:{tag}"])
+        self.import_image(containerregistry_endpoint, repo, [tag])
 
         async with self.create_registry_client(containerregistry_endpoint) as client:
             received = await client.update_tag_properties(
@@ -366,7 +366,7 @@ class TestContainerRegistryClientAsync(AsyncContainerRegistryTestClass):
     async def test_delete_tag(self, containerregistry_endpoint):
         repo = self.get_resource_name("repo")
         tag = "test"
-        self.import_image(containerregistry_endpoint, HELLO_WORLD, [f"{repo}:{tag}"])
+        self.import_image(containerregistry_endpoint, repo, [tag])
 
         async with self.create_registry_client(containerregistry_endpoint) as client:
             await client.delete_tag(repo, tag)
@@ -390,7 +390,7 @@ class TestContainerRegistryClientAsync(AsyncContainerRegistryTestClass):
     async def test_delete_manifest(self, containerregistry_endpoint):
         repo = self.get_resource_name("repo")
         tag = "test"
-        self.import_image(containerregistry_endpoint, HELLO_WORLD, [f"{repo}:{tag}"])
+        self.import_image(containerregistry_endpoint, repo, [tag])
 
         async with self.create_registry_client(containerregistry_endpoint) as client:
             await client.delete_manifest(repo, tag)
@@ -461,243 +461,243 @@ class TestContainerRegistryClientAsync(AsyncContainerRegistryTestClass):
     
     # Live only, as test proxy now cannot handle spaces correctly
     # issue: https://github.com/Azure/azure-sdk-tools/issues/5968
-    # @pytest.mark.live_test_only
-    # @acr_preparer()
-    # async def test_set_oci_manifest(self, **kwargs):
-    #     containerregistry_endpoint = kwargs.pop("containerregistry_endpoint")
-    #     repo = self.get_resource_name("repo")
-    #     path = os.path.join(self.get_test_directory(), "data", "oci_artifact", "manifest.json")
-    #     async with self.create_registry_client(containerregistry_endpoint) as client:
-    #         await self.upload_oci_manifest_prerequisites(repo, client)
+    @pytest.mark.live_test_only
+    @acr_preparer()
+    async def test_set_oci_manifest(self, **kwargs):
+        containerregistry_endpoint = kwargs.pop("containerregistry_endpoint")
+        repo = self.get_resource_name("repo")
+        path = os.path.join(self.get_test_directory(), "data", "oci_artifact", "manifest.json")
+        async with self.create_registry_client(containerregistry_endpoint) as client:
+            await self.upload_oci_manifest_prerequisites(repo, client)
             
-    #         with open(path, "rb") as manifest_stream:
-    #             # test set oci manifest in stream format
-    #             with pytest.raises(HttpResponseError):
-    #                 await client.set_manifest(repo, manifest_stream, tag="v1", media_type=DOCKER_MANIFEST)
-    #             manifest_stream.seek(0)
-    #             digest1 = await client.set_manifest(repo, manifest_stream, tag="v1")
-    #             manifest_stream.seek(0)
+            with open(path, "rb") as manifest_stream:
+                # test set oci manifest in stream format
+                with pytest.raises(HttpResponseError):
+                    await client.set_manifest(repo, manifest_stream, tag="v1", media_type=DOCKER_MANIFEST)
+                manifest_stream.seek(0)
+                digest1 = await client.set_manifest(repo, manifest_stream, tag="v1")
+                manifest_stream.seek(0)
                 
-    #             # test set oci manifest in JSON format
-    #             manifest_json = json.loads(manifest_stream.read().decode())
-    #             with pytest.raises(HttpResponseError):
-    #                 await client.set_manifest(repo, manifest_json, tag="v2", media_type=DOCKER_MANIFEST)
-    #             digest2 = await client.set_manifest(repo, manifest_json, tag="v2")
+                # test set oci manifest in JSON format
+                manifest_json = json.loads(manifest_stream.read().decode())
+                with pytest.raises(HttpResponseError):
+                    await client.set_manifest(repo, manifest_json, tag="v2", media_type=DOCKER_MANIFEST)
+                digest2 = await client.set_manifest(repo, manifest_json, tag="v2")
                 
-    #         assert digest1 == digest2
+            assert digest1 == digest2
             
-    #         # test get oci manifest by digest
-    #         response = await client.get_manifest(repo, digest1)
-    #         assert response.media_type == OCI_IMAGE_MANIFEST
+            # test get oci manifest by digest
+            response = await client.get_manifest(repo, digest1)
+            assert response.media_type == OCI_IMAGE_MANIFEST
             
-    #         # test get oci manifest by tag
-    #         response = await client.get_manifest(repo, "v1")
-    #         assert response.media_type == OCI_IMAGE_MANIFEST
-    #         response = await client.get_manifest(repo, "v2")
-    #         assert response.media_type == OCI_IMAGE_MANIFEST
+            # test get oci manifest by tag
+            response = await client.get_manifest(repo, "v1")
+            assert response.media_type == OCI_IMAGE_MANIFEST
+            response = await client.get_manifest(repo, "v2")
+            assert response.media_type == OCI_IMAGE_MANIFEST
 
-    #         await client.delete_manifest(repo, digest1)
-    #         await client.delete_repository(repo)
+            await client.delete_manifest(repo, digest1)
+            await client.delete_repository(repo)
     
     # Reading data from a no space file to make this test pass in playback as test proxy cannot handle spaces correctly.
     # issue: https://github.com/Azure/azure-sdk-tools/issues/5968
-    # @acr_preparer()
-    # @recorded_by_proxy_async
-    # async def test_set_oci_manifest_without_spaces(self, containerregistry_endpoint):
-    #     if self.is_china_endpoint(containerregistry_endpoint):
-    #         pytest.skip("Running in china cloud may cause all tests finishing longer than the max time of 120 mins.")
+    @acr_preparer()
+    @recorded_by_proxy_async
+    async def test_set_oci_manifest_without_spaces(self, containerregistry_endpoint):
+        if self.is_china_endpoint(containerregistry_endpoint):
+            pytest.skip("Running in china cloud may cause all tests finishing longer than the max time of 120 mins.")
         
-    #     repo = self.get_resource_name("repo")
-    #     path = os.path.join(self.get_test_directory(), "data", "oci_artifact", "manifest_without_spaces.json")
-    #     async with self.create_registry_client(containerregistry_endpoint) as client:
-    #         await self.upload_oci_manifest_prerequisites(repo, client)
+        repo = self.get_resource_name("repo")
+        path = os.path.join(self.get_test_directory(), "data", "oci_artifact", "manifest_without_spaces.json")
+        async with self.create_registry_client(containerregistry_endpoint) as client:
+            await self.upload_oci_manifest_prerequisites(repo, client)
 
-    #         with open(path, "rb") as manifest_stream:
-    #             # test set oci manifest in stream format
-    #             with pytest.raises(HttpResponseError):
-    #                 await client.set_manifest(repo, manifest_stream, tag="v1", media_type=DOCKER_MANIFEST)
-    #             manifest_stream.seek(0)
-    #             digest = await client.set_manifest(repo, manifest_stream, tag="v1")
+            with open(path, "rb") as manifest_stream:
+                # test set oci manifest in stream format
+                with pytest.raises(HttpResponseError):
+                    await client.set_manifest(repo, manifest_stream, tag="v1", media_type=DOCKER_MANIFEST)
+                manifest_stream.seek(0)
+                digest = await client.set_manifest(repo, manifest_stream, tag="v1")
                 
-    #         # test get oci manifest by digest
-    #         response = await client.get_manifest(repo, digest)
-    #         assert response.media_type == OCI_IMAGE_MANIFEST
+            # test get oci manifest by digest
+            response = await client.get_manifest(repo, digest)
+            assert response.media_type == OCI_IMAGE_MANIFEST
             
-    #         # test get oci manifest by tag
-    #         response = await client.get_manifest(repo, "v1")
-    #         assert response.media_type == OCI_IMAGE_MANIFEST
+            # test get oci manifest by tag
+            response = await client.get_manifest(repo, "v1")
+            assert response.media_type == OCI_IMAGE_MANIFEST
 
-    #         await client.delete_manifest(repo, digest)
-    #         await client.delete_repository(repo)
+            await client.delete_manifest(repo, digest)
+            await client.delete_repository(repo)
 
     # Live only, as test proxy now cannot handle spaces correctly
     # issue: https://github.com/Azure/azure-sdk-tools/issues/5968
-    # @pytest.mark.live_test_only
-    # @acr_preparer()
-    # async def test_set_docker_manifest(self, **kwargs):
-    #     containerregistry_endpoint = kwargs.pop("containerregistry_endpoint")
-    #     if self.is_china_endpoint(containerregistry_endpoint):
-    #         pytest.skip("Not run in China cloud")
-    #     repo = self.get_resource_name("repo")
-    #     path = os.path.join(self.get_test_directory(), "data", "docker_artifact", "manifest.json")
-    #     async with self.create_registry_client(containerregistry_endpoint) as client:
-    #         await self.upload_docker_manifest_prerequisites(repo, client)
+    @pytest.mark.live_test_only
+    @acr_preparer()
+    async def test_set_docker_manifest(self, **kwargs):
+        containerregistry_endpoint = kwargs.pop("containerregistry_endpoint")
+        if self.is_china_endpoint(containerregistry_endpoint):
+            pytest.skip("Not run in China cloud")
+        repo = self.get_resource_name("repo")
+        path = os.path.join(self.get_test_directory(), "data", "docker_artifact", "manifest.json")
+        async with self.create_registry_client(containerregistry_endpoint) as client:
+            await self.upload_docker_manifest_prerequisites(repo, client)
             
-    #         with open(path, "rb") as manifest_stream:
-    #             # test set Docker manifest in stream format
-    #             with pytest.raises(HttpResponseError):
-    #                 # It fails as the default media type is oci image manifest media type
-    #                 await client.set_manifest(repo, manifest_stream, tag="v1")
-    #             manifest_stream.seek(0)
-    #             digest1 = await client.set_manifest(repo, manifest_stream, tag="v1", media_type=DOCKER_MANIFEST)
-    #             manifest_stream.seek(0)
+            with open(path, "rb") as manifest_stream:
+                # test set Docker manifest in stream format
+                with pytest.raises(HttpResponseError):
+                    # It fails as the default media type is oci image manifest media type
+                    await client.set_manifest(repo, manifest_stream, tag="v1")
+                manifest_stream.seek(0)
+                digest1 = await client.set_manifest(repo, manifest_stream, tag="v1", media_type=DOCKER_MANIFEST)
+                manifest_stream.seek(0)
                 
-    #             # test set Docker manifest in JSON format
-    #             manifest_json = json.loads(manifest_stream.read().decode())
-    #             with pytest.raises(HttpResponseError):
-    #                 # It fails as the default media type is oci image manifest media type
-    #                 await client.set_manifest(repo, manifest_json, tag="v2")
-    #             digest2 = await client.set_manifest(repo, manifest_json, tag="v2", media_type=DOCKER_MANIFEST)
+                # test set Docker manifest in JSON format
+                manifest_json = json.loads(manifest_stream.read().decode())
+                with pytest.raises(HttpResponseError):
+                    # It fails as the default media type is oci image manifest media type
+                    await client.set_manifest(repo, manifest_json, tag="v2")
+                digest2 = await client.set_manifest(repo, manifest_json, tag="v2", media_type=DOCKER_MANIFEST)
             
-    #         assert digest1 == digest2
+            assert digest1 == digest2
                 
-    #         # test get Docker manifest by digest
-    #         response = await client.get_manifest(repo, digest1)
-    #         assert response.media_type == DOCKER_MANIFEST
+            # test get Docker manifest by digest
+            response = await client.get_manifest(repo, digest1)
+            assert response.media_type == DOCKER_MANIFEST
             
-    #         # test get Docker manifest by tag
-    #         response = await client.get_manifest(repo, "v1")
-    #         assert response.media_type == DOCKER_MANIFEST
-    #         response = await client.get_manifest(repo, "v2")
-    #         assert response.media_type == DOCKER_MANIFEST
+            # test get Docker manifest by tag
+            response = await client.get_manifest(repo, "v1")
+            assert response.media_type == DOCKER_MANIFEST
+            response = await client.get_manifest(repo, "v2")
+            assert response.media_type == DOCKER_MANIFEST
 
-    #         await client.delete_manifest(repo, digest1)
-    #         await client.delete_repository(repo)
+            await client.delete_manifest(repo, digest1)
+            await client.delete_repository(repo)
     
     # Reading data from a no space file to make this test pass in playback as test proxy cannot handle spaces correctly.
     # issue: https://github.com/Azure/azure-sdk-tools/issues/5968
-    # @acr_preparer()
-    # @recorded_by_proxy_async
-    # async def test_set_docker_manifest_without_spaces(self, containerregistry_endpoint):
-    #     if self.is_china_endpoint(containerregistry_endpoint):
-    #         pytest.skip("Running in china cloud may cause all tests finishing longer than the max time of 120 mins.")
+    @acr_preparer()
+    @recorded_by_proxy_async
+    async def test_set_docker_manifest_without_spaces(self, containerregistry_endpoint):
+        if self.is_china_endpoint(containerregistry_endpoint):
+            pytest.skip("Running in china cloud may cause all tests finishing longer than the max time of 120 mins.")
         
-    #     repo = self.get_resource_name("repo")
-    #     path = os.path.join(self.get_test_directory(), "data", "docker_artifact", "manifest_without_spaces.json")
-    #     async with self.create_registry_client(containerregistry_endpoint) as client:
-    #         await self.upload_docker_manifest_prerequisites(repo, client)
+        repo = self.get_resource_name("repo")
+        path = os.path.join(self.get_test_directory(), "data", "docker_artifact", "manifest_without_spaces.json")
+        async with self.create_registry_client(containerregistry_endpoint) as client:
+            await self.upload_docker_manifest_prerequisites(repo, client)
             
-    #         with open(path, "rb") as manifest_stream:
-    #             # test set Docker manifest in stream format
-    #             with pytest.raises(HttpResponseError):
-    #                 # It fails as the default media type is oci image manifest media type
-    #                 await client.set_manifest(repo, manifest_stream, tag="v1")
-    #             manifest_stream.seek(0)
-    #             digest = await client.set_manifest(repo, manifest_stream, tag="v1", media_type=DOCKER_MANIFEST)
+            with open(path, "rb") as manifest_stream:
+                # test set Docker manifest in stream format
+                with pytest.raises(HttpResponseError):
+                    # It fails as the default media type is oci image manifest media type
+                    await client.set_manifest(repo, manifest_stream, tag="v1")
+                manifest_stream.seek(0)
+                digest = await client.set_manifest(repo, manifest_stream, tag="v1", media_type=DOCKER_MANIFEST)
                 
-    #         # test get Docker manifest by digest
-    #         response = await client.get_manifest(repo, digest)
-    #         assert response.media_type == DOCKER_MANIFEST
+            # test get Docker manifest by digest
+            response = await client.get_manifest(repo, digest)
+            assert response.media_type == DOCKER_MANIFEST
             
-    #         # test get Docker manifest by tag
-    #         response = await client.get_manifest(repo, "v1")
-    #         assert response.media_type == DOCKER_MANIFEST
+            # test get Docker manifest by tag
+            response = await client.get_manifest(repo, "v1")
+            assert response.media_type == DOCKER_MANIFEST
 
-    #         await client.delete_manifest(repo, digest)
-    #         await client.delete_repository(repo)
+            await client.delete_manifest(repo, digest)
+            await client.delete_repository(repo)
 
-    # @acr_preparer()
-    # @recorded_by_proxy_async
-    # async def test_upload_blob(self, containerregistry_endpoint):
-    #     repo = self.get_resource_name("repo")
-    #     blob = BytesIO(b"hello world")
+    @acr_preparer()
+    @recorded_by_proxy_async
+    async def test_upload_blob(self, containerregistry_endpoint):
+        repo = self.get_resource_name("repo")
+        blob = BytesIO(b"hello world")
 
-    #     async with self.create_registry_client(containerregistry_endpoint) as client:
-    #         # Act
-    #         digest, blob_size = await client.upload_blob(repo, blob)
+        async with self.create_registry_client(containerregistry_endpoint) as client:
+            # Act
+            digest, blob_size = await client.upload_blob(repo, blob)
 
-    #         # Assert
-    #         blob_content = b""
-    #         stream = await client.download_blob(repo, digest)
-    #         async for chunk in stream:
-    #             blob_content += chunk
-    #         assert len(blob_content) == blob_size
+            # Assert
+            blob_content = b""
+            stream = await client.download_blob(repo, digest)
+            async for chunk in stream:
+                blob_content += chunk
+            assert len(blob_content) == blob_size
 
-    #         await client.delete_blob(repo, digest)
-    #         await client.delete_repository(repo)
+            await client.delete_blob(repo, digest)
+            await client.delete_repository(repo)
 
-    # @pytest.mark.live_test_only
-    # @acr_preparer()
-    # async def test_upload_large_blob_in_chunk(self, **kwargs):
-    #     containerregistry_endpoint = kwargs.pop("containerregistry_endpoint")
-    #     if not self.is_public_endpoint(containerregistry_endpoint):
-    #         pytest.skip("Running in non-public cloud may cause all tests finishing longer than the max time of 120 mins.")
+    @pytest.mark.live_test_only
+    @acr_preparer()
+    async def test_upload_large_blob_in_chunk(self, **kwargs):
+        containerregistry_endpoint = kwargs.pop("containerregistry_endpoint")
+        if not self.is_public_endpoint(containerregistry_endpoint):
+            pytest.skip("Running in non-public cloud may cause all tests finishing longer than the max time of 120 mins.")
         
-    #     repo = self.get_resource_name("repo")
-    #     async with self.create_registry_client(containerregistry_endpoint) as client:
-    #         # Test blob upload and download in equal size chunks
-    #         try:
-    #             blob_size = DEFAULT_CHUNK_SIZE * 1024 # 4GB
-    #             data = b'\x00' * int(blob_size)
-    #             digest, size = await client.upload_blob(repo, BytesIO(data))
-    #             assert size == blob_size
+        repo = self.get_resource_name("repo")
+        async with self.create_registry_client(containerregistry_endpoint) as client:
+            # Test blob upload and download in equal size chunks
+            try:
+                blob_size = DEFAULT_CHUNK_SIZE * 1024 # 4GB
+                data = b'\x00' * int(blob_size)
+                digest, size = await client.upload_blob(repo, BytesIO(data))
+                assert size == blob_size
 
-    #             stream = await client.download_blob(repo, digest)
-    #             size = 0
-    #             with open("text1.txt", "wb") as file:
-    #                 async for chunk in stream:
-    #                     size += file.write(chunk)
-    #             assert size == blob_size
+                stream = await client.download_blob(repo, digest)
+                size = 0
+                with open("text1.txt", "wb") as file:
+                    async for chunk in stream:
+                        size += file.write(chunk)
+                assert size == blob_size
 
-    #             await client.delete_blob(repo, digest)
-    #         except (ServiceRequestError, ServiceResponseError) as err:
-    #             # Service does not support resumable upload when get transient error while uploading
-    #             # issue: https://github.com/Azure/azure-sdk-for-python/issues/29738
-    #             print(f"Failed to upload blob: {err.message}")
-    #         except ResourceNotFoundError as err:
-    #             # Service does not support resumable upload when get transient error while uploading
-    #             # issue: https://github.com/Azure/azure-sdk-for-python/issues/29738
-    #             assert err.status_code == 404
-    #             assert err.response.request.method == "PATCH"
-    #             assert err.response.text() == '{"errors":[{"code":"BLOB_UPLOAD_INVALID","message":"blob upload invalid"}]}\n'
+                await client.delete_blob(repo, digest)
+            except (ServiceRequestError, ServiceResponseError) as err:
+                # Service does not support resumable upload when get transient error while uploading
+                # issue: https://github.com/Azure/azure-sdk-for-python/issues/29738
+                print(f"Failed to upload blob: {err.message}")
+            except ResourceNotFoundError as err:
+                # Service does not support resumable upload when get transient error while uploading
+                # issue: https://github.com/Azure/azure-sdk-for-python/issues/29738
+                assert err.status_code == 404
+                assert err.response.request.method == "PATCH"
+                assert err.response.text() == '{"errors":[{"code":"BLOB_UPLOAD_INVALID","message":"blob upload invalid"}]}\n'
 
-    #         # Test blob upload and download in unequal size chunks
-    #         try:
-    #             blob_size = DEFAULT_CHUNK_SIZE * 1024 + 20
-    #             data = b'\x00' * int(blob_size)
-    #             digest, size = await client.upload_blob(repo, BytesIO(data))
-    #             assert size == blob_size
+            # Test blob upload and download in unequal size chunks
+            try:
+                blob_size = DEFAULT_CHUNK_SIZE * 1024 + 20
+                data = b'\x00' * int(blob_size)
+                digest, size = await client.upload_blob(repo, BytesIO(data))
+                assert size == blob_size
 
-    #             stream = await client.download_blob(repo, digest)
-    #             size = 0
-    #             with open("text2.txt", "wb") as file:
-    #                 async for chunk in stream:
-    #                     size += file.write(chunk)
-    #             assert size == blob_size
+                stream = await client.download_blob(repo, digest)
+                size = 0
+                with open("text2.txt", "wb") as file:
+                    async for chunk in stream:
+                        size += file.write(chunk)
+                assert size == blob_size
 
-    #             await client.delete_blob(repo, digest)
-    #         except (ServiceRequestError, ServiceResponseError) as err:
-    #             # Service does not support resumable upload when get transient error while uploading
-    #             # issue: https://github.com/Azure/azure-sdk-for-python/issues/29738
-    #             print(f"Failed to upload blob: {err.message}")
-    #         except ResourceNotFoundError as err:
-    #             # Service does not support resumable upload when get transient error while uploading
-    #             # issue: https://github.com/Azure/azure-sdk-for-python/issues/29738
-    #             assert err.status_code == 404
-    #             assert err.response.request.method == "PATCH"
-    #             assert err.response.text() == '{"errors":[{"code":"BLOB_UPLOAD_INVALID","message":"blob upload invalid"}]}\n'
+                await client.delete_blob(repo, digest)
+            except (ServiceRequestError, ServiceResponseError) as err:
+                # Service does not support resumable upload when get transient error while uploading
+                # issue: https://github.com/Azure/azure-sdk-for-python/issues/29738
+                print(f"Failed to upload blob: {err.message}")
+            except ResourceNotFoundError as err:
+                # Service does not support resumable upload when get transient error while uploading
+                # issue: https://github.com/Azure/azure-sdk-for-python/issues/29738
+                assert err.status_code == 404
+                assert err.response.request.method == "PATCH"
+                assert err.response.text() == '{"errors":[{"code":"BLOB_UPLOAD_INVALID","message":"blob upload invalid"}]}\n'
 
-    #         # Cleanup
-    #         await client.delete_repository(repo)
+            # Cleanup
+            await client.delete_repository(repo)
 
-    # @acr_preparer()
-    # @recorded_by_proxy_async
-    # async def test_delete_blob_does_not_exist(self, containerregistry_endpoint):
-    #     repo = self.get_resource_name("repo")
-    #     hash_value = hashlib.sha256(b"test").hexdigest()
-    #     digest = f"sha256:{hash_value}"
-    #     async with self.create_registry_client(containerregistry_endpoint) as client:
-    #         await client.delete_blob(repo, digest)
+    @acr_preparer()
+    @recorded_by_proxy_async
+    async def test_delete_blob_does_not_exist(self, containerregistry_endpoint):
+        repo = self.get_resource_name("repo")
+        hash_value = hashlib.sha256(b"test").hexdigest()
+        digest = f"sha256:{hash_value}"
+        async with self.create_registry_client(containerregistry_endpoint) as client:
+            await client.delete_blob(repo, digest)
 
     @acr_preparer()
     @recorded_by_proxy_async
@@ -729,7 +729,7 @@ class TestContainerRegistryClientAsync(AsyncContainerRegistryTestClass):
     @recorded_by_proxy_async
     async def test_list_in_empty_repo(self, containerregistry_endpoint):
         repo = self.get_resource_name("repo")
-        self.import_image(containerregistry_endpoint, HELLO_WORLD, [repo])
+        self.import_image(containerregistry_endpoint, repo, ["test"])
         async with self.create_registry_client(containerregistry_endpoint) as client:
             # cleanup tags in repo
             async for tag in client.list_tag_properties(repo):

--- a/sdk/containerregistry/azure-containerregistry/tests/test_container_registry_client_async.py
+++ b/sdk/containerregistry/azure-containerregistry/tests/test_container_registry_client_async.py
@@ -538,8 +538,6 @@ class TestContainerRegistryClientAsync(AsyncContainerRegistryTestClass):
     @acr_preparer()
     async def test_set_docker_manifest(self, **kwargs):
         containerregistry_endpoint = kwargs.pop("containerregistry_endpoint")
-        if is_china_endpoint(containerregistry_endpoint):
-            pytest.skip("Not run in China cloud")
         repo = self.get_resource_name("repo")
         path = os.path.join(self.get_test_directory(), "data", "docker_artifact", "manifest.json")
         async with self.create_registry_client(containerregistry_endpoint) as client:

--- a/sdk/containerregistry/azure-containerregistry/tests/test_container_registry_client_async.py
+++ b/sdk/containerregistry/azure-containerregistry/tests/test_container_registry_client_async.py
@@ -84,6 +84,7 @@ class TestContainerRegistryClientAsync(AsyncContainerRegistryTestClass):
     async def test_delete_repository(self, containerregistry_endpoint):
         repo = self.get_resource_name("repo")
         self.import_image(containerregistry_endpoint, repo, ["test"])
+        self.sleep(5)
         async with self.create_registry_client(containerregistry_endpoint) as client:
             await client.delete_repository(repo)
 
@@ -110,7 +111,7 @@ class TestContainerRegistryClientAsync(AsyncContainerRegistryTestClass):
     async def test_update_repository_properties(self, containerregistry_endpoint):
         repo = self.get_resource_name("repo")
         self.import_image(containerregistry_endpoint, repo, ["test"])
-
+        self.sleep(5)
         async with self.create_registry_client(containerregistry_endpoint) as client:
             properties = self.set_all_properties(RepositoryProperties(), False)
             received = await client.update_repository_properties(repo, properties)
@@ -128,7 +129,7 @@ class TestContainerRegistryClientAsync(AsyncContainerRegistryTestClass):
     async def test_update_repository_properties_kwargs(self, containerregistry_endpoint):
         repo = self.get_resource_name("repo")
         self.import_image(containerregistry_endpoint, repo, ["test"])
-
+        self.sleep(5)
         async with self.create_registry_client(containerregistry_endpoint) as client:
             received = await client.update_repository_properties(
                 repo, can_delete=False, can_read=False, can_write=False, can_list=False
@@ -234,7 +235,7 @@ class TestContainerRegistryClientAsync(AsyncContainerRegistryTestClass):
         repo = self.get_resource_name("repo")
         tag = "test"
         self.import_image(containerregistry_endpoint, repo, [tag])
-
+        self.sleep(5)
         async with self.create_registry_client(containerregistry_endpoint) as client: 
             properties = self.set_all_properties(ArtifactManifestProperties(), False)
             received = await client.update_manifest_properties(repo, tag, properties)
@@ -253,7 +254,7 @@ class TestContainerRegistryClientAsync(AsyncContainerRegistryTestClass):
         repo = self.get_resource_name("repo")
         tag = "test"
         self.import_image(containerregistry_endpoint, repo, [tag])
-
+        self.sleep(5)
         async with self.create_registry_client(containerregistry_endpoint) as client:
             received = await client.update_manifest_properties(
                 repo, tag, can_delete=False, can_read=False, can_write=False, can_list=False
@@ -291,7 +292,7 @@ class TestContainerRegistryClientAsync(AsyncContainerRegistryTestClass):
         repo = self.get_resource_name("repo")
         tag = "test"
         self.import_image(containerregistry_endpoint, repo, [tag])
-
+        self.sleep(5)
         async with self.create_registry_client(containerregistry_endpoint) as client:
             properties = self.set_all_properties(ArtifactTagProperties(), False)
             received = await client.update_tag_properties(repo, tag, properties)
@@ -310,7 +311,7 @@ class TestContainerRegistryClientAsync(AsyncContainerRegistryTestClass):
         repo = self.get_resource_name("repo")
         tag = "test"
         self.import_image(containerregistry_endpoint, repo, [tag])
-
+        self.sleep(5)
         async with self.create_registry_client(containerregistry_endpoint) as client:
             received = await client.update_tag_properties(
                 repo, tag, can_delete=False, can_read=False, can_write=False, can_list=False
@@ -368,7 +369,7 @@ class TestContainerRegistryClientAsync(AsyncContainerRegistryTestClass):
         repo = self.get_resource_name("repo")
         tag = "test"
         self.import_image(containerregistry_endpoint, repo, [tag])
-
+        self.sleep(5)
         async with self.create_registry_client(containerregistry_endpoint) as client:
             await client.delete_tag(repo, tag)
 
@@ -392,7 +393,7 @@ class TestContainerRegistryClientAsync(AsyncContainerRegistryTestClass):
         repo = self.get_resource_name("repo")
         tag = "test"
         self.import_image(containerregistry_endpoint, repo, [tag])
-
+        self.sleep(5)
         async with self.create_registry_client(containerregistry_endpoint) as client:
             await client.delete_manifest(repo, tag)
 
@@ -731,6 +732,7 @@ class TestContainerRegistryClientAsync(AsyncContainerRegistryTestClass):
     async def test_list_in_empty_repo(self, containerregistry_endpoint):
         repo = self.get_resource_name("repo")
         self.import_image(containerregistry_endpoint, repo, ["test"])
+        self.sleep(5)
         async with self.create_registry_client(containerregistry_endpoint) as client:
             # cleanup tags in repo
             async for tag in client.list_tag_properties(repo):

--- a/sdk/containerregistry/azure-containerregistry/tests/test_container_registry_client_async.py
+++ b/sdk/containerregistry/azure-containerregistry/tests/test_container_registry_client_async.py
@@ -33,6 +33,7 @@ from azure.core.async_paging import AsyncItemPaged
 from azure.core.pipeline import PipelineRequest
 from azure.identity import AzureAuthorityHosts
 from asynctestcase import AsyncContainerRegistryTestClass, get_authority, get_audience
+from testcase import is_public_endpoint, is_china_endpoint
 from constants import HELLO_WORLD, DOES_NOT_EXIST
 from preparer import acr_preparer
 from devtools_testutils.aio import recorded_by_proxy_async
@@ -504,7 +505,7 @@ class TestContainerRegistryClientAsync(AsyncContainerRegistryTestClass):
     @acr_preparer()
     @recorded_by_proxy_async
     async def test_set_oci_manifest_without_spaces(self, containerregistry_endpoint):
-        if self.is_china_endpoint(containerregistry_endpoint):
+        if is_china_endpoint(containerregistry_endpoint):
             pytest.skip("Running in china cloud may cause all tests finishing longer than the max time of 120 mins.")
         
         repo = self.get_resource_name("repo")
@@ -536,7 +537,7 @@ class TestContainerRegistryClientAsync(AsyncContainerRegistryTestClass):
     @acr_preparer()
     async def test_set_docker_manifest(self, **kwargs):
         containerregistry_endpoint = kwargs.pop("containerregistry_endpoint")
-        if self.is_china_endpoint(containerregistry_endpoint):
+        if is_china_endpoint(containerregistry_endpoint):
             pytest.skip("Not run in China cloud")
         repo = self.get_resource_name("repo")
         path = os.path.join(self.get_test_directory(), "data", "docker_artifact", "manifest.json")
@@ -579,7 +580,7 @@ class TestContainerRegistryClientAsync(AsyncContainerRegistryTestClass):
     @acr_preparer()
     @recorded_by_proxy_async
     async def test_set_docker_manifest_without_spaces(self, containerregistry_endpoint):
-        if self.is_china_endpoint(containerregistry_endpoint):
+        if is_china_endpoint(containerregistry_endpoint):
             pytest.skip("Running in china cloud may cause all tests finishing longer than the max time of 120 mins.")
         
         repo = self.get_resource_name("repo")
@@ -630,7 +631,7 @@ class TestContainerRegistryClientAsync(AsyncContainerRegistryTestClass):
     @acr_preparer()
     async def test_upload_large_blob_in_chunk(self, **kwargs):
         containerregistry_endpoint = kwargs.pop("containerregistry_endpoint")
-        if not self.is_public_endpoint(containerregistry_endpoint):
+        if not is_public_endpoint(containerregistry_endpoint):
             pytest.skip("Running in non-public cloud may cause all tests finishing longer than the max time of 120 mins.")
         
         repo = self.get_resource_name("repo")

--- a/sdk/containerregistry/azure-containerregistry/tests/test_container_registry_client_async.py
+++ b/sdk/containerregistry/azure-containerregistry/tests/test_container_registry_client_async.py
@@ -536,6 +536,8 @@ class TestContainerRegistryClientAsync(AsyncContainerRegistryTestClass):
     @acr_preparer()
     async def test_set_docker_manifest(self, **kwargs):
         containerregistry_endpoint = kwargs.pop("containerregistry_endpoint")
+        if self.is_china_endpoint(containerregistry_endpoint):
+            pytest.skip("Not run in China cloud")
         repo = self.get_resource_name("repo")
         path = os.path.join(self.get_test_directory(), "data", "docker_artifact", "manifest.json")
         async with self.create_registry_client(containerregistry_endpoint) as client:

--- a/sdk/containerregistry/azure-containerregistry/tests/test_container_registry_client_async.py
+++ b/sdk/containerregistry/azure-containerregistry/tests/test_container_registry_client_async.py
@@ -33,7 +33,7 @@ from azure.core.async_paging import AsyncItemPaged
 from azure.core.pipeline import PipelineRequest
 from azure.identity import AzureAuthorityHosts
 from asynctestcase import AsyncContainerRegistryTestClass, get_authority, get_audience
-from testcase import is_public_endpoint, is_china_endpoint
+from testcase import is_public_endpoint
 from constants import HELLO_WORLD, DOES_NOT_EXIST
 from preparer import acr_preparer
 from devtools_testutils.aio import recorded_by_proxy_async
@@ -506,8 +506,8 @@ class TestContainerRegistryClientAsync(AsyncContainerRegistryTestClass):
     @acr_preparer()
     @recorded_by_proxy_async
     async def test_set_oci_manifest_without_spaces(self, containerregistry_endpoint):
-        if is_china_endpoint(containerregistry_endpoint):
-            pytest.skip("Running in china cloud may cause all tests finishing longer than the max time of 120 mins.")
+        if not is_public_endpoint(containerregistry_endpoint):
+            pytest.skip("This test is for testing test_set_docker_manifest in playback.")
         
         repo = self.get_resource_name("repo")
         path = os.path.join(self.get_test_directory(), "data", "oci_artifact", "manifest_without_spaces.json")
@@ -579,8 +579,8 @@ class TestContainerRegistryClientAsync(AsyncContainerRegistryTestClass):
     @acr_preparer()
     @recorded_by_proxy_async
     async def test_set_docker_manifest_without_spaces(self, containerregistry_endpoint):
-        if is_china_endpoint(containerregistry_endpoint):
-            pytest.skip("Running in china cloud may cause all tests finishing longer than the max time of 120 mins.")
+        if not is_public_endpoint(containerregistry_endpoint):
+            pytest.skip("This test is for testing test_set_docker_manifest in playback.")
         
         repo = self.get_resource_name("repo")
         path = os.path.join(self.get_test_directory(), "data", "docker_artifact", "manifest_without_spaces.json")
@@ -630,6 +630,9 @@ class TestContainerRegistryClientAsync(AsyncContainerRegistryTestClass):
     @acr_preparer()
     async def test_upload_large_blob_in_chunk(self, **kwargs):
         containerregistry_endpoint = kwargs.pop("containerregistry_endpoint")
+        if not is_public_endpoint(containerregistry_endpoint):
+            pytest.skip("Running on non-public cloud may cause all tests finishing longer than the max time of 120 mins.")
+        
         repo = self.get_resource_name("repo")
         async with self.create_registry_client(containerregistry_endpoint) as client:
             # Test blob upload and download in equal size chunks

--- a/sdk/containerregistry/azure-containerregistry/tests/testcase.py
+++ b/sdk/containerregistry/azure-containerregistry/tests/testcase.py
@@ -59,12 +59,6 @@ class ContainerRegistryTestClass(AzureRecordedTestCase):
 
     def create_fully_qualified_reference(self, registry, repository, digest):
         return f"{registry}/{repository}{':' if _is_tag(digest) else '@'}{digest.split(':')[-1]}"
-
-    def is_public_endpoint(self, endpoint):
-        return ".azurecr.io" in endpoint
-    
-    def is_china_endpoint(self, endpoint):
-        return ".azurecr.cn" in endpoint
     
     def upload_oci_manifest_prerequisites(self, repo, client):
         layer = "654b93f61054e4ce90ed203bb8d556a6200d5f906cf3eca0620738d6dc18cbed"
@@ -87,6 +81,12 @@ class ContainerRegistryTestClass(AzureRecordedTestCase):
     def get_test_directory(self):
         return os.path.join(os.getcwd(), "tests")
 
+
+def is_public_endpoint(endpoint):
+    return ".azurecr.io" in endpoint
+
+def is_china_endpoint(self, endpoint):
+    return ".azurecr.cn" in endpoint
 
 def get_authority(endpoint: str) -> str:
     if ".azurecr.io" in endpoint:

--- a/sdk/containerregistry/azure-containerregistry/tests/testcase.py
+++ b/sdk/containerregistry/azure-containerregistry/tests/testcase.py
@@ -85,7 +85,7 @@ class ContainerRegistryTestClass(AzureRecordedTestCase):
 def is_public_endpoint(endpoint):
     return ".azurecr.io" in endpoint
 
-def is_china_endpoint(self, endpoint):
+def is_china_endpoint(endpoint):
     return ".azurecr.cn" in endpoint
 
 def get_authority(endpoint: str) -> str:

--- a/sdk/containerregistry/azure-containerregistry/tests/testcase.py
+++ b/sdk/containerregistry/azure-containerregistry/tests/testcase.py
@@ -85,9 +85,6 @@ class ContainerRegistryTestClass(AzureRecordedTestCase):
 def is_public_endpoint(endpoint):
     return ".azurecr.io" in endpoint
 
-def is_china_endpoint(endpoint):
-    return ".azurecr.cn" in endpoint
-
 def get_authority(endpoint: str) -> str:
     if ".azurecr.io" in endpoint:
         logger.warning("Public cloud Authority")

--- a/sdk/containerregistry/azure-containerregistry/tests/testcase.py
+++ b/sdk/containerregistry/azure-containerregistry/tests/testcase.py
@@ -125,11 +125,11 @@ def import_image(endpoint, repository, tags):
         # Upload a layer
         layer = BytesIO(b"Sample layer")
         layer_digest, layer_size = client.upload_blob(repository, layer)
-        logger.warning(f"Uploaded layer: digest - {layer_digest}, size - {layer_size}")
+        logger.info(f"Uploaded layer: digest - {layer_digest}, size - {layer_size}")
         # Upload a config
         config = BytesIO(json.dumps({"sample config": "content"}).encode())
         config_digest, config_size = client.upload_blob(repository, config)
-        logger.warning(f"Uploaded config: digest - {config_digest}, size - {config_size}")
+        logger.info(f"Uploaded config: digest - {config_digest}, size - {config_size}")
         # Upload images
         oci_manifest = {
             "config": {
@@ -151,4 +151,4 @@ def import_image(endpoint, repository, tags):
         }
         for tag in tags:
             manifest_digest = client.set_manifest(repository, oci_manifest, tag=tag)
-            logger.warning(f"Uploaded manifest: digest - {manifest_digest}")
+            logger.info(f"Uploaded manifest: digest - {manifest_digest}")

--- a/sdk/containerregistry/azure-containerregistry/tests/testcase.py
+++ b/sdk/containerregistry/azure-containerregistry/tests/testcase.py
@@ -5,14 +5,12 @@
 # ------------------------------------
 import logging
 import os
-import pytest
+import json
+from io import BytesIO
 
 from azure.containerregistry import ContainerRegistryClient
 from azure.containerregistry._helpers import _is_tag
-
-from azure.mgmt.containerregistry import ContainerRegistryManagementClient
-from azure.mgmt.containerregistry.models import ImportImageParameters, ImportSource, ImportMode
-from azure.identity import DefaultAzureCredential, AzureAuthorityHosts, ClientSecretCredential
+from azure.identity import AzureAuthorityHosts, ClientSecretCredential
 
 from devtools_testutils import AzureRecordedTestCase, FakeTokenCredential
 
@@ -20,24 +18,16 @@ logger = logging.getLogger()
 
 
 class ContainerRegistryTestClass(AzureRecordedTestCase):
-    def import_image(self, endpoint, repository, tags, is_anonymous=False):
+    def import_image(self, endpoint, repository, tags):
         # repository must be a docker hub repository
         # tags is a List of repository/tag combos in the format <repository>:<tag>
         if not self.is_live:
             return
-        authority = get_authority(endpoint)
-        import_image(authority, repository, tags, is_anonymous=is_anonymous)
+        import_image(endpoint, repository, tags)
 
     def get_credential(self, authority=None, **kwargs):
         if self.is_live:
-            if authority != AzureAuthorityHosts.AZURE_PUBLIC_CLOUD:
-                return ClientSecretCredential(
-                    tenant_id=os.environ.get("CONTAINERREGISTRY_TENANT_ID"),
-                    client_id=os.environ.get("CONTAINERREGISTRY_CLIENT_ID"),
-                    client_secret=os.environ.get("CONTAINERREGISTRY_CLIENT_SECRET"),
-                    authority=authority
-                )
-            return DefaultAzureCredential(**kwargs)
+            return get_credential(authority)
         return FakeTokenCredential()
 
     def create_registry_client(self, endpoint, **kwargs):
@@ -121,36 +111,47 @@ def get_audience(authority: str) -> str:
         logger.warning("US Gov cloud auth audience")
         return "https://management.usgovcloudapi.net"
 
-def import_image(authority, repository, tags, is_anonymous=False):
+def get_credential(authority: str, **kwargs):
+    return ClientSecretCredential(
+        tenant_id=os.environ.get("CONTAINERREGISTRY_TENANT_ID"),
+        client_id=os.environ.get("CONTAINERREGISTRY_CLIENT_ID"),
+        client_secret=os.environ.get("CONTAINERREGISTRY_CLIENT_SECRET"),
+        authority=authority
+    )
+
+def import_image(endpoint, repository, tags):
+    authority = get_authority(endpoint)
     logger.warning(f"Import image authority: {authority}")
-    if is_anonymous:
-        registry_name = os.environ.get("CONTAINERREGISTRY_ANONREGISTRY_NAME")
-    else:
-        registry_name = os.environ.get("CONTAINERREGISTRY_REGISTRY_NAME")
-    sub_id = os.environ.get("CONTAINERREGISTRY_SUBSCRIPTION_ID")
-    tenant_id=os.environ.get("CONTAINERREGISTRY_TENANT_ID")
-    client_id=os.environ.get("CONTAINERREGISTRY_CLIENT_ID")
-    client_secret=os.environ.get("CONTAINERREGISTRY_CLIENT_SECRET")
-    credential = ClientSecretCredential(
-        tenant_id=tenant_id, client_id=client_id, client_secret=client_secret, authority=authority
-    )
-    audience = get_audience(authority)
-    scope = [audience + "/.default"]
-    mgmt_client = ContainerRegistryManagementClient(
-        credential, sub_id, api_version="2019-05-01", base_url=audience, credential_scopes=scope
-    )
-    logger.warning(f"LOGGING: {sub_id}{tenant_id}")
-    registry_uri = "registry.hub.docker.com"
-    rg_name = os.environ.get("CONTAINERREGISTRY_RESOURCE_GROUP")
+    credential = get_credential(authority)
 
-    import_source = ImportSource(source_image=repository, registry_uri=registry_uri)
-
-    import_params = ImportImageParameters(mode=ImportMode.Force, source=import_source, target_tags=tags)
-
-    result = mgmt_client.registries.begin_import_image(
-        rg_name,
-        registry_name,
-        parameters=import_params,
-    )
-
-    result.wait()
+    with ContainerRegistryClient(endpoint, credential) as client:
+        # Upload a layer
+        layer = BytesIO(b"Sample layer")
+        layer_digest, layer_size = client.upload_blob(repository, layer)
+        logger.warning(f"Uploaded layer: digest - {layer_digest}, size - {layer_size}")
+        # Upload a config
+        config = BytesIO(json.dumps({"sample config": "content"}).encode())
+        config_digest, config_size = client.upload_blob(repository, config)
+        logger.warning(f"Uploaded config: digest - {config_digest}, size - {config_size}")
+        # Upload images
+        oci_manifest = {
+            "config": {
+                "mediaType": "application/vnd.oci.image.config.v1+json",
+                "digest": config_digest,
+                "sizeInBytes": config_size,
+            },
+            "schemaVersion": 2,
+            "layers": [
+                {
+                    "mediaType": "application/vnd.oci.image.layer.v1.tar",
+                    "digest": layer_digest,
+                    "size": layer_size,
+                    "annotations": {
+                        "org.opencontainers.image.ref.name": "artifact.txt",
+                    },
+                },
+            ],
+        }
+        for tag in tags:
+            manifest_digest = client.set_manifest(repository, oci_manifest, tag=tag)
+            logger.warning(f"Uploaded manifest: digest - {manifest_digest}")

--- a/sdk/containerregistry/tests.yml
+++ b/sdk/containerregistry/tests.yml
@@ -6,6 +6,14 @@ stages:
       BuildTargetingString: azure-containerregistry
       ServiceDirectory: containerregistry
       SupportedClouds: 'Public,UsGov,China'
+      CloudConfig:
+        Public:
+          SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
+        UsGov:
+          SubscriptionConfiguration: $(sub-config-gov-test-resources)
+        China:
+          SubscriptionConfiguration: $(sub-config-cn-test-resources)
+          Location: chinanorth3
       MatrixReplace:
         - TestSamples=.*/true
       EnvVars:


### PR DESCRIPTION
This PR includes updates on:
- Changed the default location in China cloud to `chinanorth3` as the current one having connection issues.
- Removed dependency on management API on ACR for importing images. We originally using management API to import images in tests because we didn't have the capability in our package.
- Changed to import small sample images made by ourselves. We found there's an issue on pulling images from docker hub in China cloud which made pipelines running in China cloud are timeout. To avoid blocking by docker hub issues in one cloud, changed to use the sample image we made for tests. Another benefit is that we can control the image size to be small enough so that can improve pipeline performance.