### PR TITLE
[Storage] [Next-Pylint] ChangeFeed Package

### DIFF
--- a/sdk/storage/azure-storage-blob-changefeed/azure/storage/blob/changefeed/_models.py
+++ b/sdk/storage/azure-storage-blob-changefeed/azure/storage/blob/changefeed/_models.py
@@ -394,7 +394,7 @@ class ChangeFeedStreamer(object):
         self._chunk_size_snapshot = blob_client.get_blob_properties().size
         length = self._chunk_size_snapshot - self._chunk_file_start
         self._iterator = blob_client.download_blob(offset=self._chunk_file_start,
-                                                   length=length).chunks() if length > 0 else iter(list())
+                                                   length=length).chunks() if length > 0 else iter([])
 
     def __len__(self):
         return self._download_offset

--- a/sdk/storage/azure-storage-blob-changefeed/setup.py
+++ b/sdk/storage/azure-storage-blob-changefeed/setup.py
@@ -28,7 +28,7 @@ try:
     try:
         ver = azure.storage.__version__
         raise Exception(
-            'This package is incompatible with azure-storage=={}. '.format(ver) +
+            f'This package is incompatible with azure-storage=={ver}. ' +
             ' Uninstall it with "pip uninstall azure-storage".'
         )
     except AttributeError:
@@ -47,7 +47,7 @@ if not version:
 setup(
     name=PACKAGE_NAME,
     version=version,
-    description='Microsoft {} Client Library for Python'.format(PACKAGE_PPRINT_NAME),
+    description=f'Microsoft {PACKAGE_PPRINT_NAME} Client Library for Python',
     long_description=open('README.md', 'r').read(),
     long_description_content_type='text/markdown',
     license='MIT License',


### PR DESCRIPTION
```
************* Module C:\azure-sdk-for-python\pylintrc
C:\azure-sdk-for-python\pylintrc:1: [E0015(unrecognized-option), ] Unrecognized option found: module-name-hint, const-name-hint, class-name-hint, class-attribute-name-hint, attr-name-hint, method-name-hint, function-name-hint, argument-name-hint, variable-name-hint, inlinevar-name-hint
C:\azure-sdk-for-python\pylintrc:1: [R0022(useless-option-value), ] Useless option value for '--disable', 'bad-continuation' was removed from pylint, see https://github.com/PyCQA/pylint/pull/3571.
C:\azure-sdk-for-python\pylintrc:1: [W0012(unknown-option-value), ] Unknown option value for '--disable', expected a valid pylint message and got 'check-docstrings'
C:\azure-sdk-for-python\pylintrc:1: [W0012(unknown-option-value), ] Unknown option value for '--disable', expected a valid pylint message and got 'ignored-arguments-name'
C:\azure-sdk-for-python\pylintrc:1: [W0012(unknown-option-value), ] Unknown option value for '--disable', expected a valid pylint message and got 'empty-comment'
************* Module azure.storage.blob.changefeed._change_feed_client
azure\storage\blob\changefeed\_change_feed_client.py:6: [R0022(useless-option-value), ] Useless option value for 'disable', 'no-self-use' was moved to an optional extension, see https://pylint.pycqa.org/en/latest/whatsnew/2/2.14/summary.html#removed-checkers.  
************* Module azure.storage.blob.changefeed._models
azure\storage\blob\changefeed\_models.py:433: [C2801(unnecessary-dunder-call), ChangeFeedStreamer.read] Unnecessarily calls dunder method __next__. Use next built-in function.
```