### PR TITLE
[Core] Add CAE flag to auth policies

### DIFF
--- a/sdk/communication/azure-communication-callautomation/tests/_shared/async_fake_token_credential.py
+++ b/sdk/communication/azure-communication-callautomation/tests/_shared/async_fake_token_credential.py
@@ -10,5 +10,5 @@ class AsyncFakeTokenCredential(object):
     def __init__(self):
         self.token = AccessToken("Fake Token", 0)
 
-    async def get_token(self, *args):
+    async def get_token(self, *args, **kwargs):
         return self.token

--- a/sdk/communication/azure-communication-callautomation/tests/_shared/fake_token_credential.py
+++ b/sdk/communication/azure-communication-callautomation/tests/_shared/fake_token_credential.py
@@ -10,5 +10,5 @@ class FakeTokenCredential(object):
     def __init__(self):
         self.token = AccessToken("Fake Token", 0)
 
-    def get_token(self, *args):
+    def get_token(self, *args, **kwargs):
         return self.token

--- a/sdk/communication/azure-communication-chat/tests/_shared/async_fake_token_credential.py
+++ b/sdk/communication/azure-communication-chat/tests/_shared/async_fake_token_credential.py
@@ -10,5 +10,5 @@ class AsyncFakeTokenCredential(object):
     def __init__(self):
         self.token = AccessToken("Fake Token", 0)
 
-    async def get_token(self, *args):
+    async def get_token(self, *args, **kwargs):
         return self.token

--- a/sdk/communication/azure-communication-chat/tests/_shared/fake_token_credential.py
+++ b/sdk/communication/azure-communication-chat/tests/_shared/fake_token_credential.py
@@ -10,5 +10,5 @@ class FakeTokenCredential(object):
     def __init__(self):
         self.token = AccessToken("Fake Token", 0)
 
-    def get_token(self, *args):
+    def get_token(self, *args, **kwargs):
         return self.token

--- a/sdk/communication/azure-communication-email/tests/_shared/async_fake_token_credential.py
+++ b/sdk/communication/azure-communication-email/tests/_shared/async_fake_token_credential.py
@@ -10,5 +10,5 @@ class AsyncFakeTokenCredential(object):
     def __init__(self):
         self.token = AccessToken("Fake Token", 0)
 
-    async def get_token(self, *args):
+    async def get_token(self, *args, **kwargs):
         return self.token

--- a/sdk/communication/azure-communication-email/tests/_shared/fake_token_credential.py
+++ b/sdk/communication/azure-communication-email/tests/_shared/fake_token_credential.py
@@ -10,5 +10,5 @@ class FakeTokenCredential(object):
     def __init__(self):
         self.token = AccessToken("Fake Token", 0)
 
-    def get_token(self, *args):
+    def get_token(self, *args, **kwargs):
         return self.token

--- a/sdk/communication/azure-communication-identity/tests/_shared/async_fake_token_credential.py
+++ b/sdk/communication/azure-communication-identity/tests/_shared/async_fake_token_credential.py
@@ -10,5 +10,5 @@ class AsyncFakeTokenCredential(object):
     def __init__(self):
         self.token = AccessToken("Fake Token", 0)
 
-    async def get_token(self, *args):
+    async def get_token(self, *args, **kwargs):
         return self.token

--- a/sdk/communication/azure-communication-identity/tests/_shared/fake_token_credential.py
+++ b/sdk/communication/azure-communication-identity/tests/_shared/fake_token_credential.py
@@ -10,5 +10,5 @@ class FakeTokenCredential(object):
     def __init__(self):
         self.token = AccessToken("Fake Token", 0)
 
-    def get_token(self, *args):
+    def get_token(self, *args, **kwargs):
         return self.token

--- a/sdk/communication/azure-communication-jobrouter/tests/_shared/async_fake_token_credential.py
+++ b/sdk/communication/azure-communication-jobrouter/tests/_shared/async_fake_token_credential.py
@@ -10,5 +10,5 @@ class AsyncFakeTokenCredential(object):
     def __init__(self):
         self.token = AccessToken("Fake Token", 0)
 
-    async def get_token(self, *args):
+    async def get_token(self, *args, **kwargs):
         return self.token

--- a/sdk/communication/azure-communication-jobrouter/tests/_shared/fake_token_credential.py
+++ b/sdk/communication/azure-communication-jobrouter/tests/_shared/fake_token_credential.py
@@ -10,5 +10,5 @@ class FakeTokenCredential(object):
     def __init__(self):
         self.token = AccessToken("Fake Token", 0)
 
-    def get_token(self, *args):
+    def get_token(self, *args, **kwargs):
         return self.token

--- a/sdk/communication/azure-communication-networktraversal/tests/_shared/async_fake_token_credential.py
+++ b/sdk/communication/azure-communication-networktraversal/tests/_shared/async_fake_token_credential.py
@@ -10,5 +10,5 @@ class AsyncFakeTokenCredential(object):
     def __init__(self):
         self.token = AccessToken("Fake Token", 0)
 
-    async def get_token(self, *args):
+    async def get_token(self, *args, **kwargs):
         return self.token

--- a/sdk/communication/azure-communication-networktraversal/tests/_shared/fake_token_credential.py
+++ b/sdk/communication/azure-communication-networktraversal/tests/_shared/fake_token_credential.py
@@ -10,5 +10,5 @@ class FakeTokenCredential(object):
     def __init__(self):
         self.token = AccessToken("Fake Token", 0)
 
-    def get_token(self, *args):
+    def get_token(self, *args, **kwargs):
         return self.token

--- a/sdk/communication/azure-communication-phonenumbers/test/_shared/async_fake_token_credential.py
+++ b/sdk/communication/azure-communication-phonenumbers/test/_shared/async_fake_token_credential.py
@@ -10,5 +10,5 @@ class AsyncFakeTokenCredential(object):
     def __init__(self):
         self.token = AccessToken("Fake Token", 0)
 
-    async def get_token(self, *args):
+    async def get_token(self, *args, **kwargs):
         return self.token

--- a/sdk/communication/azure-communication-phonenumbers/test/_shared/fake_token_credential.py
+++ b/sdk/communication/azure-communication-phonenumbers/test/_shared/fake_token_credential.py
@@ -10,5 +10,5 @@ class FakeTokenCredential(object):
     def __init__(self):
         self.token = AccessToken("Fake Token", 0)
 
-    def get_token(self, *args):
+    def get_token(self, *args, **kwargs):
         return self.token

--- a/sdk/communication/azure-communication-rooms/tests/_shared/async_fake_token_credential.py
+++ b/sdk/communication/azure-communication-rooms/tests/_shared/async_fake_token_credential.py
@@ -10,5 +10,5 @@ class AsyncFakeTokenCredential(object):
     def __init__(self):
         self.token = AccessToken("Fake Token", 0)
 
-    async def get_token(self, *args):
+    async def get_token(self, *args, **kwargs):
         return self.token

--- a/sdk/communication/azure-communication-rooms/tests/_shared/fake_token_credential.py
+++ b/sdk/communication/azure-communication-rooms/tests/_shared/fake_token_credential.py
@@ -10,5 +10,5 @@ class FakeTokenCredential(object):
     def __init__(self):
         self.token = AccessToken("Fake Token", 0)
 
-    def get_token(self, *args):
+    def get_token(self, *args, **kwargs):
         return self.token

--- a/sdk/communication/azure-communication-sms/tests/_shared/async_fake_token_credential.py
+++ b/sdk/communication/azure-communication-sms/tests/_shared/async_fake_token_credential.py
@@ -10,5 +10,5 @@ class AsyncFakeTokenCredential(object):
     def __init__(self):
         self.token = AccessToken("Fake Token", 0)
 
-    async def get_token(self, *args):
+    async def get_token(self, *args, **kwargs):
         return self.token

--- a/sdk/communication/azure-communication-sms/tests/_shared/fake_token_credential.py
+++ b/sdk/communication/azure-communication-sms/tests/_shared/fake_token_credential.py
@@ -10,5 +10,5 @@ class FakeTokenCredential(object):
     def __init__(self):
         self.token = AccessToken("Fake Token", 0)
 
-    def get_token(self, *args):
+    def get_token(self, *args, **kwargs):
         return self.token

--- a/sdk/communication/azure-communication-sms/tests/test_sms_client.py
+++ b/sdk/communication/azure-communication-sms/tests/test_sms_client.py
@@ -15,7 +15,7 @@ class FakeTokenCredential(object):
     def __init__(self):
         self.token = AccessToken("Fake Token", 0)
 
-    def get_token(self, *args):
+    def get_token(self, *args, **kwargs):
         return self.token
 
 class TestSMSClient(unittest.TestCase):
@@ -36,7 +36,7 @@ class TestSMSClient(unittest.TestCase):
                     }
                 ]
             })
-            
+
         sms_client = SmsClient("https://endpoint", FakeTokenCredential(), transport=Mock(send=mock_send))
 
         sms_response = None
@@ -74,7 +74,7 @@ class TestSMSClient(unittest.TestCase):
             message=msg,
             enable_delivery_report=True,
             tag=tag)
-        
+
         send_message_request = mock_send.call_args[0][0]
         self.assertEqual(phone_number, send_message_request.from_property)
         self.assertEqual(phone_number, send_message_request.sms_recipients[0].to)

--- a/sdk/communication/azure-communication-sms/tests/test_sms_client_async.py
+++ b/sdk/communication/azure-communication-sms/tests/test_sms_client_async.py
@@ -15,7 +15,7 @@ class FakeTokenCredential(object):
     def __init__(self):
         self.token = AccessToken("Fake Token", 0)
 
-    async def get_token(self, *args):
+    async def get_token(self, *args, **kwargs):
         return self.token
 
 class TestSMSClientAsync(aiounittest.AsyncTestCase):
@@ -58,7 +58,7 @@ class TestSMSClientAsync(aiounittest.AsyncTestCase):
         self.assertEqual(202, sms_response.http_status_code)
         self.assertIsNotNone(sms_response.error_message)
         self.assertTrue(sms_response.successful)
-    
+
     @patch(
         "azure.communication.sms._generated.aio.operations._sms_operations.SmsOperations.send"
     )

--- a/sdk/containerregistry/azure-containerregistry/tests/asynctestcase.py
+++ b/sdk/containerregistry/azure-containerregistry/tests/asynctestcase.py
@@ -25,7 +25,7 @@ class AsyncFakeTokenCredential(object):
     def __init__(self):
         self.token = AccessToken("YOU SHALL NOT PASS", 0)
 
-    async def get_token(self, *args):
+    async def get_token(self, *args, **kwargs):
         return self.token
 
 
@@ -54,7 +54,7 @@ class AsyncContainerRegistryTestClass(ContainerRegistryTestClass):
         authority = get_authority(endpoint)
         audience = get_audience(authority)
         return ContainerRegistryClient(endpoint=endpoint, credential=None, audience=audience, **kwargs)
-    
+
     async def upload_oci_manifest_prerequisites(self, repo, client):
         layer = "654b93f61054e4ce90ed203bb8d556a6200d5f906cf3eca0620738d6dc18cbed"
         config = "config.json"

--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Features Added
 
+- A keyword argument `enable_cae` was added to the `get_token` method of the `TokenCredential` protocol.  #31012
+- `BearerTokenCredentialPolicy` and `AsyncBearerTokenCredentialPolicy` now accept `enable_cae` keyword arguments in their constructors. This is used in determining if Continuous Access Evaluation (CAE) should be enabled for each `get_token` request.  #31012
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Features Added
 
 - A keyword argument `enable_cae` was added to the `get_token` method of the `TokenCredential` protocol.  #31012
-- `BearerTokenCredentialPolicy` and `AsyncBearerTokenCredentialPolicy` now accept `enable_cae` keyword arguments in their constructors. This is used in determining if Continuous Access Evaluation (CAE) should be enabled for each `get_token` request.  #31012
+- `BearerTokenCredentialPolicy` and `AsyncBearerTokenCredentialPolicy` now accept `enable_cae` keyword arguments in their constructors. This is used in determining if [Continuous Access Evaluation (CAE)](https://learn.microsoft.com/azure/active-directory/conditional-access/concept-continuous-access-evaluation) should be enabled for each `get_token` request.  #31012
 
 ### Breaking Changes
 

--- a/sdk/core/azure-core/CLIENT_LIBRARY_DEVELOPER.md
+++ b/sdk/core/azure-core/CLIENT_LIBRARY_DEVELOPER.md
@@ -122,10 +122,10 @@ For example if you would like to alter connection pool you can initialise `Reque
  adapter = requests.adapters.HTTPAdapter(pool_connections=42, pool_maxsize=42)
  session.mount('https://', adapter)
  client = FooServiceClient(endpoint, creds, transport=RequestsTransport(session=session, session_owner=False))
- 
+
  # Here we want to manage the session by ourselves. When we are done with the session, we need to close the session.
  session.close()
- 
+
  # Note: `session_owner` gives the information of ownership of the requests sessions to the transport instance, to authorize it to close on customer's behalf. If you're ok that the client closes your session on your behalf as necessary, you don't need to pass a value.
  ```
 
@@ -568,6 +568,8 @@ class TokenCredential(Protocol):
         :keyword str claims: Additional claims required in the token, such as those returned in a resource
             provider's claims challenge following an authorization failure.
         :keyword str tenant_id: Optional tenant to include in the token request.
+        :keyword bool enable_cae: Indicates whether to enable Continuous Access Evaluation (CAE) for the requested
+            token. Defaults to False.
 
         :rtype: AccessToken
         :return: An AccessToken instance containing the token string and its expiration time in Unix time.
@@ -595,13 +597,31 @@ manager, with `__aenter__`, `__aexit__`, and `close` methods.
 
 | Service/Feature | Reason |
 | --- | --- |
-| [Continuous Access Evaluation][cae_doc] | Respond to claim challenges when unexpired tokens have access revoked
+| [Continuous Access Evaluation (CAE)][cae_doc] | Respond to claim challenges when unexpired tokens have access revoked
 
 **`tenant_id`**
 
 | Service/Feature | Reason |
 | --- | --- |
 | Key Vault ([example][kv_tenant_id]) | Request access in a tenant that was discovered as part of an authentication challenge
+
+**`enable_cae`**
+
+| Service/Feature | Reason |
+| --- | --- |
+| [Continuous Access Evaluation (CAE)][cae_doc] | Indicates that handling CAE claim challenges is supported and that a CAE-enabled token should be requested
+
+### BearerTokenCredentialPolicy and AsyncBearerTokenCredentialPolicy
+
+`BearerTokenCredentialPolicy` and `AsyncBearerTokenCredentialPolicy` are HTTP policies that are used to authenticate requests to services that accept bearer tokens in their authorization headers. These credential policies take a `TokenCredential` instance and scopes as parameters in their constructors. The `TokenCredential` instance is used to get an access token for the scopes, and the policy adds the token to the request's authorization header.
+
+Both of these policies also accept an `enable_cae` keyword argument that is passed to the `TokenCredential` instance's `get_token` method if set to `True`. This argument is used to indicate that the requested token should be [CAE-enabled][cae_doc]. If an SDK's service supports CAE, it should set this value to `True` when creating the policy.
+
+```python
+from azure.core.pipeline.policies import BearerTokenCredentialPolicy
+
+authentication_policy = BearerTokenCredentialPolicy(credential, scopes, enable_cae=True)
+```
 
 ## Long-running operation (LRO) customization
 

--- a/sdk/core/azure-core/azure/core/credentials.py
+++ b/sdk/core/azure-core/azure/core/credentials.py
@@ -33,6 +33,8 @@ class TokenCredential(Protocol):
         :keyword str claims: Additional claims required in the token, such as those returned in a resource
             provider's claims challenge following an authorization failure.
         :keyword str tenant_id: Optional tenant to include in the token request.
+        :keyword bool enable_cae: Indicates whether to enable Continuous Access Evaluation (CAE) for the requested
+            token. Defaults to False.
 
         :rtype: AccessToken
         :return: An AccessToken instance containing the token string and its expiration time in Unix time.

--- a/sdk/core/azure-core/azure/core/credentials_async.py
+++ b/sdk/core/azure-core/azure/core/credentials_async.py
@@ -21,6 +21,8 @@ class AsyncTokenCredential(Protocol):
         :keyword str claims: Additional claims required in the token, such as those returned in a resource
             provider's claims challenge following an authorization failure.
         :keyword str tenant_id: Optional tenant to include in the token request.
+        :keyword bool enable_cae: Indicates whether to enable Continuous Access Evaluation (CAE) for the requested
+            token. Defaults to False.
 
         :rtype: AccessToken
         :return: An AccessToken instance containing the token string and its expiration time in Unix time.

--- a/sdk/core/azure-core/azure/core/pipeline/policies/_authentication.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/_authentication.py
@@ -35,7 +35,9 @@ class _BearerTokenCredentialPolicyBase:
         tokens. Defaults to False.
     """
 
-    def __init__(self, credential: "TokenCredential", *scopes: str, **kwargs: Any) -> None:  # pylint:disable=unused-argument
+    def __init__(
+        self, credential: "TokenCredential", *scopes: str, **kwargs: Any
+    ) -> None:  # pylint:disable=unused-argument
         super(_BearerTokenCredentialPolicyBase, self).__init__()
         self._scopes = scopes
         self._credential = credential

--- a/sdk/core/azure-core/azure/core/pipeline/policies/_authentication.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/_authentication.py
@@ -35,9 +35,7 @@ class _BearerTokenCredentialPolicyBase:
         tokens. Defaults to False.
     """
 
-    def __init__(
-        self, credential: "TokenCredential", *scopes: str, **kwargs: Any
-    ) -> None:  # pylint:disable=unused-argument
+    def __init__(self, credential: "TokenCredential", *scopes: str, **kwargs: Any) -> None:
         super(_BearerTokenCredentialPolicyBase, self).__init__()
         self._scopes = scopes
         self._credential = credential

--- a/sdk/core/azure-core/azure/core/pipeline/policies/_authentication.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/_authentication.py
@@ -93,8 +93,7 @@ class BearerTokenCredentialPolicy(_BearerTokenCredentialPolicyBase, HTTPPolicy[H
         self._enforce_https(request)
 
         if self._token is None or self._need_new_token:
-            get_token_args: MutableMapping[str, Any] = {"enable_cae": True} if self._enable_cae else {}
-            self._token = self._credential.get_token(*self._scopes, **get_token_args)
+            self._token = self._credential.get_token(*self._scopes, enable_cae=self._enable_cae)
         self._update_headers(request.http_request.headers, self._token.token)
 
     def authorize_request(self, request: PipelineRequest[HTTPRequestType], *scopes: str, **kwargs) -> None:
@@ -106,9 +105,7 @@ class BearerTokenCredentialPolicy(_BearerTokenCredentialPolicyBase, HTTPPolicy[H
         :param ~azure.core.pipeline.PipelineRequest request: the request
         :param str scopes: required scopes of authentication
         """
-        if self._enable_cae:
-            # Only set enable_cae in kwargs if it's enabled on the policy.
-            kwargs["enable_cae"] = kwargs.get("enable_cae", self._enable_cae)
+        kwargs.setdefault("enable_cae", self._enable_cae)
         self._token = self._credential.get_token(*scopes, **kwargs)
         self._update_headers(request.http_request.headers, self._token.token)
 

--- a/sdk/core/azure-core/azure/core/pipeline/policies/_authentication_async.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/_authentication_async.py
@@ -31,6 +31,8 @@ class AsyncBearerTokenCredentialPolicy(AsyncHTTPPolicy[HTTPRequestType, AsyncHTT
     :param credential: The credential.
     :type credential: ~azure.core.credentials.TokenCredential
     :param str scopes: Lets you specify the type of access needed.
+    :keyword bool enable_cae: Indicates whether to enable Continuous Access Evaluation (CAE) on all requested
+        tokens. Defaults to False.
     """
 
     def __init__(self, credential: "AsyncTokenCredential", *scopes: str, **kwargs: Any) -> None:
@@ -40,6 +42,7 @@ class AsyncBearerTokenCredentialPolicy(AsyncHTTPPolicy[HTTPRequestType, AsyncHTT
         self._lock = asyncio.Lock()
         self._scopes = scopes
         self._token: Optional["AccessToken"] = None
+        self._enable_cae: bool = kwargs.get("enable_cae", False)
 
     async def on_request(self, request: PipelineRequest[HTTPRequestType]) -> None:
         """Adds a bearer token Authorization header to request and sends request to next policy.
@@ -54,7 +57,8 @@ class AsyncBearerTokenCredentialPolicy(AsyncHTTPPolicy[HTTPRequestType, AsyncHTT
             async with self._lock:
                 # double check because another coroutine may have acquired a token while we waited to acquire the lock
                 if self._token is None or self._need_new_token():
-                    self._token = await await_result(self._credential.get_token, *self._scopes)
+                    get_token_args = {"enable_cae": True} if self._enable_cae else {}
+                    self._token = await await_result(self._credential.get_token, *self._scopes, **get_token_args)
         request.http_request.headers["Authorization"] = "Bearer " + cast(AccessToken, self._token).token
 
     async def authorize_request(self, request: PipelineRequest[HTTPRequestType], *scopes: str, **kwargs: Any) -> None:
@@ -66,6 +70,9 @@ class AsyncBearerTokenCredentialPolicy(AsyncHTTPPolicy[HTTPRequestType, AsyncHTT
         :param ~azure.core.pipeline.PipelineRequest request: the request
         :param str scopes: required scopes of authentication
         """
+        if self._enable_cae:
+            # Only set enable_cae in kwargs if it's enabled on the policy.
+            kwargs["enable_cae"] = kwargs.get("enable_cae", self._enable_cae)
         async with self._lock:
             self._token = await await_result(self._credential.get_token, *scopes, **kwargs)
         request.http_request.headers["Authorization"] = "Bearer " + cast(AccessToken, self._token).token

--- a/sdk/core/azure-core/azure/core/pipeline/policies/_authentication_async.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/_authentication_async.py
@@ -56,8 +56,7 @@ class AsyncBearerTokenCredentialPolicy(AsyncHTTPPolicy[HTTPRequestType, AsyncHTT
             async with self._lock:
                 # double check because another coroutine may have acquired a token while we waited to acquire the lock
                 if self._token is None or self._need_new_token():
-                    get_token_args = {"enable_cae": True} if self._enable_cae else {}
-                    self._token = await await_result(self._credential.get_token, *self._scopes, **get_token_args)
+                    self._token = await await_result(self._credential.get_token, *self._scopes, enable_cae=self._enable_cae)
         request.http_request.headers["Authorization"] = "Bearer " + cast(AccessToken, self._token).token
 
     async def authorize_request(self, request: PipelineRequest[HTTPRequestType], *scopes: str, **kwargs: Any) -> None:
@@ -69,9 +68,7 @@ class AsyncBearerTokenCredentialPolicy(AsyncHTTPPolicy[HTTPRequestType, AsyncHTT
         :param ~azure.core.pipeline.PipelineRequest request: the request
         :param str scopes: required scopes of authentication
         """
-        if self._enable_cae:
-            # Only set enable_cae in kwargs if it's enabled on the policy.
-            kwargs["enable_cae"] = kwargs.get("enable_cae", self._enable_cae)
+        kwargs.setdefault("enable_cae", self._enable_cae)
         async with self._lock:
             self._token = await await_result(self._credential.get_token, *scopes, **kwargs)
         request.http_request.headers["Authorization"] = "Bearer " + cast(AccessToken, self._token).token

--- a/sdk/core/azure-core/azure/core/pipeline/policies/_authentication_async.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/_authentication_async.py
@@ -56,7 +56,9 @@ class AsyncBearerTokenCredentialPolicy(AsyncHTTPPolicy[HTTPRequestType, AsyncHTT
             async with self._lock:
                 # double check because another coroutine may have acquired a token while we waited to acquire the lock
                 if self._token is None or self._need_new_token():
-                    self._token = await await_result(self._credential.get_token, *self._scopes, enable_cae=self._enable_cae)
+                    self._token = await await_result(
+                        self._credential.get_token, *self._scopes, enable_cae=self._enable_cae
+                    )
         request.http_request.headers["Authorization"] = "Bearer " + cast(AccessToken, self._token).token
 
     async def authorize_request(self, request: PipelineRequest[HTTPRequestType], *scopes: str, **kwargs: Any) -> None:

--- a/sdk/core/azure-core/azure/core/pipeline/policies/_authentication_async.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/_authentication_async.py
@@ -36,7 +36,6 @@ class AsyncBearerTokenCredentialPolicy(AsyncHTTPPolicy[HTTPRequestType, AsyncHTT
     """
 
     def __init__(self, credential: "AsyncTokenCredential", *scopes: str, **kwargs: Any) -> None:
-        # pylint:disable=unused-argument
         super().__init__()
         self._credential = credential
         self._lock = asyncio.Lock()

--- a/sdk/core/azure-core/tests/async_tests/test_authentication_async.py
+++ b/sdk/core/azure-core/tests/async_tests/test_authentication_async.py
@@ -36,7 +36,7 @@ async def test_bearer_policy_adds_header(http_request):
 
     get_token_calls = 0
 
-    async def get_token(_):
+    async def get_token(*_, **__):
         nonlocal get_token_calls
         get_token_calls += 1
         return expected_token
@@ -63,7 +63,8 @@ async def test_bearer_policy_send(http_request):
         assert request.http_request is expected_request
         return expected_response
 
-    fake_credential = Mock(get_token=lambda *_, **__: get_completed_future(AccessToken("", 0)))
+    get_token = get_completed_future(AccessToken("***", 42))
+    fake_credential = Mock(get_token=lambda *_, **__: get_token)
     policies = [AsyncBearerTokenCredentialPolicy(fake_credential, "scope"), Mock(send=verify_request)]
     response = await AsyncPipeline(transport=Mock(), policies=policies).run(expected_request)
 
@@ -80,7 +81,8 @@ async def test_bearer_policy_sync_send(http_request):
         assert request.http_request is expected_request
         return expected_response
 
-    fake_credential = Mock(get_token=lambda _: AccessToken("", 0))
+    get_token = get_completed_future(AccessToken("***", 42))
+    fake_credential = Mock(get_token=lambda *_, **__: get_token)
     policies = [AsyncBearerTokenCredentialPolicy(fake_credential, "scope"), Mock(send=verify_request)]
     response = await AsyncPipeline(transport=Mock(), policies=policies).run(expected_request)
 
@@ -93,7 +95,7 @@ async def test_bearer_policy_token_caching(http_request):
     expected_token = good_for_one_hour
     get_token_calls = 0
 
-    async def get_token(_):
+    async def get_token(*_, **__):
         nonlocal get_token_calls
         get_token_calls += 1
         return expected_token
@@ -284,7 +286,7 @@ async def test_bearer_policy_redirect_same_domain():
     auth_headder = "token"
     expected_scope = "scope"
 
-    async def get_token(_):
+    async def get_token(*_, **__):
         token = AccessToken(auth_headder, 0)
         return token
 
@@ -328,7 +330,7 @@ async def test_bearer_policy_redirect_different_domain():
     auth_headder = "token"
     expected_scope = "scope"
 
-    async def get_token(_):
+    async def get_token(*_, **__):
         token = AccessToken(auth_headder, 0)
         return token
 
@@ -372,7 +374,7 @@ async def test_bearer_policy_redirect_opt_out_clean_up():
     auth_headder = "token"
     expected_scope = "scope"
 
-    async def get_token(_):
+    async def get_token(*_, **__):
         token = AccessToken(auth_headder, 0)
         return token
 
@@ -416,7 +418,7 @@ async def test_bearer_policy_redirect_customize_sensitive_headers():
     auth_headder = "token"
     expected_scope = "scope"
 
-    async def get_token(_):
+    async def get_token(*_, **__):
         token = AccessToken(auth_headder, 0)
         return token
 

--- a/sdk/core/azure-core/tests/test_authentication.py
+++ b/sdk/core/azure-core/tests/test_authentication.py
@@ -60,7 +60,10 @@ def test_bearer_policy_send(http_request):
         assert request.http_request is expected_request
         return expected_response
 
-    fake_credential = Mock(get_token=lambda _: AccessToken("", 0))
+    def get_token(*_, **__):
+        return AccessToken("***", 42)
+
+    fake_credential = Mock(get_token=get_token)
     policies = [BearerTokenCredentialPolicy(fake_credential, "scope"), Mock(send=verify_request)]
     response = Pipeline(transport=Mock(), policies=policies).run(expected_request)
 
@@ -99,7 +102,10 @@ def test_bearer_policy_optionally_enforces_https(http_request):
         assert "enforce_https" not in kwargs, "BearerTokenCredentialPolicy didn't pop the 'enforce_https' option"
         return Mock()
 
-    credential = Mock(get_token=lambda *_, **__: AccessToken("***", 42))
+    def get_token(*_, **__):
+        return AccessToken("***", 42)
+
+    credential = Mock(get_token=get_token)
     pipeline = Pipeline(
         transport=Mock(send=assert_option_popped), policies=[BearerTokenCredentialPolicy(credential, "scope")]
     )
@@ -146,7 +152,21 @@ def test_bearer_policy_default_context(http_request):
 
     pipeline.run(http_request("GET", "https://localhost"))
 
-    credential.get_token.assert_called_once_with(expected_scope)
+    credential.get_token.assert_called_once_with(expected_scope, enable_cae=False)
+
+
+@pytest.mark.parametrize("http_request", HTTP_REQUESTS)
+def test_bearer_policy_enable_cae(http_request):
+    """The policy should set enable_cae to True in the get_token request if it is set in constructor."""
+    expected_scope = "scope"
+    token = AccessToken("", 0)
+    credential = Mock(get_token=Mock(return_value=token))
+    policy = BearerTokenCredentialPolicy(credential, expected_scope, enable_cae=True)
+    pipeline = Pipeline(transport=Mock(), policies=[policy])
+
+    pipeline.run(http_request("GET", "https://localhost"))
+
+    credential.get_token.assert_called_once_with(expected_scope, enable_cae=True)
 
 
 @pytest.mark.parametrize("http_request", HTTP_REQUESTS)
@@ -202,7 +222,7 @@ def test_bearer_policy_cannot_complete_challenge(http_request):
 
     assert response.http_response is expected_response
     assert transport.send.call_count == 1
-    credential.get_token.assert_called_once_with(expected_scope)
+    credential.get_token.assert_called_once_with(expected_scope, enable_cae=False)
 
 
 @pytest.mark.parametrize("http_request", HTTP_REQUESTS)

--- a/sdk/core/azure-mgmt-core/azure/mgmt/core/policies/_authentication.py
+++ b/sdk/core/azure-mgmt-core/azure/mgmt/core/policies/_authentication.py
@@ -25,14 +25,11 @@
 # --------------------------------------------------------------------------
 import base64
 import time
-from typing import Optional, TypeVar, TYPE_CHECKING, Any
+from typing import Optional, TypeVar
 
 from azure.core.pipeline.policies import BearerTokenCredentialPolicy, SansIOHTTPPolicy
 from azure.core.pipeline import PipelineRequest, PipelineResponse
 from azure.core.exceptions import ServiceRequestError
-
-if TYPE_CHECKING:
-    from azure.core.credentials import TokenCredential
 
 
 HTTPRequestType = TypeVar("HTTPRequestType")
@@ -48,11 +45,6 @@ class ARMChallengeAuthenticationPolicy(BearerTokenCredentialPolicy):
     :param ~azure.core.credentials.TokenCredential credential: credential for authorizing requests
     :param str scopes: required authentication scopes
     """
-
-    def __init__(self, credential: "TokenCredential", *scopes: str, **kwargs: Any) -> None:
-        # ARM supports Continuous Access Evaluation (CAE). This policy will enable it by default.
-        kwargs.setdefault("enable_cae", True)
-        super().__init__(credential, *scopes, **kwargs)
 
     def on_challenge(
         self,

--- a/sdk/core/azure-mgmt-core/azure/mgmt/core/policies/_authentication.py
+++ b/sdk/core/azure-mgmt-core/azure/mgmt/core/policies/_authentication.py
@@ -25,11 +25,14 @@
 # --------------------------------------------------------------------------
 import base64
 import time
-from typing import Optional, TypeVar
+from typing import Optional, TypeVar, TYPE_CHECKING, Any
 
 from azure.core.pipeline.policies import BearerTokenCredentialPolicy, SansIOHTTPPolicy
 from azure.core.pipeline import PipelineRequest, PipelineResponse
 from azure.core.exceptions import ServiceRequestError
+
+if TYPE_CHECKING:
+    from azure.core.credentials import TokenCredential
 
 
 HTTPRequestType = TypeVar("HTTPRequestType")
@@ -45,6 +48,11 @@ class ARMChallengeAuthenticationPolicy(BearerTokenCredentialPolicy):
     :param ~azure.core.credentials.TokenCredential credential: credential for authorizing requests
     :param str scopes: required authentication scopes
     """
+
+    def __init__(self, credential: "TokenCredential", *scopes: str, **kwargs: Any) -> None:
+        # ARM supports Continuous Access Evaluation (CAE). This policy will enable it by default.
+        kwargs.setdefault("enable_cae", True)
+        super().__init__(credential, *scopes, **kwargs)
 
     def on_challenge(
         self,

--- a/sdk/core/azure-mgmt-core/azure/mgmt/core/policies/_authentication_async.py
+++ b/sdk/core/azure-mgmt-core/azure/mgmt/core/policies/_authentication_async.py
@@ -23,7 +23,7 @@
 # IN THE SOFTWARE.
 #
 # --------------------------------------------------------------------------
-from typing import TypeVar, Awaitable, Optional
+from typing import TypeVar, Awaitable, Optional, TYPE_CHECKING, Any
 import inspect
 
 from azure.core.pipeline.policies import (
@@ -33,6 +33,9 @@ from azure.core.pipeline.policies import (
 from azure.core.pipeline import PipelineRequest, PipelineResponse
 
 from ._authentication import _parse_claims_challenge, _AuxiliaryAuthenticationPolicyBase
+
+if TYPE_CHECKING:
+    from azure.core.credentials_async import AsyncTokenCredential
 
 
 HTTPRequestType = TypeVar("HTTPRequestType")
@@ -62,6 +65,11 @@ class AsyncARMChallengeAuthenticationPolicy(AsyncBearerTokenCredentialPolicy):
     :param ~azure.core.credentials.TokenCredential credential: credential for authorizing requests
     :param str scopes: required authentication scopes
     """
+
+    def __init__(self, credential: "AsyncTokenCredential", *scopes: str, **kwargs: Any) -> None:
+        # ARM supports Continuous Access Evaluation (CAE). This policy will enable it by default.
+        kwargs.setdefault("enable_cae", True)
+        super().__init__(credential, *scopes, **kwargs)
 
     # pylint:disable=unused-argument
     async def on_challenge(

--- a/sdk/core/azure-mgmt-core/azure/mgmt/core/policies/_authentication_async.py
+++ b/sdk/core/azure-mgmt-core/azure/mgmt/core/policies/_authentication_async.py
@@ -23,7 +23,7 @@
 # IN THE SOFTWARE.
 #
 # --------------------------------------------------------------------------
-from typing import TypeVar, Awaitable, Optional, TYPE_CHECKING, Any
+from typing import TypeVar, Awaitable, Optional
 import inspect
 
 from azure.core.pipeline.policies import (
@@ -33,9 +33,6 @@ from azure.core.pipeline.policies import (
 from azure.core.pipeline import PipelineRequest, PipelineResponse
 
 from ._authentication import _parse_claims_challenge, _AuxiliaryAuthenticationPolicyBase
-
-if TYPE_CHECKING:
-    from azure.core.credentials_async import AsyncTokenCredential
 
 
 HTTPRequestType = TypeVar("HTTPRequestType")
@@ -65,11 +62,6 @@ class AsyncARMChallengeAuthenticationPolicy(AsyncBearerTokenCredentialPolicy):
     :param ~azure.core.credentials.TokenCredential credential: credential for authorizing requests
     :param str scopes: required authentication scopes
     """
-
-    def __init__(self, credential: "AsyncTokenCredential", *scopes: str, **kwargs: Any) -> None:
-        # ARM supports Continuous Access Evaluation (CAE). This policy will enable it by default.
-        kwargs.setdefault("enable_cae", True)
-        super().__init__(credential, *scopes, **kwargs)
 
     # pylint:disable=unused-argument
     async def on_challenge(

--- a/sdk/core/azure-mgmt-core/tests/asynctests/test_authentication_async.py
+++ b/sdk/core/azure-mgmt-core/tests/asynctests/test_authentication_async.py
@@ -85,7 +85,11 @@ async def test_claims_challenge():
     assert response.http_response.status_code == 200
     assert transport.send.call_count == 2
     assert credential.get_token.call_count == 2
-    credential.get_token.assert_called_with(expected_scope, claims=expected_claims)
+
+    args, kwargs = credential.get_token.call_args
+    assert expected_scope in args
+    assert kwargs["claims"] == expected_claims
+
     with pytest.raises(StopIteration):
         next(tokens)
     with pytest.raises(StopIteration):

--- a/sdk/core/azure-mgmt-core/tests/asynctests/test_authentication_async.py
+++ b/sdk/core/azure-mgmt-core/tests/asynctests/test_authentication_async.py
@@ -85,7 +85,13 @@ async def test_claims_challenge():
     assert response.http_response.status_code == 200
     assert transport.send.call_count == 2
     assert credential.get_token.call_count == 2
-    credential.get_token.assert_called_with(expected_scope, claims=expected_claims)
+
+    args, kwargs = credential.get_token.call_args
+    assert expected_scope in args
+    assert kwargs["claims"] == expected_claims
+    if "enable_cae" in kwargs:
+        assert kwargs["enable_cae"] == True
+
     with pytest.raises(StopIteration):
         next(tokens)
     with pytest.raises(StopIteration):

--- a/sdk/core/azure-mgmt-core/tests/asynctests/test_authentication_async.py
+++ b/sdk/core/azure-mgmt-core/tests/asynctests/test_authentication_async.py
@@ -85,13 +85,7 @@ async def test_claims_challenge():
     assert response.http_response.status_code == 200
     assert transport.send.call_count == 2
     assert credential.get_token.call_count == 2
-
-    args, kwargs = credential.get_token.call_args
-    assert expected_scope in args
-    assert kwargs["claims"] == expected_claims
-    if "enable_cae" in kwargs:
-        assert kwargs["enable_cae"] == True
-
+    credential.get_token.assert_called_with(expected_scope, claims=expected_claims)
     with pytest.raises(StopIteration):
         next(tokens)
     with pytest.raises(StopIteration):

--- a/sdk/core/azure-mgmt-core/tests/test_authentication.py
+++ b/sdk/core/azure-mgmt-core/tests/test_authentication.py
@@ -146,7 +146,11 @@ def test_claims_challenge():
     assert response.http_response.status_code == 200
     assert transport.send.call_count == 2
     assert credential.get_token.call_count == 2
-    credential.get_token.assert_called_with(expected_scope, claims=expected_claims)
+
+    args, kwargs = credential.get_token.call_args
+    assert expected_scope in args
+    assert kwargs["claims"] == expected_claims
+
     with pytest.raises(StopIteration):
         next(tokens)
     with pytest.raises(StopIteration):

--- a/sdk/core/azure-mgmt-core/tests/test_authentication.py
+++ b/sdk/core/azure-mgmt-core/tests/test_authentication.py
@@ -146,13 +146,7 @@ def test_claims_challenge():
     assert response.http_response.status_code == 200
     assert transport.send.call_count == 2
     assert credential.get_token.call_count == 2
-
-    args, kwargs = credential.get_token.call_args
-    assert expected_scope in args
-    assert kwargs["claims"] == expected_claims
-    if "enable_cae" in kwargs:
-        assert kwargs["enable_cae"] == True
-
+    credential.get_token.assert_called_with(expected_scope, claims=expected_claims)
     with pytest.raises(StopIteration):
         next(tokens)
     with pytest.raises(StopIteration):

--- a/sdk/core/azure-mgmt-core/tests/test_authentication.py
+++ b/sdk/core/azure-mgmt-core/tests/test_authentication.py
@@ -146,7 +146,13 @@ def test_claims_challenge():
     assert response.http_response.status_code == 200
     assert transport.send.call_count == 2
     assert credential.get_token.call_count == 2
-    credential.get_token.assert_called_with(expected_scope, claims=expected_claims)
+
+    args, kwargs = credential.get_token.call_args
+    assert expected_scope in args
+    assert kwargs["claims"] == expected_claims
+    if "enable_cae" in kwargs:
+        assert kwargs["enable_cae"] == True
+
     with pytest.raises(StopIteration):
         next(tokens)
     with pytest.raises(StopIteration):

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/asynctestcase.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/asynctestcase.py
@@ -19,7 +19,7 @@ class AsyncFakeTokenCredential(object):
     def __init__(self):
         self.token = AccessToken("YOU SHALL NOT PASS", 0)
 
-    async def get_token(self, *args):
+    async def get_token(self, *args, **kwargs):
         return self.token
 
 

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/testcase.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/testcase.py
@@ -35,7 +35,7 @@ class FakeTokenCredential(object):
     def __init__(self):
         self.token = AccessToken("YOU SHALL NOT PASS", 0)
 
-    def get_token(self, *args):
+    def get_token(self, *args, **kwargs):
         return self.token
 
 class FormRecognizerTest(AzureRecordedTestCase):
@@ -569,7 +569,7 @@ class FormRecognizerTest(AzureRecordedTestCase):
     def assertDocumentStylesTransformCorrect(self, transformed_styles, raw_styles, **kwargs):
         if transformed_styles == [] and not raw_styles:
             return
-        
+
         for style, expected in zip(transformed_styles, raw_styles):
             assert style.is_handwritten == expected.is_handwritten
             assert style.similar_font_family == expected.similar_font_family
@@ -578,7 +578,7 @@ class FormRecognizerTest(AzureRecordedTestCase):
             assert style.color == expected.color
             assert style.background_color == expected.background_color
             assert style.confidence == expected.confidence
-            
+
             for span, expected_span in zip(style.spans or [], expected.spans or []):
                     self.assertSpanTransformCorrect(span, expected_span)
 
@@ -586,10 +586,10 @@ class FormRecognizerTest(AzureRecordedTestCase):
         if not element or not expected:
             return
         assert element.content == expected.content
-        
+
         for span, expected_span in zip(element.spans or [], expected.spans or []):
                 self.assertSpanTransformCorrect(span, expected_span)
-            
+
         self.assertBoundingRegionsTransformCorrect(element.bounding_regions, expected.bounding_regions)
 
     def assertDocumentTablesTransformCorrect(self, transformed_tables, raw_tables, **kwargs):
@@ -604,7 +604,7 @@ class FormRecognizerTest(AzureRecordedTestCase):
 
             for span, expected_span in zip(table.spans or [], expected.spans or []):
                 self.assertSpanTransformCorrect(span, expected_span)
-            
+
             self.assertBoundingRegionsTransformCorrect(table.bounding_regions, expected.bounding_regions)
 
     def assertDocumentParagraphsTransformCorrect(self, transformed_paragraphs, raw_paragraphs, **kwargs):
@@ -616,7 +616,7 @@ class FormRecognizerTest(AzureRecordedTestCase):
 
             for span, expected_span in zip(par.spans or [], expected.spans or []):
                 self.assertSpanTransformCorrect(span, expected_span)
-            
+
             self.assertBoundingRegionsTransformCorrect(par.bounding_regions, expected.bounding_regions)
 
     def assertDocumentTableCellTransformCorrect(self, transformed_cell, raw_cell, **kwargs):
@@ -638,7 +638,7 @@ class FormRecognizerTest(AzureRecordedTestCase):
 
         for span, expected_span in zip(transformed_cell.spans or [], raw_cell.spans or []):
                 self.assertSpanTransformCorrect(span, expected_span)
-            
+
         self.assertBoundingRegionsTransformCorrect(transformed_cell.bounding_regions, raw_cell.bounding_regions)
 
     def assertDocumentPagesTransformCorrect(self, transformed_pages, raw_pages, **kwargs):
@@ -710,7 +710,7 @@ class FormRecognizerTest(AzureRecordedTestCase):
         for region, expected_region in zip(bounding_regions, expected):
             assert region.page_number == expected_region.page_number
             self.assertBoundingPolygonTransformCorrect(region.polygon, expected_region.polygon)
-            
+
 
     def assertDocumentFieldValueTransformCorrect(self, document_field, expected):
         if expected is None:

--- a/tools/azure-sdk-tools/devtools_testutils/fake_credentials.py
+++ b/tools/azure-sdk-tools/devtools_testutils/fake_credentials.py
@@ -20,6 +20,6 @@ class FakeTokenCredential(object):
         self.token = AccessToken("YOU SHALL NOT PASS", 0)
         self.get_token_count = 0
 
-    def get_token(self, *args):
+    def get_token(self, *args, **kwargs):
         self.get_token_count += 1
         return self.token


### PR DESCRIPTION
The `get_token` protocol is updated to allow an optional `enable_cae` keyword argument. The overall signature doesn't change as we just document that `enable_cae` can be passed in as a part of `kwargs`.

With the flag, we can enable users and client SDKs to speciify that `get_token` requests should be requesting [CAE-enabled tokens](https://learn.microsoft.com/azure/active-directory/develop/app-resilience-continuous-access-evaluation?tabs=dotnet).

If the underlying credential's `get_token` implementation supports this flag, then a CAE-enabled token should be requested. Otherwise, a non-CAE token should be requested.

In this PR `BearerTokenCredentialPolicy` and `AsyncBearerTokenCredentialPolicy` are updated to also allow an `enable_cae` keyword argument in the constructors. This will be used in determining if `enable_cae` should be used in their respective `get_token` requests.

Since, ARM supports CAE and has logic for handling these CAE claims challenges, `ARMChallengeAuthenticationPolicy` and `AsyncARMChallengeAuthenticationPolicy` were updated to ensure that `enable_cae` is set to `True`. **Edit**: This will be split out into a separate PR

More info here: https://github.com/Azure/azure-sdk-for-python/pull/30777

**Notes**

- From what I can tell, all current (non-test) `get_token` implementations across our SDKs take in `**kwargs`, so `enable_cae` being passed in shouldn't cause any breakage. If needed, we can always catch TypeErrors for unexpected keyword arguments.