### PR TITLE
[Storage] [Next-Pylint] Datalake Package

### DIFF
--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_data_lake_directory_client.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_data_lake_directory_client.py
@@ -378,14 +378,11 @@ class DataLakeDirectoryClient(PathClient):
         new_file_system, new_path, new_dir_sas = self._parse_rename_path(new_name)
 
         new_directory_client = DataLakeDirectoryClient(
-            "{}://{}".format(self.scheme, self.primary_hostname), new_file_system, directory_name=new_path,
-            credential=self._raw_credential or new_dir_sas,
-            _hosts=self._hosts, _configuration=self._config, _pipeline=self._pipeline)
+            f"{self.scheme}://{self.primary_hostname}", new_file_system, directory_name=new_path,
+            credential=self._raw_credential or new_dir_sas, _hosts=self._hosts, _configuration=self._config,
+            _pipeline=self._pipeline)
         new_directory_client._rename_path(  # pylint: disable=protected-access
-            '/{}/{}{}'.format(quote(unquote(self.file_system_name)),
-                              quote(unquote(self.path_name)),
-                              self._query_str),
-            **kwargs)
+            f'/{quote(unquote(self.file_system_name))}/{quote(unquote(self.path_name))}{self._query_str}', **kwargs)
         return new_directory_client
 
     def create_sub_directory(self, sub_directory,  # type: Union[DirectoryProperties, str]

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_data_lake_file_client.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_data_lake_file_client.py
@@ -361,7 +361,7 @@ class DataLakeFileClient(PathClient):
         elif hasattr(data, '__aiter__'):
             stream = AsyncIterStreamer(data, encoding=encoding)
         else:
-            raise TypeError("Unsupported data type: {}".format(type(data)))
+            raise TypeError(f"Unsupported data type: {type(data)}")
 
         validate_content = kwargs.pop('validate_content', False)
         content_settings = kwargs.pop('content_settings', None)
@@ -838,16 +838,13 @@ class DataLakeFileClient(PathClient):
         new_file_system, new_path, new_file_sas = self._parse_rename_path(new_name)
 
         new_file_client = DataLakeFileClient(
-            "{}://{}".format(self.scheme, self.primary_hostname), new_file_system, file_path=new_path,
+            f"{self.scheme}://{self.primary_hostname}", new_file_system, file_path=new_path,
             credential=self._raw_credential or new_file_sas,
             _hosts=self._hosts, _configuration=self._config, _pipeline=self._pipeline,
             _location_mode=self._location_mode
         )
         new_file_client._rename_path(  # pylint: disable=protected-access
-            '/{}/{}{}'.format(quote(unquote(self.file_system_name)),
-                              quote(unquote(self.path_name)),
-                              self._query_str),
-            **kwargs)
+            f'/{quote(unquote(self.file_system_name))}/{quote(unquote(self.path_name))}{self._query_str}', **kwargs)
         return new_file_client
 
     def query_file(self, query_expression, **kwargs):

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_data_lake_service_client.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_data_lake_service_client.py
@@ -85,7 +85,7 @@ class DataLakeServiceClient(StorageAccountHostsMixin):
             raise ValueError("Account URL must be a string.")
         parsed_url = urlparse(account_url.rstrip('/'))
         if not parsed_url.netloc:
-            raise ValueError("Invalid URL: {}".format(account_url))
+            raise ValueError(f"Invalid URL: {account_url}")
 
         blob_account_url = convert_dfs_url_to_blob_url(account_url)
         self._blob_account_url = blob_account_url
@@ -121,7 +121,7 @@ class DataLakeServiceClient(StorageAccountHostsMixin):
     def _format_url(self, hostname):
         """Format the endpoint URL according to hostname
         """
-        formated_url = "{}://{}/{}".format(self.scheme, hostname, self._query_str)
+        formated_url = f"{self.scheme}://{hostname}/{self._query_str}"
         return formated_url
 
     @classmethod

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_file_system_client.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_file_system_client.py
@@ -86,7 +86,7 @@ class FileSystemClient(StorageAccountHostsMixin):
         if not file_system_name:
             raise ValueError("Please specify a file system name.")
         if not parsed_url.netloc:
-            raise ValueError("Invalid URL: {}".format(account_url))
+            raise ValueError(f"Invalid URL: {account_url}")
 
         blob_account_url = convert_dfs_url_to_blob_url(account_url)
         # TODO: add self.account_url to base_client and remove _blob_account_url
@@ -122,11 +122,7 @@ class FileSystemClient(StorageAccountHostsMixin):
         file_system_name = self.file_system_name
         if isinstance(file_system_name, str):
             file_system_name = file_system_name.encode('UTF-8')
-        return "{}://{}/{}{}".format(
-            self.scheme,
-            hostname,
-            quote(file_system_name),
-            self._query_str)
+        return f"{self.scheme}://{hostname}/{quote(file_system_name)}{self._query_str}"
 
     def __exit__(self, *args):
         self._container_client.close()
@@ -323,7 +319,7 @@ class FileSystemClient(StorageAccountHostsMixin):
         self._container_client._rename_container(new_name, **kwargs)   # pylint: disable=protected-access
         #TODO: self._raw_credential would not work with SAS tokens
         renamed_file_system = FileSystemClient(
-                "{}://{}".format(self.scheme, self.primary_hostname), file_system_name=new_name,
+                f"{self.scheme}://{self.primary_hostname}", file_system_name=new_name,
                 credential=self._raw_credential, api_version=self.api_version, _configuration=self._config,
                 _pipeline=self._pipeline, _location_mode=self._location_mode, _hosts=self._hosts)
         return renamed_file_system
@@ -877,7 +873,7 @@ class FileSystemClient(StorageAccountHostsMixin):
         except IndexError:
             url = url_and_token[0] + '/' + quoted_path
 
-        undelete_source = quoted_path + '?deletionid={}'.format(deletion_id) if deletion_id else None
+        undelete_source = quoted_path + f'?deletionid={deletion_id}' if deletion_id else None
 
         return quoted_path, url, undelete_source
 

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_models.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_models.py
@@ -992,7 +992,7 @@ class AnalyticsLogging(GenLogging):
     """
 
     def __init__(self, **kwargs):
-        self.version = kwargs.get('version', u'1.0')
+        self.version = kwargs.get('version', '1.0')
         self.delete = kwargs.get('delete', False)
         self.read = kwargs.get('read', False)
         self.write = kwargs.get('write', False)
@@ -1027,7 +1027,7 @@ class Metrics(GenMetrics):
     """
 
     def __init__(self, **kwargs):
-        self.version = kwargs.get('version', u'1.0')
+        self.version = kwargs.get('version', '1.0')
         self.enabled = kwargs.get('enabled', False)
         self.include_apis = kwargs.get('include_apis')
         self.retention_policy = kwargs.get('retention_policy') or RetentionPolicy()

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_path_client.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_path_client.py
@@ -78,7 +78,7 @@ class PathClient(StorageAccountHostsMixin):
         if not (file_system_name and path_name):
             raise ValueError("Please specify a file system name and file path.")
         if not parsed_url.netloc:
-            raise ValueError("Invalid URL: {}".format(account_url))
+            raise ValueError(f"Invalid URL: {account_url}")
 
         blob_account_url = convert_dfs_url_to_blob_url(account_url)
         self._blob_account_url = blob_account_url
@@ -131,12 +131,8 @@ class PathClient(StorageAccountHostsMixin):
         file_system_name = self.file_system_name
         if isinstance(file_system_name, str):
             file_system_name = file_system_name.encode('UTF-8')
-        return "{}://{}/{}/{}{}".format(
-            self.scheme,
-            hostname,
-            quote(file_system_name),
-            quote(self.path_name, safe='~'),
-            self._query_str)
+        return (f"{self.scheme}://{hostname}/{quote(file_system_name)}/"
+                f"{quote(self.path_name, safe='~')}{self._query_str}")
 
     def _create_path_options(self, resource_type,
                              content_settings=None,  # type: Optional[ContentSettings]

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_serialize.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_serialize.py
@@ -37,7 +37,7 @@ def get_api_version(kwargs):
     api_version = kwargs.get('api_version', None)
     if api_version and api_version not in _SUPPORTED_API_VERSIONS:
         versions = '\n'.join(_SUPPORTED_API_VERSIONS)
-        raise ValueError("Unsupported API version '{}'. Please select from:\n{}".format(api_version, versions))
+        raise ValueError(f"Unsupported API version '{api_version}'. Please select from:\n{versions}")
     return api_version or _SUPPORTED_API_VERSIONS[-1]
 
 
@@ -49,15 +49,14 @@ def convert_datetime_to_rfc1123(date):
     weekday = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"][date.weekday()]
     month = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep",
              "Oct", "Nov", "Dec"][date.month - 1]
-    return "%s, %02d %s %04d %02d:%02d:%02d GMT" % (weekday, date.day, month,
-                                                    date.year, date.hour, date.minute, date.second)
+    return f"{weekday}, {date.day:02} {month} {date.year:04} {date.hour:02}:{date.minute:02}:{date.second:02} GMT"
 
 
 def add_metadata_headers(metadata=None):
     # type: (Optional[Dict[str, str]]) -> str
     if not metadata:
         return None
-    headers = list()
+    headers = []
     if metadata:
         for key, value in metadata.items():
             headers.append(key + '=')

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/authentication.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/authentication.py
@@ -40,7 +40,7 @@ def _storage_header_sort(input_headers: List[Tuple[str, str]]) -> List[Tuple[str
     custom_weights = "-!#$%&*.^_|~+\"\'(),/`~0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[]abcdefghijklmnopqrstuvwxyz{}"
 
     # Build dict of tuples and list of keys
-    header_dict = dict()
+    header_dict = {}
     header_keys = []
     for k, v in input_headers:
         header_dict[k] = v

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/request_handlers.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/request_handlers.py
@@ -42,9 +42,7 @@ def serialize_iso(attr):
         if utc.tm_year > 9999 or utc.tm_year < 1:
             raise OverflowError("Hit max or min date")
 
-        date = "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}".format(
-            utc.tm_year, utc.tm_mon, utc.tm_mday,
-            utc.tm_hour, utc.tm_min, utc.tm_sec)
+        date = f"{utc.tm_year:04}-{utc.tm_mon:02}-{utc.tm_mday:02}T{utc.tm_hour:02}:{utc.tm_min:02}:{utc.tm_sec:02}"
         return date + 'Z'
     except (ValueError, OverflowError) as err:
         msg = "Unable to serialize datetime object."
@@ -178,7 +176,7 @@ def serialize_batch_body(requests, batch_id):
 
     delimiter_bytes = (_get_batch_request_delimiter(batch_id, True, False) + _HTTP_LINE_ENDING).encode('utf-8')
     newline_bytes = _HTTP_LINE_ENDING.encode('utf-8')
-    batch_body = list()
+    batch_body = []
 
     content_index = 0
     for request in requests:
@@ -237,7 +235,7 @@ def _make_body_from_sub_request(sub_request):
      """
 
     # put the sub-request's headers into a list for efficient str concatenation
-    sub_request_body = list()
+    sub_request_body = []
 
     # get headers for ease of manipulation; remove headers as they are used
     headers = sub_request.headers

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/uploads.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/uploads.py
@@ -268,7 +268,7 @@ class BlockBlobChunkUploader(_ChunkUploader):
 
     def _upload_substream_block(self, index, block_stream):
         try:
-            block_id = f'BlockId{"%05d" % (index/self.chunk_size)}'
+            block_id = f'BlockId{(index/self.chunk_size):05}'
             self.service.stage_block(
                 block_id,
                 len(block_stream),
@@ -578,8 +578,6 @@ class IterStreamer(object):
 
     def __next__(self):
         return next(self.iterator)
-
-    next = __next__  # Python 2 compatibility.
 
     def tell(self, *args, **kwargs):
         raise UnsupportedOperation("Data generator does not support tell.")

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/uploads.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/uploads.py
@@ -590,7 +590,7 @@ class IterStreamer(object):
         count = len(self.leftover)
         try:
             while count < size:
-                chunk = self.__next__()
+                chunk = self.__next__()  # pylint: disable=unnecessary-dunder-call
                 if isinstance(chunk, str):
                     chunk = chunk.encode(self.encoding)
                 data += chunk

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/uploads.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/uploads.py
@@ -590,7 +590,7 @@ class IterStreamer(object):
         count = len(self.leftover)
         try:
             while count < size:
-                chunk = self.__next__()  # pylint: disable=unnecessary-dunder-call
+                chunk = self.__next__()
                 if isinstance(chunk, str):
                     chunk = chunk.encode(self.encoding)
                 data += chunk

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/uploads_async.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/uploads_async.py
@@ -294,7 +294,7 @@ class BlockBlobChunkUploader(_ChunkUploader):
 
     async def _upload_substream_block(self, index, block_stream):
         try:
-            block_id = f'BlockId{"%05d" % (index/self.chunk_size)}'
+            block_id = f'BlockId{(index/self.chunk_size):05}'
             await self.service.stage_block(
                 block_id,
                 len(block_stream),

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/uploads_async.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/uploads_async.py
@@ -28,7 +28,7 @@ async def _async_parallel_uploads(uploader, pending, running):
         range_ids.extend([chunk.result() for chunk in done])
         try:
             for _ in range(0, len(done)):
-                next_chunk = await pending.__anext__()  # pylint: disable=unnecessary-dunder-call
+                next_chunk = await pending.__anext__()
                 running.add(asyncio.ensure_future(uploader(next_chunk)))
         except StopAsyncIteration:
             break
@@ -89,7 +89,7 @@ async def upload_data_chunks(
         running_futures = []
         for _ in range(max_concurrency):
             try:
-                chunk = await upload_tasks.__anext__()  # pylint: disable=unnecessary-dunder-call
+                chunk = await upload_tasks.__anext__()
                 running_futures.append(asyncio.ensure_future(uploader.process_chunk(chunk)))
             except StopAsyncIteration:
                 break
@@ -446,7 +446,7 @@ class AsyncIterStreamer():
         count = len(self.leftover)
         try:
             while count < size:
-                chunk = await self.iterator.__anext__()  # pylint: disable=unnecessary-dunder-call
+                chunk = await self.iterator.__anext__()
                 if isinstance(chunk, str):
                     chunk = chunk.encode(self.encoding)
                 data += chunk

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/uploads_async.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/uploads_async.py
@@ -28,7 +28,7 @@ async def _async_parallel_uploads(uploader, pending, running):
         range_ids.extend([chunk.result() for chunk in done])
         try:
             for _ in range(0, len(done)):
-                next_chunk = await pending.__anext__()
+                next_chunk = await pending.__anext__()  # pylint: disable=unnecessary-dunder-call
                 running.add(asyncio.ensure_future(uploader(next_chunk)))
         except StopAsyncIteration:
             break
@@ -89,7 +89,7 @@ async def upload_data_chunks(
         running_futures = []
         for _ in range(max_concurrency):
             try:
-                chunk = await upload_tasks.__anext__()
+                chunk = await upload_tasks.__anext__()  # pylint: disable=unnecessary-dunder-call
                 running_futures.append(asyncio.ensure_future(uploader.process_chunk(chunk)))
             except StopAsyncIteration:
                 break
@@ -446,7 +446,7 @@ class AsyncIterStreamer():
         count = len(self.leftover)
         try:
             while count < size:
-                chunk = await self.iterator.__anext__()
+                chunk = await self.iterator.__anext__()  # pylint: disable=unnecessary-dunder-call
                 if isinstance(chunk, str):
                     chunk = chunk.encode(self.encoding)
                 data += chunk

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/aio/_data_lake_directory_client_async.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/aio/_data_lake_directory_client_async.py
@@ -347,14 +347,11 @@ class DataLakeDirectoryClient(PathClient, DataLakeDirectoryClientBase):
         new_file_system, new_path, new_dir_sas = self._parse_rename_path(new_name)
 
         new_directory_client = DataLakeDirectoryClient(
-            "{}://{}".format(self.scheme, self.primary_hostname), new_file_system, directory_name=new_path,
+            f"{self.scheme}://{self.primary_hostname}", new_file_system, directory_name=new_path,
             credential=self._raw_credential or new_dir_sas,
             _hosts=self._hosts, _configuration=self._config, _pipeline=self._pipeline)
         await new_directory_client._rename_path(  # pylint: disable=protected-access
-            '/{}/{}{}'.format(quote(unquote(self.file_system_name)),
-                              quote(unquote(self.path_name)),
-                              self._query_str),
-            **kwargs)
+            f'/{quote(unquote(self.file_system_name))}/{quote(unquote(self.path_name))}{self._query_str}', **kwargs)
         return new_directory_client
 
     async def create_sub_directory(self, sub_directory,  # type: Union[DirectoryProperties, str]

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/aio/_data_lake_file_client_async.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/aio/_data_lake_file_client_async.py
@@ -683,13 +683,10 @@ class DataLakeFileClient(PathClient, DataLakeFileClientBase):
         new_file_system, new_path, new_file_sas = self._parse_rename_path(new_name)
 
         new_file_client = DataLakeFileClient(
-            "{}://{}".format(self.scheme, self.primary_hostname), new_file_system, file_path=new_path,
+            f"{self.scheme}://{self.primary_hostname}", new_file_system, file_path=new_path,
             credential=self._raw_credential or new_file_sas,
             _hosts=self._hosts, _configuration=self._config, _pipeline=self._pipeline,
             _location_mode=self._location_mode)
         await new_file_client._rename_path(  # pylint: disable=protected-access
-            '/{}/{}{}'.format(quote(unquote(self.file_system_name)),
-                              quote(unquote(self.path_name)),
-                              self._query_str),
-            **kwargs)
+            f'/{quote(unquote(self.file_system_name))}/{quote(unquote(self.path_name))}{self._query_str}', **kwargs)
         return new_file_client

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/aio/_file_system_client_async.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/aio/_file_system_client_async.py
@@ -270,7 +270,7 @@ class FileSystemClient(AsyncStorageAccountHostsMixin, FileSystemClientBase):
         """
         await self._container_client._rename_container(new_name, **kwargs)   # pylint: disable=protected-access
         renamed_file_system = FileSystemClient(
-                "{}://{}".format(self.scheme, self.primary_hostname), file_system_name=new_name,
+                f"{self.scheme}://{self.primary_hostname}", file_system_name=new_name,
                 credential=self._raw_credential, api_version=self.api_version, _configuration=self._config,
                 _pipeline=self._pipeline, _location_mode=self._location_mode, _hosts=self._hosts)
         return renamed_file_system

--- a/sdk/storage/azure-storage-file-datalake/setup.py
+++ b/sdk/storage/azure-storage-file-datalake/setup.py
@@ -28,7 +28,7 @@ try:
     try:
         ver = azure.storage.__version__
         raise Exception(
-            'This package is incompatible with azure-storage=={}. '.format(ver) +
+            f'This package is incompatible with azure-storage=={ver}. ' +
             ' Uninstall it with "pip uninstall azure-storage".'
         )
     except AttributeError:
@@ -48,7 +48,7 @@ setup(
     name=PACKAGE_NAME,
     version=version,
     include_package_data=True,
-    description='Microsoft {} Client Library for Python'.format(PACKAGE_PPRINT_NAME),
+    description=f'Microsoft {PACKAGE_PPRINT_NAME} Client Library for Python',
     long_description=open('README.md', 'r').read(),
     long_description_content_type='text/markdown',
     license='MIT License',


### PR DESCRIPTION
```
************* Module C:\azure-sdk-for-python\pylintrc
C:\azure-sdk-for-python\pylintrc:1: [E0015(unrecognized-option), ] Unrecognized option found: module-name-hint, const-name-hint, class-name-hint, class-attribute-name-hint, attr-name-hint, method-name-hint, function-name-hint, argument-name-hint, variable-name-hint, inlinevar-name-hint
C:\azure-sdk-for-python\pylintrc:1: [R0022(useless-option-value), ] Useless option value for '--disable', 'bad-continuation' was removed from pylint, see https://github.com/PyCQA/pylint/pull/3571.
C:\azure-sdk-for-python\pylintrc:1: [W0012(unknown-option-value), ] Unknown option value for '--disable', expected a valid pylint message and got 'check-docstrings'
C:\azure-sdk-for-python\pylintrc:1: [W0012(unknown-option-value), ] Unknown option value for '--disable', expected a valid pylint message and got 'ignored-arguments-name'
C:\azure-sdk-for-python\pylintrc:1: [W0012(unknown-option-value), ] Unknown option value for '--disable', expected a valid pylint message and got 'empty-comment'
************* Module azure.storage.filedatalake._path_client
azure\storage\filedatalake\_path_client.py:764: [R0022(useless-option-value), ] Useless option value for 'disable', 'no-self-use' was moved to an optional extension, see https://pylint.pycqa.org/en/latest/whatsnew/2/2.14/summary.html#removed-checkers.
************* Module azure.storage.filedatalake._upload_helper
azure\storage\filedatalake\_upload_helper.py:6: [R0022(useless-option-value), ] Useless option value for 'disable', 'no-self-use' was moved to an optional extension, see https://pylint.pycqa.org/en/latest/whatsnew/2/2.14/summary.html#removed-checkers.
************* Module azure.storage.filedatalake.aio._upload_helper
azure\storage\filedatalake\aio\_upload_helper.py:6: [R0022(useless-option-value), ] Useless option value for 'disable', 'no-self-use' was moved to an optional extension, see https://pylint.pycqa.org/en/latest/whatsnew/2/2.14/summary.html#removed-checkers.
************* Module azure.storage.filedatalake._shared.authentication
azure\storage\filedatalake\_shared\authentication.py:70: [R0022(useless-option-value), ] Useless option value for 'disable', 'no-self-use' was moved to an optional extension, see https://pylint.pycqa.org/en/latest/whatsnew/2/2.14/summary.html#removed-checkers.
************* Module azure.storage.filedatalake._shared.policies
azure\storage\filedatalake\_shared\policies.py:410: [R0022(useless-option-value), ] Useless option value for 'disable', 'no-self-use' was moved to an optional extension, see https://pylint.pycqa.org/en/latest/whatsnew/2/2.14/summary.html#removed-checkers.
azure\storage\filedatalake\_shared\policies.py:428: [R0022(useless-option-value), ] Useless option value for 'disable', 'no-self-use' was moved to an optional extension, see https://pylint.pycqa.org/en/latest/whatsnew/2/2.14/summary.html#removed-checkers.
azure\storage\filedatalake\_shared\policies.py:451: [R0022(useless-option-value), ] Useless option value for 'disable', 'no-self-use' was moved to an optional extension, see https://pylint.pycqa.org/en/latest/whatsnew/2/2.14/summary.html#removed-checkers.
************* Module azure.storage.filedatalake._shared.request_handlers
azure\storage\filedatalake\_shared\request_handlers.py:73: [E1101(no-member), get_length] Module 'stat' has no 'S_ISREG' member
azure\storage\filedatalake\_shared\request_handlers.py:73: [E1101(no-member), get_length] Module 'stat' has no 'S_ISLNK' member
************* Module azure.storage.filedatalake._shared.uploads
azure\storage\filedatalake\_shared\uploads.py:6: [R0022(useless-option-value), ] Useless option value for 'disable', 'no-self-use' was moved to an optional extension, see https://pylint.pycqa.org/en/latest/whatsnew/2/2.14/summary.html#removed-checkers.
azure\storage\filedatalake\_shared\uploads.py:593: [C2801(unnecessary-dunder-call), IterStreamer.read] Unnecessarily calls dunder method __next__. Use next built-in function.
************* Module azure.storage.filedatalake._shared.uploads_async
azure\storage\filedatalake\_shared\uploads_async.py:6: [R0022(useless-option-value), ] Useless option value for 'disable', 'no-self-use' was moved to an optional extension, see https://pylint.pycqa.org/en/latest/whatsnew/2/2.14/summary.html#removed-checkers.
azure\storage\filedatalake\_shared\uploads_async.py:31: [C2801(unnecessary-dunder-call), _async_parallel_uploads] Unnecessarily calls dunder method __anext__. Use next built-in function.
azure\storage\filedatalake\_shared\uploads_async.py:92: [C2801(unnecessary-dunder-call), upload_data_chunks] Unnecessarily calls dunder method __anext__. Use next built-in function.
azure\storage\filedatalake\_shared\uploads_async.py:449: [C2801(unnecessary-dunder-call), AsyncIterStreamer.read] Unnecessarily calls dunder method __anext__. Use next built-in function.
```