### PR TITLE
[Key Vault] Extend pipeline timeouts

### DIFF
--- a/sdk/keyvault/tests.yml
+++ b/sdk/keyvault/tests.yml
@@ -17,6 +17,7 @@ stages:
         BuildTargetingString: ${{ service }}
         JobName: ${{ replace(service, '-', '_') }}
         SupportedClouds: 'Public,UsGov,China'
+        TestTimeoutInMinutes: 180
         CloudConfig:
           Public:
             SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)


### PR DESCRIPTION
# Description

Key Vault tests are now all passing in weekly pipelines -- yay! -- but latency in China cloud is making some platforms time out. This bumps our timeout to three hours instead of the two hour default.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
