### PR TITLE
[Key Vault] Raise useful error when `KeyReleasePolicy` is incorrectly created

### DIFF
--- a/sdk/keyvault/azure-keyvault-keys/CHANGELOG.md
+++ b/sdk/keyvault/azure-keyvault-keys/CHANGELOG.md
@@ -9,6 +9,8 @@
 ### Bugs Fixed
 
 ### Other Changes
+- The `KeyReleasePolicy` constructor raises a useful `TypeError` if the provided `encoded_policy` has an incorrect type
+  ([#30000](https://github.com/Azure/azure-sdk-for-python/issues/30000))
 
 ## 4.9.0b1 (2023-05-16)
 

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_models.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_models.py
@@ -269,6 +269,8 @@ class KeyReleasePolicy(object):
     """
 
     def __init__(self, encoded_policy: bytes, **kwargs) -> None:
+        if not hasattr(encoded_policy, "decode"):
+            raise TypeError("The encoded release policy must be provided as bytes instead of a string.")
         self.encoded_policy = encoded_policy
         self.content_type = kwargs.get("content_type", None)
         self.immutable = kwargs.get("immutable", None)

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_key_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_key_client.py
@@ -832,3 +832,9 @@ def test_empty_rotation_policy_actions():
     assert generated_policy.lifetime_actions is None
     policy = KeyRotationPolicy._from_generated(generated_policy)
     assert policy.lifetime_actions == []
+
+
+def test_release_policy_raises_on_string_policy():
+    """Ensure the KeyReleasePolicy constructor raises an error when the `encoded_policy` is given as a string"""
+    with pytest.raises(TypeError):
+        KeyReleasePolicy(encoded_policy="policy")


### PR DESCRIPTION
# Description

Resolves https://github.com/Azure/azure-sdk-for-python/issues/30000. Though we usually don't validate inputs, the error that Key Vault raises for an incorrectly-created `KeyReleasePolicy` gives no context for this failure case. The model expects a `bytes` policy, but if a string is given, the service suggests no policy was provided at all:
```text
azure.core.exceptions.HttpResponseError: (BadParameter) AKV.SKR.1004: Exportable keys must have release policy.
```

https://github.com/Azure/azure-sdk-for-python/issues/29945 is an example of how this can confuse users. To avoid this, this PR adds a check to verify that the provided policy has a `decode` attribute (and raises a `TypeError` otherwise).

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
