### PR TITLE
[Storage] Deprecate `BlobProperties` as substitute input for `blob` parameter

### DIFF
--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_service_client.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_service_client.py
@@ -730,7 +730,7 @@ class BlobServiceClient(StorageAccountHostsMixin, StorageEncryptionMixin):
 
     def get_blob_client(
             self, container,  # type: Union[ContainerProperties, str]
-            blob,  # type: Union[BlobProperties, str]
+            blob,  # type: str
             snapshot=None,  # type: Optional[Union[Dict[str, Any], str]]
             *,
             version_id=None  # type: Optional[str]
@@ -743,11 +743,9 @@ class BlobServiceClient(StorageAccountHostsMixin, StorageEncryptionMixin):
         :param container:
             The container that the blob is in. This can either be the name of the container,
             or an instance of ContainerProperties.
+        :paramtype container: Union[ContainerProperties, str]
         :type container: str or ~azure.storage.blob.ContainerProperties
-        :param blob:
-            The blob with which to interact. This can either be the name of the blob,
-            or an instance of BlobProperties.
-        :type blob: str or ~azure.storage.blob.BlobProperties
+        :param str blob: The name of the blob with which to interact.
         :param snapshot:
             The optional blob snapshot on which to operate. This can either be the ID of the snapshot,
             or a dictionary output returned by :func:`~azure.storage.blob.BlobClient.create_snapshot()`.

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_container_client.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_container_client.py
@@ -953,7 +953,7 @@ class ContainerClient(StorageAccountHostsMixin, StorageEncryptionMixin):    # py
 
     @distributed_trace
     def upload_blob(
-            self, name: Union[str, BlobProperties],
+            self, name: str,
             data: Union[bytes, str, Iterable[AnyStr], IO[AnyStr]],
             blob_type: Union[str, BlobType] = BlobType.BlockBlob,
             length: Optional[int] = None,
@@ -962,9 +962,9 @@ class ContainerClient(StorageAccountHostsMixin, StorageEncryptionMixin):    # py
         ) -> BlobClient:
         """Creates a new blob from a data source with automatic chunking.
 
-        :param name: The blob with which to interact. If specified, this value will override
+        :param str name: 
+            The blob with which to interact. If specified, this value will override
             a blob value specified in the blob URL.
-        :type name: str or ~azure.storage.blob.BlobProperties
         :param data: The blob data to upload.
         :param ~azure.storage.blob.BlobType blob_type: The type of the blob. This can be
             either BlockBlob, PageBlob or AppendBlob. The default value is BlockBlob.
@@ -1091,7 +1091,7 @@ class ContainerClient(StorageAccountHostsMixin, StorageEncryptionMixin):    # py
 
     @distributed_trace
     def delete_blob(
-            self, blob,  # type: Union[str, BlobProperties]
+            self, blob,  # type: str
             delete_snapshots=None,  # type: Optional[str]
             **kwargs
         ):
@@ -1109,9 +1109,9 @@ class ContainerClient(StorageAccountHostsMixin, StorageEncryptionMixin):    # py
         Soft deleted blob or snapshot is accessible through :func:`list_blobs()` specifying `include=["deleted"]`
         option. Soft-deleted blob or snapshot can be restored using :func:`~azure.storage.blob.BlobClient.undelete()`
 
-        :param blob: The blob with which to interact. If specified, this value will override
+        :param str blob:
+            The blob with which to interact. If specified, this value will override
             a blob value specified in the blob URL.
-        :type blob: str or ~azure.storage.blob.BlobProperties
         :param str delete_snapshots:
             Required if the blob has associated snapshots. Values include:
              - "only": Deletes only the blobs snapshots.
@@ -1168,7 +1168,7 @@ class ContainerClient(StorageAccountHostsMixin, StorageEncryptionMixin):    # py
 
     @overload
     def download_blob(
-            self, blob: Union[str, BlobProperties],
+            self, blob: str,
             offset: int = None,
             length: int = None,
             *,
@@ -1178,7 +1178,7 @@ class ContainerClient(StorageAccountHostsMixin, StorageEncryptionMixin):    # py
 
     @overload
     def download_blob(
-            self, blob: Union[str, BlobProperties],
+            self, blob: str,
             offset: int = None,
             length: int = None,
             *,
@@ -1188,7 +1188,7 @@ class ContainerClient(StorageAccountHostsMixin, StorageEncryptionMixin):    # py
 
     @distributed_trace
     def download_blob(
-            self, blob: Union[str, BlobProperties],
+            self, blob: str,
             offset: int = None,
             length: int = None,
             *,
@@ -1198,9 +1198,9 @@ class ContainerClient(StorageAccountHostsMixin, StorageEncryptionMixin):    # py
         be used to read all the content or readinto() must be used to download the blob into
         a stream. Using chunks() returns an iterator which allows the user to iterate over the content in chunks.
 
-        :param blob: The blob with which to interact. If specified, this value will override
+        :param str blob:
+            The blob with which to interact. If specified, this value will override
             a blob value specified in the blob URL.
-        :type blob: str or ~azure.storage.blob.BlobProperties
         :param int offset:
             Start of byte range to use for downloading a section of the blob.
             Must be set if length is provided.
@@ -1352,7 +1352,7 @@ class ContainerClient(StorageAccountHostsMixin, StorageEncryptionMixin):    # py
         return query_parameters, header_parameters
 
     def _generate_delete_blobs_options(
-            self, *blobs: Union[str, Dict[str, Any], BlobProperties],
+            self, *blobs: Union[str, Dict[str, Any]],
             **kwargs: Any
         ):
         timeout = kwargs.pop('timeout', None)
@@ -1409,7 +1409,7 @@ class ContainerClient(StorageAccountHostsMixin, StorageEncryptionMixin):    # py
 
     @distributed_trace
     def delete_blobs(
-            self, *blobs: Union[str, Dict[str, Any], BlobProperties],
+            self, *blobs: Union[str, Dict[str, Any]],
             **kwargs: Any
         ) -> Iterator[HttpResponse]:
         """Marks the specified blobs or snapshots for deletion.
@@ -1428,7 +1428,7 @@ class ContainerClient(StorageAccountHostsMixin, StorageEncryptionMixin):    # py
 
         :param blobs:
             The blobs to delete. This can be a single blob, or multiple values can
-            be supplied, where each value is either the name of the blob (str) or BlobProperties.
+            be supplied, where each value is either the name of the blob (str).
 
             .. note::
                 When the blob type is dict, here's a list of keys, value rules.
@@ -1454,7 +1454,7 @@ class ContainerClient(StorageAccountHostsMixin, StorageEncryptionMixin):    # py
                 timeout for subrequest:
                     key: 'timeout', value type: int
 
-        :type blobs: str or dict(str, Any) or ~azure.storage.blob.BlobProperties
+        :type blobs: str or dict(str, Any)
         :keyword str delete_snapshots:
             Required if a blob has associated snapshots. Values include:
              - "only": Deletes only the blobs snapshots.
@@ -1549,7 +1549,7 @@ class ContainerClient(StorageAccountHostsMixin, StorageEncryptionMixin):    # py
 
     def _generate_set_tiers_options(
             self, blob_tier: Optional[Union[str, 'StandardBlobTier', 'PremiumPageBlobTier']],
-            *blobs: Union[str, Dict[str, Any], BlobProperties],
+            *blobs: Union[str, Dict[str, Any]],
             **kwargs: Any
         ):
         timeout = kwargs.pop('timeout', None)
@@ -1596,7 +1596,7 @@ class ContainerClient(StorageAccountHostsMixin, StorageEncryptionMixin):    # py
     @distributed_trace
     def set_standard_blob_tier_blobs(
         self, standard_blob_tier: Optional[Union[str, 'StandardBlobTier']],
-        *blobs: Union[str, Dict[str, Any], BlobProperties],
+        *blobs: Union[str, Dict[str, Any]],
         **kwargs: Any
     ) -> Iterator[HttpResponse]:
         """This operation sets the tier on block blobs.
@@ -1621,7 +1621,7 @@ class ContainerClient(StorageAccountHostsMixin, StorageEncryptionMixin):    # py
         :type standard_blob_tier: str or ~azure.storage.blob.StandardBlobTier
         :param blobs:
             The blobs with which to interact. This can be a single blob, or multiple values can
-            be supplied, where each value is either the name of the blob (str) or BlobProperties.
+            be supplied, where each value is the name of the blob (str).
 
             .. note::
                 When the blob type is dict, here's a list of keys, value rules.
@@ -1643,7 +1643,7 @@ class ContainerClient(StorageAccountHostsMixin, StorageEncryptionMixin):    # py
                 timeout for subrequest:
                     key: 'timeout', value type: int
 
-        :type blobs: str or dict(str, Any) or ~azure.storage.blob.BlobProperties
+        :type blobs: str or dict(str, Any)
         :keyword ~azure.storage.blob.RehydratePriority rehydrate_priority:
             Indicates the priority with which to rehydrate an archived blob
         :keyword str if_tags_match_condition:
@@ -1671,7 +1671,7 @@ class ContainerClient(StorageAccountHostsMixin, StorageEncryptionMixin):    # py
     @distributed_trace
     def set_premium_page_blob_tier_blobs(
         self, premium_page_blob_tier: Optional[Union[str, 'PremiumPageBlobTier']],
-        *blobs: Union[str, Dict[str, Any], BlobProperties],
+        *blobs: Union[str, Dict[str, Any]],
         **kwargs: Any
     ) -> Iterator[HttpResponse]:
         """Sets the page blob tiers on all blobs. This API is only supported for page blobs on premium accounts.
@@ -1690,7 +1690,7 @@ class ContainerClient(StorageAccountHostsMixin, StorageEncryptionMixin):    # py
         :type premium_page_blob_tier: ~azure.storage.blob.PremiumPageBlobTier
         :param blobs:
             The blobs with which to interact. This can be a single blob, or multiple values can
-            be supplied, where each value is either the name of the blob (str) or BlobProperties.
+            be supplied, where each value is either the name of the blob (str).
 
             .. note::
                 When the blob type is dict, here's a list of keys, value rules.
@@ -1704,7 +1704,7 @@ class ContainerClient(StorageAccountHostsMixin, StorageEncryptionMixin):    # py
                 timeout for subrequest:
                     key: 'timeout', value type: int
 
-        :type blobs: str or dict(str, Any) or ~azure.storage.blob.BlobProperties
+        :type blobs: str or dict(str, Any) or ~azure.storage.blob
         :keyword int timeout:
             Sets the server-side timeout for the operation in seconds. For more details see
             https://learn.microsoft.com/rest/api/storageservices/setting-timeouts-for-blob-service-operations.
@@ -1722,7 +1722,7 @@ class ContainerClient(StorageAccountHostsMixin, StorageEncryptionMixin):    # py
         return self._batch_send(*reqs, **options)
 
     def get_blob_client(
-            self, blob,  # type: Union[str, BlobProperties]
+            self, blob,  # type: str
             snapshot=None,  # type: str
             *,
             version_id=None  # type: Optional[str]
@@ -1732,9 +1732,7 @@ class ContainerClient(StorageAccountHostsMixin, StorageEncryptionMixin):    # py
 
         The blob need not already exist.
 
-        :param blob:
-            The blob with which to interact.
-        :type blob: str or ~azure.storage.blob.BlobProperties
+        :param str blob: The blob with which to interact.
         :param str snapshot:
             The optional blob snapshot on which to operate. This can be the snapshot ID string
             or the response returned from :func:`~BlobClient.create_snapshot()`.

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_blob_service_client_async.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_blob_service_client_async.py
@@ -678,7 +678,7 @@ class BlobServiceClient(AsyncStorageAccountHostsMixin, BlobServiceClientBase, St
 
     def get_blob_client(
             self, container,  # type: Union[ContainerProperties, str]
-            blob,  # type: Union[BlobProperties, str]
+            blob,  # type: str
             snapshot=None,  # type: Optional[Union[Dict[str, Any], str]]
             *,
             version_id=None  # type: Optional[str]
@@ -692,10 +692,9 @@ class BlobServiceClient(AsyncStorageAccountHostsMixin, BlobServiceClientBase, St
             The container that the blob is in. This can either be the name of the container,
             or an instance of ContainerProperties.
         :type container: str or ~azure.storage.blob.ContainerProperties
-        :param blob:
-            The blob with which to interact. This can either be the name of the blob,
-            or an instance of BlobProperties.
-        :type blob: str or ~azure.storage.blob.BlobProperties
+        :param str blob:
+            The name of the blob with which to interact.
+        :type blob: str
         :param snapshot:
             The optional blob snapshot on which to operate. This can either be the ID of the snapshot,
             or a dictionary output returned by

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_container_client_async.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_container_client_async.py
@@ -822,7 +822,7 @@ class ContainerClient(AsyncStorageAccountHostsMixin, ContainerClientBase, Storag
 
     @distributed_trace_async
     async def upload_blob(
-            self, name: Union[str, BlobProperties],
+            self, name: str,
             data: Union[bytes, str, Iterable[AnyStr], AsyncIterable[AnyStr], IO[AnyStr]],
             blob_type: Union[str, BlobType] = BlobType.BlockBlob,
             length: Optional[int] = None,
@@ -831,9 +831,9 @@ class ContainerClient(AsyncStorageAccountHostsMixin, ContainerClientBase, Storag
         ) -> BlobClient:
         """Creates a new blob from a data source with automatic chunking.
 
-        :param name: The blob with which to interact. If specified, this value will override
+        :param str name: 
+            The blob with which to interact. If specified, this value will override
             a blob value specified in the blob URL.
-        :type name: str or ~azure.storage.blob.BlobProperties
         :param data: The blob data to upload.
         :param ~azure.storage.blob.BlobType blob_type: The type of the blob. This can be
             either BlockBlob, PageBlob or AppendBlob. The default value is BlockBlob.
@@ -962,7 +962,7 @@ class ContainerClient(AsyncStorageAccountHostsMixin, ContainerClientBase, Storag
 
     @distributed_trace_async
     async def delete_blob(
-            self, blob,  # type: Union[str, BlobProperties]
+            self, blob,  # type: str
             delete_snapshots=None,  # type: Optional[str]
             **kwargs
         ):
@@ -980,9 +980,9 @@ class ContainerClient(AsyncStorageAccountHostsMixin, ContainerClientBase, Storag
         Soft deleted blobs or snapshots are accessible through :func:`list_blobs()` specifying `include=["deleted"]`
         Soft-deleted blob or snapshot can be restored using :func:`~azure.storage.blob.aio.BlobClient.undelete()`
 
-        :param blob: The blob with which to interact. If specified, this value will override
+        :param str blob:
+            The blob with which to interact. If specified, this value will override
             a blob value specified in the blob URL.
-        :type blob: str or ~azure.storage.blob.BlobProperties
         :param str delete_snapshots:
             Required if the blob has associated snapshots. Values include:
              - "only": Deletes only the blobs snapshots.
@@ -1039,7 +1039,7 @@ class ContainerClient(AsyncStorageAccountHostsMixin, ContainerClientBase, Storag
 
     @overload
     async def download_blob(
-            self, blob: Union[str, BlobProperties],
+            self, blob: str,
             offset: int = None,
             length: int = None,
             *,
@@ -1049,7 +1049,7 @@ class ContainerClient(AsyncStorageAccountHostsMixin, ContainerClientBase, Storag
 
     @overload
     async def download_blob(
-            self, blob: Union[str, BlobProperties],
+            self, blob: str,
             offset: int = None,
             length: int = None,
             *,
@@ -1059,7 +1059,7 @@ class ContainerClient(AsyncStorageAccountHostsMixin, ContainerClientBase, Storag
 
     @distributed_trace_async
     async def download_blob(
-            self, blob: Union[str, BlobProperties],
+            self, blob: str,
             offset: int = None,
             length: int = None,
             *,
@@ -1069,9 +1069,9 @@ class ContainerClient(AsyncStorageAccountHostsMixin, ContainerClientBase, Storag
         be used to read all the content or readinto() must be used to download the blob into
         a stream. Using chunks() returns an async iterator which allows the user to iterate over the content in chunks.
 
-        :param blob: The blob with which to interact. If specified, this value will override
+        :param str blob: 
+            The blob with which to interact. If specified, this value will override
             a blob value specified in the blob URL.
-        :type blob: str or ~azure.storage.blob.BlobProperties
         :param int offset:
             Start of byte range to use for downloading a section of the blob.
             Must be set if length is provided.
@@ -1158,7 +1158,7 @@ class ContainerClient(AsyncStorageAccountHostsMixin, ContainerClientBase, Storag
 
     @distributed_trace_async
     async def delete_blobs(
-        self, *blobs: Union[str, Dict[str, Any], BlobProperties],
+        self, *blobs: Union[str, Dict[str, Any]],
         **kwargs: Any
     ) -> AsyncIterator[AsyncHttpResponse]:
         """Marks the specified blobs or snapshots for deletion.
@@ -1177,7 +1177,7 @@ class ContainerClient(AsyncStorageAccountHostsMixin, ContainerClientBase, Storag
 
         :param blobs:
             The blobs to delete. This can be a single blob, or multiple values can
-            be supplied, where each value is either the name of the blob (str) or BlobProperties.
+            be supplied, where each value is the name of the blob (str).
 
             .. note::
                 When the blob type is dict, here's a list of keys, value rules.
@@ -1201,7 +1201,7 @@ class ContainerClient(AsyncStorageAccountHostsMixin, ContainerClientBase, Storag
                 timeout for subrequest:
                     key: 'timeout', value type: int
 
-        :type blobs: str or dict(str, Any) or ~azure.storage.blob.BlobProperties
+        :type blobs: str or dict(str, Any)
         :keyword str delete_snapshots:
             Required if a blob has associated snapshots. Values include:
              - "only": Deletes only the blobs snapshots.
@@ -1256,7 +1256,7 @@ class ContainerClient(AsyncStorageAccountHostsMixin, ContainerClientBase, Storag
     @distributed_trace_async
     async def set_standard_blob_tier_blobs(
         self, standard_blob_tier: Union[str, 'StandardBlobTier'],
-        *blobs: Union[str, Dict[str, Any], BlobProperties],
+        *blobs: Union[str, Dict[str, Any]],
         **kwargs: Any
     ) -> AsyncIterator[AsyncHttpResponse]:
         """This operation sets the tier on block blobs.
@@ -1281,7 +1281,7 @@ class ContainerClient(AsyncStorageAccountHostsMixin, ContainerClientBase, Storag
         :type standard_blob_tier: str or ~azure.storage.blob.StandardBlobTier
         :param blobs:
             The blobs with which to interact. This can be a single blob, or multiple values can
-            be supplied, where each value is either the name of the blob (str) or BlobProperties.
+            be supplied, where each value is the name of the blob (str).
 
             .. note::
                 When the blob type is dict, here's a list of keys, value rules.
@@ -1298,7 +1298,7 @@ class ContainerClient(AsyncStorageAccountHostsMixin, ContainerClientBase, Storag
                 timeout for subrequest:
                     key: 'timeout', value type: int
 
-        :type blobs: str or dict(str, Any) or ~azure.storage.blob.BlobProperties
+        :type blobs: str or dict(str, Any)
         :keyword ~azure.storage.blob.RehydratePriority rehydrate_priority:
             Indicates the priority with which to rehydrate an archived blob
         :keyword str if_tags_match_condition:
@@ -1327,7 +1327,7 @@ class ContainerClient(AsyncStorageAccountHostsMixin, ContainerClientBase, Storag
     @distributed_trace_async
     async def set_premium_page_blob_tier_blobs(
         self, premium_page_blob_tier: Union[str, 'PremiumPageBlobTier'],
-        *blobs: Union[str, Dict[str, Any], BlobProperties],
+        *blobs: Union[str, Dict[str, Any]],
         **kwargs: Any
     ) -> AsyncIterator[AsyncHttpResponse]:
         """Sets the page blob tiers on the blobs. This API is only supported for page blobs on premium accounts.
@@ -1345,7 +1345,7 @@ class ContainerClient(AsyncStorageAccountHostsMixin, ContainerClientBase, Storag
 
         :type premium_page_blob_tier: ~azure.storage.blob.PremiumPageBlobTier
         :param blobs: The blobs with which to interact. This can be a single blob, or multiple values can
-            be supplied, where each value is either the name of the blob (str) or BlobProperties.
+            be supplied, where each value is the name of the blob (str).
 
             .. note::
                 When the blob type is dict, here's a list of keys, value rules.
@@ -1359,7 +1359,7 @@ class ContainerClient(AsyncStorageAccountHostsMixin, ContainerClientBase, Storag
                 timeout for subrequest:
                     key: 'timeout', value type: int
 
-        :type blobs: str or dict(str, Any) or ~azure.storage.blob.BlobProperties
+        :type blobs: str or dict(str, Any)
         :keyword int timeout:
             Sets the server-side timeout for the operation in seconds. For more details see
             https://learn.microsoft.com/rest/api/storageservices/setting-timeouts-for-blob-service-operations.
@@ -1378,7 +1378,7 @@ class ContainerClient(AsyncStorageAccountHostsMixin, ContainerClientBase, Storag
         return await self._batch_send(*reqs, **options)
 
     def get_blob_client(
-            self, blob,  # type: Union[BlobProperties, str]
+            self, blob,  # type: str
             snapshot=None,  # type: str
             *,
             version_id=None  # type: Optional[str]
@@ -1388,9 +1388,8 @@ class ContainerClient(AsyncStorageAccountHostsMixin, ContainerClientBase, Storag
 
         The blob need not already exist.
 
-        :param blob:
+        :param str blob:
             The blob with which to interact.
-        :type blob: str or ~azure.storage.blob.BlobProperties
         :param str snapshot:
             The optional blob snapshot on which to operate. This can be the snapshot ID string
             or the response returned from :func:`~BlobClient.create_snapshot()`.

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_shared_access_signature.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_shared_access_signature.py
@@ -5,7 +5,7 @@
 # --------------------------------------------------------------------------
 
 from typing import (
-    Union, Optional, Any, TYPE_CHECKING
+    Union, Optional, TYPE_CHECKING
 )
 
 from azure.storage.queue._shared import sign_string
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
         AccountSasPermissions,
         QueueSasPermissions
     )
+    from typing import Any
 
 class QueueSharedAccessSignature(SharedAccessSignature):
     '''
@@ -132,7 +133,7 @@ def generate_account_sas(
         expiry,  # type: Optional[Union[datetime, str]]
         start=None,  # type: Optional[Union[datetime, str]]
         ip=None,  # type: Optional[str]
-        **kwargs  # type: Any
+        **kwargs  # type: "Any"
     ):  # type: (...) -> str
     """Generates a shared access signature for the queue service.
 
@@ -194,7 +195,7 @@ def generate_queue_sas(
         start=None,  # type: Optional[Union[datetime, str]]
         policy_id=None,  # type: Optional[str]
         ip=None,  # type: Optional[str]
-        **kwargs  # type: Any
+        **kwargs  # type: "Any"
     ):  # type: (...) -> str
     """Generates a shared access signature for a queue.
 


### PR DESCRIPTION
After some discussion, we will be removing `BlobProperties` as an input for places that would usually take a blob `str`. This is to avoid confusion for what sort of properties are parsed from `BlobProperties`, and so `BlobProperties` will be deprecated.

TODO: Changelog