### PR TITLE
Update ownership of Mixed Reality projects

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -262,8 +262,8 @@
 /sdk/maps/                                                           @alextts627
 
 # PRLabel: %Mixed Reality
-/sdk/mixedreality/azure-mixedreality-authentication/                 @crtreasu
-/sdk/remoterendering/                                                @rikogeln
+/sdk/mixedreality/azure-mixedreality-authentication/                 @RamonArguelles
+/sdk/remoterendering/                                                @FlorianBorn71
 
 # PRLabel: %Open AI
 /sdk/openai                                                          @kristapratico @glecaros


### PR DESCRIPTION
Change ownership to reflect the current lead of each Mixed Reality project.