### PR TITLE
[Identity] Remove dependency on six

### DIFF
--- a/sdk/identity/azure-identity/CHANGELOG.md
+++ b/sdk/identity/azure-identity/CHANGELOG.md
@@ -11,7 +11,9 @@
 ### Bugs Fixed
 
 ### Other Changes
+
 - VisualStudioCodeCredential prints an informative error message when used (as it is currently broken) ([#30385](https://github.com/Azure/azure-sdk-for-python/pull/30385))
+- Removed dependency on `six`. ([#30613](https://github.com/Azure/azure-sdk-for-python/pull/30613))
 
 ## 1.13.0 (2023-05-11)
 

--- a/sdk/identity/azure-identity/azure/identity/_credentials/azd_cli.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/azd_cli.py
@@ -11,7 +11,6 @@ import shutil
 import subprocess
 import sys
 from typing import Any, Dict, List, Optional
-import six
 
 from azure.core.credentials import AccessToken
 from azure.core.exceptions import ClientAuthenticationError
@@ -206,8 +205,8 @@ def _run_command(command: str, timeout: int) -> str:
     except OSError as ex:
         # failed to execute 'cmd' or '/bin/sh'
         error = CredentialUnavailableError(message="Failed to execute '{}'".format(args[0]))
-        six.raise_from(error, ex)
+        raise error from ex
     except Exception as ex:  # pylint:disable=broad-except
         # could be a timeout, for example
         error = CredentialUnavailableError(message="Failed to invoke the Azure Developer CLI")
-        six.raise_from(error, ex)
+        raise error from ex

--- a/sdk/identity/azure-identity/azure/identity/_credentials/azure_cli.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/azure_cli.py
@@ -11,7 +11,6 @@ import subprocess
 import sys
 import time
 from typing import List, Optional, Any, Dict
-import six
 
 from azure.core.credentials import AccessToken
 from azure.core.exceptions import ClientAuthenticationError
@@ -184,8 +183,8 @@ def _run_command(command: str, timeout: int) -> str:
     except OSError as ex:
         # failed to execute 'cmd' or '/bin/sh'
         error = CredentialUnavailableError(message="Failed to execute '{}'".format(args[0]))
-        six.raise_from(error, ex)
+        raise error from ex
     except Exception as ex:  # pylint:disable=broad-except
         # could be a timeout, for example
         error = CredentialUnavailableError(message="Failed to invoke the Azure CLI")
-        six.raise_from(error, ex)
+        raise error from ex

--- a/sdk/identity/azure-identity/azure/identity/_credentials/azure_powershell.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/azure_powershell.py
@@ -7,7 +7,6 @@ import logging
 import subprocess
 import sys
 from typing import List, Tuple, Optional, Any
-import six
 
 from azure.core.credentials import AccessToken
 from azure.core.exceptions import ClientAuthenticationError
@@ -135,7 +134,7 @@ def run_command_line(command_line: List[str], timeout: int) -> str:
             message="Failed to invoke PowerShell.\n"
                     "To mitigate this issue, please refer to the troubleshooting guidelines here at "
                     "https://aka.ms/azsdk/python/identity/powershellcredential/troubleshoot.")
-        six.raise_from(error, ex)
+        raise error from ex
 
     raise_for_error(proc.returncode, stdout, stderr)
     return stdout

--- a/sdk/identity/azure-identity/azure/identity/_credentials/imds.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/imds.py
@@ -5,8 +5,6 @@
 import os
 from typing import Any, Optional, Dict
 
-import six
-
 from azure.core.exceptions import ClientAuthenticationError, HttpResponseError
 from azure.core.pipeline.transport import HttpRequest
 from azure.core.credentials import AccessToken
@@ -83,7 +81,7 @@ class ImdsCredential(GetTokenMixin):
                 self._error_message = (
                     "ManagedIdentityCredential authentication unavailable, no response from the IMDS endpoint."
                 )
-                six.raise_from(CredentialUnavailableError(self._error_message), ex)
+                raise CredentialUnavailableError(self._error_message) from ex
 
         if not self._endpoint_available:
             raise CredentialUnavailableError(self._error_message)
@@ -100,8 +98,8 @@ class ImdsCredential(GetTokenMixin):
                     self._error_message += "The requested identity has not been assigned to this resource."
                 else:
                     self._error_message += "No identity has been assigned to this resource."
-                six.raise_from(CredentialUnavailableError(message=self._error_message), ex)
+                raise CredentialUnavailableError(message=self._error_message) from ex
 
             # any other error is unexpected
-            six.raise_from(ClientAuthenticationError(message=ex.message, response=ex.response), ex)
+            raise ClientAuthenticationError(message=ex.message, response=ex.response) from ex
         return token

--- a/sdk/identity/azure-identity/azure/identity/_credentials/on_behalf_of.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/on_behalf_of.py
@@ -5,7 +5,6 @@
 import time
 from typing import Any, Optional
 
-import six
 import msal
 
 from azure.core.credentials import AccessToken
@@ -89,7 +88,7 @@ class OnBehalfOfCredential(MsalCredential, GetTokenMixin):
                 message = (
                     '"client_certificate" is not a valid certificate in PEM or PKCS12 format'
                 )
-                six.raise_from(ValueError(message), ex)
+                raise ValueError(message) from ex
         elif client_secret:
             credential = client_secret
         else:

--- a/sdk/identity/azure-identity/azure/identity/_internal/aad_client_base.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/aad_client_base.py
@@ -10,7 +10,6 @@ import time
 from uuid import uuid4
 from typing import TYPE_CHECKING, List, Any, Iterable, Optional, Union, Dict
 
-import six
 from msal import TokenCache
 
 from azure.core.pipeline import PipelineResponse
@@ -208,22 +207,15 @@ class AadClientBase(abc.ABC):
 
     def _get_client_certificate_assertion(self, certificate: AadClientCertificate, **kwargs: Any) -> str:
         now = int(time.time())
-        header = six.ensure_binary(
-            json.dumps({"typ": "JWT", "alg": "RS256", "x5t": certificate.thumbprint}), encoding="utf-8"
-        )
-        payload = six.ensure_binary(
-            json.dumps(
-                {
-                    "jti": str(uuid4()),
-                    "aud": self._get_token_url(**kwargs),
-                    "iss": self._client_id,
-                    "sub": self._client_id,
-                    "nbf": now,
-                    "exp": now + (60 * 30),
-                }
-            ),
-            encoding="utf-8",
-        )
+        header = json.dumps({"typ": "JWT", "alg": "RS256", "x5t": certificate.thumbprint}).encode("utf-8")
+        payload = json.dumps({
+            "jti": str(uuid4()),
+            "aud": self._get_token_url(**kwargs),
+            "iss": self._client_id,
+            "sub": self._client_id,
+            "nbf": now,
+            "exp": now + (60 * 30),
+        }).encode("utf-8")
         jws = base64.urlsafe_b64encode(header) + b"." + base64.urlsafe_b64encode(payload)
         signature = certificate.sign(jws)
         jwt_bytes = jws + b"." + base64.urlsafe_b64encode(signature)

--- a/sdk/identity/azure-identity/azure/identity/_internal/aadclient_certificate.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/aadclient_certificate.py
@@ -9,7 +9,6 @@ from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import padding
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey
 from cryptography.hazmat.backends import default_backend
-import six
 
 
 class AadClientCertificate:
@@ -30,7 +29,7 @@ class AadClientCertificate:
 
         cert = x509.load_pem_x509_certificate(pem_bytes, default_backend())
         fingerprint = cert.fingerprint(hashes.SHA1())  # nosec
-        self._thumbprint = six.ensure_str(base64.urlsafe_b64encode(fingerprint), encoding="utf-8")
+        self._thumbprint = base64.urlsafe_b64encode(fingerprint).decode("utf-8")
 
     @property
     def thumbprint(self) -> str:

--- a/sdk/identity/azure-identity/azure/identity/_internal/decorators.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/decorators.py
@@ -7,7 +7,6 @@ import logging
 import json
 import base64
 
-from six import raise_from
 from azure.core.exceptions import ClientAuthenticationError
 
 from .utils import within_credential_chain
@@ -76,6 +75,6 @@ def wrap_exceptions(fn):
             raise
         except Exception as ex:  # pylint:disable=broad-except
             auth_error = ClientAuthenticationError(message="Authentication failed: {}".format(ex))
-            raise_from(auth_error, ex)
+            raise auth_error from ex
 
     return wrapper

--- a/sdk/identity/azure-identity/azure/identity/_internal/interactive.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/interactive.py
@@ -10,7 +10,7 @@ import json
 import logging
 import time
 from typing import Any, Optional
-import six
+from urllib.parse import urlparse
 
 from azure.core.credentials import AccessToken
 from azure.core.exceptions import ClientAuthenticationError
@@ -55,7 +55,7 @@ def _build_auth_record(response):
             home_account_id = id_token["sub"]
 
         # "iss" is the URL of the issuing tenant e.g. https://authority/tenant
-        issuer = six.moves.urllib_parse.urlparse(id_token["iss"])
+        issuer = urlparse(id_token["iss"])
 
         # tenant which issued the token, not necessarily user's home tenant
         tenant_id = id_token.get("tid") or issuer.path.strip("/")
@@ -74,7 +74,7 @@ def _build_auth_record(response):
         auth_error = ClientAuthenticationError(
             message="Failed to build AuthenticationRecord from unexpected identity token"
         )
-        six.raise_from(auth_error, ex)
+        raise auth_error from ex
 
 
 class InteractiveCredential(MsalCredential, ABC):

--- a/sdk/identity/azure-identity/azure/identity/_internal/managed_identity_client.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/managed_identity_client.py
@@ -7,7 +7,6 @@ import time
 from typing import Any, Callable, Dict, Optional
 
 from msal import TokenCache
-import six
 
 from azure.core.credentials import AccessToken
 from azure.core.exceptions import ClientAuthenticationError, DecodeError
@@ -47,7 +46,7 @@ class ManagedIdentityClientBase(abc.ABC):
                     message = "Failed to deserialize JSON from response"
                 else:
                     message = 'Unexpected content type "{}"'.format(response.http_response.content_type)
-                six.raise_from(ClientAuthenticationError(message=message, response=response.http_response), ex)
+                raise ClientAuthenticationError(message=message, response=response.http_response) from ex
 
         if not content:
             raise ClientAuthenticationError(message="No token received.", response=response.http_response)

--- a/sdk/identity/azure-identity/azure/identity/_internal/msal_client.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/msal_client.py
@@ -4,7 +4,6 @@
 # ------------------------------------
 import threading
 from typing import Any, Dict, Optional, Union
-import six
 
 from azure.core.exceptions import ClientAuthenticationError
 from azure.core.pipeline.policies import ContentDecodePolicy
@@ -84,8 +83,8 @@ class MsalClient:  # pylint:disable=client-accepts-api-version-keyword
             if isinstance(data, dict):
                 request.headers["Content-Type"] = "application/x-www-form-urlencoded"
                 request.set_formdata_body(data)
-            elif isinstance(data, six.text_type):
-                body_bytes = six.ensure_binary(data)
+            elif isinstance(data, str):
+                body_bytes = data.encode("utf-8")
                 request.set_bytes_body(body_bytes)
             else:
                 raise ValueError('expected "data" to be text or a dict')

--- a/sdk/identity/azure-identity/azure/identity/_internal/shared_token_cache.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/shared_token_cache.py
@@ -7,7 +7,6 @@ import platform
 import time
 from typing import Any, Iterable, List, Mapping, Optional, cast
 from urllib.parse import urlparse
-import six
 import msal
 
 from azure.core.credentials import AccessToken
@@ -195,7 +194,7 @@ class SharedTokenCacheBase(ABC):
                     return AccessToken(token["secret"], expires_on)
         except Exception as ex:  # pylint:disable=broad-except
             message = "Error accessing cached data: {}".format(ex)
-            six.raise_from(CredentialUnavailableError(message=message), ex)
+            raise CredentialUnavailableError(message=message) from ex
 
         return None
 
@@ -210,7 +209,7 @@ class SharedTokenCacheBase(ABC):
             return [token["secret"] for token in cache_entries if "secret" in token]
         except Exception as ex:  # pylint:disable=broad-except
             message = "Error accessing cached data: {}".format(ex)
-            six.raise_from(CredentialUnavailableError(message=message), ex)
+            raise CredentialUnavailableError(message=message) from ex
 
     @staticmethod
     def supported() -> bool:

--- a/sdk/identity/azure-identity/azure/identity/_persistent_cache.py
+++ b/sdk/identity/azure-identity/azure/identity/_persistent_cache.py
@@ -7,8 +7,6 @@ import os
 import sys
 from typing import TYPE_CHECKING, Any
 
-import six
-
 if TYPE_CHECKING:
     import msal_extensions
 
@@ -107,7 +105,7 @@ def _get_persistence(allow_unencrypted, account_name, cache_name):
                     + ' more information. Specify "allow_unencrypted_storage=True" to store the cache unencrypted'
                     + " instead of raising this exception."
                 )
-                six.raise_from(error, ex)
+                raise error from ex
         return msal_extensions.FilePersistence(file_path)
 
     raise NotImplementedError("A persistent cache is not available in this environment.")

--- a/sdk/identity/azure-identity/setup.py
+++ b/sdk/identity/azure-identity/setup.py
@@ -62,6 +62,5 @@ setup(
         "cryptography>=2.5",
         "msal<2.0.0,>=1.20.0",
         "msal-extensions<2.0.0,>=0.3.0",
-        "six>=1.12.0",
     ],
 )

--- a/sdk/identity/azure-identity/tests/helpers.py
+++ b/sdk/identity/azure-identity/tests/helpers.py
@@ -5,8 +5,7 @@
 import base64
 import json
 import time
-
-import six
+from urllib.parse import urlparse
 
 try:
     from unittest import mock
@@ -111,7 +110,7 @@ class Request:
         if self.url_substring and self.url_substring not in request.url:
             add_discrepancy("url substring", self.url_substring, request.url)
 
-        parsed = six.moves.urllib_parse.urlparse(request.url)
+        parsed = urlparse(request.url)
         if self.authority and parsed.netloc != self.authority:
             add_discrepancy("authority", self.authority, parsed.netloc)
 
@@ -194,7 +193,7 @@ def msal_validating_transport(requests, responses, **kwargs):
 
 
 def urlsafeb64_decode(s):
-    if isinstance(s, six.text_type):
+    if isinstance(s, str):
         s = s.encode("ascii")
 
     padding_needed = 4 - len(s) % 4

--- a/sdk/identity/azure-identity/tests/test_aad_client.py
+++ b/sdk/identity/azure-identity/tests/test_aad_client.py
@@ -10,7 +10,7 @@ from azure.identity._internal import AadClient, AadClientCertificate
 
 import pytest
 from msal import TokenCache
-from six.moves.urllib_parse import urlparse
+from urllib.parse import urlparse
 
 from helpers import build_aad_response, mock_response
 from test_certificate_credential import PEM_CERT_PATH

--- a/sdk/identity/azure-identity/tests/test_application_credential.py
+++ b/sdk/identity/azure-identity/tests/test_application_credential.py
@@ -9,7 +9,7 @@ from azure.identity import CredentialUnavailableError
 from azure.identity._credentials.application import AzureApplicationCredential
 from azure.identity._constants import EnvironmentVariables
 import pytest
-from six.moves.urllib_parse import urlparse
+from urllib.parse import urlparse
 
 try:
     from unittest.mock import Mock, patch

--- a/sdk/identity/azure-identity/tests/test_application_credential_async.py
+++ b/sdk/identity/azure-identity/tests/test_application_credential_async.py
@@ -10,7 +10,7 @@ from azure.identity import CredentialUnavailableError
 from azure.identity.aio._credentials.application import AzureApplicationCredential
 from azure.identity._constants import EnvironmentVariables
 import pytest
-from six.moves.urllib_parse import urlparse
+from urllib.parse import urlparse
 
 from helpers import build_aad_response, mock_response
 from helpers_async import get_completed_future

--- a/sdk/identity/azure-identity/tests/test_auth_code.py
+++ b/sdk/identity/azure-identity/tests/test_auth_code.py
@@ -9,7 +9,7 @@ from azure.identity._constants import EnvironmentVariables
 from azure.identity._internal.user_agent import USER_AGENT
 import msal
 import pytest
-from six.moves.urllib_parse import urlparse
+from urllib.parse import urlparse
 
 from helpers import build_aad_response, mock_response, Request, validating_transport
 

--- a/sdk/identity/azure-identity/tests/test_certificate_credential.py
+++ b/sdk/identity/azure-identity/tests/test_certificate_credential.py
@@ -19,8 +19,7 @@ from cryptography.hazmat.primitives.asymmetric import padding
 from msal import TokenCache
 import msal
 import pytest
-import six
-from six.moves.urllib_parse import urlparse
+from urllib.parse import urlparse
 
 from helpers import (
     build_aad_response,
@@ -253,12 +252,15 @@ def validate_jwt(request, client_id, cert_bytes, cert_password, expect_x5c=False
         cert = x509.load_pem_x509_certificate(cert_bytes, default_backend())
     except ValueError:
         if cert_password:
-            cert_password = six.ensure_binary(cert_password)
+            if isinstance(cert_password, str):
+                cert_password = cert_password.encode("utf-8")
         cert_bytes = load_pkcs12_certificate(cert_bytes, cert_password).pem_bytes
         cert = x509.load_pem_x509_certificate(cert_bytes, default_backend())
 
     # jwt is of the form 'header.payload.signature'; 'signature' is 'header.payload' signed with cert's private key
-    jwt = six.ensure_str(request.body["client_assertion"])
+    jwt = request.body["client_assertion"]
+    if isinstance(jwt, bytes):
+        jwt = jwt.decode("utf-8")
     header, payload, signature = (urlsafeb64_decode(s) for s in jwt.split("."))
     signed_part = jwt[: jwt.rfind(".")]
 

--- a/sdk/identity/azure-identity/tests/test_client_secret_credential.py
+++ b/sdk/identity/azure-identity/tests/test_client_secret_credential.py
@@ -10,7 +10,7 @@ from azure.identity._internal.user_agent import USER_AGENT
 from msal import TokenCache
 import msal
 import pytest
-from six.moves.urllib_parse import urlparse
+from urllib.parse import urlparse
 
 from helpers import (
     build_aad_response,

--- a/sdk/identity/azure-identity/tests/test_default.py
+++ b/sdk/identity/azure-identity/tests/test_default.py
@@ -20,7 +20,7 @@ from azure.identity._credentials.azure_cli import AzureCliCredential
 from azure.identity._credentials.azd_cli import AzureDeveloperCliCredential
 from azure.identity._credentials.managed_identity import ManagedIdentityCredential
 import pytest
-from six.moves.urllib_parse import urlparse
+from urllib.parse import urlparse
 
 from helpers import mock_response, Request, validating_transport
 from test_shared_cache_credential import build_aad_response, get_account_event, populated_cache

--- a/sdk/identity/azure-identity/tests/test_shared_cache_credential.py
+++ b/sdk/identity/azure-identity/tests/test_shared_cache_credential.py
@@ -23,7 +23,7 @@ from azure.identity._internal import get_default_authority
 from azure.identity._internal.user_agent import USER_AGENT
 from msal import TokenCache
 import pytest
-from six.moves.urllib_parse import urlparse
+from urllib.parse import urlparse
 
 try:
     from unittest.mock import MagicMock, Mock, patch

--- a/sdk/identity/azure-identity/tests/test_vscode_credential.py
+++ b/sdk/identity/azure-identity/tests/test_vscode_credential.py
@@ -12,7 +12,7 @@ from azure.core.pipeline.policies import SansIOHTTPPolicy
 from azure.identity._constants import EnvironmentVariables
 from azure.identity._internal.user_agent import USER_AGENT
 import pytest
-from six.moves.urllib_parse import urlparse
+from urllib.parse import urlparse
 
 from helpers import build_aad_response, mock_response, Request, validating_transport
 


### PR DESCRIPTION
Compatibility with Python 2.7 is no longer needed, so this finishes up the six cleanup.
