### PR TITLE
update components feature flag, add component model for nlp tests

### DIFF
--- a/sdk/ml/azure-ai-ml/tests/automl_job/e2etests/test_automl_image_classification.py
+++ b/sdk/ml/azure-ai-ml/tests/automl_job/e2etests/test_automl_image_classification.py
@@ -87,7 +87,7 @@ class TestAutoMLImageClassification(AzureRecordedTestCase):
 
         properties = get_automl_job_properties()
         if components:
-            properties["_aml_internal_automl_subgraph_orchestration"] = "true"
+            properties["_automl_subgraph_orchestration"] = "true"
             properties[
                 "_pipeline_id_override"
             ] = "azureml://registries/azmlft-dev-registry01/components/image_classification_pipeline"

--- a/sdk/ml/azure-ai-ml/tests/automl_job/e2etests/test_automl_image_classification_multilabel.py
+++ b/sdk/ml/azure-ai-ml/tests/automl_job/e2etests/test_automl_image_classification_multilabel.py
@@ -95,7 +95,7 @@ class TestAutoMLImageClassificationMultilabel(AzureRecordedTestCase):
 
         properties = get_automl_job_properties()
         if components:
-            properties["_aml_internal_automl_subgraph_orchestration"] = "true"
+            properties["_automl_subgraph_orchestration"] = "true"
             properties[
                 "_pipeline_id_override"
             ] = "azureml://registries/azmlft-dev-registry01/components/image_classification_pipeline"

--- a/sdk/ml/azure-ai-ml/tests/automl_job/e2etests/test_automl_image_object_detection.py
+++ b/sdk/ml/azure-ai-ml/tests/automl_job/e2etests/test_automl_image_object_detection.py
@@ -119,7 +119,7 @@ class TestAutoMLImageObjectDetection(AzureRecordedTestCase):
 
         properties = get_automl_job_properties()
         if components:
-            properties["_aml_internal_automl_subgraph_orchestration"] = "true"
+            properties["_automl_subgraph_orchestration"] = "true"
             properties[
                 "_pipeline_id_override"
             ] = "azureml://registries/azmlft-dev-registry01/components/image_object_detection_pipeline"

--- a/sdk/ml/azure-ai-ml/tests/automl_job/e2etests/test_automl_image_segmentation.py
+++ b/sdk/ml/azure-ai-ml/tests/automl_job/e2etests/test_automl_image_segmentation.py
@@ -80,7 +80,7 @@ class TestAutoMLImageSegmentation(AzureRecordedTestCase):
 
         properties = get_automl_job_properties()
         if components:
-            properties["_aml_internal_automl_subgraph_orchestration"] = "true"
+            properties["_automl_subgraph_orchestration"] = "true"
             properties[
                 "_pipeline_id_override"
             ] = "azureml://registries/azmlft-dev-registry01/components/image_instance_segmentation_pipeline"

--- a/sdk/ml/azure-ai-ml/tests/automl_job/e2etests/test_remote_text_classification.py
+++ b/sdk/ml/azure-ai-ml/tests/automl_job/e2etests/test_remote_text_classification.py
@@ -41,6 +41,7 @@ class TestTextClassification(AzureRecordedTestCase):
             properties=properties,
         )
 
+        # use component specific model name so that the test fails if components are not run
         if components:
             job.set_training_parameters(model_name="microsoft/deberta-base")
 

--- a/sdk/ml/azure-ai-ml/tests/automl_job/e2etests/test_remote_text_classification.py
+++ b/sdk/ml/azure-ai-ml/tests/automl_job/e2etests/test_remote_text_classification.py
@@ -27,7 +27,7 @@ class TestTextClassification(AzureRecordedTestCase):
 
         properties = get_automl_job_properties()
         if components:
-            properties["_aml_internal_automl_subgraph_orchestration"] = "true"
+            properties["_automl_subgraph_orchestration"] = "true"
             properties["_pipeline_id_override"] = (
                 "azureml://registries/azmlft-dev-registry01/" "components/nlp_textclassification_multiclass"
             )
@@ -40,6 +40,10 @@ class TestTextClassification(AzureRecordedTestCase):
             experiment_name="DPv2-text-classification",
             properties=properties,
         )
+
+        if components:
+            job.set_training_parameters(model_name="microsoft/deberta-base")
+
         job.set_limits(timeout_minutes=60, max_concurrent_trials=1)
         job.set_featurization(dataset_language="eng")
 

--- a/sdk/ml/azure-ai-ml/tests/automl_job/e2etests/test_remote_text_classification_multilabel.py
+++ b/sdk/ml/azure-ai-ml/tests/automl_job/e2etests/test_remote_text_classification_multilabel.py
@@ -41,6 +41,7 @@ class TestTextClassificationMultilabel(AzureRecordedTestCase):
             properties=properties,
         )
 
+        # use component specific model name so that the test fails if components are not run
         if components:
             job.set_training_parameters(model_name="microsoft/deberta-base")
 

--- a/sdk/ml/azure-ai-ml/tests/automl_job/e2etests/test_remote_text_classification_multilabel.py
+++ b/sdk/ml/azure-ai-ml/tests/automl_job/e2etests/test_remote_text_classification_multilabel.py
@@ -27,7 +27,7 @@ class TestTextClassificationMultilabel(AzureRecordedTestCase):
 
         properties = get_automl_job_properties()
         if components:
-            properties["_aml_internal_automl_subgraph_orchestration"] = "true"
+            properties["_automl_subgraph_orchestration"] = "true"
             properties[
                 "_pipeline_id_override"
             ] = "azureml://registries/azmlft-dev-registry01/components/nlp_textclassification_multilabel"
@@ -40,6 +40,10 @@ class TestTextClassificationMultilabel(AzureRecordedTestCase):
             experiment_name="DPv2-text-classification-multilabel",
             properties=properties,
         )
+
+        if components:
+            job.set_training_parameters(model_name="microsoft/deberta-base")
+
         job.set_limits(timeout_minutes=60, max_concurrent_trials=1)
 
         created_job = client.jobs.create_or_update(job)

--- a/sdk/ml/azure-ai-ml/tests/automl_job/e2etests/test_remote_text_ner.py
+++ b/sdk/ml/azure-ai-ml/tests/automl_job/e2etests/test_remote_text_ner.py
@@ -38,6 +38,7 @@ class TestTextNer(AzureRecordedTestCase):
             properties=properties,
         )
 
+        # use component specific model name so that the test fails if components are not run
         if components:
             job.set_training_parameters(model_name="microsoft/deberta-base")
 

--- a/sdk/ml/azure-ai-ml/tests/automl_job/e2etests/test_remote_text_ner.py
+++ b/sdk/ml/azure-ai-ml/tests/automl_job/e2etests/test_remote_text_ner.py
@@ -25,7 +25,7 @@ class TestTextNer(AzureRecordedTestCase):
 
         properties = get_automl_job_properties()
         if components:
-            properties["_aml_internal_automl_subgraph_orchestration"] = "true"
+            properties["_automl_subgraph_orchestration"] = "true"
             properties[
                 "_pipeline_id_override"
             ] = "azureml://registries/azmlft-dev-registry01/components/nlp_textclassification_ner"
@@ -37,6 +37,10 @@ class TestTextNer(AzureRecordedTestCase):
             experiment_name="DPv2-text-ner",
             properties=properties,
         )
+
+        if components:
+            job.set_training_parameters(model_name="microsoft/deberta-base")
+
         job.set_limits(timeout_minutes=60, max_concurrent_trials=1)
 
         created_job = client.jobs.create_or_update(job)


### PR DESCRIPTION
# Description

A recent JOS change updated the subgraph orchestration feature flag by removing the "_aml_internal" prefix. This PR updates the flag in the Vision and NLP e2e live tests. Additionally, this PR also includes component specific model name for NLP component runs.

Sample Runs from sdkv2 e2e tests:

test_automl_image_classification
[image classification component sweep](https://ml.azure.com/experiments/id/63ba9bf3-a3ea-46ce-a0da-13f1ec3dd36d/runs/frank_map_8bsgvlbm9s?wsid=/subscriptions/dbd697c3-ef40-488f-83e6-5ad4dfb78f9b/resourcegroups/rbhimani-rg/workspaces/rbhimani-ws&tid=72f988bf-86f1-41af-91ab-2d7cd011db47#)
[image classification component automode](https://ml.azure.com/experiments/id/63ba9bf3-a3ea-46ce-a0da-13f1ec3dd36d/runs/sincere_arm_6gzxfmrb4b?wsid=/subscriptions/dbd697c3-ef40-488f-83e6-5ad4dfb78f9b/resourcegroups/rbhimani-rg/workspaces/rbhimani-ws&tid=72f988bf-86f1-41af-91ab-2d7cd011db47)
[image classification runtime component sweep](https://ml.azure.com/experiments/id/63ba9bf3-a3ea-46ce-a0da-13f1ec3dd36d/runs/neat_napkin_2cn48zk22j?wsid=/subscriptions/dbd697c3-ef40-488f-83e6-5ad4dfb78f9b/resourcegroups/rbhimani-rg/workspaces/rbhimani-ws&tid=72f988bf-86f1-41af-91ab-2d7cd011db47#)

test_remote_run_text_classification_multilabel
[text multilabel classification component](https://ml.azure.com/experiments/id/889f59c0-30e8-43fb-b6aa-9507b536fd05/runs/musing_diamond_c071qsjgyg?wsid=/subscriptions/dbd697c3-ef40-488f-83e6-5ad4dfb78f9b/resourcegroups/rbhimani-rg/workspaces/rbhimani-ws&tid=72f988bf-86f1-41af-91ab-2d7cd011db47)

If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
