### PR TITLE
[Cosmos] Bugfix - async patch_items method conditional filtering fix

### DIFF
--- a/sdk/cosmos/azure-cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos/CHANGELOG.md
@@ -8,7 +8,7 @@
 #### Breaking Changes
 
 #### Bugs Fixed
-* Fixed bug with async patch_item method. See [PR 12345]().
+* Fixed bug with async patch_item method. See [PR 30804](https://github.com/Azure/azure-sdk-for-python/pull/30804).
 
 #### Other Changes
 

--- a/sdk/cosmos/azure-cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos/CHANGELOG.md
@@ -5,10 +5,10 @@
 #### Features Added
 * Added **provisional** ability to limit Continuation Token size when querying for items. See [PR 30731](https://github.com/Azure/azure-sdk-for-python/pull/30731)
 
-
 #### Breaking Changes
 
 #### Bugs Fixed
+* Fixed bug with async patch_item method. See [PR 12345]().
 
 #### Other Changes
 

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_container.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_container.py
@@ -565,7 +565,7 @@ class ContainerProxy(object):
         response_hook = kwargs.pop('response_hook', None)
         request_options["disableAutomaticIdGeneration"] = True
         request_options["partitionKey"] = partition_key
-        filter_predicate = kwargs.pop("filter_predicate")
+        filter_predicate = kwargs.pop("filter_predicate", None)
         if filter_predicate is not None:
             request_options["filterPredicate"] = filter_predicate
 


### PR DESCRIPTION
We missed a small "None" here in case there is no `filter_predicate` arg being passed in, which breaks the method. This small fix takes care of that. 