### PR TITLE
Allow exporter to use OTel 1.15-1.18

### DIFF
--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Features Added
 
+- Upgrading to OpenTelemetry SDK/API 1.18.
+    ([#30611](https://github.com/Azure/azure-sdk-for-python/pull/30611))
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/setup.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/setup.py
@@ -84,8 +84,8 @@ setup(
         "azure-core<2.0.0,>=1.23.0",
         "fixedint==0.1.6",
         "msrest>=0.6.10",
-        "opentelemetry-api==1.17.0",
-        "opentelemetry-sdk==1.17.0",
+        "opentelemetry-api==1.18.0",
+        "opentelemetry-sdk==1.18.0",
         "importlib-metadata~=6.0.0; python_version < '3.8'"
     ],
     entry_points={

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/setup.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/setup.py
@@ -84,8 +84,8 @@ setup(
         "azure-core<2.0.0,>=1.23.0",
         "fixedint==0.1.6",
         "msrest>=0.6.10",
-        "opentelemetry-api==1.18.0",
-        "opentelemetry-sdk==1.18.0",
+        "opentelemetry-api>=1.15.0,<=1.18.0",
+        "opentelemetry-sdk>=1.15.0,<=1.18.0",
         "importlib-metadata~=6.0.0; python_version < '3.8'"
     ],
     entry_points={


### PR DESCRIPTION
# Description

Follow up to this PR. Though, we should not use "~=" to avoid breaking changes from instability, I realized that there is not a reason to not loosen the versioning in between breaking changes.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
