### PR TITLE
No poll if success

### DIFF
--- a/sdk/core/azure-core/azure/core/polling/base_polling.py
+++ b/sdk/core/azure-core/azure/core/polling/base_polling.py
@@ -246,13 +246,12 @@ class OperationResourcePolling(LongRunningOperation):
 
         self._set_async_url_if_present(response)
 
-        # Check if we can extract status from initial response, if present
-        try:
-            return self.get_status(pipeline_response)
-        except BadResponse:
-            pass
-
         if response.status_code in {200, 201, 202, 204} and self._async_url:
+            # Check if we can extract status from initial response, if present
+            try:
+                return self.get_status(pipeline_response)
+            except BadResponse:
+                pass
             return "InProgress"
         raise OperationFailed("Operation failed or canceled")
 

--- a/sdk/core/azure-core/azure/core/polling/base_polling.py
+++ b/sdk/core/azure-core/azure/core/polling/base_polling.py
@@ -246,6 +246,12 @@ class OperationResourcePolling(LongRunningOperation):
 
         self._set_async_url_if_present(response)
 
+        # Check if we can extract status from initial response, if present
+        try:
+            return self.get_status(pipeline_response)
+        except BadResponse:
+            pass
+
         if response.status_code in {200, 201, 202, 204} and self._async_url:
             return "InProgress"
         raise OperationFailed("Operation failed or canceled")

--- a/sdk/core/azure-core/azure/core/polling/base_polling.py
+++ b/sdk/core/azure-core/azure/core/polling/base_polling.py
@@ -250,7 +250,8 @@ class OperationResourcePolling(LongRunningOperation):
             # Check if we can extract status from initial response, if present
             try:
                 return self.get_status(pipeline_response)
-            except BadResponse:
+            # Wide catch, it may not even be JSON at all, deserialization is lenient
+            except Exception:  # pylint: disable=broad-except
                 pass
             return "InProgress"
         raise OperationFailed("Operation failed or canceled")

--- a/sdk/core/azure-core/tests/async_tests/test_base_polling_async.py
+++ b/sdk/core/azure-core/tests/async_tests/test_base_polling_async.py
@@ -300,9 +300,7 @@ async def test_post_direct_success(async_pipeline_client_builder, deserializatio
         {
             "operation-location": "http://example.org/async_monitor",
         },
-        {
-            "status": "succeeded"
-        },
+        {"status": "succeeded"},
     )
 
     async def send(request, **kwargs):

--- a/sdk/core/azure-core/tests/async_tests/test_base_polling_async.py
+++ b/sdk/core/azure-core/tests/async_tests/test_base_polling_async.py
@@ -283,6 +283,38 @@ async def test_post_resource_location(async_pipeline_client_builder, deserializa
     assert result["location_result"] == True
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "http_request,http_response", request_and_responses_product(ASYNCIO_REQUESTS_TRANSPORT_RESPONSES)
+)
+async def test_post_direct_success(async_pipeline_client_builder, deserialization_cb, http_request, http_response):
+
+    # ResourceLocation
+
+    # The initial response contains both Location and Operation-Location, a 202 and a success body
+    initial_response = TestBasePolling.mock_send(
+        http_request,
+        http_response,
+        "POST",
+        202,
+        {
+            "operation-location": "http://example.org/async_monitor",
+        },
+        {
+            "status": "succeeded"
+        },
+    )
+
+    async def send(request, **kwargs):
+        pytest.fail("No requests allowed")
+
+    client = async_pipeline_client_builder(send)
+
+    poll = async_poller(client, initial_response, deserialization_cb, AsyncLROBasePolling(0))
+    result = await poll
+    assert result["status"] == "succeeded"
+
+
 class TestBasePolling(object):
 
     convert = re.compile("([a-z0-9])([A-Z])")

--- a/sdk/core/azure-core/tests/test_base_polling.py
+++ b/sdk/core/azure-core/tests/test_base_polling.py
@@ -332,6 +332,30 @@ def test_post_direct_success(pipeline_client_builder, deserialization_cb, http_r
     assert result["status"] == "succeeded"
 
 
+@pytest.mark.parametrize("http_request,http_response", request_and_responses_product(REQUESTS_TRANSPORT_RESPONSES))
+def test_post_fail(pipeline_client_builder, deserialization_cb, http_request, http_response):
+
+    # ResourceLocation
+
+    # The initial response contains both Location and Operation-Location, a 202 and a success body
+    initial_response = TestBasePolling.mock_send(
+        http_request,
+        http_response,
+        "POST",
+        500,
+        {"status": "failed"},
+    )
+
+    def send(request, **kwargs):
+        pytest.fail("No requests allowed")
+
+    client = pipeline_client_builder(send)
+
+    with pytest.raises(HttpResponseError):
+        poll = LROPoller(client, initial_response, deserialization_cb, LROBasePolling(0))
+        result = poll.result()
+
+
 class TestBasePolling(object):
 
     convert = re.compile("([a-z0-9])([A-Z])")

--- a/sdk/core/azure-core/tests/test_base_polling.py
+++ b/sdk/core/azure-core/tests/test_base_polling.py
@@ -310,7 +310,7 @@ def test_post_direct_success(pipeline_client_builder, deserialization_cb, http_r
 
     # ResourceLocation
 
-    # The initial response contains both Location and Operation-Location, a 202 and no Body
+    # The initial response contains both Location and Operation-Location, a 202 and a success body
     initial_response = TestBasePolling.mock_send(
         http_request,
         http_response,

--- a/sdk/core/azure-core/tests/test_base_polling.py
+++ b/sdk/core/azure-core/tests/test_base_polling.py
@@ -319,9 +319,7 @@ def test_post_direct_success(pipeline_client_builder, deserialization_cb, http_r
         {
             "operation-location": "http://example.org/async_monitor",
         },
-        {
-            "status": "succeeded"
-        },
+        {"status": "succeeded"},
     )
 
     def send(request, **kwargs):


### PR DESCRIPTION
Follow more closely Azure guidelines: if the initial response body has a status and the polling strategy was Operation-Location, follow that status.