### PR TITLE
[Az Core Experimental] Httpx transport fixes

### DIFF
--- a/sdk/core/azure-core-experimental/CHANGELOG.md
+++ b/sdk/core/azure-core-experimental/CHANGELOG.md
@@ -1,14 +1,11 @@
 # Release History
 
-## 1.0.0b3 (Unreleased)
+## 1.0.0b3 (2023-07-06)
 
-### Features Added
+### Bug Fixes
 
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
+- Update httpx transport to handle timeout and connection verify kwargs from `azure.core.pipeline.transport.HttpRequest`.
+- Add a read override for `read` for clients using `azure.core.rest.HttpResponse` to get the response body.
 
 ## 1.0.0b2 (2023-04-06)
 

--- a/sdk/core/azure-core-experimental/azure/core/experimental/transport/_httpx.py
+++ b/sdk/core/azure-core-experimental/azure/core/experimental/transport/_httpx.py
@@ -23,7 +23,7 @@
 # IN THE SOFTWARE.
 #
 # --------------------------------------------------------------------------
-from typing import ContextManager, Iterator, Optional
+from typing import Any, ContextManager, Iterator, Optional
 
 import httpx
 from azure.core.pipeline import Pipeline
@@ -32,6 +32,7 @@ from azure.core.exceptions import ServiceRequestError, ServiceResponseError
 from azure.core.pipeline.transport import HttpTransport
 from azure.core.rest import HttpRequest
 from azure.core.rest._http_response_impl import HttpResponseImpl
+from azure.core.configuration import ConnectionConfiguration
 
 
 class HttpXTransportResponse(HttpResponseImpl):
@@ -47,6 +48,8 @@ class HttpXTransportResponse(HttpResponseImpl):
             content_type=httpx_response.headers.get("content-type"),
             stream_download_generator=stream_contextmanager,
         )
+        
+        self._content = self._internal_response.content
 
     def body(self) -> bytes:
         return self.internal_response.content
@@ -92,12 +95,18 @@ class HttpXTransport(HttpTransport):
     :keyword httpx.Client client: HTTPX client to use instead of the default one
     """
 
-    def __init__(self, **kwargs) -> None:
-        self.client = kwargs.get("client", None)
+    def __init__(self, *, client:Optional[httpx.Client] = None, **kwargs:Any) -> None:
+        self.client = client
+        self.connection_config = ConnectionConfiguration(**kwargs)
+        self._use_env_settings = kwargs.pop("use_env_settings", True)
 
     def open(self) -> None:
         if self.client is None:
-            self.client = httpx.Client()
+            self.client = httpx.Client(
+                trust_env=self._use_env_settings,
+                verify=self.connection_config.verify,
+                cert=self.connection_config.cert,
+            )
 
     def close(self) -> None:
         if self.client:
@@ -113,15 +122,22 @@ class HttpXTransport(HttpTransport):
 
     def send(self, request: HttpRequest, **kwargs) -> HttpXTransportResponse:
         stream_response = kwargs.pop("stream", False)
+        timeout = kwargs.pop("connection_timeout", self.connection_config.timeout)
+        # not needed here as its already handled during init
+        kwargs.pop("connection_verify", None)
         parameters = {
             "method": request.method,
             "url": request.url,
             "headers": request.headers.items(),
             "data": request.data,
-            "content": request.content,
             "files": request.files,
+            "timeout": timeout if timeout else request.timeout,
             **kwargs,
         }
+        
+        if hasattr(request,"content"):
+            parameters["content"] = request.content
+
         stream_ctx: Optional[ContextManager] = None
         try:
             if stream_response:

--- a/sdk/core/azure-core-experimental/azure/core/experimental/transport/_httpx.py
+++ b/sdk/core/azure-core-experimental/azure/core/experimental/transport/_httpx.py
@@ -98,7 +98,7 @@ class HttpXTransport(HttpTransport):
     :keyword httpx.Client client: HTTPX client to use instead of the default one
     """
 
-    def __init__(self, *, client:Optional[httpx.Client] = None, **kwargs:Any) -> None:
+    def __init__(self, *, client: Optional[httpx.Client] = None, **kwargs: Any) -> None:
         self.client = client
         self.connection_config = ConnectionConfiguration(**kwargs)
         self._use_env_settings = kwargs.pop("use_env_settings", True)
@@ -138,7 +138,7 @@ class HttpXTransport(HttpTransport):
             **kwargs,
         }
 
-        if hasattr(request,"content"):
+        if hasattr(request, "content"):
             parameters["content"] = request.content
 
         stream_ctx: Optional[ContextManager] = None

--- a/sdk/core/azure-core-experimental/azure/core/experimental/transport/_httpx.py
+++ b/sdk/core/azure-core-experimental/azure/core/experimental/transport/_httpx.py
@@ -48,12 +48,15 @@ class HttpXTransportResponse(HttpResponseImpl):
             content_type=httpx_response.headers.get("content-type"),
             stream_download_generator=stream_contextmanager,
         )
-        
-        self._content = self._internal_response.content
 
+    def read(self) -> bytes:
+        if self._content is None:
+            self._content = self.internal_response.read()
+        return self.content
+        
     def body(self) -> bytes:
         return self.internal_response.content
-
+    
     def stream_download(self, pipeline: Pipeline, **kwargs) -> Iterator[bytes]:
         return HttpXStreamDownloadGenerator(pipeline, self, **kwargs)
 

--- a/sdk/core/azure-core-experimental/azure/core/experimental/transport/_httpx.py
+++ b/sdk/core/azure-core-experimental/azure/core/experimental/transport/_httpx.py
@@ -53,10 +53,10 @@ class HttpXTransportResponse(HttpResponseImpl):
         if self._content is None:
             self._content = self.internal_response.read()
         return self.content
-        
+
     def body(self) -> bytes:
         return self.internal_response.content
-    
+
     def stream_download(self, pipeline: Pipeline, **kwargs) -> Iterator[bytes]:
         return HttpXStreamDownloadGenerator(pipeline, self, **kwargs)
 

--- a/sdk/core/azure-core-experimental/azure/core/experimental/transport/_httpx.py
+++ b/sdk/core/azure-core-experimental/azure/core/experimental/transport/_httpx.py
@@ -137,7 +137,7 @@ class HttpXTransport(HttpTransport):
             "timeout": timeout if timeout else request.timeout,
             **kwargs,
         }
-        
+
         if hasattr(request,"content"):
             parameters["content"] = request.content
 


### PR DESCRIPTION
This PR contains two fixes:
* Handle some of the kwargs named differently between httpx and old http request
* Add a override read in to response for rest.httpresponse