### PR TITLE
[SchemaRegistry] update failing avro recordings

### DIFF
--- a/sdk/schemaregistry/azure-schemaregistry-avroencoder/assets.json
+++ b/sdk/schemaregistry/azure-schemaregistry-avroencoder/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "python",
   "TagPrefix": "python/schemaregistry/azure-schemaregistry-avroencoder",
-  "Tag": "python/schemaregistry/azure-schemaregistry-avroencoder_406aea9310"
+  "Tag": "python/schemaregistry/azure-schemaregistry-avroencoder_50158ba496"
 }

--- a/sdk/schemaregistry/azure-schemaregistry-avroencoder/assets.json
+++ b/sdk/schemaregistry/azure-schemaregistry-avroencoder/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "python",
   "TagPrefix": "python/schemaregistry/azure-schemaregistry-avroencoder",
-  "Tag": "python/schemaregistry/azure-schemaregistry-avroencoder_de42f2c6e6"
+  "Tag": "python/schemaregistry/azure-schemaregistry-avroencoder_406aea9310"
 }

--- a/sdk/schemaregistry/azure-schemaregistry-avroencoder/tests/test_avro_encoder.py
+++ b/sdk/schemaregistry/azure-schemaregistry-avroencoder/tests/test_avro_encoder.py
@@ -41,7 +41,7 @@ from devtools_testutils import AzureTestCase
 SchemaRegistryEnvironmentVariableLoader = functools.partial(
     EnvironmentVariableLoader,
     "schemaregistry",
-    schemaregistry_avro_fully_qualified_namespace="fake_resource_avro.servicebus.windows.net/",
+    schemaregistry_avro_fully_qualified_namespace="fake_resource_avro.servicebus.windows.net",
     schemaregistry_group="fakegroup"
 )
 


### PR DESCRIPTION
Found that a few Avro recordings were failing due to an extra backslash in the EnvVarLoader described here: #30935