### PR TITLE
add ruff to tox

### DIFF
--- a/eng/pipelines/templates/stages/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tests.yml
@@ -204,3 +204,16 @@ stages:
                 --service="${{ parameters.ServiceDirectory }}"
                 --toxenv="next-pyright"
                 --disablecov
+
+          - task: PythonScript@0
+            displayName: 'Run Ruff'
+            continueOnError: true
+            inputs:
+              scriptPath: 'scripts/devops_tasks/setup_execute_tests.py'
+              arguments: >-
+                "azure*" 
+                --mark_arg="${{ parameters.TestMarkArgument }}" 
+                --service="${{ parameters.ServiceDirectory }}" 
+                --toxenv="ruff"
+                --disablecov
+            env: ${{ parameters.EnvVars }}

--- a/eng/tox/run_ruff.py
+++ b/eng/tox/run_ruff.py
@@ -1,0 +1,42 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+# This script is used to execute ruff within a tox environment.
+
+import subprocess
+import argparse
+import os
+import sys
+from ci_tools.parsing import ParsedSetup
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Run ruff against target folder."
+    )
+
+    parser.add_argument(
+        "-t",
+        "--target",
+        dest="target_package",
+        help="The target package directory on disk. The target module passed to ruff will be <target_package>/azure.",
+        required=True,
+    )
+
+    args = parser.parse_args()
+
+    pkg_dir = os.path.abspath(args.target_package)
+    pkg_details = ParsedSetup.from_path(pkg_dir)
+    top_level_module = pkg_details.namespace.split('.')[0]
+
+    subprocess.check_call(
+        [
+            sys.executable,
+            "-m",
+            "ruff",
+            "check",
+            os.path.join(args.target_package, top_level_module),
+        ]
+    )

--- a/eng/tox/tox.ini
+++ b/eng/tox/tox.ini
@@ -115,6 +115,25 @@ commands =
       --package-type sdist
     python {repository_root}/eng/tox/run_pylint.py -t {tox_root} --next=True
 
+[testenv:ruff]
+description=Lints a package with ruff
+skipsdist = true
+skip_install = true
+usedevelop = false
+setenv =
+  {[testenv]setenv}
+  PROXY_URL=http://localhost:5022
+deps =
+  {[base]deps}
+  ruff
+commands =
+    python {repository_root}/eng/tox/create_package_and_install.py \
+      -d {envtmpdir}/dist \
+      -p {tox_root} \
+      -w {envtmpdir} \
+      --package-type sdist
+    python {repository_root}/eng/tox/run_ruff.py -t {tox_root}
+
 [testenv:mypy]
 description=Typechecks a package with mypy (version {[testenv:mypy]mypy_version})
 mypy_version=1.0.0

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,1 @@
+line-length = 120

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,1 +1,2 @@
 line-length = 120
+target-version = "py37"


### PR DESCRIPTION
Evaluating `ruff`, a new linter, for the repo. Starting by adding it to tox and having it run on the tests - weekly pipelines (alongside the other "vnext" checks which run against our libraries and fail with only warnings) so we have time to look at the linting errors per library and decide if we want to enable it.