### PR TITLE
[ML][Pipelines] fix: use workspace-id to distinguish on-disk cache

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_utils/_cache_utils.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_utils/_cache_utils.py
@@ -95,34 +95,17 @@ class CachedNodeResolver(object):
     def __init__(
         self,
         resolver: Callable[[Union[Component, str]], str],
-        subscription_id: Optional[str],
-        resource_group_name: Optional[str],
-        workspace_name: Optional[str],
-        registry_name: Optional[str],
+        client_key: str,
     ):
         self._resolver = resolver
         self._cache: Dict[str, _CacheContent] = {}
         self._nodes_to_resolve: List[BaseNode] = []
 
-        self._client_hash = self._get_client_hash(subscription_id, resource_group_name, workspace_name, registry_name)
+        hash_obj = hashlib.sha256()
+        hash_obj.update(client_key.encode("utf-8"))
+        self._client_hash = hash_obj.hexdigest()
         # the same client share 1 lock
         self._lock = _node_resolution_lock[self._client_hash]
-
-    @staticmethod
-    def _get_client_hash(
-        subscription_id: Optional[str],
-        resource_group_name: Optional[str],
-        workspace_name: Optional[str],
-        registry_name: Optional[str],
-    ) -> str:
-        """Get a hash for used client.
-
-        Works for both workspace client and registry client.
-        """
-        object_hash = hashlib.sha256()
-        for s in [subscription_id, resource_group_name, workspace_name, registry_name]:
-            object_hash.update(str(s).encode("utf-8"))
-        return object_hash.hexdigest()
 
     @staticmethod
     def _get_component_registration_max_workers():

--- a/sdk/ml/azure-ai-ml/tests/component/e2etests/test_component_without_mock.py
+++ b/sdk/ml/azure-ai-ml/tests/component/e2etests/test_component_without_mock.py
@@ -1,0 +1,34 @@
+import pytest
+from devtools_testutils import AzureRecordedTestCase
+
+from azure.ai.ml import MLClient
+
+from .._util import _COMPONENT_TIMEOUT_SECOND
+
+
+@pytest.mark.e2etest
+@pytest.mark.timeout(_COMPONENT_TIMEOUT_SECOND)
+@pytest.mark.usefixtures("recorded_test")
+@pytest.mark.pipeline_test
+class TestComponentWithoutMock(AzureRecordedTestCase):
+    """Do not use component related mock here."""
+
+    def test_get_client_key(
+        self, client: MLClient, registry_client: MLClient, pipelines_registry_client: MLClient
+    ) -> None:
+        """
+        Test private interface to get client key.
+        If you need to change the private interfaces and this test, please also update related code in
+        mock_component_hash.
+        """
+        workspace_key = client.components._get_workspace_key()
+        assert workspace_key
+        assert "workspace/" + workspace_key == client.components._get_client_key()
+
+        registry_key1 = registry_client.components._get_registry_key()
+        registry_key2 = pipelines_registry_client.components._get_registry_key()
+        assert registry_key1
+        assert registry_key2
+        assert "registry/" + registry_key1 == registry_client.components._get_client_key()
+        assert "registry/" + registry_key2 == pipelines_registry_client.components._get_client_key()
+        assert registry_key1 != registry_key2

--- a/sdk/ml/azure-ai-ml/tests/conftest.py
+++ b/sdk/ml/azure-ai-ml/tests/conftest.py
@@ -1,5 +1,4 @@
 import base64
-import hashlib
 import json
 import os
 import random
@@ -9,11 +8,10 @@ import time
 import uuid
 from collections import namedtuple
 from datetime import datetime
-from functools import partial
 from importlib import reload
 from os import getenv
 from pathlib import Path
-from typing import Callable, Optional, Tuple, Union
+from typing import Callable, Tuple, Union
 from unittest.mock import Mock, patch
 
 import pytest
@@ -664,26 +662,6 @@ def generate_component_hash(*args, **kwargs):
     return dict_hash
 
 
-def get_client_hash_with_request_node_name(
-    subscription_id: Optional[str],
-    resource_group_name: Optional[str],
-    workspace_name: Optional[str],
-    registry_name: Optional[str],
-    random_seed: str,
-):
-    """Generate a hash for the client."""
-    object_hash = hashlib.sha256()
-    for s in [
-        subscription_id,
-        resource_group_name,
-        workspace_name,
-        registry_name,
-        random_seed,
-    ]:
-        object_hash.update(str(s).encode("utf-8"))
-    return object_hash.hexdigest()
-
-
 def clear_on_disk_cache(cached_resolver):
     """Clear on disk cache for current client."""
     cached_resolver._lock.acquire()
@@ -724,26 +702,30 @@ def mock_component_hash(mocker: MockFixture, request: FixtureRequest):
     #   and test2 in workspace B, the version in recordings can be different.
     # So we use a random (probably unique) on-disk cache base directory for each test, and on-disk cache operations
     # will be thread-safe when concurrently running different tests.
-    mocker.patch(
-        "azure.ai.ml._utils._cache_utils.CachedNodeResolver._get_client_hash",
-        side_effect=partial(get_client_hash_with_request_node_name, random_seed=uuid.uuid4().hex),
-    )
+    involved_client_keys = set()
+    if not is_live_and_not_recording():
+        # Get client id will involve a new request to server, which is specifically tested in some tests.
+        # We mock it in playback mode to avoid changing recordings for most tests.
+        mock_workspace_id, mock_registry_id = uuid.uuid4().hex, uuid.uuid4().hex
+        mocker.patch(
+            "azure.ai.ml.operations._component_operations.ComponentOperations._get_workspace_key",
+            return_value=mock_workspace_id,
+        )
+        mocker.patch(
+            "azure.ai.ml.operations._component_operations.ComponentOperations._get_registry_key",
+            return_value=mock_registry_id,
+        )
+        involved_client_keys = {mock_workspace_id, mock_registry_id}
 
     # Collect involved resolvers before yield, as fixtures may be destroyed after yield.
     from azure.ai.ml._utils._cache_utils import CachedNodeResolver
 
     involved_resolvers = []
-    for client_fixture_name in ["client", "registry_client"]:
-        if client_fixture_name not in request.fixturenames:
-            continue
-        client: MLClient = request.getfixturevalue(client_fixture_name)
+    for client_key in involved_client_keys:
         involved_resolvers.append(
             CachedNodeResolver(
                 resolver=None,
-                subscription_id=client.subscription_id,
-                resource_group_name=client.resource_group_name,
-                workspace_name=client.workspace_name,
-                registry_name=client._operation_scope.registry_name,
+                client_key=client_key,
             )
         )
 

--- a/sdk/ml/azure-ai-ml/tests/internal_utils/unittests/test_cache_utils.py
+++ b/sdk/ml/azure-ai-ml/tests/internal_utils/unittests/test_cache_utils.py
@@ -5,6 +5,7 @@ from typing import Union
 
 import mock
 import pytest
+
 from azure.ai.ml import MLClient, load_job
 from azure.ai.ml._utils._cache_utils import CachedNodeResolver
 from azure.ai.ml.entities import Component, PipelineJob
@@ -30,10 +31,7 @@ class TestCacheUtils:
     def create_resolver(client: MLClient) -> CachedNodeResolver:
         return CachedNodeResolver(
             resolver=TestCacheUtils._mock_resolver,
-            subscription_id=client.subscription_id,
-            resource_group_name=client.resource_group_name,
-            workspace_name=client.workspace_name,
-            registry_name=client._operation_scope.registry_name,
+            client_key=client.components._get_client_key(),
         )
 
     @staticmethod

--- a/sdk/ml/azure-ai-ml/tests/job_common/unittests/test_job_operations.py
+++ b/sdk/ml/azure-ai-ml/tests/job_common/unittests/test_job_operations.py
@@ -7,13 +7,14 @@ import jwt
 import pytest
 import vcr
 import yaml
-from azure.ai.ml._azure_environments import _get_aml_resource_id_from_metadata, _resource_to_scopes
-from azure.ai.ml.exceptions import ValidationException
 from azure.core.credentials import AccessToken
+from azure.core.exceptions import HttpResponseError
+from azure.identity import DefaultAzureCredential
 from msrest import Deserializer
 from pytest_mock import MockFixture
 
 from azure.ai.ml import MLClient, load_job
+from azure.ai.ml._azure_environments import _get_aml_resource_id_from_metadata, _resource_to_scopes
 from azure.ai.ml._restclient.v2023_04_01_preview import models
 from azure.ai.ml._scope_dependent_operations import OperationConfig, OperationScope
 from azure.ai.ml.constants._common import AZUREML_PRIVATE_FEATURES_ENV_VAR, AzureMLResourceType
@@ -22,13 +23,12 @@ from azure.ai.ml.entities._job.automl.automl_job import AutoMLJob
 from azure.ai.ml.entities._job.automl.training_settings import TrainingSettings
 from azure.ai.ml.entities._job.job import Job
 from azure.ai.ml.entities._job.sweep.sweep_job import SweepJob
+from azure.ai.ml.exceptions import ValidationException
 from azure.ai.ml.operations import DatastoreOperations, EnvironmentOperations, JobOperations, WorkspaceOperations
 from azure.ai.ml.operations._code_operations import CodeOperations
 from azure.ai.ml.operations._job_ops_helper import get_git_properties
 from azure.ai.ml.operations._run_history_constants import RunHistoryConstants
 from azure.ai.ml.operations._run_operations import RunOperations
-from azure.core.exceptions import HttpResponseError
-from azure.identity import DefaultAzureCredential
 
 from .test_vcr_utils import before_record_cb, vcr_header_filters
 
@@ -147,6 +147,8 @@ class TestJobOperations:
         mock_job_operation.get("randon_name")
         mock_job_operation._operation_2023_02_preview.get.assert_called_once()
 
+    # use mock_component_hash to avoid passing a Mock object as client key
+    @pytest.mark.usefixtures("mock_component_hash")
     @patch.object(JobOperations, "_get_job")
     def test_get_job(self, mock_method, mock_job_operation: JobOperations) -> None:
         from azure.ai.ml import Input, dsl, load_component

--- a/sdk/ml/azure-ai-ml/tests/recordings/component/e2etests/test_component_without_mock.pyTestComponentWithoutMocktest_get_client_key.json
+++ b/sdk/ml/azure-ai-ml/tests/recordings/component/e2etests/test_component_without_mock.pyTestComponentWithoutMocktest_get_client_key.json
@@ -1,0 +1,314 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://eastus.api.azureml.ms/registrymanagement/v1.0/registries/testFeed/discovery",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json, text/json",
+        "Accept-Encoding": "gzip, deflate",
+        "Connection": "keep-alive",
+        "User-Agent": "azsdk-python-mgmt-machinelearningservices/0.1.0 Python/3.9.10 (Windows-10-10.0.22621-SP0)"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Connection": "keep-alive",
+        "Content-Encoding": "gzip",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 13 Jun 2023 04:14:57 GMT",
+        "Request-Context": "appId=cid-v1:2d2e8e63-272e-4b3c-8598-4ee570a0e70d",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "Vary": "Accept-Encoding",
+        "x-aml-cluster": "vienna-eastus-01",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-response-type": "standard",
+        "x-request-time": "0.026"
+      },
+      "ResponseBody": {
+        "registryId": "3b513a6b-f110-4e7f-9ce3-472b5aa28170",
+        "registryName": "testFeed",
+        "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
+        "primaryRegion": "centraluseuap",
+        "regions": [
+          "centraluseuap"
+        ],
+        "subscriptionId": "4f26493f-21d2-4726-92ea-1ddd550b1d27",
+        "resourceGroup": "test-registries",
+        "workspaceName": null,
+        "primaryRegionResourceProviderUri": "https://cert-int.experiments.azureml-test.net/",
+        "registryFqdns": {
+          "centraluseuap": {
+            "uri": "https://int.api.azureml-test.ms"
+          },
+          "int": {
+            "uri": "https://int.api.azureml-test.ms"
+          }
+        },
+        "intellectualPropertyPublisher": null
+      }
+    },
+    {
+      "RequestUri": "https://eastus.api.azureml.ms/registrymanagement/v1.0/registries/sdk-test/discovery",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json, text/json",
+        "Accept-Encoding": "gzip, deflate",
+        "Connection": "keep-alive",
+        "User-Agent": "azsdk-python-mgmt-machinelearningservices/0.1.0 Python/3.9.10 (Windows-10-10.0.22621-SP0)"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Connection": "keep-alive",
+        "Content-Encoding": "gzip",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 13 Jun 2023 04:15:00 GMT",
+        "Request-Context": "appId=cid-v1:2d2e8e63-272e-4b3c-8598-4ee570a0e70d",
+        "Strict-Transport-Security": "max-age=15724800; includeSubDomains; preload",
+        "Transfer-Encoding": "chunked",
+        "Vary": "Accept-Encoding",
+        "x-aml-cluster": "vienna-eastus-01",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-response-type": "standard",
+        "x-request-time": "0.622"
+      },
+      "ResponseBody": {
+        "registryId": "584f9ef8-1989-40a2-9dec-453611954463",
+        "registryName": "sdk-test",
+        "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
+        "primaryRegion": "eastus2euap",
+        "regions": [
+          "eastus2euap",
+          "eastus"
+        ],
+        "subscriptionId": "96aede12-2f73-41cb-b983-6d11a904839b",
+        "resourceGroup": "sdk",
+        "workspaceName": null,
+        "primaryRegionResourceProviderUri": "https://cert-eastus2euap.experiments.azureml.net/",
+        "registryFqdns": {
+          "eastus2euap": {
+            "uri": "https://eastus2euap.api.azureml.ms"
+          },
+          "eastus": {
+            "uri": "https://eastus.api.azureml.ms"
+          }
+        },
+        "intellectualPropertyPublisher": null
+      }
+    },
+    {
+      "RequestUri": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000/resourceGroups/00000/providers/Microsoft.MachineLearningServices/workspaces/00000?api-version=2023-04-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip, deflate",
+        "Connection": "keep-alive",
+        "User-Agent": "azure-ai-ml/1.9.0 azsdk-python-mgmt-machinelearningservices/0.1.0 Python/3.9.10 (Windows-10-10.0.22621-SP0)"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Encoding": "gzip",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 13 Jun 2023 04:15:03 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Request-Context": "appId=cid-v1:2d2e8e63-272e-4b3c-8598-4ee570a0e70d",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "Transfer-Encoding": "chunked",
+        "Vary": [
+          "Accept-Encoding",
+          "Accept-Encoding"
+        ],
+        "x-aml-cluster": "vienna-eastus-02",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-correlation-request-id": "a06c0875-b8f8-4e44-b2e7-208f522d2e8c",
+        "x-ms-ratelimit-remaining-subscription-reads": "11999",
+        "x-ms-response-type": "standard",
+        "x-ms-routing-request-id": "JAPANEAST:20230613T041504Z:a06c0875-b8f8-4e44-b2e7-208f522d2e8c",
+        "x-request-time": "0.020"
+      },
+      "ResponseBody": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000/resourceGroups/AmlComponentNotebook/providers/Microsoft.MachineLearningServices/workspaces/00000",
+        "name": "00000",
+        "type": "Microsoft.MachineLearningServices/workspaces",
+        "location": "eastus",
+        "tags": {
+          "createdByToolkit": "sdk-v1-1.51.0"
+        },
+        "etag": null,
+        "properties": {
+          "friendlyName": "00000",
+          "description": "",
+          "storageAccount": "/subscriptions/00000000-0000-0000-0000-000000000/resourceGroups/AmlComponentNotebook/providers/Microsoft.Storage/storageAccounts/sdknotebstorage3e70be1bd",
+          "keyVault": "/subscriptions/00000000-0000-0000-0000-000000000/resourceGroups/AmlComponentNotebook/providers/Microsoft.Keyvault/vaults/sdknotebkeyvaulte14e4119",
+          "applicationInsights": "/subscriptions/00000000-0000-0000-0000-000000000/resourceGroups/AmlComponentNotebook/providers/Microsoft.insights/components/sdknotebinsightsf8fbaf56",
+          "hbiWorkspace": false,
+          "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
+          "imageBuildCompute": null,
+          "provisioningState": "Succeeded",
+          "managedNetwork": {
+            "changeableIsolationModes": [
+              "AllowInternetOutbound",
+              "AllowOnlyApprovedOutbound"
+            ],
+            "isolationMode": "Disabled"
+          },
+          "v1LegacyMode": false,
+          "softDeleteEnabled": false,
+          "containerRegistry": "/subscriptions/00000000-0000-0000-0000-000000000/resourceGroups/AmlComponentNotebook/providers/Microsoft.ContainerRegistry/registries/6e7c71a33e6a4fc38b43d405a7a17c8a",
+          "creationTime": "2023-06-12T00:26:25.6288725Z",
+          "notebookInfo": {
+            "resourceId": "8f892f32398e4504b08859466507dfb5",
+            "fqdn": "ml-sdk-notebook-sta-eastus-6e7c71a3-3e6a-4fc3-8b43-d405a7a17c8a.eastus.notebooks.azure.net",
+            "isPrivateLinkEnabled": false,
+            "notebookPreparationError": null
+          },
+          "storageHnsEnabled": false,
+          "workspaceId": "6e7c71a3-3e6a-4fc3-8b43-d405a7a17c8a",
+          "linkedModelInventoryArmId": null,
+          "privateLinkCount": 0,
+          "publicNetworkAccess": "Enabled",
+          "discoveryUrl": "https://eastus.api.azureml.ms/discovery",
+          "mlFlowTrackingUri": "azureml://eastus.api.azureml.ms/mlflow/v1.0/subscriptions/00000000-0000-0000-0000-000000000/resourceGroups/AmlComponentNotebook/providers/Microsoft.MachineLearningServices/workspaces/00000",
+          "sdkTelemetryAppInsightsKey": "f5784ccd-178d-4ecc-9998-b05841b44ae9",
+          "sasGetterUri": "",
+          "enableDataIsolation": false,
+          "azureOpenAI": {
+            "provisioningState": "NotStarted",
+            "resourceId": null,
+            "endpoint": null,
+            "proxyResourceId": null
+          }
+        },
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "167a3407-94ed-4682-be01-d590b5680585",
+          "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+        },
+        "kind": "Default",
+        "sku": {
+          "name": "Basic",
+          "tier": "Basic"
+        },
+        "systemData": {
+          "createdAt": "2023-06-12T00:26:25.6288725Z",
+          "createdBy": "38db1e0d-0eab-4d80-91ef-8ac385645110",
+          "createdByType": "Application",
+          "lastModifiedAt": "2023-06-12T00:26:25.6288725Z",
+          "lastModifiedBy": "38db1e0d-0eab-4d80-91ef-8ac385645110",
+          "lastModifiedByType": "Application"
+        }
+      }
+    },
+    {
+      "RequestUri": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000/resourceGroups/00000/providers/Microsoft.MachineLearningServices/workspaces/00000?api-version=2023-04-01-preview",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip, deflate",
+        "Connection": "keep-alive",
+        "User-Agent": "azure-ai-ml/1.9.0 azsdk-python-mgmt-machinelearningservices/0.1.0 Python/3.9.10 (Windows-10-10.0.22621-SP0)"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Encoding": "gzip",
+        "Content-Type": "application/json; charset=utf-8",
+        "Date": "Tue, 13 Jun 2023 04:15:03 GMT",
+        "Expires": "-1",
+        "Pragma": "no-cache",
+        "Request-Context": "appId=cid-v1:2d2e8e63-272e-4b3c-8598-4ee570a0e70d",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "Transfer-Encoding": "chunked",
+        "Vary": [
+          "Accept-Encoding",
+          "Accept-Encoding"
+        ],
+        "x-aml-cluster": "vienna-eastus-02",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-correlation-request-id": "4f0a47f6-f254-4837-9164-f30ea622ab22",
+        "x-ms-ratelimit-remaining-subscription-reads": "11998",
+        "x-ms-response-type": "standard",
+        "x-ms-routing-request-id": "JAPANEAST:20230613T041504Z:4f0a47f6-f254-4837-9164-f30ea622ab22",
+        "x-request-time": "0.020"
+      },
+      "ResponseBody": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000/resourceGroups/AmlComponentNotebook/providers/Microsoft.MachineLearningServices/workspaces/00000",
+        "name": "00000",
+        "type": "Microsoft.MachineLearningServices/workspaces",
+        "location": "eastus",
+        "tags": {
+          "createdByToolkit": "sdk-v1-1.51.0"
+        },
+        "etag": null,
+        "properties": {
+          "friendlyName": "00000",
+          "description": "",
+          "storageAccount": "/subscriptions/00000000-0000-0000-0000-000000000/resourceGroups/AmlComponentNotebook/providers/Microsoft.Storage/storageAccounts/sdknotebstorage3e70be1bd",
+          "keyVault": "/subscriptions/00000000-0000-0000-0000-000000000/resourceGroups/AmlComponentNotebook/providers/Microsoft.Keyvault/vaults/sdknotebkeyvaulte14e4119",
+          "applicationInsights": "/subscriptions/00000000-0000-0000-0000-000000000/resourceGroups/AmlComponentNotebook/providers/Microsoft.insights/components/sdknotebinsightsf8fbaf56",
+          "hbiWorkspace": false,
+          "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
+          "imageBuildCompute": null,
+          "provisioningState": "Succeeded",
+          "managedNetwork": {
+            "changeableIsolationModes": [
+              "AllowInternetOutbound",
+              "AllowOnlyApprovedOutbound"
+            ],
+            "isolationMode": "Disabled"
+          },
+          "v1LegacyMode": false,
+          "softDeleteEnabled": false,
+          "containerRegistry": "/subscriptions/00000000-0000-0000-0000-000000000/resourceGroups/AmlComponentNotebook/providers/Microsoft.ContainerRegistry/registries/6e7c71a33e6a4fc38b43d405a7a17c8a",
+          "creationTime": "2023-06-12T00:26:25.6288725Z",
+          "notebookInfo": {
+            "resourceId": "8f892f32398e4504b08859466507dfb5",
+            "fqdn": "ml-sdk-notebook-sta-eastus-6e7c71a3-3e6a-4fc3-8b43-d405a7a17c8a.eastus.notebooks.azure.net",
+            "isPrivateLinkEnabled": false,
+            "notebookPreparationError": null
+          },
+          "storageHnsEnabled": false,
+          "workspaceId": "6e7c71a3-3e6a-4fc3-8b43-d405a7a17c8a",
+          "linkedModelInventoryArmId": null,
+          "privateLinkCount": 0,
+          "publicNetworkAccess": "Enabled",
+          "discoveryUrl": "https://eastus.api.azureml.ms/discovery",
+          "mlFlowTrackingUri": "azureml://eastus.api.azureml.ms/mlflow/v1.0/subscriptions/00000000-0000-0000-0000-000000000/resourceGroups/AmlComponentNotebook/providers/Microsoft.MachineLearningServices/workspaces/00000",
+          "sdkTelemetryAppInsightsKey": "f5784ccd-178d-4ecc-9998-b05841b44ae9",
+          "sasGetterUri": "",
+          "enableDataIsolation": false,
+          "azureOpenAI": {
+            "provisioningState": "NotStarted",
+            "resourceId": null,
+            "endpoint": null,
+            "proxyResourceId": null
+          }
+        },
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "167a3407-94ed-4682-be01-d590b5680585",
+          "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+        },
+        "kind": "Default",
+        "sku": {
+          "name": "Basic",
+          "tier": "Basic"
+        },
+        "systemData": {
+          "createdAt": "2023-06-12T00:26:25.6288725Z",
+          "createdBy": "38db1e0d-0eab-4d80-91ef-8ac385645110",
+          "createdByType": "Application",
+          "lastModifiedAt": "2023-06-12T00:26:25.6288725Z",
+          "lastModifiedBy": "38db1e0d-0eab-4d80-91ef-8ac385645110",
+          "lastModifiedByType": "Application"
+        }
+      }
+    }
+  ],
+  "Variables": {}
+}


### PR DESCRIPTION
# Description

Previously we used workspace arm id to distinguish on-disk cache, which brought potential problems if the workspace is deleted and recreated with the same name. We switch to use workspace id in this PR.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
