### PR TITLE
[Monitor][Exporter] Next pylint updates

### DIFF
--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_connection_string_parser.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_connection_string_parser.py
@@ -18,7 +18,6 @@ uuid_regex_pattern = re.compile(
 )
 
 
-# pylint: disable=R0201
 class ConnectionStringParser:
     """ConnectionString parser.
 
@@ -69,9 +68,9 @@ class ConnectionStringParser:
 
     def _validate_instrumentation_key(self) -> None:
         """Validates the instrumentation key used for Azure Monitor.
+
         An instrumentation key cannot be null or empty. An instrumentation key
         is valid for Azure Monitor only if it is a valid UUID.
-        :param instrumentation_key: The instrumentation key to validate
         """
         if not self.instrumentation_key:
             raise ValueError("Instrumentation key cannot be none or empty.")
@@ -88,8 +87,8 @@ class ConnectionStringParser:
             result = dict(s.split("=") for s in pairs)
             # Convert keys to lower-case due to case type-insensitive checking
             result = {key.lower(): value for key, value in result.items()}
-        except Exception:
-            raise ValueError("Invalid connection string")
+        except Exception as exc:
+            raise ValueError("Invalid connection string") from exc
         # Validate authorization
         auth = result.get("authorization")
         if auth is not None and auth.lower() != "ikey":

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_storage.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_storage.py
@@ -37,17 +37,18 @@ class LocalFileBlob:
 
     def get(self):
         try:
-            with open(self.fullpath, "r") as file:
+            with open(self.fullpath, "r", encoding="utf-8") as file:
                 return tuple(
                     json.loads(line.strip()) for line in file.readlines()
                 )
         except Exception:
             pass  # keep silent
+        return ()
 
     def put(self, data, lease_period=0):
         try:
             fullpath = self.fullpath + ".tmp"
-            with open(fullpath, "w") as file:
+            with open(fullpath, "w", encoding="utf-8") as file:
                 for item in data:
                     file.write(json.dumps(item))
                     # The official Python doc: Do not use os.linesep as a line
@@ -61,6 +62,7 @@ class LocalFileBlob:
             return self
         except Exception:
             pass  # keep silent
+        return None
 
     def lease(self, period):
         timestamp = _now() + _seconds(period)
@@ -202,7 +204,7 @@ class LocalFileStorage:
                         size += os.path.getsize(path)
                     except OSError:
                         logger.error(
-                            "Path %s does not exist or is " "inaccessible.",
+                            "Path %s does not exist or is inaccessible.",
                             path,
                         )
                         continue

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_storage.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_storage.py
@@ -43,7 +43,7 @@ class LocalFileBlob:
                 )
         except Exception:
             pass  # keep silent
-        return ()
+        return None
 
     def put(self, data, lease_period=0):
         try:

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/_base.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/_base.py
@@ -160,12 +160,16 @@ class BaseExporter:
 
         Returns an ExportResult, this function should never
         throw an exception.
+        :param envelopes: The list of telemetry items to transmit.
+        :type envelopes: list of ~azure.monitor.opentelemetry.exporter._generated.models.TelemetryItem
+        :return: The result of the export.
+        :rtype: ~azure.monitor.opentelemetry.exporter.export._base._ExportResult
         """
         if len(envelopes) > 0:
             result = ExportResult.SUCCESS
             reach_ingestion = False
+            start_time = time.time()
             try:
-                start_time = time.time()
                 track_response = self.client.track(envelopes)
                 if not track_response.errors:  # 200
                     self._consecutive_redirects = 0
@@ -332,29 +336,41 @@ def _get_auth_policy(credential, default_auth_policy):
 
 
 def _is_redirect_code(response_code: int) -> bool:
-    """
-    Determine if response is a redirect response.
+    """Determine if response is a redirect response.
+
+    :param int response_code: HTTP response code
+    :return: True if response is a redirect response
+    :rtype: bool
     """
     return response_code in _REDIRECT_STATUS_CODES
 
 
 def _is_retryable_code(response_code: int) -> bool:
-    """
-    Determine if response is retryable
+    """Determine if response is retryable.
+
+    :param int response_code: HTTP response code
+    :return: True if response is retryable
+    :rtype: bool
     """
     return response_code in _RETRYABLE_STATUS_CODES
 
 
 def _is_throttle_code(response_code: int) -> bool:
-    """
-    Determine if response is throttle response
+    """Determine if response is throttle response.
+
+    :param int response_code: HTTP response code
+    :return: True if response is throttle response
+    :rtype: bool
     """
     return response_code in _THROTTLE_STATUS_CODES
 
 
 def _reached_ingestion_code(response_code: int) -> bool:
-    """
-    Determine if response indicates ingestion service has been reached
+    """Determine if response indicates ingestion service has been reached.
+
+    :param int response_code: HTTP response code
+    :return: True if response indicates ingestion service has been reached
+    :rtype: bool
     """
     return response_code in _REACHED_INGESTION_STATUS_CODES
 

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/logs/_exporter.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/logs/_exporter.py
@@ -35,9 +35,11 @@ class AzureMonitorLogExporter(BaseExporter, LogExporter):
     def export(
         self, batch: Sequence[LogData], **kwargs: Any  # pylint: disable=unused-argument
     ) -> LogExportResult:
-        """Export log data
-        :param batch: Open Telemetry LogData(s) to export.
-        :type batch: Sequence[~opentelemetry._logs.LogData]
+        """Export log data.
+
+        :param batch: OpenTelemetry LogData(s) to export.
+        :type batch: ~typing.Sequence[~opentelemetry._logs.LogData]
+        :return: The result of the export.
         :rtype: ~opentelemetry.sdk._logs.export.LogData
         """
         envelopes = [self._log_to_envelope(log) for log in batch]
@@ -77,6 +79,7 @@ class AzureMonitorLogExporter(BaseExporter, LogExporter):
         :param str conn_str: The connection string to be used for authentication.
         :keyword str api_version: The service API version used. Defaults to latest.
         :returns an instance of ~AzureMonitorLogExporter
+        :rtype ~azure.monitor.opentelemetry.exporter.AzureMonitorLogExporter
         """
         return cls(connection_string=conn_str, **kwargs)
 

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/metrics/_exporter.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/metrics/_exporter.py
@@ -72,8 +72,12 @@ class AzureMonitorMetricExporter(BaseExporter, MetricExporter):
         **kwargs: Any,  # pylint: disable=unused-argument
     ) -> MetricExportResult:
         """Exports a batch of metric data
-        :param metrics: Open Telemetry Metric(s) to export.
+
+        :param metrics_data: OpenTelemetry Metric(s) to export.
         :type metrics_data: Sequence[~opentelemetry.sdk.metrics._internal.point.MetricsData]
+        :param timeout_millis: The maximum amount of time to wait for each export. Not currently used.
+        :type timeout_millis: float
+        :return: The result of the export.
         :rtype: ~opentelemetry.sdk.metrics.export.MetricExportResult
         """
         envelopes = []
@@ -104,10 +108,8 @@ class AzureMonitorMetricExporter(BaseExporter, MetricExporter):
         self,
         timeout_millis: float = 10_000,
     ) -> bool:
-        """
-        Ensure that export of any metrics currently received by the exporter
-        are completed as soon as possible.
-        """
+        # Ensure that export of any metrics currently received by the exporter are completed as soon as possible.
+
         return True
 
     def shutdown(
@@ -118,6 +120,9 @@ class AzureMonitorMetricExporter(BaseExporter, MetricExporter):
         """Shuts down the exporter.
 
         Called when the SDK is shut down.
+
+        :param timeout_millis: The maximum amount of time to wait for shutdown. Not currently used.
+        :type timeout_millis: float
         """
         self.storage.close()
 
@@ -148,7 +153,8 @@ class AzureMonitorMetricExporter(BaseExporter, MetricExporter):
 
         :param str conn_str: The connection string to be used for authentication.
         :keyword str api_version: The service API version used. Defaults to latest.
-        :returns an instance of ~AzureMonitorMetricExporter
+        :return: An instance of ~AzureMonitorMetricExporter
+        :rtype ~azure.monitor.opentelemetry.exporter.AzureMonitorMetricExporter
         """
         return cls(connection_string=conn_str, **kwargs)
 

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/trace/_exporter.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/trace/_exporter.py
@@ -60,9 +60,11 @@ class AzureMonitorTraceExporter(BaseExporter, SpanExporter):
     """Azure Monitor Trace exporter for OpenTelemetry."""
 
     def export(self, spans: Sequence[ReadableSpan], **kwargs: Any) -> SpanExportResult: # pylint: disable=unused-argument
-        """Export span data
+        """Export span data.
+
         :param spans: Open Telemetry Spans to export.
-        :type spans: Sequence[~opentelemetry.trace.Span]
+        :type spans: ~typing.Sequence[~opentelemetry.trace.Span]
+        :return: The result of the export.
         :rtype: ~opentelemetry.sdk.trace.export.SpanExportResult
         """
         envelopes = []
@@ -101,8 +103,7 @@ class AzureMonitorTraceExporter(BaseExporter, SpanExporter):
 
     @classmethod
     def from_connection_string(cls, conn_str: str, **kwargs: Any) -> "AzureMonitorTraceExporter":
-        """
-        Create an AzureMonitorTraceExporter from a connection string.
+        """Create an AzureMonitorTraceExporter from a connection string.
 
         This is the recommended way of instantation if a connection string is passed in explicitly.
         If a user wants to use a connection string provided by environment variable, the constructor
@@ -111,6 +112,7 @@ class AzureMonitorTraceExporter(BaseExporter, SpanExporter):
         :param str conn_str: The connection string to be used for authentication.
         :keyword str api_version: The service API version used. Defaults to latest.
         :returns an instance of ~AzureMonitorTraceExporter
+        :rtype: ~azure.monitor.opentelemetry.exporter.AzureMonitorTraceExporter
         """
         return cls(connection_string=conn_str, **kwargs)
 
@@ -590,6 +592,7 @@ def _get_azure_sdk_target_source(attributes: Attributes) -> Optional[str]:
     destination = attributes.get("message_bus.destination")
     if peer_address and destination:
         return peer_address + "/" + destination
+    return None
 
 
 def _get_trace_export_result(result: ExportResult) -> SpanExportResult:

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/trace/_sampling.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/trace/_sampling.py
@@ -2,6 +2,7 @@
 # Licensed under the MIT License.
 from typing import Optional, Sequence
 
+# pylint:disable=no-name-in-module
 from fixedint import Int32
 # pylint:disable=W0611
 from opentelemetry.context import Context
@@ -71,7 +72,6 @@ class ApplicationInsightsSampler(Sampler):
             _get_parent_trace_state(parent_context),
         )
 
-    # pylint:disable=R0201
     def _get_DJB2_sample_score(self, trace_id_hex: str) -> int:
         # This algorithm uses 32bit integers
         hash_value = Int32(_HASH)
@@ -91,7 +91,7 @@ class ApplicationInsightsSampler(Sampler):
         return "ApplicationInsightsSampler{}".format(self._ratio)
 
 
-def azure_monitor_opentelemetry_sampler_factory(sampler_argument):
+def azure_monitor_opentelemetry_sampler_factory(sampler_argument):  # pylint: disable=name-too-long
     try:
         rate = float(sampler_argument)
         return ApplicationInsightsSampler(rate)

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/statsbeat/_state.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/statsbeat/_state.py
@@ -19,12 +19,12 @@ def is_statsbeat_enabled():
     return disabled is None or disabled.lower() != "true"
 
 
-def increment_statsbeat_initial_failure_count():
+def increment_statsbeat_initial_failure_count():  # pylint: disable=name-too-long
     with _STATSBEAT_STATE_LOCK:
         _STATSBEAT_STATE["INITIAL_FAILURE_COUNT"] += 1
 
 
-def increment_and_check_statsbeat_failure_count():
+def increment_and_check_statsbeat_failure_count():  # pylint: disable=name-too-long
     increment_statsbeat_initial_failure_count()
     return get_statsbeat_initial_failure_count() >= _STATSBEAT_FAILURE_COUNT_THRESHOLD
 

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/statsbeat/_statsbeat_metrics.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/statsbeat/_statsbeat_metrics.py
@@ -8,7 +8,7 @@ import sys
 import threading
 from typing import Iterable
 
-import requests
+import requests  # pylint: disable=networking-import-outside-azure-core-transport
 
 from opentelemetry.metrics import CallbackOptions, Observation
 from opentelemetry.sdk.metrics import MeterProvider
@@ -299,7 +299,6 @@ class _StatsbeatMetrics:
 
     # pylint: disable=unused-argument
     # pylint: disable=protected-access
-    # pylint: disable=no-self-use
     def _get_failure_count(self, options: CallbackOptions) -> Iterable[Observation]:
         observations = []
         attributes = dict(_StatsbeatMetrics._COMMON_ATTRIBUTES)
@@ -317,7 +316,6 @@ class _StatsbeatMetrics:
 
     # pylint: disable=unused-argument
     # pylint: disable=protected-access
-    # pylint: disable=no-self-use
     def _get_average_duration(self, options: CallbackOptions) -> Iterable[Observation]:
         observations = []
         attributes = dict(_StatsbeatMetrics._COMMON_ATTRIBUTES)
@@ -337,7 +335,6 @@ class _StatsbeatMetrics:
 
     # pylint: disable=unused-argument
     # pylint: disable=protected-access
-    # pylint: disable=no-self-use
     def _get_retry_count(self, options: CallbackOptions) -> Iterable[Observation]:
         observations = []
         attributes = dict(_StatsbeatMetrics._COMMON_ATTRIBUTES)
@@ -355,7 +352,6 @@ class _StatsbeatMetrics:
 
     # pylint: disable=unused-argument
     # pylint: disable=protected-access
-    # pylint: disable=no-self-use
     def _get_throttle_count(self, options: CallbackOptions) -> Iterable[Observation]:
         observations = []
         attributes = dict(_StatsbeatMetrics._COMMON_ATTRIBUTES)
@@ -373,7 +369,6 @@ class _StatsbeatMetrics:
 
     # pylint: disable=unused-argument
     # pylint: disable=protected-access
-    # pylint: disable=no-self-use
     def _get_exception_count(self, options: CallbackOptions) -> Iterable[Observation]:
         observations = []
         attributes = dict(_StatsbeatMetrics._COMMON_ATTRIBUTES)


### PR DESCRIPTION
Several updates to allow `azure-monitor-opentelemetry-exporter` to pass the newer version of pylint. This should help us avoid failing pipelines when the pylint version is switched next week.
