### PR TITLE
Avoid Newest `typing-extensions`, introduces break in `virtualenv` used by `tox`

### DIFF
--- a/eng/ci_tools.txt
+++ b/eng/ci_tools.txt
@@ -15,6 +15,7 @@ pip==20.3.3
 wrapt==1.12.1; python_version <= '3.10'
 wrapt==1.14.1; python_version >= '3.11'
 markupsafe==2.0.1
+typing-extensions<=4.6.3
 
 # locking packages defined as deps from azure-sdk-tools or azure-devtools
 pytoml==0.1.21

--- a/eng/regression_test_tools.txt
+++ b/eng/regression_test_tools.txt
@@ -12,6 +12,7 @@ bandit==1.6.2
 protobuf==3.17.3; python_version == '2.7'
 chardet>=2.0,<5.0
 cmarkgfm<0.7.0
+typing-extensions<=4.6.3
 
 # locking packages defined as deps from azure-sdk-tools or azure-devtools
 pytoml==0.1.21

--- a/eng/regression_tools.txt
+++ b/eng/regression_tools.txt
@@ -15,6 +15,7 @@ pip==20.3.3
 wrapt==1.12.1; python_version <= '3.10'
 wrapt==1.14.1; python_version >= '3.11'
 markupsafe==2.0.1
+typing-extensions<=4.6.3
 
 # locking packages defined as deps from azure-sdk-tools or azure-devtools
 pytoml==0.1.21

--- a/eng/test_tools.txt
+++ b/eng/test_tools.txt
@@ -11,6 +11,7 @@ bandit==1.6.2
 protobuf==3.17.3; python_version == '2.7'
 chardet>=2.0,<5.0
 cmarkgfm<0.7.0
+typing-extensions<=4.6.3
 
 # locking packages defined as deps from azure-sdk-tools or azure-devtools
 pytoml==0.1.21


### PR DESCRIPTION
See title.

I want our `pypy` tests to work, so let's pin this while virtualenv hunts down a fix.

@mccoyp for FYI