### PR TITLE
Remove unnecessary and type unsafe usage of error_map

### DIFF
--- a/sdk/appconfiguration/azure-appconfiguration/assets.json
+++ b/sdk/appconfiguration/azure-appconfiguration/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "python",
   "TagPrefix": "python/appconfiguration/azure-appconfiguration",
-  "Tag": "python/appconfiguration/azure-appconfiguration_32fa1f73f9"
+  "Tag": "python/appconfiguration/azure-appconfiguration_55ff13c98d"
 }

--- a/sdk/appconfiguration/azure-appconfiguration/azure/appconfiguration/_azure_appconfiguration_client.py
+++ b/sdk/appconfiguration/azure-appconfiguration/azure/appconfiguration/_azure_appconfiguration_client.py
@@ -244,8 +244,6 @@ class AzureAppConfigurationClient:
         error_map = {}
         if match_condition == MatchConditions.IfNotModified:
             error_map[412] = ResourceModifiedError
-        if match_condition == MatchConditions.IfModified:
-            error_map[304] = ResourceNotModifiedError
         if match_condition == MatchConditions.IfPresent:
             error_map[412] = ResourceNotFoundError
         if match_condition == MatchConditions.IfMissing:

--- a/sdk/appconfiguration/azure-appconfiguration/azure/appconfiguration/_azure_appconfiguration_client.py
+++ b/sdk/appconfiguration/azure-appconfiguration/azure/appconfiguration/_azure_appconfiguration_client.py
@@ -195,7 +195,6 @@ class AzureAppConfigurationClient:
         select = kwargs.pop("fields", None)
         if select:
             select = ["locked" if x == "read_only" else x for x in select]
-        error_map = {401: ClientAuthenticationError}
 
         try:
             return self._impl.get_key_values(  # type: ignore
@@ -203,7 +202,6 @@ class AzureAppConfigurationClient:
                 key=key_filter,
                 select=select,
                 cls=lambda objs: [ConfigurationSetting._from_generated(x) for x in objs],
-                error_map=error_map,
                 **kwargs
             )
         except binascii.Error as exc:
@@ -245,7 +243,7 @@ class AzureAppConfigurationClient:
                 key="MyKey", label="MyLabel"
             )
         """
-        error_map = {401: ClientAuthenticationError, 404: ResourceNotFoundError}
+        error_map = {}
         if match_condition == MatchConditions.IfNotModified:
             error_map[412] = ResourceModifiedError
         if match_condition == MatchConditions.IfModified:
@@ -297,7 +295,7 @@ class AzureAppConfigurationClient:
         """
         key_value = configuration_setting._to_generated()
         custom_headers = CaseInsensitiveDict(kwargs.get("headers"))  # type: Mapping[str, Any]
-        error_map = {401: ClientAuthenticationError, 412: ResourceExistsError}
+        error_map = {412: ResourceExistsError}
         try:
             key_value_added = self._impl.put_key_value(
                 entity=key_value,
@@ -353,7 +351,7 @@ class AzureAppConfigurationClient:
         """
         key_value = configuration_setting._to_generated()
         custom_headers = CaseInsensitiveDict(kwargs.get("headers"))  # type: Mapping[str, Any]
-        error_map = {401: ClientAuthenticationError, 409: ResourceReadOnlyError}
+        error_map = {409: ResourceReadOnlyError}
         if match_condition == MatchConditions.IfNotModified:
             error_map[412] = ResourceModifiedError
         if match_condition == MatchConditions.IfModified:
@@ -411,7 +409,7 @@ class AzureAppConfigurationClient:
         etag = kwargs.pop("etag", None)
         match_condition = kwargs.pop("match_condition", MatchConditions.Unconditionally)
         custom_headers = CaseInsensitiveDict(kwargs.get("headers"))  # type: Mapping[str, Any]
-        error_map = {401: ClientAuthenticationError, 409: ResourceReadOnlyError}
+        error_map = {409: ResourceReadOnlyError}
         if match_condition == MatchConditions.IfNotModified:
             error_map[412] = ResourceModifiedError
         if match_condition == MatchConditions.IfModified:
@@ -474,7 +472,6 @@ class AzureAppConfigurationClient:
         select = kwargs.pop("fields", None)
         if select:
             select = ["locked" if x == "read_only" else x for x in select]
-        error_map = {401: ClientAuthenticationError}
 
         try:
             return self._impl.get_revisions(  # type: ignore
@@ -482,7 +479,6 @@ class AzureAppConfigurationClient:
                 key=key_filter,
                 select=select,
                 cls=lambda objs: [ConfigurationSetting._from_generated(x) for x in objs],
-                error_map=error_map,
                 **kwargs
             )
         except binascii.Error as exc:
@@ -518,7 +514,7 @@ class AzureAppConfigurationClient:
             read_only_config_setting = client.set_read_only(config_setting)
             read_only_config_setting = client.set_read_only(config_setting, read_only=False)
         """
-        error_map = {401: ClientAuthenticationError, 404: ResourceNotFoundError}
+        error_map = {}
 
         match_condition = kwargs.pop("match_condition", MatchConditions.Unconditionally)
         if match_condition == MatchConditions.IfNotModified:

--- a/sdk/appconfiguration/azure-appconfiguration/azure/appconfiguration/_azure_appconfiguration_client.py
+++ b/sdk/appconfiguration/azure-appconfiguration/azure/appconfiguration/_azure_appconfiguration_client.py
@@ -169,8 +169,7 @@ class AzureAppConfigurationClient:
         :keyword list[str] fields: specify which fields to include in the results. Leave None to include all fields
         :return: An iterator of :class:`~azure.appconfiguration.ConfigurationSetting`
         :rtype: ~azure.core.paging.ItemPaged[~azure.appconfiguration.ConfigurationSetting]
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`, \
-            :class:`~azure.core.exceptions.ClientAuthenticationError`
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example
 
@@ -226,12 +225,8 @@ class AzureAppConfigurationClient:
         :type match_condition: ~azure.core.MatchConditions
         :keyword str accept_datetime: retrieve ConfigurationSetting existed at this datetime
         :return: The matched ConfigurationSetting object
-        :rtype: ~azure.appconfiguration.ConfigurationSetting
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`, \
-            :class:`~azure.core.exceptions.ClientAuthenticationError`, \
-            :class:`~azure.core.exceptions.ResourceNotFoundError`, \
-            :class:`~azure.core.exceptions.ResourceModifiedError`, \
-            :class:`~azure.core.exceptions.ResourceExistsError`
+        :rtype: ~azure.appconfiguration.ConfigurationSetting or None
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example
 
@@ -272,9 +267,7 @@ class AzureAppConfigurationClient:
         :type configuration_setting: ~azure.appconfiguration.ConfigurationSetting
         :return: The ConfigurationSetting object returned from the App Configuration service
         :rtype: ~azure.appconfiguration.ConfigurationSetting
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`, \
-            :class:`~azure.core.exceptions.ClientAuthenticationError`, \
-            :class:`~azure.core.exceptions.ResourceExistsError`
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example
 
@@ -324,13 +317,7 @@ class AzureAppConfigurationClient:
         :keyword str etag: check if the ConfigurationSetting is changed. Set None to skip checking etag
         :return: The ConfigurationSetting returned from the service
         :rtype: ~azure.appconfiguration.ConfigurationSetting
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`, \
-            :class:`~azure.core.exceptions.ClientAuthenticationError`, \
-            :class:`~azure.core.exceptions.ResourceReadOnlyError`, \
-            :class:`~azure.core.exceptions.ResourceModifiedError`, \
-            :class:`~azure.core.exceptions.ResourceNotModifiedError`, \
-            :class:`~azure.core.exceptions.ResourceNotFoundError`, \
-            :class:`~azure.core.exceptions.ResourceExistsError`
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example
 
@@ -386,13 +373,7 @@ class AzureAppConfigurationClient:
         :paramtype match_condition: ~azure.core.MatchConditions
         :return: The deleted ConfigurationSetting returned from the service, or None if it doesn't exist.
         :rtype: ~azure.appconfiguration.ConfigurationSetting
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`, \
-            :class:`~azure.core.exceptions.ClientAuthenticationError`, \
-            :class:`~azure.core.exceptions.ResourceReadOnlyError`, \
-            :class:`~azure.core.exceptions.ResourceModifiedError`, \
-            :class:`~azure.core.exceptions.ResourceNotModifiedError`, \
-            :class:`~azure.core.exceptions.ResourceNotFoundError`, \
-            :class:`~azure.core.exceptions.ResourceExistsError`
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example
 
@@ -444,8 +425,7 @@ class AzureAppConfigurationClient:
         :keyword list[str] fields: specify which fields to include in the results. Leave None to include all fields
         :return: An iterator of :class:`~azure.appconfiguration.ConfigurationSetting`
         :rtype: ~azure.core.paging.ItemPaged[~azure.appconfiguration.ConfigurationSetting]
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`, \
-            :class:`~azure.core.exceptions.ClientAuthenticationError`
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example
 
@@ -495,9 +475,7 @@ class AzureAppConfigurationClient:
         :keyword str etag: check if the ConfigurationSetting is changed. Set None to skip checking etag
         :return: The ConfigurationSetting returned from the service
         :rtype: ~azure.appconfiguration.ConfigurationSetting
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`, \
-            :class:`~azure.core.exceptions.ClientAuthenticationError`, \
-            :class:`~azure.core.exceptions.ResourceNotFoundError`
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example
 
@@ -575,6 +553,7 @@ class AzureAppConfigurationClient:
         :return: A poller for create snapshot operation. Call `result()` on this object to wait for the
             operation to complete and get the created snapshot.
         :rtype: ~azure.core.polling.LROPoller[~azure.appconfiguration.Snapshot]
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
         """
         snapshot = Snapshot(
             filters=filters, composition_type=composition_type, retention_period=retention_period, tags=tags
@@ -608,6 +587,7 @@ class AzureAppConfigurationClient:
         :keyword str etag: Check if the Snapshot is changed. Set None to skip checking etag.
         :return: The Snapshot returned from the service.
         :rtype: ~azure.appconfiguration.Snapshot
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
         """
         error_map = {}
         if match_condition == MatchConditions.IfNotModified:
@@ -649,6 +629,7 @@ class AzureAppConfigurationClient:
         :keyword str etag: Check if the Snapshot is changed. Set None to skip checking etag.
         :return: The Snapshot returned from the service.
         :rtype: ~azure.appconfiguration.Snapshot
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
         """
         error_map = {}
         if match_condition == MatchConditions.IfNotModified:
@@ -681,6 +662,7 @@ class AzureAppConfigurationClient:
         :keyword list[str] fields: Specify which fields to include in the results. Leave None to include all fields.
         :return: The Snapshot returned from the service.
         :rtype: ~azure.appconfiguration.Snapshot
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
         """
         try:
             generated_snapshot = self._impl.get_snapshot(
@@ -707,6 +689,7 @@ class AzureAppConfigurationClient:
         :keyword list[str] status: Filter results based on snapshot keys.
         :return: An iterator of :class:`~azure.appconfiguration.Snapshot`
         :rtype: ~azure.core.paging.ItemPaged[~azure.appconfiguration.Snapshot]
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
         """
         try:
             return self._impl.get_snapshots(  # type: ignore
@@ -731,6 +714,7 @@ class AzureAppConfigurationClient:
         :keyword list[str] fields: Specify which fields to include in the results. Leave None to include all fields
         :return: An iterator of :class:`~azure.appconfiguration.ConfigurationSetting`
         :rtype: ~azure.core.paging.ItemPaged[~azure.appconfiguration.ConfigurationSetting]
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
         """
         if fields:
             fields = ["locked" if x == "read_only" else x for x in fields]

--- a/sdk/appconfiguration/azure-appconfiguration/azure/appconfiguration/_azure_appconfiguration_client.py
+++ b/sdk/appconfiguration/azure-appconfiguration/azure/appconfiguration/_azure_appconfiguration_client.py
@@ -236,7 +236,7 @@ class AzureAppConfigurationClient:
                 key="MyKey", label="MyLabel"
             )
         """
-        error_map = {}
+        error_map = {}  # type: Dict[int, Any]
         if match_condition == MatchConditions.IfNotModified:
             error_map.update({412: ResourceModifiedError})
         if match_condition == MatchConditions.IfPresent:
@@ -334,7 +334,7 @@ class AzureAppConfigurationClient:
         """
         key_value = configuration_setting._to_generated()
         custom_headers = CaseInsensitiveDict(kwargs.get("headers"))  # type: Mapping[str, Any]
-        error_map = {409: ResourceReadOnlyError}
+        error_map = {409: ResourceReadOnlyError}  # type: Dict[int, Any]
         if match_condition == MatchConditions.IfNotModified:
             error_map.update({412: ResourceModifiedError})
         if match_condition == MatchConditions.IfModified:
@@ -386,7 +386,7 @@ class AzureAppConfigurationClient:
         etag = kwargs.pop("etag", None)
         match_condition = kwargs.pop("match_condition", MatchConditions.Unconditionally)
         custom_headers = CaseInsensitiveDict(kwargs.get("headers"))  # type: Mapping[str, Any]
-        error_map = {409: ResourceReadOnlyError}
+        error_map = {409: ResourceReadOnlyError}  # type: Dict[int, Any]
         if match_condition == MatchConditions.IfNotModified:
             error_map.update({412: ResourceModifiedError})
         if match_condition == MatchConditions.IfModified:
@@ -488,8 +488,7 @@ class AzureAppConfigurationClient:
             read_only_config_setting = client.set_read_only(config_setting)
             read_only_config_setting = client.set_read_only(config_setting, read_only=False)
         """
-        error_map = {}
-
+        error_map = {}  # type: Dict[int, Any]
         match_condition = kwargs.pop("match_condition", MatchConditions.Unconditionally)
         if match_condition == MatchConditions.IfNotModified:
             error_map.update({412: ResourceModifiedError})
@@ -589,7 +588,7 @@ class AzureAppConfigurationClient:
         :rtype: ~azure.appconfiguration.Snapshot
         :raises: :class:`~azure.core.exceptions.HttpResponseError`
         """
-        error_map = {}
+        error_map = {}  # type: Dict[int, Any]
         if match_condition == MatchConditions.IfNotModified:
             error_map.update({412: ResourceModifiedError})
         if match_condition == MatchConditions.IfModified:
@@ -631,7 +630,7 @@ class AzureAppConfigurationClient:
         :rtype: ~azure.appconfiguration.Snapshot
         :raises: :class:`~azure.core.exceptions.HttpResponseError`
         """
-        error_map = {}
+        error_map = {}  # type: Dict[int, Any]
         if match_condition == MatchConditions.IfNotModified:
             error_map.update({412: ResourceModifiedError})
         if match_condition == MatchConditions.IfModified:

--- a/sdk/appconfiguration/azure-appconfiguration/azure/appconfiguration/_azure_appconfiguration_client.py
+++ b/sdk/appconfiguration/azure-appconfiguration/azure/appconfiguration/_azure_appconfiguration_client.py
@@ -243,11 +243,11 @@ class AzureAppConfigurationClient:
         """
         error_map = {}
         if match_condition == MatchConditions.IfNotModified:
-            error_map[412] = ResourceModifiedError
+            error_map.update({412: ResourceModifiedError})
         if match_condition == MatchConditions.IfPresent:
-            error_map[412] = ResourceNotFoundError
+            error_map.update({412: ResourceNotFoundError})
         if match_condition == MatchConditions.IfMissing:
-            error_map[412] = ResourceExistsError
+            error_map.update({412: ResourceExistsError})
 
         try:
             key_value = self._impl.get_key_value(
@@ -349,13 +349,13 @@ class AzureAppConfigurationClient:
         custom_headers = CaseInsensitiveDict(kwargs.get("headers"))  # type: Mapping[str, Any]
         error_map = {409: ResourceReadOnlyError}
         if match_condition == MatchConditions.IfNotModified:
-            error_map[412] = ResourceModifiedError
+            error_map.update({412: ResourceModifiedError})
         if match_condition == MatchConditions.IfModified:
-            error_map[412] = ResourceNotModifiedError
+            error_map.update({412: ResourceNotModifiedError})
         if match_condition == MatchConditions.IfPresent:
-            error_map[412] = ResourceNotFoundError
+            error_map.update({412: ResourceNotFoundError})
         if match_condition == MatchConditions.IfMissing:
-            error_map[412] = ResourceExistsError
+            error_map.update({412: ResourceExistsError})
 
         try:
             key_value_set = self._impl.put_key_value(
@@ -407,13 +407,13 @@ class AzureAppConfigurationClient:
         custom_headers = CaseInsensitiveDict(kwargs.get("headers"))  # type: Mapping[str, Any]
         error_map = {409: ResourceReadOnlyError}
         if match_condition == MatchConditions.IfNotModified:
-            error_map[412] = ResourceModifiedError
+            error_map.update({412: ResourceModifiedError})
         if match_condition == MatchConditions.IfModified:
-            error_map[412] = ResourceNotModifiedError
+            error_map.update({412: ResourceNotModifiedError})
         if match_condition == MatchConditions.IfPresent:
-            error_map[412] = ResourceNotFoundError
+            error_map.update({412: ResourceNotFoundError})
         if match_condition == MatchConditions.IfMissing:
-            error_map[412] = ResourceExistsError
+            error_map.update({412: ResourceExistsError})
 
         try:
             key_value_deleted = self._impl.delete_key_value(
@@ -514,13 +514,13 @@ class AzureAppConfigurationClient:
 
         match_condition = kwargs.pop("match_condition", MatchConditions.Unconditionally)
         if match_condition == MatchConditions.IfNotModified:
-            error_map[412] = ResourceModifiedError
+            error_map.update({412: ResourceModifiedError})
         if match_condition == MatchConditions.IfModified:
-            error_map[412] = ResourceNotModifiedError
+            error_map.update({412: ResourceNotModifiedError})
         if match_condition == MatchConditions.IfPresent:
-            error_map[412] = ResourceNotFoundError
+            error_map.update({412: ResourceNotFoundError})
         if match_condition == MatchConditions.IfMissing:
-            error_map[412] = ResourceExistsError
+            error_map.update({412: ResourceExistsError})
 
         try:
             if read_only:
@@ -611,13 +611,13 @@ class AzureAppConfigurationClient:
         """
         error_map = {}
         if match_condition == MatchConditions.IfNotModified:
-            error_map[412] = ResourceModifiedError
+            error_map.update({412: ResourceModifiedError})
         if match_condition == MatchConditions.IfModified:
-            error_map[412] = ResourceNotModifiedError
+            error_map.update({412: ResourceNotModifiedError})
         if match_condition == MatchConditions.IfPresent:
-            error_map[412] = ResourceNotFoundError
+            error_map.update({412: ResourceNotFoundError})
         if match_condition == MatchConditions.IfMissing:
-            error_map[412] = ResourceExistsError
+            error_map.update({412: ResourceExistsError})
         try:
             generated_snapshot = self._impl.update_snapshot(
                 name=name,
@@ -652,13 +652,13 @@ class AzureAppConfigurationClient:
         """
         error_map = {}
         if match_condition == MatchConditions.IfNotModified:
-            error_map[412] = ResourceModifiedError
+            error_map.update({412: ResourceModifiedError})
         if match_condition == MatchConditions.IfModified:
-            error_map[412] = ResourceNotModifiedError
+            error_map.update({412: ResourceNotModifiedError})
         if match_condition == MatchConditions.IfPresent:
-            error_map[412] = ResourceNotFoundError
+            error_map.update({412: ResourceNotFoundError})
         if match_condition == MatchConditions.IfMissing:
-            error_map[412] = ResourceExistsError
+            error_map.update({412: ResourceExistsError})
         try:
             generated_snapshot = self._impl.update_snapshot(
                 name=name,

--- a/sdk/appconfiguration/azure-appconfiguration/azure/appconfiguration/_azure_appconfiguration_client.py
+++ b/sdk/appconfiguration/azure-appconfiguration/azure/appconfiguration/_azure_appconfiguration_client.py
@@ -611,12 +611,22 @@ class AzureAppConfigurationClient:
         :return: The Snapshot returned from the service.
         :rtype: ~azure.appconfiguration.Snapshot
         """
+        error_map = {}
+        if match_condition == MatchConditions.IfNotModified:
+            error_map[412] = ResourceModifiedError
+        if match_condition == MatchConditions.IfModified:
+            error_map[412] = ResourceNotModifiedError
+        if match_condition == MatchConditions.IfPresent:
+            error_map[412] = ResourceNotFoundError
+        if match_condition == MatchConditions.IfMissing:
+            error_map[412] = ResourceExistsError
         try:
             generated_snapshot = self._impl.update_snapshot(
                 name=name,
                 entity=SnapshotUpdateParameters(status=SnapshotStatus.ARCHIVED),
                 if_match=prep_if_match(etag, match_condition),
                 if_none_match=prep_if_none_match(etag, match_condition),
+                error_map=error_map,
                 **kwargs
             )
             return Snapshot._from_generated(generated_snapshot)
@@ -642,12 +652,22 @@ class AzureAppConfigurationClient:
         :return: The Snapshot returned from the service.
         :rtype: ~azure.appconfiguration.Snapshot
         """
+        error_map = {}
+        if match_condition == MatchConditions.IfNotModified:
+            error_map[412] = ResourceModifiedError
+        if match_condition == MatchConditions.IfModified:
+            error_map[412] = ResourceNotModifiedError
+        if match_condition == MatchConditions.IfPresent:
+            error_map[412] = ResourceNotFoundError
+        if match_condition == MatchConditions.IfMissing:
+            error_map[412] = ResourceExistsError
         try:
             generated_snapshot = self._impl.update_snapshot(
                 name=name,
                 entity=SnapshotUpdateParameters(status=SnapshotStatus.READY),
                 if_match=prep_if_match(etag, match_condition),
                 if_none_match=prep_if_none_match(etag, match_condition),
+                error_map=error_map,
                 **kwargs
             )
             return Snapshot._from_generated(generated_snapshot)

--- a/sdk/appconfiguration/azure-appconfiguration/azure/appconfiguration/_azure_appconfiguration_client.py
+++ b/sdk/appconfiguration/azure-appconfiguration/azure/appconfiguration/_azure_appconfiguration_client.py
@@ -169,7 +169,8 @@ class AzureAppConfigurationClient:
         :keyword list[str] fields: specify which fields to include in the results. Leave None to include all fields
         :return: An iterator of :class:`~azure.appconfiguration.ConfigurationSetting`
         :rtype: ~azure.core.paging.ItemPaged[~azure.appconfiguration.ConfigurationSetting]
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`, \
+            :class:`~azure.core.exceptions.ClientAuthenticationError`
 
         Example
 
@@ -226,7 +227,11 @@ class AzureAppConfigurationClient:
         :keyword str accept_datetime: retrieve ConfigurationSetting existed at this datetime
         :return: The matched ConfigurationSetting object
         :rtype: ~azure.appconfiguration.ConfigurationSetting or None
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`, \
+            :class:`~azure.core.exceptions.ClientAuthenticationError`, \
+            :class:`~azure.core.exceptions.ResourceNotFoundError`, \
+            :class:`~azure.core.exceptions.ResourceModifiedError`, \
+            :class:`~azure.core.exceptions.ResourceExistsError`
 
         Example
 
@@ -267,7 +272,9 @@ class AzureAppConfigurationClient:
         :type configuration_setting: ~azure.appconfiguration.ConfigurationSetting
         :return: The ConfigurationSetting object returned from the App Configuration service
         :rtype: ~azure.appconfiguration.ConfigurationSetting
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`, \
+            :class:`~azure.core.exceptions.ClientAuthenticationError`, \
+            :class:`~azure.core.exceptions.ResourceExistsError`
 
         Example
 
@@ -317,7 +324,13 @@ class AzureAppConfigurationClient:
         :keyword str etag: check if the ConfigurationSetting is changed. Set None to skip checking etag
         :return: The ConfigurationSetting returned from the service
         :rtype: ~azure.appconfiguration.ConfigurationSetting
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`, \
+            :class:`~azure.core.exceptions.ClientAuthenticationError`, \
+            :class:`~azure.core.exceptions.ResourceReadOnlyError`, \
+            :class:`~azure.core.exceptions.ResourceModifiedError`, \
+            :class:`~azure.core.exceptions.ResourceNotModifiedError`, \
+            :class:`~azure.core.exceptions.ResourceNotFoundError`, \
+            :class:`~azure.core.exceptions.ResourceExistsError`
 
         Example
 
@@ -373,7 +386,13 @@ class AzureAppConfigurationClient:
         :paramtype match_condition: ~azure.core.MatchConditions
         :return: The deleted ConfigurationSetting returned from the service, or None if it doesn't exist.
         :rtype: ~azure.appconfiguration.ConfigurationSetting
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`, \
+            :class:`~azure.core.exceptions.ClientAuthenticationError`, \
+            :class:`~azure.core.exceptions.ResourceReadOnlyError`, \
+            :class:`~azure.core.exceptions.ResourceModifiedError`, \
+            :class:`~azure.core.exceptions.ResourceNotModifiedError`, \
+            :class:`~azure.core.exceptions.ResourceNotFoundError`, \
+            :class:`~azure.core.exceptions.ResourceExistsError`
 
         Example
 
@@ -425,7 +444,8 @@ class AzureAppConfigurationClient:
         :keyword list[str] fields: specify which fields to include in the results. Leave None to include all fields
         :return: An iterator of :class:`~azure.appconfiguration.ConfigurationSetting`
         :rtype: ~azure.core.paging.ItemPaged[~azure.appconfiguration.ConfigurationSetting]
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`, \
+            :class:`~azure.core.exceptions.ClientAuthenticationError`
 
         Example
 
@@ -475,7 +495,9 @@ class AzureAppConfigurationClient:
         :keyword str etag: check if the ConfigurationSetting is changed. Set None to skip checking etag
         :return: The ConfigurationSetting returned from the service
         :rtype: ~azure.appconfiguration.ConfigurationSetting
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`, \
+            :class:`~azure.core.exceptions.ClientAuthenticationError`, \
+            :class:`~azure.core.exceptions.ResourceNotFoundError`
 
         Example
 

--- a/sdk/appconfiguration/azure-appconfiguration/azure/appconfiguration/_azure_appconfiguration_client.py
+++ b/sdk/appconfiguration/azure-appconfiguration/azure/appconfiguration/_azure_appconfiguration_client.py
@@ -206,9 +206,6 @@ class AzureAppConfigurationClient:
                 error_map=error_map,
                 **kwargs
             )
-        except HttpResponseError as error:
-            e = error_map[error.status_code]
-            raise e(message=error.message, response=error.response) from error
         except binascii.Error as exc:
             raise binascii.Error("Connection string secret has incorrect padding") from exc
 
@@ -270,9 +267,6 @@ class AzureAppConfigurationClient:
             return ConfigurationSetting._from_generated(key_value)
         except ResourceNotModifiedError:
             return None
-        except HttpResponseError as error:
-            e = error_map[error.status_code]
-            raise e(message=error.message, response=error.response) from error
         except binascii.Error as exc:
             raise binascii.Error("Connection string secret has incorrect padding") from exc
 
@@ -314,9 +308,6 @@ class AzureAppConfigurationClient:
                 error_map=error_map,
             )
             return ConfigurationSetting._from_generated(key_value_added)
-        except HttpResponseError as error:
-            e = error_map[error.status_code]
-            raise e(message=error.message, response=error.response) from error
         except binascii.Error as exc:
             raise binascii.Error("Connection string secret has incorrect padding") from exc
 
@@ -383,9 +374,6 @@ class AzureAppConfigurationClient:
                 error_map=error_map,
             )
             return ConfigurationSetting._from_generated(key_value_set)
-        except HttpResponseError as error:
-            e = error_map[error.status_code]
-            raise e(message=error.message, response=error.response) from error
         except binascii.Error as exc:
             raise binascii.Error("Connection string secret has incorrect padding") from exc
 
@@ -442,9 +430,6 @@ class AzureAppConfigurationClient:
                 error_map=error_map,
             )
             return ConfigurationSetting._from_generated(key_value_deleted)  # type: ignore
-        except HttpResponseError as error:
-            e = error_map[error.status_code]
-            raise e(message=error.message, response=error.response) from error
         except binascii.Error as exc:
             raise binascii.Error("Connection string secret has incorrect padding") from exc
 
@@ -500,9 +485,6 @@ class AzureAppConfigurationClient:
                 error_map=error_map,
                 **kwargs
             )
-        except HttpResponseError as error:
-            e = error_map[error.status_code]
-            raise e(message=error.message, response=error.response) from error
         except binascii.Error as exc:
             raise binascii.Error("Connection string secret has incorrect padding") from exc
 
@@ -568,9 +550,6 @@ class AzureAppConfigurationClient:
                     **kwargs
                 )
             return ConfigurationSetting._from_generated(key_value)
-        except HttpResponseError as error:
-            e = error_map[error.status_code]
-            raise e(message=error.message, response=error.response) from error
         except binascii.Error as exc:
             raise binascii.Error("Connection string secret has incorrect padding") from exc
 

--- a/sdk/appconfiguration/azure-appconfiguration/azure/appconfiguration/_azure_appconfiguration_client.py
+++ b/sdk/appconfiguration/azure-appconfiguration/azure/appconfiguration/_azure_appconfiguration_client.py
@@ -24,8 +24,6 @@ from azure.core.pipeline.policies import (
 from azure.core.polling import LROPoller
 from azure.core.tracing.decorator import distributed_trace
 from azure.core.exceptions import (
-    HttpResponseError,
-    ClientAuthenticationError,
     ResourceExistsError,
     ResourceNotFoundError,
     ResourceModifiedError,

--- a/sdk/appconfiguration/azure-appconfiguration/azure/appconfiguration/aio/_azure_appconfiguration_client_async.py
+++ b/sdk/appconfiguration/azure-appconfiguration/azure/appconfiguration/aio/_azure_appconfiguration_client_async.py
@@ -219,11 +219,11 @@ class AzureAppConfigurationClient:
         """
         error_map = {}
         if match_condition == MatchConditions.IfNotModified:
-            error_map[412] = ResourceModifiedError
+            error_map.update({412: ResourceModifiedError})
         if match_condition == MatchConditions.IfPresent:
-            error_map[412] = ResourceNotFoundError
+            error_map.update({412: ResourceNotFoundError})
         if match_condition == MatchConditions.IfMissing:
-            error_map[412] = ResourceExistsError
+            error_map.update({412: ResourceExistsError})
 
         try:
             key_value = await self._impl.get_key_value(
@@ -334,13 +334,13 @@ class AzureAppConfigurationClient:
         custom_headers = CaseInsensitiveDict(kwargs.get("headers"))  # type: Mapping[str, Any]
         error_map = {409: ResourceReadOnlyError}
         if match_condition == MatchConditions.IfNotModified:
-            error_map[412] = ResourceModifiedError
+            error_map.update({412: ResourceModifiedError})
         if match_condition == MatchConditions.IfModified:
-            error_map[412] = ResourceNotModifiedError
+            error_map.update({412: ResourceNotModifiedError})
         if match_condition == MatchConditions.IfPresent:
-            error_map[412] = ResourceNotFoundError
+            error_map.update({412: ResourceNotFoundError})
         if match_condition == MatchConditions.IfMissing:
-            error_map[412] = ResourceExistsError
+            error_map.update({412: ResourceExistsError})
 
         try:
             key_value_set = await self._impl.put_key_value(
@@ -393,13 +393,13 @@ class AzureAppConfigurationClient:
         custom_headers = CaseInsensitiveDict(kwargs.get("headers"))  # type: Mapping[str, Any]
         error_map = {409: ResourceReadOnlyError}
         if match_condition == MatchConditions.IfNotModified:
-            error_map[412] = ResourceModifiedError
+            error_map.update({412: ResourceModifiedError})
         if match_condition == MatchConditions.IfModified:
-            error_map[412] = ResourceNotModifiedError
+            error_map.update({412: ResourceNotModifiedError})
         if match_condition == MatchConditions.IfPresent:
-            error_map[412] = ResourceNotFoundError
+            error_map.update({412: ResourceNotFoundError})
         if match_condition == MatchConditions.IfMissing:
-            error_map[412] = ResourceExistsError
+            error_map.update({412: ResourceExistsError})
 
         try:
             key_value_deleted = await self._impl.delete_key_value(
@@ -503,13 +503,13 @@ class AzureAppConfigurationClient:
 
         match_condition = kwargs.pop("match_condition", MatchConditions.Unconditionally)
         if match_condition == MatchConditions.IfNotModified:
-            error_map[412] = ResourceModifiedError
+            error_map.update({412: ResourceModifiedError})
         if match_condition == MatchConditions.IfModified:
-            error_map[412] = ResourceNotModifiedError
+            error_map.update({412: ResourceNotModifiedError})
         if match_condition == MatchConditions.IfPresent:
-            error_map[412] = ResourceNotFoundError
+            error_map.update({412: ResourceNotFoundError})
         if match_condition == MatchConditions.IfMissing:
-            error_map[412] = ResourceExistsError
+            error_map.update({412: ResourceExistsError})
 
         try:
             if read_only:
@@ -600,13 +600,13 @@ class AzureAppConfigurationClient:
         """
         error_map = {}
         if match_condition == MatchConditions.IfNotModified:
-            error_map[412] = ResourceModifiedError
+            error_map.update({412: ResourceModifiedError})
         if match_condition == MatchConditions.IfModified:
-            error_map[412] = ResourceNotModifiedError
+            error_map.update({412: ResourceNotModifiedError})
         if match_condition == MatchConditions.IfPresent:
-            error_map[412] = ResourceNotFoundError
+            error_map.update({412: ResourceNotFoundError})
         if match_condition == MatchConditions.IfMissing:
-            error_map[412] = ResourceExistsError
+            error_map.update({412: ResourceExistsError})
         try:
             generated_snapshot = await self._impl.update_snapshot(
                 name=name,
@@ -641,13 +641,13 @@ class AzureAppConfigurationClient:
         """
         error_map = {}
         if match_condition == MatchConditions.IfNotModified:
-            error_map[412] = ResourceModifiedError
+            error_map.update({412: ResourceModifiedError})
         if match_condition == MatchConditions.IfModified:
-            error_map[412] = ResourceNotModifiedError
+            error_map.update({412: ResourceNotModifiedError})
         if match_condition == MatchConditions.IfPresent:
-            error_map[412] = ResourceNotFoundError
+            error_map.update({412: ResourceNotFoundError})
         if match_condition == MatchConditions.IfMissing:
-            error_map[412] = ResourceExistsError
+            error_map.update({412: ResourceExistsError})
         try:
             generated_snapshot = await self._impl.update_snapshot(
                 name=name,

--- a/sdk/appconfiguration/azure-appconfiguration/azure/appconfiguration/aio/_azure_appconfiguration_client_async.py
+++ b/sdk/appconfiguration/azure-appconfiguration/azure/appconfiguration/aio/_azure_appconfiguration_client_async.py
@@ -169,7 +169,6 @@ class AzureAppConfigurationClient:
         select = kwargs.pop("fields", None)
         if select:
             select = ["locked" if x == "read_only" else x for x in select]
-        error_map = {401: ClientAuthenticationError}
 
         try:
             return self._impl.get_key_values(  # type: ignore
@@ -177,7 +176,6 @@ class AzureAppConfigurationClient:
                 key=key_filter,
                 select=select,
                 cls=lambda objs: [ConfigurationSetting._from_generated(x) for x in objs],
-                error_map=error_map,
                 **kwargs
             )
         except binascii.Error as exc:
@@ -221,7 +219,7 @@ class AzureAppConfigurationClient:
                 key="MyKey", label="MyLabel"
             )
         """
-        error_map = {401: ClientAuthenticationError, 404: ResourceNotFoundError}
+        error_map = {}
         if match_condition == MatchConditions.IfNotModified:
             error_map[412] = ResourceModifiedError
         if match_condition == MatchConditions.IfModified:
@@ -277,7 +275,7 @@ class AzureAppConfigurationClient:
         """
         key_value = configuration_setting._to_generated()
         custom_headers = CaseInsensitiveDict(kwargs.get("headers"))  # type: Mapping[str, Any]
-        error_map = {401: ClientAuthenticationError, 412: ResourceExistsError}
+        error_map = {412: ResourceExistsError}
 
         try:
             key_value_added = await self._impl.put_key_value(
@@ -338,7 +336,7 @@ class AzureAppConfigurationClient:
 
         key_value = configuration_setting._to_generated()
         custom_headers = CaseInsensitiveDict(kwargs.get("headers"))  # type: Mapping[str, Any]
-        error_map = {401: ClientAuthenticationError, 409: ResourceReadOnlyError}
+        error_map = {409: ResourceReadOnlyError}
         if match_condition == MatchConditions.IfNotModified:
             error_map[412] = ResourceModifiedError
         if match_condition == MatchConditions.IfModified:
@@ -397,7 +395,7 @@ class AzureAppConfigurationClient:
         etag = kwargs.pop("etag", None)
         match_condition = kwargs.pop("match_condition", MatchConditions.Unconditionally)
         custom_headers = CaseInsensitiveDict(kwargs.get("headers"))  # type: Mapping[str, Any]
-        error_map = {401: ClientAuthenticationError, 409: ResourceReadOnlyError}
+        error_map = {409: ResourceReadOnlyError}
         if match_condition == MatchConditions.IfNotModified:
             error_map[412] = ResourceModifiedError
         if match_condition == MatchConditions.IfModified:
@@ -462,7 +460,6 @@ class AzureAppConfigurationClient:
         select = kwargs.pop("fields", None)
         if select:
             select = ["locked" if x == "read_only" else x for x in select]
-        error_map = {401: ClientAuthenticationError}
 
         try:
             return self._impl.get_revisions(  # type: ignore
@@ -470,7 +467,6 @@ class AzureAppConfigurationClient:
                 key=key_filter,
                 select=select,
                 cls=lambda objs: [ConfigurationSetting._from_generated(x) for x in objs],
-                error_map=error_map,
                 **kwargs
             )
         except binascii.Error as exc:
@@ -507,7 +503,7 @@ class AzureAppConfigurationClient:
             read_only_config_setting = await async_client.set_read_only(config_setting)
             read_only_config_setting = await client.set_read_only(config_setting, read_only=False)
         """
-        error_map = {401: ClientAuthenticationError, 404: ResourceNotFoundError}
+        error_map = {}
 
         match_condition = kwargs.pop("match_condition", MatchConditions.Unconditionally)
         if match_condition == MatchConditions.IfNotModified:

--- a/sdk/appconfiguration/azure-appconfiguration/azure/appconfiguration/aio/_azure_appconfiguration_client_async.py
+++ b/sdk/appconfiguration/azure-appconfiguration/azure/appconfiguration/aio/_azure_appconfiguration_client_async.py
@@ -220,8 +220,6 @@ class AzureAppConfigurationClient:
         error_map = {}
         if match_condition == MatchConditions.IfNotModified:
             error_map[412] = ResourceModifiedError
-        if match_condition == MatchConditions.IfModified:
-            error_map[304] = ResourceNotModifiedError
         if match_condition == MatchConditions.IfPresent:
             error_map[412] = ResourceNotFoundError
         if match_condition == MatchConditions.IfMissing:

--- a/sdk/appconfiguration/azure-appconfiguration/azure/appconfiguration/aio/_azure_appconfiguration_client_async.py
+++ b/sdk/appconfiguration/azure-appconfiguration/azure/appconfiguration/aio/_azure_appconfiguration_client_async.py
@@ -600,12 +600,22 @@ class AzureAppConfigurationClient:
         :return: The Snapshot returned from the service.
         :rtype: ~azure.appconfiguration.Snapshot
         """
+        error_map = {}
+        if match_condition == MatchConditions.IfNotModified:
+            error_map[412] = ResourceModifiedError
+        if match_condition == MatchConditions.IfModified:
+            error_map[412] = ResourceNotModifiedError
+        if match_condition == MatchConditions.IfPresent:
+            error_map[412] = ResourceNotFoundError
+        if match_condition == MatchConditions.IfMissing:
+            error_map[412] = ResourceExistsError
         try:
             generated_snapshot = await self._impl.update_snapshot(
                 name=name,
                 entity=SnapshotUpdateParameters(status=SnapshotStatus.ARCHIVED),
                 if_match=prep_if_match(etag, match_condition),
                 if_none_match=prep_if_none_match(etag, match_condition),
+                error_map=error_map,
                 **kwargs
             )
             return Snapshot._from_generated(generated_snapshot)
@@ -631,12 +641,22 @@ class AzureAppConfigurationClient:
         :return: The Snapshot returned from the service.
         :rtype: ~azure.appconfiguration.Snapshot
         """
+        error_map = {}
+        if match_condition == MatchConditions.IfNotModified:
+            error_map[412] = ResourceModifiedError
+        if match_condition == MatchConditions.IfModified:
+            error_map[412] = ResourceNotModifiedError
+        if match_condition == MatchConditions.IfPresent:
+            error_map[412] = ResourceNotFoundError
+        if match_condition == MatchConditions.IfMissing:
+            error_map[412] = ResourceExistsError
         try:
             generated_snapshot = await self._impl.update_snapshot(
                 name=name,
                 entity=SnapshotUpdateParameters(status=SnapshotStatus.READY),
                 if_match=prep_if_match(etag, match_condition),
                 if_none_match=prep_if_none_match(etag, match_condition),
+                error_map=error_map,
                 **kwargs
             )
             return Snapshot._from_generated(generated_snapshot)

--- a/sdk/appconfiguration/azure-appconfiguration/azure/appconfiguration/aio/_azure_appconfiguration_client_async.py
+++ b/sdk/appconfiguration/azure-appconfiguration/azure/appconfiguration/aio/_azure_appconfiguration_client_async.py
@@ -143,7 +143,8 @@ class AzureAppConfigurationClient:
         :keyword list[str] fields: specify which fields to include in the results. Leave None to include all fields
         :return: An async iterator of :class:`~azure.appconfiguration.ConfigurationSetting`
         :rtype: ~azure.core.async_paging.AsyncItemPaged[~azure.appconfiguration.ConfigurationSetting]
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`, \
+            :class:`~azure.core.exceptions.ClientAuthenticationError`
 
         Example
 
@@ -201,7 +202,11 @@ class AzureAppConfigurationClient:
         :keyword str accept_datetime: retrieve ConfigurationSetting existed at this datetime
         :return: The matched ConfigurationSetting object
         :rtype: ~azure.appconfiguration.ConfigurationSetting or None
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`, \
+            :class:`~azure.core.exceptions.ClientAuthenticationError`, \
+            :class:`~azure.core.exceptions.ResourceNotFoundError`, \
+            :class:`~azure.core.exceptions.ResourceModifiedError`, \
+            :class:`~azure.core.exceptions.ResourceExistsError`
 
         Example
 
@@ -246,7 +251,9 @@ class AzureAppConfigurationClient:
         :type configuration_setting: ~azure.appconfiguration.ConfigurationSetting
         :return: The ConfigurationSetting object returned from the App Configuration service
         :rtype: ~azure.appconfiguration.ConfigurationSetting
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`, \
+            :class:`~azure.core.exceptions.ClientAuthenticationError`, \
+            :class:`~azure.core.exceptions.ResourceExistsError`
 
         Example
 
@@ -299,7 +306,13 @@ class AzureAppConfigurationClient:
         :keyword str etag: check if the ConfigurationSetting is changed. Set None to skip checking etag
         :return: The ConfigurationSetting returned from the service
         :rtype: ~azure.appconfiguration.ConfigurationSetting
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`, \
+            :class:`~azure.core.exceptions.ClientAuthenticationError`, \
+            :class:`~azure.core.exceptions.ResourceReadOnlyError`, \
+            :class:`~azure.core.exceptions.ResourceModifiedError`, \
+            :class:`~azure.core.exceptions.ResourceNotModifiedError`, \
+            :class:`~azure.core.exceptions.ResourceNotFoundError`, \
+            :class:`~azure.core.exceptions.ResourceExistsError`
 
         Example
 
@@ -358,7 +371,13 @@ class AzureAppConfigurationClient:
         :paramtype match_condition: ~azure.core.MatchConditions
         :return: The deleted ConfigurationSetting returned from the service, or None if it doesn't exist.
         :rtype: ~azure.appconfiguration.ConfigurationSetting
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`, \
+            :class:`~azure.core.exceptions.ClientAuthenticationError`, \
+            :class:`~azure.core.exceptions.ResourceReadOnlyError`, \
+            :class:`~azure.core.exceptions.ResourceModifiedError`, \
+            :class:`~azure.core.exceptions.ResourceNotModifiedError`, \
+            :class:`~azure.core.exceptions.ResourceNotFoundError`, \
+            :class:`~azure.core.exceptions.ResourceExistsError`
 
         Example
 
@@ -412,7 +431,8 @@ class AzureAppConfigurationClient:
         :keyword list[str] fields: specify which fields to include in the results. Leave None to include all fields
         :return: An async iterator of :class:`~azure.appconfiguration.ConfigurationSetting`
         :rtype: ~azure.core.async_paging.AsyncItemPaged[~azure.appconfiguration.ConfigurationSetting]
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`, \
+            :class:`~azure.core.exceptions.ClientAuthenticationError`
 
         Example
 
@@ -464,7 +484,9 @@ class AzureAppConfigurationClient:
         :keyword str etag: check if the ConfigurationSetting is changed. Set None to skip checking etag
         :return: The ConfigurationSetting returned from the service
         :rtype: ~azure.appconfiguration.ConfigurationSetting
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`, \
+            :class:`~azure.core.exceptions.ClientAuthenticationError`, \
+            :class:`~azure.core.exceptions.ResourceNotFoundError`
 
         Example
 

--- a/sdk/appconfiguration/azure-appconfiguration/azure/appconfiguration/aio/_azure_appconfiguration_client_async.py
+++ b/sdk/appconfiguration/azure-appconfiguration/azure/appconfiguration/aio/_azure_appconfiguration_client_async.py
@@ -212,7 +212,7 @@ class AzureAppConfigurationClient:
                 key="MyKey", label="MyLabel"
             )
         """
-        error_map = {}
+        error_map = {}  # type: Dict[int, Any]
         if match_condition == MatchConditions.IfNotModified:
             error_map.update({412: ResourceModifiedError})
         if match_condition == MatchConditions.IfPresent:
@@ -319,7 +319,7 @@ class AzureAppConfigurationClient:
 
         key_value = configuration_setting._to_generated()
         custom_headers = CaseInsensitiveDict(kwargs.get("headers"))  # type: Mapping[str, Any]
-        error_map = {409: ResourceReadOnlyError}
+        error_map = {409: ResourceReadOnlyError}  # type: Dict[int, Any]
         if match_condition == MatchConditions.IfNotModified:
             error_map.update({412: ResourceModifiedError})
         if match_condition == MatchConditions.IfModified:
@@ -372,7 +372,7 @@ class AzureAppConfigurationClient:
         etag = kwargs.pop("etag", None)
         match_condition = kwargs.pop("match_condition", MatchConditions.Unconditionally)
         custom_headers = CaseInsensitiveDict(kwargs.get("headers"))  # type: Mapping[str, Any]
-        error_map = {409: ResourceReadOnlyError}
+        error_map = {409: ResourceReadOnlyError}  # type: Dict[int, Any]
         if match_condition == MatchConditions.IfNotModified:
             error_map.update({412: ResourceModifiedError})
         if match_condition == MatchConditions.IfModified:
@@ -477,8 +477,7 @@ class AzureAppConfigurationClient:
             read_only_config_setting = await async_client.set_read_only(config_setting)
             read_only_config_setting = await client.set_read_only(config_setting, read_only=False)
         """
-        error_map = {}
-
+        error_map = {}  # type: Dict[int, Any]
         match_condition = kwargs.pop("match_condition", MatchConditions.Unconditionally)
         if match_condition == MatchConditions.IfNotModified:
             error_map.update({412: ResourceModifiedError})
@@ -578,7 +577,7 @@ class AzureAppConfigurationClient:
         :rtype: ~azure.appconfiguration.Snapshot
         :raises: :class:`~azure.core.exceptions.HttpResponseError`
         """
-        error_map = {}
+        error_map = {}  # type: Dict[int, Any]
         if match_condition == MatchConditions.IfNotModified:
             error_map.update({412: ResourceModifiedError})
         if match_condition == MatchConditions.IfModified:
@@ -620,7 +619,7 @@ class AzureAppConfigurationClient:
         :rtype: ~azure.appconfiguration.Snapshot
         :raises: :class:`~azure.core.exceptions.HttpResponseError`
         """
-        error_map = {}
+        error_map = {}  # type: Dict[int, Any]
         if match_condition == MatchConditions.IfNotModified:
             error_map.update({412: ResourceModifiedError})
         if match_condition == MatchConditions.IfModified:

--- a/sdk/appconfiguration/azure-appconfiguration/azure/appconfiguration/aio/_azure_appconfiguration_client_async.py
+++ b/sdk/appconfiguration/azure-appconfiguration/azure/appconfiguration/aio/_azure_appconfiguration_client_async.py
@@ -17,8 +17,6 @@ from azure.core.polling import AsyncLROPoller
 from azure.core.tracing.decorator import distributed_trace
 from azure.core.tracing.decorator_async import distributed_trace_async
 from azure.core.exceptions import (
-    HttpResponseError,
-    ClientAuthenticationError,
     ResourceExistsError,
     ResourceModifiedError,
     ResourceNotFoundError,

--- a/sdk/appconfiguration/azure-appconfiguration/azure/appconfiguration/aio/_azure_appconfiguration_client_async.py
+++ b/sdk/appconfiguration/azure-appconfiguration/azure/appconfiguration/aio/_azure_appconfiguration_client_async.py
@@ -180,9 +180,6 @@ class AzureAppConfigurationClient:
                 error_map=error_map,
                 **kwargs
             )
-        except HttpResponseError as error:
-            e = error_map[error.status_code]
-            raise e(message=error.message, response=error.response) from error
         except binascii.Error as exc:
             raise binascii.Error("Connection string secret has incorrect padding") from exc
 
@@ -246,9 +243,6 @@ class AzureAppConfigurationClient:
             return ConfigurationSetting._from_generated(key_value)
         except ResourceNotModifiedError:
             return None
-        except HttpResponseError as error:
-            e = error_map[error.status_code]
-            raise e(message=error.message, response=error.response) from error
         except binascii.Error as exc:
             raise binascii.Error("Connection string secret has incorrect padding") from exc
 
@@ -295,9 +289,6 @@ class AzureAppConfigurationClient:
                 error_map=error_map,
             )
             return ConfigurationSetting._from_generated(key_value_added)
-        except HttpResponseError as error:
-            e = error_map[error.status_code]
-            raise e(message=error.message, response=error.response) from error
         except binascii.Error as exc:
             raise binascii.Error("Connection string secret has incorrect padding") from exc
 
@@ -368,9 +359,6 @@ class AzureAppConfigurationClient:
                 error_map=error_map,
             )
             return ConfigurationSetting._from_generated(key_value_set)
-        except HttpResponseError as error:
-            e = error_map[error.status_code]
-            raise e(message=error.message, response=error.response) from error
         except binascii.Error as exc:
             raise binascii.Error("Connection string secret has incorrect padding") from exc
 
@@ -428,9 +416,6 @@ class AzureAppConfigurationClient:
                 error_map=error_map,
             )
             return ConfigurationSetting._from_generated(key_value_deleted)  # type: ignore
-        except HttpResponseError as error:
-            e = error_map[error.status_code]
-            raise e(message=error.message, response=error.response) from error
         except binascii.Error as exc:
             raise binascii.Error("Connection string secret has incorrect padding") from exc
 
@@ -488,9 +473,6 @@ class AzureAppConfigurationClient:
                 error_map=error_map,
                 **kwargs
             )
-        except HttpResponseError as error:
-            e = error_map[error.status_code]
-            raise e(message=error.message, response=error.response) from error
         except binascii.Error as exc:
             raise binascii.Error("Connection string secret has incorrect padding") from exc
 
@@ -557,9 +539,6 @@ class AzureAppConfigurationClient:
                     **kwargs
                 )
             return ConfigurationSetting._from_generated(key_value)
-        except HttpResponseError as error:
-            e = error_map[error.status_code]
-            raise e(message=error.message, response=error.response) from error
         except binascii.Error as exc:
             raise binascii.Error("Connection string secret has incorrect padding") from exc
 

--- a/sdk/appconfiguration/azure-appconfiguration/azure/appconfiguration/aio/_azure_appconfiguration_client_async.py
+++ b/sdk/appconfiguration/azure-appconfiguration/azure/appconfiguration/aio/_azure_appconfiguration_client_async.py
@@ -141,10 +141,9 @@ class AzureAppConfigurationClient:
         :type label_filter: str
         :keyword str accept_datetime: retrieve ConfigurationSetting existed at this datetime
         :keyword list[str] fields: specify which fields to include in the results. Leave None to include all fields
-        :return: An iterator of :class:`~azure.appconfiguration.ConfigurationSetting`
+        :return: An async iterator of :class:`~azure.appconfiguration.ConfigurationSetting`
         :rtype: ~azure.core.async_paging.AsyncItemPaged[~azure.appconfiguration.ConfigurationSetting]
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`, \
-            :class:`~azure.core.exceptions.ClientAuthenticationError`
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example
 
@@ -201,12 +200,8 @@ class AzureAppConfigurationClient:
         :type match_condition: ~azure.core.MatchConditions
         :keyword str accept_datetime: retrieve ConfigurationSetting existed at this datetime
         :return: The matched ConfigurationSetting object
-        :rtype: ~azure.appconfiguration.ConfigurationSetting
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`, \
-            :class:`~azure.core.exceptions.ClientAuthenticationError`, \
-            :class:`~azure.core.exceptions.ResourceNotFoundError`, \
-            :class:`~azure.core.exceptions.ResourceModifiedError`, \
-            :class:`~azure.core.exceptions.ResourceExistsError`
+        :rtype: ~azure.appconfiguration.ConfigurationSetting or None
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example
 
@@ -251,9 +246,7 @@ class AzureAppConfigurationClient:
         :type configuration_setting: ~azure.appconfiguration.ConfigurationSetting
         :return: The ConfigurationSetting object returned from the App Configuration service
         :rtype: ~azure.appconfiguration.ConfigurationSetting
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`, \
-            :class:`~azure.core.exceptions.ClientAuthenticationError`, \
-            :class:`~azure.core.exceptions.ResourceExistsError`
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example
 
@@ -298,7 +291,7 @@ class AzureAppConfigurationClient:
         If the configuration setting identified by key and label does not exist, this is a create.
         Otherwise this is an update.
 
-        :param configuration_setting: the ConfigurationSetting to be added (if not exists) \
+        :param configuration_setting: the ConfigurationSetting to be added (if not exists)
             or updated (if exists) to the service
         :type configuration_setting: ~azure.appconfiguration.ConfigurationSetting
         :param match_condition: The match condition to use upon the etag
@@ -306,13 +299,7 @@ class AzureAppConfigurationClient:
         :keyword str etag: check if the ConfigurationSetting is changed. Set None to skip checking etag
         :return: The ConfigurationSetting returned from the service
         :rtype: ~azure.appconfiguration.ConfigurationSetting
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`, \
-            :class:`~azure.core.exceptions.ClientAuthenticationError`, \
-            :class:`~azure.core.exceptions.ResourceReadOnlyError`, \
-            :class:`~azure.core.exceptions.ResourceModifiedError`, \
-            :class:`~azure.core.exceptions.ResourceNotModifiedError`, \
-            :class:`~azure.core.exceptions.ResourceNotFoundError`, \
-            :class:`~azure.core.exceptions.ResourceExistsError`
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example
 
@@ -371,13 +358,7 @@ class AzureAppConfigurationClient:
         :paramtype match_condition: ~azure.core.MatchConditions
         :return: The deleted ConfigurationSetting returned from the service, or None if it doesn't exist.
         :rtype: ~azure.appconfiguration.ConfigurationSetting
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`, \
-            :class:`~azure.core.exceptions.ClientAuthenticationError`, \
-            :class:`~azure.core.exceptions.ResourceReadOnlyError`, \
-            :class:`~azure.core.exceptions.ResourceModifiedError`, \
-            :class:`~azure.core.exceptions.ResourceNotModifiedError`, \
-            :class:`~azure.core.exceptions.ResourceNotFoundError`, \
-            :class:`~azure.core.exceptions.ResourceExistsError`
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example
 
@@ -429,10 +410,9 @@ class AzureAppConfigurationClient:
         :type label_filter: str
         :keyword str accept_datetime: retrieve ConfigurationSetting existed at this datetime
         :keyword list[str] fields: specify which fields to include in the results. Leave None to include all fields
-        :return: An iterator of :class:`~azure.appconfiguration.ConfigurationSetting`
+        :return: An async iterator of :class:`~azure.appconfiguration.ConfigurationSetting`
         :rtype: ~azure.core.async_paging.AsyncItemPaged[~azure.appconfiguration.ConfigurationSetting]
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`, \
-            :class:`~azure.core.exceptions.ClientAuthenticationError`
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example
 
@@ -484,9 +464,7 @@ class AzureAppConfigurationClient:
         :keyword str etag: check if the ConfigurationSetting is changed. Set None to skip checking etag
         :return: The ConfigurationSetting returned from the service
         :rtype: ~azure.appconfiguration.ConfigurationSetting
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`, \
-            :class:`~azure.core.exceptions.ClientAuthenticationError`, \
-            :class:`~azure.core.exceptions.ResourceNotFoundError`
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example
 
@@ -561,9 +539,10 @@ class AzureAppConfigurationClient:
             snapshot. If not specified, will set to 2592000(30 days). If specified, should be
             in range 3600(1 hour) to 7776000(90 days).
         :keyword dict[str, str] tags: The tags of the snapshot.
-        :return: A poller for create snapshot operation. Call `result()` on this object to wait for the
+        :return: An async poller for create snapshot operation. Call `result()` on this object to wait for the
             operation to complete and get the created snapshot.
         :rtype: ~azure.core.polling.AsyncLROPoller[~azure.appconfiguration.Snapshot]
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
         """
         snapshot = Snapshot(
             filters=filters, composition_type=composition_type, retention_period=retention_period, tags=tags
@@ -597,6 +576,7 @@ class AzureAppConfigurationClient:
         :keyword str etag: Check if the Snapshot is changed. Set None to skip checking etag.
         :return: The Snapshot returned from the service.
         :rtype: ~azure.appconfiguration.Snapshot
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
         """
         error_map = {}
         if match_condition == MatchConditions.IfNotModified:
@@ -638,6 +618,7 @@ class AzureAppConfigurationClient:
         :keyword str etag: Check if the Snapshot is changed. Set None to skip checking etag.
         :return: The Snapshot returned from the service.
         :rtype: ~azure.appconfiguration.Snapshot
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
         """
         error_map = {}
         if match_condition == MatchConditions.IfNotModified:
@@ -670,6 +651,7 @@ class AzureAppConfigurationClient:
         :keyword list[str] fields: Specify which fields to include in the results. Leave None to include all fields.
         :return: The Snapshot returned from the service.
         :rtype: ~azure.appconfiguration.Snapshot
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
         """
         try:
             generated_snapshot = await self._impl.get_snapshot(
@@ -694,8 +676,9 @@ class AzureAppConfigurationClient:
         :keyword str name: Filter results based on snapshot name.
         :keyword list[str] fields: Specify which fields to include in the results. Leave None to include all fields.
         :keyword list[str] status: Filter results based on snapshot keys.
-        :return: An iterator of :class:`~azure.appconfiguration.Snapshot`
+        :return: An async iterator of :class:`~azure.appconfiguration.Snapshot`
         :rtype: ~azure.core.async_paging.AsyncItemPaged[~azure.appconfiguration.Snapshot]
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
         """
         try:
             return self._impl.get_snapshots(  # type: ignore
@@ -718,8 +701,9 @@ class AzureAppConfigurationClient:
         :param str name: The snapshot name.
         :keyword str accept_datetime: Filter out ConfigurationSetting created after this datetime.
         :keyword list[str] fields: Specify which fields to include in the results. Leave None to include all fields.
-        :return: An iterator of :class:`~azure.appconfiguration.ConfigurationSetting`
+        :return: An async iterator of :class:`~azure.appconfiguration.ConfigurationSetting`
         :rtype: ~azure.core.paging.AsyncItemPaged[~azure.appconfiguration.ConfigurationSetting]
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
         """
         if fields:
             fields = ["locked" if x == "read_only" else x for x in fields]

--- a/sdk/appconfiguration/azure-appconfiguration/tests/test_azure_appconfiguration_client.py
+++ b/sdk/appconfiguration/azure-appconfiguration/tests/test_azure_appconfiguration_client.py
@@ -47,29 +47,26 @@ class TestAppConfigurationClient(AppConfigTestCase):
     @recorded_by_proxy
     def test_add_configuration_setting(self, appconfiguration_connection_string):
         client = self.create_client(appconfiguration_connection_string)
-        kv = ConfigurationSetting(
+        test_config_setting = ConfigurationSetting(
             key=KEY + "_ADD",
             label=LABEL,
             value=TEST_VALUE,
             content_type=TEST_CONTENT_TYPE,
             tags={"tag1": "tag1", "tag2": "tag2"},
         )
-        created_kv = client.add_configuration_setting(kv)
+        created_kv = client.add_configuration_setting(test_config_setting)
         assert (
-            created_kv.label == kv.label
-            and kv.value == kv.value
-            and created_kv.content_type == kv.content_type
-            and created_kv.tags == kv.tags
+            created_kv.label == test_config_setting.label
+            and created_kv.value == test_config_setting.value
+            and created_kv.content_type == test_config_setting.content_type
+            and created_kv.tags == test_config_setting.tags
+            and created_kv.etag != None
+            and created_kv.etag != test_config_setting.etag
+            and created_kv.last_modified != None
+            and created_kv.read_only == False
         )
-        assert created_kv.etag is not None and created_kv.last_modified is not None and created_kv.read_only is False
-        client.delete_configuration_setting(key=created_kv.key, label=created_kv.label)
 
-    @app_config_decorator
-    @recorded_by_proxy
-    def test_add_existing_configuration_setting(self, appconfiguration_connection_string):
-        client = self.create_client(appconfiguration_connection_string)
-        test_config_setting = self.create_config_setting()
-        self.add_for_test(client, test_config_setting)
+        # test add existing configuration setting
         with pytest.raises(ResourceExistsError):
             client.add_configuration_setting(
                 ConfigurationSetting(
@@ -77,64 +74,16 @@ class TestAppConfigurationClient(AppConfigTestCase):
                     label=test_config_setting.label,
                 )
             )
-        client.delete_configuration_setting(key=test_config_setting.key, label=test_config_setting.label)
+        client.delete_configuration_setting(key=created_kv.key, label=created_kv.label)
 
     # method: set_configuration_setting
     @app_config_decorator
     @recorded_by_proxy
-    def test_set_existing_configuration_setting_label_etag(self, appconfiguration_connection_string):
+    def test_set_configuration_setting(self, appconfiguration_connection_string):
         client = self.create_client(appconfiguration_connection_string)
         to_set_kv = self.create_config_setting()
         to_set_kv.value = to_set_kv.value + "a"
         to_set_kv.tags = {"a": "b", "c": "d"}
-        set_kv = client.set_configuration_setting(to_set_kv)
-        assert (
-            to_set_kv.key == set_kv.key
-            and to_set_kv.label == to_set_kv.label
-            and to_set_kv.value == set_kv.value
-            and to_set_kv.content_type == set_kv.content_type
-            and to_set_kv.tags == set_kv.tags
-            and to_set_kv.etag != set_kv.etag
-        )
-        client.delete_configuration_setting(key=to_set_kv.key, label=to_set_kv.label)
-
-    @app_config_decorator
-    @recorded_by_proxy
-    def test_set_existing_configuration_setting_label_wrong_etag(self, appconfiguration_connection_string):
-        client = self.create_client(appconfiguration_connection_string)
-        to_set_kv = self.create_config_setting()
-        to_set_kv.value = to_set_kv.value + "a"
-        to_set_kv.tags = {"a": "b", "c": "d"}
-        to_set_kv.etag = "wrong etag"
-        with pytest.raises(ResourceModifiedError):
-            client.set_configuration_setting(to_set_kv, match_condition=MatchConditions.IfNotModified)
-
-    @app_config_decorator
-    @recorded_by_proxy
-    def test_set_configuration_setting_etag(self, appconfiguration_connection_string):
-        client = self.create_client(appconfiguration_connection_string)
-        kv = ConfigurationSetting(
-            key=KEY + "_SET",
-            label=LABEL,
-            value=TEST_VALUE,
-            content_type=TEST_CONTENT_TYPE,
-            tags={"tag1": "tag1", "tag2": "tag2"},
-        )
-        kv.etag = "random etag"
-        with pytest.raises(ResourceModifiedError):
-            client.set_configuration_setting(kv, match_condition=MatchConditions.IfNotModified)
-
-    @app_config_decorator
-    @recorded_by_proxy
-    def test_set_configuration_setting_no_etag(self, appconfiguration_connection_string):
-        client = self.create_client(appconfiguration_connection_string)
-        to_set_kv = ConfigurationSetting(
-            key=KEY + "_SET",
-            label=LABEL,
-            value=TEST_VALUE,
-            content_type=TEST_CONTENT_TYPE,
-            tags={"tag1": "tag1", "tag2": "tag2"},
-        )
         set_kv = client.set_configuration_setting(to_set_kv)
         assert (
             to_set_kv.key == set_kv.key
@@ -145,6 +94,17 @@ class TestAppConfigurationClient(AppConfigTestCase):
             and to_set_kv.etag != set_kv.etag
         )
         client.delete_configuration_setting(key=to_set_kv.key, label=to_set_kv.label)
+
+    @app_config_decorator
+    @recorded_by_proxy
+    def test_set_configuration_setting_wrong_etag(self, appconfiguration_connection_string):
+        client = self.create_client(appconfiguration_connection_string)
+        to_set_kv = self.create_config_setting()
+        to_set_kv.value = to_set_kv.value + "a"
+        to_set_kv.tags = {"a": "b", "c": "d"}
+        to_set_kv.etag = "wrong etag"
+        with pytest.raises(ResourceModifiedError):
+            client.set_configuration_setting(to_set_kv, match_condition=MatchConditions.IfNotModified)
 
     # method: get_configuration_setting
     @app_config_decorator
@@ -165,7 +125,7 @@ class TestAppConfigurationClient(AppConfigTestCase):
 
     @app_config_decorator
     @recorded_by_proxy
-    def test_get_configuration_setting_label(self, appconfiguration_connection_string):
+    def test_get_configuration_setting(self, appconfiguration_connection_string):
         client = self.create_client(appconfiguration_connection_string)
         compare_kv = self.create_config_setting()
         self.add_for_test(client, compare_kv)
@@ -185,15 +145,33 @@ class TestAppConfigurationClient(AppConfigTestCase):
     def test_get_non_existing_configuration_setting(self, appconfiguration_connection_string):
         client = self.create_client(appconfiguration_connection_string)
         compare_kv = self.create_config_setting()
-        self.add_for_test(client, compare_kv)
         with pytest.raises(ResourceNotFoundError):
             client.get_configuration_setting(compare_kv.key, compare_kv.label + "a")
+    
+    @app_config_decorator
+    @recorded_by_proxy
+    def test_get_configuration_setting_with_etag(self, appconfiguration_connection_string):
+        client = self.create_client(appconfiguration_connection_string)
+        compare_kv = self.create_config_setting()
+        self.add_for_test(client, compare_kv)
+        compare_kv = client.get_configuration_setting(compare_kv.key, compare_kv.label)
+
+        # test get with wrong etag
+        with pytest.raises(ResourceModifiedError):
+            client.get_configuration_setting(
+                compare_kv.key, compare_kv.label, etag="wrong etag", match_condition=MatchConditions.IfNotModified
+            )
+        # test get with correct etag
+        with pytest.raises(ResourceNotFoundError):
+            client.get_configuration_setting(compare_kv.key, etag=compare_kv.etag)
+        client.get_configuration_setting(compare_kv.key, compare_kv.label, etag=compare_kv.etag)
+            
         client.delete_configuration_setting(key=compare_kv.key, label=compare_kv.label)
 
     # method: delete_configuration_setting
     @app_config_decorator
     @recorded_by_proxy
-    def test_delete_with_key_no_label(self, appconfiguration_connection_string):
+    def test_delete_configuration_setting_with_key_no_label(self, appconfiguration_connection_string):
         client = self.create_client(appconfiguration_connection_string)
         to_delete_kv = self.create_config_setting_no_label()
         self.add_for_test(client, to_delete_kv)
@@ -204,7 +182,7 @@ class TestAppConfigurationClient(AppConfigTestCase):
 
     @app_config_decorator
     @recorded_by_proxy
-    def test_delete_with_key_label(self, appconfiguration_connection_string):
+    def test_delete_configuration_setting_with_key_label(self, appconfiguration_connection_string):
         client = self.create_client(appconfiguration_connection_string)
         to_delete_kv = self.create_config_setting()
         self.add_for_test(client, to_delete_kv)
@@ -215,33 +193,29 @@ class TestAppConfigurationClient(AppConfigTestCase):
 
     @app_config_decorator
     @recorded_by_proxy
-    def test_delete_not_existing(self, appconfiguration_connection_string):
+    def test_delete_not_existing_configuration_setting(self, appconfiguration_connection_string):
         client = self.create_client(appconfiguration_connection_string)
         deleted_kv = client.delete_configuration_setting("not_exist_" + KEY)
         assert deleted_kv is None
 
     @app_config_decorator
     @recorded_by_proxy
-    def test_delete_correct_etag(self, appconfiguration_connection_string):
+    def test_delete_configuration_setting_with_etag(self, appconfiguration_connection_string):
         client = self.create_client(appconfiguration_connection_string)
         to_delete_kv = self.create_config_setting_no_label()
         self.add_for_test(client, to_delete_kv)
-        deleted_kv = client.delete_configuration_setting(to_delete_kv.key, etag=to_delete_kv.etag)
-        assert deleted_kv is not None
-        with pytest.raises(ResourceNotFoundError):
-            client.get_configuration_setting(to_delete_kv.key)
-
-    @app_config_decorator
-    @recorded_by_proxy
-    def test_delete_wrong_etag(self, appconfiguration_connection_string):
-        client = self.create_client(appconfiguration_connection_string)
-        to_delete_kv = self.create_config_setting_no_label()
-        self.add_for_test(client, to_delete_kv)
+        to_delete_kv = client.get_configuration_setting(to_delete_kv.key, to_delete_kv.label)
+        
+        # test delete with wrong etag
         with pytest.raises(ResourceModifiedError):
             client.delete_configuration_setting(
                 to_delete_kv.key, etag="wrong etag", match_condition=MatchConditions.IfNotModified
             )
-        client.delete_configuration_setting(key=to_delete_kv.key, label=to_delete_kv.label)
+        # test delete with correct etag
+        deleted_kv = client.delete_configuration_setting(to_delete_kv.key, etag=to_delete_kv.etag)
+        assert deleted_kv is not None
+        with pytest.raises(ResourceNotFoundError):
+            client.get_configuration_setting(to_delete_kv.key)
 
     # method: list_configuration_settings
     @app_config_decorator
@@ -309,6 +283,7 @@ class TestAppConfigurationClient(AppConfigTestCase):
         client = self.create_client(appconfiguration_connection_string)
         to_list_kv = self.create_config_setting()
         self.add_for_test(client, to_list_kv)
+        to_list_kv = client.get_configuration_setting(to_list_kv.key, to_list_kv.label)
         custom_headers = {"If-Match": to_list_kv.etag}
         items = list(
             client.list_configuration_settings(
@@ -418,67 +393,52 @@ class TestAppConfigurationClient(AppConfigTestCase):
         client = self.create_client(appconfiguration_connection_string)
         to_list_kv = self.create_config_setting()
         self.add_for_test(client, to_list_kv)
+        to_list_kv = client.get_configuration_setting(to_list_kv.key, to_list_kv.label)
         custom_headers = {"If-Match": to_list_kv.etag}
         items = list(
             client.list_revisions(key_filter=to_list_kv.key, label_filter=to_list_kv.label, headers=custom_headers)
         )
         assert len(items) >= 1
         assert all(x.key == to_list_kv.key and x.label == to_list_kv.label for x in items)
+        
         client.delete_configuration_setting(to_list_kv.key)
 
-    @app_config_decorator
-    @recorded_by_proxy
-    def test_read_only(self, appconfiguration_connection_string):
-        client = self.create_client(appconfiguration_connection_string)
-        kv = self.create_config_setting_no_label()
-        self.add_for_test(client, kv)
-        read_only_kv = client.set_read_only(kv)
-        assert read_only_kv.read_only
-        readable_kv = client.set_read_only(read_only_kv, False)
-        assert not readable_kv.read_only
-        client.delete_configuration_setting(kv.key)
-
-    @app_config_decorator
-    @recorded_by_proxy
-    def test_delete_read_only(self, appconfiguration_connection_string):
-        client = self.create_client(appconfiguration_connection_string)
-        to_delete_kv = self.create_config_setting_no_label()
-        self.add_for_test(client, to_delete_kv)
-        read_only_kv = client.set_read_only(to_delete_kv)
-        with pytest.raises(ResourceReadOnlyError):
-            client.delete_configuration_setting(to_delete_kv.key)
-        client.set_read_only(read_only_kv, False)
-        client.delete_configuration_setting(to_delete_kv.key)
-        with pytest.raises(ResourceNotFoundError):
-            client.get_configuration_setting(to_delete_kv.key)
-
+    # method: set_read_only
     @app_config_decorator
     @recorded_by_proxy
     def test_set_read_only(self, appconfiguration_connection_string):
         client = self.create_client(appconfiguration_connection_string)
         to_set_kv = self.create_config_setting()
         self.add_for_test(client, to_set_kv)
-        to_set_kv.value = to_set_kv.value + "a"
-        to_set_kv.tags = {"a": "b", "c": "d"}
+        to_set_kv = client.get_configuration_setting(to_set_kv.key, to_set_kv.label)
+        
         read_only_kv = client.set_read_only(to_set_kv)
+        assert read_only_kv.read_only
         with pytest.raises(ResourceReadOnlyError):
             client.set_configuration_setting(read_only_kv)
-        readable_kv = client.set_read_only(read_only_kv, False)
-        readable_kv.value = to_set_kv.value
-        readable_kv.tags = to_set_kv.tags
-        set_kv = client.set_configuration_setting(readable_kv)
-        assert (
-            to_set_kv.key == set_kv.key
-            and to_set_kv.label == to_set_kv.label
-            and to_set_kv.value == set_kv.value
-            and to_set_kv.content_type == set_kv.content_type
-            and to_set_kv.tags == set_kv.tags
-            and to_set_kv.etag != set_kv.etag
-        )
-        set_kv.etag = "bad"
+        with pytest.raises(ResourceReadOnlyError):
+            client.delete_configuration_setting(read_only_kv.key, read_only_kv.label)
+        
+        writable_kv = client.set_read_only(read_only_kv, False)
+        assert not writable_kv.read_only
+        client.set_configuration_setting(writable_kv)
+        client.delete_configuration_setting(writable_kv.key)
+
+    @app_config_decorator
+    @recorded_by_proxy
+    def test_set_read_only_with_wrong_etag(self, appconfiguration_connection_string):
+        client = self.create_client(appconfiguration_connection_string)
+        to_set_kv = self.create_config_setting()
+        self.add_for_test(client, to_set_kv)
+        to_set_kv = client.get_configuration_setting(to_set_kv.key, to_set_kv.label)
+
+        to_set_kv.etag = "wrong etag"
         with pytest.raises(ResourceModifiedError):
-            client.set_read_only(set_kv, True, match_condition=MatchConditions.IfNotModified)
-        client.delete_configuration_setting(to_set_kv.key)
+            client.set_read_only(
+                to_set_kv, False, match_condition=MatchConditions.IfNotModified
+            )
+        
+        client.delete_configuration_setting(to_set_kv)
 
     @app_config_decorator
     @recorded_by_proxy
@@ -516,7 +476,8 @@ class TestAppConfigurationClient(AppConfigTestCase):
         sync_token_header3 = ",".join(str(x) for x in sync_token_header3.values())
         assert sync_token_header2 != sync_token_header3
 
-        client.delete_configuration_setting(new.key)
+        client.delete_configuration_setting("KEY1")
+        client.delete_configuration_setting("KEY2")
 
     @app_config_decorator
     @recorded_by_proxy
@@ -875,6 +836,8 @@ class TestAppConfigurationClient(AppConfigTestCase):
         client.set_configuration_setting(new)
         client.get_configuration_setting(new.key)
 
+        client.delete_configuration_setting(new.key)
+
         new = SecretReferenceConfigurationSetting("aref1", "notaurl")  # cspell:disable-line
         new.content_type = "fkaeyjfdkal;"  # cspell:disable-line
         client.set_configuration_setting(new)
@@ -916,6 +879,26 @@ class TestAppConfigurationClient(AppConfigTestCase):
 
         recovered_snapshot = self.client.recover_snapshot(name=snapshot_name)
         assert recovered_snapshot.status == "ready"
+
+        self.tear_down()
+    
+    @app_config_decorator
+    @recorded_by_proxy
+    def test_update_snapshot_status_with_etag(self, appconfiguration_connection_string):
+        self.set_up(appconfiguration_connection_string)
+        snapshot_name = self.get_resource_name("snapshot")
+        filters = [ConfigurationSettingFilter(key=KEY, label=LABEL)]
+        response = self.client.begin_create_snapshot(name=snapshot_name, filters=filters)
+        created_snapshot = response.result()
+
+        # test update with wrong etag
+        with pytest.raises(ResourceModifiedError):
+            self.client.archive_snapshot(
+                name=snapshot_name, etag="wrong etag", match_condition=MatchConditions.IfNotModified
+            )
+        # test update with correct etag
+        archived_snapshot = self.client.archive_snapshot(name=snapshot_name, etag=created_snapshot.etag)
+        assert archived_snapshot.status == "archived"
 
         self.tear_down()
 

--- a/sdk/appconfiguration/azure-appconfiguration/tests/test_azure_appconfiguration_client.py
+++ b/sdk/appconfiguration/azure-appconfiguration/tests/test_azure_appconfiguration_client.py
@@ -147,7 +147,7 @@ class TestAppConfigurationClient(AppConfigTestCase):
         compare_kv = self.create_config_setting()
         with pytest.raises(ResourceNotFoundError):
             client.get_configuration_setting(compare_kv.key, compare_kv.label + "a")
-    
+
     @app_config_decorator
     @recorded_by_proxy
     def test_get_configuration_setting_with_etag(self, appconfiguration_connection_string):
@@ -165,7 +165,7 @@ class TestAppConfigurationClient(AppConfigTestCase):
         with pytest.raises(ResourceNotFoundError):
             client.get_configuration_setting(compare_kv.key, etag=compare_kv.etag)
         client.get_configuration_setting(compare_kv.key, compare_kv.label, etag=compare_kv.etag)
-            
+
         client.delete_configuration_setting(key=compare_kv.key, label=compare_kv.label)
 
     # method: delete_configuration_setting
@@ -205,7 +205,7 @@ class TestAppConfigurationClient(AppConfigTestCase):
         to_delete_kv = self.create_config_setting_no_label()
         self.add_for_test(client, to_delete_kv)
         to_delete_kv = client.get_configuration_setting(to_delete_kv.key, to_delete_kv.label)
-        
+
         # test delete with wrong etag
         with pytest.raises(ResourceModifiedError):
             client.delete_configuration_setting(
@@ -400,7 +400,7 @@ class TestAppConfigurationClient(AppConfigTestCase):
         )
         assert len(items) >= 1
         assert all(x.key == to_list_kv.key and x.label == to_list_kv.label for x in items)
-        
+
         client.delete_configuration_setting(to_list_kv.key)
 
     # method: set_read_only
@@ -411,14 +411,14 @@ class TestAppConfigurationClient(AppConfigTestCase):
         to_set_kv = self.create_config_setting()
         self.add_for_test(client, to_set_kv)
         to_set_kv = client.get_configuration_setting(to_set_kv.key, to_set_kv.label)
-        
+
         read_only_kv = client.set_read_only(to_set_kv)
         assert read_only_kv.read_only
         with pytest.raises(ResourceReadOnlyError):
             client.set_configuration_setting(read_only_kv)
         with pytest.raises(ResourceReadOnlyError):
             client.delete_configuration_setting(read_only_kv.key, read_only_kv.label)
-        
+
         writable_kv = client.set_read_only(read_only_kv, False)
         assert not writable_kv.read_only
         client.set_configuration_setting(writable_kv)
@@ -434,10 +434,8 @@ class TestAppConfigurationClient(AppConfigTestCase):
 
         to_set_kv.etag = "wrong etag"
         with pytest.raises(ResourceModifiedError):
-            client.set_read_only(
-                to_set_kv, False, match_condition=MatchConditions.IfNotModified
-            )
-        
+            client.set_read_only(to_set_kv, False, match_condition=MatchConditions.IfNotModified)
+
         client.delete_configuration_setting(to_set_kv)
 
     @app_config_decorator
@@ -881,7 +879,7 @@ class TestAppConfigurationClient(AppConfigTestCase):
         assert recovered_snapshot.status == "ready"
 
         self.tear_down()
-    
+
     @app_config_decorator
     @recorded_by_proxy
     def test_update_snapshot_status_with_etag(self, appconfiguration_connection_string):

--- a/sdk/appconfiguration/azure-appconfiguration/tests/test_azure_appconfiguration_client_aad.py
+++ b/sdk/appconfiguration/azure-appconfiguration/tests/test_azure_appconfiguration_client_aad.py
@@ -44,29 +44,26 @@ class TestAppConfigurationClientAAD(AppConfigTestCase):
     @recorded_by_proxy
     def test_add_configuration_setting(self, appconfiguration_endpoint_string):
         client = self.create_aad_client(appconfiguration_endpoint_string)
-        kv = ConfigurationSetting(
+        test_config_setting = ConfigurationSetting(
             key=KEY + "_ADD",
             label=LABEL,
             value=TEST_VALUE,
             content_type=TEST_CONTENT_TYPE,
             tags={"tag1": "tag1", "tag2": "tag2"},
         )
-        created_kv = client.add_configuration_setting(kv)
+        created_kv = client.add_configuration_setting(test_config_setting)
         assert (
-            created_kv.label == kv.label
-            and kv.value == kv.value
-            and created_kv.content_type == kv.content_type
-            and created_kv.tags == kv.tags
+            created_kv.label == test_config_setting.label
+            and created_kv.value == test_config_setting.value
+            and created_kv.content_type == test_config_setting.content_type
+            and created_kv.tags == test_config_setting.tags
+            and created_kv.etag != None
+            and created_kv.etag != test_config_setting.etag
+            and created_kv.last_modified != None
+            and created_kv.read_only == False
         )
-        assert created_kv.etag is not None and created_kv.last_modified is not None and created_kv.read_only is False
-        client.delete_configuration_setting(key=created_kv.key, label=created_kv.label)
 
-    @app_config_aad_decorator
-    @recorded_by_proxy
-    def test_add_existing_configuration_setting(self, appconfiguration_endpoint_string):
-        client = self.create_aad_client(appconfiguration_endpoint_string)
-        test_config_setting = self.create_config_setting()
-        self.add_for_test(client, test_config_setting)
+        # test add existing configuration setting
         with pytest.raises(ResourceExistsError):
             client.add_configuration_setting(
                 ConfigurationSetting(
@@ -74,7 +71,7 @@ class TestAppConfigurationClientAAD(AppConfigTestCase):
                     label=test_config_setting.label,
                 )
             )
-        client.delete_configuration_setting(key=test_config_setting.key, label=test_config_setting.label)
+        client.delete_configuration_setting(key=created_kv.key, label=created_kv.label)
 
     # method: set_configuration_setting
     @app_config_aad_decorator
@@ -97,7 +94,7 @@ class TestAppConfigurationClientAAD(AppConfigTestCase):
 
     @app_config_aad_decorator
     @recorded_by_proxy
-    def test_set_existing_configuration_setting_label_wrong_etag(self, appconfiguration_endpoint_string):
+    def test_set_configuration_setting_wrong_etag(self, appconfiguration_endpoint_string):
         client = self.create_aad_client(appconfiguration_endpoint_string)
         to_set_kv = self.create_config_setting()
         to_set_kv.value = to_set_kv.value + "a"
@@ -106,63 +103,10 @@ class TestAppConfigurationClientAAD(AppConfigTestCase):
         with pytest.raises(ResourceModifiedError):
             client.set_configuration_setting(to_set_kv, match_condition=MatchConditions.IfNotModified)
 
-    @app_config_aad_decorator
-    @recorded_by_proxy
-    def test_set_configuration_setting_etag(self, appconfiguration_endpoint_string):
-        client = self.create_aad_client(appconfiguration_endpoint_string)
-        kv = ConfigurationSetting(
-            key=KEY + "_SET",
-            label=LABEL,
-            value=TEST_VALUE,
-            content_type=TEST_CONTENT_TYPE,
-            tags={"tag1": "tag1", "tag2": "tag2"},
-        )
-        kv.etag = "random etag"
-        with pytest.raises(ResourceModifiedError):
-            client.set_configuration_setting(kv, match_condition=MatchConditions.IfNotModified)
-
-    @app_config_aad_decorator
-    @recorded_by_proxy
-    def test_set_configuration_setting_no_etag(self, appconfiguration_endpoint_string):
-        client = self.create_aad_client(appconfiguration_endpoint_string)
-        to_set_kv = ConfigurationSetting(
-            key=KEY + "_SET",
-            label=LABEL,
-            value=TEST_VALUE,
-            content_type=TEST_CONTENT_TYPE,
-            tags={"tag1": "tag1", "tag2": "tag2"},
-        )
-        set_kv = client.set_configuration_setting(to_set_kv)
-        assert (
-            to_set_kv.key == set_kv.key
-            and to_set_kv.label == set_kv.label
-            and to_set_kv.value == set_kv.value
-            and to_set_kv.content_type == set_kv.content_type
-            and to_set_kv.tags == set_kv.tags
-            and to_set_kv.etag != set_kv.etag
-        )
-        client.delete_configuration_setting(key=to_set_kv.key, label=to_set_kv.label)
-
     # method: get_configuration_setting
     @app_config_aad_decorator
     @recorded_by_proxy
-    def test_get_configuration_setting_no_label(self, appconfiguration_endpoint_string):
-        client = self.create_aad_client(appconfiguration_endpoint_string)
-        compare_kv = self.create_config_setting_no_label()
-        self.add_for_test(client, compare_kv)
-        fetched_kv = client.get_configuration_setting(compare_kv.key)
-        assert (
-            fetched_kv.key == compare_kv.key
-            and fetched_kv.value == compare_kv.value
-            and fetched_kv.content_type == compare_kv.content_type
-            and fetched_kv.tags == compare_kv.tags
-        )
-        assert fetched_kv.label is None
-        client.delete_configuration_setting(key=compare_kv.key, label=compare_kv.label)
-
-    @app_config_aad_decorator
-    @recorded_by_proxy
-    def test_get_configuration_setting_label(self, appconfiguration_endpoint_string):
+    def test_get_configuration_setting(self, appconfiguration_endpoint_string):
         client = self.create_aad_client(appconfiguration_endpoint_string)
         compare_kv = self.create_config_setting()
         self.add_for_test(client, compare_kv)
@@ -172,6 +116,7 @@ class TestAppConfigurationClientAAD(AppConfigTestCase):
             and fetched_kv.value == compare_kv.value
             and fetched_kv.content_type == compare_kv.content_type
             and fetched_kv.tags == compare_kv.tags
+            and fetched_kv.label == compare_kv.label
         )
         assert fetched_kv.label is not None
         client.delete_configuration_setting(key=compare_kv.key, label=compare_kv.label)
@@ -181,15 +126,33 @@ class TestAppConfigurationClientAAD(AppConfigTestCase):
     def test_get_non_existing_configuration_setting(self, appconfiguration_endpoint_string):
         client = self.create_aad_client(appconfiguration_endpoint_string)
         compare_kv = self.create_config_setting()
-        self.add_for_test(client, compare_kv)
         with pytest.raises(ResourceNotFoundError):
             client.get_configuration_setting(compare_kv.key, compare_kv.label + "a")
+    
+    @app_config_aad_decorator
+    @recorded_by_proxy
+    def test_get_configuration_setting_with_etag(self, appconfiguration_endpoint_string):
+        client = self.create_aad_client(appconfiguration_endpoint_string)
+        compare_kv = self.create_config_setting()
+        self.add_for_test(client, compare_kv)
+        compare_kv = client.get_configuration_setting(compare_kv.key, compare_kv.label)
+
+        # test get with wrong etag
+        with pytest.raises(ResourceModifiedError):
+            client.get_configuration_setting(
+                compare_kv.key, compare_kv.label, etag="wrong etag", match_condition=MatchConditions.IfNotModified
+            )
+        # test get with correct etag
+        with pytest.raises(ResourceNotFoundError):
+            client.get_configuration_setting(compare_kv.key, etag=compare_kv.etag)
+        client.get_configuration_setting(compare_kv.key, compare_kv.label, etag=compare_kv.etag)
+            
         client.delete_configuration_setting(key=compare_kv.key, label=compare_kv.label)
 
     # method: delete_configuration_setting
     @app_config_aad_decorator
     @recorded_by_proxy
-    def test_delete_with_key_no_label(self, appconfiguration_endpoint_string):
+    def test_delete_configuration_setting_with_key_no_label(self, appconfiguration_endpoint_string):
         client = self.create_aad_client(appconfiguration_endpoint_string)
         to_delete_kv = self.create_config_setting_no_label()
         self.add_for_test(client, to_delete_kv)
@@ -200,7 +163,7 @@ class TestAppConfigurationClientAAD(AppConfigTestCase):
 
     @app_config_aad_decorator
     @recorded_by_proxy
-    def test_delete_with_key_label(self, appconfiguration_endpoint_string):
+    def test_delete_configuration_setting_with_key_label(self, appconfiguration_endpoint_string):
         client = self.create_aad_client(appconfiguration_endpoint_string)
         to_delete_kv = self.create_config_setting()
         self.add_for_test(client, to_delete_kv)
@@ -211,33 +174,29 @@ class TestAppConfigurationClientAAD(AppConfigTestCase):
 
     @app_config_aad_decorator
     @recorded_by_proxy
-    def test_delete_not_existing(self, appconfiguration_endpoint_string):
+    def test_delete_not_existing_configuration_setting(self, appconfiguration_endpoint_string):
         client = self.create_aad_client(appconfiguration_endpoint_string)
         deleted_kv = client.delete_configuration_setting("not_exist_" + KEY)
         assert deleted_kv is None
 
     @app_config_aad_decorator
     @recorded_by_proxy
-    def test_delete_correct_etag(self, appconfiguration_endpoint_string):
+    def test_delete_configuration_setting_with_etag(self, appconfiguration_endpoint_string):
         client = self.create_aad_client(appconfiguration_endpoint_string)
         to_delete_kv = self.create_config_setting_no_label()
         self.add_for_test(client, to_delete_kv)
-        deleted_kv = client.delete_configuration_setting(to_delete_kv.key, etag=to_delete_kv.etag)
-        assert deleted_kv is not None
-        with pytest.raises(ResourceNotFoundError):
-            client.get_configuration_setting(to_delete_kv.key)
-
-    @app_config_aad_decorator
-    @recorded_by_proxy
-    def test_delete_wrong_etag(self, appconfiguration_endpoint_string):
-        client = self.create_aad_client(appconfiguration_endpoint_string)
-        to_delete_kv = self.create_config_setting_no_label()
-        self.add_for_test(client, to_delete_kv)
+        to_delete_kv = client.get_configuration_setting(to_delete_kv.key, to_delete_kv.label)
+        
+        # test delete with wrong etag
         with pytest.raises(ResourceModifiedError):
             client.delete_configuration_setting(
                 to_delete_kv.key, etag="wrong etag", match_condition=MatchConditions.IfNotModified
             )
-        client.delete_configuration_setting(key=to_delete_kv.key, label=to_delete_kv.label)
+        # test delete with correct etag
+        deleted_kv = client.delete_configuration_setting(to_delete_kv.key, etag=to_delete_kv.etag)
+        assert deleted_kv is not None
+        with pytest.raises(ResourceNotFoundError):
+            client.get_configuration_setting(to_delete_kv.key)
 
     # method: list_configuration_settings
     @app_config_aad_decorator
@@ -305,6 +264,7 @@ class TestAppConfigurationClientAAD(AppConfigTestCase):
         client = self.create_aad_client(appconfiguration_endpoint_string)
         to_list_kv = self.create_config_setting()
         self.add_for_test(client, to_list_kv)
+        to_list_kv = client.get_configuration_setting(to_list_kv.key, to_list_kv.label)
         custom_headers = {"If-Match": to_list_kv.etag}
         items = list(
             client.list_configuration_settings(
@@ -411,6 +371,7 @@ class TestAppConfigurationClientAAD(AppConfigTestCase):
         client = self.create_aad_client(appconfiguration_endpoint_string)
         to_list_kv = self.create_config_setting()
         self.add_for_test(client, to_list_kv)
+        to_list_kv = client.get_configuration_setting(to_list_kv.key, to_list_kv.label)
         custom_headers = {"If-Match": to_list_kv.etag}
         items = list(
             client.list_revisions(key_filter=to_list_kv.key, label_filter=to_list_kv.label, headers=custom_headers)
@@ -419,59 +380,42 @@ class TestAppConfigurationClientAAD(AppConfigTestCase):
         assert all(x.key == to_list_kv.key and x.label == to_list_kv.label for x in items)
         client.delete_configuration_setting(to_list_kv.key)
 
-    @app_config_aad_decorator
-    @recorded_by_proxy
-    def test_read_only(self, appconfiguration_endpoint_string):
-        client = self.create_aad_client(appconfiguration_endpoint_string)
-        kv = self.create_config_setting_no_label()
-        self.add_for_test(client, kv)
-        read_only_kv = client.set_read_only(kv)
-        assert read_only_kv.read_only
-        readable_kv = client.set_read_only(read_only_kv, False)
-        assert not readable_kv.read_only
-        client.delete_configuration_setting(kv.key)
-
-    @app_config_aad_decorator
-    @recorded_by_proxy
-    def test_delete_read_only(self, appconfiguration_endpoint_string):
-        client = self.create_aad_client(appconfiguration_endpoint_string)
-        to_delete_kv = self.create_config_setting_no_label()
-        self.add_for_test(client, to_delete_kv)
-        read_only_kv = client.set_read_only(to_delete_kv)
-        with pytest.raises(ResourceReadOnlyError):
-            client.delete_configuration_setting(to_delete_kv.key)
-        client.set_read_only(read_only_kv, False)
-        client.delete_configuration_setting(to_delete_kv.key)
-        with pytest.raises(ResourceNotFoundError):
-            client.get_configuration_setting(to_delete_kv.key)
-
+    # method: set_read_only
     @app_config_aad_decorator
     @recorded_by_proxy
     def test_set_read_only(self, appconfiguration_endpoint_string):
         client = self.create_aad_client(appconfiguration_endpoint_string)
         to_set_kv = self.create_config_setting()
         self.add_for_test(client, to_set_kv)
-        to_set_kv.value = to_set_kv.value + "a"
-        to_set_kv.tags = {"a": "b", "c": "d"}
+        to_set_kv = client.get_configuration_setting(to_set_kv.key, to_set_kv.label)
+        
         read_only_kv = client.set_read_only(to_set_kv)
+        assert read_only_kv.read_only
         with pytest.raises(ResourceReadOnlyError):
             client.set_configuration_setting(read_only_kv)
-        readable_kv = client.set_read_only(read_only_kv, False)
-        readable_kv.value = to_set_kv.value
-        readable_kv.tags = to_set_kv.tags
-        set_kv = client.set_configuration_setting(readable_kv)
-        assert (
-            to_set_kv.key == set_kv.key
-            and to_set_kv.label == to_set_kv.label
-            and to_set_kv.value == set_kv.value
-            and to_set_kv.content_type == set_kv.content_type
-            and to_set_kv.tags == set_kv.tags
-            and to_set_kv.etag != set_kv.etag
-        )
-        set_kv.etag = "bad"
+        with pytest.raises(ResourceReadOnlyError):
+            client.delete_configuration_setting(read_only_kv.key, read_only_kv.label)
+        
+        writable_kv = client.set_read_only(read_only_kv, False)
+        assert not writable_kv.read_only
+        client.set_configuration_setting(writable_kv)
+        client.delete_configuration_setting(writable_kv.key)
+
+    @app_config_aad_decorator
+    @recorded_by_proxy
+    def test_set_read_only_with_wrong_etag(self, appconfiguration_endpoint_string):
+        client = self.create_aad_client(appconfiguration_endpoint_string)
+        to_set_kv = self.create_config_setting()
+        self.add_for_test(client, to_set_kv)
+        to_set_kv = client.get_configuration_setting(to_set_kv.key, to_set_kv.label)
+
+        to_set_kv.etag = "wrong etag"
         with pytest.raises(ResourceModifiedError):
-            client.set_read_only(set_kv, True, match_condition=MatchConditions.IfNotModified)
-        client.delete_configuration_setting(to_set_kv.key)
+            client.set_read_only(
+                to_set_kv, False, match_condition=MatchConditions.IfNotModified
+            )
+        
+        client.delete_configuration_setting(to_set_kv)
 
     @app_config_aad_decorator
     @recorded_by_proxy
@@ -509,7 +453,8 @@ class TestAppConfigurationClientAAD(AppConfigTestCase):
         sync_token_header3 = ",".join(str(x) for x in sync_token_header3.values())
         assert sync_token_header2 != sync_token_header3
 
-        client.delete_configuration_setting(new.key)
+        client.delete_configuration_setting("KEY1")
+        client.delete_configuration_setting("KEY2")
 
     @app_config_aad_decorator
     @recorded_by_proxy

--- a/sdk/appconfiguration/azure-appconfiguration/tests/test_azure_appconfiguration_client_aad.py
+++ b/sdk/appconfiguration/azure-appconfiguration/tests/test_azure_appconfiguration_client_aad.py
@@ -128,7 +128,7 @@ class TestAppConfigurationClientAAD(AppConfigTestCase):
         compare_kv = self.create_config_setting()
         with pytest.raises(ResourceNotFoundError):
             client.get_configuration_setting(compare_kv.key, compare_kv.label + "a")
-    
+
     @app_config_aad_decorator
     @recorded_by_proxy
     def test_get_configuration_setting_with_etag(self, appconfiguration_endpoint_string):
@@ -146,7 +146,7 @@ class TestAppConfigurationClientAAD(AppConfigTestCase):
         with pytest.raises(ResourceNotFoundError):
             client.get_configuration_setting(compare_kv.key, etag=compare_kv.etag)
         client.get_configuration_setting(compare_kv.key, compare_kv.label, etag=compare_kv.etag)
-            
+
         client.delete_configuration_setting(key=compare_kv.key, label=compare_kv.label)
 
     # method: delete_configuration_setting
@@ -186,7 +186,7 @@ class TestAppConfigurationClientAAD(AppConfigTestCase):
         to_delete_kv = self.create_config_setting_no_label()
         self.add_for_test(client, to_delete_kv)
         to_delete_kv = client.get_configuration_setting(to_delete_kv.key, to_delete_kv.label)
-        
+
         # test delete with wrong etag
         with pytest.raises(ResourceModifiedError):
             client.delete_configuration_setting(
@@ -388,14 +388,14 @@ class TestAppConfigurationClientAAD(AppConfigTestCase):
         to_set_kv = self.create_config_setting()
         self.add_for_test(client, to_set_kv)
         to_set_kv = client.get_configuration_setting(to_set_kv.key, to_set_kv.label)
-        
+
         read_only_kv = client.set_read_only(to_set_kv)
         assert read_only_kv.read_only
         with pytest.raises(ResourceReadOnlyError):
             client.set_configuration_setting(read_only_kv)
         with pytest.raises(ResourceReadOnlyError):
             client.delete_configuration_setting(read_only_kv.key, read_only_kv.label)
-        
+
         writable_kv = client.set_read_only(read_only_kv, False)
         assert not writable_kv.read_only
         client.set_configuration_setting(writable_kv)
@@ -411,10 +411,8 @@ class TestAppConfigurationClientAAD(AppConfigTestCase):
 
         to_set_kv.etag = "wrong etag"
         with pytest.raises(ResourceModifiedError):
-            client.set_read_only(
-                to_set_kv, False, match_condition=MatchConditions.IfNotModified
-            )
-        
+            client.set_read_only(to_set_kv, False, match_condition=MatchConditions.IfNotModified)
+
         client.delete_configuration_setting(to_set_kv)
 
     @app_config_aad_decorator

--- a/sdk/appconfiguration/azure-appconfiguration/tests/test_azure_appconfiguration_client_aad_async.py
+++ b/sdk/appconfiguration/azure-appconfiguration/tests/test_azure_appconfiguration_client_aad_async.py
@@ -163,9 +163,9 @@ class TestAppConfigurationClientAADAsync(AsyncAppConfigTestCase):
             with pytest.raises(ResourceNotFoundError):
                 await client.get_configuration_setting(compare_kv.key, etag=compare_kv.etag)
             await client.get_configuration_setting(compare_kv.key, compare_kv.label, etag=compare_kv.etag)
-                
+
             await client.delete_configuration_setting(key=compare_kv.key, label=compare_kv.label)
-    
+
     # method: delete_configuration_setting
     @app_config_aad_decorator_async
     @recorded_by_proxy_async
@@ -203,7 +203,7 @@ class TestAppConfigurationClientAADAsync(AsyncAppConfigTestCase):
             to_delete_kv = self.create_config_setting_no_label()
             await self.add_for_test(client, to_delete_kv)
             to_delete_kv = await client.get_configuration_setting(to_delete_kv.key, to_delete_kv.label)
-            
+
             # test delete with wrong etag
             with pytest.raises(ResourceModifiedError):
                 await client.delete_configuration_setting(
@@ -404,7 +404,7 @@ class TestAppConfigurationClientAADAsync(AsyncAppConfigTestCase):
             )
             assert len(items) >= 1
             assert all(x.key == to_list_kv.key and x.label == to_list_kv.label for x in items)
-            
+
             await client.delete_configuration_setting(to_list_kv.key)
 
     # method: set_read_only
@@ -415,14 +415,14 @@ class TestAppConfigurationClientAADAsync(AsyncAppConfigTestCase):
             to_set_kv = self.create_config_setting()
             await self.add_for_test(client, to_set_kv)
             to_set_kv = await client.get_configuration_setting(to_set_kv.key, to_set_kv.label)
-            
+
             read_only_kv = await client.set_read_only(to_set_kv)
             assert read_only_kv.read_only
             with pytest.raises(ResourceReadOnlyError):
                 await client.set_configuration_setting(read_only_kv)
             with pytest.raises(ResourceReadOnlyError):
                 await client.delete_configuration_setting(read_only_kv.key, read_only_kv.label)
-            
+
             writable_kv = await client.set_read_only(read_only_kv, False)
             assert not writable_kv.read_only
             await client.set_configuration_setting(writable_kv)
@@ -435,13 +435,11 @@ class TestAppConfigurationClientAADAsync(AsyncAppConfigTestCase):
             to_set_kv = self.create_config_setting()
             await self.add_for_test(client, to_set_kv)
             to_set_kv = await client.get_configuration_setting(to_set_kv.key, to_set_kv.label)
-            
+
             to_set_kv.etag = "wrong etag"
             with pytest.raises(ResourceModifiedError):
-                await client.set_read_only(
-                    to_set_kv, False, match_condition=MatchConditions.IfNotModified
-                )
-            
+                await client.set_read_only(to_set_kv, False, match_condition=MatchConditions.IfNotModified)
+
             await client.delete_configuration_setting(to_set_kv)
 
     @app_config_aad_decorator_async

--- a/sdk/appconfiguration/azure-appconfiguration/tests/test_azure_appconfiguration_client_aad_async.py
+++ b/sdk/appconfiguration/azure-appconfiguration/tests/test_azure_appconfiguration_client_aad_async.py
@@ -45,31 +45,26 @@ class TestAppConfigurationClientAADAsync(AsyncAppConfigTestCase):
     @recorded_by_proxy_async
     async def test_add_configuration_setting(self, appconfiguration_endpoint_string):
         async with self.create_aad_client(appconfiguration_endpoint_string) as client:
-            kv = ConfigurationSetting(
+            test_config_setting = ConfigurationSetting(
                 key=KEY + "_ADD",
                 label=LABEL,
                 value=TEST_VALUE,
                 content_type=TEST_CONTENT_TYPE,
                 tags={"tag1": "tag1", "tag2": "tag2"},
             )
-            created_kv = await client.add_configuration_setting(kv)
+            created_kv = await client.add_configuration_setting(test_config_setting)
             assert (
-                created_kv.label == kv.label
-                and kv.value == kv.value
-                and created_kv.content_type == kv.content_type
-                and created_kv.tags == kv.tags
+                created_kv.label == test_config_setting.label
+                and created_kv.value == test_config_setting.value
+                and created_kv.content_type == test_config_setting.content_type
+                and created_kv.tags == test_config_setting.tags
+                and created_kv.etag != None
+                and created_kv.etag != test_config_setting.etag
+                and created_kv.last_modified != None
+                and created_kv.read_only == False
             )
-            assert (
-                created_kv.etag is not None and created_kv.last_modified is not None and created_kv.read_only is False
-            )
-            await client.delete_configuration_setting(key=created_kv.key, label=created_kv.label)
 
-    @app_config_aad_decorator_async
-    @recorded_by_proxy_async
-    async def test_add_existing_configuration_setting(self, appconfiguration_endpoint_string):
-        async with self.create_aad_client(appconfiguration_endpoint_string) as client:
-            test_config_setting = self.create_config_setting()
-            await self.add_for_test(client, test_config_setting)
+            # test add existing configuration setting
             with pytest.raises(ResourceExistsError):
                 await client.add_configuration_setting(
                     ConfigurationSetting(
@@ -77,12 +72,12 @@ class TestAppConfigurationClientAADAsync(AsyncAppConfigTestCase):
                         label=test_config_setting.label,
                     )
                 )
-            await client.delete_configuration_setting(key=test_config_setting.key, label=test_config_setting.label)
+            await client.delete_configuration_setting(key=created_kv.key, label=created_kv.label)
 
     # method: set_configuration_setting
     @app_config_aad_decorator_async
     @recorded_by_proxy_async
-    async def test_set_existing_configuration_setting_label_etag(self, appconfiguration_endpoint_string):
+    async def test_set_configuration_setting(self, appconfiguration_endpoint_string):
         async with self.create_aad_client(appconfiguration_endpoint_string) as client:
             to_set_kv = self.create_config_setting()
             to_set_kv.value = to_set_kv.value + "a"
@@ -100,7 +95,7 @@ class TestAppConfigurationClientAADAsync(AsyncAppConfigTestCase):
 
     @app_config_aad_decorator_async
     @recorded_by_proxy_async
-    async def test_set_existing_configuration_setting_label_wrong_etag(self, appconfiguration_endpoint_string):
+    async def test_set_configuration1_setting_with_wrong_etag(self, appconfiguration_endpoint_string):
         async with self.create_aad_client(appconfiguration_endpoint_string) as client:
             to_set_kv = self.create_config_setting()
             to_set_kv.value = to_set_kv.value + "a"
@@ -108,43 +103,6 @@ class TestAppConfigurationClientAADAsync(AsyncAppConfigTestCase):
             to_set_kv.etag = "wrong etag"
             with pytest.raises(ResourceModifiedError):
                 await client.set_configuration_setting(to_set_kv, match_condition=MatchConditions.IfNotModified)
-
-    @app_config_aad_decorator_async
-    @recorded_by_proxy_async
-    async def test_set_configuration_setting_etag(self, appconfiguration_endpoint_string):
-        async with self.create_aad_client(appconfiguration_endpoint_string) as client:
-            kv = ConfigurationSetting(
-                key=KEY + "_SET",
-                label=LABEL,
-                value=TEST_VALUE,
-                content_type=TEST_CONTENT_TYPE,
-                tags={"tag1": "tag1", "tag2": "tag2"},
-            )
-            kv.etag = "random etag"
-            with pytest.raises(ResourceModifiedError):
-                await client.set_configuration_setting(kv, match_condition=MatchConditions.IfNotModified)
-
-    @app_config_aad_decorator_async
-    @recorded_by_proxy_async
-    async def test_set_configuration_setting_no_etag(self, appconfiguration_endpoint_string):
-        async with self.create_aad_client(appconfiguration_endpoint_string) as client:
-            to_set_kv = ConfigurationSetting(
-                key=KEY + "_SET",
-                label=LABEL,
-                value=TEST_VALUE,
-                content_type=TEST_CONTENT_TYPE,
-                tags={"tag1": "tag1", "tag2": "tag2"},
-            )
-            set_kv = await client.set_configuration_setting(to_set_kv)
-            assert (
-                to_set_kv.key == set_kv.key
-                and to_set_kv.label == set_kv.label
-                and to_set_kv.value == set_kv.value
-                and to_set_kv.content_type == set_kv.content_type
-                and to_set_kv.tags == set_kv.tags
-                and to_set_kv.etag != set_kv.etag
-            )
-            await client.delete_configuration_setting(key=to_set_kv.key, label=to_set_kv.label)
 
     # method: get_configuration_setting
     @app_config_aad_decorator_async
@@ -165,7 +123,7 @@ class TestAppConfigurationClientAADAsync(AsyncAppConfigTestCase):
 
     @app_config_aad_decorator_async
     @recorded_by_proxy_async
-    async def test_get_configuration_setting_label(self, appconfiguration_endpoint_string):
+    async def test_get_configuration_setting(self, appconfiguration_endpoint_string):
         async with self.create_aad_client(appconfiguration_endpoint_string) as client:
             compare_kv = self.create_config_setting()
             await self.add_for_test(client, compare_kv)
@@ -175,6 +133,7 @@ class TestAppConfigurationClientAADAsync(AsyncAppConfigTestCase):
                 and fetched_kv.value == compare_kv.value
                 and fetched_kv.content_type == compare_kv.content_type
                 and fetched_kv.tags == compare_kv.tags
+                and fetched_kv.label == compare_kv.label
             )
             assert fetched_kv.label is not None
             await client.delete_configuration_setting(key=compare_kv.key, label=compare_kv.label)
@@ -187,10 +146,30 @@ class TestAppConfigurationClientAADAsync(AsyncAppConfigTestCase):
             with pytest.raises(ResourceNotFoundError):
                 await client.get_configuration_setting(compare_kv.key, compare_kv.label + "a")
 
+    @app_config_aad_decorator_async
+    @recorded_by_proxy_async
+    async def test_get_configuration_setting_with_etag(self, appconfiguration_endpoint_string):
+        async with self.create_aad_client(appconfiguration_endpoint_string) as client:
+            compare_kv = self.create_config_setting()
+            await self.add_for_test(client, compare_kv)
+            compare_kv = await client.get_configuration_setting(compare_kv.key, compare_kv.label)
+
+            # test get with wrong etag
+            with pytest.raises(ResourceModifiedError):
+                await client.get_configuration_setting(
+                    compare_kv.key, compare_kv.label, etag="wrong etag", match_condition=MatchConditions.IfNotModified
+                )
+            # test get with correct etag
+            with pytest.raises(ResourceNotFoundError):
+                await client.get_configuration_setting(compare_kv.key, etag=compare_kv.etag)
+            await client.get_configuration_setting(compare_kv.key, compare_kv.label, etag=compare_kv.etag)
+                
+            await client.delete_configuration_setting(key=compare_kv.key, label=compare_kv.label)
+    
     # method: delete_configuration_setting
     @app_config_aad_decorator_async
     @recorded_by_proxy_async
-    async def test_delete_with_key_no_label(self, appconfiguration_endpoint_string):
+    async def test_delete_configuration_setting_with_key_no_label(self, appconfiguration_endpoint_string):
         async with self.create_aad_client(appconfiguration_endpoint_string) as client:
             to_delete_kv = self.create_config_setting_no_label()
             await self.add_for_test(client, to_delete_kv)
@@ -201,7 +180,7 @@ class TestAppConfigurationClientAADAsync(AsyncAppConfigTestCase):
 
     @app_config_aad_decorator_async
     @recorded_by_proxy_async
-    async def test_delete_with_key_label(self, appconfiguration_endpoint_string):
+    async def test_delete_configuration_setting_with_key_label(self, appconfiguration_endpoint_string):
         async with self.create_aad_client(appconfiguration_endpoint_string) as client:
             to_delete_kv = self.create_config_setting()
             await self.add_for_test(client, to_delete_kv)
@@ -212,32 +191,29 @@ class TestAppConfigurationClientAADAsync(AsyncAppConfigTestCase):
 
     @app_config_aad_decorator_async
     @recorded_by_proxy_async
-    async def test_delete_not_existing(self, appconfiguration_endpoint_string):
+    async def test_delete_not_existing_configuration_setting(self, appconfiguration_endpoint_string):
         async with self.create_aad_client(appconfiguration_endpoint_string) as client:
             deleted_kv = await client.delete_configuration_setting("not_exist_" + KEY)
             assert deleted_kv is None
 
     @app_config_aad_decorator_async
     @recorded_by_proxy_async
-    async def test_delete_correct_etag(self, appconfiguration_endpoint_string):
+    async def test_delete_configuration_setting_with_etag(self, appconfiguration_endpoint_string):
         async with self.create_aad_client(appconfiguration_endpoint_string) as client:
             to_delete_kv = self.create_config_setting_no_label()
             await self.add_for_test(client, to_delete_kv)
-            deleted_kv = await client.delete_configuration_setting(to_delete_kv.key, etag=to_delete_kv.etag)
-            assert deleted_kv is not None
-            with pytest.raises(ResourceNotFoundError):
-                await client.get_configuration_setting(to_delete_kv.key)
-
-    @app_config_aad_decorator_async
-    @recorded_by_proxy_async
-    async def test_delete_wrong_etag(self, appconfiguration_endpoint_string):
-        async with self.create_aad_client(appconfiguration_endpoint_string) as client:
-            to_delete_kv = self.create_config_setting_no_label()
+            to_delete_kv = await client.get_configuration_setting(to_delete_kv.key, to_delete_kv.label)
+            
+            # test delete with wrong etag
             with pytest.raises(ResourceModifiedError):
                 await client.delete_configuration_setting(
                     to_delete_kv.key, etag="wrong etag", match_condition=MatchConditions.IfNotModified
                 )
-            await client.delete_configuration_setting(key=to_delete_kv.key, label=to_delete_kv.label)
+            # test delete with correct etag
+            deleted_kv = await client.delete_configuration_setting(to_delete_kv.key, etag=to_delete_kv.etag)
+            assert deleted_kv is not None
+            with pytest.raises(ResourceNotFoundError):
+                await client.get_configuration_setting(to_delete_kv.key)
 
     # method: list_configuration_settings
     @app_config_aad_decorator_async
@@ -306,6 +282,7 @@ class TestAppConfigurationClientAADAsync(AsyncAppConfigTestCase):
         async with self.create_aad_client(appconfiguration_endpoint_string) as client:
             to_list_kv = self.create_config_setting()
             await self.add_for_test(client, to_list_kv)
+            to_list_kv = await client.get_configuration_setting(to_list_kv.key, to_list_kv.label)
             custom_headers = {"If-Match": to_list_kv.etag or ""}
             items = await self.convert_to_list(
                 client.list_configuration_settings(
@@ -417,69 +394,55 @@ class TestAppConfigurationClientAADAsync(AsyncAppConfigTestCase):
     @app_config_aad_decorator_async
     @recorded_by_proxy_async
     async def test_list_revisions_correct_etag(self, appconfiguration_endpoint_string):
-        await self.set_up(appconfiguration_endpoint_string, is_aad=True)
-        to_list_kv = self.create_config_setting()
-        custom_headers = {"If-Match": to_list_kv.etag or ""}
-        items = await self.convert_to_list(
-            self.client.list_revisions(key_filter=to_list_kv.key, label_filter=to_list_kv.label, headers=custom_headers)
-        )
-        assert len(items) >= 1
-        assert all(x.key == to_list_kv.key and x.label == to_list_kv.label for x in items)
-        await self.tear_down()
-
-    @app_config_aad_decorator_async
-    @recorded_by_proxy_async
-    async def test_read_only(self, appconfiguration_endpoint_string):
         async with self.create_aad_client(appconfiguration_endpoint_string) as client:
-            kv = self.create_config_setting_no_label()
-            await self.add_for_test(client, kv)
-            read_only_kv = await client.set_read_only(kv)
-            assert read_only_kv.read_only
-            readable_kv = await client.set_read_only(read_only_kv, False)
-            assert not readable_kv.read_only
-            await client.delete_configuration_setting(kv.key)
+            to_list_kv = self.create_config_setting()
+            await self.add_for_test(client, to_list_kv)
+            to_list_kv = await client.get_configuration_setting(to_list_kv.key, to_list_kv.label)
+            custom_headers = {"If-Match": to_list_kv.etag or ""}
+            items = await self.convert_to_list(
+                client.list_revisions(key_filter=to_list_kv.key, label_filter=to_list_kv.label, headers=custom_headers)
+            )
+            assert len(items) >= 1
+            assert all(x.key == to_list_kv.key and x.label == to_list_kv.label for x in items)
+            
+            await client.delete_configuration_setting(to_list_kv.key)
 
-    @app_config_aad_decorator_async
-    @recorded_by_proxy_async
-    async def test_delete_read_only(self, appconfiguration_endpoint_string):
-        async with self.create_aad_client(appconfiguration_endpoint_string) as client:
-            to_delete_kv = self.create_config_setting_no_label()
-            await self.add_for_test(client, to_delete_kv)
-            read_only_kv = await client.set_read_only(to_delete_kv)
-            with pytest.raises(ResourceReadOnlyError):
-                await client.delete_configuration_setting(to_delete_kv.key)
-            await client.set_read_only(read_only_kv, False)
-            await client.delete_configuration_setting(to_delete_kv.key)
-            with pytest.raises(ResourceNotFoundError):
-                await client.get_configuration_setting(to_delete_kv.key)
-
+    # method: set_read_only
     @app_config_aad_decorator_async
     @recorded_by_proxy_async
     async def test_set_read_only(self, appconfiguration_endpoint_string):
         async with self.create_aad_client(appconfiguration_endpoint_string) as client:
-            to_set_kv = self.create_config_setting_no_label()
+            to_set_kv = self.create_config_setting()
             await self.add_for_test(client, to_set_kv)
-            to_set_kv.value = to_set_kv.value + "a"
-            to_set_kv.tags = {"a": "b", "c": "d"}
+            to_set_kv = await client.get_configuration_setting(to_set_kv.key, to_set_kv.label)
+            
             read_only_kv = await client.set_read_only(to_set_kv)
+            assert read_only_kv.read_only
             with pytest.raises(ResourceReadOnlyError):
                 await client.set_configuration_setting(read_only_kv)
-            readable_kv = await client.set_read_only(read_only_kv, False)
-            readable_kv.value = to_set_kv.value
-            readable_kv.tags = to_set_kv.tags
-            set_kv = await client.set_configuration_setting(readable_kv)
-            assert (
-                to_set_kv.key == set_kv.key
-                and to_set_kv.label == to_set_kv.label
-                and to_set_kv.value == set_kv.value
-                and to_set_kv.content_type == set_kv.content_type
-                and to_set_kv.tags == set_kv.tags
-                and to_set_kv.etag != set_kv.etag
-            )
-            set_kv.etag = "bad"
-            with pytest.raises(ResourceModifiedError):
-                await client.set_read_only(set_kv, True, match_condition=MatchConditions.IfNotModified)
+            with pytest.raises(ResourceReadOnlyError):
+                await client.delete_configuration_setting(read_only_kv.key, read_only_kv.label)
+            
+            writable_kv = await client.set_read_only(read_only_kv, False)
+            assert not writable_kv.read_only
+            await client.set_configuration_setting(writable_kv)
             await client.delete_configuration_setting(to_set_kv.key)
+
+    @app_config_aad_decorator_async
+    @recorded_by_proxy_async
+    async def test_set_read_only_with_wrong_etag(self, appconfiguration_endpoint_string):
+        async with self.create_aad_client(appconfiguration_endpoint_string) as client:
+            to_set_kv = self.create_config_setting()
+            await self.add_for_test(client, to_set_kv)
+            to_set_kv = await client.get_configuration_setting(to_set_kv.key, to_set_kv.label)
+            
+            to_set_kv.etag = "wrong etag"
+            with pytest.raises(ResourceModifiedError):
+                await client.set_read_only(
+                    to_set_kv, False, match_condition=MatchConditions.IfNotModified
+                )
+            
+            await client.delete_configuration_setting(to_set_kv)
 
     @app_config_aad_decorator_async
     @recorded_by_proxy_async

--- a/sdk/appconfiguration/azure-appconfiguration/tests/test_azure_appconfiguration_client_async.py
+++ b/sdk/appconfiguration/azure-appconfiguration/tests/test_azure_appconfiguration_client_async.py
@@ -47,31 +47,26 @@ class TestAppConfigurationClientAsync(AsyncAppConfigTestCase):
     @recorded_by_proxy_async
     async def test_add_configuration_setting(self, appconfiguration_connection_string):
         async with self.create_client(appconfiguration_connection_string) as client:
-            kv = ConfigurationSetting(
+            test_config_setting = ConfigurationSetting(
                 key=KEY + "_ADD",
                 label=LABEL,
                 value=TEST_VALUE,
                 content_type=TEST_CONTENT_TYPE,
                 tags={"tag1": "tag1", "tag2": "tag2"},
             )
-            created_kv = await client.add_configuration_setting(kv)
+            created_kv = await client.add_configuration_setting(test_config_setting)
             assert (
-                created_kv.label == kv.label
-                and kv.value == kv.value
-                and created_kv.content_type == kv.content_type
-                and created_kv.tags == kv.tags
+                created_kv.label == test_config_setting.label
+                and created_kv.value == test_config_setting.value
+                and created_kv.content_type == test_config_setting.content_type
+                and created_kv.tags == test_config_setting.tags
+                and created_kv.etag != None
+                and created_kv.etag != test_config_setting.etag
+                and created_kv.last_modified != None
+                and created_kv.read_only == False
             )
-            assert (
-                created_kv.etag is not None and created_kv.last_modified is not None and created_kv.read_only is False
-            )
-            await client.delete_configuration_setting(key=created_kv.key, label=created_kv.label)
 
-    @app_config_decorator_async
-    @recorded_by_proxy_async
-    async def test_add_existing_configuration_setting(self, appconfiguration_connection_string):
-        async with self.create_client(appconfiguration_connection_string) as client:
-            test_config_setting = self.create_config_setting()
-            await self.add_for_test(client, test_config_setting)
+            # test add existing configuration setting
             with pytest.raises(ResourceExistsError):
                 await client.add_configuration_setting(
                     ConfigurationSetting(
@@ -79,12 +74,12 @@ class TestAppConfigurationClientAsync(AsyncAppConfigTestCase):
                         label=test_config_setting.label,
                     )
                 )
-            await client.delete_configuration_setting(key=test_config_setting.key, label=test_config_setting.label)
+            await client.delete_configuration_setting(key=created_kv.key, label=created_kv.label)
 
     # method: set_configuration_setting
     @app_config_decorator_async
     @recorded_by_proxy_async
-    async def test_set_existing_configuration_setting_label_etag(self, appconfiguration_connection_string):
+    async def test_set_configuration_setting(self, appconfiguration_connection_string):
         async with self.create_client(appconfiguration_connection_string) as client:
             to_set_kv = self.create_config_setting()
             to_set_kv.value = to_set_kv.value + "a"
@@ -102,7 +97,7 @@ class TestAppConfigurationClientAsync(AsyncAppConfigTestCase):
 
     @app_config_decorator_async
     @recorded_by_proxy_async
-    async def test_set_existing_configuration_setting_label_wrong_etag(self, appconfiguration_connection_string):
+    async def test_set_configuration1_setting_with_wrong_etag(self, appconfiguration_connection_string):
         async with self.create_client(appconfiguration_connection_string) as client:
             to_set_kv = self.create_config_setting()
             to_set_kv.value = to_set_kv.value + "a"
@@ -110,43 +105,6 @@ class TestAppConfigurationClientAsync(AsyncAppConfigTestCase):
             to_set_kv.etag = "wrong etag"
             with pytest.raises(ResourceModifiedError):
                 await client.set_configuration_setting(to_set_kv, match_condition=MatchConditions.IfNotModified)
-
-    @app_config_decorator_async
-    @recorded_by_proxy_async
-    async def test_set_configuration_setting_etag(self, appconfiguration_connection_string):
-        async with self.create_client(appconfiguration_connection_string) as client:
-            kv = ConfigurationSetting(
-                key=KEY + "_SET",
-                label=LABEL,
-                value=TEST_VALUE,
-                content_type=TEST_CONTENT_TYPE,
-                tags={"tag1": "tag1", "tag2": "tag2"},
-            )
-            kv.etag = "random etag"
-            with pytest.raises(ResourceModifiedError):
-                await client.set_configuration_setting(kv, match_condition=MatchConditions.IfNotModified)
-
-    @app_config_decorator_async
-    @recorded_by_proxy_async
-    async def test_set_configuration_setting_no_etag(self, appconfiguration_connection_string):
-        async with self.create_client(appconfiguration_connection_string) as client:
-            to_set_kv = ConfigurationSetting(
-                key=KEY + "_SET",
-                label=LABEL,
-                value=TEST_VALUE,
-                content_type=TEST_CONTENT_TYPE,
-                tags={"tag1": "tag1", "tag2": "tag2"},
-            )
-            set_kv = await client.set_configuration_setting(to_set_kv)
-            assert (
-                to_set_kv.key == set_kv.key
-                and to_set_kv.label == set_kv.label
-                and to_set_kv.value == set_kv.value
-                and to_set_kv.content_type == set_kv.content_type
-                and to_set_kv.tags == set_kv.tags
-                and to_set_kv.etag != set_kv.etag
-            )
-            await client.delete_configuration_setting(key=to_set_kv.key, label=to_set_kv.label)
 
     # method: get_configuration_setting
     @app_config_decorator_async
@@ -167,7 +125,7 @@ class TestAppConfigurationClientAsync(AsyncAppConfigTestCase):
 
     @app_config_decorator_async
     @recorded_by_proxy_async
-    async def test_get_configuration_setting_label(self, appconfiguration_connection_string):
+    async def test_get_configuration_setting(self, appconfiguration_connection_string):
         async with self.create_client(appconfiguration_connection_string) as client:
             compare_kv = self.create_config_setting()
             await self.add_for_test(client, compare_kv)
@@ -177,6 +135,7 @@ class TestAppConfigurationClientAsync(AsyncAppConfigTestCase):
                 and fetched_kv.value == compare_kv.value
                 and fetched_kv.content_type == compare_kv.content_type
                 and fetched_kv.tags == compare_kv.tags
+                and fetched_kv.label == compare_kv.label
             )
             assert fetched_kv.label is not None
             await client.delete_configuration_setting(key=compare_kv.key, label=compare_kv.label)
@@ -186,15 +145,33 @@ class TestAppConfigurationClientAsync(AsyncAppConfigTestCase):
     async def test_get_non_existing_configuration_setting(self, appconfiguration_connection_string):
         async with self.create_client(appconfiguration_connection_string) as client:
             compare_kv = self.create_config_setting()
-            await self.add_for_test(client, compare_kv)
             with pytest.raises(ResourceNotFoundError):
                 await client.get_configuration_setting(compare_kv.key, compare_kv.label + "a")
+    
+    @app_config_decorator_async
+    @recorded_by_proxy_async
+    async def test_get_configuration_setting_with_etag(self, appconfiguration_connection_string):
+        async with self.create_client(appconfiguration_connection_string) as client:
+            compare_kv = self.create_config_setting()
+            await self.add_for_test(client, compare_kv)
+            compare_kv = await client.get_configuration_setting(compare_kv.key, compare_kv.label)
+
+            # test get with wrong etag
+            with pytest.raises(ResourceModifiedError):
+                await client.get_configuration_setting(
+                    compare_kv.key, compare_kv.label, etag="wrong etag", match_condition=MatchConditions.IfNotModified
+                )
+            # test get with correct etag
+            with pytest.raises(ResourceNotFoundError):
+                await client.get_configuration_setting(compare_kv.key, etag=compare_kv.etag)
+            await client.get_configuration_setting(compare_kv.key, compare_kv.label, etag=compare_kv.etag)
+                
             await client.delete_configuration_setting(key=compare_kv.key, label=compare_kv.label)
 
     # method: delete_configuration_setting
     @app_config_decorator_async
     @recorded_by_proxy_async
-    async def test_delete_with_key_no_label(self, appconfiguration_connection_string):
+    async def test_delete_configuration_setting_with_key_no_label(self, appconfiguration_connection_string):
         async with self.create_client(appconfiguration_connection_string) as client:
             to_delete_kv = self.create_config_setting_no_label()
             await self.add_for_test(client, to_delete_kv)
@@ -205,7 +182,7 @@ class TestAppConfigurationClientAsync(AsyncAppConfigTestCase):
 
     @app_config_decorator_async
     @recorded_by_proxy_async
-    async def test_delete_with_key_label(self, appconfiguration_connection_string):
+    async def test_delete_configuration_setting_with_key_label(self, appconfiguration_connection_string):
         async with self.create_client(appconfiguration_connection_string) as client:
             to_delete_kv = self.create_config_setting()
             await self.add_for_test(client, to_delete_kv)
@@ -216,33 +193,29 @@ class TestAppConfigurationClientAsync(AsyncAppConfigTestCase):
 
     @app_config_decorator_async
     @recorded_by_proxy_async
-    async def test_delete_not_existing(self, appconfiguration_connection_string):
+    async def test_delete_not_existing_configuration_setting(self, appconfiguration_connection_string):
         async with self.create_client(appconfiguration_connection_string) as client:
             deleted_kv = await client.delete_configuration_setting("not_exist_" + KEY)
             assert deleted_kv is None
 
     @app_config_decorator_async
     @recorded_by_proxy_async
-    async def test_delete_correct_etag(self, appconfiguration_connection_string):
+    async def test_delete_configuration_setting_with_etag(self, appconfiguration_connection_string):
         async with self.create_client(appconfiguration_connection_string) as client:
             to_delete_kv = self.create_config_setting_no_label()
             await self.add_for_test(client, to_delete_kv)
-            deleted_kv = await client.delete_configuration_setting(to_delete_kv.key, etag=to_delete_kv.etag)
-            assert deleted_kv is not None
-            with pytest.raises(ResourceNotFoundError):
-                await client.get_configuration_setting(to_delete_kv.key)
-
-    @app_config_decorator_async
-    @recorded_by_proxy_async
-    async def test_delete_wrong_etag(self, appconfiguration_connection_string):
-        async with self.create_client(appconfiguration_connection_string) as client:
-            to_delete_kv = self.create_config_setting_no_label()
-            await self.add_for_test(client, to_delete_kv)
+            to_delete_kv = await client.get_configuration_setting(to_delete_kv.key, to_delete_kv.label)
+            
+            # test delete with wrong etag
             with pytest.raises(ResourceModifiedError):
                 await client.delete_configuration_setting(
                     to_delete_kv.key, etag="wrong etag", match_condition=MatchConditions.IfNotModified
                 )
-            await client.delete_configuration_setting(key=to_delete_kv.key, label=to_delete_kv.label)
+            # test delete with correct etag
+            deleted_kv = await client.delete_configuration_setting(to_delete_kv.key, etag=to_delete_kv.etag)
+            assert deleted_kv is not None
+            with pytest.raises(ResourceNotFoundError):
+                await client.get_configuration_setting(to_delete_kv.key)
 
     # method: list_configuration_settings
     @app_config_decorator_async
@@ -310,7 +283,8 @@ class TestAppConfigurationClientAsync(AsyncAppConfigTestCase):
         async with self.create_client(appconfiguration_connection_string) as client:
             to_list_kv = self.create_config_setting()
             await self.add_for_test(client, to_list_kv)
-            custom_headers = {"If-Match": to_list_kv.etag or ""}
+            to_list_kv = await client.get_configuration_setting(to_list_kv.key, to_list_kv.label)
+            custom_headers = {"If-Match": to_list_kv.etag}
             items = await self.convert_to_list(
                 client.list_configuration_settings(
                     key_filter=to_list_kv.key, label_filter=to_list_kv.label, headers=custom_headers
@@ -424,69 +398,55 @@ class TestAppConfigurationClientAsync(AsyncAppConfigTestCase):
     @app_config_decorator_async
     @recorded_by_proxy_async
     async def test_list_revisions_correct_etag(self, appconfiguration_connection_string):
-        await self.set_up(appconfiguration_connection_string)
-        to_list_kv = self.create_config_setting()
-        custom_headers = {"If-Match": to_list_kv.etag or ""}
-        items = await self.convert_to_list(
-            self.client.list_revisions(key_filter=to_list_kv.key, label_filter=to_list_kv.label, headers=custom_headers)
-        )
-        assert len(items) >= 1
-        assert all(x.key == to_list_kv.key and x.label == to_list_kv.label for x in items)
-        await self.tear_down()
-
-    @app_config_decorator_async
-    @recorded_by_proxy_async
-    async def test_read_only(self, appconfiguration_connection_string):
         async with self.create_client(appconfiguration_connection_string) as client:
-            kv = self.create_config_setting_no_label()
-            await self.add_for_test(client, kv)
-            read_only_kv = await client.set_read_only(kv)
-            assert read_only_kv.read_only
-            readable_kv = await client.set_read_only(read_only_kv, False)
-            assert not readable_kv.read_only
-            await client.delete_configuration_setting(kv.key)
+            to_list_kv = self.create_config_setting()
+            await self.add_for_test(client, to_list_kv)
+            to_list_kv = await client.get_configuration_setting(to_list_kv.key, to_list_kv.label)
+            custom_headers = {"If-Match": to_list_kv.etag}
+            items = await self.convert_to_list(
+                client.list_revisions(key_filter=to_list_kv.key, label_filter=to_list_kv.label, headers=custom_headers)
+            )
+            assert len(items) >= 1
+            assert all(x.key == to_list_kv.key and x.label == to_list_kv.label for x in items)
+            
+            await client.delete_configuration_setting(to_list_kv.key)
 
-    @app_config_decorator_async
-    @recorded_by_proxy_async
-    async def test_delete_read_only(self, appconfiguration_connection_string):
-        async with self.create_client(appconfiguration_connection_string) as client:
-            to_delete_kv = self.create_config_setting_no_label()
-            await self.add_for_test(client, to_delete_kv)
-            read_only_kv = await client.set_read_only(to_delete_kv)
-            with pytest.raises(ResourceReadOnlyError):
-                await client.delete_configuration_setting(to_delete_kv.key)
-            await client.set_read_only(read_only_kv, False)
-            await client.delete_configuration_setting(to_delete_kv.key)
-            with pytest.raises(ResourceNotFoundError):
-                await client.get_configuration_setting(to_delete_kv.key)
-
+    # method: set_read_only
     @app_config_decorator_async
     @recorded_by_proxy_async
     async def test_set_read_only(self, appconfiguration_connection_string):
         async with self.create_client(appconfiguration_connection_string) as client:
-            to_set_kv = self.create_config_setting_no_label()
+            to_set_kv = self.create_config_setting()
             await self.add_for_test(client, to_set_kv)
-            to_set_kv.value = to_set_kv.value + "a"
-            to_set_kv.tags = {"a": "b", "c": "d"}
+            to_set_kv = await client.get_configuration_setting(to_set_kv.key, to_set_kv.label)
+            
             read_only_kv = await client.set_read_only(to_set_kv)
+            assert read_only_kv.read_only
             with pytest.raises(ResourceReadOnlyError):
                 await client.set_configuration_setting(read_only_kv)
-            readable_kv = await client.set_read_only(read_only_kv, False)
-            readable_kv.value = to_set_kv.value
-            readable_kv.tags = to_set_kv.tags
-            set_kv = await client.set_configuration_setting(readable_kv)
-            assert (
-                to_set_kv.key == set_kv.key
-                and to_set_kv.label == to_set_kv.label
-                and to_set_kv.value == set_kv.value
-                and to_set_kv.content_type == set_kv.content_type
-                and to_set_kv.tags == set_kv.tags
-                and to_set_kv.etag != set_kv.etag
-            )
-            set_kv.etag = "bad"
-            with pytest.raises(ResourceModifiedError):
-                await client.set_read_only(set_kv, True, match_condition=MatchConditions.IfNotModified)
+            with pytest.raises(ResourceReadOnlyError):
+                await client.delete_configuration_setting(read_only_kv.key, read_only_kv.label)
+            
+            writable_kv = await client.set_read_only(read_only_kv, False)
+            assert not writable_kv.read_only
+            await client.set_configuration_setting(writable_kv)
             await client.delete_configuration_setting(to_set_kv.key)
+
+    @app_config_decorator_async
+    @recorded_by_proxy_async
+    async def test_set_read_only_with_wrong_etag(self, appconfiguration_connection_string):
+        async with self.create_client(appconfiguration_connection_string) as client:
+            to_set_kv = self.create_config_setting()
+            await self.add_for_test(client, to_set_kv)
+            to_set_kv = await client.get_configuration_setting(to_set_kv.key, to_set_kv.label)
+            
+            to_set_kv.etag = "wrong etag"
+            with pytest.raises(ResourceModifiedError):
+                await client.set_read_only(
+                    to_set_kv, False, match_condition=MatchConditions.IfNotModified
+                )
+            
+            await client.delete_configuration_setting(to_set_kv)
 
     @app_config_decorator_async
     @recorded_by_proxy_async
@@ -524,7 +484,8 @@ class TestAppConfigurationClientAsync(AsyncAppConfigTestCase):
             sync_token_header3 = ",".join(str(x) for x in sync_token_header3.values())
             assert sync_token_header2 != sync_token_header3
 
-            await client.delete_configuration_setting(new.key)
+            await client.delete_configuration_setting("KEY1")
+            await client.delete_configuration_setting("KEY2")
 
     @app_config_decorator_async
     @recorded_by_proxy_async
@@ -896,6 +857,8 @@ class TestAppConfigurationClientAsync(AsyncAppConfigTestCase):
             new = SecretReferenceConfigurationSetting("aref", "notaurl")  # cspell:disable-line
             await client.set_configuration_setting(new)
             await client.get_configuration_setting(new.key)
+            
+            await client.delete_configuration_setting(new.key)
 
             new = SecretReferenceConfigurationSetting("aref1", "notaurl")  # cspell:disable-line
             new.content_type = "fkaeyjfdkal;"  # cspell:disable-line
@@ -938,6 +901,26 @@ class TestAppConfigurationClientAsync(AsyncAppConfigTestCase):
 
         recovered_snapshot = await self.client.recover_snapshot(name=snapshot_name)
         assert recovered_snapshot.status == "ready"
+
+        await self.tear_down()
+    
+    @app_config_decorator_async
+    @recorded_by_proxy_async
+    async def test_update_snapshot_status_with_etag(self, appconfiguration_connection_string):
+        await self.set_up(appconfiguration_connection_string)
+        snapshot_name = self.get_resource_name("snapshot")
+        filters = [ConfigurationSettingFilter(key=KEY, label=LABEL)]
+        response = await self.client.begin_create_snapshot(name=snapshot_name, filters=filters)
+        created_snapshot = await response.result()
+
+        # test update with wrong etag
+        with pytest.raises(ResourceModifiedError):
+            await self.client.archive_snapshot(
+                name=snapshot_name, etag="wrong etag", match_condition=MatchConditions.IfNotModified
+            )
+        # test update with correct etag
+        archived_snapshot = await self.client.archive_snapshot(name=snapshot_name, etag=created_snapshot.etag)
+        assert archived_snapshot.status == "archived"
 
         await self.tear_down()
 

--- a/sdk/appconfiguration/azure-appconfiguration/tests/test_azure_appconfiguration_client_async.py
+++ b/sdk/appconfiguration/azure-appconfiguration/tests/test_azure_appconfiguration_client_async.py
@@ -147,7 +147,7 @@ class TestAppConfigurationClientAsync(AsyncAppConfigTestCase):
             compare_kv = self.create_config_setting()
             with pytest.raises(ResourceNotFoundError):
                 await client.get_configuration_setting(compare_kv.key, compare_kv.label + "a")
-    
+
     @app_config_decorator_async
     @recorded_by_proxy_async
     async def test_get_configuration_setting_with_etag(self, appconfiguration_connection_string):
@@ -165,7 +165,7 @@ class TestAppConfigurationClientAsync(AsyncAppConfigTestCase):
             with pytest.raises(ResourceNotFoundError):
                 await client.get_configuration_setting(compare_kv.key, etag=compare_kv.etag)
             await client.get_configuration_setting(compare_kv.key, compare_kv.label, etag=compare_kv.etag)
-                
+
             await client.delete_configuration_setting(key=compare_kv.key, label=compare_kv.label)
 
     # method: delete_configuration_setting
@@ -205,7 +205,7 @@ class TestAppConfigurationClientAsync(AsyncAppConfigTestCase):
             to_delete_kv = self.create_config_setting_no_label()
             await self.add_for_test(client, to_delete_kv)
             to_delete_kv = await client.get_configuration_setting(to_delete_kv.key, to_delete_kv.label)
-            
+
             # test delete with wrong etag
             with pytest.raises(ResourceModifiedError):
                 await client.delete_configuration_setting(
@@ -408,7 +408,7 @@ class TestAppConfigurationClientAsync(AsyncAppConfigTestCase):
             )
             assert len(items) >= 1
             assert all(x.key == to_list_kv.key and x.label == to_list_kv.label for x in items)
-            
+
             await client.delete_configuration_setting(to_list_kv.key)
 
     # method: set_read_only
@@ -419,14 +419,14 @@ class TestAppConfigurationClientAsync(AsyncAppConfigTestCase):
             to_set_kv = self.create_config_setting()
             await self.add_for_test(client, to_set_kv)
             to_set_kv = await client.get_configuration_setting(to_set_kv.key, to_set_kv.label)
-            
+
             read_only_kv = await client.set_read_only(to_set_kv)
             assert read_only_kv.read_only
             with pytest.raises(ResourceReadOnlyError):
                 await client.set_configuration_setting(read_only_kv)
             with pytest.raises(ResourceReadOnlyError):
                 await client.delete_configuration_setting(read_only_kv.key, read_only_kv.label)
-            
+
             writable_kv = await client.set_read_only(read_only_kv, False)
             assert not writable_kv.read_only
             await client.set_configuration_setting(writable_kv)
@@ -439,13 +439,11 @@ class TestAppConfigurationClientAsync(AsyncAppConfigTestCase):
             to_set_kv = self.create_config_setting()
             await self.add_for_test(client, to_set_kv)
             to_set_kv = await client.get_configuration_setting(to_set_kv.key, to_set_kv.label)
-            
+
             to_set_kv.etag = "wrong etag"
             with pytest.raises(ResourceModifiedError):
-                await client.set_read_only(
-                    to_set_kv, False, match_condition=MatchConditions.IfNotModified
-                )
-            
+                await client.set_read_only(to_set_kv, False, match_condition=MatchConditions.IfNotModified)
+
             await client.delete_configuration_setting(to_set_kv)
 
     @app_config_decorator_async
@@ -857,7 +855,7 @@ class TestAppConfigurationClientAsync(AsyncAppConfigTestCase):
             new = SecretReferenceConfigurationSetting("aref", "notaurl")  # cspell:disable-line
             await client.set_configuration_setting(new)
             await client.get_configuration_setting(new.key)
-            
+
             await client.delete_configuration_setting(new.key)
 
             new = SecretReferenceConfigurationSetting("aref1", "notaurl")  # cspell:disable-line
@@ -903,7 +901,7 @@ class TestAppConfigurationClientAsync(AsyncAppConfigTestCase):
         assert recovered_snapshot.status == "ready"
 
         await self.tear_down()
-    
+
     @app_config_decorator_async
     @recorded_by_proxy_async
     async def test_update_snapshot_status_with_etag(self, appconfiguration_connection_string):


### PR DESCRIPTION
This code is:
- Type unsafe: we access "error_map[response.status_code]", but we're not sure it's not None (may raise `KeyError`)
- Unnecessary: codegen deals with error_map already, error_map is not supposed to be used directly, but passed as kwarg (which it is). So previous code would pass error_map, codegen will shift the type, and then convenience will catch it again, and re-shift to the same type (in the best scenario)

If we don't trust to have enough testing, tests should be added on error conditions.

Discovered while typing azure-core: https://github.com/Azure/azure-sdk-for-python/pull/31056