### PR TITLE
[Key Vault] Add `x509_thumbprint_string` property to `CertificateProperties`

### DIFF
--- a/sdk/keyvault/azure-keyvault-certificates/CHANGELOG.md
+++ b/sdk/keyvault/azure-keyvault-certificates/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## 4.8.0b2 (Unreleased)
 
 ### Features Added
+- Added `CertificateProperties.x509_thumbprint_string` to return the hexadecimal string representation of the SHA-1 hash
+  of the certificate.
 
 ### Breaking Changes
 

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_models.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_models.py
@@ -271,7 +271,7 @@ class CertificateProperties(object):
         :return: The certificate's thumbprint, as a hexadecimal string.
         :rtype: str
         """
-        return "".join(f"{byte:02X}" for byte in self._x509_thumbprint)
+        return self._x509_thumbprint.hex().upper()
 
     @property
     def tags(self) -> "Optional[Dict[str, str]]":

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_models.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_models.py
@@ -255,12 +255,23 @@ class CertificateProperties(object):
 
     @property
     def x509_thumbprint(self) -> bytes:
-        """The certificate's thumbprint.
+        """The certificate's thumbprint, in bytes.
 
         :return: The certificate's thumbprint, in bytes.
         :rtype: bytes
         """
         return self._x509_thumbprint
+
+    @property
+    def x509_thumbprint_string(self) -> str:
+        """The certificate's thumbprint, as a hexadecimal string.
+
+        The thumbprint is formatted without colon delimiters; e.g. 76E1819FADF06A55EF4B126A2EF743C2BAE8A151.
+
+        :return: The certificate's thumbprint, as a hexadecimal string.
+        :rtype: str
+        """
+        return "".join(f"{byte:02X}" for byte in self._x509_thumbprint)
 
     @property
     def tags(self) -> "Optional[Dict[str, str]]":

--- a/sdk/keyvault/azure-keyvault-certificates/tests/test_certificates_client.py
+++ b/sdk/keyvault/azure-keyvault-certificates/tests/test_certificates_client.py
@@ -19,6 +19,7 @@ from azure.keyvault.certificates import (
     CertificateContact,
     CertificatePolicyAction,
     CertificatePolicy,
+    CertificateProperties,
     KeyType,
     KeyCurveName,
     KeyUsageType,
@@ -780,3 +781,12 @@ def test_case_insensitive_key_type():
     assert KeyType("OCT") == KeyType.oct
     # KeyType with mixed-case value
     assert KeyType("oct-hsm") == KeyType.oct_hsm
+
+
+def test_thumbprint_hex():
+    """Ensure the `CertificateProperties.x509_thumbprint_string` property correctly converts a thumbprint to hex."""
+    properties = CertificateProperties(
+        cert_id="https://vaultname.vault.azure.net/certificates/certname/version",
+        x509_thumbprint=b"v\xe1\x81\x9f\xad\xf0jU\xefK\x12j.\xf7C\xc2\xba\xe8\xa1Q",
+    )
+    assert properties.x509_thumbprint_string == "76E1819FADF06A55EF4B126A2EF743C2BAE8A151"


### PR DESCRIPTION
# Description

Resolves https://github.com/Azure/azure-sdk-for-python/issues/30166. This property formats the certificate thumbprint in the same way as the thumbprint field in the Azure Portal.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
