### PR TITLE
[Key Vault] Resolve pylint error

### DIFF
--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_client.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_client.py
@@ -58,7 +58,7 @@ class CertificateClient(KeyVaultClientBase):
     @distributed_trace
     def begin_create_certificate(
         self, certificate_name: str, policy: CertificatePolicy, **kwargs
-    ) -> "LROPoller[Union[KeyVaultCertificate, CertificateOperation]]":
+    ) -> LROPoller[Union[KeyVaultCertificate, CertificateOperation]]:
         """Creates a new certificate.
 
         If this is the first version, the certificate resource is created. This operation requires the


### PR DESCRIPTION
# Description

Pipelines recently started complaining that our `Union` type import in `certificates/_client.py` is unused. This is because the type is only referenced in a quoted return value type hint and doesn't get loaded outside of type checking. Given that we're on Python 3.7+ now, we can remove these quotes around return types.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
