### PR TITLE
[pipeline] Catch the exception that load yaml failed

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_validation.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_validation.py
@@ -632,7 +632,7 @@ class _YamlLocationResolver:
         with open(source_path, encoding="utf-8") as f:
             try:
                 loaded_yaml = strictyaml.load(f.read())
-            except (ScannerError, strictyaml.exceptions.StrictYAMLError) as e:
+            except Exception as e:
                 msg = "Can't load source file %s as a strict yaml:\n%s" % (source_path, str(e))
                 module_logger.debug(msg)
                 return None, None

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_validation.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_validation.py
@@ -17,7 +17,6 @@ import msrest
 import pydash
 import strictyaml
 from marshmallow import Schema, ValidationError
-from strictyaml.ruamel.scanner import ScannerError
 
 from .._schema import PathAwareSchema
 from .._vendor.azure_resources.models import Deployment, DeploymentProperties, DeploymentValidateResult, ErrorResponse
@@ -632,7 +631,7 @@ class _YamlLocationResolver:
         with open(source_path, encoding="utf-8") as f:
             try:
                 loaded_yaml = strictyaml.load(f.read())
-            except Exception as e:
+            except Exception as e:  # pylint: disable=broad-except
                 msg = "Can't load source file %s as a strict yaml:\n%s" % (source_path, str(e))
                 module_logger.debug(msg)
                 return None, None

--- a/sdk/ml/azure-ai-ml/tests/pipeline_job/unittests/test_pipeline_job_validate.py
+++ b/sdk/ml/azure-ai-ml/tests/pipeline_job/unittests/test_pipeline_job_validate.py
@@ -342,6 +342,8 @@ class TestDSLPipelineJobValidate:
             "jobs.microsoftsamples_command_component_basic.compute": "Compute not set",
             "inputs.component_in_path": "Required input 'component_in_path' for pipeline 'pipeline' not provided.",
         }
+        validate_result.resolve_location_for_diagnostics(source_path=pipeline2.component._source_path)
+
 
     def test_pipeline_with_none_parameter_no_default_optional_false(self) -> None:
         default_optional_func = load_component(str(components_dir / "default_optional_component.yml"))

--- a/sdk/ml/azure-ai-ml/tests/pipeline_job/unittests/test_pipeline_job_validate.py
+++ b/sdk/ml/azure-ai-ml/tests/pipeline_job/unittests/test_pipeline_job_validate.py
@@ -344,7 +344,6 @@ class TestDSLPipelineJobValidate:
         }
         validate_result.resolve_location_for_diagnostics(source_path=pipeline2.component._source_path)
 
-
     def test_pipeline_with_none_parameter_no_default_optional_false(self) -> None:
         default_optional_func = load_component(str(components_dir / "default_optional_component.yml"))
 


### PR DESCRIPTION
# Description
Currently, only scannerError and StrickYAMLError are catched when load component yaml failed when fix the diagnostics. Other types of error will block the pipeline operation.
For example:
```
"""
Comments
"""
from azure.ai.ml.dsl import pipeline

@dsl.pipeline
def func():
    pass
```
When there is a warning in this pipeline validate result, it will raise ComposerError when generate diagnostic.

Please add an informative description that covers that changes made by the pull request and link all relevant issues.

If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
