### PR TITLE
[Storage] [Next-Pylint] Blob Package

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -16,9 +16,10 @@ load-plugins=pylint_guidelines_checker
 # locally-disabled: Warning locally suppressed using disable-msg
 # cyclic-import: because of https://github.com/PyCQA/pylint/issues/850
 # too-many-arguments: Due to the nature of the CLI many commands have large arguments set which reflect in large arguments set in corresponding methods.
+# Let's black deal with bad-continuation
 
 # Added disables from super-with-arguments
-disable=useless-object-inheritance,missing-docstring,locally-disabled,fixme,cyclic-import,too-many-arguments,invalid-name,duplicate-code,too-few-public-methods,import-outside-toplevel,super-with-arguments,raise-missing-from,inconsistent-return-statements,deprecated-module,use-a-generator,consider-using-max-builtin,consider-using-min-builtin,simplifiable-condition,condition-evals-to-constant,consider-using-dict-items,assigning-non-slot,consider-using-with,consider-using-generator,unused-private-member,deprecated-class,consider-using-from-import,ungrouped-imports,nan-comparison,deprecated-argument,deprecated-decorator,consider-using-dict-items,use-maxsplit-arg,unnecessary-dict-index-lookup,unused-private-member,invalid-class-object,invalid-all-format,await-outside-async,client-list-methods-use-paging,no-name-in-module, no-member
+disable=useless-object-inheritance,missing-docstring,locally-disabled,fixme,cyclic-import,too-many-arguments,invalid-name,duplicate-code,too-few-public-methods,bad-continuation,check-docstrings,import-outside-toplevel,super-with-arguments,raise-missing-from,inconsistent-return-statements,deprecated-module,use-a-generator,consider-using-max-builtin,consider-using-min-builtin,simplifiable-condition,condition-evals-to-constant,consider-using-dict-items,assigning-non-slot,consider-using-with,consider-using-generator,unused-private-member,deprecated-class,consider-using-from-import,ungrouped-imports,nan-comparison,ignored-arguments-name,empty-comment,deprecated-argument,deprecated-decorator,consider-using-dict-items,use-maxsplit-arg,unnecessary-dict-index-lookup,unused-private-member,invalid-class-object,invalid-all-format,await-outside-async,client-list-methods-use-paging,no-name-in-module
 
 [FORMAT]
 max-line-length=120
@@ -46,6 +47,17 @@ min-similarity-lines=10
 
 # The invalid-name checker must be **enabled** for these hints to be used.
 include-naming-hint=yes
+
+module-name-hint=lowercase (keep short; underscores are discouraged)
+const-name-hint=UPPER_CASE_WITH_UNDERSCORES
+class-name-hint=CapitalizedWords
+class-attribute-name-hint=lower_case_with_underscores
+attr-name-hint=lower_case_with_underscores
+method-name-hint=lower_case_with_underscores
+function-name-hint=lower_case_with_underscores
+argument-name-hint=lower_case_with_underscores
+variable-name-hint=lower_case_with_underscores
+inlinevar-name-hint=lower_case_with_underscores (short is OK)
 
 [TYPECHECK]
 generated-members=js.*

--- a/pylintrc
+++ b/pylintrc
@@ -16,10 +16,9 @@ load-plugins=pylint_guidelines_checker
 # locally-disabled: Warning locally suppressed using disable-msg
 # cyclic-import: because of https://github.com/PyCQA/pylint/issues/850
 # too-many-arguments: Due to the nature of the CLI many commands have large arguments set which reflect in large arguments set in corresponding methods.
-# Let's black deal with bad-continuation
 
 # Added disables from super-with-arguments
-disable=useless-object-inheritance,missing-docstring,locally-disabled,fixme,cyclic-import,too-many-arguments,invalid-name,duplicate-code,too-few-public-methods,bad-continuation,check-docstrings,import-outside-toplevel,super-with-arguments,raise-missing-from,inconsistent-return-statements,deprecated-module,use-a-generator,consider-using-max-builtin,consider-using-min-builtin,simplifiable-condition,condition-evals-to-constant,consider-using-dict-items,assigning-non-slot,consider-using-with,consider-using-generator,unused-private-member,deprecated-class,consider-using-from-import,ungrouped-imports,nan-comparison,ignored-arguments-name,empty-comment,deprecated-argument,deprecated-decorator,consider-using-dict-items,use-maxsplit-arg,unnecessary-dict-index-lookup,unused-private-member,invalid-class-object,invalid-all-format,await-outside-async,client-list-methods-use-paging,no-name-in-module
+disable=useless-object-inheritance,missing-docstring,locally-disabled,fixme,cyclic-import,too-many-arguments,invalid-name,duplicate-code,too-few-public-methods,import-outside-toplevel,super-with-arguments,raise-missing-from,inconsistent-return-statements,deprecated-module,use-a-generator,consider-using-max-builtin,consider-using-min-builtin,simplifiable-condition,condition-evals-to-constant,consider-using-dict-items,assigning-non-slot,consider-using-with,consider-using-generator,unused-private-member,deprecated-class,consider-using-from-import,ungrouped-imports,nan-comparison,deprecated-argument,deprecated-decorator,consider-using-dict-items,use-maxsplit-arg,unnecessary-dict-index-lookup,unused-private-member,invalid-class-object,invalid-all-format,await-outside-async,client-list-methods-use-paging,no-name-in-module, no-member
 
 [FORMAT]
 max-line-length=120
@@ -47,17 +46,6 @@ min-similarity-lines=10
 
 # The invalid-name checker must be **enabled** for these hints to be used.
 include-naming-hint=yes
-
-module-name-hint=lowercase (keep short; underscores are discouraged)
-const-name-hint=UPPER_CASE_WITH_UNDERSCORES
-class-name-hint=CapitalizedWords
-class-attribute-name-hint=lower_case_with_underscores
-attr-name-hint=lower_case_with_underscores
-method-name-hint=lower_case_with_underscores
-function-name-hint=lower_case_with_underscores
-argument-name-hint=lower_case_with_underscores
-variable-name-hint=lower_case_with_underscores
-inlinevar-name-hint=lower_case_with_underscores (short is OK)
 
 [TYPECHECK]
 generated-members=js.*

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/__init__.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/__init__.py
@@ -179,7 +179,7 @@ def download_blob_from_url(
             _download_to_stream(client, output, **kwargs)
         else:
             if not overwrite and os.path.isfile(output):
-                raise ValueError("The file '{}' already exists.".format(output))
+                raise ValueError(f"The file '{output}' already exists.")
             with open(output, 'wb') as file_handle:
                 _download_to_stream(client, file_handle, **kwargs)
 

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_client.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_client.py
@@ -3,7 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for
 # license information.
 # --------------------------------------------------------------------------
-# pylint: disable=too-many-lines
+# pylint: disable=too-many-lines,no-self-use
 
 from functools import partial
 from io import BytesIO

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_client.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_client.py
@@ -3,7 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for
 # license information.
 # --------------------------------------------------------------------------
-# pylint: disable=too-many-lines,no-self-use
+# pylint: disable=too-many-lines
 
 from functools import partial
 from io import BytesIO
@@ -166,7 +166,7 @@ class BlobClient(StorageAccountHostsMixin, StorageEncryptionMixin):  # pylint: d
         if not (container_name and blob_name):
             raise ValueError("Please specify a container name and blob name.")
         if not parsed_url.netloc:
-            raise ValueError("Invalid URL: {}".format(account_url))
+            raise ValueError(f"Invalid URL: {account_url}")
 
         path_snapshot, sas_token = parse_query(parsed_url.query)
 
@@ -192,12 +192,7 @@ class BlobClient(StorageAccountHostsMixin, StorageEncryptionMixin):  # pylint: d
         container_name = self.container_name
         if isinstance(container_name, str):
             container_name = container_name.encode('UTF-8')
-        return "{}://{}/{}/{}{}".format(
-            self.scheme,
-            hostname,
-            quote(container_name),
-            quote(self.blob_name, safe='~/'),
-            self._query_str)
+        return f"{self.scheme}://{hostname}/{quote(container_name)}/{quote(self.blob_name, safe='~/')}{self._query_str}"
 
     def _encode_source_url(self, source_url):
         parsed_source_url = urlparse(source_url)
@@ -205,7 +200,7 @@ class BlobClient(StorageAccountHostsMixin, StorageEncryptionMixin):  # pylint: d
         source_hostname = parsed_source_url.netloc.rstrip('/')
         source_path = unquote(parsed_source_url.path)
         source_query = parsed_source_url.query
-        result = ["{}://{}{}".format(source_scheme, source_hostname, quote(source_path, safe='~/'))]
+        result = [f"{source_scheme}://{source_hostname}{quote(source_path, safe='~/')}"]
         if source_query:
             result.append(source_query)
         return '?'.join(result)
@@ -248,7 +243,7 @@ class BlobClient(StorageAccountHostsMixin, StorageEncryptionMixin):  # pylint: d
         parsed_url = urlparse(blob_url.rstrip('/'))
 
         if not parsed_url.netloc:
-            raise ValueError("Invalid URL: {}".format(blob_url))
+            raise ValueError(f"Invalid URL: {blob_url}")
 
         account_path = ""
         if ".core." in parsed_url.netloc:
@@ -263,11 +258,7 @@ class BlobClient(StorageAccountHostsMixin, StorageEncryptionMixin):  # pylint: d
             if len(path_blob) > 2:
                 account_path = "/" + "/".join(path_blob[:-2])
 
-        account_url = "{}://{}{}?{}".format(
-            parsed_url.scheme,
-            parsed_url.netloc.rstrip('/'),
-            account_path,
-            parsed_url.query)
+        account_url = f"{parsed_url.scheme}://{parsed_url.netloc.rstrip('/')}{account_path}?{parsed_url.query}"
 
         msg_invalid_url = "Invalid URL. Provide a blob_url with a valid blob and container name."
         if len(path_blob) <= 1:
@@ -389,7 +380,7 @@ class BlobClient(StorageAccountHostsMixin, StorageEncryptionMixin):  # pylint: d
         elif hasattr(data, '__aiter__'):
             stream = AsyncIterStreamer(data, encoding=encoding)
         else:
-            raise TypeError("Unsupported data type: {}".format(type(data)))
+            raise TypeError(f"Unsupported data type: {type(data)}")
 
         validate_content = kwargs.pop('validate_content', False)
         content_settings = kwargs.pop('content_settings', None)
@@ -440,7 +431,7 @@ class BlobClient(StorageAccountHostsMixin, StorageEncryptionMixin):  # pylint: d
                 raise ValueError(_ERROR_UNSUPPORTED_METHOD_FOR_ENCRYPTION)
             kwargs['client'] = self._client.append_blob
         else:
-            raise ValueError("Unsupported BlobType: {}".format(blob_type))
+            raise ValueError(f"Unsupported BlobType: {blob_type}")
         return kwargs
 
     def _upload_blob_from_url_options(self, source_url, **kwargs):
@@ -3469,7 +3460,7 @@ class BlobClient(StorageAccountHostsMixin, StorageEncryptionMixin):  # pylint: d
         if length is None or length % 512 != 0:
             raise ValueError("length must be an integer that aligns with 512 page size")
         end_range = offset + length - 1  # Reformat to an inclusive range index
-        content_range = 'bytes={0}-{1}'.format(offset, end_range) # type: ignore
+        content_range = f'bytes={offset}-{end_range}' # type: ignore
         access_conditions = get_access_conditions(kwargs.pop('lease', None))
         seq_conditions = SequenceNumberAccessConditions(
             if_sequence_number_less_than_or_equal_to=kwargs.pop('if_sequence_number_lte', None),
@@ -3622,8 +3613,8 @@ class BlobClient(StorageAccountHostsMixin, StorageEncryptionMixin):  # pylint: d
 
         # Format range
         end_range = offset + length - 1
-        destination_range = 'bytes={0}-{1}'.format(offset, end_range)
-        source_range = 'bytes={0}-{1}'.format(source_offset, source_offset + length - 1)  # should subtract 1 here?
+        destination_range = f'bytes={offset}-{end_range}'
+        source_range = f'bytes={source_offset}-{source_offset + length - 1}'  # should subtract 1 here?
 
         seq_conditions = SequenceNumberAccessConditions(
             if_sequence_number_less_than_or_equal_to=kwargs.pop('if_sequence_number_lte', None),
@@ -3796,7 +3787,7 @@ class BlobClient(StorageAccountHostsMixin, StorageEncryptionMixin):  # pylint: d
         if length is None or length % 512 != 0:
             raise ValueError("length must be an integer that aligns with 512 page size")
         end_range = length + offset - 1  # Reformat to an inclusive range index
-        content_range = 'bytes={0}-{1}'.format(offset, end_range)
+        content_range = f'bytes={offset}-{end_range}'
 
         cpk = kwargs.pop('cpk', None)
         cpk_info = None
@@ -4054,9 +4045,9 @@ class BlobClient(StorageAccountHostsMixin, StorageEncryptionMixin):  # pylint: d
         source_range = None
         if source_length is not None:
             end_range = source_offset + source_length - 1
-            source_range = 'bytes={0}-{1}'.format(source_offset, end_range)
+            source_range = f'bytes={source_offset}-{end_range}'
         elif source_offset is not None:
-            source_range = "bytes={0}-".format(source_offset)
+            source_range = f"bytes={source_offset}-"
 
         appendpos_condition = kwargs.pop('appendpos_condition', None)
         maxsize_condition = kwargs.pop('maxsize_condition', None)
@@ -4307,7 +4298,7 @@ class BlobClient(StorageAccountHostsMixin, StorageEncryptionMixin):  # pylint: d
         else:
             _pipeline = self._pipeline   # pylint: disable = protected-access
         return ContainerClient(
-            "{}://{}".format(self.scheme, self.primary_hostname), container_name=self.container_name,
+            f"{self.scheme}://{self.primary_hostname}", container_name=self.container_name,
             credential=self._raw_credential, api_version=self.api_version, _configuration=self._config,
             _pipeline=_pipeline, _location_mode=self._location_mode, _hosts=self._hosts,
             require_encryption=self.require_encryption, encryption_version=self.encryption_version,

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_service_client.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_service_client.py
@@ -130,7 +130,7 @@ class BlobServiceClient(StorageAccountHostsMixin, StorageEncryptionMixin):
             raise ValueError("Account URL must be a string.")
         parsed_url = urlparse(account_url.rstrip('/'))
         if not parsed_url.netloc:
-            raise ValueError("Invalid URL: {}".format(account_url))
+            raise ValueError(f"Invalid URL: {account_url}")
 
         _, sas_token = parse_query(parsed_url.query)
         self._query_str, credential = self._format_query_string(sas_token, credential)
@@ -143,7 +143,7 @@ class BlobServiceClient(StorageAccountHostsMixin, StorageEncryptionMixin):
         """Format the endpoint URL according to the current location
         mode hostname.
         """
-        return "{}://{}/{}".format(self.scheme, hostname, self._query_str)
+        return f"{self.scheme}://{hostname}/{self._query_str}"
 
     @classmethod
     def from_connection_string(

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_container_client.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_container_client.py
@@ -150,7 +150,7 @@ class ContainerClient(StorageAccountHostsMixin, StorageEncryptionMixin):    # py
         if not container_name:
             raise ValueError("Please specify a container name.")
         if not parsed_url.netloc:
-            raise ValueError("Invalid URL: {}".format(account_url))
+            raise ValueError(f"Invalid URL: {account_url}")
 
         _, sas_token = parse_query(parsed_url.query)
         self.container_name = container_name
@@ -171,11 +171,7 @@ class ContainerClient(StorageAccountHostsMixin, StorageEncryptionMixin):    # py
         container_name = self.container_name
         if isinstance(container_name, str):
             container_name = container_name.encode('UTF-8')
-        return "{}://{}/{}{}".format(
-            self.scheme,
-            hostname,
-            quote(container_name),
-            self._query_str)
+        return f"{self.scheme}://{hostname}/{quote(container_name)}{self._query_str}"
 
     @classmethod
     def from_container_url(
@@ -209,17 +205,13 @@ class ContainerClient(StorageAccountHostsMixin, StorageEncryptionMixin):    # py
             raise ValueError("Container URL must be a string.")
         parsed_url = urlparse(container_url)
         if not parsed_url.netloc:
-            raise ValueError("Invalid URL: {}".format(container_url))
+            raise ValueError(f"Invalid URL: {container_url}")
 
         container_path = parsed_url.path.strip('/').split('/')
         account_path = ""
         if len(container_path) > 1:
             account_path = "/" + "/".join(container_path[:-1])
-        account_url = "{}://{}{}?{}".format(
-            parsed_url.scheme,
-            parsed_url.netloc.rstrip('/'),
-            account_path,
-            parsed_url.query)
+        account_url = f"{parsed_url.scheme}://{parsed_url.netloc.rstrip('/')}{account_path}?{parsed_url.query}"
         container_name = unquote(container_path[-1])
         if not container_name:
             raise ValueError("Invalid URL. Please provide a URL with a valid container name")
@@ -347,7 +339,7 @@ class ContainerClient(StorageAccountHostsMixin, StorageEncryptionMixin):    # py
             kwargs['source_lease_id'] = lease
         try:
             renamed_container = ContainerClient(
-                "{}://{}".format(self.scheme, self.primary_hostname), container_name=new_name,
+                f"{self.scheme}://{self.primary_hostname}", container_name=new_name,
                 credential=self.credential, api_version=self.api_version, _configuration=self._config,
                 _pipeline=self._pipeline, _location_mode=self._location_mode, _hosts=self._hosts,
                 require_encryption=self.require_encryption, encryption_version=self.encryption_version,
@@ -655,7 +647,7 @@ class ContainerClient(StorageAccountHostsMixin, StorageEncryptionMixin):    # py
         else:
             _pipeline = self._pipeline   # pylint: disable = protected-access
         return BlobServiceClient(
-            "{}://{}".format(self.scheme, self.primary_hostname),
+            f"{self.scheme}://{self.primary_hostname}",
             credential=self._raw_credential, api_version=self.api_version, _configuration=self._config,
             _location_mode=self._location_mode, _hosts=self._hosts, require_encryption=self.require_encryption,
             encryption_version=self.encryption_version, key_encryption_key=self.key_encryption_key,
@@ -1407,7 +1399,7 @@ class ContainerClient(StorageAccountHostsMixin, StorageEncryptionMixin):    # py
 
             req = HttpRequest(
                 "DELETE",
-                "/{}/{}{}".format(quote(container_name), quote(blob_name, safe='/~'), self._query_str),
+                f"/{quote(container_name)}/{quote(blob_name, safe='/~')}{self._query_str}",
                 headers=header_parameters
             )
             req.format_parameters(query_parameters)
@@ -1507,7 +1499,7 @@ class ContainerClient(StorageAccountHostsMixin, StorageEncryptionMixin):    # py
                 :caption: Deleting multiple blobs.
         """
         if len(blobs) == 0:
-            return iter(list())
+            return iter([])
 
         reqs, options = self._generate_delete_blobs_options(*blobs, **kwargs)
 
@@ -1593,7 +1585,7 @@ class ContainerClient(StorageAccountHostsMixin, StorageEncryptionMixin):    # py
 
             req = HttpRequest(
                 "PUT",
-                "/{}/{}{}".format(quote(container_name), quote(blob_name, safe='/~'), self._query_str),
+                f"/{quote(container_name)}/{quote(blob_name, safe='/~')}{self._query_str}",
                 headers=header_parameters
             )
             req.format_parameters(query_parameters)

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_deserialize.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_deserialize.py
@@ -3,7 +3,6 @@
 # Licensed under the MIT License. See License.txt in the project root for
 # license information.
 # --------------------------------------------------------------------------
-# pylint: disable=no-self-use
 
 from typing import (
     Dict, List, Optional, Tuple, Union,
@@ -76,7 +75,7 @@ def deserialize_ors_policies(policy_dictionary):
         rule_id = policy_and_rule_ids[1]
 
         # If we are seeing this policy for the first time, create a new list to store rule_id -> result
-        parsed_result[policy_id] = parsed_result.get(policy_id) or list()
+        parsed_result[policy_id] = parsed_result.get(policy_id) or []
         parsed_result[policy_id].append(ObjectReplicationRule(rule_id=rule_id, status=val))
 
     result_list = [ObjectReplicationPolicy(policy_id=k, rules=v) for k, v in parsed_result.items()]

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_download.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_download.py
@@ -373,11 +373,7 @@ class StorageStreamDownloader(Generic[T]):  # pylint: disable=too-many-instance-
         self.properties.size = self.size
 
         # Overwrite the content range to the user requested range
-        self.properties.content_range = "bytes {0}-{1}/{2}".format(
-            self._start_range,
-            self._end_range,
-            self._file_size
-        )
+        self.properties.content_range = f"bytes {self._start_range}-{self._end_range}/{self._file_size}"
 
         # Overwrite the content MD5 as it is the MD5 for the last range instead
         # of the stored MD5
@@ -456,8 +452,8 @@ class StorageStreamDownloader(Generic[T]):  # pylint: disable=too-many-instance-
                             download_stream_current=0,
                             **self._request_options
                         )
-                    except HttpResponseError as error:
-                        process_storage_error(error)
+                    except HttpResponseError as e:
+                        process_storage_error(e)
 
                     # Set the download size to empty
                     self.size = 0

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_encryption.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_encryption.py
@@ -41,7 +41,7 @@ _ERROR_OBJECT_INVALID = \
 
 def _validate_not_none(param_name, param):
     if param is None:
-        raise ValueError('{0} should not be None.'.format(param_name))
+        raise ValueError(f'{param_name} should not be None.')
 
 
 def _validate_key_encryption_key_wrap(kek):

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_generated/_configuration.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_generated/_configuration.py
@@ -37,7 +37,7 @@ class AzureBlobStorageConfiguration(Configuration):  # pylint: disable=too-many-
 
         self.url = url
         self.version = version
-        kwargs.setdefault("sdk_moniker", "azureblobstorage/{}".format(VERSION))
+        kwargs.setdefault("sdk_moniker", f"azureblobstorage/{VERSION}")
         self._configure(**kwargs)
 
     def _configure(

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_generated/_serialization.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_generated/_serialization.py
@@ -97,7 +97,7 @@ class RawDeserializer:
             try:
                 return json.loads(data_as_str)
             except ValueError as err:
-                raise DeserializationError("JSON is invalid: {}".format(err), err)
+                raise DeserializationError(f"JSON is invalid: {err}", err)
         elif "xml" in (content_type or []):
             try:
 
@@ -129,7 +129,7 @@ class RawDeserializer:
                 # context otherwise.
                 _LOGGER.critical("Wasn't XML not JSON, failing")
                 raise_with_traceback(DeserializationError, "XML is invalid")
-        raise DeserializationError("Cannot deserialize content-type: {}".format(content_type))
+        raise DeserializationError(f"Cannot deserialize content-type: {content_type}")
 
     @classmethod
     def deserialize_from_http_generics(cls, body_bytes, headers):
@@ -207,7 +207,7 @@ except ImportError:  # Python 2.7
             return str(self.__offset.total_seconds() / 3600)
 
         def __repr__(self):
-            return "<FixedOffset {}>".format(self.tzname(None))
+            return f"<FixedOffset {self.tzname(None)}>"
 
         def dst(self, dt):
             return datetime.timedelta(0)
@@ -605,7 +605,7 @@ class Serializer(object):
                         if xml_desc.get("attr", False):
                             if xml_ns:
                                 ET.register_namespace(xml_prefix, xml_ns)
-                                xml_name = "{}{}".format(xml_ns, xml_name)
+                                xml_name = f"{xml_ns}{xml_name}"
                             serialized.set(xml_name, new_attr)
                             continue
                         if xml_desc.get("text", False):
@@ -643,7 +643,7 @@ class Serializer(object):
                     continue
 
         except (AttributeError, KeyError, TypeError) as err:
-            msg = "Attribute {} in object {} cannot be serialized.\n{}".format(attr_name, class_name, str(target_obj))
+            msg = f"Attribute {attr_name} in object {class_name} cannot be serialized.\n{str(target_obj)}"
             raise_with_traceback(SerializationError, msg, err)
         else:
             return serialized
@@ -709,7 +709,7 @@ class Serializer(object):
             else:
                 output = quote(str(output), safe="")
         except SerializationError:
-            raise TypeError("{} must be type {}.".format(name, data_type))
+            raise TypeError(f"{name} must be type {data_type}.")
         else:
             return output
 
@@ -740,7 +740,7 @@ class Serializer(object):
             else:
                 output = quote(str(output), safe="")
         except SerializationError:
-            raise TypeError("{} must be type {}.".format(name, data_type))
+            raise TypeError(f"{name} must be type {data_type}.")
         else:
             return str(output)
 
@@ -761,7 +761,7 @@ class Serializer(object):
             if data_type == "bool":
                 output = json.dumps(output)
         except SerializationError:
-            raise TypeError("{} must be type {}.".format(name, data_type))
+            raise TypeError(f"{name} must be type {data_type}.")
         else:
             return str(output)
 
@@ -1056,7 +1056,7 @@ class Serializer(object):
         """
         if isinstance(attr, str):
             attr = isodate.parse_date(attr)
-        t = "{:04}-{:02}-{:02}".format(attr.year, attr.month, attr.day)
+        t = f"{attr.year:04}-{attr.month:02}-{attr.day:02}"
         return t
 
     @staticmethod
@@ -1068,9 +1068,9 @@ class Serializer(object):
         """
         if isinstance(attr, str):
             attr = isodate.parse_time(attr)
-        t = "{:02}:{:02}:{:02}".format(attr.hour, attr.minute, attr.second)
+        t = f"{attr.hour:02}:{attr.minute:02}:{attr.second:02}"
         if attr.microsecond:
-            t += ".{:02}".format(attr.microsecond)
+            t += f".{attr.microsecond:02}"
         return t
 
     @staticmethod
@@ -1245,7 +1245,7 @@ def _extract_name_from_internal_type(internal_type):
     xml_name = internal_type_xml_map.get("name", internal_type.__name__)
     xml_ns = internal_type_xml_map.get("ns", None)
     if xml_ns:
-        xml_name = "{}{}".format(xml_ns, xml_name)
+        xml_name = f"{xml_ns}{xml_name}"
     return xml_name
 
 
@@ -1269,7 +1269,7 @@ def xml_key_extractor(attr, attr_desc, data):
     # Integrate namespace if necessary
     xml_ns = xml_desc.get("ns", internal_type_xml_map.get("ns", None))
     if xml_ns:
-        xml_name = "{}{}".format(xml_ns, xml_name)
+        xml_name = f"{xml_ns}{xml_name}"
 
     # If it's an attribute, that's simple
     if xml_desc.get("attr", False):
@@ -1320,7 +1320,7 @@ def xml_key_extractor(attr, attr_desc, data):
 
     # Here it's not a itertype, we should have found one element only or empty
     if len(children) > 1:
-        raise DeserializationError("Find several XML '{}' where it was not expected".format(xml_name))
+        raise DeserializationError(f"Find several XML '{xml_name}' where it was not expected")
     return children[0]
 
 
@@ -1565,7 +1565,7 @@ class Deserializer(object):
                     response_obj.additional_properties = additional_properties
                 return response_obj
             except TypeError as err:
-                msg = "Unable to deserialize {} into model {}. ".format(kwargs, response)
+                msg = f"Unable to deserialize {kwargs} into model {response}. "
                 raise DeserializationError(msg + str(err))
         else:
             try:
@@ -1574,7 +1574,7 @@ class Deserializer(object):
                 return response
             except Exception as exp:
                 msg = "Unable to populate response model. "
-                msg += "Type: {}, Error: {}".format(type(response), exp)
+                msg += f"Type: {type(response)}, Error: {exp}"
                 raise DeserializationError(msg)
 
     def deserialize_data(self, data, data_type):
@@ -1615,7 +1615,7 @@ class Deserializer(object):
 
         except (ValueError, TypeError, AttributeError) as err:
             msg = "Unable to deserialize response data."
-            msg += " Data: {}, {}".format(data, data_type)
+            msg += f" Data: {data}, {data_type}"
             raise_with_traceback(DeserializationError, msg, err)
         else:
             return self._deserialize(obj_type, data)
@@ -1632,7 +1632,7 @@ class Deserializer(object):
         if isinstance(attr, ET.Element):  # If I receive an element here, get the children
             attr = list(attr)
         if not isinstance(attr, (list, set)):
-            raise DeserializationError("Cannot deserialize as [{}] an object of type {}".format(iter_type, type(attr)))
+            raise DeserializationError(f"Cannot deserialize as [{iter_type}] an object of type {type(attr)}")
         return [self.deserialize_data(a, iter_type) for a in attr]
 
     def deserialize_dict(self, attr, dict_type):
@@ -1726,7 +1726,7 @@ class Deserializer(object):
                     return True
                 elif attr.lower() in ["false", "0"]:
                     return False
-            raise TypeError("Invalid boolean value: {}".format(attr))
+            raise TypeError(f"Invalid boolean value: {attr}")
 
         if data_type == "str":
             return self.deserialize_unicode(attr)
@@ -1828,7 +1828,7 @@ class Deserializer(object):
         try:
             return decimal.Decimal(attr)
         except decimal.DecimalException as err:
-            msg = "Invalid decimal {}".format(attr)
+            msg = f"Invalid decimal {attr}"
             raise_with_traceback(DeserializationError, msg, err)
 
     @staticmethod
@@ -1872,7 +1872,7 @@ class Deserializer(object):
         if isinstance(attr, ET.Element):
             attr = attr.text
         if re.search(r"[^\W\d_]", attr, re.I + re.U):
-            raise DeserializationError("Date must have only digits and -. Received: %s" % attr)
+            raise DeserializationError(f"Date must have only digits and -. Received: {attr}")
         # This must NOT use defaultmonth/defaultday. Using None ensure this raises an exception.
         return isodate.parse_date(attr, defaultmonth=None, defaultday=None)
 
@@ -1887,7 +1887,7 @@ class Deserializer(object):
         if isinstance(attr, ET.Element):
             attr = attr.text
         if re.search(r"[^\W\d_]", attr, re.I + re.U):
-            raise DeserializationError("Date must have only digits and -. Received: %s" % attr)
+            raise DeserializationError(f"Date must have only digits and -. Received: {attr}")
         return isodate.parse_time(attr)
 
     @staticmethod

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_generated/_serialization.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_generated/_serialization.py
@@ -97,7 +97,7 @@ class RawDeserializer:
             try:
                 return json.loads(data_as_str)
             except ValueError as err:
-                raise DeserializationError(f"JSON is invalid: {err}", err)
+                raise DeserializationError("JSON is invalid: {}".format(err), err)
         elif "xml" in (content_type or []):
             try:
 
@@ -129,7 +129,7 @@ class RawDeserializer:
                 # context otherwise.
                 _LOGGER.critical("Wasn't XML not JSON, failing")
                 raise_with_traceback(DeserializationError, "XML is invalid")
-        raise DeserializationError(f"Cannot deserialize content-type: {content_type}")
+        raise DeserializationError("Cannot deserialize content-type: {}".format(content_type))
 
     @classmethod
     def deserialize_from_http_generics(cls, body_bytes, headers):
@@ -207,7 +207,7 @@ except ImportError:  # Python 2.7
             return str(self.__offset.total_seconds() / 3600)
 
         def __repr__(self):
-            return f"<FixedOffset {self.tzname(None)}>"
+            return "<FixedOffset {}>".format(self.tzname(None))
 
         def dst(self, dt):
             return datetime.timedelta(0)
@@ -605,7 +605,7 @@ class Serializer(object):
                         if xml_desc.get("attr", False):
                             if xml_ns:
                                 ET.register_namespace(xml_prefix, xml_ns)
-                                xml_name = f"{xml_ns}{xml_name}"
+                                xml_name = "{}{}".format(xml_ns, xml_name)
                             serialized.set(xml_name, new_attr)
                             continue
                         if xml_desc.get("text", False):
@@ -643,7 +643,7 @@ class Serializer(object):
                     continue
 
         except (AttributeError, KeyError, TypeError) as err:
-            msg = f"Attribute {attr_name} in object {class_name} cannot be serialized.\n{str(target_obj)}"
+            msg = "Attribute {} in object {} cannot be serialized.\n{}".format(attr_name, class_name, str(target_obj))
             raise_with_traceback(SerializationError, msg, err)
         else:
             return serialized
@@ -709,7 +709,7 @@ class Serializer(object):
             else:
                 output = quote(str(output), safe="")
         except SerializationError:
-            raise TypeError(f"{name} must be type {data_type}.")
+            raise TypeError("{} must be type {}.".format(name, data_type))
         else:
             return output
 
@@ -740,7 +740,7 @@ class Serializer(object):
             else:
                 output = quote(str(output), safe="")
         except SerializationError:
-            raise TypeError(f"{name} must be type {data_type}.")
+            raise TypeError("{} must be type {}.".format(name, data_type))
         else:
             return str(output)
 
@@ -761,7 +761,7 @@ class Serializer(object):
             if data_type == "bool":
                 output = json.dumps(output)
         except SerializationError:
-            raise TypeError(f"{name} must be type {data_type}.")
+            raise TypeError("{} must be type {}.".format(name, data_type))
         else:
             return str(output)
 
@@ -1056,7 +1056,7 @@ class Serializer(object):
         """
         if isinstance(attr, str):
             attr = isodate.parse_date(attr)
-        t = f"{attr.year:04}-{attr.month:02}-{attr.day:02}"
+        t = "{:04}-{:02}-{:02}".format(attr.year, attr.month, attr.day)
         return t
 
     @staticmethod
@@ -1068,9 +1068,9 @@ class Serializer(object):
         """
         if isinstance(attr, str):
             attr = isodate.parse_time(attr)
-        t = f"{attr.hour:02}:{attr.minute:02}:{attr.second:02}"
+        t = "{:02}:{:02}:{:02}".format(attr.hour, attr.minute, attr.second)
         if attr.microsecond:
-            t += f".{attr.microsecond:02}"
+            t += ".{:02}".format(attr.microsecond)
         return t
 
     @staticmethod
@@ -1245,7 +1245,7 @@ def _extract_name_from_internal_type(internal_type):
     xml_name = internal_type_xml_map.get("name", internal_type.__name__)
     xml_ns = internal_type_xml_map.get("ns", None)
     if xml_ns:
-        xml_name = f"{xml_ns}{xml_name}"
+        xml_name = "{}{}".format(xml_ns, xml_name)
     return xml_name
 
 
@@ -1269,7 +1269,7 @@ def xml_key_extractor(attr, attr_desc, data):
     # Integrate namespace if necessary
     xml_ns = xml_desc.get("ns", internal_type_xml_map.get("ns", None))
     if xml_ns:
-        xml_name = f"{xml_ns}{xml_name}"
+        xml_name = "{}{}".format(xml_ns, xml_name)
 
     # If it's an attribute, that's simple
     if xml_desc.get("attr", False):
@@ -1320,7 +1320,7 @@ def xml_key_extractor(attr, attr_desc, data):
 
     # Here it's not a itertype, we should have found one element only or empty
     if len(children) > 1:
-        raise DeserializationError(f"Find several XML '{xml_name}' where it was not expected")
+        raise DeserializationError("Find several XML '{}' where it was not expected".format(xml_name))
     return children[0]
 
 
@@ -1565,7 +1565,7 @@ class Deserializer(object):
                     response_obj.additional_properties = additional_properties
                 return response_obj
             except TypeError as err:
-                msg = f"Unable to deserialize {kwargs} into model {response}. "
+                msg = "Unable to deserialize {} into model {}. ".format(kwargs, response)
                 raise DeserializationError(msg + str(err))
         else:
             try:
@@ -1574,7 +1574,7 @@ class Deserializer(object):
                 return response
             except Exception as exp:
                 msg = "Unable to populate response model. "
-                msg += f"Type: {type(response)}, Error: {exp}"
+                msg += "Type: {}, Error: {}".format(type(response), exp)
                 raise DeserializationError(msg)
 
     def deserialize_data(self, data, data_type):
@@ -1615,7 +1615,7 @@ class Deserializer(object):
 
         except (ValueError, TypeError, AttributeError) as err:
             msg = "Unable to deserialize response data."
-            msg += f" Data: {data}, {data_type}"
+            msg += " Data: {}, {}".format(data, data_type)
             raise_with_traceback(DeserializationError, msg, err)
         else:
             return self._deserialize(obj_type, data)
@@ -1632,7 +1632,7 @@ class Deserializer(object):
         if isinstance(attr, ET.Element):  # If I receive an element here, get the children
             attr = list(attr)
         if not isinstance(attr, (list, set)):
-            raise DeserializationError(f"Cannot deserialize as [{iter_type}] an object of type {type(attr)}")
+            raise DeserializationError("Cannot deserialize as [{}] an object of type {}".format(iter_type, type(attr)))
         return [self.deserialize_data(a, iter_type) for a in attr]
 
     def deserialize_dict(self, attr, dict_type):
@@ -1726,7 +1726,7 @@ class Deserializer(object):
                     return True
                 elif attr.lower() in ["false", "0"]:
                     return False
-            raise TypeError(f"Invalid boolean value: {attr}")
+            raise TypeError("Invalid boolean value: {}".format(attr))
 
         if data_type == "str":
             return self.deserialize_unicode(attr)
@@ -1828,7 +1828,7 @@ class Deserializer(object):
         try:
             return decimal.Decimal(attr)
         except decimal.DecimalException as err:
-            msg = f"Invalid decimal {attr}"
+            msg = "Invalid decimal {}".format(attr)
             raise_with_traceback(DeserializationError, msg, err)
 
     @staticmethod
@@ -1872,7 +1872,7 @@ class Deserializer(object):
         if isinstance(attr, ET.Element):
             attr = attr.text
         if re.search(r"[^\W\d_]", attr, re.I + re.U):
-            raise DeserializationError(f"Date must have only digits and -. Received: {attr}")
+            raise DeserializationError("Date must have only digits and -. Received: %s" % attr)
         # This must NOT use defaultmonth/defaultday. Using None ensure this raises an exception.
         return isodate.parse_date(attr, defaultmonth=None, defaultday=None)
 
@@ -1887,7 +1887,7 @@ class Deserializer(object):
         if isinstance(attr, ET.Element):
             attr = attr.text
         if re.search(r"[^\W\d_]", attr, re.I + re.U):
-            raise DeserializationError(f"Date must have only digits and -. Received: {attr}")
+            raise DeserializationError("Date must have only digits and -. Received: %s" % attr)
         return isodate.parse_time(attr)
 
     @staticmethod

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_generated/_vendor.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_generated/_vendor.py
@@ -23,5 +23,5 @@ def _format_url_section(template, **kwargs):
             return template.format(**kwargs)
         except KeyError as key:
             formatted_components = template.split("/")
-            components = [c for c in formatted_components if "{}".format(key.args[0]) not in c]
+            components = [c for c in formatted_components if f"{key.args[0]}" not in c]
             template = "/".join(components)

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_generated/_vendor.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_generated/_vendor.py
@@ -23,5 +23,5 @@ def _format_url_section(template, **kwargs):
             return template.format(**kwargs)
         except KeyError as key:
             formatted_components = template.split("/")
-            components = [c for c in formatted_components if f"{key.args[0]}" not in c]
+            components = [c for c in formatted_components if "{}".format(key.args[0]) not in c]
             template = "/".join(components)

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_generated/aio/_configuration.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_generated/aio/_configuration.py
@@ -37,7 +37,7 @@ class AzureBlobStorageConfiguration(Configuration):  # pylint: disable=too-many-
 
         self.url = url
         self.version = version
-        kwargs.setdefault("sdk_moniker", f"azureblobstorage/{VERSION}")
+        kwargs.setdefault("sdk_moniker", "azureblobstorage/{}".format(VERSION))
         self._configure(**kwargs)
 
     def _configure(self, **kwargs: Any) -> None:

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_generated/aio/_configuration.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_generated/aio/_configuration.py
@@ -37,7 +37,7 @@ class AzureBlobStorageConfiguration(Configuration):  # pylint: disable=too-many-
 
         self.url = url
         self.version = version
-        kwargs.setdefault("sdk_moniker", "azureblobstorage/{}".format(VERSION))
+        kwargs.setdefault("sdk_moniker", f"azureblobstorage/{VERSION}")
         self._configure(**kwargs)
 
     def _configure(self, **kwargs: Any) -> None:

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_models.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_models.py
@@ -185,7 +185,7 @@ class BlobAnalyticsLogging(GeneratedLogging):
     """
 
     def __init__(self, **kwargs):
-        self.version = kwargs.get('version', u'1.0')
+        self.version = kwargs.get('version', '1.0')
         self.delete = kwargs.get('delete', False)
         self.read = kwargs.get('read', False)
         self.write = kwargs.get('write', False)
@@ -221,7 +221,7 @@ class Metrics(GeneratedMetrics):
     """
 
     def __init__(self, **kwargs):
-        self.version = kwargs.get('version', u'1.0')
+        self.version = kwargs.get('version', '1.0')
         self.enabled = kwargs.get('enabled', False)
         self.include_apis = kwargs.get('include_apis')
         self.retention_policy = kwargs.get('retention_policy') or RetentionPolicy()

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_quick_query_helper.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_quick_query_helper.py
@@ -169,7 +169,7 @@ class QuickQueryStreamer(object):
         try:
             # keep reading from the generator until the buffer of this stream has enough data to read
             while self._point + size > self._download_offset:
-                self._buf += self.__next__()
+                self._buf += self.__next__()  # pylint: disable=unnecessary-dunder-call
         except StopIteration:
             self.file_length = self._download_offset
 

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_quick_query_helper.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_quick_query_helper.py
@@ -171,7 +171,7 @@ class QuickQueryStreamer(object):
         try:
             # keep reading from the generator until the buffer of this stream has enough data to read
             while self._point + size > self._download_offset:
-                self._buf += self.__next__()
+                self._buf += self.next()
         except StopIteration:
             self.file_length = self._download_offset
 

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_quick_query_helper.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_quick_query_helper.py
@@ -152,8 +152,6 @@ class QuickQueryStreamer(object):
         self._download_offset += len(next_part)
         return next_part
 
-    next = __next__  # Python 2 compatibility.
-
     def tell(self):
         return self._point
 
@@ -171,7 +169,7 @@ class QuickQueryStreamer(object):
         try:
             # keep reading from the generator until the buffer of this stream has enough data to read
             while self._point + size > self._download_offset:
-                self._buf += self.next()
+                self._buf += self.__next__()
         except StopIteration:
             self.file_length = self._download_offset
 

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_quick_query_helper.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_quick_query_helper.py
@@ -169,7 +169,7 @@ class QuickQueryStreamer(object):
         try:
             # keep reading from the generator until the buffer of this stream has enough data to read
             while self._point + size > self._download_offset:
-                self._buf += self.__next__()  # pylint: disable=unnecessary-dunder-call
+                self._buf += self.__next__()
         except StopIteration:
             self.file_length = self._download_offset
 

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_serialize.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_serialize.py
@@ -3,7 +3,6 @@
 # Licensed under the MIT License. See License.txt in the project root for
 # license information.
 # --------------------------------------------------------------------------
-# pylint: disable=no-self-use
 from typing import (  # pylint: disable=unused-import
     Any, Dict, Optional, Tuple, Union,
     TYPE_CHECKING)
@@ -66,20 +65,20 @@ def _get_match_headers(kwargs, match_param, etag_param):
     if match_condition == MatchConditions.IfNotModified:
         if_match = kwargs.pop(etag_param, None)
         if not if_match:
-            raise ValueError("'{}' specified without '{}'.".format(match_param, etag_param))
+            raise ValueError(f"'{match_param}' specified without '{etag_param}'.")
     elif match_condition == MatchConditions.IfPresent:
         if_match = '*'
     elif match_condition == MatchConditions.IfModified:
         if_none_match = kwargs.pop(etag_param, None)
         if not if_none_match:
-            raise ValueError("'{}' specified without '{}'.".format(match_param, etag_param))
+            raise ValueError(f"'{match_param}' specified without '{etag_param}'.")
     elif match_condition == MatchConditions.IfMissing:
         if_none_match = '*'
     elif match_condition is None:
         if kwargs.get(etag_param):
-            raise ValueError("'{}' specified without '{}'.".format(etag_param, match_param))
+            raise ValueError(f"'{etag_param}' specified without '{match_param}'.")
     else:
-        raise TypeError("Invalid match condition: {}".format(match_condition))
+        raise TypeError(f"Invalid match condition: {match_condition}")
     return if_match, if_none_match
 
 
@@ -146,7 +145,7 @@ def get_api_version(kwargs):
     api_version = kwargs.get('api_version', None)
     if api_version and api_version not in _SUPPORTED_API_VERSIONS:
         versions = '\n'.join(_SUPPORTED_API_VERSIONS)
-        raise ValueError("Unsupported API version '{}'. Please select from:\n{}".format(api_version, versions))
+        raise ValueError(f"Unsupported API version '{api_version}'. Please select from:\n{versions}")
     return api_version or _SUPPORTED_API_VERSIONS[-1]
 
 
@@ -155,7 +154,7 @@ def serialize_blob_tags_header(tags=None):
     if tags is None:
         return None
 
-    components = list()
+    components = []
     if tags:
         for key, value in tags.items():
             components.append(quote(key, safe='.-'))
@@ -171,7 +170,7 @@ def serialize_blob_tags_header(tags=None):
 
 def serialize_blob_tags(tags=None):
     # type: (Optional[Dict[str, str]]) -> Union[BlobTags, None]
-    tag_list = list()
+    tag_list = []
     if tags:
         tag_list = [BlobTag(key=k, value=v) for k, v in tags.items()]
     return BlobTags(blob_tag_set=tag_list)

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/authentication.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/authentication.py
@@ -40,7 +40,7 @@ def _storage_header_sort(input_headers: List[Tuple[str, str]]) -> List[Tuple[str
     custom_weights = "-!#$%&*.^_|~+\"\'(),/`~0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[]abcdefghijklmnopqrstuvwxyz{}"
 
     # Build dict of tuples and list of keys
-    header_dict = dict()
+    header_dict = {}
     header_keys = []
     for k, v in input_headers:
         header_dict[k] = v
@@ -67,7 +67,6 @@ class AzureSigningError(ClientAuthenticationError):
     """
 
 
-# pylint: disable=no-self-use
 class SharedKeyCredentialPolicy(SansIOHTTPPolicy):
 
     def __init__(self, account_name, account_key):

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/avro/avro_io.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/avro/avro_io.py
@@ -52,7 +52,7 @@ class SchemaResolutionException(schema.AvroException):
     def __init__(self, fail_msg, writer_schema=None):
         pretty_writers = json.dumps(json.loads(str(writer_schema)), indent=2)
         if writer_schema:
-            fail_msg += "\nWriter's Schema: %s" % pretty_writers
+            fail_msg += f"\nWriter's Schema: {pretty_writers}"
         schema.AvroException.__init__(self, fail_msg)
 
 # ------------------------------------------------------------------------------
@@ -105,7 +105,7 @@ class BinaryDecoder(object):
             return True
         if b == 0:
             return False
-        fail_msg = "Invalid value for boolean: %s" % b
+        fail_msg = f"Invalid value for boolean: {b}"
         raise schema.AvroException(fail_msg)
 
     def read_int(self):
@@ -253,7 +253,7 @@ class DatumReader(object):
         elif writer_schema.type in ['record', 'error', 'request']:
             result = self.read_record(writer_schema, decoder)
         else:
-            fail_msg = "Cannot read unknown schema type: %s" % writer_schema.type
+            fail_msg = f"Cannot read unknown schema type: {writer_schema.type}"
             raise schema.AvroException(fail_msg)
         return result
 
@@ -290,7 +290,7 @@ class DatumReader(object):
             self.skip_record(writer_schema, decoder)
             result = None
         else:
-            fail_msg = "Unknown schema type: %s" % writer_schema.type
+            fail_msg = f"Unknown schema type: {writer_schema.type}"
             raise schema.AvroException(fail_msg)
         return result
 
@@ -315,8 +315,7 @@ class DatumReader(object):
         # read data
         index_of_symbol = decoder.read_int()
         if index_of_symbol >= len(writer_schema.symbols):
-            fail_msg = "Can't access enum index %d for enum with %d symbols" \
-                       % (index_of_symbol, len(writer_schema.symbols))
+            fail_msg = f"Can't access enum index {index_of_symbol} for enum with {len(writer_schema.symbols)} symbols"
             raise SchemaResolutionException(fail_msg, writer_schema)
         read_symbol = writer_schema.symbols[index_of_symbol]
         return read_symbol
@@ -410,8 +409,8 @@ class DatumReader(object):
         # schema resolution
         index_of_schema = int(decoder.read_long())
         if index_of_schema >= len(writer_schema.schemas):
-            fail_msg = "Can't access branch index %d for union with %d branches" \
-                       % (index_of_schema, len(writer_schema.schemas))
+            fail_msg = (f"Can't access branch index {index_of_schema} "
+            f"for union with {len(writer_schema.schemas)} branches")
             raise SchemaResolutionException(fail_msg, writer_schema)
         selected_writer_schema = writer_schema.schemas[index_of_schema]
 
@@ -421,8 +420,8 @@ class DatumReader(object):
     def skip_union(self, writer_schema, decoder):
         index_of_schema = int(decoder.read_long())
         if index_of_schema >= len(writer_schema.schemas):
-            fail_msg = "Can't access branch index %d for union with %d branches" \
-                       % (index_of_schema, len(writer_schema.schemas))
+            fail_msg = (f"Can't access branch index {index_of_schema} "
+            f"for union with {len(writer_schema.schemas)} branches")
             raise SchemaResolutionException(fail_msg, writer_schema)
         return self.skip_data(writer_schema.schemas[index_of_schema], decoder)
 

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/avro/avro_io.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/avro/avro_io.py
@@ -410,7 +410,7 @@ class DatumReader(object):
         index_of_schema = int(decoder.read_long())
         if index_of_schema >= len(writer_schema.schemas):
             fail_msg = (f"Can't access branch index {index_of_schema} "
-            f"for union with {len(writer_schema.schemas)} branches")
+                        f"for union with {len(writer_schema.schemas)} branches")
             raise SchemaResolutionException(fail_msg, writer_schema)
         selected_writer_schema = writer_schema.schemas[index_of_schema]
 
@@ -421,7 +421,7 @@ class DatumReader(object):
         index_of_schema = int(decoder.read_long())
         if index_of_schema >= len(writer_schema.schemas):
             fail_msg = (f"Can't access branch index {index_of_schema} "
-            f"for union with {len(writer_schema.schemas)} branches")
+                        f"for union with {len(writer_schema.schemas)} branches")
             raise SchemaResolutionException(fail_msg, writer_schema)
         return self.skip_data(writer_schema.schemas[index_of_schema], decoder)
 

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/avro/avro_io_async.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/avro/avro_io_async.py
@@ -88,7 +88,7 @@ class AsyncBinaryDecoder(object):
             return True
         if b == 0:
             return False
-        fail_msg = "Invalid value for boolean: %s" % b
+        fail_msg = f"Invalid value for boolean: {b}"
         raise schema.AvroException(fail_msg)
 
     async def read_int(self):
@@ -237,7 +237,7 @@ class AsyncDatumReader(object):
         elif writer_schema.type in ['record', 'error', 'request']:
             result = await self.read_record(writer_schema, decoder)
         else:
-            fail_msg = "Cannot read unknown schema type: %s" % writer_schema.type
+            fail_msg = f"Cannot read unknown schema type: {writer_schema.type}"
             raise schema.AvroException(fail_msg)
         return result
 
@@ -274,7 +274,7 @@ class AsyncDatumReader(object):
             await self.skip_record(writer_schema, decoder)
             result = None
         else:
-            fail_msg = "Unknown schema type: %s" % writer_schema.type
+            fail_msg = f"Unknown schema type: {writer_schema.type}"
             raise schema.AvroException(fail_msg)
         return result
 
@@ -299,8 +299,7 @@ class AsyncDatumReader(object):
         # read data
         index_of_symbol = await decoder.read_int()
         if index_of_symbol >= len(writer_schema.symbols):
-            fail_msg = "Can't access enum index %d for enum with %d symbols" \
-                       % (index_of_symbol, len(writer_schema.symbols))
+            fail_msg = f"Can't access enum index {index_of_symbol} for enum with {len(writer_schema.symbols)} symbols"
             raise SchemaResolutionException(fail_msg, writer_schema)
         read_symbol = writer_schema.symbols[index_of_symbol]
         return read_symbol
@@ -394,8 +393,8 @@ class AsyncDatumReader(object):
         # schema resolution
         index_of_schema = int(await decoder.read_long())
         if index_of_schema >= len(writer_schema.schemas):
-            fail_msg = "Can't access branch index %d for union with %d branches" \
-                       % (index_of_schema, len(writer_schema.schemas))
+            fail_msg = (f"Can't access branch index {index_of_schema} "
+                    f"for union with {len(writer_schema.schemas)} branches")
             raise SchemaResolutionException(fail_msg, writer_schema)
         selected_writer_schema = writer_schema.schemas[index_of_schema]
 
@@ -405,8 +404,8 @@ class AsyncDatumReader(object):
     async def skip_union(self, writer_schema, decoder):
         index_of_schema = int(await decoder.read_long())
         if index_of_schema >= len(writer_schema.schemas):
-            fail_msg = "Can't access branch index %d for union with %d branches" \
-                       % (index_of_schema, len(writer_schema.schemas))
+            fail_msg = (f"Can't access branch index {index_of_schema} "
+                    f"for union with {len(writer_schema.schemas)} branches")
             raise SchemaResolutionException(fail_msg, writer_schema)
         return await self.skip_data(writer_schema.schemas[index_of_schema], decoder)
 

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/avro/datafile.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/avro/datafile.py
@@ -102,7 +102,7 @@ class DataFileReader(object):  # pylint: disable=too-many-instance-attributes
         else:
             self.codec = avro_codec_raw.decode('utf-8')
         if self.codec not in VALID_CODECS:
-            raise DataFileException('Unknown codec: %s.' % self.codec)
+            raise DataFileException(f"Unknown codec: {self.codec}.")
 
         # get ready to read
         self._block_count = 0
@@ -185,8 +185,7 @@ class DataFileReader(object):  # pylint: disable=too-many-instance-attributes
 
         # check magic number
         if header.get('magic') != MAGIC:
-            fail_msg = "Not an Avro data file: %s doesn't match %s." \
-                       % (header.get('magic'), MAGIC)
+            fail_msg = f"Not an Avro data file: {header.get('magic')} doesn't match {MAGIC}."
             raise schema.AvroException(fail_msg)
 
         # set metadata
@@ -210,7 +209,7 @@ class DataFileReader(object):  # pylint: disable=too-many-instance-attributes
             uncompressed = zlib.decompress(data, -15)
             self._datum_decoder = avro_io.BinaryDecoder(io.BytesIO(uncompressed))
         else:
-            raise DataFileException("Unknown codec: %r" % self.codec)
+            raise DataFileException(f"Unknown codec: {self.codec!r}")
 
     def _skip_sync(self):
         """
@@ -255,7 +254,7 @@ class DataFileReader(object):  # pylint: disable=too-many-instance-attributes
 
     # PY2
     def next(self):
-        return self.__next__()
+        return self.next()
 
     def close(self):
         """Close this reader."""

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/avro/datafile.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/avro/datafile.py
@@ -252,10 +252,6 @@ class DataFileReader(object):  # pylint: disable=too-many-instance-attributes
 
         return datum
 
-    # PY2
-    def next(self):
-        return self.next()
-
     def close(self):
         """Close this reader."""
         self.reader.close()

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/avro/datafile_async.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/avro/datafile_async.py
@@ -64,7 +64,7 @@ class AsyncDataFileReader(object):  # pylint: disable=too-many-instance-attribut
         else:
             self.codec = avro_codec_raw.decode('utf-8')
         if self.codec not in VALID_CODECS:
-            raise DataFileException('Unknown codec: %s.' % self.codec)
+            raise DataFileException(f"Unknown codec: {self.codec}.")
 
         # get ready to read
         self._block_count = 0
@@ -146,8 +146,7 @@ class AsyncDataFileReader(object):  # pylint: disable=too-many-instance-attribut
 
         # check magic number
         if header.get('magic') != MAGIC:
-            fail_msg = "Not an Avro data file: %s doesn't match %s." \
-                       % (header.get('magic'), MAGIC)
+            fail_msg = f"Not an Avro data file: {header.get('magic')} doesn't match {MAGIC}."
             raise schema.AvroException(fail_msg)
 
         # set metadata
@@ -163,7 +162,7 @@ class AsyncDataFileReader(object):  # pylint: disable=too-many-instance-attribut
             await self.raw_decoder.skip_long()
             self._datum_decoder = self._raw_decoder
         else:
-            raise DataFileException("Unknown codec: %r" % self.codec)
+            raise DataFileException(f"Unknown codec: {self.codec!r}")
 
     async def _skip_sync(self):
         """

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/avro/schema.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/avro/schema.py
@@ -151,7 +151,7 @@ class Schema(with_metaclass(abc.ABCMeta, object)):
           other_props: Optional dictionary of additional properties.
         """
         if data_type not in VALID_TYPES:
-            raise SchemaParseException('%r is not a valid Avro type.' % data_type)
+            raise SchemaParseException(f'{data_type!r} is not a valid Avro type.')
 
         # All properties of this schema, as a map: property name -> property value
         self._props = {}
@@ -243,7 +243,7 @@ class Name(object):
             match = _RE_FULL_NAME.match(self._fullname)
             if match is None:
                 raise SchemaParseException(
-                    'Invalid absolute schema name: %r.' % self._fullname)
+                    f'Invalid absolute schema name: {self._fullname!r}.')
 
             self._name = match.group(1)
             self._namespace = self._fullname[:-(len(self._name) + 1)]
@@ -254,13 +254,12 @@ class Name(object):
             self._namespace = namespace
             self._fullname = (self._name
                               if (not self._namespace) else
-                              '%s.%s' % (self._namespace, self._name))
+                              f'{self._namespace}.{self._name}')
 
             # Validate the fullname:
             if _RE_FULL_NAME.match(self._fullname) is None:
-                raise SchemaParseException(
-                    'Invalid schema name %r inferred from name %r and namespace %r.'
-                    % (self._fullname, self._name, self._namespace))
+                raise SchemaParseException(f"Invalid schema name {self._fullname!r} inferred from "
+                                           f"name {self._name!r} and namespace {self._namespace!r}.")
 
     def __eq__(self, other):
         if not isinstance(other, Name):
@@ -372,10 +371,10 @@ class Names(object):
         """
         if schema.fullname in VALID_TYPES:
             raise SchemaParseException(
-                '%s is a reserved type name.' % schema.fullname)
+                f'{schema.fullname} is a reserved type name.')
         if schema.fullname in self.names:
             raise SchemaParseException(
-                'Avro name %r already exists.' % schema.fullname)
+                f'Avro name {schema.fullname!r} already exists.')
 
         logger.log(DEBUG_VERBOSE, 'Register new name for %r', schema.fullname)
         self._names[schema.fullname] = schema
@@ -407,7 +406,7 @@ class NamedSchema(Schema):
           names: Tracker to resolve and register Avro names.
           other_props: Optional map of additional properties of the schema.
         """
-        assert (data_type in NAMED_TYPES), ('Invalid named type: %r' % data_type)
+        assert (data_type in NAMED_TYPES), (f'Invalid named type: {data_type!r}')
         self._avro_name = names.get_name(name=name, namespace=namespace)
 
         super(NamedSchema, self).__init__(data_type, other_props)
@@ -490,9 +489,9 @@ class Field(object):
           other_props:
         """
         if (not isinstance(name, _str)) or (not name):
-            raise SchemaParseException('Invalid record field name: %r.' % name)
+            raise SchemaParseException(f'Invalid record field name: {name!r}.')
         if (order is not None) and (order not in VALID_FIELD_SORT_ORDERS):
-            raise SchemaParseException('Invalid record field order: %r.' % order)
+            raise SchemaParseException(f'Invalid record field order: {order!r}.')
 
         # All properties of this record field:
         self._props = {}
@@ -585,7 +584,7 @@ class PrimitiveSchema(Schema):
           data_type: Type of the schema to construct. Must be primitive.
         """
         if data_type not in PRIMITIVE_TYPES:
-            raise AvroException('%r is not a valid primitive type.' % data_type)
+            raise AvroException(f'{data_type!r} is not a valid primitive type.')
         super(PrimitiveSchema, self).__init__(data_type, other_props=other_props)
 
     @property
@@ -681,7 +680,7 @@ class EnumSchema(NamedSchema):
         if (len(symbol_set) != len(symbols)
                 or not all(map(lambda symbol: isinstance(symbol, _str), symbols))):
             raise AvroException(
-                'Invalid symbols for enum schema: %r.' % (symbols,))
+                f'Invalid symbols for enum schema: {symbols!r}.')
 
         super(EnumSchema, self).__init__(
             data_type=ENUM,
@@ -936,7 +935,7 @@ class RecordSchema(NamedSchema):
         for field in fields:
             if field.name in field_map:
                 raise SchemaParseException(
-                    'Duplicate record field name %r.' % field.name)
+                    f'Duplicate record field name {field.name!r}.')
             field_map[field.name] = field
         return field_map
 
@@ -984,7 +983,7 @@ class RecordSchema(NamedSchema):
             )
         else:
             raise SchemaParseException(
-                'Invalid record type: %r.' % record_type)
+                f'Invalid record type: {record_type!r}.')
 
         if record_type in [RECORD, ERROR]:
             avro_name = names.get_name(name=name, namespace=namespace)
@@ -1066,9 +1065,7 @@ def _schema_from_json_string(json_string, names):
     # Look for a known named schema:
     schema = names.get_schema(name=json_string)
     if schema is None:
-        raise SchemaParseException(
-            'Unknown named schema %r, known names: %r.'
-            % (json_string, sorted(names.names)))
+        raise SchemaParseException(f"Unknown named schema {json_string!r}, known names: {sorted(names.names)!r}.")
     return schema
 
 
@@ -1083,7 +1080,7 @@ def _schema_from_json_object(json_object, names):
     data_type = json_object.get('type')
     if data_type is None:
         raise SchemaParseException(
-            'Avro schema JSON descriptor has no "type" property: %r' % json_object)
+            f'Avro schema JSON descriptor has no "type" property: {json_object!r}')
 
     other_props = dict(
         filter_keys_out(items=json_object, keys=SCHEMA_RESERVED_PROPS))
@@ -1119,7 +1116,7 @@ def _schema_from_json_object(json_object, names):
                 other_props=other_props,
             )
         else:
-            raise Exception('Internal error: unknown type %r.' % data_type)
+            raise Exception(f'Internal error: unknown type {data_type!r}.')
 
     elif data_type in VALID_TYPES:
         # Unnamed, non-primitive Avro type:
@@ -1127,9 +1124,7 @@ def _schema_from_json_object(json_object, names):
         if data_type == ARRAY:
             items_desc = json_object.get('items')
             if items_desc is None:
-                raise SchemaParseException(
-                    'Invalid array schema descriptor with no "items" : %r.'
-                    % json_object)
+                raise SchemaParseException(f'Invalid array schema descriptor with no "items" : {json_object!r}.')
             result = ArraySchema(
                 items=schema_from_json_data(items_desc, names),
                 other_props=other_props,
@@ -1138,9 +1133,7 @@ def _schema_from_json_object(json_object, names):
         elif data_type == MAP:
             values_desc = json_object.get('values')
             if values_desc is None:
-                raise SchemaParseException(
-                    'Invalid map schema descriptor with no "values" : %r.'
-                    % json_object)
+                raise SchemaParseException(f'Invalid map schema descriptor with no "values" : {json_object!r}.')
             result = MapSchema(
                 values=schema_from_json_data(values_desc, names=names),
                 other_props=other_props,
@@ -1155,10 +1148,9 @@ def _schema_from_json_object(json_object, names):
             result = ErrorUnionSchema(schemas=error_schemas)
 
         else:
-            raise Exception('Internal error: unknown type %r.' % data_type)
+            raise Exception(f'Internal error: unknown type {data_type!r}.')
     else:
-        raise SchemaParseException(
-            'Invalid JSON descriptor for an Avro schema: %r' % json_object)
+        raise SchemaParseException(f'Invalid JSON descriptor for an Avro schema: {json_object!r}')
     return result
 
 
@@ -1188,7 +1180,7 @@ def schema_from_json_data(json_data, names=None):
     parser = _JSONDataParserTypeMap.get(type(json_data))
     if parser is None:
         raise SchemaParseException(
-            'Invalid JSON descriptor for an Avro schema: %r.' % json_data)
+            f'Invalid JSON descriptor for an Avro schema: {json_data!r}.')
     return parser(json_data, names=names)
 
 
@@ -1210,9 +1202,8 @@ def parse(json_string):
         json_data = json.loads(json_string)
     except Exception as exn:
         raise SchemaParseException(
-            'Error parsing schema from JSON: %r. '
-            'Error message: %r.'
-            % (json_string, exn))
+            f'Error parsing schema from JSON: {json_string!r}. '
+            f'Error message: {exn!r}.')
 
     # Initialize the names object
     names = Names()

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/avro/schema.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/avro/schema.py
@@ -809,22 +809,19 @@ class UnionSchema(Schema):
             filter(lambda schema: schema.type in NAMED_TYPES, self._schemas))
         unique_names = frozenset(map(lambda schema: schema.fullname, named_branches))
         if len(unique_names) != len(named_branches):
-            raise AvroException(
-                'Invalid union branches with duplicate schema name:%s'
-                % ''.join(map(lambda schema: ('\n\t - %s' % schema), self._schemas)))
+            schemas = ''.join(map(lambda schema: (f'\n\t - {schema}'), self._schemas))
+            raise AvroException(f'Invalid union branches with duplicate schema name:{schemas}')
 
         # Types are unique within unnamed schemas, and union is not allowed:
         unnamed_branches = tuple(
             filter(lambda schema: schema.type not in NAMED_TYPES, self._schemas))
         unique_types = frozenset(map(lambda schema: schema.type, unnamed_branches))
         if UNION in unique_types:
-            raise AvroException(
-                'Invalid union branches contain other unions:%s'
-                % ''.join(map(lambda schema: ('\n\t - %s' % schema), self._schemas)))
+            schemas = ''.join(map(lambda schema: (f'\n\t - {schema}'), self._schemas))
+            raise AvroException(f'Invalid union branches contain other unions:{schemas}')
         if len(unique_types) != len(unnamed_branches):
-            raise AvroException(
-                'Invalid union branches with duplicate type:%s'
-                % ''.join(map(lambda schema: ('\n\t - %s' % schema), self._schemas)))
+            schemas = ''.join(map(lambda schema: (f'\n\t - {schema}'), self._schemas))
+            raise AvroException(f'Invalid union branches with duplicate type:{schemas}')
 
     @property
     def schemas(self):

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/policies.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/policies.py
@@ -3,7 +3,6 @@
 # Licensed under the MIT License. See License.txt in the project root for
 # license information.
 # --------------------------------------------------------------------------
-# pylint: disable=no-self-use
 
 import base64
 import hashlib
@@ -408,7 +407,7 @@ class StorageRetryPolicy(HTTPPolicy):
         self.retry_to_secondary = kwargs.pop('retry_to_secondary', False)
         super(StorageRetryPolicy, self).__init__()
 
-    def _set_next_host_location(self, settings, request):
+    def _set_next_host_location(self, settings, request):  # pylint: disable=no-self-use
         """
         A function which sets the next host location on the request, if applicable.
 
@@ -426,7 +425,7 @@ class StorageRetryPolicy(HTTPPolicy):
             updated = url._replace(netloc=settings['hosts'].get(settings['mode']))
             request.url = updated.geturl()
 
-    def configure_retries(self, request):
+    def configure_retries(self, request):  # pylint: disable=no-self-use
         body_position = None
         if hasattr(request.http_request.body, 'read'):
             try:
@@ -449,7 +448,7 @@ class StorageRetryPolicy(HTTPPolicy):
             'history': []
         }
 
-    def get_backoff_time(self, settings):  # pylint: disable=unused-argument
+    def get_backoff_time(self, settings):  # pylint: disable=unused-argument,no-self-use
         """ Formula for computing the current backoff.
         Should be calculated by child class.
 

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/policies.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/policies.py
@@ -3,6 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for
 # license information.
 # --------------------------------------------------------------------------
+# pylint: disable=no-self-use
 
 import base64
 import hashlib

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/policies.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/policies.py
@@ -407,7 +407,7 @@ class StorageRetryPolicy(HTTPPolicy):
         self.retry_to_secondary = kwargs.pop('retry_to_secondary', False)
         super(StorageRetryPolicy, self).__init__()
 
-    def _set_next_host_location(self, settings, request):  # pylint: disable=no-self-use
+    def _set_next_host_location(self, settings, request):
         """
         A function which sets the next host location on the request, if applicable.
 
@@ -425,7 +425,7 @@ class StorageRetryPolicy(HTTPPolicy):
             updated = url._replace(netloc=settings['hosts'].get(settings['mode']))
             request.url = updated.geturl()
 
-    def configure_retries(self, request):  # pylint: disable=no-self-use
+    def configure_retries(self, request):
         body_position = None
         if hasattr(request.http_request.body, 'read'):
             try:
@@ -448,7 +448,7 @@ class StorageRetryPolicy(HTTPPolicy):
             'history': []
         }
 
-    def get_backoff_time(self, settings):  # pylint: disable=unused-argument,no-self-use
+    def get_backoff_time(self, settings):  # pylint: disable=unused-argument
         """ Formula for computing the current backoff.
         Should be calculated by child class.
 

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/request_handlers.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/request_handlers.py
@@ -42,9 +42,7 @@ def serialize_iso(attr):
         if utc.tm_year > 9999 or utc.tm_year < 1:
             raise OverflowError("Hit max or min date")
 
-        date = "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}".format(
-            utc.tm_year, utc.tm_mon, utc.tm_mday,
-            utc.tm_hour, utc.tm_min, utc.tm_sec)
+        date = f"{utc.tm_year:04}-{utc.tm_mon:02}-{utc.tm_mday:02}T{utc.tm_hour:02}:{utc.tm_min:02}:{utc.tm_sec:02}"
         return date + 'Z'
     except (ValueError, OverflowError) as err:
         msg = "Unable to serialize datetime object."
@@ -178,7 +176,7 @@ def serialize_batch_body(requests, batch_id):
 
     delimiter_bytes = (_get_batch_request_delimiter(batch_id, True, False) + _HTTP_LINE_ENDING).encode('utf-8')
     newline_bytes = _HTTP_LINE_ENDING.encode('utf-8')
-    batch_body = list()
+    batch_body = []
 
     content_index = 0
     for request in requests:
@@ -237,7 +235,7 @@ def _make_body_from_sub_request(sub_request):
      """
 
     # put the sub-request's headers into a list for efficient str concatenation
-    sub_request_body = list()
+    sub_request_body = []
 
     # get headers for ease of manipulation; remove headers as they are used
     headers = sub_request.headers

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/uploads.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/uploads.py
@@ -3,7 +3,6 @@
 # Licensed under the MIT License. See License.txt in the project root for
 # license information.
 # --------------------------------------------------------------------------
-# pylint: disable=no-self-use
 
 from concurrent import futures
 from io import BytesIO, IOBase, SEEK_CUR, SEEK_END, SEEK_SET, UnsupportedOperation
@@ -268,7 +267,7 @@ class BlockBlobChunkUploader(_ChunkUploader):
 
     def _upload_substream_block(self, index, block_stream):
         try:
-            block_id = f'BlockId{"%05d" % (index/self.chunk_size)}'
+            block_id = f'BlockId{(index/self.chunk_size):05}'
             self.service.stage_block(
                 block_id,
                 len(block_stream),
@@ -592,7 +591,7 @@ class IterStreamer(object):
         count = len(self.leftover)
         try:
             while count < size:
-                chunk = self.__next__()
+                chunk = self.next()
                 if isinstance(chunk, str):
                     chunk = chunk.encode(self.encoding)
                 data += chunk

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/uploads.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/uploads.py
@@ -590,7 +590,7 @@ class IterStreamer(object):
         count = len(self.leftover)
         try:
             while count < size:
-                chunk = self.__next__()
+                chunk = self.__next__()  # pylint: disable=unnecessary-dunder-call
                 if isinstance(chunk, str):
                     chunk = chunk.encode(self.encoding)
                 data += chunk

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/uploads.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/uploads.py
@@ -590,7 +590,7 @@ class IterStreamer(object):
         count = len(self.leftover)
         try:
             while count < size:
-                chunk = self.__next__()  # pylint: disable=unnecessary-dunder-call
+                chunk = self.__next__()
                 if isinstance(chunk, str):
                     chunk = chunk.encode(self.encoding)
                 data += chunk

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/uploads.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/uploads.py
@@ -3,6 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for
 # license information.
 # --------------------------------------------------------------------------
+# pylint: disable=no-self-use
 
 from concurrent import futures
 from io import BytesIO, IOBase, SEEK_CUR, SEEK_END, SEEK_SET, UnsupportedOperation

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/uploads.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/uploads.py
@@ -579,8 +579,6 @@ class IterStreamer(object):
     def __next__(self):
         return next(self.iterator)
 
-    next = __next__  # Python 2 compatibility.
-
     def tell(self, *args, **kwargs):
         raise UnsupportedOperation("Data generator does not support tell.")
 
@@ -592,7 +590,7 @@ class IterStreamer(object):
         count = len(self.leftover)
         try:
             while count < size:
-                chunk = self.next()
+                chunk = self.__next__()
                 if isinstance(chunk, str):
                     chunk = chunk.encode(self.encoding)
                 data += chunk

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/uploads_async.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/uploads_async.py
@@ -28,7 +28,7 @@ async def _async_parallel_uploads(uploader, pending, running):
         range_ids.extend([chunk.result() for chunk in done])
         try:
             for _ in range(0, len(done)):
-                next_chunk = await pending.__anext__()  # pylint: disable=unnecessary-dunder-call
+                next_chunk = await pending.__anext__()
                 running.add(asyncio.ensure_future(uploader(next_chunk)))
         except StopAsyncIteration:
             break
@@ -89,7 +89,7 @@ async def upload_data_chunks(
         running_futures = []
         for _ in range(max_concurrency):
             try:
-                chunk = await upload_tasks.__anext__()  # pylint: disable=unnecessary-dunder-call
+                chunk = await upload_tasks.__anext__()
                 running_futures.append(asyncio.ensure_future(uploader.process_chunk(chunk)))
             except StopAsyncIteration:
                 break
@@ -446,7 +446,7 @@ class AsyncIterStreamer():
         count = len(self.leftover)
         try:
             while count < size:
-                chunk = await self.iterator.__anext__()  # pylint: disable=unnecessary-dunder-call
+                chunk = await self.iterator.__anext__()
                 if isinstance(chunk, str):
                     chunk = chunk.encode(self.encoding)
                 data += chunk

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/uploads_async.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/uploads_async.py
@@ -3,6 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for
 # license information.
 # --------------------------------------------------------------------------
+# pylint: disable=no-self-use
 
 import asyncio
 import inspect

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/uploads_async.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/uploads_async.py
@@ -28,7 +28,7 @@ async def _async_parallel_uploads(uploader, pending, running):
         range_ids.extend([chunk.result() for chunk in done])
         try:
             for _ in range(0, len(done)):
-                next_chunk = await pending.__anext__()
+                next_chunk = await pending.__anext__()  # pylint: disable=unnecessary-dunder-call
                 running.add(asyncio.ensure_future(uploader(next_chunk)))
         except StopAsyncIteration:
             break
@@ -89,7 +89,7 @@ async def upload_data_chunks(
         running_futures = []
         for _ in range(max_concurrency):
             try:
-                chunk = await upload_tasks.__anext__()
+                chunk = await upload_tasks.__anext__()  # pylint: disable=unnecessary-dunder-call
                 running_futures.append(asyncio.ensure_future(uploader.process_chunk(chunk)))
             except StopAsyncIteration:
                 break
@@ -446,7 +446,7 @@ class AsyncIterStreamer():
         count = len(self.leftover)
         try:
             while count < size:
-                chunk = await self.iterator.__anext__()
+                chunk = await self.iterator.__anext__()  # pylint: disable=unnecessary-dunder-call
                 if isinstance(chunk, str):
                     chunk = chunk.encode(self.encoding)
                 data += chunk

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/uploads_async.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/uploads_async.py
@@ -428,7 +428,7 @@ class AsyncIterStreamer():
     File-like streaming object for AsyncGenerators.
     """
     def __init__(self, generator: AsyncGenerator[Union[bytes, str], None], encoding: str = "UTF-8"):
-        self.iterator = generator.aiter()
+        self.iterator = generator.__aiter__()
         self.leftover = b""
         self.encoding = encoding
 

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/uploads_async.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/uploads_async.py
@@ -28,7 +28,7 @@ async def _async_parallel_uploads(uploader, pending, running):
         range_ids.extend([chunk.result() for chunk in done])
         try:
             for _ in range(0, len(done)):
-                next_chunk = await pending.anext()
+                next_chunk = await pending.__anext__()
                 running.add(asyncio.ensure_future(uploader(next_chunk)))
         except StopAsyncIteration:
             break
@@ -89,7 +89,7 @@ async def upload_data_chunks(
         running_futures = []
         for _ in range(max_concurrency):
             try:
-                chunk = await upload_tasks.anext()
+                chunk = await upload_tasks.__anext__()
                 running_futures.append(asyncio.ensure_future(uploader.process_chunk(chunk)))
             except StopAsyncIteration:
                 break
@@ -446,7 +446,7 @@ class AsyncIterStreamer():
         count = len(self.leftover)
         try:
             while count < size:
-                chunk = await self.iterator.anext()
+                chunk = await self.iterator.__anext__()
                 if isinstance(chunk, str):
                     chunk = chunk.encode(self.encoding)
                 data += chunk

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared_access_signature.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared_access_signature.py
@@ -293,7 +293,7 @@ class _BlobSharedAccessHelper(_SharedAccessHelper):
         # a conscious decision was made to exclude the timestamp in the generated token
         # this is to avoid having two snapshot ids in the query parameters when the user appends the snapshot timestamp
         exclude = [BlobQueryStringConstants.SIGNED_TIMESTAMP]
-        return '&'.join(['{0}={1}'.format(n, url_quote(v))
+        return '&'.join([f'{n}={url_quote(v)}'
                          for n, v in self.query_dict.items() if v is not None and n not in exclude])
 
 

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_upload_helpers.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_upload_helpers.py
@@ -3,7 +3,6 @@
 # Licensed under the MIT License. See License.txt in the project root for
 # license information.
 # --------------------------------------------------------------------------
-# pylint: disable=no-self-use
 
 from io import SEEK_SET, UnsupportedOperation
 from typing import TypeVar, TYPE_CHECKING
@@ -217,8 +216,8 @@ def upload_page_blob(
         if length is None or length < 0:
             raise ValueError("A content length must be specified for a Page Blob.")
         if length % 512 != 0:
-            raise ValueError("Invalid page blob size: {0}. "
-                             "The size must be aligned to a 512-byte boundary.".format(length))
+            raise ValueError(f"Invalid page blob size: {length}. "
+                             "The size must be aligned to a 512-byte boundary.")
         tier = None
         if kwargs.get('premium_page_blob_tier'):
             premium_page_blob_tier = kwargs.pop('premium_page_blob_tier')

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/aio/__init__.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/aio/__init__.py
@@ -128,7 +128,7 @@ async def download_blob_from_url(
             await _download_to_stream(client, output, **kwargs)
         else:
             if not overwrite and os.path.isfile(output):
-                raise ValueError("The file '{}' already exists.".format(output))
+                raise ValueError(f"The file '{output}' already exists.")
             with open(output, 'wb') as file_handle:
                 await _download_to_stream(client, file_handle, **kwargs)
 

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_blob_client_async.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_blob_client_async.py
@@ -2908,7 +2908,7 @@ class BlobClient(AsyncStorageAccountHostsMixin, BlobClientBase, StorageEncryptio
         else:
             _pipeline = self._pipeline  # pylint: disable = protected-access
         return ContainerClient(
-            "{}://{}".format(self.scheme, self.primary_hostname), container_name=self.container_name,
+            f"{self.scheme}://{self.primary_hostname}", container_name=self.container_name,
             credential=self._raw_credential, api_version=self.api_version, _configuration=self._config,
             _pipeline=_pipeline, _location_mode=self._location_mode, _hosts=self._hosts,
             require_encryption=self.require_encryption, encryption_version=self.encryption_version,

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_container_client_async.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_container_client_async.py
@@ -213,7 +213,7 @@ class ContainerClient(AsyncStorageAccountHostsMixin, ContainerClientBase, Storag
             kwargs['source_lease_id'] = lease
         try:
             renamed_container = ContainerClient(
-                "{}://{}".format(self.scheme, self.primary_hostname), container_name=new_name,
+                f"{self.scheme}://{self.primary_hostname}", container_name=new_name,
                 credential=self.credential, api_version=self.api_version, _configuration=self._config,
                 _pipeline=self._pipeline, _location_mode=self._location_mode, _hosts=self._hosts,
                 require_encryption=self.require_encryption, encryption_version=self.encryption_version,
@@ -511,7 +511,7 @@ class ContainerClient(AsyncStorageAccountHostsMixin, ContainerClientBase, Storag
         else:
             _pipeline = self._pipeline  # pylint: disable = protected-access
         return BlobServiceClient(
-            "{}://{}".format(self.scheme, self.primary_hostname),
+            f"{self.scheme}://{self.primary_hostname}",
             credential=self._raw_credential, api_version=self.api_version, _configuration=self._config,
             _location_mode=self._location_mode, _hosts=self._hosts, require_encryption=self.require_encryption,
             encryption_version=self.encryption_version, key_encryption_key=self.key_encryption_key,
@@ -1247,7 +1247,7 @@ class ContainerClient(AsyncStorageAccountHostsMixin, ContainerClientBase, Storag
                 :caption: Deleting multiple blobs.
         """
         if len(blobs) == 0:
-            return iter(list())
+            return iter([])
 
         reqs, options = self._generate_delete_blobs_options(*blobs, **kwargs)
 

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_download_async.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_download_async.py
@@ -297,11 +297,7 @@ class StorageStreamDownloader(Generic[T]):  # pylint: disable=too-many-instance-
         self.properties.size = self.size
 
         # Overwrite the content range to the user requested range
-        self.properties.content_range = 'bytes {0}-{1}/{2}'.format(
-            self._start_range,
-            self._end_range,
-            self._file_size
-        )
+        self.properties.content_range = f'bytes {self._start_range}-{self._end_range}/{self._file_size}'
 
         # Overwrite the content MD5 as it is the MD5 for the last range instead
         # of the stored MD5
@@ -377,8 +373,8 @@ class StorageStreamDownloader(Generic[T]):  # pylint: disable=too-many-instance-
                         data_stream_total=0,
                         download_stream_current=0,
                         **self._request_options)
-                except HttpResponseError as error:
-                    process_storage_error(error)
+                except HttpResponseError as e:
+                    process_storage_error(e)
 
                 # Set the download size to empty
                 self.size = 0

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_upload_helpers.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_upload_helpers.py
@@ -3,7 +3,6 @@
 # Licensed under the MIT License. See License.txt in the project root for
 # license information.
 # --------------------------------------------------------------------------
-# pylint: disable=no-self-use
 
 import inspect
 from io import SEEK_SET, UnsupportedOperation
@@ -194,8 +193,8 @@ async def upload_page_blob(
         if length is None or length < 0:
             raise ValueError("A content length must be specified for a Page Blob.")
         if length % 512 != 0:
-            raise ValueError("Invalid page blob size: {0}. "
-                             "The size must be aligned to a 512-byte boundary.".format(length))
+            raise ValueError(f"Invalid page blob size: {length}. "
+                             "The size must be aligned to a 512-byte boundary.")
         tier = None
         if kwargs.get('premium_page_blob_tier'):
             premium_page_blob_tier = kwargs.pop('premium_page_blob_tier')

--- a/sdk/storage/azure-storage-blob/setup.py
+++ b/sdk/storage/azure-storage-blob/setup.py
@@ -27,7 +27,7 @@ try:
     try:
         ver = azure.storage.__version__
         raise Exception(
-            'This package is incompatible with azure-storage=={}. '.format(ver) +
+            f'This package is incompatible with azure-storage=={ver}. ' +
             ' Uninstall it with "pip uninstall azure-storage".'
         )
     except AttributeError:
@@ -47,7 +47,7 @@ setup(
     name=PACKAGE_NAME,
     version=version,
     include_package_data=True,
-    description='Microsoft {} Client Library for Python'.format(PACKAGE_PPRINT_NAME),
+    description=f'Microsoft {PACKAGE_PPRINT_NAME} Client Library for Python',
     long_description=open('README.md', 'r').read(),
     long_description_content_type='text/markdown',
     license='MIT License',


### PR DESCRIPTION
This PR aims to get ahead of the next_pylint changes coming 7/7. This starts the work with the Blob package.

Callouts:

- Running into a `no-member` Pylint error on libraries like `os`, so disabling for now in `pylintrc`(not sure if this will come up in pipeline/want to commit this in our config or not)
- Pylintrc lint errors will probably go away when we get the new pipeline + new pylintrc
- Some false positive `unncessary-dunder-call` since we add extra functionality to our homerolled calls
- `no-self-use` is going away in new pipeline, but have to leave it here for current Pylint step

```
************* Module C:\azure-sdk-for-python\pylintrc
C:\azure-sdk-for-python\pylintrc:1: [E0015(unrecognized-option), ] Unrecognized option found: module-name-hint, const-name-hint, class-name-hint, class-attribute-name-hint, attr-name-hint, method-name-hint, function-name-hint, argument-name-hint, variable-name-hint, inlinevar-name-hint
C:\azure-sdk-for-python\pylintrc:1: [R0022(useless-option-value), ] Useless option value for '--disable', 'bad-continuation' was removed from pylint, see https://github.com/PyCQA/pylint/pull/3571.
C:\azure-sdk-for-python\pylintrc:1: [W0012(unknown-option-value), ] Unknown option value for '--disable', expected a valid pylint message and got 'check-docstrings'
C:\azure-sdk-for-python\pylintrc:1: [W0012(unknown-option-value), ] Unknown option value for '--disable', expected a valid pylint message and got 'ignored-arguments-name'
C:\azure-sdk-for-python\pylintrc:1: [W0012(unknown-option-value), ] Unknown option value for '--disable', expected a valid pylint message and got 'empty-comment'
************* Module azure.storage.blob._blob_client
azure\storage\blob\_blob_client.py:6: [R0022(useless-option-value), ] Useless option value for 'disable', 'no-self-use' was moved to an optional extension, see https://pylint.pycqa.org/en/latest/whatsnew/2/2.14/summary.html#removed-checkers.        
************* Module azure.storage.blob._encryption
azure\storage\blob\_encryption.py:668: [E1101(no-member), encrypt_blob] Module 'os' has no 'urandom' member
azure\storage\blob\_encryption.py:669: [E1101(no-member), encrypt_blob] Module 'os' has no 'urandom' member
azure\storage\blob\_encryption.py:683: [E1101(no-member), encrypt_blob] Module 'os' has no 'urandom' member
azure\storage\blob\_encryption.py:717: [E1101(no-member), generate_blob_encryption_data] Module 'os' has no 'urandom' member
azure\storage\blob\_encryption.py:720: [E1101(no-member), generate_blob_encryption_data] Module 'os' has no 'urandom' member
azure\storage\blob\_encryption.py:897: [E1101(no-member), encrypt_queue_message] Module 'os' has no 'urandom' member
azure\storage\blob\_encryption.py:898: [E1101(no-member), encrypt_queue_message] Module 'os' has no 'urandom' member
azure\storage\blob\_encryption.py:912: [E1101(no-member), encrypt_queue_message] Module 'os' has no 'urandom' member
azure\storage\blob\_encryption.py:916: [E1101(no-member), encrypt_queue_message] Module 'os' has no 'urandom' member
************* Module azure.storage.blob
azure\storage\blob\__init__.py:181: [E1101(no-member), download_blob_from_url] Module 'os' has no 'path' member
************* Module azure.storage.blob.aio
azure\storage\blob\aio\__init__.py:130: [E1101(no-member), download_blob_from_url] Module 'os' has no 'path' member
************* Module azure.storage.blob._shared.policies
azure\storage\blob\_shared\policies.py:410: [R0022(useless-option-value), ] Useless option value for 'disable', 'no-self-use' was moved to an optional extension, see https://pylint.pycqa.org/en/latest/whatsnew/2/2.14/summary.html#removed-checkers.  
azure\storage\blob\_shared\policies.py:428: [R0022(useless-option-value), ] Useless option value for 'disable', 'no-self-use' was moved to an optional extension, see https://pylint.pycqa.org/en/latest/whatsnew/2/2.14/summary.html#removed-checkers.  
azure\storage\blob\_shared\policies.py:451: [R0022(useless-option-value), ] Useless option value for 'disable', 'no-self-use' was moved to an optional extension, see https://pylint.pycqa.org/en/latest/whatsnew/2/2.14/summary.html#removed-checkers.  
************* Module azure.storage.blob._shared.request_handlers
azure\storage\blob\_shared\request_handlers.py:73: [E1101(no-member), get_length] Module 'stat' has no 'S_ISREG' member
azure\storage\blob\_shared\request_handlers.py:73: [E1101(no-member), get_length] Module 'stat' has no 'S_ISLNK' member
************* Module azure.storage.blob._shared.uploads
azure\storage\blob\_shared\uploads.py:6: [R0022(useless-option-value), ] Useless option value for 'disable', 'no-self-use' was moved to an optional extension, see https://pylint.pycqa.org/en/latest/whatsnew/2/2.14/summary.html#removed-checkers.     
************* Module azure.storage.blob._shared.uploads_async
azure\storage\blob\_shared\uploads_async.py:6: [R0022(useless-option-value), ] Useless option value for 'disable', 'no-self-use' was moved to an optional extension, see https://pylint.pycqa.org/en/latest/whatsnew/2/2.14/summary.html#removed-checkers.
************* Module azure.storage.blob._shared.avro.datafile
azure\storage\blob\_shared\avro\datafile.py:210: [E1101(no-member), DataFileReader._read_block_header] Module 'io' has no 'BytesIO' member
************* Module azure.storage.blob._shared.avro.schema
azure\storage\blob\_shared\avro\schema.py:143: [E1101(no-member), Schema] Module 'abc' has no 'ABCMeta' member
azure\storage\blob\_shared\avro\schema.py:201: [E1101(no-member), Schema.to_json] Module 'abc' has no 'abstractmethod' member
azure\storage\blob\_shared\avro\schema.py:449: [E1101(no-member), NamedSchema.to_json] Module 'abc' has no 'abstractmethod' member
```