### PR TITLE
[Python AMQP] Link Error on Detach Fix

### DIFF
--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_session_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_session_async.py
@@ -414,7 +414,8 @@ class Session(object):  # pylint: disable=too-many-instance-attributes
             if self.state not in [SessionState.UNMAPPED, SessionState.DISCARDING]:
                 await self._outgoing_end(error=error)
             for _, link in self.links.items():
-                await link.detach()
+                if link._is_closed is False:
+                    await link.detach()
             new_state = SessionState.DISCARDING if error else SessionState.END_SENT
             await self._set_state(new_state)
             await self._wait_for_response(wait, SessionState.UNMAPPED)

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/session.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/session.py
@@ -461,7 +461,8 @@ class Session(object):  # pylint: disable=too-many-instance-attributes
             if self.state not in [SessionState.UNMAPPED, SessionState.DISCARDING]:
                 self._outgoing_end(error=error)
             for _, link in self.links.items():
-                link.detach()
+                if link._is_closed is False:
+                    link.detach()
             new_state = SessionState.DISCARDING if error else SessionState.END_SENT
             self._set_state(new_state)
             self._wait_for_response(wait, SessionState.UNMAPPED)


### PR DESCRIPTION
The clients currently output an error message when the sender / receiver clients close `An error occurred when detaching the link: AMQPConnectionError('Error condition: ErrorCondition.InternalError\n Error Description: Link already closed.')`

### Why this happens
client.py ( and async ) have a reference to a link and a CBSAuthenticator object (which has 2 links via management link, `request_link` & `response_link`

When a client is closing the following happen
* The client first closes its own link. Simple detach
* Then CBSAuth is closed, which detaches the management link [here](https://github.com/Azure/azure-sdk-for-python/blob/1abca3a9a479d15fb660e912a9a0256b2cf3590d/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/management_link.py#L248)
  * The close here sets management link to idle and errors out any pending operations on this link 
* Finally the session is ended
  * This step also tries to detach every link created on it. As its closing links that have already been closed above, errors are raised by the `_check_if_closed` that the link is already closed. 

Initially I thought about letting only the session detach links on end and working my way backwards ( detach links, end session and close connection). The closing of the management link and the state change step made that problematic as management would start erroring out. The management link state was not the proper one and changing it from the client looked wrong. 

The simplest way to go about this was checking if the links are already closed during session end. 