### PR TITLE
[EventHubs][Perf] Remove uampq perf CI testing

### DIFF
--- a/sdk/eventhub/perf-tests.yml
+++ b/sdk/eventhub/perf-tests.yml
@@ -15,14 +15,10 @@ Tests:
   Class: SendEventBatchTest
   Arguments:
   - --event-size 1024 --batch-size 100 --parallel 64
-  - --event-size 1024 --batch-size 100 --parallel 64 --uamqp-transport
   - --event-size 1024 --batch-size 100 --parallel 64 --transport-type 1
-  - --event-size 1024 --batch-size 100 --parallel 64 --transport-type 1 --uamqp-transport
 
 - Test: process-events-batch
   Class: ProcessEventsBatchTest
   Arguments:
   - --event-size 1024 --max-batch-size 100 --preload 1000000
-  - --event-size 1024 --max-batch-size 100 --preload 1000000 --uamqp-transport
   - --event-size 1024 --max-batch-size 100 --preload 1000000 --transport-type 1
-  - --event-size 1024 --max-batch-size 100 --preload 1000000 --transport-type 1 --uamqp-transport


### PR DESCRIPTION
This reduces the perf testing time in the nightly CI pipeline. Perf tests using the uamqp transport is being moved away from in favor of the python-based amqp transport, so these perf numbers aren't as critical anymore.
