### PR TITLE
Unclear documentation of function publish_telemetry

### DIFF
--- a/sdk/digitaltwins/azure-digitaltwins-core/azure/digitaltwins/core/_digitaltwins_client.py
+++ b/sdk/digitaltwins/azure-digitaltwins-core/azure/digitaltwins/core/_digitaltwins_client.py
@@ -397,8 +397,10 @@ class DigitalTwinsClient(object): # pylint: disable=too-many-public-methods,clie
     @distributed_trace
     def publish_telemetry(self, digital_twin_id, telemetry, **kwargs):
         # type: (str, object, **Any) -> None
-        """Publish telemetry from a digital twin, which is then consumed by
-        one or many destination endpoints (subscribers) defined under.
+        """Publish telemetry from a digital twin. The result is then
+        consumed by one or many destination endpoints (subscribers) defined under
+        DigitalTwinsEventRoute. These event routes need to be set before publishing
+        a telemetry message, in order for the telemetry message to be consumed.
 
         :param str digital_twin_id: The ID of the digital twin
         :param object telemetry: The telemetry data to be sent
@@ -428,8 +430,10 @@ class DigitalTwinsClient(object): # pylint: disable=too-many-public-methods,clie
         **kwargs
     ):
         # type: (str, str, object, **Any) -> None
-        """Publish telemetry from a digital twin's component, which is then consumed by
-        one or many destination endpoints (subscribers) defined under.
+        """Publish telemetry from a digital twin. The result is then
+        consumed by one or many destination endpoints (subscribers) defined under
+        DigitalTwinsEventRoute. These event routes need to be set before publishing
+        a telemetry message, in order for the telemetry message to be consumed.
 
         :param str digital_twin_id: The ID of the digital twin.
         :param str component_name: The name of the DTDL component.

--- a/sdk/digitaltwins/azure-digitaltwins-core/azure/digitaltwins/core/aio/_digitaltwins_client_async.py
+++ b/sdk/digitaltwins/azure-digitaltwins-core/azure/digitaltwins/core/aio/_digitaltwins_client_async.py
@@ -438,8 +438,10 @@ class DigitalTwinsClient(object): # pylint: disable=too-many-public-methods,clie
         telemetry: object,
         **kwargs
     ) -> None:
-        """Publish telemetry from a digital twin, which is then consumed by
-        one or many destination endpoints (subscribers) defined under.
+        """Publish telemetry from a digital twin. The result is then
+        consumed by one or many destination endpoints (subscribers) defined under
+        DigitalTwinsEventRoute. These event routes need to be set before publishing
+        a telemetry message, in order for the telemetry message to be consumed.
 
         :param str digital_twin_id: The ID of the digital twin
         :param object telemetry: The telemetry data to be sent
@@ -468,8 +470,10 @@ class DigitalTwinsClient(object): # pylint: disable=too-many-public-methods,clie
         telemetry: object,
         **kwargs
     ) -> None:
-        """Publish telemetry from a digital twin's component, which is then consumed
-        by one or many destination endpoints (subscribers) defined under.
+        """Publish telemetry from a digital twin. The result is then
+        consumed by one or many destination endpoints (subscribers) defined under
+        DigitalTwinsEventRoute. These event routes need to be set before publishing
+        a telemetry message, in order for the telemetry message to be consumed.
 
         :param str digital_twin_id: The ID of the digital twin.
         :param str component_name: The name of the DTDL component.


### PR DESCRIPTION
Fixes Azure/azure-sdk-for-python#30667

Documentation Link: https://learn.microsoft.com/en-us/python/api/azure-digitaltwins-core/azure.digitaltwins.core.digitaltwinsclient?view=azure-python#azure-digitaltwins-core-digitaltwinsclient-publish-telemetry

The current description for the `publish_telemetry( )` method is unclear / confusing.

Here is the detailed description:

> Publish telemetry from a digital twin. The result is then consumed by one or many destination endpoints (subscribers) defined under DigitalTwinsEventRoute. These event routes need to be set before publishing a telemetry message, in order for the telemetry message to be consumed.

# Description

Please add an informative description that covers that changes made by the pull request and link all relevant issues.

If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
