### PR TITLE
[ml] improve managed network schema

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/workspace/networking.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/workspace/networking.py
@@ -7,8 +7,7 @@
 from marshmallow import fields, EXCLUDE
 from marshmallow.decorators import post_load, pre_dump
 from azure.ai.ml._schema.core.schema_meta import PatchedSchemaMeta
-from azure.ai.ml._schema.core.fields import StringTransformedEnum
-from azure.ai.ml._schema.core.fields import NestedField
+from azure.ai.ml._schema.core.fields import StringTransformedEnum, NestedField, UnionField
 from azure.ai.ml.entities._workspace.networking import (
     ManagedNetwork,
     FqdnDestination,
@@ -22,30 +21,60 @@ from azure.ai.ml._utils._experimental import experimental
 
 
 @experimental
-class DestinationSchema(metaclass=PatchedSchemaMeta):
-    service_resource_id = fields.Str()
-    subresource_target = fields.Str()
-    spark_enabled = fields.Bool()
-    service_tag = fields.Str()
-    protocol = fields.Str()
-    port_ranges = fields.Str()
-
-
-@experimental
 class ManagedNetworkStatusSchema(metaclass=PatchedSchemaMeta):
-    spark_ready = fields.Bool()
-    status = fields.Str()
+    spark_ready = fields.Bool(dump_only=True)
+    status = fields.Str(dump_only=True)
 
 
 @experimental
-class OutboundRuleSchema(metaclass=PatchedSchemaMeta):
+class FqdnOutboundRuleSchema(metaclass=PatchedSchemaMeta):
     name = fields.Str(required=True)
     type = StringTransformedEnum(
-        allowed_values=[OutboundRuleType.FQDN, OutboundRuleType.PRIVATE_ENDPOINT, OutboundRuleType.SERVICE_TAG],
+        allowed_values=[
+            OutboundRuleType.FQDN,  # use allowed values to differentiate for unionfield ordering
+        ],
         casing_transform=camel_to_snake,
         metadata={"description": "outbound rule type."},
     )
-    destination = fields.Raw(required=True)
+    destination = fields.Str(required=True)
+    category = StringTransformedEnum(
+        allowed_values=[
+            OutboundRuleCategory.REQUIRED,
+            OutboundRuleCategory.RECOMMENDED,
+            OutboundRuleCategory.USER_DEFINED,
+        ],
+        casing_transform=camel_to_snake,
+        metadata={"description": "outbound rule category."},
+    )
+    status = fields.Str(dump_only=True)
+
+    @post_load
+    def createdestobject(self, data, **kwargs):
+        dest = data.get("destination")
+        category = data.get("category", OutboundRuleCategory.USER_DEFINED)
+        name = data.get("name")
+        status = data.get("status", None)
+        return FqdnDestination(name=name, destination=dest, category=_snake_to_camel(category), status=status)
+
+
+@experimental
+class ServiceTagDestinationSchema(metaclass=PatchedSchemaMeta):
+    service_tag = fields.Str(required=True)
+    protocol = fields.Str(required=True)
+    port_ranges = fields.Str(required=True)
+
+
+@experimental
+class ServiceTagOutboundRuleSchema(metaclass=PatchedSchemaMeta):
+    name = fields.Str(required=True)
+    type = StringTransformedEnum(
+        allowed_values=[
+            OutboundRuleType.SERVICE_TAG,  # use allowed values to differentiate for unionfield ordering
+        ],
+        casing_transform=camel_to_snake,
+        metadata={"description": "outbound rule type."},
+    )
+    destination = NestedField(ServiceTagDestinationSchema, required=True)
     category = StringTransformedEnum(
         allowed_values=[
             OutboundRuleCategory.REQUIRED,
@@ -59,52 +88,23 @@ class OutboundRuleSchema(metaclass=PatchedSchemaMeta):
 
     @pre_dump
     def predump(self, data, **kwargs):
-        if data and isinstance(data, FqdnDestination):
-            data.destination = self.fqdn_dest2dict(data.destination)
-        if data and isinstance(data, PrivateEndpointDestination):
-            data.destination = self.pe_dest2dict(data.service_resource_id, data.subresource_target, data.spark_enabled)
-        if data and isinstance(data, ServiceTagDestination):
-            data.destination = self.service_tag_dest2dict(data.service_tag, data.protocol, data.port_ranges)
+        data.destination = self.service_tag_dest2dict(data.service_tag, data.protocol, data.port_ranges)
         return data
 
     @post_load
     def createdestobject(self, data, **kwargs):
-        dest = data.get("destination", False)
+        dest = data.get("destination")
         category = data.get("category", OutboundRuleCategory.USER_DEFINED)
-        name = data.get("name", None)
+        name = data.get("name")
         status = data.get("status", None)
-        if dest:
-            if isinstance(dest, str):
-                return FqdnDestination(name=name, destination=dest, category=_snake_to_camel(category), status=status)
-            else:
-                if dest.get("subresource_target", False):
-                    return PrivateEndpointDestination(
-                        name=name,
-                        service_resource_id=dest["service_resource_id"],
-                        subresource_target=dest["subresource_target"],
-                        spark_enabled=dest["spark_enabled"],
-                        category=_snake_to_camel(category),
-                        status=status,
-                    )
-            return ServiceTagDestination(
-                name=name,
-                service_tag=dest["service_tag"],
-                protocol=dest["protocol"],
-                port_ranges=dest["port_ranges"],
-                category=_snake_to_camel(category),
-                status=status,
-            )
-
-    def fqdn_dest2dict(self, fqdndest):
-        res = fqdndest
-        return res
-
-    def pe_dest2dict(self, service_resource_id, subresource_target, spark_enabled):
-        pedest = {}
-        pedest["service_resource_id"] = service_resource_id
-        pedest["subresource_target"] = subresource_target
-        pedest["spark_enabled"] = spark_enabled
-        return pedest
+        return ServiceTagDestination(
+            name=name,
+            service_tag=dest["service_tag"],
+            protocol=dest["protocol"],
+            port_ranges=dest["port_ranges"],
+            category=_snake_to_camel(category),
+            status=status,
+        )
 
     def service_tag_dest2dict(self, service_tag, protocol, port_ranges):
         service_tag_dest = {}
@@ -112,6 +112,63 @@ class OutboundRuleSchema(metaclass=PatchedSchemaMeta):
         service_tag_dest["protocol"] = protocol
         service_tag_dest["port_ranges"] = port_ranges
         return service_tag_dest
+
+
+@experimental
+class PrivateEndpointDestinationSchema(metaclass=PatchedSchemaMeta):
+    service_resource_id = fields.Str(required=True)
+    subresource_target = fields.Str(required=True)
+    spark_enabled = fields.Bool(required=True)
+
+
+@experimental
+class PrivateEndpointOutboundRuleSchema(metaclass=PatchedSchemaMeta):
+    name = fields.Str(required=True)
+    type = StringTransformedEnum(
+        allowed_values=[
+            OutboundRuleType.PRIVATE_ENDPOINT,  # use allowed values to differentiate for unionfield ordering
+        ],
+        casing_transform=camel_to_snake,
+        metadata={"description": "outbound rule type."},
+    )
+    destination = NestedField(PrivateEndpointDestinationSchema, required=True)
+    category = StringTransformedEnum(
+        allowed_values=[
+            OutboundRuleCategory.REQUIRED,
+            OutboundRuleCategory.RECOMMENDED,
+            OutboundRuleCategory.USER_DEFINED,
+        ],
+        casing_transform=camel_to_snake,
+        metadata={"description": "outbound rule category."},
+    )
+    status = fields.Str(dump_only=True)
+
+    @pre_dump
+    def predump(self, data, **kwargs):
+        data.destination = self.pe_dest2dict(data.service_resource_id, data.subresource_target, data.spark_enabled)
+        return data
+
+    @post_load
+    def createdestobject(self, data, **kwargs):
+        dest = data.get("destination")
+        category = data.get("category", OutboundRuleCategory.USER_DEFINED)
+        name = data.get("name")
+        status = data.get("status", None)
+        return PrivateEndpointDestination(
+            name=name,
+            service_resource_id=dest["service_resource_id"],
+            subresource_target=dest["subresource_target"],
+            spark_enabled=dest["spark_enabled"],
+            category=_snake_to_camel(category),
+            status=status,
+        )
+
+    def pe_dest2dict(self, service_resource_id, subresource_target, spark_enabled):
+        pedest = {}
+        pedest["service_resource_id"] = service_resource_id
+        pedest["subresource_target"] = subresource_target
+        pedest["spark_enabled"] = spark_enabled
+        return pedest
 
 
 @experimental
@@ -125,9 +182,19 @@ class ManagedNetworkSchema(metaclass=PatchedSchemaMeta):
         casing_transform=camel_to_snake,
         metadata={"description": "isolation mode for the workspace managed network."},
     )
-    outbound_rules = fields.List(NestedField(OutboundRuleSchema, allow_none=False, unknown=EXCLUDE), allow_none=True)
-    network_id = fields.Str(required=False)
-    status = NestedField(ManagedNetworkStatusSchema, dump_only=True)
+    outbound_rules = fields.List(
+        UnionField(
+            [
+                NestedField(FqdnOutboundRuleSchema, allow_none=False, unknown=EXCLUDE),
+                NestedField(ServiceTagOutboundRuleSchema, allow_none=False, unknown=EXCLUDE),
+                NestedField(PrivateEndpointOutboundRuleSchema, allow_none=False, unknown=EXCLUDE),
+            ],
+            allow_none=False,
+        ),
+        allow_none=True,
+    )
+    network_id = fields.Str(required=False, dump_only=True)
+    status = NestedField(ManagedNetworkStatusSchema, allow_none=False, unknown=EXCLUDE)
 
     @post_load
     def make(self, data, **kwargs):

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/workspace/networking.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/workspace/networking.py
@@ -14,7 +14,7 @@ from azure.ai.ml.entities._workspace.networking import (
     ServiceTagDestination,
     PrivateEndpointDestination,
 )
-from azure.ai.ml.constants._workspace import IsolationMode, OutboundRuleCategory, OutboundRuleType
+from azure.ai.ml.constants._workspace import IsolationMode, OutboundRuleCategory
 from azure.ai.ml._utils.utils import camel_to_snake, _snake_to_camel
 
 from azure.ai.ml._utils._experimental import experimental


### PR DESCRIPTION
# Description

Work item: https://dev.azure.com/msdata/Vienna/_workitems/edit/2475216/

Workspace managed network related schema is correct and behaving as intended but the tool used to generate latest yaml schema does not correctly handle Raw marshmallow fields. To fix this, adjust the managed network schema to use unionfield so that generated json schema is as intended. This also can help make it slightly cleaner. Generated schema [azuremlschemas.azureedge.net/latest/workspace.schema.json](https://azuremlschemas.azureedge.net/latest/workspace.schema.json) will then be up to date at the next release of SDK

Tests:
using yaml schema for workspace with all type of outbound rule, for example below, ensure that load from yaml to workspace object and dump to yaml functionality continues to behave as expected. 

YAML file:
<img width="625" alt="image" src="https://github.com/Azure/azure-sdk-for-python/assets/53531213/5e3004e4-b564-4ddc-8cb8-57f715523d9d">

test and output
![image](https://github.com/Azure/azure-sdk-for-python/assets/53531213/bc49c43a-08b0-4899-9786-0012239bd71d)

Confirmed new generated workspace json schema will be as intended using _**python .\scripts\json_schema_generator.py**_ from sdk-cli-v2 repo:
```yaml
        "ManagedNetworkSchema": {
            "type": "object",
            "properties": {
                "isolation_mode": {
                    "type": "string",
                    "enum": [
                        "disabled",
                        "allow_internet_outbound",
                        "allow_only_approved_outbound"
                    ],
                    "title": "isolation_mode"
                },
                "network_id": {
                    "title": "network_id",
                    "type": "string",
                    "readonly": true
                },
                "outbound_rules": {
                    "title": "outbound_rules",
                    "type": [
                        "array",
                        "null"
                    ],
                    "items": {
                        "oneOf": [
                            {
                                "type": "object",
                                "$ref": "#/definitions/PrivateEndpointOutboundRuleSchema"
                            },
                            {
                                "type": "object",
                                "$ref": "#/definitions/ServiceTagOutboundRuleSchema"
                            },
                            {
                                "type": "object",
                                "$ref": "#/definitions/FqdnOutboundRuleSchema"
                            }
                        ]
                    }
                },
                "status": {
                    "type": "object",
                    "$ref": "#/definitions/ManagedNetworkStatusSchema"
                }
            },
            "additionalProperties": false
        },
        "PrivateEndpointOutboundRuleSchema": {
            "type": "object",
            "required": [
                "destination",
                "name"
            ],
            "properties": {
                "category": {
                    "type": "string",
                    "enum": [
                        "required",
                        "recommended",
                        "user_defined"
                    ],
                    "title": "category",
                    "readonly": true
                },
                "destination": {
                    "type": "object",
                    "$ref": "#/definitions/PrivateEndpointDestinationSchema"
                },
                "name": {
                    "title": "name",
                    "type": "string"
                },
                "status": {
                    "title": "status",
                    "type": "string",
                    "readonly": true
                },
                "type": {
                    "const": "private_endpoint"
                }
            },
            "additionalProperties": false
        },
        "PrivateEndpointDestinationSchema": {
            "type": "object",
            "required": [
                "service_resource_id",
                "spark_enabled",
                "subresource_target"
            ],
            "properties": {
                "service_resource_id": {
                    "title": "service_resource_id",
                    "type": "string"
                },
                "spark_enabled": {
                    "title": "spark_enabled",
                    "type": "boolean"
                },
                "subresource_target": {
                    "title": "subresource_target",
                    "type": "string"
                }
            },
            "additionalProperties": false
        },
        "ServiceTagOutboundRuleSchema": {
            "type": "object",
            "required": [
                "destination",
                "name"
            ],
            "properties": {
                "category": {
                    "type": "string",
                    "enum": [
                        "required",
                        "recommended",
                        "user_defined"
                    ],
                    "title": "category",
                    "readonly": true
                },
                "destination": {
                    "type": "object",
                    "$ref": "#/definitions/ServiceTagDestinationSchema"
                },
                "name": {
                    "title": "name",
                    "type": "string"
                },
                "status": {
                    "title": "status",
                    "type": "string",
                    "readonly": true
                },
                "type": {
                    "const": "service_tag"
                }
            },
            "additionalProperties": false
        },
        "ServiceTagDestinationSchema": {
            "type": "object",
            "required": [
                "port_ranges",
                "protocol",
                "service_tag"
            ],
            "properties": {
                "port_ranges": {
                    "title": "port_ranges",
                    "type": "string"
                },
                "protocol": {
                    "title": "protocol",
                    "type": "string"
                },
                "service_tag": {
                    "title": "service_tag",
                    "type": "string"
                }
            },
            "additionalProperties": false
        },
        "FqdnOutboundRuleSchema": {
            "type": "object",
            "required": [
                "destination",
                "name"
            ],
            "properties": {
                "category": {
                    "type": "string",
                    "enum": [
                        "required",
                        "recommended",
                        "user_defined"
                    ],
                    "title": "category",
                    "readonly": true
                },
                "destination": {
                    "title": "destination",
                    "type": "string"
                },
                "name": {
                    "title": "name",
                    "type": "string"
                },
                "status": {
                    "title": "status",
                    "type": "string",
                    "readonly": true
                },
                "type": {
                    "const": "fqdn"
                }
            },
            "additionalProperties": false
        },
        "ManagedNetworkStatusSchema": {
            "type": "object",
            "properties": {
                "spark_ready": {
                    "title": "spark_ready",
                    "type": "boolean",
                    "readonly": true
                },
                "status": {
                    "title": "status",
                    "type": "string",
                    "readonly": true
                }
            },
            "additionalProperties": false
        },
```

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
