### PR TITLE
Add cosmos emulator pipeline

### DIFF
--- a/eng/pipelines/templates/stages/cosmos-sdk-client.yml
+++ b/eng/pipelines/templates/stages/cosmos-sdk-client.yml
@@ -26,32 +26,3 @@ extends:
     TestMarkArgument: not cosmosEmulator
     InjectedPackages: ${{parameters.InjectedPackages}}
     Artifacts: ${{parameters.Artifacts}}
-
-#  - stage: Test_Emulator
-#    dependsOn: []
-#    jobs:
-#    - job: Emulator
-#      strategy:
-#        matrix:
-#          Windows_Python36:
-#            OSVmImage: 'windows-2022'
-#            PythonVersion: '3.6'
-#      pool:
-#        vmImage: $(OSVmImage)
-#
-#      steps:
-#        - template: /eng/common/pipelines/templates/steps/cosmos-emulator.yml
-#          parameters:
-#            EmulatorMsiUrl: ${{ parameters.EmulatorMsiUrl }}
-#            StartParameters: ${{ parameters.EmulatorStartParameters }}
-#
-#        - template: /eng/pipelines/templates/steps/build-test.yml
-#          parameters:
-#            TestMarkArgument: not globaldb
-#            EnvVars:
-#              ACCOUNT_HOST: https://localhost:8081/
-#            ServiceDirectory: ${{ parameters.ServiceDirectory }}
-#            PythonVersion: $(PythonVersion)
-#            OSVmImage: $(OSVmImage)
-#            ToxTestEnv: 'whl,sdist'
-#            InjectedPackages: ${{parameters.InjectedPackages}}

--- a/sdk/cosmos/ci.emulator.yml
+++ b/sdk/cosmos/ci.emulator.yml
@@ -1,0 +1,53 @@
+# NOTE: Please refer to https://aka.ms/azsdk/engsys/ci-yaml before editing this file.
+trigger:
+  branches:
+    include:
+    - main
+    - hotfix/*
+    - release/*
+    - restapi*
+  paths:
+    include:
+    - sdk/cosmos/
+
+pr:
+  branches:
+    include:
+    - main
+    - feature/*
+    - hotfix/*
+    - release/*
+    - restapi*
+  paths:
+    include:
+    - sdk/cosmos/
+
+stages:
+  - stage: Test_Emulator
+    dependsOn: []
+    jobs:
+    - job: Emulator
+      strategy:
+        matrix:
+          Windows_Python36:
+            OSVmImage: 'windows-2022'
+            PythonVersion: '3.6'
+      pool:
+        vmImage: $(OSVmImage)
+
+      steps:
+        - template: /eng/common/pipelines/templates/steps/cosmos-emulator.yml
+          parameters:
+            EmulatorMsiUrl: ${{ parameters.EmulatorMsiUrl }}
+            StartParameters: ${{ parameters.EmulatorStartParameters }}
+
+        - template: /eng/pipelines/templates/steps/build-test.yml
+          parameters:
+            TestMarkArgument: not globaldb
+            EnvVars:
+              ACCOUNT_HOST: https://localhost:8081/
+            ServiceDirectory: ${{ parameters.ServiceDirectory }}
+            PythonVersion: $(PythonVersion)
+            OSVmImage: $(OSVmImage)
+            ToxTestEnv: 'whl,sdist'
+            InjectedPackages: ${{parameters.InjectedPackages}}

--- a/sdk/cosmos/ci.emulator.yml
+++ b/sdk/cosmos/ci.emulator.yml
@@ -22,28 +22,23 @@ pr:
     include:
     - sdk/cosmos/
 
+variables:
+  ACCOUNT_HOST: https://localhost:8081/
+  PythonVersion: 3.9
+  Pool: azsdk-pool-mms-ubuntu-2004-general
+  OSVmImage: MMSUbuntu20.04
+  toxenv: 'whl,sdist'
+
 stages:
   - stage: Test_Emulator
     dependsOn: []
     jobs:
-    - job: Emulator
-      strategy:
-        matrix:
-          Windows_Python36:
-            OSVmImage: 'windows-2022'
-            PythonVersion: '3.6'
-      pool:
-        vmImage: $(OSVmImage)
-
-      steps:
-        - template: /eng/common/pipelines/templates/steps/cosmos-emulator.yml
-
-        - template: /eng/pipelines/templates/steps/build-test.yml
-          parameters:
-            TestMarkArgument: not globaldb
-            EnvVars:
-              ACCOUNT_HOST: https://localhost:8081/
-            ServiceDirectory: cosmos
-            PythonVersion: $(PythonVersion)
-            OSVmImage: $(OSVmImage)
-            ToxTestEnv: 'whl,sdist'
+    - template: /eng/pipelines/templates/jobs/ci.tests.yml
+      parameters:
+        ServiceDirectory: cosmos
+        BeforeTestSteps:
+          - template: /eng/common/pipelines/templates/steps/cosmos-emulator.yml
+            parameters:
+              StartParameters: '/noexplorer /noui /enablepreview /EnableSqlComputeEndpoint /SqlComputePort=9999 /disableratelimiting /partitioncount=50 /consistency=Strong'
+        BuildTargetingString: azure-cosmos
+        TestMarkArgument: not globaldb

--- a/sdk/cosmos/ci.emulator.yml
+++ b/sdk/cosmos/ci.emulator.yml
@@ -34,13 +34,10 @@ extends:
           StartParameters: '/noexplorer /noui /enablepreview /EnableSqlComputeEndpoint /SqlComputePort=9999 /disableratelimiting /partitioncount=50 /consistency=Strong'
     TestMarkArgument: not cosmosEmulator
     MatrixConfigs:
-      - name: MatrixConfigs
-        type: object
-        default:
-          - Name: Python_cosmos_emulator
-            Path: sdk/cosmos/emulator-matrix.json
-            Selection: sparse
-            GenerateVMJobs: true
+      - Name: Python_cosmos_emulator
+        Path: sdk/cosmos/emulator-matrix.json
+        Selection: sparse
+        GenerateVMJobs: true
     Artifacts:
     - name: azure-cosmos
       safeName: azurecosmos

--- a/sdk/cosmos/ci.emulator.yml
+++ b/sdk/cosmos/ci.emulator.yml
@@ -9,6 +9,7 @@ trigger:
   paths:
     include:
     - sdk/cosmos/
+    - sdk/core/
 
 pr:
   branches:
@@ -21,24 +22,25 @@ pr:
   paths:
     include:
     - sdk/cosmos/
+    - sdk/core/
 
-variables:
-  ACCOUNT_HOST: https://localhost:8081/
-  PythonVersion: 3.9
-  Pool: azsdk-pool-mms-ubuntu-2004-general
-  OSVmImage: MMSUbuntu20.04
-  toxenv: 'whl,sdist'
-
-stages:
-  - stage: Test_Emulator
-    dependsOn: []
-    jobs:
-    - template: /eng/pipelines/templates/jobs/ci.tests.yml
-      parameters:
-        ServiceDirectory: cosmos
-        BeforeTestSteps:
-          - template: /eng/common/pipelines/templates/steps/cosmos-emulator.yml
-            parameters:
-              StartParameters: '/noexplorer /noui /enablepreview /EnableSqlComputeEndpoint /SqlComputePort=9999 /disableratelimiting /partitioncount=50 /consistency=Strong'
-        BuildTargetingString: azure-cosmos
-        TestMarkArgument: not globaldb
+extends:
+  template: /eng/pipelines/templates/stages/archetype-sdk-client.yml
+  parameters:
+    ServiceDirectory: cosmos
+    BeforeTestSteps:
+      - template: /eng/common/pipelines/templates/steps/cosmos-emulator.yml
+        parameters:
+          StartParameters: '/noexplorer /noui /enablepreview /EnableSqlComputeEndpoint /SqlComputePort=9999 /disableratelimiting /partitioncount=50 /consistency=Strong'
+    TestMarkArgument: not cosmosEmulator
+    MatrixConfigs:
+      - name: MatrixConfigs
+        type: object
+        default:
+          - Name: Python_cosmos_emulator
+            Path: sdk/cosmos/emulator-matrix.json
+            Selection: sparse
+            GenerateVMJobs: true
+    Artifacts:
+    - name: azure-cosmos
+      safeName: azurecosmos

--- a/sdk/cosmos/ci.emulator.yml
+++ b/sdk/cosmos/ci.emulator.yml
@@ -37,17 +37,13 @@ stages:
 
       steps:
         - template: /eng/common/pipelines/templates/steps/cosmos-emulator.yml
-          parameters:
-            EmulatorMsiUrl: ${{ parameters.EmulatorMsiUrl }}
-            StartParameters: ${{ parameters.EmulatorStartParameters }}
 
         - template: /eng/pipelines/templates/steps/build-test.yml
           parameters:
             TestMarkArgument: not globaldb
             EnvVars:
               ACCOUNT_HOST: https://localhost:8081/
-            ServiceDirectory: ${{ parameters.ServiceDirectory }}
+            ServiceDirectory: cosmos
             PythonVersion: $(PythonVersion)
             OSVmImage: $(OSVmImage)
             ToxTestEnv: 'whl,sdist'
-            InjectedPackages: ${{parameters.InjectedPackages}}

--- a/sdk/cosmos/emulator-matrix.json
+++ b/sdk/cosmos/emulator-matrix.json
@@ -13,6 +13,7 @@
     "TestSamples": "false",
     "ToxTestEnv": "'whl,sdist'",
     "ACCOUNT_HOST": "https://localhost:8081/",
-    "ACCOUNT_KEY": "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw=="
+    "ACCOUNT_KEY": "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==",
+    "Skip.Analyze": "true"
   }
 }

--- a/sdk/cosmos/emulator-matrix.json
+++ b/sdk/cosmos/emulator-matrix.json
@@ -1,0 +1,18 @@
+{
+  "displayNames": {
+    "--disablecov": "",
+    "false": "",
+    "true": ""
+  },
+  "matrix": {
+    "Agent": {
+      "windows-2022": { "OSVmImage": "MMS2022", "Pool": "azsdk-pool-mms-win-2022-general" }
+    },
+    "PythonVersion": [ "3.9" ],
+    "CoverageArg": "--disablecov",
+    "TestSamples": "false",
+    "ToxTestEnv": "'whl,sdist'",
+    "ACCOUNT_HOST": "https://localhost:8081/",
+    "ACCOUNT_KEY": "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw=="
+  }
+}


### PR DESCRIPTION
Moving the cosmos emulator tests into their own pipeline, since we can't add it as its own stage anymore due to the use of `extends` in `cosmos-sdk-client.yml`. We are doing the same thing for Java as well.
