### PR TITLE
[DO NOT MERGE] test if message lock lost error change works w/o updating tests

### DIFF
--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_servicebus_receiver.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_servicebus_receiver.py
@@ -13,7 +13,7 @@ import warnings
 from enum import Enum
 from typing import Any, List, Optional, Dict, Iterator, Union, TYPE_CHECKING, cast
 
-from .exceptions import ServiceBusError
+from .exceptions import MessageLockLostError
 from ._base_handler import BaseHandler
 from ._common.message import ServiceBusReceivedMessage
 from ._common.utils import create_authentication
@@ -470,7 +470,7 @@ class ServiceBusReceiver(
         # subclasses in the future after we add the missing feature support in uamqp.
         # see issue: https://github.com/Azure/azure-uamqp-c/issues/274
         if not self._session and message._lock_expired:
-            raise ServiceBusError(
+            raise MessageLockLostError(
                 message="The lock on the message lock has expired.",
                 error=message.auto_renew_error,
             )

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_servicebus_receiver_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_servicebus_receiver_async.py
@@ -14,7 +14,7 @@ import warnings
 from enum import Enum
 from typing import Any, List, Optional, AsyncIterator, Union, TYPE_CHECKING, cast
 
-from ..exceptions import ServiceBusError
+from ..exceptions import MessageLockLostError
 from ._servicebus_session_async import ServiceBusSession
 from ._base_handler_async import BaseHandler
 from .._common.message import ServiceBusReceivedMessage
@@ -452,7 +452,7 @@ class ServiceBusReceiver(collections.abc.AsyncIterator, BaseHandler, ReceiverMix
         # subclasses in the future after we add the missing feature support in uamqp.
         # see issue: https://github.com/Azure/azure-uamqp-c/issues/274
         if not self._session and message._lock_expired:
-            raise ServiceBusError(
+            raise MessageLockLostError(
                 message="The lock on the message lock has expired.",
                 error=message.auto_renew_error,
             )


### PR DESCRIPTION
Checking that MessageLockLostError update in SBReceiver doesn't cause existing tests to fail, since SBError is parent. Sanity check as per https://github.com/Azure/azure-sdk-for-python/pull/30896#discussion_r1247308891