### PR TITLE
[ServiceBus&EventHubs] update china region

### DIFF
--- a/sdk/eventhub/tests.yml
+++ b/sdk/eventhub/tests.yml
@@ -14,7 +14,7 @@ stages:
           SubscriptionConfiguration: $(sub-config-gov-test-resources)
         China:
           SubscriptionConfiguration: $(sub-config-cn-test-resources)
-          Location: 'chinanorth2'
+          Location: 'chinanorth3'
       MatrixReplace:
         - TestSamples=.*/true
       MatrixFilters:

--- a/sdk/servicebus/azure-servicebus/tests/test_queues.py
+++ b/sdk/servicebus/azure-servicebus/tests/test_queues.py
@@ -1202,7 +1202,7 @@ class TestServiceBusQueue(AzureMgmtRecordedTestCase):
 
             too_large = "A" * 256 * 1024
     
-            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+            with sb_client.get_queue_sender(servicebus_queue.name, socket_timeout=0.5) as sender:
                 with pytest.raises(MessageSizeExceededError):
                     sender.send_messages(ServiceBusMessage(too_large))
 

--- a/sdk/servicebus/azure-servicebus/tests/utilities.py
+++ b/sdk/servicebus/azure-servicebus/tests/utilities.py
@@ -7,12 +7,17 @@
 import logging
 import sys
 import time
+import os
 try:
     import uamqp
     uamqp_available = True
 except (ModuleNotFoundError, ImportError):
     uamqp_available = False
 from azure.servicebus._common.utils import utc_now
+
+# TODO: temporary - disable uamqp if China b/c of 8+ hr runtime
+uamqp_available = uamqp_available and os.environ.get('SERVICEBUS_ENDPOINT_SUFFIX') != '.servicebus.chinacloudapi.cn'
+
 
 def _get_default_handler():
     handler = logging.StreamHandler(stream=sys.stdout)

--- a/sdk/servicebus/tests.yml
+++ b/sdk/servicebus/tests.yml
@@ -28,4 +28,4 @@ stages:
           Location: 'usgovarizona'
         China:
           SubscriptionConfiguration: $(sub-config-cn-test-resources)
-          Location: 'chinanorth2'
+          Location: 'chinanorth3'

--- a/sdk/servicebus/tests.yml
+++ b/sdk/servicebus/tests.yml
@@ -4,7 +4,7 @@ stages:
   - template: ../../eng/pipelines/templates/stages/archetype-sdk-tests.yml
     parameters:
       ServiceDirectory: servicebus
-      TestTimeoutInMinutes: 360
+      TestTimeoutInMinutes: 420
       BuildTargetingString: azure-servicebus*
       EnvVars:
         AZURE_SUBSCRIPTION_ID: $(SERVICEBUS_SUBSCRIPTION_ID)

--- a/sdk/servicebus/tests.yml
+++ b/sdk/servicebus/tests.yml
@@ -4,7 +4,7 @@ stages:
   - template: ../../eng/pipelines/templates/stages/archetype-sdk-tests.yml
     parameters:
       ServiceDirectory: servicebus
-      TestTimeoutInMinutes: 420
+      TestTimeoutInMinutes: 480
       BuildTargetingString: azure-servicebus*
       EnvVars:
         AZURE_SUBSCRIPTION_ID: $(SERVICEBUS_SUBSCRIPTION_ID)


### PR DESCRIPTION
update China tests to more stable region as per: #30868 

TODO:
- [x] fix failing SB message backcompat tests in usgov/china: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=2879861&view=logs&j=ea5cf89f-39b5-5004-688c-3d0113d58814&t=e2992169-3d0a-5980-30ec-f668717399cd&l=7593
 > **fix here: #31014** 