### PR TITLE
[ML] fix(next-pylint): Resolve `useless-option-value`

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_azure_environments.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_azure_environments.py
@@ -24,7 +24,7 @@ class AzureEnvironments:
     ENV_CHINA = "AzureChinaCloud"
 
 
-class EndpointURLS:  # pylint: disable=too-few-public-methods,no-init
+class EndpointURLS:  # pylint: disable=too-few-public-methods
     AZURE_PORTAL_ENDPOINT = "azure_portal"
     RESOURCE_MANAGER_ENDPOINT = "resource_manager"
     ACTIVE_DIRECTORY_ENDPOINT = "active_directory"

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_internal/_schema/component.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_internal/_schema/component.py
@@ -108,7 +108,7 @@ class InternalComponentSchema(ComponentSchema):
         ]
     )
 
-    def get_skip_fields(self):  # pylint: disable=no-self-use
+    def get_skip_fields(self):
         return ["properties"]
 
     def _serialize(self, obj, *, many: bool = False):
@@ -153,7 +153,7 @@ class InternalComponentSchema(ComponentSchema):
         return super().add_param_overrides(data, **kwargs)
 
     @post_dump(pass_original=True)
-    def simplify_input_output_port(self, data, original, **kwargs):  # pylint:disable=unused-argument, no-self-use
+    def simplify_input_output_port(self, data, original, **kwargs):  # pylint:disable=unused-argument
         # remove None in input & output
         for io_ports in [data["inputs"], data["outputs"]]:
             for port_name, port_definition in io_ports.items():
@@ -167,7 +167,7 @@ class InternalComponentSchema(ComponentSchema):
         return data
 
     @post_dump(pass_original=True)
-    def add_back_type_label(self, data, original, **kwargs):  # pylint:disable=unused-argument, no-self-use
+    def add_back_type_label(self, data, original, **kwargs):  # pylint:disable=unused-argument
         type_label = original._type_label  # pylint:disable=protected-access
         if type_label:
             data["type"] = LABELLED_RESOURCE_NAME.format(data["type"], type_label)

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_internal/_schema/input_output.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_internal/_schema/input_output.py
@@ -36,7 +36,7 @@ class InternalInputPortSchema(InputPortSchema):
     datastore_mode = fields.Str()
 
     @post_dump(pass_original=True)
-    def resolve_list_type(self, data, original_data, **kwargs):  # pylint: disable=unused-argument, no-self-use
+    def resolve_list_type(self, data, original_data, **kwargs):  # pylint: disable=unused-argument
         if isinstance(original_data.type, list):
             data["type"] = original_data.type
         return data
@@ -84,7 +84,7 @@ class InternalEnumParameterSchema(ParameterSchema):
 
     @post_dump
     @post_load
-    def enum_value_to_string(self, data, **kwargs):  # pylint: disable=unused-argument, disable=no-self-use
+    def enum_value_to_string(self, data, **kwargs):  # pylint: disable=unused-argument
         if "enum" in data:
             data["enum"] = list(map(str, data["enum"]))
         if "default" in data and data["default"] is not None:

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_internal/_schema/node.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_internal/_schema/node.py
@@ -31,7 +31,7 @@ class InternalBaseNodeSchema(BaseNodeSchema):
     )
 
     @post_load
-    def make(self, data, **kwargs):  # pylint: disable=unused-argument, no-self-use
+    def make(self, data, **kwargs):  # pylint: disable=unused-argument
         from ...entities._builders import parse_inputs_outputs
 
         # parse inputs/outputs
@@ -43,7 +43,7 @@ class InternalBaseNodeSchema(BaseNodeSchema):
         return pipeline_node_factory.load_from_dict(data=data)
 
     @pre_dump
-    def resolve_inputs_outputs(self, job, **kwargs):  # pylint: disable=unused-argument, no-self-use
+    def resolve_inputs_outputs(self, job, **kwargs):  # pylint: disable=unused-argument
         return _resolve_inputs_outputs(job)
 
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_local_endpoints/docker_client.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_local_endpoints/docker_client.py
@@ -420,7 +420,7 @@ class DockerClient(object):
                 raise
             raise LocalEndpointImageBuildError(e) from e
 
-    def _reformat_volumes(self, volumes_dict: dict) -> list:  # pylint: disable=no-self-use
+    def _reformat_volumes(self, volumes_dict: dict) -> list:
         """Returns a list of volumes to pass to docker.
 
         :param volumes_dict: custom formatted dict of volumes to mount. We expect the keys to be unique.

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_local_endpoints/endpoint_stub.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_local_endpoints/endpoint_stub.py
@@ -53,7 +53,6 @@ class EndpointStub:
         build_directory = self._get_build_directory(endpoint_name=endpoint_name)
         shutil.rmtree(build_directory)
 
-    # pylint: disable=no-self-use
     def invoke(self):
         """Invoke a local endpoint.
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_local_endpoints/vscode_debug/devcontainer_properties.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_local_endpoints/vscode_debug/devcontainer_properties.py
@@ -118,7 +118,6 @@ class OverrideCommand(object):
     def __init__(self):
         pass
 
-    # pylint: disable=no-self-use
     def to_dict(self) -> dict:
         return {"overrideCommand": True}
 
@@ -127,7 +126,6 @@ class Extensions(object):
     def __init__(self):
         pass
 
-    # pylint: disable=no-self-use
     def to_dict(self) -> dict:
         return {"extensions": ["ms-python.python", "ms-toolsai.vscode-ai-inference"]}
 
@@ -136,7 +134,6 @@ class Settings(object):
     def __init__(self):
         pass
 
-    # pylint: disable=no-self-use
     def to_dict(self) -> dict:
         return {
             "settings": {

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_local_endpoints/vscode_debug/vscode_client.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_local_endpoints/vscode_debug/vscode_client.py
@@ -12,7 +12,7 @@ from azure.ai.ml.exceptions import VSCodeCommandNotFound
 
 
 class VSCodeClient(object):
-    # pylint: disable=client-method-has-more-than-5-positional-arguments, no-self-use
+    # pylint: disable=client-method-has-more-than-5-positional-arguments
     def create_dev_container_json(
         self,
         azureml_container,  # pylint: disable=unused-argument
@@ -33,7 +33,6 @@ class VSCodeClient(object):
         devcontainer.write_file(build_directory)
         return devcontainer.local_path
 
-    # pylint: disable=no-self-use
     def invoke_dev_container(self, devcontainer_path: str, app_path: str) -> None:
         hex_encoded_devcontainer_path = _encode_hex(devcontainer_path)
         command = [

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_data/mltable_metadata_schema.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_data/mltable_metadata_schema.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 from typing import Dict
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_data_import/data_import.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_data_import/data_import.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 from marshmallow import post_load
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_data_import/schedule.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_data_import/schedule.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use,protected-access
+# pylint: disable=unused-argument,protected-access
 
 import yaml
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_datastore/_on_prem.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_datastore/_on_prem.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 from typing import Any, Dict
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_datastore/_on_prem_credentials.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_datastore/_on_prem_credentials.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 from typing import Dict
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_datastore/adls_gen1.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_datastore/adls_gen1.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 from typing import Any, Dict
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_datastore/azure_storage.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_datastore/azure_storage.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 from typing import Any, Dict
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_datastore/credentials.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_datastore/credentials.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 from typing import Any, Dict
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_deployment/batch/batch_deployment.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_deployment/batch/batch_deployment.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use,no-else-return
+# pylint: disable=unused-argument,no-else-return
 
 import logging
 from typing import Any

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_deployment/batch/batch_deployment_settings.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_deployment/batch/batch_deployment_settings.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 import logging
 from typing import Any

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_deployment/batch/batch_job.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_deployment/batch/batch_job.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use,protected-access
+# pylint: disable=unused-argument,protected-access
 
 from typing import Any
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_deployment/batch/batch_pipeline_component_deployment_configurations_schema.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_deployment/batch/batch_pipeline_component_deployment_configurations_schema.py
@@ -2,7 +2,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=no-self-use
 
 import logging
 from typing import Any

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_deployment/batch/compute_binding.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_deployment/batch/compute_binding.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 import logging
 from typing import Any

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_deployment/batch/job_definition_schema.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_deployment/batch/job_definition_schema.py
@@ -2,7 +2,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=no-self-use
 
 import logging
 from typing import Any

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_deployment/batch/model_batch_deployment.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_deployment/batch/model_batch_deployment.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 import logging
 from typing import Any

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_deployment/batch/model_batch_deployment_settings.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_deployment/batch/model_batch_deployment_settings.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 import logging
 from typing import Any

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_deployment/batch/pipeline_component_batch_deployment_schema.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_deployment/batch/pipeline_component_batch_deployment_schema.py
@@ -2,7 +2,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=no-self-use
 
 import logging
 from typing import Any

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_deployment/batch/run_settings_schema.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_deployment/batch/run_settings_schema.py
@@ -2,7 +2,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=no-self-use
 
 import logging
 from typing import Any

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_deployment/code_configuration_schema.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_deployment/code_configuration_schema.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 import logging
 from typing import Any

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_deployment/online/data_asset_schema.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_deployment/online/data_asset_schema.py
@@ -2,7 +2,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=no-self-use
 
 import logging
 from typing import Any

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_deployment/online/data_collector_schema.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_deployment/online/data_collector_schema.py
@@ -2,7 +2,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=no-self-use
 
 import logging
 from typing import Any
@@ -27,7 +26,7 @@ class DataCollectorSchema(metaclass=PatchedSchemaMeta):
     sampling_rate = fields.Float()  # Should be copied to each of the collections
     request_logging = NestedField(RequestLoggingSchema)
 
-    # pylint: disable=unused-argument,no-self-use
+    # pylint: disable=unused-argument
     @validates("sampling_rate")
     def validate_sampling_rate(self, value, **kwargs):
         if value > 1.0 or value < 0.0:

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_deployment/online/deployment_collection_schema.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_deployment/online/deployment_collection_schema.py
@@ -24,7 +24,7 @@ class DeploymentCollectionSchema(metaclass=PatchedSchemaMeta):
     )
     client_id = fields.Str()
 
-    # pylint: disable=unused-argument,no-self-use
+    # pylint: disable=unused-argument
     @post_load
     def make(self, data: Any, **kwargs: Any) -> Any:
         from azure.ai.ml.entities._deployment.deployment_collection import DeploymentCollection

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_deployment/online/event_hub_schema.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_deployment/online/event_hub_schema.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 import logging
 from typing import Any

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_deployment/online/liveness_probe.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_deployment/online/liveness_probe.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 import logging
 from typing import Any

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_deployment/online/online_deployment.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_deployment/online/online_deployment.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 import logging
 from typing import Any

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_deployment/online/oversize_data_config_schema.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_deployment/online/oversize_data_config_schema.py
@@ -16,14 +16,14 @@ module_logger = logging.getLogger(__name__)
 class OversizeDataConfigSchema(metaclass=PatchedSchemaMeta):
     path = fields.Str()
 
-    # pylint: disable=unused-argument,no-self-use
+    # pylint: disable=unused-argument
     @validates("path")
     def validate_path(self, value, **kwargs):
         datastore_path = AzureMLDatastorePathUri(value)
         if datastore_path.uri_type != "Datastore":
             raise ValidationError(f"Path '{value}' is not a properly formatted datastore path.")
 
-    # pylint: disable=unused-argument,no-self-use
+    # pylint: disable=unused-argument
     @post_load
     def make(self, data: Any, **kwargs: Any) -> Any:
         from azure.ai.ml.entities._deployment.oversize_data_config import OversizeDataConfig

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_deployment/online/payload_response_schema.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_deployment/online/payload_response_schema.py
@@ -16,7 +16,7 @@ module_logger = logging.getLogger(__name__)
 class PayloadResponseSchema(metaclass=PatchedSchemaMeta):
     enabled = StringTransformedEnum(required=True, allowed_values=[Boolean.TRUE, Boolean.FALSE])
 
-    # pylint: disable=unused-argument,no-self-use
+    # pylint: disable=unused-argument
     @post_load
     def make(self, data: Any, **kwargs: Any) -> Any:
         from azure.ai.ml.entities._deployment.payload_response import PayloadResponse

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_deployment/online/request_logging_schema.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_deployment/online/request_logging_schema.py
@@ -15,7 +15,7 @@ module_logger = logging.getLogger(__name__)
 class RequestLoggingSchema(metaclass=PatchedSchemaMeta):
     capture_headers = fields.List(fields.Str())
 
-    # pylint: disable=unused-argument,no-self-use
+    # pylint: disable=unused-argument
     @post_load
     def make(self, data: Any, **kwargs: Any) -> Any:
         from azure.ai.ml.entities._deployment.request_logging import RequestLogging

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_deployment/online/request_settings_schema.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_deployment/online/request_settings_schema.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 import logging
 from typing import Any

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_deployment/online/resource_requirements_schema.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_deployment/online/resource_requirements_schema.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 import logging
 from typing import Any

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_deployment/online/resource_settings_schema.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_deployment/online/resource_settings_schema.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 import logging
 from typing import Any

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_deployment/online/scale_settings_schema.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_deployment/online/scale_settings_schema.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 import logging
 from typing import Any

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_endpoint/batch/batch_endpoint.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_endpoint/batch/batch_endpoint.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 import logging
 from typing import Any

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_endpoint/batch/batch_endpoint_defaults.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_endpoint/batch/batch_endpoint_defaults.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 import logging
 from typing import Any

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_endpoint/online/online_endpoint.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_endpoint/online/online_endpoint.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 import logging
 from typing import Any

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_feature_set/delay_metadata_schema.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_feature_set/delay_metadata_schema.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 from marshmallow import fields, post_load
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_feature_set/feature_schema.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_feature_set/feature_schema.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 from marshmallow import fields, post_load
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_feature_set/feature_set_schema.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_feature_set/feature_set_schema.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 from marshmallow import fields, post_dump, validate
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_feature_set/feature_set_specification_schema.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_feature_set/feature_set_specification_schema.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 from marshmallow import fields, post_load
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_feature_set/feature_transformation_code_metadata_schema.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_feature_set/feature_transformation_code_metadata_schema.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 from marshmallow import fields, post_load
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_feature_set/featureset_spec_metadata_schema.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_feature_set/featureset_spec_metadata_schema.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 from typing import Dict
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_feature_set/featureset_spec_properties_schema.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_feature_set/featureset_spec_properties_schema.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 
 from marshmallow import fields

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_feature_set/materialization_settings_schema.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_feature_set/materialization_settings_schema.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 from marshmallow import fields, post_load
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_feature_set/source_metadata_schema.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_feature_set/source_metadata_schema.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 from typing import Dict
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_feature_set/timestamp_column_metadata_schema.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_feature_set/timestamp_column_metadata_schema.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 from marshmallow import fields, post_load
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_feature_store/compute_runtime_schema.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_feature_store/compute_runtime_schema.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 from marshmallow import fields, post_load
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_feature_store/materialization_store_schema.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_feature_store/materialization_store_schema.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 from marshmallow import fields, post_load
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_feature_store_entity/data_column_schema.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_feature_store_entity/data_column_schema.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 from marshmallow import fields, post_load
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_notification/notification_schema.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_notification/notification_schema.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 from marshmallow import fields, validate, post_load
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_sweep/parameterized_sweep.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_sweep/parameterized_sweep.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 from azure.ai.ml._schema.core.fields import ExperimentalField, NestedField, PathAwareSchema
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_sweep/search_space/choice.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_sweep/search_space/choice.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 from marshmallow import ValidationError, fields, post_load, pre_dump
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_sweep/search_space/normal.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_sweep/search_space/normal.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 from marshmallow import ValidationError, fields, post_load
 from marshmallow.decorators import pre_dump

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_sweep/search_space/randint.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_sweep/search_space/randint.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 from marshmallow import ValidationError, fields, post_load, pre_dump
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_sweep/search_space/uniform.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_sweep/search_space/uniform.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 from marshmallow import ValidationError, fields, post_load, pre_dump
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_sweep/sweep_fields_provider.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_sweep/sweep_fields_provider.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 from marshmallow import fields
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_sweep/sweep_job.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_sweep/sweep_job.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 from azure.ai.ml._schema._sweep.parameterized_sweep import ParameterizedSweepSchema
 from azure.ai.ml._schema.core.fields import NestedField, StringTransformedEnum

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_sweep/sweep_objective.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_sweep/sweep_objective.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 import logging
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_sweep/sweep_sampling_algorithm.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_sweep/sweep_sampling_algorithm.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 import logging
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_sweep/sweep_termination.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_sweep/sweep_termination.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 import logging
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/assets/artifact.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/assets/artifact.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 import logging
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/assets/asset.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/assets/asset.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 import logging
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/assets/code_asset.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/assets/code_asset.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 import logging
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/assets/data.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/assets/data.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 from marshmallow import fields, validate
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/assets/environment.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/assets/environment.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 import logging
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/assets/model.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/assets/model.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 import logging
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/assets/package/base_environment_source.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/assets/package/base_environment_source.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 import logging
 from marshmallow import fields, post_load

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/assets/package/inference_server.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/assets/package/inference_server.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use,redefined-builtin,no-else-return
+# pylint: disable=unused-argument,redefined-builtin,no-else-return
 
 import logging
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/assets/package/model_configuration.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/assets/package/model_configuration.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 import logging
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/assets/package/model_package.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/assets/package/model_package.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 import logging
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/assets/package/model_package_input.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/assets/package/model_package_input.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 import logging
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/assets/package/online_inference_configuration.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/assets/package/online_inference_configuration.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 import logging
 from marshmallow import fields, post_load

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/assets/package/route.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/assets/package/route.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use,bad-mcs-method-argument
+# pylint: disable=unused-argument,bad-mcs-method-argument
 
 import logging
 from marshmallow import fields, post_load

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/assets/workspace_asset_reference.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/assets/workspace_asset_reference.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 import logging
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/automl/featurization_settings.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/automl/featurization_settings.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 from marshmallow import fields as flds
 from marshmallow import post_load

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/automl/forecasting_settings.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/automl/forecasting_settings.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 from marshmallow import fields, post_load
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/automl/image_vertical/image_classification.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/automl/image_vertical/image_classification.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 from typing import Any, Dict
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/automl/image_vertical/image_limit_settings.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/automl/image_vertical/image_limit_settings.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 from marshmallow import fields, post_load
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/automl/image_vertical/image_model_distribution_settings.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/automl/image_vertical/image_model_distribution_settings.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use,protected-access
+# pylint: disable=unused-argument,protected-access
 
 from marshmallow import fields, post_dump, post_load, pre_load
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/automl/image_vertical/image_model_settings.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/automl/image_vertical/image_model_settings.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 from marshmallow import fields, post_load
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/automl/image_vertical/image_object_detection.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/automl/image_vertical/image_object_detection.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 from typing import Any, Dict
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/automl/image_vertical/image_sweep_settings.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/automl/image_vertical/image_sweep_settings.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use,protected-access
+# pylint: disable=unused-argument,protected-access
 
 from marshmallow import post_load, pre_dump
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/automl/image_vertical/image_vertical.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/automl/image_vertical/image_vertical.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 from azure.ai.ml._schema.automl.automl_vertical import AutoMLVerticalSchema
 from azure.ai.ml._schema.automl.image_vertical.image_limit_settings import ImageLimitsSchema

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/automl/nlp_vertical/nlp_fixed_parameters.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/automl/nlp_vertical/nlp_fixed_parameters.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 from marshmallow import fields, post_load
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/automl/nlp_vertical/nlp_parameter_subspace.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/automl/nlp_vertical/nlp_parameter_subspace.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use,protected-access
+# pylint: disable=unused-argument,protected-access
 
 from marshmallow import fields, post_dump, post_load, pre_load
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/automl/nlp_vertical/nlp_sweep_settings.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/automl/nlp_vertical/nlp_sweep_settings.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use,protected-access
+# pylint: disable=unused-argument,protected-access
 
 from marshmallow import post_load, pre_dump
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/automl/nlp_vertical/nlp_vertical.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/automl/nlp_vertical/nlp_vertical.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 from marshmallow import fields
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/automl/nlp_vertical/nlp_vertical_limit_settings.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/automl/nlp_vertical/nlp_vertical_limit_settings.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 from marshmallow import fields, post_load
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/automl/nlp_vertical/text_classification.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/automl/nlp_vertical/text_classification.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 from typing import Any, Dict
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/automl/nlp_vertical/text_classification_multilabel.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/automl/nlp_vertical/text_classification_multilabel.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 from typing import Any, Dict
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/automl/nlp_vertical/text_ner.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/automl/nlp_vertical/text_ner.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 from typing import Any, Dict
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/automl/table_vertical/classification.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/automl/table_vertical/classification.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 from typing import Any, Dict
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/automl/table_vertical/forecasting.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/automl/table_vertical/forecasting.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 from typing import Any, Dict
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/automl/table_vertical/regression.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/automl/table_vertical/regression.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 from typing import Any, Dict
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/automl/table_vertical/table_vertical.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/automl/table_vertical/table_vertical.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 from azure.ai.ml._restclient.v2023_04_01_preview.models import NCrossValidationsMode
 from azure.ai.ml._schema.automl.automl_vertical import AutoMLVerticalSchema

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/automl/table_vertical/table_vertical_limit_settings.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/automl/table_vertical/table_vertical_limit_settings.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 from marshmallow import fields, post_load
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/automl/training_settings.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/automl/training_settings.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 from marshmallow import fields, post_load
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/component/command_component.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/component/command_component.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use,protected-access,no-member
+# pylint: disable=unused-argument,protected-access,no-member
 
 from copy import deepcopy
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/component/component.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/component/component.py
@@ -62,13 +62,13 @@ class ComponentSchema(AssetSchema):
         super().__init__(*args, **kwargs)
 
     @pre_load
-    def convert_version_to_str(self, data, **kwargs):  # pylint: disable=unused-argument, no-self-use
+    def convert_version_to_str(self, data, **kwargs):  # pylint: disable=unused-argument
         if isinstance(data, dict) and data.get("version", None):
             data["version"] = str(data["version"])
         return data
 
     @pre_dump
-    def add_private_fields_to_dump(self, data, **kwargs):  # pylint: disable=unused-argument,no-self-use
+    def add_private_fields_to_dump(self, data, **kwargs):  # pylint: disable=unused-argument
         # The ipp field is set on the component object as "_intellectual_property".
         # We need to set it as "intellectual_property" before dumping so that Marshmallow
         # can pick up the field correctly on dump and show it back to the user.
@@ -78,7 +78,7 @@ class ComponentSchema(AssetSchema):
         return data
 
     @post_dump
-    def convert_input_value_to_str(self, data, **kwargs):  # pylint:disable=unused-argument, no-self-use
+    def convert_input_value_to_str(self, data, **kwargs):  # pylint:disable=unused-argument
         if isinstance(data, dict) and data.get("inputs", None):
             input_dict = data["inputs"]
             for input_value in input_dict.values():
@@ -91,5 +91,5 @@ class ComponentSchema(AssetSchema):
         return data
 
     @pre_dump
-    def flatten_group_inputs(self, data, **kwargs):  # pylint: disable=unused-argument, no-self-use
+    def flatten_group_inputs(self, data, **kwargs):  # pylint: disable=unused-argument
         return _resolve_group_inputs_for_component(data)

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/component/data_transfer_component.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/component/data_transfer_component.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use,protected-access,no-member
+# pylint: disable=unused-argument,protected-access,no-member
 
 from copy import deepcopy
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/component/input_output.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/component/input_output.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 from marshmallow import fields, INCLUDE, pre_dump
 
@@ -46,7 +46,7 @@ class InputPortSchema(metaclass=PatchedSchemaMeta):
         intellectual_property = ExperimentalField(NestedField(ProtectionLevelSchema))
 
     @pre_dump
-    def add_private_fields_to_dump(self, data, **kwargs):  # pylint: disable=unused-argument,no-self-use
+    def add_private_fields_to_dump(self, data, **kwargs):  # pylint: disable=unused-argument
         # The ipp field is set on the output object as "_intellectual_property".
         # We need to set it as "intellectual_property" before dumping so that Marshmallow
         # can pick up the field correctly on dump and show it back to the user.
@@ -72,7 +72,7 @@ class OutputPortSchema(metaclass=PatchedSchemaMeta):
         intellectual_property = ExperimentalField(NestedField(ProtectionLevelSchema))
 
     @pre_dump
-    def add_private_fields_to_dump(self, data, **kwargs):  # pylint: disable=unused-argument,no-self-use
+    def add_private_fields_to_dump(self, data, **kwargs):  # pylint: disable=unused-argument
         # The ipp field is set on the output object as "_intellectual_property".
         # We need to set it as "intellectual_property" before dumping so that Marshmallow
         # can pick up the field correctly on dump and show it back to the user.

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/component/resource.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/component/resource.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 from marshmallow import INCLUDE, post_dump, post_load
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/component/spark_component.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/component/spark_component.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use,protected-access,no-member
+# pylint: disable=unused-argument,protected-access,no-member
 
 from copy import deepcopy
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/compute/aml_compute.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/compute/aml_compute.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 from marshmallow import fields
 from marshmallow.decorators import post_load

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/compute/compute.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/compute/compute.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 from marshmallow import fields
 from marshmallow.decorators import post_load
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/compute/compute_instance.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/compute/compute_instance.py
@@ -5,7 +5,7 @@
 from marshmallow import fields
 from marshmallow.decorators import post_load
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 from azure.ai.ml._schema import PathAwareSchema
 from azure.ai.ml.constants._compute import ComputeType, ComputeSizeTier
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/compute/custom_applications.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/compute/custom_applications.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 from marshmallow import fields
 from marshmallow.decorators import post_load
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/compute/schedule.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/compute/schedule.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 from marshmallow import fields
 from marshmallow.decorators import post_load

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/compute/setup_scripts.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/compute/setup_scripts.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 from marshmallow import fields
 from marshmallow.decorators import post_load
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/compute/synapsespark_compute.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/compute/synapsespark_compute.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=no-self-use,unused-argument
+# pylint: disable=unused-argument
 
 from marshmallow import fields
 from marshmallow.decorators import post_load

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/compute/usage.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/compute/usage.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 from marshmallow import fields
 from marshmallow.decorators import post_load

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/compute/virtual_machine_compute.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/compute/virtual_machine_compute.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 from marshmallow import fields
 from marshmallow.decorators import post_load

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/core/auto_delete_setting.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/core/auto_delete_setting.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=no-self-use,unused-argument
+# pylint: disable=unused-argument
 
 from marshmallow import fields, post_load
 from azure.ai.ml._schema.core.fields import StringTransformedEnum

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/core/fields.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/core/fields.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use,protected-access
+# pylint: disable=unused-argument,protected-access
 
 import copy
 import logging

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/core/intellectual_property.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/core/intellectual_property.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=no-self-use,unused-argument
+# pylint: disable=unused-argument
 
 from marshmallow import fields, post_load
 from azure.ai.ml._schema.core.fields import StringTransformedEnum

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/core/resource.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/core/resource.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use,protected-access
+# pylint: disable=unused-argument,protected-access
 
 import logging
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/core/schema.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/core/schema.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 import copy
 import logging

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/core/schema_meta.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/core/schema_meta.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 import logging
 from collections import OrderedDict

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/identity.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/identity.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 from marshmallow import ValidationError, fields, post_load, pre_dump, validates
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/job/data_transfer_job.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/job/data_transfer_job.py
@@ -36,7 +36,7 @@ class DataTransferImportJobSchema(BaseJobSchema):
     source = UnionField([NestedField(DatabaseSchema), NestedField(FileSystemSchema)], required=True, allow_none=False)
 
     @validates("outputs")
-    def outputs_key(self, value):  # pylint: disable=no-self-use
+    def outputs_key(self, value):
         if len(value) != 1 or list(value.keys())[0] != "sink":
             raise ValidationError(
                 f"outputs field only support one output called sink in task type "
@@ -52,7 +52,7 @@ class DataTransferExportJobSchema(BaseJobSchema):
     sink = UnionField([NestedField(DatabaseSchema), NestedField(FileSystemSchema)], required=True, allow_none=False)
 
     @validates("inputs")
-    def inputs_key(self, value):  # pylint: disable=no-self-use
+    def inputs_key(self, value):
         if len(value) != 1 or list(value.keys())[0] != "source":
             raise ValidationError(
                 f"inputs field only support one input called source in task type "

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/job/distribution.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/job/distribution.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 import logging
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/job/identity.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/job/identity.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 import logging
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/job/import_job.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/job/import_job.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=no-self-use,unused-argument
+# pylint: disable=unused-argument
 
 from marshmallow import fields, post_load
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/job/input_output_entry.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/job/input_output_entry.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 import logging
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/job/input_port.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/job/input_port.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 import logging
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/job/job_limits.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/job/job_limits.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 from marshmallow import fields, post_load, validate
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/job/parameterized_spark.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/job/parameterized_spark.py
@@ -1,7 +1,7 @@
 # ---------------------------------------------------------
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 import re
 from typing import Any, Dict, List

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/job/services.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/job/services.py
@@ -45,7 +45,7 @@ class JobServiceSchema(JobServiceBaseSchema):
     )
 
     @post_load
-    def make(self, data, **kwargs):  # pylint: disable=unused-argument,no-self-use
+    def make(self, data, **kwargs):  # pylint: disable=unused-argument
         data.pop("type", None)
         return JobService(**data)
 
@@ -58,7 +58,7 @@ class TensorBoardJobServiceSchema(JobServiceBaseSchema):
     log_dir = fields.Str()
 
     @post_load
-    def make(self, data, **kwargs):  # pylint: disable=unused-argument,no-self-use
+    def make(self, data, **kwargs):  # pylint: disable=unused-argument
         data.pop("type", None)
         return TensorBoardJobService(**data)
 
@@ -71,7 +71,7 @@ class SshJobServiceSchema(JobServiceBaseSchema):
     ssh_public_keys = fields.Str()
 
     @post_load
-    def make(self, data, **kwargs):  # pylint: disable=unused-argument,no-self-use
+    def make(self, data, **kwargs):  # pylint: disable=unused-argument
         data.pop("type", None)
         return SshJobService(**data)
 
@@ -83,7 +83,7 @@ class VsCodeJobServiceSchema(JobServiceBaseSchema):
     )
 
     @post_load
-    def make(self, data, **kwargs):  # pylint: disable=unused-argument,no-self-use
+    def make(self, data, **kwargs):  # pylint: disable=unused-argument
         data.pop("type", None)
         return VsCodeJobService(**data)
 
@@ -95,6 +95,6 @@ class JupyterLabJobServiceSchema(JobServiceBaseSchema):
     )
 
     @post_load
-    def make(self, data, **kwargs):  # pylint: disable=unused-argument,no-self-use
+    def make(self, data, **kwargs):  # pylint: disable=unused-argument
         data.pop("type", None)
         return JupyterLabJobService(**data)

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/monitoring/alert_notification.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/monitoring/alert_notification.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 from marshmallow import fields, post_load
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/monitoring/input_data.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/monitoring/input_data.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 from marshmallow import fields, post_load
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/monitoring/monitor_definition.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/monitoring/monitor_definition.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 from marshmallow import fields, post_load
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/monitoring/signals.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/monitoring/signals.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 from marshmallow import fields, post_load, pre_dump, ValidationError
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/monitoring/target.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/monitoring/target.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 from marshmallow import fields, post_load
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/monitoring/thresholds.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/monitoring/thresholds.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 from marshmallow import fields, post_load
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/pipeline/automl_node.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/pipeline/automl_node.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use,protected-access
+# pylint: disable=unused-argument,protected-access
 
 from marshmallow import fields, post_dump, post_load, pre_dump
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/pipeline/component_job.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/pipeline/component_job.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=no-self-use,protected-access
+# pylint: disable=protected-access
 
 import logging
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/pipeline/condition_node.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/pipeline/condition_node.py
@@ -17,7 +17,7 @@ class ConditionNodeSchema(ControlFlowSchema):
     false_block = UnionField([NodeBindingStr(), fields.List(NodeBindingStr())])
 
     @post_dump
-    def simplify_blocks(self, data, **kwargs):  # pylint: disable=unused-argument, no-self-use
+    def simplify_blocks(self, data, **kwargs):  # pylint: disable=unused-argument
         # simplify true_block and false_block to single node if there is only one node in the list
         # this is to make sure the request to backend won't change after we support list true/false blocks
         block_keys = ["true_block", "false_block"]

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/pipeline/control_flow_job.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/pipeline/control_flow_job.py
@@ -16,7 +16,7 @@ from ..job.job_limits import DoWhileLimitsSchema
 from .component_job import _resolve_outputs
 from .pipeline_job_io import OutputBindingStr
 
-# pylint: disable=no-self-use,protected-access
+# pylint: disable=protected-access
 
 
 class ControlFlowSchema(PathAwareSchema):
@@ -28,7 +28,7 @@ class BaseLoopSchema(ControlFlowSchema):
     body = DataBindingStr()
 
     @pre_dump
-    def convert_control_flow_body_to_binding_str(self, data, **kwargs):  # pylint: disable=no-self-use, unused-argument
+    def convert_control_flow_body_to_binding_str(self, data, **kwargs):  # pylint: disable= unused-argument
         result = copy.copy(data)
         # Update body object to data_binding_str
         result._body = data._get_body_binding_str()
@@ -57,7 +57,7 @@ class DoWhileSchema(BaseLoopSchema):
     limits = NestedField(DoWhileLimitsSchema, required=True)
 
     @pre_dump
-    def resolve_inputs_outputs(self, data, **kwargs):  # pylint: disable=no-self-use
+    def resolve_inputs_outputs(self, data, **kwargs):
         # Try resolve object's mapping and condition and return a resolved new object
         result = copy.copy(data)
         mapping = {}
@@ -74,7 +74,7 @@ class DoWhileSchema(BaseLoopSchema):
         return result
 
     @pre_dump
-    def convert_control_flow_body_to_binding_str(self, data, **kwargs):  # pylint: disable=no-self-use, unused-argument
+    def convert_control_flow_body_to_binding_str(self, data, **kwargs):  # pylint: disable= unused-argument
         return super(DoWhileSchema, self).convert_control_flow_body_to_binding_str(data, **kwargs)
 
 
@@ -97,7 +97,7 @@ class ParallelForSchema(BaseLoopSchema):
     )
 
     @pre_load
-    def load_items(self, data, **kwargs):  # pylint: disable=no-self-use, unused-argument
+    def load_items(self, data, **kwargs):  # pylint: disable= unused-argument
         # load items from json to convert the assets in it to rest
         try:
             items = data["items"]
@@ -109,7 +109,7 @@ class ParallelForSchema(BaseLoopSchema):
         return data
 
     @pre_dump
-    def convert_control_flow_body_to_binding_str(self, data, **kwargs):  # pylint: disable=no-self-use, unused-argument
+    def convert_control_flow_body_to_binding_str(self, data, **kwargs):  # pylint: disable= unused-argument
         return super(ParallelForSchema, self).convert_control_flow_body_to_binding_str(data, **kwargs)
 
     @pre_dump
@@ -119,7 +119,7 @@ class ParallelForSchema(BaseLoopSchema):
         return result
 
     @pre_dump
-    def serialize_items(self, data, **kwargs):  # pylint: disable=no-self-use, unused-argument
+    def serialize_items(self, data, **kwargs):  # pylint: disable= unused-argument
         # serialize items to json string to avoid being removed by _dump_for_validation
         from azure.ai.ml.entities._job.pipeline._io import InputOutputBase
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/pipeline/pipeline_command_job.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/pipeline/pipeline_command_job.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 import logging
 from typing import Any

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/pipeline/pipeline_component.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/pipeline/pipeline_component.py
@@ -285,7 +285,7 @@ class PipelineSchema(BaseNodeSchema):
     type = StringTransformedEnum(allowed_values=[NodeType.PIPELINE])
 
     @post_load
-    def make(self, data, **kwargs) -> "Pipeline":  # pylint: disable=no-self-use
+    def make(self, data, **kwargs) -> "Pipeline":
         from azure.ai.ml.entities._builders import parse_inputs_outputs
         from azure.ai.ml.entities._builders.pipeline import Pipeline
 
@@ -293,5 +293,5 @@ class PipelineSchema(BaseNodeSchema):
         return Pipeline(**data)  # pylint: disable=abstract-class-instantiated
 
     @pre_dump
-    def resolve_inputs_outputs(self, data, **kwargs):  # pylint: disable=no-self-use
+    def resolve_inputs_outputs(self, data, **kwargs):
         return _resolve_inputs_outputs(data)

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/pipeline/pipeline_datatransfer_job.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/pipeline/pipeline_datatransfer_job.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 import logging
 from typing import Any

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/pipeline/pipeline_import_job.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/pipeline/pipeline_import_job.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 import logging
 from typing import Any

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/pipeline/pipeline_job.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/pipeline/pipeline_job.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use,no-member
+# pylint: disable=unused-argument,no-member
 
 import logging
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/pipeline/pipeline_job_io.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/pipeline/pipeline_job_io.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 import logging
 import re

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/pipeline/pipeline_parallel_job.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/pipeline/pipeline_parallel_job.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 import logging
 from typing import Any

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/pipeline/pipeline_spark_job.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/pipeline/pipeline_spark_job.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 import logging
 from typing import Any

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/pipeline/settings.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/pipeline/settings.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 from marshmallow import INCLUDE, Schema, fields, post_dump, post_load
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/queue_settings.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/queue_settings.py
@@ -17,7 +17,7 @@ class QueueSettingsSchema(metaclass=PatchedSchemaMeta):
     )
 
     @post_load
-    def make(self, data, **kwargs):  # pylint: disable=unused-argument, disable=no-self-use
+    def make(self, data, **kwargs):  # pylint: disable=unused-argument
         from azure.ai.ml.entities import QueueSettings
 
         return QueueSettings(**data)

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/registry/registry_region_arm_details.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/registry/registry_region_arm_details.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=no-self-use,unused-argument
+# pylint: disable=unused-argument
 
 from marshmallow import ValidationError, fields, post_load, pre_dump
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/registry/system_created_acr_account.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/registry/system_created_acr_account.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=no-self-use,unused-argument
+# pylint: disable=unused-argument
 
 from marshmallow import ValidationError, fields, post_load, pre_dump
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/registry/system_created_storage_account.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/registry/system_created_storage_account.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=no-self-use,unused-argument
+# pylint: disable=unused-argument
 
 from marshmallow import ValidationError, fields, post_load, pre_dump
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/resource_configuration.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/resource_configuration.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 from marshmallow import fields, post_load
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/schedule/schedule.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/schedule/schedule.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 from marshmallow import fields
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/schedule/trigger.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/schedule/trigger.py
@@ -22,7 +22,7 @@ class TriggerSchema(metaclass=PatchedSchemaMeta):
     time_zone = fields.Str()
 
     @post_dump(pass_original=True)
-    def resolve_time_zone(self, data, original_data, **kwargs):  # pylint: disable=no-self-use, unused-argument
+    def resolve_time_zone(self, data, original_data, **kwargs):  # pylint: disable= unused-argument
         """
         Auto-convert will get string like "TimeZone.UTC" for TimeZone enum object,
         while the valid result should be "UTC"
@@ -37,7 +37,7 @@ class CronTriggerSchema(TriggerSchema):
     expression = fields.Str(required=True)
 
     @post_load
-    def make(self, data, **kwargs) -> "CronTrigger":  # pylint: disable=no-self-use, unused-argument
+    def make(self, data, **kwargs) -> "CronTrigger":  # pylint: disable= unused-argument
         from azure.ai.ml.entities import CronTrigger
 
         data.pop("type")
@@ -61,7 +61,7 @@ class RecurrencePatternSchema(metaclass=PatchedSchemaMeta):
     )
 
     @post_load
-    def make(self, data, **kwargs) -> "RecurrencePattern":  # pylint: disable=no-self-use, unused-argument
+    def make(self, data, **kwargs) -> "RecurrencePattern":  # pylint: disable= unused-argument
         from azure.ai.ml.entities import RecurrencePattern
 
         return RecurrencePattern(**data)
@@ -74,7 +74,7 @@ class RecurrenceTriggerSchema(TriggerSchema):
     schedule = NestedField(RecurrencePatternSchema())
 
     @post_load
-    def make(self, data, **kwargs) -> "RecurrenceTrigger":  # pylint: disable=no-self-use, unused-argument
+    def make(self, data, **kwargs) -> "RecurrenceTrigger":  # pylint: disable= unused-argument
         from azure.ai.ml.entities import RecurrenceTrigger
 
         data.pop("type")

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/spark_resource_configuration.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/spark_resource_configuration.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 from marshmallow import fields, post_load
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/workspace/connections/credentials.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/workspace/connections/credentials.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 from typing import Dict
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/workspace/connections/workspace_connection.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/workspace/connections/workspace_connection.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 from marshmallow import fields, post_load
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/workspace/customer_managed_key.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/workspace/customer_managed_key.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 from marshmallow import fields, post_load
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/workspace/endpoint_connection.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/workspace/endpoint_connection.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 from marshmallow import fields, post_load
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/workspace/identity.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/workspace/identity.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 from marshmallow import fields
 from marshmallow.decorators import post_load, pre_dump

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/workspace/networking.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/workspace/networking.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use,no-else-return
+# pylint: disable=unused-argument,no-else-return
 
 from marshmallow import fields, EXCLUDE
 from marshmallow.decorators import post_load, pre_dump

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/workspace/private_endpoint.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/workspace/private_endpoint.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 from marshmallow import fields, post_load
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_utils/_http_utils.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_utils/_http_utils.py
@@ -2,7 +2,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=no-self-use
 
 from functools import wraps
 from typing import Any, Callable, Optional

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_credentials.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_credentials.py
@@ -427,7 +427,6 @@ class ManagedIdentityConfiguration(_BaseIdentityConfiguration):
             resource_id=obj.resource_id,
         )
 
-    # pylint: disable=no-self-use
     def _to_identity_configuration_rest_object(self) -> RestUserAssignedIdentity:
         return RestUserAssignedIdentity()
 
@@ -481,7 +480,6 @@ class UserIdentityConfiguration(_BaseIdentityConfiguration):
         super().__init__()
         self.type = IdentityType.USER_IDENTITY
 
-    # pylint: disable=no-self-use
     def _to_job_rest_object(self) -> RestUserIdentity:
         return RestUserIdentity()
 
@@ -516,7 +514,6 @@ class AmlTokenConfiguration(_BaseIdentityConfiguration):
         super().__init__()
         self.type = IdentityType.AML_TOKEN
 
-    # pylint: disable=no-self-use
     def _to_job_rest_object(self) -> RestAmlToken:
         return RestAmlToken()
 
@@ -671,7 +668,6 @@ class NoneCredentialConfiguration(RestTranslatableMixin):
     def __init__(self):
         self.type = CredentialsType.NONE
 
-    # pylint: disable=no-self-use
     def _to_datastore_rest_object(self) -> RestNoneDatastoreCredentials:
         return RestNoneDatastoreCredentials()
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_deployment/event_hub.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_deployment/event_hub.py
@@ -19,7 +19,7 @@ class EventHub:
 
     """
 
-    # pylint: disable=unused-argument,no-self-use
+    # pylint: disable=unused-argument
     def __init__(
         self, namespace: Optional[str] = None, oversize_data_config: Optional[OversizeDataConfig] = None, **kwargs
     ):

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_deployment/oversize_data_config.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_deployment/oversize_data_config.py
@@ -15,7 +15,7 @@ class OversizeDataConfig:
     :type path: str
     """
 
-    # pylint: disable=unused-argument,no-self-use
+    # pylint: disable=unused-argument
     def __init__(self, path: Optional[str] = None, **kwargs):
         self.path = path
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_deployment/payload_response.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_deployment/payload_response.py
@@ -15,7 +15,7 @@ class PayloadResponse:
 
     """
 
-    # pylint: disable=unused-argument,no-self-use
+    # pylint: disable=unused-argument
     def __init__(self, enabled: str = None, **kwargs):
         self.enabled = enabled
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/automl/automl_job.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/automl/automl_job.py
@@ -246,7 +246,7 @@ class AutoMLJob(Job, JobIOMixin, AutoMLNodeIOMixin, ABC):
             camel_to_snake(TaskType.TEXT_CLASSIFICATION_MULTILABEL): TextClassificationMultilabelJob,
         }
 
-    def _resolve_data_inputs(self, rest_job):  # pylint: disable=no-self-use
+    def _resolve_data_inputs(self, rest_job):
         """Resolve JobInputs to MLTableJobInputs within data_settings.
 
         :param rest_job: The rest job object.

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/automl/tabular/automl_tabular.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/automl/tabular/automl_tabular.py
@@ -540,7 +540,6 @@ class AutoMLTabular(AutoMLVertical, ABC):
         self.test_data = test_data if test_data is not None else self.test_data
         self.test_data_size = test_data_size if test_data_size is not None else self.test_data_size
 
-    # pylint: disable=no-self-use
     def _validation_data_to_rest(self, rest_obj):
         """Validation data serialization.
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/pipeline/_attr_dict.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/pipeline/_attr_dict.py
@@ -49,7 +49,7 @@ class _AttrDict(Generic[K, V], dict, ABC):
             self._key_restriction = True
         self._logger = logging.getLogger("attr_dict")
 
-    def _initializing(self) -> bool:  # pylint: disable=no-self-use
+    def _initializing(self) -> bool:
         # use this to indicate ongoing init process, sub class need to make sure this return True during init process.
         return False
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/pipeline/_io/base.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/pipeline/_io/base.py
@@ -89,7 +89,7 @@ class InputOutputBase(ABC):
         super(InputOutputBase, self).__init__(**kwargs)
 
     @abstractmethod
-    def _build_data(self, data, key=None):  # pylint: disable=unused-argument, no-self-use
+    def _build_data(self, data, key=None):  # pylint: disable=unused-argument
         """Validate if data matches type and translate it to Input/Output acceptable type."""
 
     @abstractmethod

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/pipeline/_io/mixin.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/pipeline/_io/mixin.py
@@ -78,7 +78,7 @@ class NodeIOMixin:
         # For un-configured outputs, settings it to None, so we won't pass extra fields(eg: default mode)
         return NodeOutput(port_name=name, meta=meta, data=data, owner=self)
 
-    def _get_default_input_val(self, val):  # pylint: disable=unused-argument, no-self-use
+    def _get_default_input_val(self, val):  # pylint: disable=unused-argument
         # use None value as data placeholder for unfilled inputs.
         # server side will fill the default value
         return None
@@ -319,7 +319,7 @@ def flatten_dict(dct, _type, *, allow_dict_fields=None):
 class NodeWithGroupInputMixin(NodeIOMixin):
     """This class provide build_inputs_dict for a node to use ParameterGroup as an input."""
 
-    def _validate_group_input_type(  # pylint: disable=no-self-use
+    def _validate_group_input_type(
         self,
         input_definition_dict: dict,
         inputs: Dict[str, Union[Input, str, bool, int, float]],

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/sweep/sampling_algorithm.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/sweep/sampling_algorithm.py
@@ -123,7 +123,6 @@ class GridSamplingAlgorithm(SamplingAlgorithm):
         super().__init__()
         self.type = SamplingAlgorithmType.GRID.lower()
 
-    # pylint: disable=no-self-use
     def _to_rest_object(self) -> RestGridSamplingAlgorithm:
         return RestGridSamplingAlgorithm()
 
@@ -151,7 +150,6 @@ class BayesianSamplingAlgorithm(SamplingAlgorithm):
         super().__init__()
         self.type = SamplingAlgorithmType.BAYESIAN.lower()
 
-    # pylint: disable=no-self-use
     def _to_rest_object(self) -> RestBayesianSamplingAlgorithm:
         return RestBayesianSamplingAlgorithm()
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_mixins.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_mixins.py
@@ -87,7 +87,7 @@ class DictMixin(object):
 
 
 class TelemetryMixin:
-    def _get_telemetry_values(self, *args, **kwargs):  # pylint: disable=unused-argument, no-self-use
+    def _get_telemetry_values(self, *args, **kwargs):  # pylint: disable=unused-argument
         """Return the telemetry values of object."""
         return {}
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_validation.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_validation.py
@@ -452,7 +452,7 @@ class SchemaValidatableMixin:
     @classmethod
     def _get_skip_fields_in_schema_validation(
         cls,
-    ) -> typing.List[str]:  # pylint: disable=no-self-use
+    ) -> typing.List[str]:
         """Get the fields that should be skipped in schema validation.
 
         Override this method to add customized validation logic.

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_component_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_component_operations.py
@@ -247,7 +247,6 @@ class ComponentOperations(_ScopeDependentOperations):
 
     @experimental
     @monitor_with_telemetry_mixin(logger, "Component.Validate", ActivityType.PUBLICAPI)
-    # pylint: disable=no-self-use
     def validate(
         self,
         component: Union[Component, types.FunctionType],
@@ -272,7 +271,7 @@ class ComponentOperations(_ScopeDependentOperations):
         )
 
     @monitor_with_telemetry_mixin(logger, "Component.Validate", ActivityType.INTERNALCALL)
-    def _validate(  # pylint: disable=no-self-use
+    def _validate(
         self,
         component: Union[Component, types.FunctionType],
         raise_on_failure: bool,

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_job_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_job_operations.py
@@ -1202,9 +1202,7 @@ class JobOperations(_ScopeDependentOperations):
         job.compute = self._resolve_compute_id(resolver, job.compute)
         return job
 
-    def _resolve_arm_id_for_automl_job(  # pylint: disable=no-self-use
-        self, job: Job, resolver: Callable, inside_pipeline: bool
-    ) -> Job:
+    def _resolve_arm_id_for_automl_job(self, job: Job, resolver: Callable, inside_pipeline: bool) -> Job:
         """Resolve arm_id for AutoMLJob."""
         # AutoML does not have dependency uploads. Only need to resolve reference to arm id.
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_online_deployment_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_online_deployment_operations.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-# pylint: disable=protected-access,no-self-use,broad-except
+# pylint: disable=protected-access,broad-except
 
 import random
 import re


### PR DESCRIPTION
# Description

This pull request is part of a effort to ready the Azure ML Python SDK for an impending bump to the versions of pylint and azure-pylint-guidelines-checker that is used in our CI.

This pull request specifically resolves [`R0022` (useless-option-value)](https://pylint.readthedocs.io/en/latest/user_guide/messages/warning/useless-option-value.html)

**Note for reviewers:** This PR touches many files, but makes no code changes. It only updates comments of the form `# pylint: disable=...`

Validated with:

`pylint==2.15.8`
`azure-pylint-guidelines-checker=0.0.8`

`pylint --rcfile=../../../eng/pylintc --disable=all --enable=R0022 azure/`


Methodology:

* `sed -i -e 's/, no-self-use//' -e 's/,no-self-use//' -e 's/no-self-use,//' -e 's/, disable=no-self-use//' -e 's/# pylint: disable=no-self-use//' $(grep no-self-use -l -r azure/)`
* `sed -i -e 's/,no-init//' $(grep no-init -r azure -l)`

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
