### PR TITLE
Fix url_join with double query parameters

### DIFF
--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fix url building for some complex query parameters scenarios  #30707
+
 ### Other Changes
 
 ## 1.27.0 (2023-06-01)

--- a/sdk/core/azure-core/azure/core/pipeline/transport/_base.py
+++ b/sdk/core/azure-core/azure/core/pipeline/transport/_base.py
@@ -108,14 +108,20 @@ def _urljoin(base_url: str, stub_url: str) -> str:
     :rtype: str
     """
     parsed_base_url = urlparse(base_url)
-    parsed_stub_url = urlparse(stub_url)
+
+    # Can't use "urlparse" on a partial url, we get incorrect parsing for things like
+    # document:build?format=html&api-version=2019-05-01
+    split_url = stub_url.split("?", 1)
+    stub_url_path = split_url.pop(0)
+    stub_url_query = split_url.pop() if split_url else None
+
     # Note that _replace is a public API named that way to avoid to avoid conflicts in namedtuple
     # https://docs.python.org/3/library/collections.html?highlight=namedtuple#collections.namedtuple
     parsed_base_url = parsed_base_url._replace(
-        path=parsed_base_url.path.rstrip("/") + "/" + parsed_stub_url.path,
+        path=parsed_base_url.path.rstrip("/") + "/" + stub_url_path,
     )
-    if parsed_stub_url.query:
-        query_params = [parsed_stub_url.query]
+    if stub_url_query:
+        query_params = [stub_url_query]
         if parsed_base_url.query:
             query_params.insert(0, parsed_base_url.query)
         parsed_base_url = parsed_base_url._replace(query="&".join(query_params))

--- a/sdk/core/azure-core/azure/core/pipeline/transport/_base.py
+++ b/sdk/core/azure-core/azure/core/pipeline/transport/_base.py
@@ -107,21 +107,19 @@ def _urljoin(base_url: str, stub_url: str) -> str:
     :returns: The updated URL.
     :rtype: str
     """
-    parsed_based_url = urlparse(base_url)
+    parsed_base_url = urlparse(base_url)
     parsed_stub_url = urlparse(stub_url)
     # Note that _replace is a public API named that way to avoid to avoid conflicts in namedtuple
     # https://docs.python.org/3/library/collections.html?highlight=namedtuple#collections.namedtuple
-    parsed_based_url = parsed_based_url._replace(
-        path=parsed_based_url.path.rstrip("/") + "/" + parsed_stub_url.path,
+    parsed_base_url = parsed_base_url._replace(
+        path=parsed_base_url.path.rstrip("/") + "/" + parsed_stub_url.path,
     )
     if parsed_stub_url.query:
         query_params = [parsed_stub_url.query]
-        if parsed_based_url.query:
-            query_params.insert(0, parsed_based_url.query)
-        parsed_based_url = parsed_based_url._replace(
-            query="&".join(query_params)
-        )
-    return parsed_based_url.geturl()
+        if parsed_base_url.query:
+            query_params.insert(0, parsed_base_url.query)
+        parsed_base_url = parsed_base_url._replace(query="&".join(query_params))
+    return parsed_base_url.geturl()
 
 
 class HttpTransport(AbstractContextManager, abc.ABC, Generic[HTTPRequestType, HTTPResponseType]):

--- a/sdk/core/azure-core/tests/test_basic_transport.py
+++ b/sdk/core/azure-core/tests/test_basic_transport.py
@@ -130,6 +130,9 @@ def test_url_join(http_request):
     assert _urljoin("devstoreaccount1", "testdir/") == "devstoreaccount1/testdir/"
     assert _urljoin("devstoreaccount1/", "") == "devstoreaccount1/"
     assert _urljoin("devstoreaccount1/", "testdir/") == "devstoreaccount1/testdir/"
+    assert _urljoin("devstoreaccount1?a=1", "testdir/") == "devstoreaccount1/testdir/?a=1"
+    assert _urljoin("devstoreaccount1", "testdir/?b=2") == "devstoreaccount1/testdir/?b=2"
+    assert _urljoin("devstoreaccount1?a=1", "testdir/?b=2") == "devstoreaccount1/testdir/?a=1&b=2"
 
 
 @pytest.mark.parametrize("http_request,http_response", request_and_responses_product(HTTP_CLIENT_TRANSPORT_RESPONSES))

--- a/sdk/core/azure-core/tests/test_basic_transport.py
+++ b/sdk/core/azure-core/tests/test_basic_transport.py
@@ -133,6 +133,7 @@ def test_url_join(http_request):
     assert _urljoin("devstoreaccount1?a=1", "testdir/") == "devstoreaccount1/testdir/?a=1"
     assert _urljoin("devstoreaccount1", "testdir/?b=2") == "devstoreaccount1/testdir/?b=2"
     assert _urljoin("devstoreaccount1?a=1", "testdir/?b=2") == "devstoreaccount1/testdir/?a=1&b=2"
+    assert _urljoin("devstoreaccount1", "documentModels:build") == "devstoreaccount1/documentModels:build"
 
 
 @pytest.mark.parametrize("http_request,http_response", request_and_responses_product(HTTP_CLIENT_TRANSPORT_RESPONSES))

--- a/sdk/core/azure-core/tests/test_pipeline.py
+++ b/sdk/core/azure-core/tests/test_pipeline.py
@@ -196,7 +196,7 @@ def test_format_url_no_base_url():
     assert formatted == "https://google.com/subpath/bar"
 
 
-def test_format_url_double_queury():
+def test_format_url_double_query():
     client = PipelineClientBase("https://bing.com/path?query=testvalue&x=2ndvalue")
     formatted = client.format_url("/subpath?a=X&c=Y")
     assert formatted == "https://bing.com/path/subpath?query=testvalue&x=2ndvalue&a=X&c=Y"

--- a/sdk/core/azure-core/tests/test_pipeline.py
+++ b/sdk/core/azure-core/tests/test_pipeline.py
@@ -196,6 +196,12 @@ def test_format_url_no_base_url():
     assert formatted == "https://google.com/subpath/bar"
 
 
+def test_format_url_double_queury():
+    client = PipelineClientBase("https://bing.com/path?query=testvalue&x=2ndvalue")
+    formatted = client.format_url("/subpath?a=X&c=Y")
+    assert formatted == "https://bing.com/path/subpath?query=testvalue&x=2ndvalue&a=X&c=Y"
+
+
 def test_format_incorrect_endpoint():
     # https://github.com/Azure/azure-sdk-for-python/pull/12106
     client = PipelineClientBase("{Endpoint}/text/analytics/v3.0")


### PR DESCRIPTION
Fix #28918 

Not the way I would have designed the whole thing top to bottom, but given the current investement into making `format_url` handle the entire set of possible mergeable url input, it's more consistent to fix the bug there.