### PR TITLE
[Key Vault] Fix sample snippet heading

### DIFF
--- a/sdk/keyvault/azure-keyvault-administration/samples/access_control_operations.py
+++ b/sdk/keyvault/azure-keyvault-administration/samples/access_control_operations.py
@@ -57,7 +57,7 @@ from azure.keyvault.administration import KeyVaultRoleScope
 role_definitions = client.list_role_definitions(scope=KeyVaultRoleScope.GLOBAL)
 for definition in role_definitions:
     print(f"Role name: {definition.role_name}; Role definition name: {definition.name}")
-# [START list_role_definitions]
+# [END list_role_definitions]
 
 # Let's create a custom role definition. This role permits creating keys in a Managed HSM.
 # We'll provide a friendly role name and let a unique role definition name (a UUID) be generated for us.


### PR DESCRIPTION
# Description

Recent KV pipeline runs have [started failing](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=2840488&view=logs&j=b70e5e73-bbb6-5567-0939-8415943fadb9&t=f3c2469e-6935-5949-b282-5aba94ff7e0d) because of the snippet updating script. In the `access_control_operations.py` sample file, we have a snippet that accidentally has `[START` for its start *and* end headers, meaning the following snippet is interpreted as part of the previous snippet. This PR fixes the end header to correctly use `[END`.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
