### PR TITLE
[Identity] Correctly implement TokenCredential protocols

### DIFF
--- a/sdk/identity/azure-identity/CHANGELOG.md
+++ b/sdk/identity/azure-identity/CHANGELOG.md
@@ -14,6 +14,9 @@
 
 ### Bugs Fixed
 
+- Credential types correctly implement `azure-core`'s `TokenCredential` protocol.
+  ([#25175](https://github.com/Azure/azure-sdk-for-python/issues/25175))
+
 ### Other Changes
 
 ## 1.14.0b2 (2023-07-11)

--- a/sdk/identity/azure-identity/azure/identity/_credentials/application.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/application.py
@@ -64,7 +64,7 @@ class AzureApplicationCredential(ChainedTokenCredential):
         )
 
     def get_token(
-        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs
+        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs: Any
     ) -> AccessToken:
         """Request an access token for `scopes`.
 

--- a/sdk/identity/azure-identity/azure/identity/_credentials/application.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/application.py
@@ -4,7 +4,7 @@
 # ------------------------------------
 import logging
 import os
-from typing import Any
+from typing import Any, Optional
 
 from azure.core.credentials import AccessToken
 from .chained import ChainedTokenCredential
@@ -63,7 +63,9 @@ class AzureApplicationCredential(ChainedTokenCredential):
             ManagedIdentityCredential(client_id=managed_identity_client_id, **kwargs),
         )
 
-    def get_token(self, *scopes: str, **kwargs: Any) -> AccessToken:
+    def get_token(
+        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs: Any
+    ) -> AccessToken:
         """Request an access token for `scopes`.
 
         This method is called automatically by Azure SDK clients.
@@ -71,16 +73,19 @@ class AzureApplicationCredential(ChainedTokenCredential):
         :param str scopes: desired scopes for the access token. This method requires at least one scope.
             For more information about scopes, see
             https://learn.microsoft.com/azure/active-directory/develop/scopes-oidc.
+        :keyword str claims: not used by this credential; any value provided will be ignored.
+        :keyword str tenant_id: not used by this credential; any value provided will be ignored.
+
         :return: An access token with the desired scopes.
         :rtype: ~azure.core.credentials.AccessToken
         :raises ~azure.core.exceptions.ClientAuthenticationError: authentication failed. The exception has a
             `message` attribute listing each authentication attempt and its error message.
         """
         if self._successful_credential:
-            token = self._successful_credential.get_token(*scopes, **kwargs)
+            token = self._successful_credential.get_token(*scopes, claims=claims, tenant_id=tenant_id, **kwargs)
             _LOGGER.info(
                 "%s acquired a token from %s", self.__class__.__name__, self._successful_credential.__class__.__name__
             )
             return token
 
-        return super(AzureApplicationCredential, self).get_token(*scopes, **kwargs)
+        return super(AzureApplicationCredential, self).get_token(*scopes, claims=claims, tenant_id=tenant_id, **kwargs)

--- a/sdk/identity/azure-identity/azure/identity/_credentials/application.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/application.py
@@ -64,7 +64,7 @@ class AzureApplicationCredential(ChainedTokenCredential):
         )
 
     def get_token(
-        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs: Any
+        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs
     ) -> AccessToken:
         """Request an access token for `scopes`.
 

--- a/sdk/identity/azure-identity/azure/identity/_credentials/application.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/application.py
@@ -73,8 +73,9 @@ class AzureApplicationCredential(ChainedTokenCredential):
         :param str scopes: desired scopes for the access token. This method requires at least one scope.
             For more information about scopes, see
             https://learn.microsoft.com/azure/active-directory/develop/scopes-oidc.
-        :keyword str claims: not supported by this credential.
-        :keyword str tenant_id: not supported by this credential.
+        :keyword str claims: additional claims required in the token, such as those returned in a resource provider's
+            claims challenge following an authorization failure.
+        :keyword str tenant_id: optional tenant to include in the token request.
 
         :return: An access token with the desired scopes.
         :rtype: ~azure.core.credentials.AccessToken

--- a/sdk/identity/azure-identity/azure/identity/_credentials/application.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/application.py
@@ -73,8 +73,8 @@ class AzureApplicationCredential(ChainedTokenCredential):
         :param str scopes: desired scopes for the access token. This method requires at least one scope.
             For more information about scopes, see
             https://learn.microsoft.com/azure/active-directory/develop/scopes-oidc.
-        :keyword str claims: not used by this credential; any value provided will be ignored.
-        :keyword str tenant_id: not used by this credential; any value provided will be ignored.
+        :keyword str claims: not supported by this credential.
+        :keyword str tenant_id: not supported by this credential.
 
         :return: An access token with the desired scopes.
         :rtype: ~azure.core.credentials.AccessToken

--- a/sdk/identity/azure-identity/azure/identity/_credentials/authorization_code.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/authorization_code.py
@@ -75,8 +75,9 @@ class AuthorizationCodeCredential(GetTokenMixin):
         :param str scopes: desired scopes for the access token. This method requires at least one scope.
             For more information about scopes, see
             https://learn.microsoft.com/azure/active-directory/develop/scopes-oidc.
+        :keyword str claims: additional claims required in the token, such as those returned in a resource provider's
+            claims challenge following an authorization failure.
         :keyword str tenant_id: optional tenant to include in the token request.
-        :keyword str claims: not supported by this credential.
 
         :return: An access token with the desired scopes.
         :rtype: ~azure.core.credentials.AccessToken

--- a/sdk/identity/azure-identity/azure/identity/_credentials/authorization_code.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/authorization_code.py
@@ -62,7 +62,7 @@ class AuthorizationCodeCredential(GetTokenMixin):
         self.__exit__()
 
     def get_token(
-        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs
+        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs: Any
     ) -> AccessToken:
         """Request an access token for `scopes`.
 

--- a/sdk/identity/azure-identity/azure/identity/_credentials/authorization_code.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/authorization_code.py
@@ -76,7 +76,7 @@ class AuthorizationCodeCredential(GetTokenMixin):
             For more information about scopes, see
             https://learn.microsoft.com/azure/active-directory/develop/scopes-oidc.
         :keyword str tenant_id: optional tenant to include in the token request.
-        :keyword str claims: not used by this credential; any value provided will be ignored.
+        :keyword str claims: not supported by this credential.
 
         :return: An access token with the desired scopes.
         :rtype: ~azure.core.credentials.AccessToken

--- a/sdk/identity/azure-identity/azure/identity/_credentials/authorization_code.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/authorization_code.py
@@ -61,7 +61,9 @@ class AuthorizationCodeCredential(GetTokenMixin):
         """Close the credential's transport session."""
         self.__exit__()
 
-    def get_token(self, *scopes: str, **kwargs: Any) -> AccessToken:
+    def get_token(
+        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs: Any
+    ) -> AccessToken:
         """Request an access token for `scopes`.
 
         This method is called automatically by Azure SDK clients.
@@ -74,6 +76,7 @@ class AuthorizationCodeCredential(GetTokenMixin):
             For more information about scopes, see
             https://learn.microsoft.com/azure/active-directory/develop/scopes-oidc.
         :keyword str tenant_id: optional tenant to include in the token request.
+        :keyword str claims: not used by this credential; any value provided will be ignored.
 
         :return: An access token with the desired scopes.
         :rtype: ~azure.core.credentials.AccessToken
@@ -82,7 +85,7 @@ class AuthorizationCodeCredential(GetTokenMixin):
           ``response`` attribute.
         """
         # pylint:disable=useless-super-delegation
-        return super(AuthorizationCodeCredential, self).get_token(*scopes, **kwargs)
+        return super(AuthorizationCodeCredential, self).get_token(*scopes, claims=claims, tenant_id=tenant_id, **kwargs)
 
     def _acquire_token_silently(self, *scopes: str, **kwargs) -> Optional[AccessToken]:
         return self._client.get_cached_access_token(scopes, **kwargs)

--- a/sdk/identity/azure-identity/azure/identity/_credentials/authorization_code.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/authorization_code.py
@@ -62,7 +62,7 @@ class AuthorizationCodeCredential(GetTokenMixin):
         self.__exit__()
 
     def get_token(
-        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs: Any
+        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs
     ) -> AccessToken:
         """Request an access token for `scopes`.
 

--- a/sdk/identity/azure-identity/azure/identity/_credentials/azd_cli.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/azd_cli.py
@@ -123,7 +123,6 @@ class AzureDeveloperCliCredential:
             default_tenant=self.tenant_id,
             tenant_id=tenant_id,
             additionally_allowed_tenants=self._additionally_allowed_tenants,
-            claims=claims,
             **kwargs,
         )
         if tenant:

--- a/sdk/identity/azure-identity/azure/identity/_credentials/azd_cli.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/azd_cli.py
@@ -92,7 +92,7 @@ class AzureDeveloperCliCredential:
 
     @log_get_token("AzureDeveloperCliCredential")
     def get_token(
-        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs
+        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs  # pylint:disable=unused-argument
     ) -> AccessToken:
         """Request an access token for `scopes`.
 
@@ -103,7 +103,7 @@ class AzureDeveloperCliCredential:
             For more information about scopes, see
             https://learn.microsoft.com/azure/active-directory/develop/scopes-oidc.
         :keyword str tenant_id: optional tenant to include in the token request.
-        :keyword str claims: not supported by this credential.
+        :keyword str claims: not used by this credential; any value provided will be ignored.
 
         :return: An access token with the desired scopes.
         :rtype: ~azure.core.credentials.AccessToken

--- a/sdk/identity/azure-identity/azure/identity/_credentials/azd_cli.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/azd_cli.py
@@ -106,8 +106,8 @@ class AzureDeveloperCliCredential:
         :param str scopes: desired scope for the access token. This credential allows only one scope per request.
             For more information about scopes, see
             https://learn.microsoft.com/azure/active-directory/develop/scopes-oidc.
-        :keyword str tenant_id: optional tenant to include in the token request.
         :keyword str claims: not used by this credential; any value provided will be ignored.
+        :keyword str tenant_id: optional tenant to include in the token request.
 
         :return: An access token with the desired scopes.
         :rtype: ~azure.core.credentials.AccessToken

--- a/sdk/identity/azure-identity/azure/identity/_credentials/azd_cli.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/azd_cli.py
@@ -94,9 +94,9 @@ class AzureDeveloperCliCredential:
     def get_token(
         self,
         *scopes: str,
-        claims: Optional[str] = None,
+        claims: Optional[str] = None,  # pylint:disable=unused-argument
         tenant_id: Optional[str] = None,
-        **kwargs: Any,  # pylint:disable=unused-argument
+        **kwargs: Any,
     ) -> AccessToken:
         """Request an access token for `scopes`.
 

--- a/sdk/identity/azure-identity/azure/identity/_credentials/azd_cli.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/azd_cli.py
@@ -91,7 +91,9 @@ class AzureDeveloperCliCredential:
         """Calling this method is unnecessary."""
 
     @log_get_token("AzureDeveloperCliCredential")
-    def get_token(self, *scopes: str, **kwargs: Any) -> AccessToken:
+    def get_token(
+        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs: Any
+    ) -> AccessToken:
         """Request an access token for `scopes`.
 
         This method is called automatically by Azure SDK clients. Applications calling this method directly must
@@ -101,6 +103,7 @@ class AzureDeveloperCliCredential:
             For more information about scopes, see
             https://learn.microsoft.com/azure/active-directory/develop/scopes-oidc.
         :keyword str tenant_id: optional tenant to include in the token request.
+        :keyword str claims: not used by this credential; any value provided will be ignored.
 
         :return: An access token with the desired scopes.
         :rtype: ~azure.core.credentials.AccessToken
@@ -117,7 +120,11 @@ class AzureDeveloperCliCredential:
         commandString = " --scope ".join(scopes)
         command = COMMAND_LINE.format(commandString)
         tenant = resolve_tenant(
-            default_tenant=self.tenant_id, additionally_allowed_tenants=self._additionally_allowed_tenants, **kwargs
+            default_tenant=self.tenant_id,
+            tenant_id=tenant_id,
+            additionally_allowed_tenants=self._additionally_allowed_tenants,
+            claims=claims,
+            **kwargs,
         )
         if tenant:
             command += " --tenant-id " + tenant

--- a/sdk/identity/azure-identity/azure/identity/_credentials/azd_cli.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/azd_cli.py
@@ -92,7 +92,11 @@ class AzureDeveloperCliCredential:
 
     @log_get_token("AzureDeveloperCliCredential")
     def get_token(
-        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs  # pylint:disable=unused-argument
+        self,
+        *scopes: str,
+        claims: Optional[str] = None,
+        tenant_id: Optional[str] = None,
+        **kwargs,  # pylint:disable=unused-argument
     ) -> AccessToken:
         """Request an access token for `scopes`.
 

--- a/sdk/identity/azure-identity/azure/identity/_credentials/azd_cli.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/azd_cli.py
@@ -92,7 +92,7 @@ class AzureDeveloperCliCredential:
 
     @log_get_token("AzureDeveloperCliCredential")
     def get_token(
-        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs: Any
+        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs
     ) -> AccessToken:
         """Request an access token for `scopes`.
 

--- a/sdk/identity/azure-identity/azure/identity/_credentials/azd_cli.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/azd_cli.py
@@ -103,7 +103,7 @@ class AzureDeveloperCliCredential:
             For more information about scopes, see
             https://learn.microsoft.com/azure/active-directory/develop/scopes-oidc.
         :keyword str tenant_id: optional tenant to include in the token request.
-        :keyword str claims: not used by this credential; any value provided will be ignored.
+        :keyword str claims: not supported by this credential.
 
         :return: An access token with the desired scopes.
         :rtype: ~azure.core.credentials.AccessToken

--- a/sdk/identity/azure-identity/azure/identity/_credentials/azd_cli.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/azd_cli.py
@@ -96,7 +96,7 @@ class AzureDeveloperCliCredential:
         *scopes: str,
         claims: Optional[str] = None,
         tenant_id: Optional[str] = None,
-        **kwargs,  # pylint:disable=unused-argument
+        **kwargs: Any,  # pylint:disable=unused-argument
     ) -> AccessToken:
         """Request an access token for `scopes`.
 

--- a/sdk/identity/azure-identity/azure/identity/_credentials/azure_cli.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/azure_cli.py
@@ -72,9 +72,9 @@ class AzureCliCredential:
     def get_token(
         self,
         *scopes: str,
-        claims: Optional[str] = None,
+        claims: Optional[str] = None,  # pylint:disable=unused-argument
         tenant_id: Optional[str] = None,
-        **kwargs: Any,  # pylint:disable=unused-argument
+        **kwargs: Any,
     ) -> AccessToken:
         """Request an access token for `scopes`.
 

--- a/sdk/identity/azure-identity/azure/identity/_credentials/azure_cli.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/azure_cli.py
@@ -74,7 +74,7 @@ class AzureCliCredential:
         *scopes: str,
         claims: Optional[str] = None,
         tenant_id: Optional[str] = None,
-        **kwargs,  # pylint:disable=unused-argument
+        **kwargs: Any,  # pylint:disable=unused-argument
     ) -> AccessToken:
         """Request an access token for `scopes`.
 

--- a/sdk/identity/azure-identity/azure/identity/_credentials/azure_cli.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/azure_cli.py
@@ -70,7 +70,7 @@ class AzureCliCredential:
 
     @log_get_token("AzureCliCredential")
     def get_token(
-        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs
+        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs  # pylint:disable=unused-argument
     ) -> AccessToken:
         """Request an access token for `scopes`.
 
@@ -81,7 +81,7 @@ class AzureCliCredential:
             For more information about scopes, see
             https://learn.microsoft.com/azure/active-directory/develop/scopes-oidc.
         :keyword str tenant_id: optional tenant to include in the token request.
-        :keyword str claims: not supported by this credential.
+        :keyword str claims: not used by this credential; any value provided will be ignored.
 
         :return: An access token with the desired scopes.
         :rtype: ~azure.core.credentials.AccessToken

--- a/sdk/identity/azure-identity/azure/identity/_credentials/azure_cli.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/azure_cli.py
@@ -84,8 +84,8 @@ class AzureCliCredential:
         :param str scopes: desired scope for the access token. This credential allows only one scope per request.
             For more information about scopes, see
             https://learn.microsoft.com/azure/active-directory/develop/scopes-oidc.
-        :keyword str tenant_id: optional tenant to include in the token request.
         :keyword str claims: not used by this credential; any value provided will be ignored.
+        :keyword str tenant_id: optional tenant to include in the token request.
 
         :return: An access token with the desired scopes.
         :rtype: ~azure.core.credentials.AccessToken

--- a/sdk/identity/azure-identity/azure/identity/_credentials/azure_cli.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/azure_cli.py
@@ -70,7 +70,7 @@ class AzureCliCredential:
 
     @log_get_token("AzureCliCredential")
     def get_token(
-        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs: Any
+        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs
     ) -> AccessToken:
         """Request an access token for `scopes`.
 

--- a/sdk/identity/azure-identity/azure/identity/_credentials/azure_cli.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/azure_cli.py
@@ -69,7 +69,9 @@ class AzureCliCredential:
         """Calling this method is unnecessary."""
 
     @log_get_token("AzureCliCredential")
-    def get_token(self, *scopes: str, **kwargs: Any) -> AccessToken:
+    def get_token(
+        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs: Any
+    ) -> AccessToken:
         """Request an access token for `scopes`.
 
         This method is called automatically by Azure SDK clients. Applications calling this method directly must
@@ -79,6 +81,7 @@ class AzureCliCredential:
             For more information about scopes, see
             https://learn.microsoft.com/azure/active-directory/develop/scopes-oidc.
         :keyword str tenant_id: optional tenant to include in the token request.
+        :keyword str claims: not used by this credential; any value provided will be ignored.
 
         :return: An access token with the desired scopes.
         :rtype: ~azure.core.credentials.AccessToken
@@ -91,7 +94,11 @@ class AzureCliCredential:
         resource = _scopes_to_resource(*scopes)
         command = COMMAND_LINE.format(resource)
         tenant = resolve_tenant(
-            default_tenant=self.tenant_id, additionally_allowed_tenants=self._additionally_allowed_tenants, **kwargs
+            default_tenant=self.tenant_id,
+            tenant_id=tenant_id,
+            additionally_allowed_tenants=self._additionally_allowed_tenants,
+            claims=claims,
+            **kwargs,
         )
         if tenant:
             command += " --tenant " + tenant

--- a/sdk/identity/azure-identity/azure/identity/_credentials/azure_cli.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/azure_cli.py
@@ -70,7 +70,11 @@ class AzureCliCredential:
 
     @log_get_token("AzureCliCredential")
     def get_token(
-        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs  # pylint:disable=unused-argument
+        self,
+        *scopes: str,
+        claims: Optional[str] = None,
+        tenant_id: Optional[str] = None,
+        **kwargs,  # pylint:disable=unused-argument
     ) -> AccessToken:
         """Request an access token for `scopes`.
 

--- a/sdk/identity/azure-identity/azure/identity/_credentials/azure_cli.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/azure_cli.py
@@ -81,7 +81,7 @@ class AzureCliCredential:
             For more information about scopes, see
             https://learn.microsoft.com/azure/active-directory/develop/scopes-oidc.
         :keyword str tenant_id: optional tenant to include in the token request.
-        :keyword str claims: not used by this credential; any value provided will be ignored.
+        :keyword str claims: not supported by this credential.
 
         :return: An access token with the desired scopes.
         :rtype: ~azure.core.credentials.AccessToken

--- a/sdk/identity/azure-identity/azure/identity/_credentials/azure_cli.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/azure_cli.py
@@ -97,7 +97,6 @@ class AzureCliCredential:
             default_tenant=self.tenant_id,
             tenant_id=tenant_id,
             additionally_allowed_tenants=self._additionally_allowed_tenants,
-            claims=claims,
             **kwargs,
         )
         if tenant:

--- a/sdk/identity/azure-identity/azure/identity/_credentials/azure_powershell.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/azure_powershell.py
@@ -86,9 +86,9 @@ class AzurePowerShellCredential:
     def get_token(
         self,
         *scopes: str,
-        claims: Optional[str] = None,
+        claims: Optional[str] = None,  # pylint:disable=unused-argument
         tenant_id: Optional[str] = None,
-        **kwargs: Any,  # pylint:disable=unused-argument
+        **kwargs: Any,
     ) -> AccessToken:
         """Request an access token for `scopes`.
 

--- a/sdk/identity/azure-identity/azure/identity/_credentials/azure_powershell.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/azure_powershell.py
@@ -6,7 +6,7 @@ import base64
 import logging
 import subprocess
 import sys
-from typing import List, Tuple, Optional, Any
+from typing import List, Tuple, Optional
 
 from azure.core.credentials import AccessToken
 from azure.core.exceptions import ClientAuthenticationError

--- a/sdk/identity/azure-identity/azure/identity/_credentials/azure_powershell.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/azure_powershell.py
@@ -84,7 +84,7 @@ class AzurePowerShellCredential:
 
     @log_get_token("AzurePowerShellCredential")
     def get_token(
-        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs
+        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs  # pylint:disable=unused-argument
     ) -> AccessToken:
         """Request an access token for `scopes`.
 
@@ -95,7 +95,7 @@ class AzurePowerShellCredential:
             For more information about scopes, see
             https://learn.microsoft.com/azure/active-directory/develop/scopes-oidc.
         :keyword str tenant_id: optional tenant to include in the token request.
-        :keyword str claims: not supported by this credential.
+        :keyword str claims: not used by this credential; any value provided will be ignored.
 
         :return: An access token with the desired scopes.
         :rtype: ~azure.core.credentials.AccessToken

--- a/sdk/identity/azure-identity/azure/identity/_credentials/azure_powershell.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/azure_powershell.py
@@ -84,7 +84,7 @@ class AzurePowerShellCredential:
 
     @log_get_token("AzurePowerShellCredential")
     def get_token(
-        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs: Any
+        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs
     ) -> AccessToken:
         """Request an access token for `scopes`.
 

--- a/sdk/identity/azure-identity/azure/identity/_credentials/azure_powershell.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/azure_powershell.py
@@ -84,7 +84,11 @@ class AzurePowerShellCredential:
 
     @log_get_token("AzurePowerShellCredential")
     def get_token(
-        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs  # pylint:disable=unused-argument
+        self,
+        *scopes: str,
+        claims: Optional[str] = None,
+        tenant_id: Optional[str] = None,
+        **kwargs,  # pylint:disable=unused-argument
     ) -> AccessToken:
         """Request an access token for `scopes`.
 

--- a/sdk/identity/azure-identity/azure/identity/_credentials/azure_powershell.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/azure_powershell.py
@@ -98,8 +98,8 @@ class AzurePowerShellCredential:
         :param str scopes: desired scope for the access token. This credential allows only one scope per request.
             For more information about scopes, see
             https://learn.microsoft.com/azure/active-directory/develop/scopes-oidc.
-        :keyword str tenant_id: optional tenant to include in the token request.
         :keyword str claims: not used by this credential; any value provided will be ignored.
+        :keyword str tenant_id: optional tenant to include in the token request.
 
         :return: An access token with the desired scopes.
         :rtype: ~azure.core.credentials.AccessToken

--- a/sdk/identity/azure-identity/azure/identity/_credentials/azure_powershell.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/azure_powershell.py
@@ -6,7 +6,7 @@ import base64
 import logging
 import subprocess
 import sys
-from typing import List, Tuple, Optional
+from typing import Any, List, Tuple, Optional
 
 from azure.core.credentials import AccessToken
 from azure.core.exceptions import ClientAuthenticationError
@@ -88,7 +88,7 @@ class AzurePowerShellCredential:
         *scopes: str,
         claims: Optional[str] = None,
         tenant_id: Optional[str] = None,
-        **kwargs,  # pylint:disable=unused-argument
+        **kwargs: Any,  # pylint:disable=unused-argument
     ) -> AccessToken:
         """Request an access token for `scopes`.
 

--- a/sdk/identity/azure-identity/azure/identity/_credentials/azure_powershell.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/azure_powershell.py
@@ -95,7 +95,7 @@ class AzurePowerShellCredential:
             For more information about scopes, see
             https://learn.microsoft.com/azure/active-directory/develop/scopes-oidc.
         :keyword str tenant_id: optional tenant to include in the token request.
-        :keyword str claims: not used by this credential; any value provided will be ignored.
+        :keyword str claims: not supported by this credential.
 
         :return: An access token with the desired scopes.
         :rtype: ~azure.core.credentials.AccessToken

--- a/sdk/identity/azure-identity/azure/identity/_credentials/azure_powershell.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/azure_powershell.py
@@ -83,7 +83,9 @@ class AzurePowerShellCredential:
         """Calling this method is unnecessary."""
 
     @log_get_token("AzurePowerShellCredential")
-    def get_token(self, *scopes: str, **kwargs: Any) -> AccessToken:
+    def get_token(
+        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs: Any
+    ) -> AccessToken:
         """Request an access token for `scopes`.
 
         This method is called automatically by Azure SDK clients. Applications calling this method directly must
@@ -93,6 +95,7 @@ class AzurePowerShellCredential:
             For more information about scopes, see
             https://learn.microsoft.com/azure/active-directory/develop/scopes-oidc.
         :keyword str tenant_id: optional tenant to include in the token request.
+        :keyword str claims: not used by this credential; any value provided will be ignored.
 
         :return: An access token with the desired scopes.
         :rtype: ~azure.core.credentials.AccessToken
@@ -103,7 +106,11 @@ class AzurePowerShellCredential:
           receive an access token
         """
         tenant_id = resolve_tenant(
-            default_tenant=self.tenant_id, additionally_allowed_tenants=self._additionally_allowed_tenants, **kwargs
+            default_tenant=self.tenant_id,
+            tenant_id=tenant_id,
+            additionally_allowed_tenants=self._additionally_allowed_tenants,
+            claims=claims,
+            **kwargs,
         )
         command_line = get_command_line(scopes, tenant_id)
         output = run_command_line(command_line, self._process_timeout)

--- a/sdk/identity/azure-identity/azure/identity/_credentials/azure_powershell.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/azure_powershell.py
@@ -109,7 +109,6 @@ class AzurePowerShellCredential:
             default_tenant=self.tenant_id,
             tenant_id=tenant_id,
             additionally_allowed_tenants=self._additionally_allowed_tenants,
-            claims=claims,
             **kwargs,
         )
         command_line = get_command_line(scopes, tenant_id)

--- a/sdk/identity/azure-identity/azure/identity/_credentials/chained.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/chained.py
@@ -70,7 +70,7 @@ class ChainedTokenCredential:
         self.__exit__()
 
     def get_token(
-            self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs: Any
+            self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs
     ) -> AccessToken:
         """Request a token from each chained credential, in order, returning the first token received.
 

--- a/sdk/identity/azure-identity/azure/identity/_credentials/chained.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/chained.py
@@ -70,7 +70,7 @@ class ChainedTokenCredential:
         self.__exit__()
 
     def get_token(
-        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs
+        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs: Any
     ) -> AccessToken:
         """Request a token from each chained credential, in order, returning the first token received.
 

--- a/sdk/identity/azure-identity/azure/identity/_credentials/chained.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/chained.py
@@ -79,8 +79,9 @@ class ChainedTokenCredential:
         :param str scopes: desired scopes for the access token. This method requires at least one scope.
             For more information about scopes, see
             https://learn.microsoft.com/azure/active-directory/develop/scopes-oidc.
-        :keyword str claims: not supported by this credential.
-        :keyword str tenant_id: not supported by this credential.
+        :keyword str claims: additional claims required in the token, such as those returned in a resource provider's
+            claims challenge following an authorization failure.
+        :keyword str tenant_id: optional tenant to include in the token request.
 
         :return: An access token with the desired scopes.
         :rtype: ~azure.core.credentials.AccessToken

--- a/sdk/identity/azure-identity/azure/identity/_credentials/chained.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/chained.py
@@ -79,8 +79,8 @@ class ChainedTokenCredential:
         :param str scopes: desired scopes for the access token. This method requires at least one scope.
             For more information about scopes, see
             https://learn.microsoft.com/azure/active-directory/develop/scopes-oidc.
-        :keyword str claims: not used by this credential; any value provided will be ignored.
-        :keyword str tenant_id: not used by this credential; any value provided will be ignored.
+        :keyword str claims: not supported by this credential.
+        :keyword str tenant_id: not supported by this credential.
 
         :return: An access token with the desired scopes.
         :rtype: ~azure.core.credentials.AccessToken

--- a/sdk/identity/azure-identity/azure/identity/_credentials/chained.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/chained.py
@@ -8,7 +8,7 @@ from azure.core.exceptions import ClientAuthenticationError
 
 from azure.core.credentials import AccessToken
 from .. import CredentialUnavailableError
-from .._internal import get_token_request_additions, within_credential_chain
+from .._internal import within_credential_chain
 
 if TYPE_CHECKING:
     from azure.core.credentials import TokenCredential
@@ -86,13 +86,11 @@ class ChainedTokenCredential:
         :rtype: ~azure.core.credentials.AccessToken
         :raises ~azure.core.exceptions.ClientAuthenticationError: no credential in the chain provided a token
         """
-        additions = get_token_request_additions(claims, tenant_id)
-        kwargs.update(additions)
         within_credential_chain.set(True)
         history = []
         for credential in self.credentials:
             try:
-                token = credential.get_token(*scopes, **kwargs)
+                token = credential.get_token(*scopes, claims=claims, tenant_id=tenant_id, **kwargs)
                 _LOGGER.info("%s acquired a token from %s", self.__class__.__name__, credential.__class__.__name__)
                 self._successful_credential = credential
                 return token

--- a/sdk/identity/azure-identity/azure/identity/_credentials/chained.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/chained.py
@@ -70,7 +70,7 @@ class ChainedTokenCredential:
         self.__exit__()
 
     def get_token(
-            self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs
+        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs
     ) -> AccessToken:
         """Request a token from each chained credential, in order, returning the first token received.
 

--- a/sdk/identity/azure-identity/azure/identity/_credentials/default.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/default.py
@@ -196,7 +196,7 @@ class DefaultAzureCredential(ChainedTokenCredential):
         super(DefaultAzureCredential, self).__init__(*credentials)
 
     def get_token(
-        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs
+        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs: Any
     ) -> AccessToken:
         """Request an access token for `scopes`.
 

--- a/sdk/identity/azure-identity/azure/identity/_credentials/default.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/default.py
@@ -214,6 +214,8 @@ class DefaultAzureCredential(ChainedTokenCredential):
         :raises ~azure.core.exceptions.ClientAuthenticationError: authentication failed. The exception has a
           `message` attribute listing each authentication attempt and its error message.
         """
+        additions = get_token_request_additions(claims, tenant_id)
+        kwargs.update(additions)
         if self._successful_credential:
             token = self._successful_credential.get_token(*scopes, **kwargs)
             _LOGGER.info(

--- a/sdk/identity/azure-identity/azure/identity/_credentials/default.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/default.py
@@ -206,7 +206,7 @@ class DefaultAzureCredential(ChainedTokenCredential):
             For more information about scopes, see
             https://learn.microsoft.com/azure/active-directory/develop/scopes-oidc.
         :keyword str tenant_id: optional tenant to include in the token request.
-        :keyword str claims: not used by this credential; any value provided will be ignored.
+        :keyword str claims: not supported by this credential.
 
         :return: An access token with the desired scopes.
         :rtype: ~azure.core.credentials.AccessToken

--- a/sdk/identity/azure-identity/azure/identity/_credentials/default.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/default.py
@@ -4,7 +4,7 @@
 # ------------------------------------
 import logging
 import os
-from typing import List, TYPE_CHECKING, Any, cast
+from typing import List, TYPE_CHECKING, Any, Optional, cast
 
 from azure.core.credentials import AccessToken
 from .._constants import EnvironmentVariables
@@ -195,7 +195,9 @@ class DefaultAzureCredential(ChainedTokenCredential):
 
         super(DefaultAzureCredential, self).__init__(*credentials)
 
-    def get_token(self, *scopes: str, **kwargs) -> AccessToken:
+    def get_token(
+        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs: Any
+    ) -> AccessToken:
         """Request an access token for `scopes`.
 
         This method is called automatically by Azure SDK clients.
@@ -204,6 +206,7 @@ class DefaultAzureCredential(ChainedTokenCredential):
             For more information about scopes, see
             https://learn.microsoft.com/azure/active-directory/develop/scopes-oidc.
         :keyword str tenant_id: optional tenant to include in the token request.
+        :keyword str claims: not used by this credential; any value provided will be ignored.
 
         :return: An access token with the desired scopes.
         :rtype: ~azure.core.credentials.AccessToken

--- a/sdk/identity/azure-identity/azure/identity/_credentials/default.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/default.py
@@ -205,8 +205,9 @@ class DefaultAzureCredential(ChainedTokenCredential):
         :param str scopes: desired scopes for the access token. This method requires at least one scope.
             For more information about scopes, see
             https://learn.microsoft.com/azure/active-directory/develop/scopes-oidc.
+        :keyword str claims: additional claims required in the token, such as those returned in a resource provider's
+            claims challenge following an authorization failure.
         :keyword str tenant_id: optional tenant to include in the token request.
-        :keyword str claims: not supported by this credential.
 
         :return: An access token with the desired scopes.
         :rtype: ~azure.core.credentials.AccessToken

--- a/sdk/identity/azure-identity/azure/identity/_credentials/default.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/default.py
@@ -214,15 +214,13 @@ class DefaultAzureCredential(ChainedTokenCredential):
         :raises ~azure.core.exceptions.ClientAuthenticationError: authentication failed. The exception has a
           `message` attribute listing each authentication attempt and its error message.
         """
-        additions = get_token_request_additions(claims, tenant_id)
-        kwargs.update(additions)
         if self._successful_credential:
-            token = self._successful_credential.get_token(*scopes, **kwargs)
+            token = self._successful_credential.get_token(*scopes, claims=claims, tenant_id=tenant_id, **kwargs)
             _LOGGER.info(
                 "%s acquired a token from %s", self.__class__.__name__, self._successful_credential.__class__.__name__
             )
             return token
         within_dac.set(True)
-        token = super(DefaultAzureCredential, self).get_token(*scopes, **kwargs)
+        token = super().get_token(*scopes, claims=claims, tenant_id=tenant_id, **kwargs)
         within_dac.set(False)
         return token

--- a/sdk/identity/azure-identity/azure/identity/_credentials/default.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/default.py
@@ -196,7 +196,7 @@ class DefaultAzureCredential(ChainedTokenCredential):
         super(DefaultAzureCredential, self).__init__(*credentials)
 
     def get_token(
-        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs: Any
+        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs
     ) -> AccessToken:
         """Request an access token for `scopes`.
 

--- a/sdk/identity/azure-identity/azure/identity/_credentials/environment.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/environment.py
@@ -120,7 +120,9 @@ class EnvironmentCredential:
         self.__exit__()
 
     @log_get_token("EnvironmentCredential")
-    def get_token(self, *scopes: str, **kwargs: Any) -> AccessToken:
+    def get_token(
+        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs: Any
+    ) -> AccessToken:
         """Request an access token for `scopes`.
 
         This method is called automatically by Azure SDK clients.
@@ -129,6 +131,7 @@ class EnvironmentCredential:
             For more information about scopes, see
             https://learn.microsoft.com/azure/active-directory/develop/scopes-oidc.
         :keyword str tenant_id: optional tenant to include in the token request.
+        :keyword str claims: not used by this credential; any value provided will be ignored.
 
         :return: An access token with the desired scopes.
         :rtype: ~azure.core.credentials.AccessToken

--- a/sdk/identity/azure-identity/azure/identity/_credentials/environment.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/environment.py
@@ -131,7 +131,7 @@ class EnvironmentCredential:
             For more information about scopes, see
             https://learn.microsoft.com/azure/active-directory/develop/scopes-oidc.
         :keyword str tenant_id: optional tenant to include in the token request.
-        :keyword str claims: not used by this credential; any value provided will be ignored.
+        :keyword str claims: not supported by this credential.
 
         :return: An access token with the desired scopes.
         :rtype: ~azure.core.credentials.AccessToken

--- a/sdk/identity/azure-identity/azure/identity/_credentials/environment.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/environment.py
@@ -130,8 +130,9 @@ class EnvironmentCredential:
         :param str scopes: desired scopes for the access token. This method requires at least one scope.
             For more information about scopes, see
             https://learn.microsoft.com/azure/active-directory/develop/scopes-oidc.
+        :keyword str claims: additional claims required in the token, such as those returned in a resource provider's
+            claims challenge following an authorization failure.
         :keyword str tenant_id: optional tenant to include in the token request.
-        :keyword str claims: not supported by this credential.
 
         :return: An access token with the desired scopes.
         :rtype: ~azure.core.credentials.AccessToken

--- a/sdk/identity/azure-identity/azure/identity/_credentials/environment.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/environment.py
@@ -9,6 +9,7 @@ from azure.core.credentials import AccessToken
 
 from .. import CredentialUnavailableError
 from .._constants import EnvironmentVariables
+from .._internal import get_token_request_additions
 from .._internal.decorators import log_get_token
 from .certificate import CertificateCredential
 from .client_secret import ClientSecretCredential
@@ -138,6 +139,8 @@ class EnvironmentCredential:
 
         :raises ~azure.identity.CredentialUnavailableError: environment variable configuration is incomplete
         """
+        additions = get_token_request_additions(claims, tenant_id)
+        kwargs.update(additions)
         if not self._credential:
             message = (
                 "EnvironmentCredential authentication unavailable. Environment variables are not fully configured.\n"

--- a/sdk/identity/azure-identity/azure/identity/_credentials/environment.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/environment.py
@@ -121,7 +121,7 @@ class EnvironmentCredential:
 
     @log_get_token("EnvironmentCredential")
     def get_token(
-        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs: Any
+        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs
     ) -> AccessToken:
         """Request an access token for `scopes`.
 

--- a/sdk/identity/azure-identity/azure/identity/_credentials/environment.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/environment.py
@@ -121,7 +121,7 @@ class EnvironmentCredential:
 
     @log_get_token("EnvironmentCredential")
     def get_token(
-        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs
+        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs: Any
     ) -> AccessToken:
         """Request an access token for `scopes`.
 

--- a/sdk/identity/azure-identity/azure/identity/_credentials/environment.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/environment.py
@@ -9,7 +9,6 @@ from azure.core.credentials import AccessToken
 
 from .. import CredentialUnavailableError
 from .._constants import EnvironmentVariables
-from .._internal import get_token_request_additions
 from .._internal.decorators import log_get_token
 from .certificate import CertificateCredential
 from .client_secret import ClientSecretCredential
@@ -139,8 +138,6 @@ class EnvironmentCredential:
 
         :raises ~azure.identity.CredentialUnavailableError: environment variable configuration is incomplete
         """
-        additions = get_token_request_additions(claims, tenant_id)
-        kwargs.update(additions)
         if not self._credential:
             message = (
                 "EnvironmentCredential authentication unavailable. Environment variables are not fully configured.\n"
@@ -148,4 +145,4 @@ class EnvironmentCredential:
                 "this issue."
             )
             raise CredentialUnavailableError(message=message)
-        return self._credential.get_token(*scopes, **kwargs)
+        return self._credential.get_token(*scopes, claims=claims, tenant_id=tenant_id, **kwargs)

--- a/sdk/identity/azure-identity/azure/identity/_credentials/managed_identity.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/managed_identity.py
@@ -9,7 +9,6 @@ from typing import Optional, TYPE_CHECKING, Any
 from azure.core.credentials import AccessToken
 from .. import CredentialUnavailableError
 from .._constants import EnvironmentVariables
-from .._internal import get_token_request_additions
 from .._internal.decorators import log_get_token
 
 if TYPE_CHECKING:
@@ -128,8 +127,6 @@ class ManagedIdentityCredential:
         :raises ~azure.identity.CredentialUnavailableError: managed identity isn't available in the hosting environment
         """
 
-        additions = get_token_request_additions(claims, tenant_id)
-        kwargs.update(additions)
         if not self._credential:
             raise CredentialUnavailableError(
                 message="No managed identity endpoint found. \n"
@@ -137,4 +134,4 @@ class ManagedIdentityCredential:
                 "Visit https://aka.ms/azsdk/python/identity/managedidentitycredential/troubleshoot to "
                 "troubleshoot this issue."
             )
-        return self._credential.get_token(*scopes, **kwargs)
+        return self._credential.get_token(*scopes, claims=claims, tenant_id=tenant_id, **kwargs)

--- a/sdk/identity/azure-identity/azure/identity/_credentials/managed_identity.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/managed_identity.py
@@ -119,8 +119,8 @@ class ManagedIdentityCredential:
             For more information about scopes, see
             https://learn.microsoft.com/azure/active-directory/develop/scopes-oidc.
 
-        :keyword str claims: not used by this credential; any value provided will be ignored.
-        :keyword str tenant_id: not used by this credential; any value provided will be ignored.
+        :keyword str claims: not supported by this credential.
+        :keyword str tenant_id: not supported by this credential.
 
         :return: An access token with the desired scopes.
         :rtype: ~azure.core.credentials.AccessToken

--- a/sdk/identity/azure-identity/azure/identity/_credentials/managed_identity.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/managed_identity.py
@@ -119,8 +119,8 @@ class ManagedIdentityCredential:
             For more information about scopes, see
             https://learn.microsoft.com/azure/active-directory/develop/scopes-oidc.
 
-        :keyword str claims: not supported by this credential.
-        :keyword str tenant_id: not supported by this credential.
+        :keyword str claims: not used by this credential; any value provided will be ignored.
+        :keyword str tenant_id: not used by this credential; any value provided will be ignored.
 
         :return: An access token with the desired scopes.
         :rtype: ~azure.core.credentials.AccessToken

--- a/sdk/identity/azure-identity/azure/identity/_credentials/managed_identity.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/managed_identity.py
@@ -109,7 +109,7 @@ class ManagedIdentityCredential:
 
     @log_get_token("ManagedIdentityCredential")
     def get_token(
-        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs: Any
+        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs
     ) -> AccessToken:
         """Request an access token for `scopes`.
 

--- a/sdk/identity/azure-identity/azure/identity/_credentials/managed_identity.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/managed_identity.py
@@ -109,7 +109,7 @@ class ManagedIdentityCredential:
 
     @log_get_token("ManagedIdentityCredential")
     def get_token(
-        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs
+        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs: Any
     ) -> AccessToken:
         """Request an access token for `scopes`.
 

--- a/sdk/identity/azure-identity/azure/identity/_credentials/managed_identity.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/managed_identity.py
@@ -9,6 +9,7 @@ from typing import Optional, TYPE_CHECKING, Any
 from azure.core.credentials import AccessToken
 from .. import CredentialUnavailableError
 from .._constants import EnvironmentVariables
+from .._internal import get_token_request_additions
 from .._internal.decorators import log_get_token
 
 if TYPE_CHECKING:
@@ -127,6 +128,8 @@ class ManagedIdentityCredential:
         :raises ~azure.identity.CredentialUnavailableError: managed identity isn't available in the hosting environment
         """
 
+        additions = get_token_request_additions(claims, tenant_id)
+        kwargs.update(additions)
         if not self._credential:
             raise CredentialUnavailableError(
                 message="No managed identity endpoint found. \n"

--- a/sdk/identity/azure-identity/azure/identity/_credentials/managed_identity.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/managed_identity.py
@@ -108,7 +108,9 @@ class ManagedIdentityCredential:
         self.__exit__()
 
     @log_get_token("ManagedIdentityCredential")
-    def get_token(self, *scopes: str, **kwargs: Any) -> AccessToken:
+    def get_token(
+        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs: Any
+    ) -> AccessToken:
         """Request an access token for `scopes`.
 
         This method is called automatically by Azure SDK clients.
@@ -116,6 +118,9 @@ class ManagedIdentityCredential:
         :param str scopes: desired scope for the access token. This credential allows only one scope per request.
             For more information about scopes, see
             https://learn.microsoft.com/azure/active-directory/develop/scopes-oidc.
+
+        :keyword str claims: not used by this credential; any value provided will be ignored.
+        :keyword str tenant_id: not used by this credential; any value provided will be ignored.
 
         :return: An access token with the desired scopes.
         :rtype: ~azure.core.credentials.AccessToken

--- a/sdk/identity/azure-identity/azure/identity/_credentials/shared_cache.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/shared_cache.py
@@ -66,7 +66,7 @@ class SharedTokenCacheCredential:
             https://learn.microsoft.com/azure/active-directory/develop/scopes-oidc.
         :keyword str claims: additional claims required in the token, such as those returned in a resource provider's
             claims challenge following an authorization failure
-        :keyword str tenant_id: not used by this credential; any value provided will be ignored.
+        :keyword str tenant_id: not supported by this credential.
         :keyword bool enable_cae: indicates whether to enable Continuous Access Evaluation (CAE) for the requested
             token. Defaults to False.
 

--- a/sdk/identity/azure-identity/azure/identity/_credentials/shared_cache.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/shared_cache.py
@@ -53,7 +53,7 @@ class SharedTokenCacheCredential:
 
     @log_get_token("SharedTokenCacheCredential")
     def get_token(
-        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs
+        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs: Any
     ) -> AccessToken:
         """Get an access token for `scopes` from the shared cache.
 
@@ -102,7 +102,7 @@ class _SharedTokenCacheCredential(SharedTokenCacheBase):
             self._client.__exit__(*args)
 
     def get_token(
-        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs
+        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs: Any
     ) -> AccessToken:
         if not scopes:
             raise ValueError("'get_token' requires at least one scope")

--- a/sdk/identity/azure-identity/azure/identity/_credentials/shared_cache.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/shared_cache.py
@@ -52,7 +52,9 @@ class SharedTokenCacheCredential:
         self.__exit__()
 
     @log_get_token("SharedTokenCacheCredential")
-    def get_token(self, *scopes: str, **kwargs: Any) -> AccessToken:
+    def get_token(
+        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs: Any
+    ) -> AccessToken:
         """Get an access token for `scopes` from the shared cache.
 
         If no access token is cached, attempt to acquire one using a cached refresh token.
@@ -64,8 +66,10 @@ class SharedTokenCacheCredential:
             https://learn.microsoft.com/azure/active-directory/develop/scopes-oidc.
         :keyword str claims: additional claims required in the token, such as those returned in a resource provider's
             claims challenge following an authorization failure
+        :keyword str tenant_id: not used by this credential; any value provided will be ignored.
         :keyword bool enable_cae: indicates whether to enable Continuous Access Evaluation (CAE) for the requested
             token. Defaults to False.
+
         :return: An access token with the desired scopes.
         :rtype: ~azure.core.credentials.AccessToken
         :raises ~azure.identity.CredentialUnavailableError: the cache is unavailable or contains insufficient user

--- a/sdk/identity/azure-identity/azure/identity/_credentials/shared_cache.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/shared_cache.py
@@ -53,7 +53,7 @@ class SharedTokenCacheCredential:
 
     @log_get_token("SharedTokenCacheCredential")
     def get_token(
-        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs: Any
+        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs
     ) -> AccessToken:
         """Get an access token for `scopes` from the shared cache.
 
@@ -102,7 +102,7 @@ class _SharedTokenCacheCredential(SharedTokenCacheBase):
             self._client.__exit__(*args)
 
     def get_token(
-        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs: Any
+        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs
     ) -> AccessToken:
         if not scopes:
             raise ValueError("'get_token' requires at least one scope")

--- a/sdk/identity/azure-identity/azure/identity/_credentials/shared_cache.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/shared_cache.py
@@ -8,7 +8,7 @@ from azure.core.credentials import AccessToken
 from .silent import SilentAuthenticationCredential
 from .. import CredentialUnavailableError
 from .._constants import DEVELOPER_SIGN_ON_CLIENT_ID
-from .._internal import AadClient, AadClientBase
+from .._internal import AadClient, AadClientBase, get_token_request_additions
 from .._internal.decorators import log_get_token
 from .._internal.shared_token_cache import NO_TOKEN, SharedTokenCacheBase
 
@@ -77,6 +77,8 @@ class SharedTokenCacheCredential:
         :raises ~azure.core.exceptions.ClientAuthenticationError: authentication failed. The error's ``message``
             attribute gives a reason.
         """
+        additions = get_token_request_additions(claims, tenant_id)
+        kwargs.update(additions)
         return self._credential.get_token(*scopes, **kwargs)
 
     @staticmethod

--- a/sdk/identity/azure-identity/azure/identity/_credentials/shared_cache.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/shared_cache.py
@@ -101,7 +101,9 @@ class _SharedTokenCacheCredential(SharedTokenCacheBase):
         if self._client:
             self._client.__exit__(*args)
 
-    def get_token(self, *scopes: str, **kwargs: Any) -> AccessToken:
+    def get_token(
+        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs: Any
+    ) -> AccessToken:
         if not scopes:
             raise ValueError("'get_token' requires at least one scope")
 
@@ -127,7 +129,9 @@ class _SharedTokenCacheCredential(SharedTokenCacheBase):
 
         # try each refresh token, returning the first access token acquired
         for refresh_token in self._get_refresh_tokens(account, is_cae=is_cae):
-            token = self._client.obtain_token_by_refresh_token(scopes, refresh_token, **kwargs)
+            token = self._client.obtain_token_by_refresh_token(
+                scopes, refresh_token, claims=claims, tenant_id=tenant_id, **kwargs
+            )
             return token
 
         raise CredentialUnavailableError(message=NO_TOKEN.format(account.get("username")))

--- a/sdk/identity/azure-identity/azure/identity/_credentials/shared_cache.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/shared_cache.py
@@ -8,7 +8,7 @@ from azure.core.credentials import AccessToken
 from .silent import SilentAuthenticationCredential
 from .. import CredentialUnavailableError
 from .._constants import DEVELOPER_SIGN_ON_CLIENT_ID
-from .._internal import AadClient, AadClientBase, get_token_request_additions
+from .._internal import AadClient, AadClientBase
 from .._internal.decorators import log_get_token
 from .._internal.shared_token_cache import NO_TOKEN, SharedTokenCacheBase
 
@@ -77,9 +77,7 @@ class SharedTokenCacheCredential:
         :raises ~azure.core.exceptions.ClientAuthenticationError: authentication failed. The error's ``message``
             attribute gives a reason.
         """
-        additions = get_token_request_additions(claims, tenant_id)
-        kwargs.update(additions)
-        return self._credential.get_token(*scopes, **kwargs)
+        return self._credential.get_token(*scopes, claims=claims, tenant_id=tenant_id, **kwargs)
 
     @staticmethod
     def supported() -> bool:

--- a/sdk/identity/azure-identity/azure/identity/_credentials/shared_cache.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/shared_cache.py
@@ -66,7 +66,7 @@ class SharedTokenCacheCredential:
             https://learn.microsoft.com/azure/active-directory/develop/scopes-oidc.
         :keyword str claims: additional claims required in the token, such as those returned in a resource provider's
             claims challenge following an authorization failure
-        :keyword str tenant_id: not supported by this credential.
+        :keyword str tenant_id: not used by this credential; any value provided will be ignored.
         :keyword bool enable_cae: indicates whether to enable Continuous Access Evaluation (CAE) for the requested
             token. Defaults to False.
 

--- a/sdk/identity/azure-identity/azure/identity/_credentials/silent.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/silent.py
@@ -55,7 +55,7 @@ class SilentAuthenticationCredential:
         self._client.__exit__(*args)
 
     def get_token(
-        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs
+        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs: Any
     ) -> AccessToken:
         if not scopes:
             raise ValueError('"get_token" requires at least one scope')

--- a/sdk/identity/azure-identity/azure/identity/_credentials/silent.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/silent.py
@@ -55,7 +55,7 @@ class SilentAuthenticationCredential:
         self._client.__exit__(*args)
 
     def get_token(
-        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs: Any
+        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs
     ) -> AccessToken:
         if not scopes:
             raise ValueError('"get_token" requires at least one scope')

--- a/sdk/identity/azure-identity/azure/identity/_credentials/silent.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/silent.py
@@ -54,7 +54,9 @@ class SilentAuthenticationCredential:
     def __exit__(self, *args):
         self._client.__exit__(*args)
 
-    def get_token(self, *scopes: str, **kwargs: Any) -> AccessToken:
+    def get_token(
+        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs: Any
+    ) -> AccessToken:
         if not scopes:
             raise ValueError('"get_token" requires at least one scope')
 
@@ -70,7 +72,7 @@ class SilentAuthenticationCredential:
                     raise CredentialUnavailableError(message="Shared token cache unavailable")
                 raise ClientAuthenticationError(message="Shared token cache unavailable")
 
-        return self._acquire_token_silent(*scopes, **kwargs)
+        return self._acquire_token_silent(*scopes, claims=claims, tenant_id=tenant_id, **kwargs)
 
     def _initialize_cache(self, is_cae: bool = False) -> Optional[TokenCache]:
 

--- a/sdk/identity/azure-identity/azure/identity/_credentials/vscode.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/vscode.py
@@ -140,7 +140,9 @@ class VisualStudioCodeCredential(_VSCodeCredentialBase, GetTokenMixin):
         self.__exit__()
 
     @log_get_token("VSCodeCredential")
-    def get_token(self, *scopes: str, **kwargs: Any) -> AccessToken:
+    def get_token(
+        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs: Any
+    ) -> AccessToken:
         """Request an access token for `scopes` as the user currently signed in to Visual Studio Code.
 
         This method is called automatically by Azure SDK clients.

--- a/sdk/identity/azure-identity/azure/identity/_credentials/vscode.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/vscode.py
@@ -150,8 +150,8 @@ class VisualStudioCodeCredential(_VSCodeCredentialBase, GetTokenMixin):
         :param str scopes: desired scopes for the access token. This method requires at least one scope.
             For more information about scopes, see
             https://learn.microsoft.com/azure/active-directory/develop/scopes-oidc.
-        :keyword str claims: not used by this credential; any value provided will be ignored.
-        :keyword str tenant_id: not used by this credential; any value provided will be ignored.
+        :keyword str claims: not supported by this credential.
+        :keyword str tenant_id: not supported by this credential.
 
         :return: An access token with the desired scopes.
         :rtype: ~azure.core.credentials.AccessToken

--- a/sdk/identity/azure-identity/azure/identity/_credentials/vscode.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/vscode.py
@@ -156,6 +156,8 @@ class VisualStudioCodeCredential(_VSCodeCredentialBase, GetTokenMixin):
         :raises ~azure.identity.CredentialUnavailableError: the credential cannot retrieve user details from Visual
           Studio Code
         """
+        additions = get_token_request_additions(claims, tenant_id)
+        kwargs.update(additions)
         if self._unavailable_reason:
             error_message = (
                 self._unavailable_reason + "\n"

--- a/sdk/identity/azure-identity/azure/identity/_credentials/vscode.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/vscode.py
@@ -141,7 +141,7 @@ class VisualStudioCodeCredential(_VSCodeCredentialBase, GetTokenMixin):
 
     @log_get_token("VSCodeCredential")
     def get_token(
-        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs: Any
+        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs
     ) -> AccessToken:
         """Request an access token for `scopes` as the user currently signed in to Visual Studio Code.
 
@@ -150,6 +150,8 @@ class VisualStudioCodeCredential(_VSCodeCredentialBase, GetTokenMixin):
         :param str scopes: desired scopes for the access token. This method requires at least one scope.
             For more information about scopes, see
             https://learn.microsoft.com/azure/active-directory/develop/scopes-oidc.
+        :keyword str claims: not used by this credential; any value provided will be ignored.
+        :keyword str tenant_id: not used by this credential; any value provided will be ignored.
 
         :return: An access token with the desired scopes.
         :rtype: ~azure.core.credentials.AccessToken

--- a/sdk/identity/azure-identity/azure/identity/_credentials/vscode.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/vscode.py
@@ -150,8 +150,9 @@ class VisualStudioCodeCredential(_VSCodeCredentialBase, GetTokenMixin):
         :param str scopes: desired scopes for the access token. This method requires at least one scope.
             For more information about scopes, see
             https://learn.microsoft.com/azure/active-directory/develop/scopes-oidc.
-        :keyword str claims: not supported by this credential.
-        :keyword str tenant_id: not supported by this credential.
+        :keyword str claims: additional claims required in the token, such as those returned in a resource provider's
+            claims challenge following an authorization failure.
+        :keyword str tenant_id: optional tenant to include in the token request.
 
         :return: An access token with the desired scopes.
         :rtype: ~azure.core.credentials.AccessToken

--- a/sdk/identity/azure-identity/azure/identity/_credentials/vscode.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/vscode.py
@@ -141,7 +141,7 @@ class VisualStudioCodeCredential(_VSCodeCredentialBase, GetTokenMixin):
 
     @log_get_token("VSCodeCredential")
     def get_token(
-        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs
+        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs: Any
     ) -> AccessToken:
         """Request an access token for `scopes` as the user currently signed in to Visual Studio Code.
 

--- a/sdk/identity/azure-identity/azure/identity/_credentials/vscode.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/vscode.py
@@ -156,8 +156,6 @@ class VisualStudioCodeCredential(_VSCodeCredentialBase, GetTokenMixin):
         :raises ~azure.identity.CredentialUnavailableError: the credential cannot retrieve user details from Visual
           Studio Code
         """
-        additions = get_token_request_additions(claims, tenant_id)
-        kwargs.update(additions)
         if self._unavailable_reason:
             error_message = (
                 self._unavailable_reason + "\n"
@@ -167,11 +165,11 @@ class VisualStudioCodeCredential(_VSCodeCredentialBase, GetTokenMixin):
             raise CredentialUnavailableError(message=error_message)
         if within_dac.get():
             try:
-                token = super(VisualStudioCodeCredential, self).get_token(*scopes, **kwargs)
+                token = super().get_token(*scopes, claims=claims, tenant_id=tenant_id, **kwargs)
                 return token
             except ClientAuthenticationError as ex:
                 raise CredentialUnavailableError(message=ex.message) from ex
-        return super(VisualStudioCodeCredential, self).get_token(*scopes, **kwargs)
+        return super().get_token(*scopes, claims=claims, tenant_id=tenant_id, **kwargs)
 
     def _acquire_token_silently(self, *scopes: str, **kwargs: Any) -> Optional[AccessToken]:
         self._client = cast(AadClient, self._client)

--- a/sdk/identity/azure-identity/azure/identity/_internal/__init__.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/__init__.py
@@ -10,7 +10,6 @@ from .decorators import wrap_exceptions
 from .interactive import InteractiveCredential
 from .utils import (
     get_default_authority,
-    get_token_request_additions,
     normalize_authority,
     resolve_tenant,
     validate_tenant_id,
@@ -45,7 +44,6 @@ __all__ = [
     "AuthCodeRedirectServer",
     "AadClientCertificate",
     "get_default_authority",
-    "get_token_request_additions",
     "InteractiveCredential",
     "normalize_authority",
     "resolve_tenant",

--- a/sdk/identity/azure-identity/azure/identity/_internal/__init__.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/__init__.py
@@ -10,6 +10,7 @@ from .decorators import wrap_exceptions
 from .interactive import InteractiveCredential
 from .utils import (
     get_default_authority,
+    get_token_request_additions,
     normalize_authority,
     resolve_tenant,
     validate_tenant_id,
@@ -44,6 +45,7 @@ __all__ = [
     "AuthCodeRedirectServer",
     "AadClientCertificate",
     "get_default_authority",
+    "get_token_request_additions",
     "InteractiveCredential",
     "normalize_authority",
     "resolve_tenant",

--- a/sdk/identity/azure-identity/azure/identity/_internal/get_token_mixin.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/get_token_mixin.py
@@ -10,6 +10,7 @@ from typing import Any, Optional
 from azure.core.credentials import AccessToken
 from .utils import within_credential_chain
 from .._constants import DEFAULT_REFRESH_OFFSET, DEFAULT_TOKEN_REFRESH_RETRY_DELAY
+from .._internal import get_token_request_additions
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -78,6 +79,8 @@ class GetTokenMixin(abc.ABC):
         if not scopes:
             raise ValueError('"get_token" requires at least one scope')
 
+        additions = get_token_request_additions(claims, tenant_id)
+        kwargs.update(additions)
         try:
             token = self._acquire_token_silently(*scopes, **kwargs)
             if not token:

--- a/sdk/identity/azure-identity/azure/identity/_internal/get_token_mixin.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/get_token_mixin.py
@@ -53,7 +53,9 @@ class GetTokenMixin(abc.ABC):
             return False
         return True
 
-    def get_token(self, *scopes: str, **kwargs: Any) -> AccessToken:
+    def get_token(
+        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs: Any
+    ) -> AccessToken:
         """Request an access token for `scopes`.
 
         This method is called automatically by Azure SDK clients.
@@ -62,8 +64,10 @@ class GetTokenMixin(abc.ABC):
             For more information about scopes, see
             https://learn.microsoft.com/azure/active-directory/develop/scopes-oidc.
         :keyword str tenant_id: optional tenant to include in the token request.
+        :keyword str claims: not used by this credential; any value provided will be ignored.
         :keyword bool enable_cae: indicates whether to enable Continuous Access Evaluation (CAE) for the requested
             token. Defaults to False.
+
         :return: An access token with the desired scopes.
         :rtype: ~azure.core.credentials.AccessToken
         :raises CredentialUnavailableError: the credential is unable to attempt authentication because it lacks

--- a/sdk/identity/azure-identity/azure/identity/_internal/get_token_mixin.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/get_token_mixin.py
@@ -63,8 +63,9 @@ class GetTokenMixin(abc.ABC):
         :param str scopes: desired scopes for the access token. This method requires at least one scope.
             For more information about scopes, see
             https://learn.microsoft.com/azure/active-directory/develop/scopes-oidc.
+        :keyword str claims: additional claims required in the token, such as those returned in a resource provider's
+            claims challenge following an authorization failure.
         :keyword str tenant_id: optional tenant to include in the token request.
-        :keyword str claims: not supported by this credential.
         :keyword bool enable_cae: indicates whether to enable Continuous Access Evaluation (CAE) for the requested
             token. Defaults to False.
 

--- a/sdk/identity/azure-identity/azure/identity/_internal/get_token_mixin.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/get_token_mixin.py
@@ -54,7 +54,7 @@ class GetTokenMixin(abc.ABC):
         return True
 
     def get_token(
-        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs
+        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs: Any
     ) -> AccessToken:
         """Request an access token for `scopes`.
 

--- a/sdk/identity/azure-identity/azure/identity/_internal/get_token_mixin.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/get_token_mixin.py
@@ -64,7 +64,7 @@ class GetTokenMixin(abc.ABC):
             For more information about scopes, see
             https://learn.microsoft.com/azure/active-directory/develop/scopes-oidc.
         :keyword str tenant_id: optional tenant to include in the token request.
-        :keyword str claims: not used by this credential; any value provided will be ignored.
+        :keyword str claims: not supported by this credential.
         :keyword bool enable_cae: indicates whether to enable Continuous Access Evaluation (CAE) for the requested
             token. Defaults to False.
 

--- a/sdk/identity/azure-identity/azure/identity/_internal/get_token_mixin.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/get_token_mixin.py
@@ -10,7 +10,6 @@ from typing import Any, Optional
 from azure.core.credentials import AccessToken
 from .utils import within_credential_chain
 from .._constants import DEFAULT_REFRESH_OFFSET, DEFAULT_TOKEN_REFRESH_RETRY_DELAY
-from .._internal import get_token_request_additions
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -79,17 +78,15 @@ class GetTokenMixin(abc.ABC):
         if not scopes:
             raise ValueError('"get_token" requires at least one scope')
 
-        additions = get_token_request_additions(claims, tenant_id)
-        kwargs.update(additions)
         try:
-            token = self._acquire_token_silently(*scopes, **kwargs)
+            token = self._acquire_token_silently(*scopes, claims=claims, tenant_id=tenant_id, **kwargs)
             if not token:
                 self._last_request_time = int(time.time())
-                token = self._request_token(*scopes, **kwargs)
+                token = self._request_token(*scopes, claims=claims, tenant_id=tenant_id, **kwargs)
             elif self._should_refresh(token):
                 try:
                     self._last_request_time = int(time.time())
-                    token = self._request_token(*scopes, **kwargs)
+                    token = self._request_token(*scopes, claims=claims, tenant_id=tenant_id, **kwargs)
                 except Exception:  # pylint:disable=broad-except
                     pass
             _LOGGER.log(

--- a/sdk/identity/azure-identity/azure/identity/_internal/get_token_mixin.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/get_token_mixin.py
@@ -54,7 +54,7 @@ class GetTokenMixin(abc.ABC):
         return True
 
     def get_token(
-        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs: Any
+        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs
     ) -> AccessToken:
         """Request an access token for `scopes`.
 

--- a/sdk/identity/azure-identity/azure/identity/_internal/interactive.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/interactive.py
@@ -112,7 +112,7 @@ class InteractiveCredential(MsalCredential, ABC):
             super(InteractiveCredential, self).__init__(**kwargs)
 
     def get_token(
-        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs
+        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs: Any
     ) -> AccessToken:
         """Request an access token for `scopes`.
 

--- a/sdk/identity/azure-identity/azure/identity/_internal/interactive.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/interactive.py
@@ -112,7 +112,7 @@ class InteractiveCredential(MsalCredential, ABC):
             super(InteractiveCredential, self).__init__(**kwargs)
 
     def get_token(
-        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs: Any
+        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs
     ) -> AccessToken:
         """Request an access token for `scopes`.
 

--- a/sdk/identity/azure-identity/azure/identity/_internal/interactive.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/interactive.py
@@ -111,7 +111,9 @@ class InteractiveCredential(MsalCredential, ABC):
         else:
             super(InteractiveCredential, self).__init__(**kwargs)
 
-    def get_token(self, *scopes: str, **kwargs: Any) -> AccessToken:
+    def get_token(
+        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs: Any
+    ) -> AccessToken:
         """Request an access token for `scopes`.
 
         This method is called automatically by Azure SDK clients.
@@ -120,7 +122,7 @@ class InteractiveCredential(MsalCredential, ABC):
             For more information about scopes, see
             https://learn.microsoft.com/azure/active-directory/develop/scopes-oidc.
         :keyword str claims: additional claims required in the token, such as those returned in a resource provider's
-          claims challenge following an authorization failure
+            claims challenge following an authorization failure
         :keyword str tenant_id: optional tenant to include in the token request.
         :keyword bool enable_cae: indicates whether to enable Continuous Access Evaluation (CAE) for the requested
             token. Defaults to False.
@@ -140,7 +142,7 @@ class InteractiveCredential(MsalCredential, ABC):
 
         allow_prompt = kwargs.pop("_allow_prompt", not self._disable_automatic_authentication)
         try:
-            token = self._acquire_token_silent(*scopes, **kwargs)
+            token = self._acquire_token_silent(*scopes, claims=claims, tenant_id=tenant_id, **kwargs)
             _LOGGER.info("%s.get_token succeeded", self.__class__.__name__)
             return token
         except Exception as ex:  # pylint:disable=broad-except
@@ -157,7 +159,7 @@ class InteractiveCredential(MsalCredential, ABC):
         now = int(time.time())
 
         try:
-            result = self._request_token(*scopes, **kwargs)
+            result = self._request_token(*scopes, claims=claims, tenant_id=tenant_id, **kwargs)
             if "access_token" not in result:
                 message = "Authentication failed: {}".format(result.get("error_description") or result.get("error"))
                 response = self._client.get_error_response(result)

--- a/sdk/identity/azure-identity/azure/identity/_internal/managed_identity_base.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/managed_identity_base.py
@@ -40,7 +40,7 @@ class ManagedIdentityBase(GetTokenMixin):
         self.__exit__()
 
     def get_token(
-        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs: Any
+        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs
     ) -> AccessToken:
         if not self._client:
             raise CredentialUnavailableError(message=self.get_unavailable_message())

--- a/sdk/identity/azure-identity/azure/identity/_internal/managed_identity_base.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/managed_identity_base.py
@@ -40,7 +40,7 @@ class ManagedIdentityBase(GetTokenMixin):
         self.__exit__()
 
     def get_token(
-        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs
+        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs: Any
     ) -> AccessToken:
         if not self._client:
             raise CredentialUnavailableError(message=self.get_unavailable_message())

--- a/sdk/identity/azure-identity/azure/identity/_internal/managed_identity_base.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/managed_identity_base.py
@@ -39,10 +39,12 @@ class ManagedIdentityBase(GetTokenMixin):
     def close(self) -> None:
         self.__exit__()
 
-    def get_token(self, *scopes: str, **kwargs: Any) -> AccessToken:
+    def get_token(
+        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs: Any
+    ) -> AccessToken:
         if not self._client:
             raise CredentialUnavailableError(message=self.get_unavailable_message())
-        return super(ManagedIdentityBase, self).get_token(*scopes, **kwargs)
+        return super(ManagedIdentityBase, self).get_token(*scopes, claims=claims, tenant_id=tenant_id, **kwargs)
 
     def _acquire_token_silently(self, *scopes: str, **kwargs: Any) -> Optional[AccessToken]:
         # casting because mypy can't determine that these methods are called

--- a/sdk/identity/azure-identity/azure/identity/_internal/utils.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/utils.py
@@ -5,7 +5,7 @@
 import os
 import logging
 from contextvars import ContextVar
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 from urllib.parse import urlparse
 
@@ -41,6 +41,30 @@ def normalize_authority(authority: str) -> str:
 def get_default_authority() -> str:
     authority = os.environ.get(EnvironmentVariables.AZURE_AUTHORITY_HOST, KnownAuthorities.AZURE_PUBLIC_CLOUD)
     return normalize_authority(authority)
+
+
+def get_token_request_additions(claims: Optional[str], tenant_id: Optional[str]) -> Dict[str, str]:
+    """Return a dictionary that **kwargs can be updated with in a get_token method.
+
+    This method centralizes the logic of pulling keyword-only arguments out of get_token requests so that they're not
+    erroneously sent through to the pipeline if unspecified.
+
+    :param claims: additional claims required in the token, such as those returned in a resource provider's
+        claims challenge following an authorization failure
+    :type claims: str or None
+    :param tenant_id: optional tenant to include in the token request
+    :type tenant_id: str or None
+
+    :return: A dictionary containing each parameter as a key, mapped to its value, if the parameter has a non-None value
+    :rtype: dict
+    """
+
+    additions = {}
+    if claims is not None:
+        additions["claims"] = claims
+    if tenant_id is not None:
+        additions["tenant_id"] = tenant_id
+    return additions
 
 
 VALID_TENANT_ID_CHARACTERS = frozenset("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz" + "0123456789" + "-.")

--- a/sdk/identity/azure-identity/azure/identity/_internal/utils.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/utils.py
@@ -5,7 +5,7 @@
 import os
 import logging
 from contextvars import ContextVar
-from typing import Dict, List, Optional
+from typing import List, Optional
 
 from urllib.parse import urlparse
 

--- a/sdk/identity/azure-identity/azure/identity/_internal/utils.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/utils.py
@@ -43,30 +43,6 @@ def get_default_authority() -> str:
     return normalize_authority(authority)
 
 
-def get_token_request_additions(claims: Optional[str], tenant_id: Optional[str]) -> Dict[str, str]:
-    """Return a dictionary that **kwargs can be updated with in a get_token method.
-
-    This method centralizes the logic of pulling keyword-only arguments out of get_token requests so that they're not
-    erroneously sent through to the pipeline if unspecified.
-
-    :param claims: additional claims required in the token, such as those returned in a resource provider's
-        claims challenge following an authorization failure
-    :type claims: str or None
-    :param tenant_id: optional tenant to include in the token request
-    :type tenant_id: str or None
-
-    :return: A dictionary containing each parameter as a key, mapped to its value, if the parameter has a non-None value
-    :rtype: dict
-    """
-
-    additions = {}
-    if claims is not None:
-        additions["claims"] = claims
-    if tenant_id is not None:
-        additions["tenant_id"] = tenant_id
-    return additions
-
-
 VALID_TENANT_ID_CHARACTERS = frozenset("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz" + "0123456789" + "-.")
 
 

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/application.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/application.py
@@ -63,7 +63,7 @@ class AzureApplicationCredential(ChainedTokenCredential):
         )
 
     async def get_token(
-        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs
+        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs: Any
     ) -> AccessToken:
         """Asynchronously request an access token for `scopes`.
 

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/application.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/application.py
@@ -72,8 +72,8 @@ class AzureApplicationCredential(ChainedTokenCredential):
         :param str scopes: desired scopes for the access token. This method requires at least one scope.
             For more information about scopes, see
             https://learn.microsoft.com/azure/active-directory/develop/scopes-oidc.
-        :keyword str claims: not used by this credential; any value provided will be ignored.
-        :keyword str tenant_id: not used by this credential; any value provided will be ignored.
+        :keyword str claims: not supported by this credential.
+        :keyword str tenant_id: not supported by this credential.
 
         :return: An access token with the desired scopes.
         :rtype: ~azure.core.credentials.AccessToken

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/application.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/application.py
@@ -62,7 +62,9 @@ class AzureApplicationCredential(ChainedTokenCredential):
             ManagedIdentityCredential(client_id=managed_identity_client_id, **kwargs),
         )
 
-    async def get_token(self, *scopes: str, **kwargs: Any) -> AccessToken:
+    async def get_token(
+        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs
+    ) -> AccessToken:
         """Asynchronously request an access token for `scopes`.
 
         This method is called automatically by Azure SDK clients.
@@ -70,6 +72,8 @@ class AzureApplicationCredential(ChainedTokenCredential):
         :param str scopes: desired scopes for the access token. This method requires at least one scope.
             For more information about scopes, see
             https://learn.microsoft.com/azure/active-directory/develop/scopes-oidc.
+        :keyword str claims: not used by this credential; any value provided will be ignored.
+        :keyword str tenant_id: not used by this credential; any value provided will be ignored.
 
         :return: An access token with the desired scopes.
         :rtype: ~azure.core.credentials.AccessToken
@@ -77,10 +81,10 @@ class AzureApplicationCredential(ChainedTokenCredential):
             `message` attribute listing each authentication attempt and its error message.
         """
         if self._successful_credential:
-            token = await self._successful_credential.get_token(*scopes, **kwargs)
+            token = await self._successful_credential.get_token(*scopes, claims=claims, tenant_id=tenant_id, **kwargs)
             _LOGGER.info(
                 "%s acquired a token from %s", self.__class__.__name__, self._successful_credential.__class__.__name__
             )
             return token
 
-        return await super().get_token(*scopes, **kwargs)
+        return await super().get_token(*scopes, claims=claims, tenant_id=tenant_id, **kwargs)

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/application.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/application.py
@@ -72,8 +72,9 @@ class AzureApplicationCredential(ChainedTokenCredential):
         :param str scopes: desired scopes for the access token. This method requires at least one scope.
             For more information about scopes, see
             https://learn.microsoft.com/azure/active-directory/develop/scopes-oidc.
-        :keyword str claims: not supported by this credential.
-        :keyword str tenant_id: not supported by this credential.
+        :keyword str claims: additional claims required in the token, such as those returned in a resource provider's
+            claims challenge following an authorization failure.
+        :keyword str tenant_id: optional tenant to include in the token request.
 
         :return: An access token with the desired scopes.
         :rtype: ~azure.core.credentials.AccessToken

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/authorization_code.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/authorization_code.py
@@ -68,7 +68,9 @@ class AuthorizationCodeCredential(AsyncContextManager, GetTokenMixin):
         self._redirect_uri = redirect_uri
         super().__init__()
 
-    async def get_token(self, *scopes: str, **kwargs: Any) -> AccessToken:
+    async def get_token(
+        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs
+    ) -> AccessToken:
         """Request an access token for `scopes`.
 
         This method is called automatically by Azure SDK clients.
@@ -81,6 +83,7 @@ class AuthorizationCodeCredential(AsyncContextManager, GetTokenMixin):
             For more information about scopes, see
             https://learn.microsoft.com/azure/active-directory/develop/scopes-oidc.
         :keyword str tenant_id: optional tenant to include in the token request.
+        :keyword str claims: not used by this credential; any value provided will be ignored.
 
         :return: An access token with the desired scopes.
         :rtype: ~azure.core.credentials.AccessToken
@@ -88,7 +91,7 @@ class AuthorizationCodeCredential(AsyncContextManager, GetTokenMixin):
           attribute gives a reason. Any error response from Azure Active Directory is available as the error's
           ``response`` attribute.
         """
-        return await super().get_token(*scopes, **kwargs)
+        return await super().get_token(*scopes, claims=claims, tenant_id=tenant_id, **kwargs)
 
     async def _acquire_token_silently(self, *scopes: str, **kwargs: Any) -> Optional[AccessToken]:
         return self._client.get_cached_access_token(scopes, **kwargs)

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/authorization_code.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/authorization_code.py
@@ -82,8 +82,9 @@ class AuthorizationCodeCredential(AsyncContextManager, GetTokenMixin):
         :param str scopes: desired scopes for the access token. This method requires at least one scope.
             For more information about scopes, see
             https://learn.microsoft.com/azure/active-directory/develop/scopes-oidc.
+        :keyword str claims: additional claims required in the token, such as those returned in a resource provider's
+            claims challenge following an authorization failure.
         :keyword str tenant_id: optional tenant to include in the token request.
-        :keyword str claims: not supported by this credential.
 
         :return: An access token with the desired scopes.
         :rtype: ~azure.core.credentials.AccessToken

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/authorization_code.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/authorization_code.py
@@ -83,7 +83,7 @@ class AuthorizationCodeCredential(AsyncContextManager, GetTokenMixin):
             For more information about scopes, see
             https://learn.microsoft.com/azure/active-directory/develop/scopes-oidc.
         :keyword str tenant_id: optional tenant to include in the token request.
-        :keyword str claims: not used by this credential; any value provided will be ignored.
+        :keyword str claims: not supported by this credential.
 
         :return: An access token with the desired scopes.
         :rtype: ~azure.core.credentials.AccessToken

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/authorization_code.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/authorization_code.py
@@ -69,7 +69,7 @@ class AuthorizationCodeCredential(AsyncContextManager, GetTokenMixin):
         super().__init__()
 
     async def get_token(
-        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs
+        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs: Any
     ) -> AccessToken:
         """Request an access token for `scopes`.
 

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/azd_cli.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/azd_cli.py
@@ -6,7 +6,7 @@ import asyncio
 import os
 import shutil
 import sys
-from typing import List, Optional
+from typing import Any, List, Optional
 
 from azure.core.exceptions import ClientAuthenticationError
 from azure.core.credentials import AccessToken
@@ -84,7 +84,7 @@ class AzureDeveloperCliCredential(AsyncContextManager):
         *scopes: str,
         claims: Optional[str] = None,
         tenant_id: Optional[str] = None,
-        **kwargs,  # pylint:disable=unused-argument
+        **kwargs: Any,  # pylint:disable=unused-argument
     ) -> AccessToken:
         """Request an access token for `scopes`.
 

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/azd_cli.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/azd_cli.py
@@ -112,7 +112,6 @@ class AzureDeveloperCliCredential(AsyncContextManager):
             default_tenant=self.tenant_id,
             tenant_id=tenant_id,
             additionally_allowed_tenants=self._additionally_allowed_tenants,
-            claims=claims,
             **kwargs,
         )
 

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/azd_cli.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/azd_cli.py
@@ -80,7 +80,11 @@ class AzureDeveloperCliCredential(AsyncContextManager):
 
     @log_get_token_async
     async def get_token(
-        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs  # pylint:disable=unused-argument
+        self,
+        *scopes: str,
+        claims: Optional[str] = None,
+        tenant_id: Optional[str] = None,
+        **kwargs,  # pylint:disable=unused-argument
     ) -> AccessToken:
         """Request an access token for `scopes`.
 

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/azd_cli.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/azd_cli.py
@@ -80,7 +80,7 @@ class AzureDeveloperCliCredential(AsyncContextManager):
 
     @log_get_token_async
     async def get_token(
-        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs
+        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs  # pylint:disable=unused-argument
     ) -> AccessToken:
         """Request an access token for `scopes`.
 
@@ -91,7 +91,7 @@ class AzureDeveloperCliCredential(AsyncContextManager):
             For more information about scopes, see
             https://learn.microsoft.com/azure/active-directory/develop/scopes-oidc.
         :keyword str tenant_id: optional tenant to include in the token request.
-        :keyword str claims: not supported by this credential.
+        :keyword str claims: not used by this credential; any value provided will be ignored.
 
         :return: An access token with the desired scopes.
         :rtype: ~azure.core.credentials.AccessToken
@@ -101,7 +101,7 @@ class AzureDeveloperCliCredential(AsyncContextManager):
         """
         # only ProactorEventLoop supports subprocesses on Windows (and it isn't the default loop on Python < 3.8)
         if sys.platform.startswith("win") and not isinstance(asyncio.get_event_loop(), asyncio.ProactorEventLoop):
-            return _SyncAzureDeveloperCliCredential().get_token(*scopes, claims=claims, tenant_id=tenant_id, **kwargs)
+            return _SyncAzureDeveloperCliCredential().get_token(*scopes, tenant_id=tenant_id, **kwargs)
 
         if not scopes:
             raise ValueError("Missing scope in request. \n")

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/azd_cli.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/azd_cli.py
@@ -82,9 +82,9 @@ class AzureDeveloperCliCredential(AsyncContextManager):
     async def get_token(
         self,
         *scopes: str,
-        claims: Optional[str] = None,
+        claims: Optional[str] = None,  # pylint:disable=unused-argument
         tenant_id: Optional[str] = None,
-        **kwargs: Any,  # pylint:disable=unused-argument
+        **kwargs: Any,
     ) -> AccessToken:
         """Request an access token for `scopes`.
 

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/azd_cli.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/azd_cli.py
@@ -79,7 +79,9 @@ class AzureDeveloperCliCredential(AsyncContextManager):
         self._process_timeout = process_timeout
 
     @log_get_token_async
-    async def get_token(self, *scopes: str, **kwargs: Any) -> AccessToken:
+    async def get_token(
+        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs
+    ) -> AccessToken:
         """Request an access token for `scopes`.
 
         This method is called automatically by Azure SDK clients. Applications calling this method directly must
@@ -89,6 +91,7 @@ class AzureDeveloperCliCredential(AsyncContextManager):
             For more information about scopes, see
             https://learn.microsoft.com/azure/active-directory/develop/scopes-oidc.
         :keyword str tenant_id: optional tenant to include in the token request.
+        :keyword str claims: not used by this credential; any value provided will be ignored.
 
         :return: An access token with the desired scopes.
         :rtype: ~azure.core.credentials.AccessToken
@@ -98,7 +101,7 @@ class AzureDeveloperCliCredential(AsyncContextManager):
         """
         # only ProactorEventLoop supports subprocesses on Windows (and it isn't the default loop on Python < 3.8)
         if sys.platform.startswith("win") and not isinstance(asyncio.get_event_loop(), asyncio.ProactorEventLoop):
-            return _SyncAzureDeveloperCliCredential().get_token(*scopes, **kwargs)
+            return _SyncAzureDeveloperCliCredential().get_token(*scopes, claims=claims, tenant_id=tenant_id, **kwargs)
 
         if not scopes:
             raise ValueError("Missing scope in request. \n")
@@ -106,7 +109,11 @@ class AzureDeveloperCliCredential(AsyncContextManager):
         commandString = " --scope ".join(scopes)
         command = COMMAND_LINE.format(commandString)
         tenant = resolve_tenant(
-            default_tenant=self.tenant_id, additionally_allowed_tenants=self._additionally_allowed_tenants, **kwargs
+            default_tenant=self.tenant_id,
+            tenant_id=tenant_id,
+            additionally_allowed_tenants=self._additionally_allowed_tenants,
+            claims=claims,
+            **kwargs,
         )
 
         if tenant:

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/azd_cli.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/azd_cli.py
@@ -94,8 +94,8 @@ class AzureDeveloperCliCredential(AsyncContextManager):
         :param str scopes: desired scope for the access token. This credential allows only one scope per request.
             For more information about scopes, see
             https://learn.microsoft.com/azure/active-directory/develop/scopes-oidc.
-        :keyword str tenant_id: optional tenant to include in the token request.
         :keyword str claims: not used by this credential; any value provided will be ignored.
+        :keyword str tenant_id: optional tenant to include in the token request.
 
         :return: An access token with the desired scopes.
         :rtype: ~azure.core.credentials.AccessToken

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/azd_cli.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/azd_cli.py
@@ -6,7 +6,7 @@ import asyncio
 import os
 import shutil
 import sys
-from typing import Any, List, Optional
+from typing import List, Optional
 
 from azure.core.exceptions import ClientAuthenticationError
 from azure.core.credentials import AccessToken

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/azd_cli.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/azd_cli.py
@@ -91,7 +91,7 @@ class AzureDeveloperCliCredential(AsyncContextManager):
             For more information about scopes, see
             https://learn.microsoft.com/azure/active-directory/develop/scopes-oidc.
         :keyword str tenant_id: optional tenant to include in the token request.
-        :keyword str claims: not used by this credential; any value provided will be ignored.
+        :keyword str claims: not supported by this credential.
 
         :return: An access token with the desired scopes.
         :rtype: ~azure.core.credentials.AccessToken

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/azure_cli.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/azure_cli.py
@@ -61,7 +61,11 @@ class AzureCliCredential(AsyncContextManager):
 
     @log_get_token_async
     async def get_token(
-        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs  # pylint:disable=unused-argument
+        self,
+        *scopes: str,
+        claims: Optional[str] = None,
+        tenant_id: Optional[str] = None,
+        **kwargs,  # pylint:disable=unused-argument
     ) -> AccessToken:
         """Request an access token for `scopes`.
 

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/azure_cli.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/azure_cli.py
@@ -6,7 +6,7 @@ import asyncio
 import os
 import shutil
 import sys
-from typing import List, Optional
+from typing import Any, List, Optional
 
 from azure.core.exceptions import ClientAuthenticationError
 from azure.core.credentials import AccessToken
@@ -65,7 +65,7 @@ class AzureCliCredential(AsyncContextManager):
         *scopes: str,
         claims: Optional[str] = None,
         tenant_id: Optional[str] = None,
-        **kwargs,  # pylint:disable=unused-argument
+        **kwargs: Any,  # pylint:disable=unused-argument
     ) -> AccessToken:
         """Request an access token for `scopes`.
 

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/azure_cli.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/azure_cli.py
@@ -72,7 +72,7 @@ class AzureCliCredential(AsyncContextManager):
             For more information about scopes, see
             https://learn.microsoft.com/azure/active-directory/develop/scopes-oidc.
         :keyword str tenant_id: optional tenant to include in the token request.
-        :keyword str claims: not used by this credential; any value provided will be ignored.
+        :keyword str claims: not supported by this credential.
 
         :return: An access token with the desired scopes.
         :rtype: ~azure.core.credentials.AccessToken

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/azure_cli.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/azure_cli.py
@@ -75,8 +75,8 @@ class AzureCliCredential(AsyncContextManager):
         :param str scopes: desired scope for the access token. This credential allows only one scope per request.
             For more information about scopes, see
             https://learn.microsoft.com/azure/active-directory/develop/scopes-oidc.
-        :keyword str tenant_id: optional tenant to include in the token request.
         :keyword str claims: not used by this credential; any value provided will be ignored.
+        :keyword str tenant_id: optional tenant to include in the token request.
 
         :return: An access token with the desired scopes.
         :rtype: ~azure.core.credentials.AccessToken

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/azure_cli.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/azure_cli.py
@@ -6,7 +6,7 @@ import asyncio
 import os
 import shutil
 import sys
-from typing import List, Any, Optional
+from typing import List, Optional
 
 from azure.core.exceptions import ClientAuthenticationError
 from azure.core.credentials import AccessToken

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/azure_cli.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/azure_cli.py
@@ -63,9 +63,9 @@ class AzureCliCredential(AsyncContextManager):
     async def get_token(
         self,
         *scopes: str,
-        claims: Optional[str] = None,
+        claims: Optional[str] = None,  # pylint:disable=unused-argument
         tenant_id: Optional[str] = None,
-        **kwargs: Any,  # pylint:disable=unused-argument
+        **kwargs: Any,
     ) -> AccessToken:
         """Request an access token for `scopes`.
 

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/azure_cli.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/azure_cli.py
@@ -90,7 +90,6 @@ class AzureCliCredential(AsyncContextManager):
             default_tenant=self.tenant_id,
             tenant_id=tenant_id,
             additionally_allowed_tenants=self._additionally_allowed_tenants,
-            claims=claims,
             **kwargs,
         )
 

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/azure_cli.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/azure_cli.py
@@ -61,7 +61,7 @@ class AzureCliCredential(AsyncContextManager):
 
     @log_get_token_async
     async def get_token(
-        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs
+        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs  # pylint:disable=unused-argument
     ) -> AccessToken:
         """Request an access token for `scopes`.
 
@@ -72,7 +72,7 @@ class AzureCliCredential(AsyncContextManager):
             For more information about scopes, see
             https://learn.microsoft.com/azure/active-directory/develop/scopes-oidc.
         :keyword str tenant_id: optional tenant to include in the token request.
-        :keyword str claims: not supported by this credential.
+        :keyword str claims: not used by this credential; any value provided will be ignored.
 
         :return: An access token with the desired scopes.
         :rtype: ~azure.core.credentials.AccessToken
@@ -82,7 +82,7 @@ class AzureCliCredential(AsyncContextManager):
         """
         # only ProactorEventLoop supports subprocesses on Windows (and it isn't the default loop on Python < 3.8)
         if sys.platform.startswith("win") and not isinstance(asyncio.get_event_loop(), asyncio.ProactorEventLoop):
-            return _SyncAzureCliCredential().get_token(*scopes, claims=claims, tenant_id=tenant_id, **kwargs)
+            return _SyncAzureCliCredential().get_token(*scopes, tenant_id=tenant_id, **kwargs)
 
         resource = _scopes_to_resource(*scopes)
         command = COMMAND_LINE.format(resource)

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/azure_powershell.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/azure_powershell.py
@@ -4,7 +4,7 @@
 # ------------------------------------
 import asyncio
 import sys
-from typing import cast, List, Any, Optional
+from typing import cast, List, Optional
 from azure.core.credentials import AccessToken
 
 from .._internal import AsyncContextManager

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/azure_powershell.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/azure_powershell.py
@@ -4,7 +4,7 @@
 # ------------------------------------
 import asyncio
 import sys
-from typing import cast, List, Optional
+from typing import Any, cast, List, Optional
 from azure.core.credentials import AccessToken
 
 from .._internal import AsyncContextManager
@@ -59,7 +59,7 @@ class AzurePowerShellCredential(AsyncContextManager):
         *scopes: str,
         claims: Optional[str] = None,
         tenant_id: Optional[str] = None,
-        **kwargs,  # pylint:disable=unused-argument
+        **kwargs: Any,  # pylint:disable=unused-argument
     ) -> AccessToken:
         """Request an access token for `scopes`.
 

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/azure_powershell.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/azure_powershell.py
@@ -69,8 +69,8 @@ class AzurePowerShellCredential(AsyncContextManager):
         :param str scopes: desired scope for the access token. This credential allows only one scope per request.
             For more information about scopes, see
             https://learn.microsoft.com/azure/active-directory/develop/scopes-oidc.
-        :keyword str tenant_id: optional tenant to include in the token request.
         :keyword str claims: not used by this credential; any value provided will be ignored.
+        :keyword str tenant_id: optional tenant to include in the token request.
 
         :return: An access token with the desired scopes.
         :rtype: ~azure.core.credentials.AccessToken

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/azure_powershell.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/azure_powershell.py
@@ -57,9 +57,9 @@ class AzurePowerShellCredential(AsyncContextManager):
     async def get_token(
         self,
         *scopes: str,
-        claims: Optional[str] = None,
+        claims: Optional[str] = None,  # pylint:disable=unused-argument
         tenant_id: Optional[str] = None,
-        **kwargs: Any,  # pylint:disable=unused-argument
+        **kwargs: Any,
     ) -> AccessToken:
         """Request an access token for `scopes`.
 

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/azure_powershell.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/azure_powershell.py
@@ -55,7 +55,11 @@ class AzurePowerShellCredential(AsyncContextManager):
 
     @log_get_token_async
     async def get_token(
-        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs  # pylint:disable=unused-argument
+        self,
+        *scopes: str,
+        claims: Optional[str] = None,
+        tenant_id: Optional[str] = None,
+        **kwargs,  # pylint:disable=unused-argument
     ) -> AccessToken:
         """Request an access token for `scopes`.
 

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/azure_powershell.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/azure_powershell.py
@@ -55,7 +55,7 @@ class AzurePowerShellCredential(AsyncContextManager):
 
     @log_get_token_async
     async def get_token(
-        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs
+        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs  # pylint:disable=unused-argument
     ) -> AccessToken:
         """Request an access token for `scopes`.
 
@@ -66,7 +66,7 @@ class AzurePowerShellCredential(AsyncContextManager):
             For more information about scopes, see
             https://learn.microsoft.com/azure/active-directory/develop/scopes-oidc.
         :keyword str tenant_id: optional tenant to include in the token request.
-        :keyword str claims: not supported by this credential.
+        :keyword str claims: not used by this credential; any value provided will be ignored.
 
         :return: An access token with the desired scopes.
         :rtype: ~azure.core.credentials.AccessToken
@@ -77,7 +77,7 @@ class AzurePowerShellCredential(AsyncContextManager):
         """
         # only ProactorEventLoop supports subprocesses on Windows (and it isn't the default loop on Python < 3.8)
         if sys.platform.startswith("win") and not isinstance(asyncio.get_event_loop(), asyncio.ProactorEventLoop):
-            return _SyncCredential().get_token(*scopes, claims=claims, tenant_id=tenant_id, **kwargs)
+            return _SyncCredential().get_token(*scopes, tenant_id=tenant_id, **kwargs)
 
         tenant_id = resolve_tenant(
             default_tenant=self.tenant_id,

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/azure_powershell.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/azure_powershell.py
@@ -66,7 +66,7 @@ class AzurePowerShellCredential(AsyncContextManager):
             For more information about scopes, see
             https://learn.microsoft.com/azure/active-directory/develop/scopes-oidc.
         :keyword str tenant_id: optional tenant to include in the token request.
-        :keyword str claims: not used by this credential; any value provided will be ignored.
+        :keyword str claims: not supported by this credential.
 
         :return: An access token with the desired scopes.
         :rtype: ~azure.core.credentials.AccessToken

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/azure_powershell.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/azure_powershell.py
@@ -83,7 +83,6 @@ class AzurePowerShellCredential(AsyncContextManager):
             default_tenant=self.tenant_id,
             tenant_id=tenant_id,
             additionally_allowed_tenants=self._additionally_allowed_tenants,
-            claims=claims,
             **kwargs,
         )
         command_line = get_command_line(scopes, tenant_id)

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/chained.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/chained.py
@@ -63,8 +63,8 @@ class ChainedTokenCredential(AsyncContextManager):
         :param str scopes: desired scopes for the access token. This method requires at least one scope.
             For more information about scopes, see
             https://learn.microsoft.com/azure/active-directory/develop/scopes-oidc.
-        :keyword str claims: not used by this credential; any value provided will be ignored.
-        :keyword str tenant_id: not used by this credential; any value provided will be ignored.
+        :keyword str claims: not supported by this credential.
+        :keyword str tenant_id: not supported by this credential.
 
         :return: An access token with the desired scopes.
         :rtype: ~azure.core.credentials.AccessToken

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/chained.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/chained.py
@@ -4,7 +4,7 @@
 # ------------------------------------
 import asyncio
 import logging
-from typing import Optional, TYPE_CHECKING
+from typing import Any, Optional, TYPE_CHECKING
 
 from azure.core.exceptions import ClientAuthenticationError
 from azure.core.credentials import AccessToken
@@ -51,7 +51,7 @@ class ChainedTokenCredential(AsyncContextManager):
         await asyncio.gather(*(credential.close() for credential in self.credentials))
 
     async def get_token(
-        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs
+        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs: Any
     ) -> AccessToken:
         """Asynchronously request a token from each credential, in order, returning the first token received.
 

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/chained.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/chained.py
@@ -63,8 +63,9 @@ class ChainedTokenCredential(AsyncContextManager):
         :param str scopes: desired scopes for the access token. This method requires at least one scope.
             For more information about scopes, see
             https://learn.microsoft.com/azure/active-directory/develop/scopes-oidc.
-        :keyword str claims: not supported by this credential.
-        :keyword str tenant_id: not supported by this credential.
+        :keyword str claims: additional claims required in the token, such as those returned in a resource provider's
+            claims challenge following an authorization failure.
+        :keyword str tenant_id: optional tenant to include in the token request.
 
         :return: An access token with the desired scopes.
         :rtype: ~azure.core.credentials.AccessToken

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/chained.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/chained.py
@@ -4,7 +4,7 @@
 # ------------------------------------
 import asyncio
 import logging
-from typing import Optional, TYPE_CHECKING, Any
+from typing import Optional, TYPE_CHECKING
 
 from azure.core.exceptions import ClientAuthenticationError
 from azure.core.credentials import AccessToken

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/chained.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/chained.py
@@ -50,7 +50,9 @@ class ChainedTokenCredential(AsyncContextManager):
 
         await asyncio.gather(*(credential.close() for credential in self.credentials))
 
-    async def get_token(self, *scopes: str, **kwargs: Any) -> AccessToken:
+    async def get_token(
+        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs
+    ) -> AccessToken:
         """Asynchronously request a token from each credential, in order, returning the first token received.
 
         If no credential provides a token, raises :class:`azure.core.exceptions.ClientAuthenticationError`
@@ -61,6 +63,8 @@ class ChainedTokenCredential(AsyncContextManager):
         :param str scopes: desired scopes for the access token. This method requires at least one scope.
             For more information about scopes, see
             https://learn.microsoft.com/azure/active-directory/develop/scopes-oidc.
+        :keyword str claims: not used by this credential; any value provided will be ignored.
+        :keyword str tenant_id: not used by this credential; any value provided will be ignored.
 
         :return: An access token with the desired scopes.
         :rtype: ~azure.core.credentials.AccessToken
@@ -70,7 +74,7 @@ class ChainedTokenCredential(AsyncContextManager):
         history = []
         for credential in self.credentials:
             try:
-                token = await credential.get_token(*scopes, **kwargs)
+                token = await credential.get_token(*scopes, claims=claims, tenant_id=tenant_id, **kwargs)
                 _LOGGER.info("%s acquired a token from %s", self.__class__.__name__, credential.__class__.__name__)
                 self._successful_credential = credential
                 return token

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/default.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/default.py
@@ -186,8 +186,9 @@ class DefaultAzureCredential(ChainedTokenCredential):
         :param str scopes: desired scopes for the access token. This method requires at least one scope.
             For more information about scopes, see
             https://learn.microsoft.com/azure/active-directory/develop/scopes-oidc.
+        :keyword str claims: additional claims required in the token, such as those returned in a resource provider's
+            claims challenge following an authorization failure.
         :keyword str tenant_id: optional tenant to include in the token request.
-        :keyword str claims: not supported by this credential.
 
         :return: An access token with the desired scopes.
         :rtype: ~azure.core.credentials.AccessToken

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/default.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/default.py
@@ -4,7 +4,7 @@
 # ------------------------------------
 import logging
 import os
-from typing import List, TYPE_CHECKING, Any, cast
+from typing import List, Optional, TYPE_CHECKING, Any, cast
 
 from azure.core.credentials import AccessToken
 from ..._constants import EnvironmentVariables
@@ -176,7 +176,9 @@ class DefaultAzureCredential(ChainedTokenCredential):
 
         super().__init__(*credentials)
 
-    async def get_token(self, *scopes: str, **kwargs: Any) -> AccessToken:
+    async def get_token(
+        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs
+    ) -> AccessToken:
         """Asynchronously request an access token for `scopes`.
 
         This method is called automatically by Azure SDK clients.
@@ -185,6 +187,7 @@ class DefaultAzureCredential(ChainedTokenCredential):
             For more information about scopes, see
             https://learn.microsoft.com/azure/active-directory/develop/scopes-oidc.
         :keyword str tenant_id: optional tenant to include in the token request.
+        :keyword str claims: not used by this credential; any value provided will be ignored.
 
         :return: An access token with the desired scopes.
         :rtype: ~azure.core.credentials.AccessToken
@@ -192,8 +195,8 @@ class DefaultAzureCredential(ChainedTokenCredential):
           `message` attribute listing each authentication attempt and its error message.
         """
         if self._successful_credential:
-            return await self._successful_credential.get_token(*scopes, **kwargs)
+            return await self._successful_credential.get_token(*scopes, claims=claims, tenant_id=tenant_id, **kwargs)
         within_dac.set(True)
-        token = await super().get_token(*scopes, **kwargs)
+        token = await super().get_token(*scopes, claims=claims, tenant_id=tenant_id, **kwargs)
         within_dac.set(False)
         return token

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/default.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/default.py
@@ -177,7 +177,7 @@ class DefaultAzureCredential(ChainedTokenCredential):
         super().__init__(*credentials)
 
     async def get_token(
-        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs
+        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs: Any
     ) -> AccessToken:
         """Asynchronously request an access token for `scopes`.
 

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/default.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/default.py
@@ -187,7 +187,7 @@ class DefaultAzureCredential(ChainedTokenCredential):
             For more information about scopes, see
             https://learn.microsoft.com/azure/active-directory/develop/scopes-oidc.
         :keyword str tenant_id: optional tenant to include in the token request.
-        :keyword str claims: not used by this credential; any value provided will be ignored.
+        :keyword str claims: not supported by this credential.
 
         :return: An access token with the desired scopes.
         :rtype: ~azure.core.credentials.AccessToken

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/environment.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/environment.py
@@ -103,8 +103,9 @@ class EnvironmentCredential(AsyncContextManager):
         :param str scopes: desired scopes for the access token. This method requires at least one scope.
             For more information about scopes, see
             https://learn.microsoft.com/azure/active-directory/develop/scopes-oidc.
+        :keyword str claims: additional claims required in the token, such as those returned in a resource provider's
+            claims challenge following an authorization failure.
         :keyword str tenant_id: optional tenant to include in the token request.
-        :keyword str claims: not supported by this credential.
 
         :return: An access token with the desired scopes.
         :rtype: ~azure.core.credentials.AccessToken

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/environment.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/environment.py
@@ -94,7 +94,7 @@ class EnvironmentCredential(AsyncContextManager):
 
     @log_get_token_async
     async def get_token(
-        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs
+        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs: Any
     ) -> AccessToken:
         """Asynchronously request an access token for `scopes`.
 

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/environment.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/environment.py
@@ -104,7 +104,7 @@ class EnvironmentCredential(AsyncContextManager):
             For more information about scopes, see
             https://learn.microsoft.com/azure/active-directory/develop/scopes-oidc.
         :keyword str tenant_id: optional tenant to include in the token request.
-        :keyword str claims: not used by this credential; any value provided will be ignored.
+        :keyword str claims: not supported by this credential.
 
         :return: An access token with the desired scopes.
         :rtype: ~azure.core.credentials.AccessToken

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/environment.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/environment.py
@@ -93,7 +93,9 @@ class EnvironmentCredential(AsyncContextManager):
             await self._credential.__aexit__()
 
     @log_get_token_async
-    async def get_token(self, *scopes: str, **kwargs: Any) -> AccessToken:
+    async def get_token(
+        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs
+    ) -> AccessToken:
         """Asynchronously request an access token for `scopes`.
 
         This method is called automatically by Azure SDK clients.
@@ -102,6 +104,7 @@ class EnvironmentCredential(AsyncContextManager):
             For more information about scopes, see
             https://learn.microsoft.com/azure/active-directory/develop/scopes-oidc.
         :keyword str tenant_id: optional tenant to include in the token request.
+        :keyword str claims: not used by this credential; any value provided will be ignored.
 
         :return: An access token with the desired scopes.
         :rtype: ~azure.core.credentials.AccessToken
@@ -114,4 +117,4 @@ class EnvironmentCredential(AsyncContextManager):
                 "this issue."
             )
             raise CredentialUnavailableError(message=message)
-        return await self._credential.get_token(*scopes, **kwargs)
+        return await self._credential.get_token(*scopes, claims=claims, tenant_id=tenant_id, **kwargs)

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/managed_identity.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/managed_identity.py
@@ -124,8 +124,8 @@ class ManagedIdentityCredential(AsyncContextManager):
         :param str scopes: desired scope for the access token. This credential allows only one scope per request.
             For more information about scopes, see
             https://learn.microsoft.com/azure/active-directory/develop/scopes-oidc.
-        :keyword str claims: not supported by this credential.
-        :keyword str tenant_id: not supported by this credential.
+        :keyword str claims: not used by this credential; any value provided will be ignored.
+        :keyword str tenant_id: not used by this credential; any value provided will be ignored.
 
         :return: An access token with the desired scopes.
         :rtype: ~azure.core.credentials.AccessToken

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/managed_identity.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/managed_identity.py
@@ -124,8 +124,8 @@ class ManagedIdentityCredential(AsyncContextManager):
         :param str scopes: desired scope for the access token. This credential allows only one scope per request.
             For more information about scopes, see
             https://learn.microsoft.com/azure/active-directory/develop/scopes-oidc.
-        :keyword str claims: not used by this credential; any value provided will be ignored.
-        :keyword str tenant_id: not used by this credential; any value provided will be ignored.
+        :keyword str claims: not supported by this credential.
+        :keyword str tenant_id: not supported by this credential.
 
         :return: An access token with the desired scopes.
         :rtype: ~azure.core.credentials.AccessToken

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/managed_identity.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/managed_identity.py
@@ -114,7 +114,9 @@ class ManagedIdentityCredential(AsyncContextManager):
             await self._credential.close()
 
     @log_get_token_async
-    async def get_token(self, *scopes: str, **kwargs: Any) -> AccessToken:
+    async def get_token(
+        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs
+    ) -> AccessToken:
         """Asynchronously request an access token for `scopes`.
 
         This method is called automatically by Azure SDK clients.
@@ -122,6 +124,8 @@ class ManagedIdentityCredential(AsyncContextManager):
         :param str scopes: desired scope for the access token. This credential allows only one scope per request.
             For more information about scopes, see
             https://learn.microsoft.com/azure/active-directory/develop/scopes-oidc.
+        :keyword str claims: not used by this credential; any value provided will be ignored.
+        :keyword str tenant_id: not used by this credential; any value provided will be ignored.
 
         :return: An access token with the desired scopes.
         :rtype: ~azure.core.credentials.AccessToken
@@ -134,4 +138,4 @@ class ManagedIdentityCredential(AsyncContextManager):
                 "Visit https://aka.ms/azsdk/python/identity/managedidentitycredential/troubleshoot to "
                 "troubleshoot this issue."
             )
-        return await self._credential.get_token(*scopes, **kwargs)
+        return await self._credential.get_token(*scopes, claims=claims, tenant_id=tenant_id, **kwargs)

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/managed_identity.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/managed_identity.py
@@ -115,7 +115,7 @@ class ManagedIdentityCredential(AsyncContextManager):
 
     @log_get_token_async
     async def get_token(
-        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs
+        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs: Any
     ) -> AccessToken:
         """Asynchronously request an access token for `scopes`.
 

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/shared_cache.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/shared_cache.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
-from typing import Any
+from typing import Any, Optional
 from azure.core.credentials import AccessToken
 from ..._internal.aad_client import AadClientBase
 from ... import CredentialUnavailableError
@@ -42,7 +42,9 @@ class SharedTokenCacheCredential(SharedTokenCacheBase, AsyncContextManager):
             await self._client.__aexit__()  # type: ignore
 
     @log_get_token_async
-    async def get_token(self, *scopes: str, **kwargs: Any) -> AccessToken:  # pylint:disable=unused-argument
+    async def get_token(
+        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs
+    ) -> AccessToken:
         """Get an access token for `scopes` from the shared cache.
 
         If no access token is cached, attempt to acquire one using a cached refresh token.
@@ -53,8 +55,10 @@ class SharedTokenCacheCredential(SharedTokenCacheBase, AsyncContextManager):
             For more information about scopes, see
             https://learn.microsoft.com/azure/active-directory/develop/scopes-oidc.
         :keyword str tenant_id: optional tenant to include in the token request.
+        :keyword str claims: not used by this credential; any value provided will be ignored.
         :keyword bool enable_cae: indicates whether to enable Continuous Access Evaluation (CAE) for the requested
             token. Defaults to False.
+
         :return: An access token with the desired scopes.
         :rtype: ~azure.core.credentials.AccessToken
         :raises ~azure.identity.CredentialUnavailableError: the cache is unavailable or contains insufficient user
@@ -88,7 +92,9 @@ class SharedTokenCacheCredential(SharedTokenCacheBase, AsyncContextManager):
 
         # try each refresh token, returning the first access token acquired
         for refresh_token in self._get_refresh_tokens(account, is_cae=is_cae):
-            token = await self._client.obtain_token_by_refresh_token(scopes, refresh_token, **kwargs)
+            token = await self._client.obtain_token_by_refresh_token(
+                scopes, refresh_token, claims=claims, tenant_id=tenant_id, **kwargs
+            )
             return token
 
         raise CredentialUnavailableError(message=NO_TOKEN.format(account.get("username")))

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/shared_cache.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/shared_cache.py
@@ -55,7 +55,7 @@ class SharedTokenCacheCredential(SharedTokenCacheBase, AsyncContextManager):
             For more information about scopes, see
             https://learn.microsoft.com/azure/active-directory/develop/scopes-oidc.
         :keyword str tenant_id: optional tenant to include in the token request.
-        :keyword str claims: not used by this credential; any value provided will be ignored.
+        :keyword str claims: not supported by this credential.
         :keyword bool enable_cae: indicates whether to enable Continuous Access Evaluation (CAE) for the requested
             token. Defaults to False.
 

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/shared_cache.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/shared_cache.py
@@ -43,7 +43,7 @@ class SharedTokenCacheCredential(SharedTokenCacheBase, AsyncContextManager):
 
     @log_get_token_async
     async def get_token(
-        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs
+        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs: Any
     ) -> AccessToken:
         """Get an access token for `scopes` from the shared cache.
 

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/shared_cache.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/shared_cache.py
@@ -54,8 +54,9 @@ class SharedTokenCacheCredential(SharedTokenCacheBase, AsyncContextManager):
         :param str scopes: desired scopes for the access token. This method requires at least one scope.
             For more information about scopes, see
             https://learn.microsoft.com/azure/active-directory/develop/scopes-oidc.
+        :keyword str claims: additional claims required in the token, such as those returned in a resource provider's
+            claims challenge following an authorization failure.
         :keyword str tenant_id: optional tenant to include in the token request.
-        :keyword str claims: not supported by this credential.
         :keyword bool enable_cae: indicates whether to enable Continuous Access Evaluation (CAE) for the requested
             token. Defaults to False.
 

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/vscode.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/vscode.py
@@ -58,7 +58,7 @@ class VisualStudioCodeCredential(_VSCodeCredentialBase, AsyncContextManager, Get
             For more information about scopes, see
             https://learn.microsoft.com/azure/active-directory/develop/scopes-oidc.
         :keyword str tenant_id: optional tenant to include in the token request.
-        :keyword str claims: not used by this credential; any value provided will be ignored.
+        :keyword str claims: not supported by this credential.
 
         :return: An access token with the desired scopes.
         :rtype: ~azure.core.credentials.AccessToken

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/vscode.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/vscode.py
@@ -47,7 +47,9 @@ class VisualStudioCodeCredential(_VSCodeCredentialBase, AsyncContextManager, Get
             await self._client.__aexit__()
 
     @log_get_token_async
-    async def get_token(self, *scopes: str, **kwargs: Any) -> AccessToken:
+    async def get_token(
+        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs
+    ) -> AccessToken:
         """Request an access token for `scopes` as the user currently signed in to Visual Studio Code.
 
         This method is called automatically by Azure SDK clients.
@@ -56,6 +58,7 @@ class VisualStudioCodeCredential(_VSCodeCredentialBase, AsyncContextManager, Get
             For more information about scopes, see
             https://learn.microsoft.com/azure/active-directory/develop/scopes-oidc.
         :keyword str tenant_id: optional tenant to include in the token request.
+        :keyword str claims: not used by this credential; any value provided will be ignored.
 
         :return: An access token with the desired scopes.
         :rtype: ~azure.core.credentials.AccessToken
@@ -73,11 +76,11 @@ class VisualStudioCodeCredential(_VSCodeCredentialBase, AsyncContextManager, Get
             raise CredentialUnavailableError("Initialization failed")
         if within_dac.get():
             try:
-                token = await super().get_token(*scopes, **kwargs)
+                token = await super().get_token(*scopes, claims=claims, tenant_id=tenant_id, **kwargs)
                 return token
             except ClientAuthenticationError as ex:
                 raise CredentialUnavailableError(message=ex.message) from ex
-        return await super().get_token(*scopes, **kwargs)
+        return await super().get_token(*scopes, claims=claims, tenant_id=tenant_id, **kwargs)
 
     async def _acquire_token_silently(self, *scopes: str, **kwargs: Any) -> Optional[AccessToken]:
         self._client = cast(AadClient, self._client)

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/vscode.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/vscode.py
@@ -48,7 +48,7 @@ class VisualStudioCodeCredential(_VSCodeCredentialBase, AsyncContextManager, Get
 
     @log_get_token_async
     async def get_token(
-        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs
+        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs: Any
     ) -> AccessToken:
         """Request an access token for `scopes` as the user currently signed in to Visual Studio Code.
 

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/vscode.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/vscode.py
@@ -57,8 +57,9 @@ class VisualStudioCodeCredential(_VSCodeCredentialBase, AsyncContextManager, Get
         :param str scopes: desired scopes for the access token. This method requires at least one scope.
             For more information about scopes, see
             https://learn.microsoft.com/azure/active-directory/develop/scopes-oidc.
+        :keyword str claims: additional claims required in the token, such as those returned in a resource provider's
+            claims challenge following an authorization failure.
         :keyword str tenant_id: optional tenant to include in the token request.
-        :keyword str claims: not supported by this credential.
 
         :return: An access token with the desired scopes.
         :rtype: ~azure.core.credentials.AccessToken

--- a/sdk/identity/azure-identity/azure/identity/aio/_internal/get_token_mixin.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_internal/get_token_mixin.py
@@ -5,7 +5,7 @@
 import abc
 import logging
 import time
-from typing import Optional
+from typing import Any, Optional
 
 from azure.core.credentials import AccessToken
 from ..._constants import DEFAULT_REFRESH_OFFSET, DEFAULT_TOKEN_REFRESH_RETRY_DELAY
@@ -54,7 +54,7 @@ class GetTokenMixin(abc.ABC):
         return True
 
     async def get_token(
-        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs
+        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs: Any
     ) -> AccessToken:
         """Request an access token for `scopes`.
 

--- a/sdk/identity/azure-identity/azure/identity/aio/_internal/get_token_mixin.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_internal/get_token_mixin.py
@@ -63,8 +63,9 @@ class GetTokenMixin(abc.ABC):
         :param str scopes: desired scopes for the access token. This method requires at least one scope.
             For more information about scopes, see
             https://learn.microsoft.com/azure/active-directory/develop/scopes-oidc.
+        :keyword str claims: additional claims required in the token, such as those returned in a resource provider's
+            claims challenge following an authorization failure.
         :keyword str tenant_id: optional tenant to include in the token request.
-        :keyword str claims: not supported by this credential.
         :keyword bool enable_cae: indicates whether to enable Continuous Access Evaluation (CAE) for the requested
             token. Defaults to False.
 

--- a/sdk/identity/azure-identity/azure/identity/aio/_internal/get_token_mixin.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_internal/get_token_mixin.py
@@ -53,7 +53,9 @@ class GetTokenMixin(abc.ABC):
             return False
         return True
 
-    async def get_token(self, *scopes: str, **kwargs) -> AccessToken:
+    async def get_token(
+        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs
+    ) -> AccessToken:
         """Request an access token for `scopes`.
 
         This method is called automatically by Azure SDK clients.
@@ -62,8 +64,10 @@ class GetTokenMixin(abc.ABC):
             For more information about scopes, see
             https://learn.microsoft.com/azure/active-directory/develop/scopes-oidc.
         :keyword str tenant_id: optional tenant to include in the token request.
+        :keyword str claims: not used by this credential; any value provided will be ignored.
         :keyword bool enable_cae: indicates whether to enable Continuous Access Evaluation (CAE) for the requested
             token. Defaults to False.
+
         :return: An access token with the desired scopes.
         :rtype: ~azure.core.credentials.AccessToken
         :raises CredentialUnavailableError: the credential is unable to attempt authentication because it lacks

--- a/sdk/identity/azure-identity/azure/identity/aio/_internal/get_token_mixin.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_internal/get_token_mixin.py
@@ -64,7 +64,7 @@ class GetTokenMixin(abc.ABC):
             For more information about scopes, see
             https://learn.microsoft.com/azure/active-directory/develop/scopes-oidc.
         :keyword str tenant_id: optional tenant to include in the token request.
-        :keyword str claims: not used by this credential; any value provided will be ignored.
+        :keyword str claims: not supported by this credential.
         :keyword bool enable_cae: indicates whether to enable Continuous Access Evaluation (CAE) for the requested
             token. Defaults to False.
 

--- a/sdk/identity/azure-identity/azure/identity/aio/_internal/get_token_mixin.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_internal/get_token_mixin.py
@@ -79,14 +79,14 @@ class GetTokenMixin(abc.ABC):
             raise ValueError('"get_token" requires at least one scope')
 
         try:
-            token = await self._acquire_token_silently(*scopes, **kwargs)
+            token = await self._acquire_token_silently(*scopes, claims=claims, tenant_id=tenant_id, **kwargs)
             if not token:
                 self._last_request_time = int(time.time())
-                token = await self._request_token(*scopes, **kwargs)
+                token = await self._request_token(*scopes, claims=claims, tenant_id=tenant_id, **kwargs)
             elif self._should_refresh(token):
                 try:
                     self._last_request_time = int(time.time())
-                    token = await self._request_token(*scopes, **kwargs)
+                    token = await self._request_token(*scopes, claims=claims, tenant_id=tenant_id, **kwargs)
                 except Exception:  # pylint:disable=broad-except
                     pass
             _LOGGER.log(

--- a/sdk/identity/azure-identity/azure/identity/aio/_internal/managed_identity_base.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_internal/managed_identity_base.py
@@ -39,10 +39,12 @@ class AsyncManagedIdentityBase(AsyncContextManager, GetTokenMixin):
     async def close(self) -> None:
         await self.__aexit__()
 
-    async def get_token(self, *scopes: str, **kwargs) -> AccessToken:
+    async def get_token(
+        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs
+    ) -> AccessToken:
         if not self._client:
             raise CredentialUnavailableError(message=self.get_unavailable_message())
-        return await super().get_token(*scopes, **kwargs)
+        return await super().get_token(*scopes, claims=claims, tenant_id=tenant_id, **kwargs)
 
     async def _acquire_token_silently(self, *scopes: str, **kwargs) -> Optional[AccessToken]:
         # casting because mypy can't determine that these methods are called

--- a/sdk/identity/azure-identity/azure/identity/aio/_internal/managed_identity_base.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_internal/managed_identity_base.py
@@ -3,7 +3,7 @@
 # Licensed under the MIT License.
 # ------------------------------------
 import abc
-from typing import cast, Optional
+from typing import Any, cast, Optional
 
 from azure.core.credentials import AccessToken
 from . import AsyncContextManager
@@ -40,7 +40,7 @@ class AsyncManagedIdentityBase(AsyncContextManager, GetTokenMixin):
         await self.__aexit__()
 
     async def get_token(
-        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs
+        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs: Any
     ) -> AccessToken:
         if not self._client:
             raise CredentialUnavailableError(message=self.get_unavailable_message())

--- a/sdk/identity/azure-identity/samples/custom_credentials.py
+++ b/sdk/identity/azure-identity/samples/custom_credentials.py
@@ -5,34 +5,31 @@
 """Demonstrates custom credential implementations using existing access tokens and an MSAL client"""
 
 import time
-from typing import TYPE_CHECKING
+from typing import Optional, Union
 
 from azure.core.credentials import AccessToken
 from azure.identity import AuthenticationRequiredError, AzureAuthorityHosts
 import msal
 
-if TYPE_CHECKING:
-    from typing import Any, Union
-
 
 class StaticTokenCredential(object):
-    """Authenticates with a previously acquired access token
+    """Authenticates with a previously-acquired access token
 
     Note that an access token is valid only for certain resources and eventually expires. This credential is therefore
     quite limited. An application using it must ensure the token is valid and contains all claims required by any
     service client given an instance of this credential.
     """
 
-    def __init__(self, access_token):
-        # type: (Union[str, AccessToken]) -> None
+    def __init__(self, access_token: Union[str, AccessToken]) -> None:
         if isinstance(access_token, AccessToken):
             self._token = access_token
         else:
             # setting expires_on in the past causes Azure SDK clients to call get_token every time they need a token
             self._token = AccessToken(token=access_token, expires_on=0)
 
-    def get_token(self, *scopes, **kwargs):
-        # type: (*str, **Any) -> AccessToken
+    def get_token(
+        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs
+    ) -> AccessToken:
         """get_token is the only method a credential must implement"""
 
         return self._token
@@ -41,18 +38,18 @@ class StaticTokenCredential(object):
 class MsalTokenCredential(object):
     """Uses an MSAL client directly to obtain access tokens with an interactive flow."""
 
-    def __init__(self, tenant_id, client_id):
-        # type: (str, str) -> None
+    def __init__(self, tenant_id: str, client_id: str) -> None:
         self._app = msal.PublicClientApplication(
             client_id=client_id, authority="https://{}/{}".format(AzureAuthorityHosts.AZURE_PUBLIC_CLOUD, tenant_id)
         )
 
-    def get_token(self, *scopes, **kwargs):
-        # type: (*str, **Any) -> AccessToken
+    def get_token(
+        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs
+    ) -> AccessToken:
         """get_token is the only method a credential must implement"""
 
         now = int(time.time())
-        result = self._app.acquire_token_interactive(list(scopes), **kwargs)
+        result = self._app.acquire_token_interactive(list(scopes), claims=claims, tenant_id=tenant_id, **kwargs)
 
         try:
             return AccessToken(result["access_token"], now + int(result["expires_in"]))

--- a/sdk/identity/azure-identity/tests/test_application_credential.py
+++ b/sdk/identity/azure-identity/tests/test_application_credential.py
@@ -22,7 +22,10 @@ from helpers import build_aad_response, get_discovery_response, mock_response
 def test_get_token():
     expected_token = "***"
 
-    def send(request, **_):
+    def send(request, **kwargs):
+        # ensure the `claims` and `tenant_id` keywords from credential's `get_token` method don't make it to transport
+        assert "claims" not in kwargs
+        assert "tenant_id" not in kwargs
         parsed = urlparse(request.url)
         tenant_id = parsed.path.split("/")[1]
         if "/oauth2/v2.0/token" in request.url:

--- a/sdk/identity/azure-identity/tests/test_application_credential_async.py
+++ b/sdk/identity/azure-identity/tests/test_application_credential_async.py
@@ -79,7 +79,10 @@ def test_authority(authority):
 async def test_get_token():
     expected_token = "***"
 
-    async def send(request, **_):
+    async def send(request, **kwargs):
+        # ensure the `claims` and `tenant_id` keywords from credential's `get_token` method don't make it to transport
+        assert "claims" not in kwargs
+        assert "tenant_id" not in kwargs
         return mock_response(json_payload=build_aad_response(access_token=expected_token))
 
     with patch.dict("os.environ", {var: "..." for var in EnvironmentVariables.CLIENT_SECRET_VARS}, clear=True):

--- a/sdk/identity/azure-identity/tests/test_auth_code.py
+++ b/sdk/identity/azure-identity/tests/test_auth_code.py
@@ -30,7 +30,10 @@ def test_no_scopes():
 def test_policies_configurable():
     policy = Mock(spec_set=SansIOHTTPPolicy, on_request=Mock())
 
-    def send(*_, **__):
+    def send(*_, **kwargs):
+        # ensure the `claims` and `tenant_id` keywords from credential's `get_token` method don't make it to transport
+        assert "claims" not in kwargs
+        assert "tenant_id" not in kwargs
         return mock_response(json_payload=build_aad_response(access_token="**"))
 
     credential = AuthorizationCodeCredential(
@@ -142,7 +145,10 @@ def test_multitenant_authentication():
     second_tenant = "second-tenant"
     second_token = first_token * 2
 
-    def send(request, **_):
+    def send(request, **kwargs):
+        # ensure the `claims` and `tenant_id` keywords from credential's `get_token` method don't make it to transport
+        assert "claims" not in kwargs
+        assert "tenant_id" not in kwargs
         parsed = urlparse(request.url)
         tenant = parsed.path.split("/")[1]
         assert tenant in (first_tenant, second_tenant), 'unexpected tenant "{}"'.format(tenant)
@@ -175,7 +181,10 @@ def test_multitenant_authentication_not_allowed():
     expected_tenant = "expected-tenant"
     expected_token = "***"
 
-    def send(request, **_):
+    def send(request, **kwargs):
+        # ensure the `claims` and `tenant_id` keywords from credential's `get_token` method don't make it to transport
+        assert "claims" not in kwargs
+        assert "tenant_id" not in kwargs
         parsed = urlparse(request.url)
         tenant = parsed.path.split("/")[1]
         token = expected_token if tenant == expected_tenant else expected_token * 2

--- a/sdk/identity/azure-identity/tests/test_auth_code_async.py
+++ b/sdk/identity/azure-identity/tests/test_auth_code_async.py
@@ -30,7 +30,10 @@ async def test_no_scopes():
 async def test_policies_configurable():
     policy = Mock(spec_set=SansIOHTTPPolicy, on_request=Mock())
 
-    async def send(*_, **__):
+    async def send(*_, **kwargs):
+        # ensure the `claims` and `tenant_id` keywords from credential's `get_token` method don't make it to transport
+        assert "claims" not in kwargs
+        assert "tenant_id" not in kwargs
         return mock_response(json_payload=build_aad_response(access_token="**"))
 
     credential = AuthorizationCodeCredential(
@@ -166,7 +169,10 @@ async def test_multitenant_authentication():
     second_tenant = "second-tenant"
     second_token = first_token * 2
 
-    async def send(request, **_):
+    async def send(request, **kwargs):
+        # ensure the `claims` and `tenant_id` keywords from credential's `get_token` method don't make it to transport
+        assert "claims" not in kwargs
+        assert "tenant_id" not in kwargs
         parsed = urlparse(request.url)
         tenant = parsed.path.split("/")[1]
         assert tenant in (first_tenant, second_tenant), 'unexpected tenant "{}"'.format(tenant)
@@ -199,7 +205,10 @@ async def test_multitenant_authentication_not_allowed():
     expected_tenant = "expected-tenant"
     expected_token = "***"
 
-    async def send(request, **_):
+    async def send(request, **kwargs):
+        # ensure the `claims` and `tenant_id` keywords from credential's `get_token` method don't make it to transport
+        assert "claims" not in kwargs
+        assert "tenant_id" not in kwargs
         parsed = urlparse(request.url)
         tenant = parsed.path.split("/")[1]
         token = expected_token if tenant == expected_tenant else expected_token * 2

--- a/sdk/identity/azure-identity/tests/test_certificate_credential.py
+++ b/sdk/identity/azure-identity/tests/test_certificate_credential.py
@@ -299,7 +299,10 @@ def test_token_cache_persistent(cert_path, cert_password):
 
     access_token = "foo token"
 
-    def send(request, **_):
+    def send(request, **kwargs):
+        # ensure the `claims` and `tenant_id` keywords from credential's `get_token` method don't make it to transport
+        assert "claims" not in kwargs
+        assert "tenant_id" not in kwargs
         parsed = urlparse(request.url)
         tenant = parsed.path.split("/")[1]
         if "/oauth2/v2.0/token" not in parsed.path:
@@ -337,7 +340,10 @@ def test_token_cache_memory(cert_path, cert_password):
     """The credential should default to in-memory cache if no persistence options are provided."""
     access_token = "foo token"
 
-    def send(request, **_):
+    def send(request, **kwargs):
+        # ensure the `claims` and `tenant_id` keywords from credential's `get_token` method don't make it to transport
+        assert "claims" not in kwargs
+        assert "tenant_id" not in kwargs
         parsed = urlparse(request.url)
         tenant = parsed.path.split("/")[1]
         if "/oauth2/v2.0/token" not in parsed.path:
@@ -427,7 +433,10 @@ def test_multitenant_authentication(cert_path, cert_password):
     second_tenant = "second-tenant"
     second_token = first_token * 2
 
-    def send(request, **_):
+    def send(request, **kwargs):
+        # ensure the `claims` and `tenant_id` keywords from credential's `get_token` method don't make it to transport
+        assert "claims" not in kwargs
+        assert "tenant_id" not in kwargs
         parsed = urlparse(request.url)
         tenant = parsed.path.split("/")[1]
         assert tenant in (first_tenant, second_tenant, "common"), 'unexpected tenant "{}"'.format(tenant)
@@ -464,7 +473,10 @@ def test_multitenant_authentication_backcompat(cert_path, cert_password):
     expected_tenant = "expected-tenant"
     expected_token = "***"
 
-    def send(request, **_):
+    def send(request, **kwargs):
+        # ensure the `claims` and `tenant_id` keywords from credential's `get_token` method don't make it to transport
+        assert "claims" not in kwargs
+        assert "tenant_id" not in kwargs
         parsed = urlparse(request.url)
         if "/oauth2/v2.0/token" not in parsed.path:
             return get_discovery_response("https://{}/{}".format(parsed.netloc, expected_tenant))

--- a/sdk/identity/azure-identity/tests/test_certificate_credential_async.py
+++ b/sdk/identity/azure-identity/tests/test_certificate_credential_async.py
@@ -76,7 +76,10 @@ async def test_context_manager():
 async def test_policies_configurable():
     policy = Mock(spec_set=SansIOHTTPPolicy, on_request=Mock())
 
-    async def send(*_, **__):
+    async def send(*_, **kwargs):
+        # ensure the `claims` and `tenant_id` keywords from credential's `get_token` method don't make it to transport
+        assert "claims" not in kwargs
+        assert "tenant_id" not in kwargs
         return mock_response(json_payload=build_aad_response(access_token="**"))
 
     credential = CertificateCredential(
@@ -351,7 +354,10 @@ async def test_multitenant_authentication(cert_path, cert_password):
     second_tenant = "second-tenant"
     second_token = first_token * 2
 
-    async def send(request, **_):
+    async def send(request, **kwargs):
+        # ensure the `claims` and `tenant_id` keywords from credential's `get_token` method don't make it to transport
+        assert "claims" not in kwargs
+        assert "tenant_id" not in kwargs
         parsed = urlparse(request.url)
         tenant = parsed.path.split("/")[1]
         assert tenant in (first_tenant, second_tenant), 'unexpected tenant "{}"'.format(tenant)
@@ -386,7 +392,10 @@ async def test_multitenant_authentication_backcompat(cert_path, cert_password):
     expected_tenant = "expected-tenant"
     expected_token = "***"
 
-    async def send(request, **_):
+    async def send(request, **kwargs):
+        # ensure the `claims` and `tenant_id` keywords from credential's `get_token` method don't make it to transport
+        assert "claims" not in kwargs
+        assert "tenant_id" not in kwargs
         parsed = urlparse(request.url)
         tenant = parsed.path.split("/")[1]
         token = expected_token if tenant == expected_tenant else expected_token * 2

--- a/sdk/identity/azure-identity/tests/test_chained_credential.py
+++ b/sdk/identity/azure-identity/tests/test_chained_credential.py
@@ -102,7 +102,7 @@ def test_raises_for_unexpected_error():
 
 def test_returns_first_token():
     expected_token = Mock()
-    first_credential = Mock(get_token=lambda _: expected_token)
+    first_credential = Mock(get_token=lambda _, **__: expected_token)
     second_credential = Mock(get_token=Mock())
 
     aggregate = ChainedTokenCredential(first_credential, second_credential)

--- a/sdk/identity/azure-identity/tests/test_client_secret_credential.py
+++ b/sdk/identity/azure-identity/tests/test_client_secret_credential.py
@@ -153,7 +153,10 @@ def test_token_cache_persistent():
 
     access_token = "foo token"
 
-    def send(request, **_):
+    def send(request, **kwargs):
+        # ensure the `claims` and `tenant_id` keywords from credential's `get_token` method don't make it to transport
+        assert "claims" not in kwargs
+        assert "tenant_id" not in kwargs
         parsed = urlparse(request.url)
         tenant = parsed.path.split("/")[1]
         if "/oauth2/v2.0/token" not in parsed.path:
@@ -188,7 +191,10 @@ def test_token_cache_memory():
     """The credential should default to in-memory cache if no persistence options are provided."""
     access_token = "foo token"
 
-    def send(request, **_):
+    def send(request, **kwargs):
+        # ensure the `claims` and `tenant_id` keywords from credential's `get_token` method don't make it to transport
+        assert "claims" not in kwargs
+        assert "tenant_id" not in kwargs
         parsed = urlparse(request.url)
         tenant = parsed.path.split("/")[1]
         if "/oauth2/v2.0/token" not in parsed.path:
@@ -264,7 +270,9 @@ def test_multitenant_authentication():
     second_token = first_token * 2
 
     def send(request, **kwargs):
-        assert "tenant_id" not in kwargs, "tenant_id kwarg shouldn't get passed to send method"
+        # ensure the `claims` and `tenant_id` keywords from credential's `get_token` method don't make it to transport
+        assert "claims" not in kwargs
+        assert "tenant_id" not in kwargs
 
         parsed = urlparse(request.url)
         tenant = parsed.path.split("/")[1]
@@ -310,7 +318,10 @@ def test_multitenant_authentication_not_allowed():
     expected_tenant = "expected-tenant"
     expected_token = "***"
 
-    def send(request, **_):
+    def send(request, **kwargs):
+        # ensure the `claims` and `tenant_id` keywords from credential's `get_token` method don't make it to transport
+        assert "claims" not in kwargs
+        assert "tenant_id" not in kwargs
         parsed = urlparse(request.url)
         if "/oauth2/v2.0/token" not in parsed.path:
             return get_discovery_response("https://{}/{}".format(parsed.netloc, expected_tenant))

--- a/sdk/identity/azure-identity/tests/test_client_secret_credential_async.py
+++ b/sdk/identity/azure-identity/tests/test_client_secret_credential_async.py
@@ -67,7 +67,10 @@ async def test_context_manager():
 async def test_policies_configurable():
     policy = Mock(spec_set=SansIOHTTPPolicy, on_request=Mock())
 
-    async def send(*_, **__):
+    async def send(*_, **kwargs):
+        # ensure the `claims` and `tenant_id` keywords from credential's `get_token` method don't make it to transport
+        assert "claims" not in kwargs
+        assert "tenant_id" not in kwargs
         return mock_response(json_payload=build_aad_response(access_token="**"))
 
     credential = ClientSecretCredential(
@@ -312,7 +315,9 @@ async def test_multitenant_authentication():
     second_token = first_token * 2
 
     async def send(request, **kwargs):
-        assert "tenant_id" not in kwargs, "tenant_id kwarg shouldn't get passed to send method"
+        # ensure the `claims` and `tenant_id` keywords from credential's `get_token` method don't make it to transport
+        assert "claims" not in kwargs
+        assert "tenant_id" not in kwargs
 
         parsed = urlparse(request.url)
         tenant = parsed.path.split("/")[1]
@@ -360,7 +365,10 @@ async def test_multitenant_authentication_not_allowed():
     expected_tenant = "expected-tenant"
     expected_token = "***"
 
-    async def send(request, **_):
+    async def send(request, **kwargs):
+        # ensure the `claims` and `tenant_id` keywords from credential's `get_token` method don't make it to transport
+        assert "claims" not in kwargs
+        assert "tenant_id" not in kwargs
         parsed = urlparse(request.url)
         tenant = parsed.path.split("/")[1]
         token = expected_token if tenant == expected_tenant else expected_token * 2

--- a/sdk/identity/azure-identity/tests/test_get_token_mixin.py
+++ b/sdk/identity/azure-identity/tests/test_get_token_mixin.py
@@ -40,8 +40,8 @@ def test_no_cached_token():
     credential = MockCredential()
     token = credential.get_token(SCOPE)
 
-    credential.acquire_token_silently.assert_called_once_with(SCOPE)
-    credential.request_token.assert_called_once_with(SCOPE)
+    credential.acquire_token_silently.assert_called_once_with(SCOPE, claims=None, tenant_id=None)
+    credential.request_token.assert_called_once_with(SCOPE, claims=None, tenant_id=None)
     assert token.token == MockCredential.NEW_TOKEN.token
 
 
@@ -61,7 +61,7 @@ def test_token_acquisition_failure():
         with pytest.raises(Exception):
             credential.get_token(SCOPE)
         assert credential.request_token.call_count == i + 1
-        credential.request_token.assert_called_with(SCOPE)
+        credential.request_token.assert_called_with(SCOPE, claims=None, tenant_id=None)
 
 
 def test_expired_token():
@@ -71,8 +71,8 @@ def test_expired_token():
     credential = MockCredential(cached_token=AccessToken(CACHED_TOKEN, now - 1))
     token = credential.get_token(SCOPE)
 
-    credential.acquire_token_silently.assert_called_once_with(SCOPE)
-    credential.request_token.assert_called_once_with(SCOPE)
+    credential.acquire_token_silently.assert_called_once_with(SCOPE, claims=None, tenant_id=None)
+    credential.request_token.assert_called_once_with(SCOPE, claims=None, tenant_id=None)
     assert token.token == MockCredential.NEW_TOKEN.token
 
 
@@ -82,7 +82,7 @@ def test_cached_token_outside_refresh_window():
     credential = MockCredential(cached_token=AccessToken(CACHED_TOKEN, time.time() + DEFAULT_REFRESH_OFFSET + 1))
     token = credential.get_token(SCOPE)
 
-    credential.acquire_token_silently.assert_called_once_with(SCOPE)
+    credential.acquire_token_silently.assert_called_once_with(SCOPE, claims=None, tenant_id=None)
     assert credential.request_token.call_count == 0
     assert token.token == CACHED_TOKEN
 
@@ -93,8 +93,8 @@ def test_cached_token_within_refresh_window():
     credential = MockCredential(cached_token=AccessToken(CACHED_TOKEN, time.time() + DEFAULT_REFRESH_OFFSET - 1))
     token = credential.get_token(SCOPE)
 
-    credential.acquire_token_silently.assert_called_once_with(SCOPE)
-    credential.request_token.assert_called_once_with(SCOPE)
+    credential.acquire_token_silently.assert_called_once_with(SCOPE, claims=None, tenant_id=None)
+    credential.request_token.assert_called_once_with(SCOPE, claims=None, tenant_id=None)
     assert token.token == MockCredential.NEW_TOKEN.token
 
 
@@ -109,5 +109,5 @@ def test_retry_delay():
     for i in range(4):
         token = credential.get_token(SCOPE)
         assert token.token == CACHED_TOKEN
-        credential.acquire_token_silently.assert_called_with(SCOPE)
-        credential.request_token.assert_called_once_with(SCOPE)
+        credential.acquire_token_silently.assert_called_with(SCOPE, claims=None, tenant_id=None)
+        credential.request_token.assert_called_once_with(SCOPE, claims=None, tenant_id=None)

--- a/sdk/identity/azure-identity/tests/test_get_token_mixin_async.py
+++ b/sdk/identity/azure-identity/tests/test_get_token_mixin_async.py
@@ -43,8 +43,8 @@ async def test_no_cached_token():
     credential = MockCredential()
     token = await credential.get_token(SCOPE)
 
-    credential.acquire_token_silently.assert_called_once_with(SCOPE)
-    credential.request_token.assert_called_once_with(SCOPE)
+    credential.acquire_token_silently.assert_called_once_with(SCOPE, claims=None, tenant_id=None)
+    credential.request_token.assert_called_once_with(SCOPE, claims=None, tenant_id=None)
     assert token.token == MockCredential.NEW_TOKEN.token
 
 
@@ -64,7 +64,7 @@ async def test_token_acquisition_failure():
         with pytest.raises(Exception):
             await credential.get_token(SCOPE)
         assert credential.request_token.call_count == i + 1
-        credential.request_token.assert_called_with(SCOPE)
+        credential.request_token.assert_called_with(SCOPE, claims=None, tenant_id=None)
 
 
 async def test_expired_token():
@@ -74,8 +74,8 @@ async def test_expired_token():
     credential = MockCredential(cached_token=AccessToken(CACHED_TOKEN, now - 1))
     token = await credential.get_token(SCOPE)
 
-    credential.acquire_token_silently.assert_called_once_with(SCOPE)
-    credential.request_token.assert_called_once_with(SCOPE)
+    credential.acquire_token_silently.assert_called_once_with(SCOPE, claims=None, tenant_id=None)
+    credential.request_token.assert_called_once_with(SCOPE, claims=None, tenant_id=None)
     assert token.token == MockCredential.NEW_TOKEN.token
 
 
@@ -85,7 +85,7 @@ async def test_cached_token_outside_refresh_window():
     credential = MockCredential(cached_token=AccessToken(CACHED_TOKEN, time.time() + DEFAULT_REFRESH_OFFSET + 1))
     token = await credential.get_token(SCOPE)
 
-    credential.acquire_token_silently.assert_called_once_with(SCOPE)
+    credential.acquire_token_silently.assert_called_once_with(SCOPE, claims=None, tenant_id=None)
     assert credential.request_token.call_count == 0
     assert token.token == CACHED_TOKEN
 
@@ -96,8 +96,8 @@ async def test_cached_token_within_refresh_window():
     credential = MockCredential(cached_token=AccessToken(CACHED_TOKEN, time.time() + DEFAULT_REFRESH_OFFSET - 1))
     token = await credential.get_token(SCOPE)
 
-    credential.acquire_token_silently.assert_called_once_with(SCOPE)
-    credential.request_token.assert_called_once_with(SCOPE)
+    credential.acquire_token_silently.assert_called_once_with(SCOPE, claims=None, tenant_id=None)
+    credential.request_token.assert_called_once_with(SCOPE, claims=None, tenant_id=None)
     assert token.token == MockCredential.NEW_TOKEN.token
 
 
@@ -112,5 +112,5 @@ async def test_retry_delay():
     for i in range(4):
         token = await credential.get_token(SCOPE)
         assert token.token == CACHED_TOKEN
-        credential.acquire_token_silently.assert_called_with(SCOPE)
-        credential.request_token.assert_called_once_with(SCOPE)
+        credential.acquire_token_silently.assert_called_with(SCOPE, claims=None, tenant_id=None)
+        credential.request_token.assert_called_once_with(SCOPE, claims=None, tenant_id=None)

--- a/sdk/identity/azure-identity/tests/test_imds_credential.py
+++ b/sdk/identity/azure-identity/tests/test_imds_credential.py
@@ -62,7 +62,10 @@ def test_unexpected_error():
 
     for code in range(401, 600):
 
-        def send(request, **_):
+        def send(request, **kwargs):
+            # ensure the `claims` and `tenant_id` kwargs from credential's `get_token` method don't make it to transport
+            assert "claims" not in kwargs
+            assert "tenant_id" not in kwargs
             if "resource" not in request.query:
                 # availability probe
                 return mock_response(status_code=400, json_payload={})

--- a/sdk/identity/azure-identity/tests/test_imds_credential_async.py
+++ b/sdk/identity/azure-identity/tests/test_imds_credential_async.py
@@ -92,7 +92,10 @@ async def test_unexpected_error():
 
     for code in range(401, 600):
 
-        async def send(request, **_):
+        async def send(request, **kwargs):
+            # ensure the `claims` and `tenant_id` kwargs from credential's `get_token` method don't make it to transport
+            assert "claims" not in kwargs
+            assert "tenant_id" not in kwargs
             if "resource" not in request.query:
                 # availability probe
                 return mock_response(status_code=400, json_payload={})

--- a/sdk/identity/azure-identity/tests/test_interactive_credential.py
+++ b/sdk/identity/azure-identity/tests/test_interactive_credential.py
@@ -157,7 +157,7 @@ def test_scopes_round_trip():
 def test_authenticate_default_scopes(authority, expected_scope):
     """when given no scopes, authenticate should default to the ARM scope appropriate for the configured authority"""
 
-    def validate_scopes(*scopes):
+    def validate_scopes(*scopes, **_):
         assert scopes == (expected_scope,)
         return REQUEST_TOKEN_RESULT
 

--- a/sdk/identity/azure-identity/tests/test_interactive_credential.py
+++ b/sdk/identity/azure-identity/tests/test_interactive_credential.py
@@ -328,7 +328,10 @@ def test_multitenant_authentication():
             ),
         )
 
-    def send(request, **_):
+    def send(request, **kwargs):
+        # ensure the `claims` and `tenant_id` keywords from credential's `get_token` method don't make it to transport
+        assert "claims" not in kwargs
+        assert "tenant_id" not in kwargs
         assert "/oauth2/v2.0/token" not in request.url, 'mock "request_token" should prevent sending a token request'
         parsed = urlparse(request.url)
         tenant = parsed.path.split("/")[1]
@@ -371,7 +374,10 @@ def test_multitenant_authentication_not_allowed():
             ),
         )
 
-    def send(request, **_):
+    def send(request, **kwargs):
+        # ensure the `claims` and `tenant_id` keywords from credential's `get_token` method don't make it to transport
+        assert "claims" not in kwargs
+        assert "tenant_id" not in kwargs
         assert "/oauth2/v2.0/token" not in request.url, 'mock "request_token" should prevent sending a token request'
         parsed = urlparse(request.url)
         tenant = parsed.path.split("/")[1]

--- a/sdk/identity/azure-identity/tests/test_managed_identity.py
+++ b/sdk/identity/azure-identity/tests/test_managed_identity.py
@@ -487,7 +487,10 @@ def test_app_service_2019_08_01():
     new_secret = "new-expected-secret"
     scope = "scope"
 
-    def send(request, **_):
+    def send(request, **kwargs):
+        # ensure the `claims` and `tenant_id` keywords from credential's `get_token` method don't make it to transport
+        assert "claims" not in kwargs
+        assert "tenant_id" not in kwargs
         assert request.url.startswith(new_endpoint)
         assert request.method == "GET"
         assert request.headers["X-IDENTITY-HEADER"] == new_secret
@@ -531,7 +534,10 @@ def test_app_service_2019_08_01_tenant_id():
     new_secret = "new-expected-secret"
     scope = "scope"
 
-    def send(request, **_):
+    def send(request, **kwargs):
+        # ensure the `claims` and `tenant_id` keywords from credential's `get_token` method don't make it to transport
+        assert "claims" not in kwargs
+        assert "tenant_id" not in kwargs
         assert request.url.startswith(new_endpoint)
         assert request.method == "GET"
         assert request.headers["X-IDENTITY-HEADER"] == new_secret
@@ -707,7 +713,10 @@ def test_client_id_none():
     expected_access_token = "****"
     scope = "scope"
 
-    def send(request, **_):
+    def send(request, **kwargs):
+        # ensure the `claims` and `tenant_id` keywords from credential's `get_token` method don't make it to transport
+        assert "claims" not in kwargs
+        assert "tenant_id" not in kwargs
         assert "client_id" not in request.query
         if request.data:
             assert "client_id" not in request.body  # Cloud Shell
@@ -779,7 +788,10 @@ def test_service_fabric():
     thumbprint = "SHA1HEX"
     scope = "scope"
 
-    def send(request, **_):
+    def send(request, **kwargs):
+        # ensure the `claims` and `tenant_id` keywords from credential's `get_token` method don't make it to transport
+        assert "claims" not in kwargs
+        assert "tenant_id" not in kwargs
         assert request.url.startswith(endpoint)
         assert request.method == "GET"
         assert request.headers["Secret"] == secret
@@ -816,7 +828,10 @@ def test_service_fabric_tenant_id():
     thumbprint = "SHA1HEX"
     scope = "scope"
 
-    def send(request, **_):
+    def send(request, **kwargs):
+        # ensure the `claims` and `tenant_id` keywords from credential's `get_token` method don't make it to transport
+        assert "claims" not in kwargs
+        assert "tenant_id" not in kwargs
         assert request.url.startswith(endpoint)
         assert request.method == "GET"
         assert request.headers["Secret"] == secret

--- a/sdk/identity/azure-identity/tests/test_managed_identity_async.py
+++ b/sdk/identity/azure-identity/tests/test_managed_identity_async.py
@@ -451,7 +451,10 @@ async def test_app_service_2019_08_01():
     new_secret = "new-expected-secret"
     scope = "scope"
 
-    async def send(request, **_):
+    async def send(request, **kwargs):
+        # ensure the `claims` and `tenant_id` keywords from credential's `get_token` method don't make it to transport
+        assert "claims" not in kwargs
+        assert "tenant_id" not in kwargs
         assert request.url.startswith(new_endpoint)
         assert request.method == "GET"
         assert request.headers["X-IDENTITY-HEADER"] == new_secret
@@ -494,7 +497,10 @@ async def test_app_service_2019_08_01_tenant_id():
     new_secret = "new-expected-secret"
     scope = "scope"
 
-    async def send(request, **_):
+    async def send(request, **kwargs):
+        # ensure the `claims` and `tenant_id` keywords from credential's `get_token` method don't make it to transport
+        assert "claims" not in kwargs
+        assert "tenant_id" not in kwargs
         assert request.url.startswith(new_endpoint)
         assert request.method == "GET"
         assert request.headers["X-IDENTITY-HEADER"] == new_secret
@@ -592,7 +598,10 @@ async def test_client_id_none():
     expected_access_token = "****"
     scope = "scope"
 
-    async def send(request, **_):
+    async def send(request, **kwargs):
+        # ensure the `claims` and `tenant_id` keywords from credential's `get_token` method don't make it to transport
+        assert "claims" not in kwargs
+        assert "tenant_id" not in kwargs
         assert "client_id" not in request.query  # IMDS
         if request.data:
             assert "client_id" not in request.body  # Cloud Shell
@@ -742,7 +751,10 @@ async def test_service_fabric():
     thumbprint = "SHA1HEX"
     scope = "scope"
 
-    async def send(request, **_):
+    async def send(request, **kwargs):
+        # ensure the `claims` and `tenant_id` keywords from credential's `get_token` method don't make it to transport
+        assert "claims" not in kwargs
+        assert "tenant_id" not in kwargs
         assert request.url.startswith(endpoint)
         assert request.method == "GET"
         assert request.headers["Secret"] == secret
@@ -780,7 +792,10 @@ async def test_service_fabric_tenant_id():
     thumbprint = "SHA1HEX"
     scope = "scope"
 
-    async def send(request, **_):
+    async def send(request, **kwargs):
+        # ensure the `claims` and `tenant_id` keywords from credential's `get_token` method don't make it to transport
+        assert "claims" not in kwargs
+        assert "tenant_id" not in kwargs
         assert request.url.startswith(endpoint)
         assert request.method == "GET"
         assert request.headers["Secret"] == secret

--- a/sdk/identity/azure-identity/tests/test_obo.py
+++ b/sdk/identity/azure-identity/tests/test_obo.py
@@ -100,7 +100,10 @@ def test_multitenant_authentication():
     second_tenant = "second-tenant"
     second_token = first_token * 2
 
-    def send(request, **_):
+    def send(request, **kwargs):
+        # ensure the `claims` and `tenant_id` keywords from credential's `get_token` method don't make it to transport
+        assert "claims" not in kwargs
+        assert "tenant_id" not in kwargs
         assert request.headers["User-Agent"].startswith(USER_AGENT)
         parsed = urlparse(request.url)
         tenant = parsed.path.split("/")[1]
@@ -193,7 +196,10 @@ def test_no_scopes():
 def test_policies_configurable():
     policy = Mock(spec_set=SansIOHTTPPolicy, on_request=Mock(), on_exception=lambda _: False)
 
-    def send(request, **_):
+    def send(request, **kwargs):
+        # ensure the `claims` and `tenant_id` keywords from credential's `get_token` method don't make it to transport
+        assert "claims" not in kwargs
+        assert "tenant_id" not in kwargs
         parsed = urlparse(request.url)
         tenant = parsed.path.split("/")[1]
         if "/oauth2/v2.0/token" not in parsed.path:

--- a/sdk/identity/azure-identity/tests/test_obo_async.py
+++ b/sdk/identity/azure-identity/tests/test_obo_async.py
@@ -128,7 +128,10 @@ async def test_multitenant_authentication():
     second_tenant = "second-tenant"
     second_token = first_token * 2
 
-    async def send(request, **_):
+    async def send(request, **kwargs):
+        # ensure the `claims` and `tenant_id` keywords from credential's `get_token` method don't make it to transport
+        assert "claims" not in kwargs
+        assert "tenant_id" not in kwargs
         assert request.headers["User-Agent"].startswith(USER_AGENT)
         parsed = urlparse(request.url)
         tenant = parsed.path.split("/")[1]
@@ -174,7 +177,10 @@ async def test_authority(authority):
     expected_authority = "https://{}/{}".format(expected_netloc, tenant_id)
     expected_token = "***"
 
-    async def send(request, **_):
+    async def send(request, **kwargs):
+        # ensure the `claims` and `tenant_id` keywords from credential's `get_token` method don't make it to transport
+        assert "claims" not in kwargs
+        assert "tenant_id" not in kwargs
         assert request.url.startswith(expected_authority)
         return mock_response(json_payload=build_aad_response(access_token=expected_token))
 
@@ -203,7 +209,10 @@ async def test_authority(authority):
 async def test_policies_configurable():
     policy = Mock(spec_set=SansIOHTTPPolicy, on_request=Mock(), on_exception=lambda _: False)
 
-    async def send(request, **_):
+    async def send(request, **kwargs):
+        # ensure the `claims` and `tenant_id` keywords from credential's `get_token` method don't make it to transport
+        assert "claims" not in kwargs
+        assert "tenant_id" not in kwargs
         parsed = urlparse(request.url)
         tenant = parsed.path.split("/")[1]
         if "/oauth2/v2.0/token" not in parsed.path:
@@ -235,7 +244,10 @@ async def test_refresh_token():
     refresh_token = "refresh-token"
     requests = 0
 
-    async def send(request, **_):
+    async def send(request, **kwargs):
+        # ensure the `claims` and `tenant_id` keywords from credential's `get_token` method don't make it to transport
+        assert "claims" not in kwargs
+        assert "tenant_id" not in kwargs
         nonlocal requests
         assert requests < 3, "unexpected request"
         requests += 1

--- a/sdk/identity/azure-identity/tests/test_shared_cache_credential.py
+++ b/sdk/identity/azure-identity/tests/test_shared_cache_credential.py
@@ -103,7 +103,10 @@ def test_no_scopes():
 def test_policies_configurable():
     policy = Mock(spec_set=SansIOHTTPPolicy, on_request=Mock())
 
-    def send(*_, **__):
+    def send(*_, **kwargs):
+        # ensure the `claims` and `tenant_id` keywords from credential's `get_token` method don't make it to transport
+        assert "claims" not in kwargs
+        assert "tenant_id" not in kwargs
         return mock_response(json_payload=build_aad_response(access_token="**"))
 
     credential = SharedTokenCacheCredential(
@@ -585,7 +588,10 @@ def test_authority_environment_variable():
 def test_authentication_record_empty_cache():
     record = AuthenticationRecord("tenant-id", "client_id", "authority", "home_account_id", "username")
 
-    def send(request, **_):
+    def send(request, **kwargs):
+        # ensure the `claims` and `tenant_id` keywords from credential's `get_token` method don't make it to transport
+        assert "claims" not in kwargs
+        assert "tenant_id" not in kwargs
         # expecting only MSAL discovery requests
         assert request.method == "GET"
         return get_discovery_response()
@@ -607,7 +613,10 @@ def test_authentication_record_no_match():
     username = "me"
     record = AuthenticationRecord(tenant_id, client_id, authority, home_account_id, username)
 
-    def send(request, **_):
+    def send(request, **kwargs):
+        # ensure the `claims` and `tenant_id` keywords from credential's `get_token` method don't make it to transport
+        assert "claims" not in kwargs
+        assert "tenant_id" not in kwargs
         # expecting only MSAL discovery requests
         assert request.method == "GET"
         return get_discovery_response()
@@ -811,7 +820,10 @@ def test_authentication_record_authenticating_tenant():
 def test_client_capabilities():
     """the credential should configure MSAL for capability CP1 only if enable_cae is passed."""
 
-    def send(request, **_):
+    def send(request, **kwargs):
+        # ensure the `claims` and `tenant_id` keywords from credential's `get_token` method don't make it to transport
+        assert "claims" not in kwargs
+        assert "tenant_id" not in kwargs
         # expecting only the discovery requests triggered by creating an msal.PublicClientApplication
         # because the cache is empty--the credential shouldn't send a token request
         return get_discovery_response("https://localhost/tenant")
@@ -836,7 +848,10 @@ def test_client_capabilities():
 
 
 def test_within_dac_error():
-    def send(request, **_):
+    def send(request, **kwargs):
+        # ensure the `claims` and `tenant_id` keywords from credential's `get_token` method don't make it to transport
+        assert "claims" not in kwargs
+        assert "tenant_id" not in kwargs
         # expecting only the discovery requests triggered by creating an msal.PublicClientApplication
         # because the cache is empty--the credential shouldn't send a token request
         return get_discovery_response("https://localhost/tenant")
@@ -880,7 +895,10 @@ def test_multitenant_authentication():
     second_tenant = "second-tenant"
     second_token = first_token * 2
 
-    def send(request, **_):
+    def send(request, **kwargs):
+        # ensure the `claims` and `tenant_id` keywords from credential's `get_token` method don't make it to transport
+        assert "claims" not in kwargs
+        assert "tenant_id" not in kwargs
         parsed = urlparse(request.url)
         tenant_id = parsed.path.split("/")[1]
         assert tenant_id in (default_tenant, second_tenant), 'unexpected tenant "{}"'.format(tenant_id)
@@ -925,7 +943,10 @@ def test_multitenant_authentication_auth_record():
     home_account_id = object_id + "." + default_tenant
     record = AuthenticationRecord(default_tenant, "client-id", authority, home_account_id, "user")
 
-    def send(request, **_):
+    def send(request, **kwargs):
+        # ensure the `claims` and `tenant_id` keywords from credential's `get_token` method don't make it to transport
+        assert "claims" not in kwargs
+        assert "tenant_id" not in kwargs
         parsed = urlparse(request.url)
         tenant_id = parsed.path.split("/")[1]
         if "/oauth2/v2.0/token" not in request.url:
@@ -1000,7 +1021,10 @@ def test_multitenant_authentication_not_allowed():
     default_tenant = "organizations"
     expected_token = "***"
 
-    def send(request, **_):
+    def send(request, **kwargs):
+        # ensure the `claims` and `tenant_id` keywords from credential's `get_token` method don't make it to transport
+        assert "claims" not in kwargs
+        assert "tenant_id" not in kwargs
         parsed = urlparse(request.url)
         tenant_id = parsed.path.split("/")[1]
         assert tenant_id == default_tenant

--- a/sdk/identity/azure-identity/tests/test_shared_cache_credential_async.py
+++ b/sdk/identity/azure-identity/tests/test_shared_cache_credential_async.py
@@ -42,7 +42,10 @@ async def test_no_scopes():
 
 @pytest.mark.asyncio
 async def test_close():
-    async def send(*_, **__):
+    async def send(*_, **kwargs):
+        # ensure the `claims` and `tenant_id` keywords from credential's `get_token` method don't make it to transport
+        assert "claims" not in kwargs
+        assert "tenant_id" not in kwargs
         return mock_response(json_payload=build_aad_response(access_token="**"))
 
     transport = AsyncMockTransport(send=send)
@@ -60,7 +63,10 @@ async def test_close():
 
 @pytest.mark.asyncio
 async def test_context_manager():
-    async def send(*_, **__):
+    async def send(*_, **kwargs):
+        # ensure the `claims` and `tenant_id` keywords from credential's `get_token` method don't make it to transport
+        assert "claims" not in kwargs
+        assert "tenant_id" not in kwargs
         return mock_response(json_payload=build_aad_response(access_token="**"))
 
     transport = AsyncMockTransport(send=send)
@@ -102,7 +108,10 @@ async def test_context_manager_no_cache():
 async def test_policies_configurable():
     policy = Mock(spec_set=SansIOHTTPPolicy, on_request=Mock())
 
-    async def send(*_, **__):
+    async def send(*_, **kwargs):
+        # ensure the `claims` and `tenant_id` keywords from credential's `get_token` method don't make it to transport
+        assert "claims" not in kwargs
+        assert "tenant_id" not in kwargs
         return mock_response(json_payload=build_aad_response(access_token="**"))
 
     credential = SharedTokenCacheCredential(
@@ -643,7 +652,10 @@ async def test_multitenant_authentication():
     second_tenant = "second-tenant"
     second_token = first_token * 2
 
-    async def send(request, **_):
+    async def send(request, **kwargs):
+        # ensure the `claims` and `tenant_id` keywords from credential's `get_token` method don't make it to transport
+        assert "claims" not in kwargs
+        assert "tenant_id" not in kwargs
         parsed = urlparse(request.url)
         tenant_id = parsed.path.split("/")[1]
         return mock_response(
@@ -681,7 +693,10 @@ async def test_multitenant_authentication_not_allowed():
     default_tenant = "organizations"
     expected_token = "***"
 
-    async def send(request, **_):
+    async def send(request, **kwargs):
+        # ensure the `claims` and `tenant_id` keywords from credential's `get_token` method don't make it to transport
+        assert "claims" not in kwargs
+        assert "tenant_id" not in kwargs
         parsed = urlparse(request.url)
         tenant_id = parsed.path.split("/")[1]
         assert tenant_id == default_tenant

--- a/sdk/identity/azure-identity/tests/test_vscode_credential.py
+++ b/sdk/identity/azure-identity/tests/test_vscode_credential.py
@@ -87,7 +87,10 @@ def test_no_scopes():
 def test_policies_configurable():
     policy = mock.Mock(spec_set=SansIOHTTPPolicy, on_request=mock.Mock())
 
-    def send(*_, **__):
+    def send(*_, **kwargs):
+        # ensure the `claims` and `tenant_id` keywords from credential's `get_token` method don't make it to transport
+        assert "claims" not in kwargs
+        assert "tenant_id" not in kwargs
         return mock_response(json_payload=build_aad_response(access_token="**"))
 
     credential = get_credential(policies=[policy], transport=mock.Mock(send=send))
@@ -285,7 +288,10 @@ def test_multitenant_authentication():
     second_tenant = "second-tenant"
     second_token = first_token * 2
 
-    def send(request, **_):
+    def send(request, **kwargs):
+        # ensure the `claims` and `tenant_id` keywords from credential's `get_token` method don't make it to transport
+        assert "claims" not in kwargs
+        assert "tenant_id" not in kwargs
         parsed = urlparse(request.url)
         tenant = parsed.path.split("/")[1]
         assert tenant in (first_tenant, second_tenant), 'unexpected tenant "{}"'.format(tenant)
@@ -315,7 +321,10 @@ def test_multitenant_authentication_not_allowed():
     expected_tenant = "expected-tenant"
     expected_token = "***"
 
-    def send(request, **_):
+    def send(request, **kwargs):
+        # ensure the `claims` and `tenant_id` keywords from credential's `get_token` method don't make it to transport
+        assert "claims" not in kwargs
+        assert "tenant_id" not in kwargs
         parsed = urlparse(request.url)
         tenant = parsed.path.split("/")[1]
         token = expected_token if tenant == expected_tenant else expected_token * 2

--- a/sdk/identity/azure-identity/tests/test_vscode_credential.py
+++ b/sdk/identity/azure-identity/tests/test_vscode_credential.py
@@ -157,7 +157,9 @@ def test_redeem_token():
         credential = get_credential(_client=mock_client)
         token = credential.get_token("scope")
         assert token is expected_token
-        mock_client.obtain_token_by_refresh_token.assert_called_with(("scope",), expected_value)
+        mock_client.obtain_token_by_refresh_token.assert_called_with(
+            ("scope",), expected_value, claims=None, tenant_id=None
+        )
         assert mock_client.obtain_token_by_refresh_token.call_count == 1
 
 

--- a/sdk/identity/azure-identity/tests/test_vscode_credential_async.py
+++ b/sdk/identity/azure-identity/tests/test_vscode_credential_async.py
@@ -85,7 +85,10 @@ async def test_no_scopes():
 async def test_policies_configurable():
     policy = mock.Mock(spec_set=SansIOHTTPPolicy, on_request=mock.Mock())
 
-    async def send(*_, **__):
+    async def send(*_, **kwargs):
+        # ensure the `claims` and `tenant_id` keywords from credential's `get_token` method don't make it to transport
+        assert "claims" not in kwargs
+        assert "tenant_id" not in kwargs
         return mock_response(json_payload=build_aad_response(access_token="**"))
 
     credential = get_credential(policies=[policy], transport=mock.Mock(send=send))
@@ -274,7 +277,10 @@ async def test_multitenant_authentication():
     second_tenant = "second-tenant"
     second_token = first_token * 2
 
-    async def send(request, **_):
+    async def send(request, **kwargs):
+        # ensure the `claims` and `tenant_id` keywords from credential's `get_token` method don't make it to transport
+        assert "claims" not in kwargs
+        assert "tenant_id" not in kwargs
         parsed = urlparse(request.url)
         tenant = parsed.path.split("/")[1]
         assert tenant in (first_tenant, second_tenant), 'unexpected tenant "{}"'.format(tenant)
@@ -305,7 +311,10 @@ async def test_multitenant_authentication_not_allowed():
     expected_tenant = "expected-tenant"
     expected_token = "***"
 
-    async def send(request, **_):
+    async def send(request, **kwargs):
+        # ensure the `claims` and `tenant_id` keywords from credential's `get_token` method don't make it to transport
+        assert "claims" not in kwargs
+        assert "tenant_id" not in kwargs
         parsed = urlparse(request.url)
         tenant = parsed.path.split("/")[1]
         token = expected_token if tenant == expected_tenant else expected_token * 2

--- a/sdk/identity/azure-identity/tests/test_vscode_credential_async.py
+++ b/sdk/identity/azure-identity/tests/test_vscode_credential_async.py
@@ -160,7 +160,7 @@ async def test_redeem_token():
         credential = get_credential(_client=mock_client)
         token = await credential.get_token("scope")
         assert token is expected_token
-        token_by_refresh_token.assert_called_with(("scope",), expected_value)
+        token_by_refresh_token.assert_called_with(("scope",), expected_value, claims=None, tenant_id=None)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# Description

Resolves https://github.com/Azure/azure-sdk-for-python/issues/25175.

`azure-identity` credentials should all implement the TokenCredential protocol, but they technically don't at the moment. For both sync and async credentials, our `get_token` methods don't include all the parameters specified in the protocol. This PR update method signatures to match, and clarifies which parameters may be ignored in docstrings.

Validating live Key Vault pipeline run: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=2958066&view=results

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
