### PR TITLE
[ML] fix(next-pylint): Resolve `consider-using-with` for _Local_job_invoker

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_local_job_invoker.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_local_job_invoker.py
@@ -112,7 +112,7 @@ def invoke_command(project_temp_dir: Path) -> None:
 
     env = os.environ.copy()
     env.pop("AZUREML_TARGET_TYPE", None)
-    subprocess.Popen(
+    subprocess.Popen(  # pylint: disable=consider-using-with
         invoked_command,
         cwd=project_temp_dir,
         env=env,
@@ -203,8 +203,12 @@ class CommonRuntimeHelper:
             self.common_runtime_temp_folder,
             CommonRuntimeHelper.VM_BOOTSTRAPPER_FILE_NAME,
         )
-        self.stdout = open(os.path.join(self.common_runtime_temp_folder, "stdout"), "w+")
-        self.stderr = open(os.path.join(self.common_runtime_temp_folder, "stderr"), "w+")
+        self.stdout = open(  # pylint: disable=consider-using-with
+            os.path.join(self.common_runtime_temp_folder, "stdout"), "w+"
+        )
+        self.stderr = open(  # pylint: disable=consider-using-with
+            os.path.join(self.common_runtime_temp_folder, "stderr"), "w+"
+        )
 
     def get_docker_client(self, registry: Dict[str, str]) -> "docker.DockerClient":
         """Retrieves the Docker client for performing docker operations.
@@ -344,7 +348,7 @@ class CommonRuntimeHelper:
 
         env = self.LOCAL_JOB_ENV_VARS
 
-        process = subprocess.Popen(
+        process = subprocess.Popen(  # pylint: disable=consider-using-with
             cmd,
             env=env,
             stdout=subprocess.PIPE,


### PR DESCRIPTION
# Description

This pull request is part of a effort to ready the Azure ML Python SDK for an impending bump to the versions of pylint and azure-pylint-guidelines-checker that is used in our CI.

This pull request specifically resolves [`R1732` (consider-using-with)](https://pylint.pycqa.org/en/latest/user_guide/messages/refactor/consider-using-with.html) for sdk/ml/azure-ai-ml/azure/ai/ml/operations/_local_job_invoker.py, which was skipped in the [previous PR for R1732](https://github.com/Azure/azure-sdk-for-python/pull/30659)


Validated with:

`pylint==2.15.8`
`azure-pylint-guidelines-checker=0.0.8`

`pylint --rcfile=../../../eng/pylintc --disable=all --enable=R1732 azure/`

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
