### PR TITLE
[Monitor Ingestion] Code gen updates

### DIFF
--- a/sdk/monitor/azure-monitor-ingestion/azure/__init__.py
+++ b/sdk/monitor/azure-monitor-ingestion/azure/__init__.py
@@ -1,1 +1,1 @@
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/sdk/monitor/azure-monitor-ingestion/azure/monitor/__init__.py
+++ b/sdk/monitor/azure-monitor-ingestion/azure/monitor/__init__.py
@@ -1,1 +1,1 @@
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/sdk/monitor/azure-monitor-ingestion/azure/monitor/ingestion/_helpers.py
+++ b/sdk/monitor/azure-monitor-ingestion/azure/monitor/ingestion/_helpers.py
@@ -17,7 +17,7 @@ else:
 _LOGGER = logging.getLogger(__name__)
 JSON = MutableMapping[str, Any]  # pylint: disable=unsubscriptable-object
 
-MAX_CHUNK_SIZE_BYTES = 1024 * 1024 # 1 MiB
+MAX_CHUNK_SIZE_BYTES = 1024 * 1024  # 1 MiB
 GZIP_MAGIC_NUMBER = b"\x1f\x8b"
 
 
@@ -31,12 +31,12 @@ def _split_chunks(logs: List[JSON], max_size_bytes: int = MAX_CHUNK_SIZE_BYTES) 
             chunk_size += size
         else:
             if curr_chunk:
-                _LOGGER.debug('Yielding chunk with size: %d', chunk_size)
+                _LOGGER.debug("Yielding chunk with size: %d", chunk_size)
                 yield curr_chunk
             curr_chunk = [log]
             chunk_size = size
     if len(curr_chunk) > 0:
-        _LOGGER.debug('Yielding chunk with size: %d', chunk_size)
+        _LOGGER.debug("Yielding chunk with size: %d", chunk_size)
         yield curr_chunk
 
 
@@ -46,5 +46,5 @@ def _create_gzip_requests(logs: List[JSON]) -> Generator[Tuple[bytes, List[JSON]
         _compress = zlib.compressobj(wbits=zlib_mode)
         data = _compress.compress(bytes(json.dumps(chunk), encoding="utf-8"))
         data += _compress.flush()
-        _LOGGER.debug('Yielding gzip compressed data, Length: %d', len(data))
+        _LOGGER.debug("Yielding gzip compressed data, Length: %d", len(data))
         yield data, chunk

--- a/sdk/monitor/azure-monitor-ingestion/azure/monitor/ingestion/_operations/_operations.py
+++ b/sdk/monitor/azure-monitor-ingestion/azure/monitor/ingestion/_operations/_operations.py
@@ -8,7 +8,7 @@
 # --------------------------------------------------------------------------
 from io import IOBase
 import sys
-from typing import Any, Callable, Dict, IO, List, Optional, TypeVar, Union
+from typing import Any, Callable, Dict, IO, List, Optional, TypeVar, Union, overload
 
 from azure.core.exceptions import (
     ClientAuthenticationError,
@@ -79,9 +79,36 @@ def build_logs_ingestion_upload_request(
 
 
 class LogsIngestionClientOperationsMixin(LogsIngestionClientMixinABC):
+    @overload
+    def _upload(  # pylint: disable=inconsistent-return-statements
+        self,
+        rule_id: str,
+        stream: str,
+        body: List[JSON],
+        *,
+        content_encoding: Optional[str] = None,
+        x_ms_client_request_id: Optional[str] = None,
+        content_type: str = "application/json",
+        **kwargs: Any
+    ) -> None:
+        ...
+
+    @overload
+    def _upload(  # pylint: disable=inconsistent-return-statements
+        self,
+        rule_id: str,
+        stream: str,
+        body: IO,
+        *,
+        content_encoding: Optional[str] = None,
+        x_ms_client_request_id: Optional[str] = None,
+        content_type: str = "application/json",
+        **kwargs: Any
+    ) -> None:
+        ...
 
     @distributed_trace
-    def upload(  # pylint: disable=inconsistent-return-statements
+    def _upload(  # pylint: disable=inconsistent-return-statements
         self,
         rule_id: str,
         stream: str,

--- a/sdk/monitor/azure-monitor-ingestion/azure/monitor/ingestion/_operations/_patch.py
+++ b/sdk/monitor/azure-monitor-ingestion/azure/monitor/ingestion/_operations/_patch.py
@@ -64,12 +64,12 @@ class LogsIngestionClientOperationsMixin(GeneratedOps):
                     content_encoding = "gzip"
                 logs.seek(0)
 
-            super().upload(rule_id, stream=stream_name, body=logs, content_encoding=content_encoding, **kwargs)
+            super()._upload(rule_id, stream=stream_name, body=logs, content_encoding=content_encoding, **kwargs)
             return
 
         for gzip_data, log_chunk in _create_gzip_requests(cast(List[JSON], logs)):
             try:
-                super().upload(
+                super()._upload(  # type: ignore
                     rule_id, stream=stream_name, body=gzip_data, content_encoding="gzip", **kwargs  # type: ignore
                 )
             except Exception as err:  # pylint: disable=broad-except

--- a/sdk/monitor/azure-monitor-ingestion/azure/monitor/ingestion/_operations/_patch.py
+++ b/sdk/monitor/azure-monitor-ingestion/azure/monitor/ingestion/_operations/_patch.py
@@ -26,7 +26,7 @@ JSON = MutableMapping[str, Any]  # pylint: disable=unsubscriptable-object
 
 
 class LogsIngestionClientOperationsMixin(GeneratedOps):
-    def upload(  # type: ignore[override] # pylint: disable=arguments-renamed, arguments-differ
+    def upload(
         self,
         rule_id: str,
         stream_name: str,

--- a/sdk/monitor/azure-monitor-ingestion/azure/monitor/ingestion/aio/_operations/_operations.py
+++ b/sdk/monitor/azure-monitor-ingestion/azure/monitor/ingestion/aio/_operations/_operations.py
@@ -8,7 +8,7 @@
 # --------------------------------------------------------------------------
 from io import IOBase
 import sys
-from typing import Any, Callable, Dict, IO, List, Optional, TypeVar, Union
+from typing import Any, Callable, Dict, IO, List, Optional, TypeVar, Union, overload
 
 from azure.core.exceptions import (
     ClientAuthenticationError,
@@ -37,9 +37,36 @@ ClsType = Optional[Callable[[PipelineResponse[HttpRequest, AsyncHttpResponse], T
 
 
 class LogsIngestionClientOperationsMixin(LogsIngestionClientMixinABC):
+    @overload
+    async def _upload(  # pylint: disable=inconsistent-return-statements
+        self,
+        rule_id: str,
+        stream: str,
+        body: List[JSON],
+        *,
+        content_encoding: Optional[str] = None,
+        x_ms_client_request_id: Optional[str] = None,
+        content_type: str = "application/json",
+        **kwargs: Any
+    ) -> None:
+        ...
+
+    @overload
+    async def _upload(  # pylint: disable=inconsistent-return-statements
+        self,
+        rule_id: str,
+        stream: str,
+        body: IO,
+        *,
+        content_encoding: Optional[str] = None,
+        x_ms_client_request_id: Optional[str] = None,
+        content_type: str = "application/json",
+        **kwargs: Any
+    ) -> None:
+        ...
 
     @distributed_trace_async
-    async def upload(  # pylint: disable=inconsistent-return-statements
+    async def _upload(  # pylint: disable=inconsistent-return-statements
         self,
         rule_id: str,
         stream: str,

--- a/sdk/monitor/azure-monitor-ingestion/azure/monitor/ingestion/aio/_operations/_patch.py
+++ b/sdk/monitor/azure-monitor-ingestion/azure/monitor/ingestion/aio/_operations/_patch.py
@@ -64,14 +64,15 @@ class LogsIngestionClientOperationsMixin(GeneratedOps):
                     content_encoding = "gzip"
                 logs.seek(0)
 
-            await super().upload(rule_id, stream=stream_name, body=logs, content_encoding=content_encoding, **kwargs)
+            await super()._upload(rule_id, stream=stream_name, body=logs, content_encoding=content_encoding, **kwargs)
             return
 
         for gzip_data, log_chunk in _create_gzip_requests(cast(List[JSON], logs)):
             try:
-                await super().upload(
+                await super()._upload(  # type: ignore
                     rule_id, stream=stream_name, body=gzip_data, content_encoding="gzip", **kwargs  # type: ignore
                 )
+
             except Exception as err:  # pylint: disable=broad-except
                 if on_error:
                     await on_error(LogsUploadError(error=err, failed_logs=cast(List[Mapping[str, Any]], log_chunk)))

--- a/sdk/monitor/azure-monitor-ingestion/azure/monitor/ingestion/aio/_operations/_patch.py
+++ b/sdk/monitor/azure-monitor-ingestion/azure/monitor/ingestion/aio/_operations/_patch.py
@@ -26,7 +26,7 @@ JSON = MutableMapping[str, Any]  # pylint: disable=unsubscriptable-object
 
 
 class LogsIngestionClientOperationsMixin(GeneratedOps):
-    async def upload(  # type: ignore[override] # pylint: disable=arguments-renamed, arguments-differ
+    async def upload(
         self,
         rule_id: str,
         stream_name: str,

--- a/sdk/monitor/azure-monitor-ingestion/azure/monitor/ingestion/aio/_patch.py
+++ b/sdk/monitor/azure-monitor-ingestion/azure/monitor/ingestion/aio/_patch.py
@@ -23,6 +23,7 @@ class LogsIngestionClient(GeneratedClient):
     :paramtype api_version: str
     """
 
+
 __all__: List[str] = ["LogsIngestionClient"]
 
 

--- a/sdk/monitor/azure-monitor-ingestion/swagger/README.PYTHON.md
+++ b/sdk/monitor/azure-monitor-ingestion/swagger/README.PYTHON.md
@@ -22,3 +22,15 @@ version-tolerant: true
 python3-only: true
 black: true
 ```
+
+## Customizations
+
+### Make generated operation methods/overloads internal
+
+```yaml
+directive:
+  - from: swagger-document
+    where: '$["paths"]["/dataCollectionRules/{ruleId}/streams/{stream}"]["post"]'
+    transform: >
+      $["x-ms-internal"] = true;
+```

--- a/sdk/monitor/azure-monitor-ingestion/tests/test_logs_ingestion.py
+++ b/sdk/monitor/azure-monitor-ingestion/tests/test_logs_ingestion.py
@@ -118,7 +118,7 @@ class TestLogsIngestionClient(AzureRecordedTestCase):
 
         with client:
             # No exception should be raised
-            with mock.patch("azure.monitor.ingestion._operations._patch.GeneratedOps.upload",
+            with mock.patch("azure.monitor.ingestion._operations._patch.GeneratedOps._upload",
                             side_effect=ConnectionError):
                 client.upload(
                     rule_id=monitor_info['dcr_id'],
@@ -130,7 +130,7 @@ class TestLogsIngestionClient(AzureRecordedTestCase):
 
             on_error.called = False
             # Exception should now be raised since error handler checked for RuntimeError.
-            with mock.patch("azure.monitor.ingestion._operations._patch.GeneratedOps.upload",
+            with mock.patch("azure.monitor.ingestion._operations._patch.GeneratedOps._upload",
                             side_effect=RuntimeError):
                 with pytest.raises(TestException):
                     client.upload(

--- a/sdk/monitor/azure-monitor-ingestion/tests/test_logs_ingestion_async.py
+++ b/sdk/monitor/azure-monitor-ingestion/tests/test_logs_ingestion_async.py
@@ -143,7 +143,7 @@ class TestLogsIngestionClientAsync(AzureRecordedTestCase):
 
         async with client:
             # No exception should be raised
-            with mock.patch("azure.monitor.ingestion.aio._operations._patch.GeneratedOps.upload",
+            with mock.patch("azure.monitor.ingestion.aio._operations._patch.GeneratedOps._upload",
                             side_effect=ConnectionError):
                 await client.upload(
                     rule_id=monitor_info['dcr_id'],
@@ -155,7 +155,7 @@ class TestLogsIngestionClientAsync(AzureRecordedTestCase):
 
             on_error.called = False
             # Exception should now be raised since error handler checked for RuntimeError.
-            with mock.patch("azure.monitor.ingestion.aio._operations._patch.GeneratedOps.upload",
+            with mock.patch("azure.monitor.ingestion.aio._operations._patch.GeneratedOps._upload",
                             side_effect=RuntimeError):
                 with pytest.raises(TestException):
                     await client.upload(


### PR DESCRIPTION
The swagger was updated to mark the `upload` operation as internal. This prevents overloads that are ultimately overriden from showing up in the public API/APIView. With this change, the generated overloads no longer need to be manually deleted.

Also, `black` was run on the codebase.

