### PR TITLE
[Test Proxy] Create HTTP clients at runtime to support dynamic certificate setup

### DIFF
--- a/tools/azure-sdk-tools/devtools_testutils/proxy_testcase.py
+++ b/tools/azure-sdk-tools/devtools_testutils/proxy_testcase.py
@@ -19,9 +19,8 @@ from azure.core.pipeline.transport import RequestsTransport
 from azure_devtools.scenario_tests.utilities import trim_kwargs_from_test_function
 
 from .config import PROXY_URL
-from .helpers import get_test_id, is_live, is_live_and_not_recording, set_recording_id
+from .helpers import get_http_client, get_test_id, is_live, is_live_and_not_recording, set_recording_id
 from .proxy_startup import discovered_roots
-from urllib3 import PoolManager, Retry
 from urllib3.exceptions import HTTPError
 import json
 
@@ -32,15 +31,6 @@ if TYPE_CHECKING:
 # To learn about how to migrate SDK tests to the test proxy, please refer to the migration guide at
 # https://github.com/Azure/azure-sdk-for-python/blob/main/doc/dev/test_proxy_migration_guide.md
 
-if os.getenv("REQUESTS_CA_BUNDLE"):
-    http_client = PoolManager(
-        retries=Retry(total=3, raise_on_status=False),
-        cert_reqs="CERT_REQUIRED",
-        ca_certs=os.getenv("REQUESTS_CA_BUNDLE"),
-    )
-else:
-    http_client = PoolManager(retries=Retry(total=3, raise_on_status=False))
-
 # defaults
 RECORDING_START_URL = "{}/record/start".format(PROXY_URL)
 RECORDING_STOP_URL = "{}/record/stop".format(PROXY_URL)
@@ -49,9 +39,7 @@ PLAYBACK_STOP_URL = "{}/playback/stop".format(PROXY_URL)
 
 
 def get_recording_assets(test_id: str) -> str:
-    """
-    Used to retrieve the assets.json given a PYTEST_CURRENT_TEST test id.
-    """
+    """Used to retrieve the assets.json given a PYTEST_CURRENT_TEST test id."""
     for root in discovered_roots:
         current_dir = os.path.dirname(test_id)
         while current_dir is not None and not (os.path.dirname(current_dir) == current_dir):
@@ -85,6 +73,7 @@ def start_record_or_playback(test_id: str) -> "Tuple[str, Dict[str, str]]":
         json_payload["x-recording-assets-file"] = assets_json
 
     encoded_payload = json.dumps(json_payload).encode("utf-8")
+    http_client = get_http_client()
 
     if is_live():
         result = http_client.request(
@@ -127,6 +116,7 @@ def start_record_or_playback(test_id: str) -> "Tuple[str, Dict[str, str]]":
 
 def stop_record_or_playback(test_id: str, recording_id: str, test_variables: "Dict[str, str]") -> None:
     try:
+        http_client = get_http_client()
         if is_live():
             http_client.request(
                 method="POST",

--- a/tools/azure-sdk-tools/devtools_testutils/sanitizers.py
+++ b/tools/azure-sdk-tools/devtools_testutils/sanitizers.py
@@ -3,26 +3,15 @@
 # Licensed under the MIT License. See License.txt in the project root for
 # license information.
 # --------------------------------------------------------------------------
+import json
 from typing import TYPE_CHECKING
 
-
-from urllib3 import PoolManager, Retry
-import json, os
-
 from .config import PROXY_URL
-from .helpers import get_recording_id, is_live, is_live_and_not_recording
+from .helpers import get_http_client, get_recording_id, is_live, is_live_and_not_recording
 
 if TYPE_CHECKING:
     from typing import Optional
 
-if os.getenv("REQUESTS_CA_BUNDLE"):
-    http_client = PoolManager(
-        retries=Retry(total=3, raise_on_status=True),
-        cert_reqs="CERT_REQUIRED",
-        ca_certs=os.getenv("REQUESTS_CA_BUNDLE"),
-    )
-else:
-    http_client = PoolManager(retries=Retry(total=3, raise_on_status=True))
 
 # This file contains methods for adjusting many aspects of test proxy behavior:
 #
@@ -635,6 +624,7 @@ def _send_matcher_request(matcher: str, headers: dict, parameters: "Optional[dic
         if headers[key] is not None:
             headers_to_send[key] = headers[key]
 
+    http_client = get_http_client()
     http_client.request(
         method="POST",
         url=f"{PROXY_URL}/Admin/SetMatcher",
@@ -662,6 +652,7 @@ def _send_recording_options_request(parameters: dict, headers: "Optional[dict]" 
         if headers[key] is not None:
             headers_to_send[key] = headers[key]
 
+    http_client = get_http_client()
     http_client.request(
         method="POST",
         url=f"{PROXY_URL}/Admin/SetRecordingOptions",
@@ -687,6 +678,7 @@ def _send_reset_request(headers: dict) -> None:
         if headers[key] is not None:
             headers_to_send[key] = headers[key]
 
+    http_client = get_http_client()
     http_client.request(method="POST", url=f"{PROXY_URL}/Admin/Reset", headers=headers_to_send)
 
 
@@ -708,6 +700,7 @@ def _send_sanitizer_request(sanitizer: str, parameters: dict, headers: "Optional
         if headers[key] is not None:
             headers_to_send[key] = headers[key]
 
+    http_client = get_http_client()
     http_client.request(
         method="POST",
         url="{}/Admin/AddSanitizer".format(PROXY_URL),
@@ -733,6 +726,7 @@ def _send_transform_request(transform: str, parameters: dict, headers: "Optional
         if headers[key] is not None:
             headers_to_send[key] = headers[key]
 
+    http_client = get_http_client()
     http_client.request(
         method="POST",
         url=f"{PROXY_URL}/Admin/AddTransform",


### PR DESCRIPTION
# Description

Module-level, shared HTTP clients are more efficient but will be set up before `SSL_CERT_DIR` and `REQUESTS_CA_BUNDLE` are automatically set by the test proxy's setup script. This results in certificate errors when making requests to the test proxy if these environment variables aren't manually set beforehand in either a `.env` file or in the user's test-running environment.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
