### PR TITLE
[ServiceBus] update error raised when completing lock expired messages

### DIFF
--- a/sdk/servicebus/azure-servicebus/CHANGELOG.md
+++ b/sdk/servicebus/azure-servicebus/CHANGELOG.md
@@ -1,6 +1,5 @@
 # Release History
 
-
 ## 7.11.1 (Unreleased)
 
 ### Features Added
@@ -11,8 +10,9 @@
 
 ### Other Changes
 
-## 7.11.0 (2023-06-12)
+- The error raised when attempting to complete a message with an expired lock received from a non-sessionful entity has been updated to the more fine-grained `MessageLockLostError` from the superclass `ServiceBusError`.
 
+## 7.11.0 (2023-06-12)
 
 ### Features Added
 

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_servicebus_receiver.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_servicebus_receiver.py
@@ -13,7 +13,7 @@ import warnings
 from enum import Enum
 from typing import Any, List, Optional, Dict, Iterator, Union, TYPE_CHECKING, cast
 
-from .exceptions import ServiceBusError
+from .exceptions import MessageLockLostError
 from ._base_handler import BaseHandler
 from ._common.message import ServiceBusReceivedMessage
 from ._common.utils import create_authentication
@@ -464,13 +464,11 @@ class ServiceBusReceiver(
 
         # The following condition check is a hot fix for settling a message received for non-session queue after
         # lock expiration.
-        # uamqp doesn't have the ability to receive disposition result returned from the service after settlement,
-        # so there's no way we could tell whether a disposition succeeds or not and there's no error condition info.
-        # Throwing a general message error type here gives us the evolvability to have more fine-grained exception
-        # subclasses in the future after we add the missing feature support in uamqp.
-        # see issue: https://github.com/Azure/azure-uamqp-c/issues/274
+        # pyamqp doesn't currently (and uamqp doesn't have the ability to) wait to receive disposition result returned
+        # from the service after settlement, so there's no way we could tell whether a disposition succeeds or not and
+        # there's no error condition info. (for uamqp, see issue: https://github.com/Azure/azure-uamqp-c/issues/274)
         if not self._session and message._lock_expired:
-            raise ServiceBusError(
+            raise MessageLockLostError(
                 message="The lock on the message lock has expired.",
                 error=message.auto_renew_error,
             )

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_servicebus_receiver_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_servicebus_receiver_async.py
@@ -14,7 +14,7 @@ import warnings
 from enum import Enum
 from typing import Any, List, Optional, AsyncIterator, Union, TYPE_CHECKING, cast
 
-from ..exceptions import ServiceBusError
+from ..exceptions import MessageLockLostError
 from ._servicebus_session_async import ServiceBusSession
 from ._base_handler_async import BaseHandler
 from .._common.message import ServiceBusReceivedMessage
@@ -446,13 +446,11 @@ class ServiceBusReceiver(collections.abc.AsyncIterator, BaseHandler, ReceiverMix
 
         # The following condition check is a hot fix for settling a message received for non-session queue after
         # lock expiration.
-        # uamqp doesn't have the ability to receive disposition result returned from the service after settlement,
-        # so there's no way we could tell whether a disposition succeeds or not and there's no error condition info.
-        # Throwing a general message error type here gives us the evolvability to have more fine-grained exception
-        # subclasses in the future after we add the missing feature support in uamqp.
-        # see issue: https://github.com/Azure/azure-uamqp-c/issues/274
+        # pyamqp doesn't currently (and uamqp doesn't have the ability to) wait to receive disposition result returned
+        # from the service after settlement, so there's no way we could tell whether a disposition succeeds or not and
+        # there's no error condition info. (for uamqp, see issue: https://github.com/Azure/azure-uamqp-c/issues/274)
         if not self._session and message._lock_expired:
-            raise ServiceBusError(
+            raise MessageLockLostError(
                 message="The lock on the message lock has expired.",
                 error=message.auto_renew_error,
             )

--- a/sdk/servicebus/azure-servicebus/tests/async_tests/test_queues_async.py
+++ b/sdk/servicebus/azure-servicebus/tests/async_tests/test_queues_async.py
@@ -1093,7 +1093,7 @@ class TestServiceBusQueueAsync(AzureMgmtRecordedTestCase):
                     await receiver.complete_message(messages[0])
                     await receiver.complete_message(messages[1])
                     sleep_until_expired(messages[2])
-                    with pytest.raises(ServiceBusError):
+                    with pytest.raises(MessageLockLostError):
                         await receiver.complete_message(messages[2])
 
     
@@ -1137,14 +1137,14 @@ class TestServiceBusQueueAsync(AzureMgmtRecordedTestCase):
                         assert message._lock_expired
                         try:
                             await receiver.complete_message(message)
-                            raise AssertionError("Didn't raise ServiceBusError")
-                        except ServiceBusError as e:
+                            raise AssertionError("Didn't raise MessageLockLostError")
+                        except MessageLockLostError as e:
                             assert isinstance(e.inner_exception, AutoLockRenewTimeout)
                     else:
                         if message._lock_expired:
                             print("Remaining messages", message.locked_until_utc, utc_now())
                             assert message._lock_expired
-                            with pytest.raises(ServiceBusError):
+                            with pytest.raises(MessageLockLostError):
                                 await receiver.complete_message(message)
                         else:
                             assert message.delivery_count >= 1
@@ -1194,14 +1194,14 @@ class TestServiceBusQueueAsync(AzureMgmtRecordedTestCase):
                         assert message._lock_expired
                         try:
                             await receiver.complete_message(message)
-                            raise AssertionError("Didn't raise ServiceBusError")
-                        except ServiceBusError as e:
+                            raise AssertionError("Didn't raise MessageLockLostError")
+                        except MessageLockLostError as e:
                             assert isinstance(e.inner_exception, AutoLockRenewTimeout)
                     else:
                         if message._lock_expired:
                             print("Remaining messages", message.locked_until_utc, utc_now())
                             assert message._lock_expired
-                            with pytest.raises(ServiceBusError):
+                            with pytest.raises(MessageLockLostError):
                                 await receiver.complete_message(message)
                         else:
                             assert message.delivery_count >= 1
@@ -1345,7 +1345,7 @@ class TestServiceBusQueueAsync(AzureMgmtRecordedTestCase):
                 assert len(messages) == 1
                 time.sleep(60)
                 assert messages[0]._lock_expired
-                with pytest.raises(ServiceBusError):
+                with pytest.raises(MessageLockLostError):
                     await receiver.complete_message(messages[0])
                 with pytest.raises(MessageLockLostError):
                     await receiver.renew_message_lock(messages[0])

--- a/sdk/servicebus/azure-servicebus/tests/async_tests/test_subscriptions_async.py
+++ b/sdk/servicebus/azure-servicebus/tests/async_tests/test_subscriptions_async.py
@@ -14,7 +14,7 @@ from datetime import datetime, timedelta
 from azure.servicebus import ServiceBusMessage, ServiceBusReceiveMode
 from azure.servicebus.aio import ServiceBusClient
 from azure.servicebus.aio._base_handler_async import ServiceBusSharedKeyCredential
-from azure.servicebus.exceptions import ServiceBusError
+from azure.servicebus.exceptions import ServiceBusError, MessageLockLostError
 from azure.servicebus._common.constants import ServiceBusSubQueue
 
 from devtools_testutils import AzureMgmtRecordedTestCase, RandomNameResourceGroupPreparer
@@ -185,3 +185,49 @@ class TestServiceBusSubscriptionAsync(AzureMgmtRecordedTestCase):
                     assert message.application_properties[b'DeadLetterReason'] == b'Testing reason'
                     assert message.application_properties[b'DeadLetterErrorDescription'] == b'Testing description'
                 assert count == 10
+
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusTopicPreparer(name_prefix='servicebustest')
+    @ServiceBusSubscriptionPreparer(name_prefix='servicebustest', lock_duration='PT5S')
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_subscription_message_expiry(self, uamqp_transport, *, servicebus_namespace=None, servicebus_namespace_key_name=None, servicebus_namespace_primary_key=None, servicebus_topic=None, servicebus_subscription=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        async with ServiceBusClient(
+            fully_qualified_namespace=fully_qualified_namespace,
+            credential=ServiceBusSharedKeyCredential(
+                policy=servicebus_namespace_key_name,
+                key=servicebus_namespace_primary_key
+            ),
+            logging_enable=False,
+            uamqp_transport=uamqp_transport
+        ) as sb_client:
+
+            async with sb_client.get_topic_sender(topic_name=servicebus_topic.name) as sender:
+                message = ServiceBusMessage(b"Testing topic message expiry")
+                await sender.send_messages(message)
+
+            async with sb_client.get_subscription_receiver(
+                    topic_name=servicebus_topic.name,
+                    subscription_name=servicebus_subscription.name
+            ) as receiver:
+                messages = await receiver.receive_messages(max_wait_time=10)
+                assert len(messages) == 1
+                time.sleep(10)
+                assert messages[0]._lock_expired
+                with pytest.raises(MessageLockLostError):
+                    await receiver.complete_message(messages[0])
+                with pytest.raises(MessageLockLostError):
+                    await receiver.renew_message_lock(messages[0])
+            async with sb_client.get_subscription_receiver(
+                    topic_name=servicebus_topic.name,
+                    subscription_name=servicebus_subscription.name
+            ) as receiver:
+                messages = await receiver.receive_messages(max_wait_time=10)
+                assert len(messages) == 1
+                assert messages[0].delivery_count > 0
+                await receiver.complete_message(messages[0])

--- a/sdk/servicebus/azure-servicebus/tests/servicebus_preparer.py
+++ b/sdk/servicebus/azure-servicebus/tests/servicebus_preparer.py
@@ -306,6 +306,7 @@ class ServiceBusSubscriptionPreparer(_ServiceBusChildResourcePreparer):
                  servicebus_namespace_parameter_name=SERVICEBUS_NAMESPACE_PARAM,
                  servicebus_topic_parameter_name=SERVICEBUS_TOPIC_PARAM,
                  requires_session=False,
+                 lock_duration='PT60S',
                  disable_recording=True, playback_fake_resource=None,
                  client_kwargs=None, random_name_enabled=True):
         super(ServiceBusSubscriptionPreparer, self).__init__(name_prefix,
@@ -319,8 +320,9 @@ class ServiceBusSubscriptionPreparer(_ServiceBusChildResourcePreparer):
         self.parameter_name = parameter_name
         if random_name_enabled:
             self.resource_moniker = self.name_prefix + "sbsub"
-        self.set_cache(use_cache, requires_session)
+        self.set_cache(use_cache, requires_session, lock_duration)
         self.requires_session=requires_session
+        self.lock_duration = lock_duration
         if random_name_enabled:
             self.resource_moniker = self.name_prefix + "sbqueue"
 
@@ -339,7 +341,8 @@ class ServiceBusSubscriptionPreparer(_ServiceBusChildResourcePreparer):
                         topic.name,
                         name,
                         SBSubscription(
-                            requires_session=self.requires_session
+                            requires_session=self.requires_session,
+                            lock_duration=self.lock_duration,
                         )
                     )
                     break

--- a/sdk/servicebus/azure-servicebus/tests/test_queues.py
+++ b/sdk/servicebus/azure-servicebus/tests/test_queues.py
@@ -1251,7 +1251,7 @@ class TestServiceBusQueue(AzureMgmtRecordedTestCase):
                     receiver.complete_message(messages[1])
                     assert (messages[2].locked_until_utc - utc_now()) <= timedelta(seconds=60)
                     sleep_until_expired(messages[2])
-                    with pytest.raises(ServiceBusError):
+                    with pytest.raises(MessageLockLostError):
                         receiver.complete_message(messages[2])
 
     
@@ -1294,13 +1294,13 @@ class TestServiceBusQueue(AzureMgmtRecordedTestCase):
                         try:
                             receiver.complete_message(message)
                             raise AssertionError("Didn't raise MessageLockLostError")
-                        except ServiceBusError as e:
+                        except MessageLockLostError as e:
                             assert isinstance(e.inner_exception, AutoLockRenewTimeout)
                     else:
                         if message._lock_expired:
                             print("Remaining messages", message.locked_until_utc, utc_now())
                             assert message._lock_expired
-                            with pytest.raises(ServiceBusError):
+                            with pytest.raises(MessageLockLostError):
                                 receiver.complete_message(message)
                         else:
                             assert message.delivery_count >= 1
@@ -1415,13 +1415,13 @@ class TestServiceBusQueue(AzureMgmtRecordedTestCase):
                         try:
                             receiver.complete_message(message)
                             raise AssertionError("Didn't raise MessageLockLostError")
-                        except ServiceBusError as e:
+                        except MessageLockLostError as e:
                             assert isinstance(e.inner_exception, AutoLockRenewTimeout)
                     else:
                         if message._lock_expired:
                             print("Remaining messages", message.locked_until_utc, utc_now())
                             assert message._lock_expired
-                            with pytest.raises(ServiceBusError):
+                            with pytest.raises(MessageLockLostError):
                                 receiver.complete_message(message)
                         else:
                             assert message.delivery_count >= 1
@@ -1547,7 +1547,7 @@ class TestServiceBusQueue(AzureMgmtRecordedTestCase):
                 assert len(messages) == 1
                 time.sleep((messages[0].locked_until_utc - utc_now()).total_seconds()+1)
                 assert messages[0]._lock_expired
-                with pytest.raises(ServiceBusError):
+                with pytest.raises(MessageLockLostError):
                     receiver.complete_message(messages[0])
                 with pytest.raises(MessageLockLostError):
                     receiver.renew_message_lock(messages[0])


### PR DESCRIPTION
addressing: #29667

It seems MessageLockLostError should have been raised when completing messages with expired locks. Currently, ServiceBusError is being raised. Multiple reasons why this was probably just an oversight:
1) According to [the comment](https://github.com/Azure/azure-sdk-for-python/pull/15364/files/5443a7e4c971e949e61bc4eb7636c5ce08a976ca#r527044365) on the PR where this was added, the block checking for an expired lock was moved from the _receiver_mixins.py file to _servicebus_receiver.py. In there, the error was MessageLockExpired (renamed MessageLockLostError).
2) When a session is used and the lock expires, a [[SessionLockLostError is raised](https://github.com/Azure/azure-sdk-for-python/blob/7f85cbc8e2595e43b466d32e078e4b9d673b9ef3/sdk/servicebus/azure-servicebus/azure/servicebus/_base_handler.py#L384)], not a ServiceBusError. It should be similar for when a session is not used.