### PR TITLE
RemoteRendering: Fix for pylint error: Use CaseInsensitiveEnumMeta

### DIFF
--- a/sdk/remoterendering/azure-mixedreality-remoterendering/CHANGELOG.md
+++ b/sdk/remoterendering/azure-mixedreality-remoterendering/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0b2 (2023-06-12)
+## 1.0.0b2 (2023-06-26)
 
 ### Other Changes
 

--- a/sdk/remoterendering/azure-mixedreality-remoterendering/CHANGELOG.md
+++ b/sdk/remoterendering/azure-mixedreality-remoterendering/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0b2 (2023-06-26)
+## 1.0.0b2 (2023-07-03)
 
 ### Other Changes
 

--- a/sdk/remoterendering/azure-mixedreality-remoterendering/CHANGELOG.md
+++ b/sdk/remoterendering/azure-mixedreality-remoterendering/CHANGELOG.md
@@ -1,11 +1,10 @@
 # Release History
 
-## 1.0.0b3 (Unreleased)
-
-## 1.0.0b2 (Unreleased)
+## 1.0.0b2 (2023-06-12)
 
 ### Other Changes
 
+- Added case-insensitive support for enums.
 - Python 2.7 is no longer supported. Please use Python version 3.7 or later.
 
 ## 1.0.0b1 (2021-11-15)

--- a/sdk/remoterendering/azure-mixedreality-remoterendering/azure/mixedreality/remoterendering/_api_version.py
+++ b/sdk/remoterendering/azure-mixedreality-remoterendering/azure/mixedreality/remoterendering/_api_version.py
@@ -5,11 +5,10 @@
 # --------------------------------------------------------------------------
 
 from enum import Enum
-from six import with_metaclass
 
 from azure.core import CaseInsensitiveEnumMeta
 
-class RemoteRenderingApiVersion(with_metaclass(CaseInsensitiveEnumMeta, str, Enum)):
+class RemoteRenderingApiVersion(str, Enum, metaclass=CaseInsensitiveEnumMeta):
     """Remote Rendering API versions supported by this package"""
 
     #: This is the default version

--- a/sdk/remoterendering/azure-mixedreality-remoterendering/azure/mixedreality/remoterendering/_api_version.py
+++ b/sdk/remoterendering/azure-mixedreality-remoterendering/azure/mixedreality/remoterendering/_api_version.py
@@ -5,9 +5,11 @@
 # --------------------------------------------------------------------------
 
 from enum import Enum
+from six import with_metaclass
 
+from azure.core import CaseInsensitiveEnumMeta
 
-class RemoteRenderingApiVersion(str, Enum):
+class RemoteRenderingApiVersion(with_metaclass(CaseInsensitiveEnumMeta, str, Enum)):
     """Remote Rendering API versions supported by this package"""
 
     #: This is the default version

--- a/sdk/remoterendering/azure-mixedreality-remoterendering/pyproject.toml
+++ b/sdk/remoterendering/azure-mixedreality-remoterendering/pyproject.toml
@@ -2,3 +2,4 @@
 pyright = false
 type_check_samples = false
 verifytypes = false
+pylint = false

--- a/sdk/remoterendering/azure-mixedreality-remoterendering/pyproject.toml
+++ b/sdk/remoterendering/azure-mixedreality-remoterendering/pyproject.toml
@@ -2,4 +2,3 @@
 pyright = false
 type_check_samples = false
 verifytypes = false
-pylint = false

--- a/sdk/remoterendering/azure-mixedreality-remoterendering/tests/conftest.py
+++ b/sdk/remoterendering/azure-mixedreality-remoterendering/tests/conftest.py
@@ -4,6 +4,7 @@
 # license information.
 # --------------------------------------------------------------------------
 import pytest
+import pytest_asyncio
 
 from azure.core.credentials import AzureKeyCredential
 from azure.mixedreality.remoterendering import RemoteRenderingClient
@@ -91,7 +92,7 @@ def arr_client(account_info):
     client.close()
 
 
-@pytest.fixture
+@pytest_asyncio.fixture
 async def async_arr_client(account_info):
     polling_interval = 10 if is_live() else 0
     client = RemoteRenderingClientAsync(

--- a/sdk/remoterendering/test-resources.json
+++ b/sdk/remoterendering/test-resources.json
@@ -30,7 +30,7 @@
   },
   "variables": {
     "apiVersion": "2020-05-01",
-    "arrApiVersion": "2020-04-06-preview",
+    "arrApiVersion": "2021-03-01-preview",
     "arrAccountName": "[concat(parameters('baseName'), '-arr-account')]",
     "storageApiVersion": "2019-06-01",
     "storageAccountName": "[parameters('baseName')]",


### PR DESCRIPTION
# Description

Fixes pylint error: Use CaseInsensitiveEnumMeta.
This allows customers to ignore casing when setting enum values.