### PR TITLE
[verifytypes] compare PR code against main instead of pypi

### DIFF
--- a/doc/dev/static_type_checking.md
+++ b/doc/dev/static_type_checking.md
@@ -245,7 +245,7 @@ Full documentation on pyright config options can be found here: https://github.c
 a py.typed library. It analyzes all the symbols that are part of the public interface and reports whether that symbol is known (fully typed), unknown, or ambiguous.
 The report can be used to view where type hints and docstrings are missing in a library, but differs from mypy/pyright in that it does not judge whether the provided type hints are accurate.
 verifytypes also reports a type completeness score which is the percentage of known types in the library. This score is used in the CI check to fail if the type completeness of the library worsens
-from the code in the PR vs. the latest release on PyPi.
+from the code in the PR vs. the code in main.
 
 To run verifytypes on your library, run the tox verifytypes env at the package level:
 

--- a/eng/tox/run_verifytypes.py
+++ b/eng/tox/run_verifytypes.py
@@ -9,6 +9,7 @@
 # the package from main and compares its type completeness score with
 # that of the current code. If type completeness worsens from the code in main, the check fails.
 
+import typing
 import pathlib
 import subprocess
 import json
@@ -25,7 +26,7 @@ logging.getLogger().setLevel(logging.INFO)
 root_dir = os.path.abspath(os.path.join(os.path.abspath(__file__), "..", "..", ".."))
 
 
-def install_from_main(setup_path):
+def install_from_main(setup_path: str) -> None:
     path = pathlib.Path(setup_path)
     subdirectory = path.relative_to(root_dir)
     cwd = os.getcwd()
@@ -64,7 +65,7 @@ def install_from_main(setup_path):
 
 
 
-def get_type_complete_score(commands, check_pytyped=False):
+def get_type_complete_score(commands: typing.List[str], check_pytyped: bool = False) -> float:
     try:
         response = subprocess.run(
             commands,

--- a/eng/tox/run_verifytypes.py
+++ b/eng/tox/run_verifytypes.py
@@ -15,6 +15,7 @@ import argparse
 import os
 import logging
 import sys
+import tempfile
 
 from ci_tools.environment_exclusions import is_check_enabled, is_typing_ignored
 from ci_tools.variables import in_ci
@@ -22,19 +23,41 @@ from ci_tools.variables import in_ci
 logging.getLogger().setLevel(logging.INFO)
 
 
-def install_from_main(subdirectory, package_name):
-    main_url = f"git+https://github.com/Azure/azure-sdk-for-python@main#subdirectory={subdirectory}&egg={package_name}"
+def install_from_main(setup_path):
+    subdirectory = setup_path.split("azure-sdk-for-python")[1].lstrip("/\\")
+    cwd = os.getcwd()
+    with tempfile.TemporaryDirectory() as temp_dir_name:
+        os.chdir(temp_dir_name)
+        try:
+            subprocess.check_call(['git', 'init'], stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
+            subprocess.check_call(
+                ['git', 'clone', '--no-checkout', 'https://github.com/Azure/azure-sdk-for-python.git', '--depth', '1'],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.STDOUT
+            )
+            os.chdir("azure-sdk-for-python")
+            subprocess.check_call(['git', 'sparse-checkout', 'init', '--cone'], stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
+            subprocess.check_call(['git', 'sparse-checkout', 'set', subdirectory], stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
+            subprocess.check_call(['git', 'checkout', 'main'], stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
 
-    commands = [
-        sys.executable,
-        "-m",
-        "pip",
-        "install",
-        main_url,
-        "--force-reinstall"
-    ]
+            if not os.path.exists(os.path.join(os.getcwd(), subdirectory)):
+                # code is not checked into main yet, nothing to compare
+                exit(0)
 
-    subprocess.check_call(commands, stdout=subprocess.DEVNULL)
+            os.chdir(subdirectory)
+
+            command = [
+                sys.executable,
+                "-m",
+                "pip",
+                "install",
+                ".",
+                "--force-reinstall"
+            ]
+
+            subprocess.check_call(command, stdout=subprocess.DEVNULL)
+        finally:
+            os.chdir(cwd)  # allow temp dir to be deleted
 
 
 
@@ -104,17 +127,15 @@ if __name__ == "__main__":
 
     # get type completeness score from current code
     score_from_current = get_type_complete_score(commands, check_pytyped=True)
+
+    # show output
     try:
         subprocess.check_call(commands[:-1])
     except subprocess.CalledProcessError:
         pass  # we don't fail on verifytypes, only if type completeness score worsens from main
 
     # get type completeness score from main
-    try:
-        install_from_main(setup_path.split("azure-sdk-for-python")[1].lstrip("/\\"), package_name)
-    except subprocess.CalledProcessError:
-        exit(0)  # there is no code in main yet, nothing to compare
-
+    install_from_main(setup_path)
     score_from_main = get_type_complete_score(commands)
 
     score_from_main_rounded = round(score_from_main * 100, 1)
@@ -123,7 +144,7 @@ if __name__ == "__main__":
     print(f"Score in main: {score_from_main_rounded}%")
     if score_from_current_rounded < score_from_main_rounded:
         print(
-            f"\nERROR: The type completeness score of {package_name} has decreased compared to main. "
+            f"\nERROR: The type completeness score of {package_name} has decreased compared to the score in main. "
             f"See the above output for areas to improve. See https://aka.ms/python/typing-guide for information."
         )
         exit(1)

--- a/eng/tox/run_verifytypes.py
+++ b/eng/tox/run_verifytypes.py
@@ -9,6 +9,7 @@
 # the package from main and compares its type completeness score with
 # that of the current code. If type completeness worsens from the code in main, the check fails.
 
+import pathlib
 import subprocess
 import json
 import argparse
@@ -21,10 +22,12 @@ from ci_tools.environment_exclusions import is_check_enabled, is_typing_ignored
 from ci_tools.variables import in_ci
 
 logging.getLogger().setLevel(logging.INFO)
+root_dir = os.path.abspath(os.path.join(os.path.abspath(__file__), "..", "..", ".."))
 
 
 def install_from_main(setup_path):
-    subdirectory = setup_path.split("azure-sdk-for-python")[1].lstrip("/\\")
+    path = pathlib.Path(setup_path)
+    subdirectory = path.relative_to(root_dir)
     cwd = os.getcwd()
     with tempfile.TemporaryDirectory() as temp_dir_name:
         os.chdir(temp_dir_name)

--- a/eng/tox/run_verifytypes.py
+++ b/eng/tox/run_verifytypes.py
@@ -139,6 +139,9 @@ if __name__ == "__main__":
         pass  # we don't fail on verifytypes, only if type completeness score worsens from main
 
     # get type completeness score from main
+    logging.info(
+        "Getting the type completeness score from the code in main..."
+    )
     install_from_main(setup_path)
     score_from_main = get_type_complete_score(commands)
 


### PR DESCRIPTION
Resolves https://github.com/Azure/azure-sdk-for-python/issues/30817

This CI check originally compared the type completeness score of the PR code against the latest release on PyPi. We are changing it to compare PR code against what is in main. It's using sparse-checkout to reduce time to install package from main (otherwise pip clones the whole repo and it takes way too long). We also do the sparse-checkout in a temp dir to avoid messing with any local changes.
