### PR TITLE
[Python AMQP] Fix End Frame Received on Invalid Channel

### DIFF
--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/_connection.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/_connection.py
@@ -531,8 +531,9 @@ class Connection(object):  # pylint:disable=too-many-instance-attributes
         """
         try:
             self._incoming_endpoints[channel]._incoming_end(frame)  # pylint:disable=protected-access
-            existing_session = self._incoming_endpoints.pop(channel)
-            self._outgoing_endpoints.pop(existing_session.channel)
+            outgoing_channel = self._incoming_endpoints[channel].channel
+            self._incoming_endpoints.pop(channel)
+            self._outgoing_endpoints.pop(outgoing_channel)
         except KeyError:
             #close the connection
             self.close(

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/_connection.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/_connection.py
@@ -531,8 +531,8 @@ class Connection(object):  # pylint:disable=too-many-instance-attributes
         """
         try:
             self._incoming_endpoints[channel]._incoming_end(frame)  # pylint:disable=protected-access
-            self._incoming_endpoints.pop(channel)
-            self._outgoing_endpoints.pop(channel)
+            existing_session = self._incoming_endpoints.pop(channel)
+            self._outgoing_endpoints.pop(existing_session.channel)
         except KeyError:
             #close the connection
             self.close(

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_connection_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_connection_async.py
@@ -548,8 +548,8 @@ class Connection(object):  # pylint:disable=too-many-instance-attributes
         """
         try:
             await self._incoming_endpoints[channel]._incoming_end(frame)  # pylint:disable=protected-access
-            self._incoming_endpoints.pop(channel)
-            self._outgoing_endpoints.pop(channel)
+            existing_session = self._incoming_endpoints.pop(channel)
+            self._outgoing_endpoints.pop(existing_session.channel)
         except KeyError:
             #close the connection
             await self.close(

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_connection_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_connection_async.py
@@ -548,8 +548,9 @@ class Connection(object):  # pylint:disable=too-many-instance-attributes
         """
         try:
             await self._incoming_endpoints[channel]._incoming_end(frame)  # pylint:disable=protected-access
-            existing_session = self._incoming_endpoints.pop(channel)
-            self._outgoing_endpoints.pop(existing_session.channel)
+            outgoing_channel = self._incoming_endpoints[channel].channel
+            self._incoming_endpoints.pop(channel)
+            self._outgoing_endpoints.pop(outgoing_channel)
         except KeyError:
             #close the connection
             await self.close(

--- a/sdk/eventhub/azure-eventhub/tests/pyamqp_tests/unittest/asynctests/test_connection_async.py
+++ b/sdk/eventhub/azure-eventhub/tests/pyamqp_tests/unittest/asynctests/test_connection_async.py
@@ -1,12 +1,18 @@
+import sys
+import asyncio
+from unittest.mock import AsyncMock, Mock
 import pytest
-from unittest.mock import AsyncMock
 from azure.eventhub._pyamqp.aio import Connection
 
 @pytest.mark.asyncio
 async def test_connection_end_session_on_timeout():
     connection = Connection("fake.host.com")
-    connection._process_outgoing_frame = AsyncMock(return_value=None)
-    connection._network_trace_params = {'amqpSession':'test_name'}
+    if sys.version_info >= (3, 8):
+        connection._process_outgoing_frame = AsyncMock(return_value=None)
+    else:
+        future = asyncio.Future()
+        future.set_result(None)
+        connection._process_outgoing_frame = Mock(return_value=future)
     # create session on the Connection
     session = connection.create_session(network_trace=False)
     outgoing_channel = session.channel
@@ -14,7 +20,7 @@ async def test_connection_end_session_on_timeout():
     incoming_channel = 0
     connection._incoming_endpoints[incoming_channel] = session
     assert outgoing_channel == connection._incoming_endpoints[incoming_channel].channel
-    # typically after some inactivity(60,000 ms), the server will force a connection close
+    # typically after some inactivity(60,000 ms) on the connection, the server will force a connection close
     # and will send across an END frame
     await connection._incoming_end(incoming_channel, None)
     # end points dont have the channels anymore and Session link is gone.

--- a/sdk/eventhub/azure-eventhub/tests/pyamqp_tests/unittest/asynctests/test_connection_async.py
+++ b/sdk/eventhub/azure-eventhub/tests/pyamqp_tests/unittest/asynctests/test_connection_async.py
@@ -1,31 +1,56 @@
 import sys
-import asyncio
 if sys.version_info >= (3, 8):
-    from unittest.mock import AsyncMock
-else:
-    from unittest.mock import Mock
+    from unittest.mock import AsyncMock, Mock
+
 import pytest
+
 from azure.eventhub._pyamqp.aio import Connection
 
 @pytest.mark.asyncio
-async def test_connection_end_session_on_timeout():
+async def test_connection_begin_session():
+    if sys.version_info < (3, 8):
+        pytest.skip("AsyncMock is not available in Python 3.7")
     connection = Connection("fake.host.com")
-    if sys.version_info >= (3, 8):
-        connection._process_outgoing_frame = AsyncMock(return_value=None)
-    else:
-        future = asyncio.Future()
-        future.set_result(None)
-        connection._process_outgoing_frame = Mock(return_value=future)
+    connection._process_outgoing_frame = AsyncMock(return_value=None)
     # create session on the Connection
     session = connection.create_session(network_trace=False)
     outgoing_channel = session.channel
-    # after a BEGIN response from the server set up incoming endpoint
+    # mock starting a begin session to the server
+    session.begin = Mock(return_value=None)
+    session.begin()
+    # in response from the server we should get back a BEGIN frame
     incoming_channel = 0
-    connection._incoming_endpoints[incoming_channel] = session
+    incoming_frame= (1,0,0,0,0,0,0,0)
+    connection.listen = AsyncMock(side_effect=await connection._incoming_begin(incoming_channel, incoming_frame))
+    await connection.listen()
+    assert incoming_channel in connection._incoming_endpoints
+    assert outgoing_channel in connection._outgoing_endpoints
     assert outgoing_channel == connection._incoming_endpoints[incoming_channel].channel
-    # typically after some inactivity(60,000 ms) on the connection, the server will force a connection close
+    assert connection._incoming_endpoints[incoming_channel] == connection._outgoing_endpoints[outgoing_channel]
+
+
+@pytest.mark.asyncio
+async def test_connection_end_session_on_timeout():
+    if sys.version_info < (3, 8):
+        pytest.skip("AsyncMock is not available in Python 3.7")
+    connection = Connection("fake.host.com")
+    connection._process_outgoing_frame = AsyncMock(return_value=None)
+    # create session on the Connection
+    session = connection.create_session(network_trace=False)
+    outgoing_channel = session.channel
+    # mock starting a begin session to the server
+    session.begin = Mock(return_value=None)
+    session.begin()
+    # in response from the server we should get back a BEGIN frame
+    incoming_channel = 0
+    incoming_frame= (1,0,0,0,0,0,0,0)
+    connection.listen = AsyncMock(side_effect=await connection._incoming_begin(incoming_channel, incoming_frame))
+    await connection.listen()
+    assert outgoing_channel == connection._incoming_endpoints[incoming_channel].channel
+    # typically after some inactivity(60,000 ms) on the connection, the server will force close a connection
     # and will send across an END frame
-    await connection._incoming_end(incoming_channel, None)
+    connection.listen = AsyncMock(side_effect=await connection._incoming_end(incoming_channel, None))
+    await connection.listen()
     # end points dont have the channels anymore and Session link is gone.
     assert outgoing_channel not in connection._outgoing_endpoints
     assert incoming_channel not in connection._incoming_endpoints

--- a/sdk/eventhub/azure-eventhub/tests/pyamqp_tests/unittest/asynctests/test_connection_async.py
+++ b/sdk/eventhub/azure-eventhub/tests/pyamqp_tests/unittest/asynctests/test_connection_async.py
@@ -1,6 +1,9 @@
 import sys
 import asyncio
-from unittest.mock import AsyncMock, Mock
+if sys.version_info >= (3, 8):
+    from unittest.mock import AsyncMock
+else:
+    from unittest.mock import Mock
 import pytest
 from azure.eventhub._pyamqp.aio import Connection
 

--- a/sdk/eventhub/azure-eventhub/tests/pyamqp_tests/unittest/asynctests/test_connection_async.py
+++ b/sdk/eventhub/azure-eventhub/tests/pyamqp_tests/unittest/asynctests/test_connection_async.py
@@ -1,0 +1,22 @@
+import pytest
+from unittest.mock import AsyncMock
+from azure.eventhub._pyamqp.aio import Connection
+
+@pytest.mark.asyncio
+async def test_connection_end_session_on_timeout():
+    connection = Connection("fake.host.com")
+    connection._process_outgoing_frame = AsyncMock(return_value=None)
+    connection._network_trace_params = {'amqpSession':'test_name'}
+    # create session on the Connection
+    session = connection.create_session(network_trace=False)
+    outgoing_channel = session.channel
+    # after a BEGIN response from the server set up incoming endpoint
+    incoming_channel = 0
+    connection._incoming_endpoints[incoming_channel] = session
+    assert outgoing_channel == connection._incoming_endpoints[incoming_channel].channel
+    # typically after some inactivity(60,000 ms), the server will force a connection close
+    # and will send across an END frame
+    await connection._incoming_end(incoming_channel, None)
+    # end points dont have the channels anymore and Session link is gone.
+    assert outgoing_channel not in connection._outgoing_endpoints
+    assert incoming_channel not in connection._incoming_endpoints

--- a/sdk/eventhub/azure-eventhub/tests/pyamqp_tests/unittest/test_connection.py
+++ b/sdk/eventhub/azure-eventhub/tests/pyamqp_tests/unittest/test_connection.py
@@ -5,7 +5,6 @@ from azure.eventhub._pyamqp import Connection
 def test_connection_end_session_on_timeout():
     connection = Connection("fake.host.com")
     connection._process_outgoing_frame = Mock(return_value=None)
-    connection._network_trace_params = {'amqpSession':'test_name'}
     # create session on the Connection
     session = connection.create_session(network_trace=False)
     outgoing_channel = session.channel

--- a/sdk/eventhub/azure-eventhub/tests/pyamqp_tests/unittest/test_connection.py
+++ b/sdk/eventhub/azure-eventhub/tests/pyamqp_tests/unittest/test_connection.py
@@ -1,0 +1,21 @@
+from unittest.mock import Mock
+from azure.eventhub._pyamqp import Connection
+
+
+def test_connection_end_session_on_timeout():
+    connection = Connection("fake.host.com")
+    connection._process_outgoing_frame = Mock(return_value=None)
+    connection._network_trace_params = {'amqpSession':'test_name'}
+    # create session on the Connection
+    session = connection.create_session(network_trace=False)
+    outgoing_channel = session.channel
+    # after a BEGIN response from the server set up incoming endpoint
+    incoming_channel = 0
+    connection._incoming_endpoints[incoming_channel] = session
+    assert outgoing_channel == connection._incoming_endpoints[incoming_channel].channel
+    # typically after some inactivity(60,000 ms) on the connection, the server will force close a connection
+    # and will send across an END frame
+    connection._incoming_end(incoming_channel, None)
+    # end points dont have the channels anymore and Session link is gone.
+    assert outgoing_channel not in connection._outgoing_endpoints
+    assert incoming_channel not in connection._incoming_endpoints

--- a/sdk/eventhub/azure-eventhub/tests/pyamqp_tests/unittest/test_connection.py
+++ b/sdk/eventhub/azure-eventhub/tests/pyamqp_tests/unittest/test_connection.py
@@ -2,19 +2,46 @@ from unittest.mock import Mock
 from azure.eventhub._pyamqp import Connection
 
 
+
+def test_connection_begin_session():
+    connection = Connection("fake.host.com")
+    connection._process_outgoing_frame = Mock(return_value=None)
+    # create session on the Connection
+    session = connection.create_session(network_trace=False)
+    outgoing_channel = session.channel
+    # mock starting a begin session to the server
+    session.begin = Mock(return_value=None)
+    session.begin()
+    # in response from the server we should get back a BEGIN frame
+    incoming_channel = 0
+    incoming_frame= (1,0,0,0,0,0,0,0)
+    connection.listen = Mock(side_effect=connection._incoming_begin(incoming_channel, incoming_frame))
+    connection.listen()
+    assert incoming_channel in connection._incoming_endpoints
+    assert outgoing_channel in connection._outgoing_endpoints
+    assert outgoing_channel == connection._incoming_endpoints[incoming_channel].channel
+    assert connection._incoming_endpoints[incoming_channel] == connection._outgoing_endpoints[outgoing_channel]
+
+
 def test_connection_end_session_on_timeout():
     connection = Connection("fake.host.com")
     connection._process_outgoing_frame = Mock(return_value=None)
     # create session on the Connection
     session = connection.create_session(network_trace=False)
     outgoing_channel = session.channel
-    # after a BEGIN response from the server set up incoming endpoint
+    # mock starting a begin session to the server
+    session.begin = Mock(return_value=None)
+    session.begin()
+    # in response from the server we should get back a BEGIN frame
     incoming_channel = 0
-    connection._incoming_endpoints[incoming_channel] = session
+    incoming_frame= (1,0,0,0,0,0,0,0)
+    connection.listen = Mock(side_effect=connection._incoming_begin(incoming_channel, incoming_frame))
+    connection.listen()
     assert outgoing_channel == connection._incoming_endpoints[incoming_channel].channel
     # typically after some inactivity(60,000 ms) on the connection, the server will force close a connection
     # and will send across an END frame
-    connection._incoming_end(incoming_channel, None)
+    connection.listen = Mock(side_effect=connection._incoming_end(incoming_channel, None))
+    connection.listen()
     # end points dont have the channels anymore and Session link is gone.
     assert outgoing_channel not in connection._outgoing_endpoints
     assert incoming_channel not in connection._incoming_endpoints

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/_connection.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/_connection.py
@@ -543,8 +543,9 @@ class Connection(object):  # pylint:disable=too-many-instance-attributes
         """
         try:
             self._incoming_endpoints[channel]._incoming_end(frame)  # pylint:disable=protected-access
+            outgoing_channel = self._incoming_endpoints[channel].channel
             self._incoming_endpoints.pop(channel)
-            self._outgoing_endpoints.pop(channel)
+            self._outgoing_endpoints.pop(outgoing_channel)
         except KeyError:
             #close the connection
             self.close(

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_connection_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_connection_async.py
@@ -564,8 +564,9 @@ class Connection(object):  # pylint:disable=too-many-instance-attributes
         """
         try:
             await self._incoming_endpoints[channel]._incoming_end(frame)  # pylint:disable=protected-access
+            outgoing_channel = self._incoming_endpoints[channel].channel
             self._incoming_endpoints.pop(channel)
-            self._outgoing_endpoints.pop(channel)
+            self._outgoing_endpoints.pop(outgoing_channel)
         except KeyError:
             #close the connection
             await self.close(


### PR DESCRIPTION
This PR fixes an error that was raised during certain scenarios such as connection force close ( force detach ) from the service. 

Error message = Invalid channel number received
Log Message = END frame received on invalid channel. Closing connection.

Why this was happening ?

`Connection` has two dictionaries that keep track of the local / remote channel on which a `Session` was created
* `_outgoing_endpoints` -> local channel
* `_incoming_endpoints` -> remote channel

When a `BEGIN` frame is started by us, the flow looks like the following 

```mermaid
flowchart LR
    Client-->|Begin - 1|Service
    Service-->|Begin - 0|Client
```

Leading endpoints to look like the following
```python
_outgoing_endpoints = {1: Session}
_incoming_endpoints = {0: Session}

Session.channel == 1
```

After a period inactivity over the Connection (60000 ms), the service will force disconnect followed by a END frame

```mermaid
flowchart LR
   Service-->|End - 0|Client
```

In `incoming_end` we were trying to pop the channel of the incoming end frame (0 in this case) from `outgoing_endpoints` causing a `KeyError` and the error messages to show. 

The fix was to get the local channel from the Session object, so we can pop properly from `_outgoing_endpoints`

Fixes #30815