### PR TITLE
[formrecognizer] Remove canary

### DIFF
--- a/sdk/formrecognizer/tests.yml
+++ b/sdk/formrecognizer/tests.yml
@@ -8,7 +8,7 @@ stages:
       TestTimeoutInMinutes: 200
       MatrixReplace:
         - TestSamples=.*/true
-      Clouds: 'Prod,Canary'
+      Clouds: 'Prod'
       # This is a specific request from the formrecognizer service team
       # their claim is that the full matrix ends up stress-testing their service.
       # As such, the canary test runs should run on a reduced matrix.
@@ -16,12 +16,6 @@ stages:
         Prod:
           SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
           Location: $(LOCATION)
-        Canary:
-          SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
-          Location: 'centraluseuap'
-          MatrixFilters:
-            - OSVmImage=^(?!macOS).*
-            - PythonVersion=^(?!pypy3).*
       EnvVars:
         AZURE_SUBSCRIPTION_ID: $(provisioner-subscription)
         AZURE_TENANT_ID: $(aad-azure-sdk-test-tenant-id)


### PR DESCRIPTION
Remove live testing in canary due to service instability in the environment. Already notified the service team as well.