### PR TITLE
[Storage] [Next-Pylint] File-share, Queue Package

### DIFF
--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_directory_client.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_directory_client.py
@@ -113,7 +113,7 @@ class ShareDirectoryClient(StorageAccountHostsMixin):
         if not share_name:
             raise ValueError("Please specify a share name.")
         if not parsed_url.netloc:
-            raise ValueError("Invalid URL: {}".format(account_url))
+            raise ValueError(f"Invalid URL: {account_url}")
 
         path_snapshot, sas_token = parse_query(parsed_url.query)
         if not sas_token and not credential:
@@ -175,7 +175,7 @@ class ShareDirectoryClient(StorageAccountHostsMixin):
             raise ValueError("Directory URL must be a string.")
         parsed_url = urlparse(directory_url.rstrip('/'))
         if not parsed_url.path and not parsed_url.netloc:
-            raise ValueError("Invalid URL: {}".format(directory_url))
+            raise ValueError(f"Invalid URL: {directory_url}")
         account_url = parsed_url.netloc.rstrip('/') + "?" + parsed_url.query
         path_snapshot, _ = parse_query(parsed_url.query)
 
@@ -199,12 +199,7 @@ class ShareDirectoryClient(StorageAccountHostsMixin):
         directory_path = ""
         if self.directory_path:
             directory_path = "/" + quote(self.directory_path, safe='~')
-        return "{}://{}/{}{}{}".format(
-            self.scheme,
-            hostname,
-            quote(share_name),
-            directory_path,
-            self._query_str)
+        return f"{self.scheme}://{hostname}/{quote(share_name)}{directory_path}{self._query_str}"
 
     @classmethod
     def from_connection_string(
@@ -482,7 +477,7 @@ class ShareDirectoryClient(StorageAccountHostsMixin):
             new_dir_sas = self._query_str.strip('?')
 
         new_directory_client = ShareDirectoryClient(
-            '{}://{}'.format(self.scheme, self.primary_hostname), self.share_name, new_dir_path,
+            f'{self.scheme}://{self.primary_hostname}', self.share_name, new_dir_path,
             credential=new_dir_sas or self.credential, api_version=self.api_version,
             _hosts=self._hosts, _configuration=self._config, _pipeline=self._pipeline,
             _location_mode=self._location_mode, allow_trailing_dot=self.allow_trailing_dot,

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_download.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_download.py
@@ -266,11 +266,7 @@ class StorageStreamDownloader(object):  # pylint: disable=too-many-instance-attr
         self.properties.size = self.size
 
         # Overwrite the content range to the user requested range
-        self.properties.content_range = "bytes {0}-{1}/{2}".format(
-            self._start_range,
-            self._end_range,
-            self._file_size
-        )
+        self.properties.content_range = f"bytes {self._start_range}-{self._end_range}/{self._file_size}"
 
         # Overwrite the content MD5 as it is the MD5 for the last range instead
         # of the stored MD5
@@ -334,8 +330,8 @@ class StorageStreamDownloader(object):  # pylint: disable=too-many-instance-attr
                         download_stream_current=0,
                         **self._request_options
                     )
-                except HttpResponseError as error:
-                    process_storage_error(error)
+                except HttpResponseError as e:
+                    process_storage_error(e)
 
                 # Set the download size to empty
                 self.size = 0

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_file_client.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_file_client.py
@@ -172,7 +172,7 @@ class ShareFileClient(StorageAccountHostsMixin):
         if not (share_name and file_path):
             raise ValueError("Please specify a share name and file name.")
         if not parsed_url.netloc:
-            raise ValueError("Invalid URL: {}".format(account_url))
+            raise ValueError(f"Invalid URL: {account_url}")
 
         path_snapshot = None
         path_snapshot, sas_token = parse_query(parsed_url.query)
@@ -237,7 +237,7 @@ class ShareFileClient(StorageAccountHostsMixin):
         parsed_url = urlparse(file_url.rstrip('/'))
 
         if not (parsed_url.netloc and parsed_url.path):
-            raise ValueError("Invalid URL: {}".format(file_url))
+            raise ValueError(f"Invalid URL: {file_url}")
         account_url = parsed_url.netloc.rstrip('/') + "?" + parsed_url.query
 
         path_share, _, path_file = parsed_url.path.lstrip('/').partition('/')
@@ -254,12 +254,8 @@ class ShareFileClient(StorageAccountHostsMixin):
         share_name = self.share_name
         if isinstance(share_name, str):
             share_name = share_name.encode('UTF-8')
-        return "{}://{}/{}/{}{}".format(
-            self.scheme,
-            hostname,
-            quote(share_name),
-            "/".join([quote(p, safe='~') for p in self.file_path]),
-            self._query_str)
+        return (f"{self.scheme}://{hostname}/{quote(share_name)}"
+                f"/{'/'.join([quote(p, safe='~') for p in self.file_path])}{self._query_str}")
 
     @classmethod
     def from_connection_string(
@@ -572,7 +568,7 @@ class ShareFileClient(StorageAccountHostsMixin):
         elif hasattr(data, '__iter__'):
             stream = IterStreamer(data, encoding=encoding)
         else:
-            raise TypeError("Unsupported data type: {}".format(type(data)))
+            raise TypeError(f"Unsupported data type: {type(data)}")
         return _upload_file_helper(
             self,
             stream,
@@ -959,7 +955,7 @@ class ShareFileClient(StorageAccountHostsMixin):
             new_file_sas = self._query_str.strip('?')
 
         new_file_client = ShareFileClient(
-            '{}://{}'.format(self.scheme, self.primary_hostname), self.share_name, new_file_path,
+            f'{self.scheme}://{self.primary_hostname}', self.share_name, new_file_path,
             credential=new_file_sas or self.credential, api_version=self.api_version,
             _hosts=self._hosts, _configuration=self._config, _pipeline=self._pipeline,
             _location_mode=self._location_mode, allow_trailing_dot=self.allow_trailing_dot,
@@ -1232,7 +1228,7 @@ class ShareFileClient(StorageAccountHostsMixin):
             data = data.encode(encoding)
 
         end_range = offset + length - 1  # Reformat to an inclusive range index
-        content_range = 'bytes={0}-{1}'.format(offset, end_range)
+        content_range = f'bytes={offset}-{end_range}'
         access_conditions = get_access_conditions(kwargs.pop('lease', None))
         try:
             return self._client.file.upload_range( # type: ignore
@@ -1266,8 +1262,8 @@ class ShareFileClient(StorageAccountHostsMixin):
 
         # Format range
         end_range = offset + length - 1
-        destination_range = 'bytes={0}-{1}'.format(offset, end_range)
-        source_range = 'bytes={0}-{1}'.format(source_offset, source_offset + length - 1)
+        destination_range = f'bytes={offset}-{end_range}'
+        source_range = f'bytes={source_offset}-{source_offset + length - 1}'
         source_authorization = kwargs.pop('source_authorization', None)
         source_mod_conditions = get_source_conditions(kwargs)
         access_conditions = get_access_conditions(kwargs.pop('lease', None))
@@ -1384,9 +1380,9 @@ class ShareFileClient(StorageAccountHostsMixin):
         if offset is not None:
             if length is not None:
                 end_range = offset + length - 1  # Reformat to an inclusive range index
-                content_range = 'bytes={0}-{1}'.format(offset, end_range)
+                content_range = f'bytes={offset}-{end_range}'
             else:
-                content_range = 'bytes={0}-'.format(offset)
+                content_range = f'bytes={offset}-'
         options = {
             'sharesnapshot': self.snapshot,
             'lease_access_conditions': access_conditions,
@@ -1531,7 +1527,7 @@ class ShareFileClient(StorageAccountHostsMixin):
         if length is None or length % 512 != 0:
             raise ValueError("length must be an integer that aligns with 512 bytes file size")
         end_range = length + offset - 1  # Reformat to an inclusive range index
-        content_range = 'bytes={0}-{1}'.format(offset, end_range)
+        content_range = f'bytes={offset}-{end_range}'
         try:
             return self._client.file.upload_range( # type: ignore
                 timeout=timeout,

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_models.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_models.py
@@ -47,7 +47,7 @@ class Metrics(GeneratedMetrics):
     """
 
     def __init__(self, **kwargs):
-        self.version = kwargs.get('version', u'1.0')
+        self.version = kwargs.get('version', '1.0')
         self.enabled = kwargs.get('enabled', False)
         self.include_apis = kwargs.get('include_apis')
         self.retention_policy = kwargs.get('retention_policy') or RetentionPolicy()

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_serialize.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_serialize.py
@@ -49,20 +49,20 @@ def _get_match_headers(kwargs, match_param, etag_param):
     if match_condition == MatchConditions.IfNotModified:
         if_match = kwargs.pop(etag_param, None)
         if not if_match:
-            raise ValueError("'{}' specified without '{}'.".format(match_param, etag_param))
+            raise ValueError(f"'{match_param}' specified without '{etag_param}'.")
     elif match_condition == MatchConditions.IfPresent:
         if_match = '*'
     elif match_condition == MatchConditions.IfModified:
         if_none_match = kwargs.pop(etag_param, None)
         if not if_none_match:
-            raise ValueError("'{}' specified without '{}'.".format(match_param, etag_param))
+            raise ValueError(f"'{match_param}' specified without '{etag_param}'.")
     elif match_condition == MatchConditions.IfMissing:
         if_none_match = '*'
     elif match_condition is None:
         if etag_param in kwargs:
-            raise ValueError("'{}' specified without '{}'.".format(etag_param, match_param))
+            raise ValueError(f"'{etag_param}' specified without '{match_param}'.")
     else:
-        raise TypeError("Invalid match condition: {}".format(match_condition))
+        raise TypeError(f"Invalid match condition: {match_condition}")
     return if_match, if_none_match
 
 
@@ -173,5 +173,5 @@ def get_api_version(kwargs):
     api_version = kwargs.get('api_version', None)
     if api_version and api_version not in _SUPPORTED_API_VERSIONS:
         versions = '\n'.join(_SUPPORTED_API_VERSIONS)
-        raise ValueError("Unsupported API version '{}'. Please select from:\n{}".format(api_version, versions))
+        raise ValueError(f"Unsupported API version '{api_version}'. Please select from:\n{versions}")
     return api_version or _SUPPORTED_API_VERSIONS[-1]

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_share_client.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_share_client.py
@@ -112,7 +112,7 @@ class ShareClient(StorageAccountHostsMixin): # pylint: disable=too-many-public-m
         if not share_name:
             raise ValueError("Please specify a share name.")
         if not parsed_url.netloc:
-            raise ValueError("Invalid URL: {}".format(account_url))
+            raise ValueError(f"Invalid URL: {account_url}")
 
         path_snapshot = None
         path_snapshot, sas_token = parse_query(parsed_url.query)
@@ -171,17 +171,13 @@ class ShareClient(StorageAccountHostsMixin): # pylint: disable=too-many-public-m
             raise ValueError("Share URL must be a string.")
         parsed_url = urlparse(share_url.rstrip('/'))
         if not (parsed_url.path and parsed_url.netloc):
-            raise ValueError("Invalid URL: {}".format(share_url))
+            raise ValueError(f"Invalid URL: {share_url}")
 
         share_path = parsed_url.path.lstrip('/').split('/')
         account_path = ""
         if len(share_path) > 1:
             account_path = "/" + "/".join(share_path[:-1])
-        account_url = "{}://{}{}?{}".format(
-            parsed_url.scheme,
-            parsed_url.netloc.rstrip('/'),
-            account_path,
-            parsed_url.query)
+        account_url = f"{parsed_url.scheme}://{parsed_url.netloc.rstrip('/')}{account_path}?{parsed_url.query}"
 
         share_name = unquote(share_path[-1])
         path_snapshot, _ = parse_query(parsed_url.query)
@@ -205,11 +201,7 @@ class ShareClient(StorageAccountHostsMixin): # pylint: disable=too-many-public-m
         share_name = self.share_name
         if isinstance(share_name, str):
             share_name = share_name.encode('UTF-8')
-        return "{}://{}/{}{}".format(
-            self.scheme,
-            hostname,
-            quote(share_name),
-            self._query_str)
+        return f"{self.scheme}://{hostname}/{quote(share_name)}{self._query_str}"
 
     @classmethod
     def from_connection_string(

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_share_service_client.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_share_service_client.py
@@ -114,7 +114,7 @@ class ShareServiceClient(StorageAccountHostsMixin):
             raise ValueError("Account URL must be a string.")
         parsed_url = urlparse(account_url.rstrip('/'))
         if not parsed_url.netloc:
-            raise ValueError("Invalid URL: {}".format(account_url))
+            raise ValueError(f"Invalid URL: {account_url}")
 
         _, sas_token = parse_query(parsed_url.query)
         if not sas_token and not credential:
@@ -135,7 +135,7 @@ class ShareServiceClient(StorageAccountHostsMixin):
         """Format the endpoint URL according to the current location
         mode hostname.
         """
-        return "{}://{}/{}".format(self.scheme, hostname, self._query_str)
+        return f"{self.scheme}://{hostname}/{self._query_str}"
 
     @classmethod
     def from_connection_string(

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/authentication.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/authentication.py
@@ -40,7 +40,7 @@ def _storage_header_sort(input_headers: List[Tuple[str, str]]) -> List[Tuple[str
     custom_weights = "-!#$%&*.^_|~+\"\'(),/`~0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[]abcdefghijklmnopqrstuvwxyz{}"
 
     # Build dict of tuples and list of keys
-    header_dict = dict()
+    header_dict = {}
     header_keys = []
     for k, v in input_headers:
         header_dict[k] = v

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/request_handlers.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/request_handlers.py
@@ -42,9 +42,7 @@ def serialize_iso(attr):
         if utc.tm_year > 9999 or utc.tm_year < 1:
             raise OverflowError("Hit max or min date")
 
-        date = "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}".format(
-            utc.tm_year, utc.tm_mon, utc.tm_mday,
-            utc.tm_hour, utc.tm_min, utc.tm_sec)
+        date = f"{utc.tm_year:04}-{utc.tm_mon:02}-{utc.tm_mday:02}T{utc.tm_hour:02}:{utc.tm_min:02}:{utc.tm_sec:02}"
         return date + 'Z'
     except (ValueError, OverflowError) as err:
         msg = "Unable to serialize datetime object."
@@ -178,7 +176,7 @@ def serialize_batch_body(requests, batch_id):
 
     delimiter_bytes = (_get_batch_request_delimiter(batch_id, True, False) + _HTTP_LINE_ENDING).encode('utf-8')
     newline_bytes = _HTTP_LINE_ENDING.encode('utf-8')
-    batch_body = list()
+    batch_body = []
 
     content_index = 0
     for request in requests:
@@ -237,7 +235,7 @@ def _make_body_from_sub_request(sub_request):
      """
 
     # put the sub-request's headers into a list for efficient str concatenation
-    sub_request_body = list()
+    sub_request_body = []
 
     # get headers for ease of manipulation; remove headers as they are used
     headers = sub_request.headers

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/uploads.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/uploads.py
@@ -268,7 +268,7 @@ class BlockBlobChunkUploader(_ChunkUploader):
 
     def _upload_substream_block(self, index, block_stream):
         try:
-            block_id = f'BlockId{"%05d" % (index/self.chunk_size)}'
+            block_id = f'BlockId{(index/self.chunk_size):05}'
             self.service.stage_block(
                 block_id,
                 len(block_stream),
@@ -597,10 +597,11 @@ class IterStreamer(object):
                     chunk = chunk.encode(self.encoding)
                 data += chunk
                 count += len(chunk)
+        # This means count < size and what's leftover will be returned in this call.
         except StopIteration:
-            pass
+            self.leftover = b""
 
-        if count > size:
+        if count >= size:
             self.leftover = data[size:]
 
         return data[:size]

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/uploads_async.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/uploads_async.py
@@ -294,7 +294,7 @@ class BlockBlobChunkUploader(_ChunkUploader):
 
     async def _upload_substream_block(self, index, block_stream):
         try:
-            block_id = f'BlockId{"%05d" % (index/self.chunk_size)}'
+            block_id = f'BlockId{(index/self.chunk_size):05}'
             await self.service.stage_block(
                 block_id,
                 len(block_stream),

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/aio/_directory_client_async.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/aio/_directory_client_async.py
@@ -360,7 +360,7 @@ class ShareDirectoryClient(AsyncStorageAccountHostsMixin, ShareDirectoryClientBa
             new_dir_sas = self._query_str.strip('?')
 
         new_directory_client = ShareDirectoryClient(
-            '{}://{}'.format(self.scheme, self.primary_hostname), self.share_name, new_dir_path,
+            f'{self.scheme}://{self.primary_hostname}', self.share_name, new_dir_path,
             credential=new_dir_sas or self.credential, api_version=self.api_version,
             _hosts=self._hosts, _configuration=self._config, _pipeline=self._pipeline,
             _location_mode=self._location_mode, allow_trailing_dot=self.allow_trailing_dot,

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/aio/_download_async.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/aio/_download_async.py
@@ -224,11 +224,7 @@ class StorageStreamDownloader(object):  # pylint: disable=too-many-instance-attr
         self.properties.size = self.size
 
         # Overwrite the content range to the user requested range
-        self.properties.content_range = 'bytes {0}-{1}/{2}'.format(
-            self._start_range,
-            self._end_range,
-            self._file_size
-        )
+        self.properties.content_range = f'bytes {self._start_range}-{self._end_range}/{self._file_size}'
 
         # Overwrite the content MD5 as it is the MD5 for the last range instead
         # of the stored MD5
@@ -286,8 +282,8 @@ class StorageStreamDownloader(object):  # pylint: disable=too-many-instance-attr
                         data_stream_total=0,
                         download_stream_current=0,
                         **self._request_options)
-                except HttpResponseError as error:
-                    process_storage_error(error)
+                except HttpResponseError as e:
+                    process_storage_error(e)
 
                 # Set the download size to empty
                 self.size = 0

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/aio/_file_client_async.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/aio/_file_client_async.py
@@ -440,7 +440,7 @@ class ShareFileClient(AsyncStorageAccountHostsMixin, ShareFileClientBase):
         elif hasattr(data, '__aiter__'):
             stream = AsyncIterStreamer(data, encoding=encoding)
         else:
-            raise TypeError("Unsupported data type: {}".format(type(data)))
+            raise TypeError(f"Unsupported data type: {type(data)}")
         return await _upload_file_helper(
             self,
             stream,
@@ -834,7 +834,7 @@ class ShareFileClient(AsyncStorageAccountHostsMixin, ShareFileClientBase):
             new_file_sas = self._query_str.strip('?')
 
         new_file_client = ShareFileClient(
-            '{}://{}'.format(self.scheme, self.primary_hostname), self.share_name, new_file_path,
+            f'{self.scheme}://{self.primary_hostname}', self.share_name, new_file_path,
             credential=new_file_sas or self.credential, api_version=self.api_version,
             _hosts=self._hosts, _configuration=self._config, _pipeline=self._pipeline,
             _location_mode=self._location_mode, allow_trailing_dot=self.allow_trailing_dot,
@@ -1106,7 +1106,7 @@ class ShareFileClient(AsyncStorageAccountHostsMixin, ShareFileClientBase):
         if isinstance(data, str):
             data = data.encode(encoding)
         end_range = offset + length - 1  # Reformat to an inclusive range index
-        content_range = 'bytes={0}-{1}'.format(offset, end_range)
+        content_range = f'bytes={offset}-{end_range}'
         access_conditions = get_access_conditions(kwargs.pop('lease', None))
         try:
             return await self._client.file.upload_range(  # type: ignore
@@ -1337,7 +1337,7 @@ class ShareFileClient(AsyncStorageAccountHostsMixin, ShareFileClientBase):
         if length is None or length % 512 != 0:
             raise ValueError("length must be an integer that aligns with 512 bytes file size")
         end_range = length + offset - 1  # Reformat to an inclusive range index
-        content_range = "bytes={0}-{1}".format(offset, end_range)
+        content_range = f"bytes={offset}-{end_range}"
         try:
             return await self._client.file.upload_range(  # type: ignore
                 timeout=timeout,

--- a/sdk/storage/azure-storage-file-share/setup.py
+++ b/sdk/storage/azure-storage-file-share/setup.py
@@ -36,7 +36,7 @@ setup(
     name=PACKAGE_NAME,
     version=version,
     include_package_data=True,
-    description='Microsoft Azure {} Client Library for Python'.format(PACKAGE_PPRINT_NAME),
+    description=f'Microsoft Azure {PACKAGE_PPRINT_NAME} Client Library for Python',
     long_description=readme + '\n\n' + changelog,
     long_description_content_type='text/markdown',
     license='MIT License',

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/authentication.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/authentication.py
@@ -40,7 +40,7 @@ def _storage_header_sort(input_headers: List[Tuple[str, str]]) -> List[Tuple[str
     custom_weights = "-!#$%&*.^_|~+\"\'(),/`~0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[]abcdefghijklmnopqrstuvwxyz{}"
 
     # Build dict of tuples and list of keys
-    header_dict = dict()
+    header_dict = {}
     header_keys = []
     for k, v in input_headers:
         header_dict[k] = v

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/request_handlers.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/request_handlers.py
@@ -42,9 +42,7 @@ def serialize_iso(attr):
         if utc.tm_year > 9999 or utc.tm_year < 1:
             raise OverflowError("Hit max or min date")
 
-        date = "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}".format(
-            utc.tm_year, utc.tm_mon, utc.tm_mday,
-            utc.tm_hour, utc.tm_min, utc.tm_sec)
+        date = f"{utc.tm_year:04}-{utc.tm_mon:02}-{utc.tm_mday:02}T{utc.tm_hour:02}:{utc.tm_min:02}:{utc.tm_sec:02}"
         return date + 'Z'
     except (ValueError, OverflowError) as err:
         msg = "Unable to serialize datetime object."
@@ -178,7 +176,7 @@ def serialize_batch_body(requests, batch_id):
 
     delimiter_bytes = (_get_batch_request_delimiter(batch_id, True, False) + _HTTP_LINE_ENDING).encode('utf-8')
     newline_bytes = _HTTP_LINE_ENDING.encode('utf-8')
-    batch_body = list()
+    batch_body = []
 
     content_index = 0
     for request in requests:
@@ -237,7 +235,7 @@ def _make_body_from_sub_request(sub_request):
      """
 
     # put the sub-request's headers into a list for efficient str concatenation
-    sub_request_body = list()
+    sub_request_body = []
 
     # get headers for ease of manipulation; remove headers as they are used
     headers = sub_request.headers

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/uploads.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/uploads.py
@@ -268,7 +268,7 @@ class BlockBlobChunkUploader(_ChunkUploader):
 
     def _upload_substream_block(self, index, block_stream):
         try:
-            block_id = f'BlockId{"%05d" % (index/self.chunk_size)}'
+            block_id = f'BlockId{(index/self.chunk_size):05}'
             self.service.stage_block(
                 block_id,
                 len(block_stream),

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/uploads_async.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/uploads_async.py
@@ -294,7 +294,7 @@ class BlockBlobChunkUploader(_ChunkUploader):
 
     async def _upload_substream_block(self, index, block_stream):
         try:
-            block_id = f'BlockId{"%05d" % (index/self.chunk_size)}'
+            block_id = f'BlockId{(index/self.chunk_size):05}'
             await self.service.stage_block(
                 block_id,
                 len(block_stream),

--- a/sdk/storage/azure-storage-queue/setup.py
+++ b/sdk/storage/azure-storage-queue/setup.py
@@ -37,7 +37,7 @@ setup(
     name=PACKAGE_NAME,
     version=version,
     include_package_data=True,
-    description='Microsoft Azure {} Client Library for Python'.format(PACKAGE_PPRINT_NAME),
+    description=f'Microsoft Azure {PACKAGE_PPRINT_NAME} Client Library for Python',
     long_description=readme + '\n\n' + changelog,
     long_description_content_type='text/markdown',
     license='MIT License',


### PR DESCRIPTION
File-share
```
************* Module C:\azure-sdk-for-python\pylintrc
C:\azure-sdk-for-python\pylintrc:1: [E0015(unrecognized-option), ] Unrecognized option found: module-name-hint, const-name-hint, class-name-hint, class-attribute-name-hint, attr-name-hint, method-name-hint, function-name-hint, argument-name-hint, variable-name-hint, inlinevar-name-hint
C:\azure-sdk-for-python\pylintrc:1: [R0022(useless-option-value), ] Useless option value for '--disable', 'bad-continuation' was removed from pylint, see https://github.com/PyCQA/pylint/pull/3571.
C:\azure-sdk-for-python\pylintrc:1: [W0012(unknown-option-value), ] Unknown option value for '--disable', expected a valid pylint message and got 'check-docstrings'
C:\azure-sdk-for-python\pylintrc:1: [W0012(unknown-option-value), ] Unknown option value for '--disable', expected a valid pylint message and got 'ignored-arguments-name'
C:\azure-sdk-for-python\pylintrc:1: [W0012(unknown-option-value), ] Unknown option value for '--disable', expected a valid pylint message and got 'empty-comment'
************* Module azure.storage.fileshare._deserialize
azure\storage\fileshare\_deserialize.py:6: [R0022(useless-option-value), ] Useless option value for 'disable', 'no-self-use' was moved to an optional extension, see https://pylint.pycqa.org/en/latest/whatsnew/2/2.14/summary.html#removed-checkers.
************* Module azure.storage.fileshare._serialize
azure\storage\fileshare\_serialize.py:6: [R0022(useless-option-value), ] Useless option value for 'disable', 'no-self-use' was moved to an optional extension, see https://pylint.pycqa.org/en/latest/whatsnew/2/2.14/summary.html#removed-checkers.
************* Module azure.storage.fileshare._shared.authentication
azure\storage\fileshare\_shared\authentication.py:70: [R0022(useless-option-value), ] Useless option value for 'disable', 'no-self-use' was moved to an optional extension, see https://pylint.pycqa.org/en/latest/whatsnew/2/2.14/summary.html#removed-checkers.    
************* Module azure.storage.fileshare._shared.policies
azure\storage\fileshare\_shared\policies.py:410: [R0022(useless-option-value), ] Useless option value for 'disable', 'no-self-use' was moved to an optional extension, see https://pylint.pycqa.org/en/latest/whatsnew/2/2.14/summary.html#removed-checkers.
azure\storage\fileshare\_shared\policies.py:428: [R0022(useless-option-value), ] Useless option value for 'disable', 'no-self-use' was moved to an optional extension, see https://pylint.pycqa.org/en/latest/whatsnew/2/2.14/summary.html#removed-checkers.
azure\storage\fileshare\_shared\policies.py:451: [R0022(useless-option-value), ] Useless option value for 'disable', 'no-self-use' was moved to an optional extension, see https://pylint.pycqa.org/en/latest/whatsnew/2/2.14/summary.html#removed-checkers.
************* Module azure.storage.fileshare._shared.request_handlers
azure\storage\fileshare\_shared\request_handlers.py:73: [E1101(no-member), get_length] Module 'stat' has no 'S_ISREG' member
azure\storage\fileshare\_shared\request_handlers.py:73: [E1101(no-member), get_length] Module 'stat' has no 'S_ISLNK' member
************* Module azure.storage.fileshare._shared.uploads
azure\storage\fileshare\_shared\uploads.py:6: [R0022(useless-option-value), ] Useless option value for 'disable', 'no-self-use' was moved to an optional extension, see https://pylint.pycqa.org/en/latest/whatsnew/2/2.14/summary.html#removed-checkers.
azure\storage\fileshare\_shared\uploads.py:595: [C2801(unnecessary-dunder-call), IterStreamer.read] Unnecessarily calls dunder method __next__. Use next built-in function.
************* Module azure.storage.fileshare._shared.uploads_async
azure\storage\fileshare\_shared\uploads_async.py:6: [R0022(useless-option-value), ] Useless option value for 'disable', 'no-self-use' was moved to an optional extension, see https://pylint.pycqa.org/en/latest/whatsnew/2/2.14/summary.html#removed-checkers.      
azure\storage\fileshare\_shared\uploads_async.py:31: [C2801(unnecessary-dunder-call), _async_parallel_uploads] Unnecessarily calls dunder method __anext__. Use next built-in function.
azure\storage\fileshare\_shared\uploads_async.py:92: [C2801(unnecessary-dunder-call), upload_data_chunks] Unnecessarily calls dunder method __anext__. Use next built-in function.
azure\storage\fileshare\_shared\uploads_async.py:449: [C2801(unnecessary-dunder-call), AsyncIterStreamer.read] Unnecessarily calls dunder method __anext__. Use next built-in function.
```

Queue
```
************* Module C:\azure-sdk-for-python\pylintrc
C:\azure-sdk-for-python\pylintrc:1: [E0015(unrecognized-option), ] Unrecognized option found: module-name-hint, const-name-hint, class-name-hint, class-attribute-name-hint, attr-name-hint, method-name-hint, function-name-hint, argument-name-hint, variable-name-hint, inlinevar-name-hint
C:\azure-sdk-for-python\pylintrc:1: [R0022(useless-option-value), ] Useless option value for '--disable', 'bad-continuation' was removed from pylint, see https://github.com/PyCQA/pylint/pull/3571.
C:\azure-sdk-for-python\pylintrc:1: [W0012(unknown-option-value), ] Unknown option value for '--disable', expected a valid pylint message and got 'check-docstrings'
C:\azure-sdk-for-python\pylintrc:1: [W0012(unknown-option-value), ] Unknown option value for '--disable', expected a valid pylint message and got 'ignored-arguments-name'
C:\azure-sdk-for-python\pylintrc:1: [W0012(unknown-option-value), ] Unknown option value for '--disable', expected a valid pylint message and got 'empty-comment'
************* Module azure.storage.queue._encryption
azure\storage\queue\_encryption.py:668: [E1101(no-member), encrypt_blob] Module 'os' has no 'urandom' member
azure\storage\queue\_encryption.py:669: [E1101(no-member), encrypt_blob] Module 'os' has no 'urandom' member
azure\storage\queue\_encryption.py:683: [E1101(no-member), encrypt_blob] Module 'os' has no 'urandom' member
azure\storage\queue\_encryption.py:717: [E1101(no-member), generate_blob_encryption_data] Module 'os' has no 'urandom' member
azure\storage\queue\_encryption.py:720: [E1101(no-member), generate_blob_encryption_data] Module 'os' has no 'urandom' member
azure\storage\queue\_encryption.py:897: [E1101(no-member), encrypt_queue_message] Module 'os' has no 'urandom' member
azure\storage\queue\_encryption.py:898: [E1101(no-member), encrypt_queue_message] Module 'os' has no 'urandom' member
azure\storage\queue\_encryption.py:912: [E1101(no-member), encrypt_queue_message] Module 'os' has no 'urandom' member
azure\storage\queue\_encryption.py:916: [E1101(no-member), encrypt_queue_message] Module 'os' has no 'urandom' member
************* Module azure.storage.queue._models
azure\storage\queue\_models.py:294: [R0022(useless-option-value), ] Useless option value for 'disable', 'no-self-use' was moved to an optional extension, see https://pylint.pycqa.org/en/latest/whatsnew/2/2.14/summary.html#removed-checkers.   
************* Module azure.storage.queue._shared.authentication
azure\storage\queue\_shared\authentication.py:70: [R0022(useless-option-value), ] Useless option value for 'disable', 'no-self-use' was moved to an optional extension, see https://pylint.pycqa.org/en/latest/whatsnew/2/2.14/summary.html#removed-checkers.
************* Module azure.storage.queue._shared.policies
azure\storage\queue\_shared\policies.py:416: [R0022(useless-option-value), ] Useless option value for 'disable', 'no-self-use' was moved to an optional extension, see https://pylint.pycqa.org/en/latest/whatsnew/2/2.14/summary.html#removed-checkers.
azure\storage\queue\_shared\policies.py:434: [R0022(useless-option-value), ] Useless option value for 'disable', 'no-self-use' was moved to an optional extension, see https://pylint.pycqa.org/en/latest/whatsnew/2/2.14/summary.html#removed-checkers.
azure\storage\queue\_shared\policies.py:457: [R0022(useless-option-value), ] Useless option value for 'disable', 'no-self-use' was moved to an optional extension, see https://pylint.pycqa.org/en/latest/whatsnew/2/2.14/summary.html#removed-checkers.
************* Module azure.storage.queue._shared.request_handlers
azure\storage\queue\_shared\request_handlers.py:73: [E1101(no-member), get_length] Module 'stat' has no 'S_ISREG' member
azure\storage\queue\_shared\request_handlers.py:73: [E1101(no-member), get_length] Module 'stat' has no 'S_ISLNK' member
************* Module azure.storage.queue._shared.uploads
azure\storage\queue\_shared\uploads.py:6: [R0022(useless-option-value), ] Useless option value for 'disable', 'no-self-use' was moved to an optional extension, see https://pylint.pycqa.org/en/latest/whatsnew/2/2.14/summary.html#removed-checkers.
azure\storage\queue\_shared\uploads.py:595: [C2801(unnecessary-dunder-call), IterStreamer.read] Unnecessarily calls dunder method __next__. Use next built-in function.
************* Module azure.storage.queue._shared.uploads_async
azure\storage\queue\_shared\uploads_async.py:6: [R0022(useless-option-value), ] Useless option value for 'disable', 'no-self-use' was moved to an optional extension, see https://pylint.pycqa.org/en/latest/whatsnew/2/2.14/summary.html#removed-checkers.
azure\storage\queue\_shared\uploads_async.py:31: [C2801(unnecessary-dunder-call), _async_parallel_uploads] Unnecessarily calls dunder method __anext__. Use next built-in function.
azure\storage\queue\_shared\uploads_async.py:92: [C2801(unnecessary-dunder-call), upload_data_chunks] Unnecessarily calls dunder method __anext__. Use next built-in function.
azure\storage\queue\_shared\uploads_async.py:449: [C2801(unnecessary-dunder-call), AsyncIterStreamer.read] Unnecessarily calls dunder method __anext__. Use next built-in function.
```