### PR TITLE
[ML][Pipelines] feat: make unknown field notification warning instead of info

### DIFF
--- a/sdk/ml/azure-ai-ml/CHANGELOG.md
+++ b/sdk/ml/azure-ai-ml/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### Breaking Changes
 
 ### Other Changes
+- Log level of unknown field notifications for pipeline nodes raised from INFO to WARNING.
 
 
 ## 1.7.2 (2023-05-18)

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_validation.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_validation.py
@@ -259,7 +259,7 @@ class MutableValidationResult(ValidationResult):
             return self
 
         if self._warnings:
-            module_logger.info("Warnings: %s" % str(self._warnings))
+            module_logger.warning("Warnings: %s" % str(self._warnings))
 
         if not self.passed:
             message = (

--- a/sdk/ml/azure-ai-ml/tests/dsl/e2etests/test_dsl_pipeline.py
+++ b/sdk/ml/azure-ai-ml/tests/dsl/e2etests/test_dsl_pipeline.py
@@ -8,12 +8,7 @@ import pydash
 import pytest
 from devtools_testutils import AzureRecordedTestCase, is_live
 from pipeline_job.e2etests.test_pipeline_job import assert_job_input_output_types
-from test_utilities.utils import (
-    _PYTEST_TIMEOUT_METHOD,
-    assert_job_cancel,
-    omit_with_wildcard,
-    sleep_if_live,
-)
+from test_utilities.utils import _PYTEST_TIMEOUT_METHOD, assert_job_cancel, omit_with_wildcard, sleep_if_live
 
 from azure.ai.ml import (
     AmlTokenConfiguration,
@@ -29,28 +24,15 @@ from azure.ai.ml import (
     dsl,
     load_component,
 )
-from azure.ai.ml._utils._arm_id_utils import (
-    is_ARM_id_for_resource,
-    is_singularity_id_for_resource,
-)
-from azure.ai.ml.constants._common import (
-    ANONYMOUS_COMPONENT_NAME,
-    SINGULARITY_ID_FORMAT,
-    AssetTypes,
-    InputOutputModes,
-)
+from azure.ai.ml._utils._arm_id_utils import is_ARM_id_for_resource, is_singularity_id_for_resource
+from azure.ai.ml.constants._common import ANONYMOUS_COMPONENT_NAME, SINGULARITY_ID_FORMAT, AssetTypes, InputOutputModes
 from azure.ai.ml.constants._job.pipeline import PipelineConstants
 from azure.ai.ml.dsl._group_decorator import group
 from azure.ai.ml.dsl._load_import import to_component
 from azure.ai.ml.entities import CommandComponent, CommandJob
 from azure.ai.ml.entities import Component
 from azure.ai.ml.entities import Component as ComponentEntity
-from azure.ai.ml.entities import (
-    Data,
-    JobResourceConfiguration,
-    PipelineJob,
-    QueueSettings,
-)
+from azure.ai.ml.entities import Data, JobResourceConfiguration, PipelineJob, QueueSettings
 from azure.ai.ml.exceptions import UnexpectedKeywordError, ValidationException
 from azure.ai.ml.parallel import ParallelJob, RunFunction, parallel_run_function
 
@@ -1537,7 +1519,7 @@ class TestDSLPipeline(AzureRecordedTestCase):
             node1.compute = "cpu-cluster"
 
         dsl_pipeline: PipelineJob = pipeline(10, job_input)
-        with patch("azure.ai.ml.entities._validation.module_logger.info") as mock_logging:
+        with patch("azure.ai.ml.entities._validation.module_logger.warning") as mock_logging:
             _ = client.jobs.create_or_update(dsl_pipeline)
             mock_logging.assert_called_with("Warnings: [jobs.node1.jeff_special_option: Unknown field.]")
 

--- a/sdk/ml/azure-ai-ml/tests/pipeline_job/unittests/test_pipeline_job_validate.py
+++ b/sdk/ml/azure-ai-ml/tests/pipeline_job/unittests/test_pipeline_job_validate.py
@@ -9,11 +9,11 @@ import pytest
 from marshmallow import ValidationError
 from pytest_mock import MockFixture
 
-from azure.ai.ml import Input, Output, MLClient, dsl, load_component, load_job
+from azure.ai.ml import Input, MLClient, Output, dsl, load_component, load_job
 from azure.ai.ml.constants._common import AssetTypes, InputOutputModes
 from azure.ai.ml.entities import Choice, CommandComponent, PipelineJob
 from azure.ai.ml.entities._validate_funcs import validate_job
-from azure.ai.ml.exceptions import ValidationException, UserErrorException
+from azure.ai.ml.exceptions import UserErrorException, ValidationException
 
 from .._util import _PIPELINE_JOB_TIMEOUT_SECOND, SERVERLESS_COMPUTE_TEST_PARAMETERS
 
@@ -595,7 +595,7 @@ class TestDSLPipelineJobValidate:
 
         dsl_pipeline: PipelineJob = pipeline(10, job_input)
 
-        with patch("azure.ai.ml.entities._validation.module_logger.info") as mock_logging:
+        with patch("azure.ai.ml.entities._validation.module_logger.warning") as mock_logging:
             dsl_pipeline._validate(raise_error=True)
             mock_logging.assert_called_with("Warnings: [jobs.node1.jeff_special_option: Unknown field.]")
 


### PR DESCRIPTION
# Description

Given all nodes have strong type schema, we change the log level of unknown notification for pipeline nodes from INFO to WARNING.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
