### PR TITLE
[AppConfig] Change China cloud deployment location

### DIFF
--- a/sdk/appconfiguration/tests.yml
+++ b/sdk/appconfiguration/tests.yml
@@ -5,6 +5,14 @@ stages:
     parameters:
       ServiceDirectory: appconfiguration
       SupportedClouds: 'Public,UsGov,China'
+      CloudConfig:
+        Public:
+          SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
+        UsGov:
+          SubscriptionConfiguration: $(sub-config-gov-test-resources)
+        China:
+          SubscriptionConfiguration: $(sub-config-cn-test-resources)
+          Location: chinanorth3
       MatrixReplace:
         - TestSamples=.*/true
       EnvVars:


### PR DESCRIPTION
Change China cloud deployment location in weekly pipeline from `chinaeast2` to `chinanorth3` to resolve connection issues in previous one, which eventually will cause tests hanging without printing any error stack and timeout.