### PR TITLE
[Storage] Fix `block_id` floating point issue

### DIFF
--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/uploads.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/uploads.py
@@ -268,7 +268,7 @@ class BlockBlobChunkUploader(_ChunkUploader):
 
     def _upload_substream_block(self, index, block_stream):
         try:
-            block_id = f'BlockId{(index/self.chunk_size):05}'
+            block_id = f'BlockId{(index//self.chunk_size):05}'
             self.service.stage_block(
                 block_id,
                 len(block_stream),

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/uploads_async.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/uploads_async.py
@@ -294,7 +294,7 @@ class BlockBlobChunkUploader(_ChunkUploader):
 
     async def _upload_substream_block(self, index, block_stream):
         try:
-            block_id = f'BlockId{(index/self.chunk_size):05}'
+            block_id = f'BlockId{(index//self.chunk_size):05}'
             await self.service.stage_block(
                 block_id,
                 len(block_stream),

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/uploads.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/uploads.py
@@ -268,7 +268,7 @@ class BlockBlobChunkUploader(_ChunkUploader):
 
     def _upload_substream_block(self, index, block_stream):
         try:
-            block_id = f'BlockId{(index/self.chunk_size):05}'
+            block_id = f'BlockId{(index//self.chunk_size):05}'
             self.service.stage_block(
                 block_id,
                 len(block_stream),

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/uploads_async.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/uploads_async.py
@@ -294,7 +294,7 @@ class BlockBlobChunkUploader(_ChunkUploader):
 
     async def _upload_substream_block(self, index, block_stream):
         try:
-            block_id = f'BlockId{(index/self.chunk_size):05}'
+            block_id = f'BlockId{(index//self.chunk_size):05}'
             await self.service.stage_block(
                 block_id,
                 len(block_stream),

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/uploads.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/uploads.py
@@ -268,7 +268,7 @@ class BlockBlobChunkUploader(_ChunkUploader):
 
     def _upload_substream_block(self, index, block_stream):
         try:
-            block_id = f'BlockId{(index/self.chunk_size):05}'
+            block_id = f'BlockId{(index//self.chunk_size):05}'
             self.service.stage_block(
                 block_id,
                 len(block_stream),
@@ -578,8 +578,6 @@ class IterStreamer(object):
 
     def __next__(self):
         return next(self.iterator)
-
-    next = __next__  # Python 2 compatibility.
 
     def tell(self, *args, **kwargs):
         raise UnsupportedOperation("Data generator does not support tell.")

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/uploads_async.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/uploads_async.py
@@ -294,7 +294,7 @@ class BlockBlobChunkUploader(_ChunkUploader):
 
     async def _upload_substream_block(self, index, block_stream):
         try:
-            block_id = f'BlockId{(index/self.chunk_size):05}'
+            block_id = f'BlockId{(index//self.chunk_size):05}'
             await self.service.stage_block(
                 block_id,
                 len(block_stream),

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/uploads.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/uploads.py
@@ -268,7 +268,7 @@ class BlockBlobChunkUploader(_ChunkUploader):
 
     def _upload_substream_block(self, index, block_stream):
         try:
-            block_id = f'BlockId{(index/self.chunk_size):05}'
+            block_id = f'BlockId{(index//self.chunk_size):05}'
             self.service.stage_block(
                 block_id,
                 len(block_stream),
@@ -578,8 +578,6 @@ class IterStreamer(object):
 
     def __next__(self):
         return next(self.iterator)
-
-    next = __next__  # Python 2 compatibility.
 
     def tell(self, *args, **kwargs):
         raise UnsupportedOperation("Data generator does not support tell.")

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/uploads_async.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/uploads_async.py
@@ -294,7 +294,7 @@ class BlockBlobChunkUploader(_ChunkUploader):
 
     async def _upload_substream_block(self, index, block_stream):
         try:
-            block_id = f'BlockId{(index/self.chunk_size):05}'
+            block_id = f'BlockId{(index//self.chunk_size):05}'
             await self.service.stage_block(
                 block_id,
                 len(block_stream),


### PR DESCRIPTION
This puts out of a fix for the typo in the f-string conversion that led to block IDs being floating point (since `int` / `int` results in floating point in Python 3.x+) and so we need to use the integer safe `//` operator