### PR TITLE
[Storage] Encryption metadata key case insensitive

### DIFF
--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_encryption.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_encryption.py
@@ -24,6 +24,7 @@ from cryptography.hazmat.primitives.ciphers.modes import CBC
 from cryptography.hazmat.primitives.padding import PKCS7
 
 from azure.core.exceptions import HttpResponseError
+from azure.core.utils import CaseInsensitiveDict
 
 from ._version import VERSION
 from ._shared import encode_base64, decode_base64_to_bytes
@@ -377,7 +378,9 @@ def parse_encryption_data(metadata: Dict[str, Any]) -> Optional[_EncryptionData]
     :rtype: Optional[_EncryptionData]
     """
     try:
-        return _dict_to_encryption_data(loads(metadata['encryptiondata']))
+        # Use case insensitive dict as key needs to be case-insensitive
+        case_insensitive_metadata = CaseInsensitiveDict(metadata)
+        return _dict_to_encryption_data(loads(case_insensitive_metadata['encryptiondata']))
     except:  # pylint: disable=bare-except
         return None
 
@@ -771,7 +774,7 @@ def decrypt_blob(  # pylint: disable=too-many-locals,too-many-statements
     except Exception as exc:  # pylint: disable=broad-except
         if require_encryption:
             raise ValueError(
-                'Encryption required, but received data does not contain appropriate metatadata.' + \
+                'Encryption required, but received data does not contain appropriate metadata.' + \
                 'Data was either not encrypted or metadata has been lost.') from exc
 
         return content

--- a/sdk/storage/azure-storage-blob/tests/recordings/test_blob_encryption_v2.pyTestStorageBlobEncryptionV2test_case_insensitive_metadata_key.json
+++ b/sdk/storage/azure-storage-blob/tests/recordings/test_blob_encryption_v2.pyTestStorageBlobEncryptionV2test_case_insensitive_metadata_key.json
@@ -1,0 +1,212 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://storagename.blob.core.windows.net/utcontainer2363471?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Accept-Encoding": "gzip, deflate",
+        "Connection": "keep-alive",
+        "Content-Length": "0",
+        "User-Agent": "azsdk-python-storage-blob/12.18.0b1 Python/3.10.11 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Wed, 19 Jul 2023 20:00:34 GMT",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 409,
+      "ResponseHeaders": {
+        "Content-Length": "230",
+        "Content-Type": "application/xml",
+        "Date": "Wed, 19 Jul 2023 20:00:33 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-error-code": "ContainerAlreadyExists",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": [
+        "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CError\u003E\u003CCode\u003EContainerAlreadyExists\u003C/Code\u003E\u003CMessage\u003EThe specified container already exists.\n",
+        "RequestId:1afeee4f-101e-0017-347b-ba73c9000000\n",
+        "Time:2023-07-19T20:00:34.5678751Z\u003C/Message\u003E\u003C/Error\u003E"
+      ]
+    },
+    {
+      "RequestUri": "https://storagename.blob.core.windows.net/utcontainer2363471/encryptionv2_blob2363471",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Accept-Encoding": "gzip, deflate",
+        "Connection": "keep-alive",
+        "Content-Length": "50",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-python-storage-blob/12.18.0b1 Python/3.10.11 (Windows-10-10.0.22621-SP0)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-date": "Wed, 19 Jul 2023 20:00:34 GMT",
+        "x-ms-meta-encryptiondata": "{\u0022WrappedContentKey\u0022: {\u0022KeyId\u0022: \u0022key1\u0022, \u0022EncryptedKey\u0022: \u0022c3EwcBUQIku7ptntzfboaKwfdJmsOcVcOgfPAe30gAhEPkek8GsgMKRREXKhWZfG\u0022, \u0022Algorithm\u0022: \u0022A256KW\u0022}, \u0022EncryptionAgent\u0022: {\u0022Protocol\u0022: \u00222.0\u0022, \u0022EncryptionAlgorithm\u0022: \u0022AES_GCM_256\u0022}, \u0022EncryptedRegionInfo\u0022: {\u0022DataLength\u0022: 4194304, \u0022NonceLength\u0022: 12}, \u0022KeyWrappingMetadata\u0022: {\u0022EncryptionLibrary\u0022: \u0022Python x.x.x\u0022}, \u0022EncryptionMode\u0022: \u0022FullBlob\u0022}",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "AAAAAAAAAAAAAAAA36fti93e3c5nphghXMQznudhdD1KYf09pvx\u002BKjk2Jr24Vj20AEg=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "xG6OVIdph565MYIjlAzAkQ==",
+        "Date": "Wed, 19 Jul 2023 20:00:34 GMT",
+        "ETag": "\u00220x8DB8892D06FBCF1\u0022",
+        "Last-Modified": "Wed, 19 Jul 2023 20:00:34 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-content-crc64": "QlU2q8PhGGs=",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://storagename.blob.core.windows.net/utcontainer2363471/encryptionv2_blob2363471",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Accept-Encoding": "gzip, deflate",
+        "Connection": "keep-alive",
+        "User-Agent": "azsdk-python-storage-blob/12.18.0b1 Python/3.10.11 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Wed, 19 Jul 2023 20:00:34 GMT",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "50",
+        "Content-MD5": "xG6OVIdph565MYIjlAzAkQ==",
+        "Content-Type": "application/octet-stream",
+        "Date": "Wed, 19 Jul 2023 20:00:34 GMT",
+        "ETag": "\u00220x8DB8892D06FBCF1\u0022",
+        "Last-Modified": "Wed, 19 Jul 2023 20:00:34 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": "Origin",
+        "x-ms-access-tier": "Hot",
+        "x-ms-access-tier-inferred": "true",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-creation-time": "Wed, 19 Jul 2023 19:07:08 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-meta-encryptiondata": "{\u0022WrappedContentKey\u0022: {\u0022KeyId\u0022: \u0022key1\u0022, \u0022EncryptedKey\u0022: \u0022c3EwcBUQIku7ptntzfboaKwfdJmsOcVcOgfPAe30gAhEPkek8GsgMKRREXKhWZfG\u0022, \u0022Algorithm\u0022: \u0022A256KW\u0022}, \u0022EncryptionAgent\u0022: {\u0022Protocol\u0022: \u00222.0\u0022, \u0022EncryptionAlgorithm\u0022: \u0022AES_GCM_256\u0022}, \u0022EncryptedRegionInfo\u0022: {\u0022DataLength\u0022: 4194304, \u0022NonceLength\u0022: 12}, \u0022KeyWrappingMetadata\u0022: {\u0022EncryptionLibrary\u0022: \u0022Python x.x.x\u0022}, \u0022EncryptionMode\u0022: \u0022FullBlob\u0022}",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://storagename.blob.core.windows.net/utcontainer2363471/encryptionv2_blob2363471?comp=metadata",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Accept-Encoding": "gzip, deflate",
+        "Connection": "keep-alive",
+        "Content-Length": "0",
+        "User-Agent": "azsdk-python-storage-blob/12.18.0b1 Python/3.10.11 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Wed, 19 Jul 2023 20:00:34 GMT",
+        "x-ms-meta-Encryptiondata": "{\u0022WrappedContentKey\u0022: {\u0022KeyId\u0022: \u0022key1\u0022, \u0022EncryptedKey\u0022: \u0022c3EwcBUQIku7ptntzfboaKwfdJmsOcVcOgfPAe30gAhEPkek8GsgMKRREXKhWZfG\u0022, \u0022Algorithm\u0022: \u0022A256KW\u0022}, \u0022EncryptionAgent\u0022: {\u0022Protocol\u0022: \u00222.0\u0022, \u0022EncryptionAlgorithm\u0022: \u0022AES_GCM_256\u0022}, \u0022EncryptedRegionInfo\u0022: {\u0022DataLength\u0022: 4194304, \u0022NonceLength\u0022: 12}, \u0022KeyWrappingMetadata\u0022: {\u0022EncryptionLibrary\u0022: \u0022Python x.x.x\u0022}, \u0022EncryptionMode\u0022: \u0022FullBlob\u0022}",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 19 Jul 2023 20:00:34 GMT",
+        "ETag": "\u00220x8DB8892D082CCFC\u0022",
+        "Last-Modified": "Wed, 19 Jul 2023 20:00:34 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://storagename.blob.core.windows.net/utcontainer2363471/encryptionv2_blob2363471",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Accept-Encoding": "gzip, deflate",
+        "Connection": "keep-alive",
+        "User-Agent": "azsdk-python-storage-blob/12.18.0b1 Python/3.10.11 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Wed, 19 Jul 2023 20:00:34 GMT",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "50",
+        "Content-MD5": "xG6OVIdph565MYIjlAzAkQ==",
+        "Content-Type": "application/octet-stream",
+        "Date": "Wed, 19 Jul 2023 20:00:34 GMT",
+        "ETag": "\u00220x8DB8892D082CCFC\u0022",
+        "Last-Modified": "Wed, 19 Jul 2023 20:00:34 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": "Origin",
+        "x-ms-access-tier": "Hot",
+        "x-ms-access-tier-inferred": "true",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-creation-time": "Wed, 19 Jul 2023 19:07:08 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-meta-Encryptiondata": "{\u0022WrappedContentKey\u0022: {\u0022KeyId\u0022: \u0022key1\u0022, \u0022EncryptedKey\u0022: \u0022c3EwcBUQIku7ptntzfboaKwfdJmsOcVcOgfPAe30gAhEPkek8GsgMKRREXKhWZfG\u0022, \u0022Algorithm\u0022: \u0022A256KW\u0022}, \u0022EncryptionAgent\u0022: {\u0022Protocol\u0022: \u00222.0\u0022, \u0022EncryptionAlgorithm\u0022: \u0022AES_GCM_256\u0022}, \u0022EncryptedRegionInfo\u0022: {\u0022DataLength\u0022: 4194304, \u0022NonceLength\u0022: 12}, \u0022KeyWrappingMetadata\u0022: {\u0022EncryptionLibrary\u0022: \u0022Python x.x.x\u0022}, \u0022EncryptionMode\u0022: \u0022FullBlob\u0022}",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://storagename.blob.core.windows.net/utcontainer2363471/encryptionv2_blob2363471",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Accept-Encoding": "gzip, deflate",
+        "Connection": "keep-alive",
+        "User-Agent": "azsdk-python-storage-blob/12.18.0b1 Python/3.10.11 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Wed, 19 Jul 2023 20:00:34 GMT",
+        "x-ms-range": "bytes=0-33554655",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "50",
+        "Content-Range": "bytes 0-49/50",
+        "Content-Type": "application/octet-stream",
+        "Date": "Wed, 19 Jul 2023 20:00:34 GMT",
+        "ETag": "\u00220x8DB8892D082CCFC\u0022",
+        "Last-Modified": "Wed, 19 Jul 2023 20:00:34 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": "Origin",
+        "x-ms-blob-content-md5": "xG6OVIdph565MYIjlAzAkQ==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-creation-time": "Wed, 19 Jul 2023 19:07:08 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-meta-Encryptiondata": "{\u0022WrappedContentKey\u0022: {\u0022KeyId\u0022: \u0022key1\u0022, \u0022EncryptedKey\u0022: \u0022c3EwcBUQIku7ptntzfboaKwfdJmsOcVcOgfPAe30gAhEPkek8GsgMKRREXKhWZfG\u0022, \u0022Algorithm\u0022: \u0022A256KW\u0022}, \u0022EncryptionAgent\u0022: {\u0022Protocol\u0022: \u00222.0\u0022, \u0022EncryptionAlgorithm\u0022: \u0022AES_GCM_256\u0022}, \u0022EncryptedRegionInfo\u0022: {\u0022DataLength\u0022: 4194304, \u0022NonceLength\u0022: 12}, \u0022KeyWrappingMetadata\u0022: {\u0022EncryptionLibrary\u0022: \u0022Python x.x.x\u0022}, \u0022EncryptionMode\u0022: \u0022FullBlob\u0022}",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "AAAAAAAAAAAAAAAA36fti93e3c5nphghXMQznudhdD1KYf09pvx\u002BKjk2Jr24Vj20AEg="
+    }
+  ],
+  "Variables": {}
+}

--- a/sdk/storage/azure-storage-blob/tests/recordings/test_blob_encryption_v2_async.pyTestStorageBlobEncryptionV2Asynctest_case_insensitive_metadata_key.json
+++ b/sdk/storage/azure-storage-blob/tests/recordings/test_blob_encryption_v2_async.pyTestStorageBlobEncryptionV2Asynctest_case_insensitive_metadata_key.json
@@ -1,0 +1,202 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://storagename.blob.core.windows.net/utcontainer6eb138ec?restype=container",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Accept-Encoding": "gzip, deflate",
+        "Content-Length": "0",
+        "User-Agent": "azsdk-python-storage-blob/12.18.0b1 Python/3.10.11 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Wed, 19 Jul 2023 20:05:52 GMT",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 19 Jul 2023 20:05:53 GMT",
+        "ETag": "\u00220x8DB88938E56DC4F\u0022",
+        "Last-Modified": "Wed, 19 Jul 2023 20:05:53 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://storagename.blob.core.windows.net/utcontainer6eb138ec/encryptionv2_blob6eb138ec",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Accept-Encoding": "gzip, deflate",
+        "Content-Length": "50",
+        "Content-Type": "application/octet-stream",
+        "User-Agent": "azsdk-python-storage-blob/12.18.0b1 Python/3.10.11 (Windows-10-10.0.22621-SP0)",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-date": "Wed, 19 Jul 2023 20:05:53 GMT",
+        "x-ms-meta-encryptiondata": "{\u0022WrappedContentKey\u0022: {\u0022KeyId\u0022: \u0022key1\u0022, \u0022EncryptedKey\u0022: \u0022pKv9VDfHXszxCTGxz66xW5QOMa9K9jgXfQVnFMxblFLf8B5KHyTH9xnfwtao7dW1\u0022, \u0022Algorithm\u0022: \u0022A256KW\u0022}, \u0022EncryptionAgent\u0022: {\u0022Protocol\u0022: \u00222.0\u0022, \u0022EncryptionAlgorithm\u0022: \u0022AES_GCM_256\u0022}, \u0022EncryptedRegionInfo\u0022: {\u0022DataLength\u0022: 4194304, \u0022NonceLength\u0022: 12}, \u0022KeyWrappingMetadata\u0022: {\u0022EncryptionLibrary\u0022: \u0022Python x.x.x\u0022}, \u0022EncryptionMode\u0022: \u0022FullBlob\u0022}",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": "AAAAAAAAAAAAAAAAOlcuVv3gwmvUkhStCUEWyB4d15KQbGlZ\u002B60MZkel9dxgZYpxsfk=",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Content-MD5": "u\u002Bxj56yWki/9bnZKdXbMkA==",
+        "Date": "Wed, 19 Jul 2023 20:05:53 GMT",
+        "ETag": "\u00220x8DB88938E65D550\u0022",
+        "Last-Modified": "Wed, 19 Jul 2023 20:05:53 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-content-crc64": "pBqwlEHg31I=",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://storagename.blob.core.windows.net/utcontainer6eb138ec/encryptionv2_blob6eb138ec",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Accept-Encoding": "gzip, deflate",
+        "User-Agent": "azsdk-python-storage-blob/12.18.0b1 Python/3.10.11 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Wed, 19 Jul 2023 20:05:53 GMT",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "50",
+        "Content-MD5": "u\u002Bxj56yWki/9bnZKdXbMkA==",
+        "Content-Type": "application/octet-stream",
+        "Date": "Wed, 19 Jul 2023 20:05:53 GMT",
+        "ETag": "\u00220x8DB88938E65D550\u0022",
+        "Last-Modified": "Wed, 19 Jul 2023 20:05:53 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": "Origin",
+        "x-ms-access-tier": "Hot",
+        "x-ms-access-tier-inferred": "true",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-creation-time": "Wed, 19 Jul 2023 20:05:53 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-meta-encryptiondata": "{\u0022WrappedContentKey\u0022: {\u0022KeyId\u0022: \u0022key1\u0022, \u0022EncryptedKey\u0022: \u0022pKv9VDfHXszxCTGxz66xW5QOMa9K9jgXfQVnFMxblFLf8B5KHyTH9xnfwtao7dW1\u0022, \u0022Algorithm\u0022: \u0022A256KW\u0022}, \u0022EncryptionAgent\u0022: {\u0022Protocol\u0022: \u00222.0\u0022, \u0022EncryptionAlgorithm\u0022: \u0022AES_GCM_256\u0022}, \u0022EncryptedRegionInfo\u0022: {\u0022DataLength\u0022: 4194304, \u0022NonceLength\u0022: 12}, \u0022KeyWrappingMetadata\u0022: {\u0022EncryptionLibrary\u0022: \u0022Python x.x.x\u0022}, \u0022EncryptionMode\u0022: \u0022FullBlob\u0022}",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://storagename.blob.core.windows.net/utcontainer6eb138ec/encryptionv2_blob6eb138ec?comp=metadata",
+      "RequestMethod": "PUT",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Accept-Encoding": "gzip, deflate",
+        "Content-Length": "0",
+        "User-Agent": "azsdk-python-storage-blob/12.18.0b1 Python/3.10.11 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Wed, 19 Jul 2023 20:05:53 GMT",
+        "x-ms-meta-Encryptiondata": "{\u0022WrappedContentKey\u0022: {\u0022KeyId\u0022: \u0022key1\u0022, \u0022EncryptedKey\u0022: \u0022pKv9VDfHXszxCTGxz66xW5QOMa9K9jgXfQVnFMxblFLf8B5KHyTH9xnfwtao7dW1\u0022, \u0022Algorithm\u0022: \u0022A256KW\u0022}, \u0022EncryptionAgent\u0022: {\u0022Protocol\u0022: \u00222.0\u0022, \u0022EncryptionAlgorithm\u0022: \u0022AES_GCM_256\u0022}, \u0022EncryptedRegionInfo\u0022: {\u0022DataLength\u0022: 4194304, \u0022NonceLength\u0022: 12}, \u0022KeyWrappingMetadata\u0022: {\u0022EncryptionLibrary\u0022: \u0022Python x.x.x\u0022}, \u0022EncryptionMode\u0022: \u0022FullBlob\u0022}",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Content-Length": "0",
+        "Date": "Wed, 19 Jul 2023 20:05:53 GMT",
+        "ETag": "\u00220x8DB88938E793371\u0022",
+        "Last-Modified": "Wed, 19 Jul 2023 20:05:53 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://storagename.blob.core.windows.net/utcontainer6eb138ec/encryptionv2_blob6eb138ec",
+      "RequestMethod": "HEAD",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Accept-Encoding": "gzip, deflate",
+        "User-Agent": "azsdk-python-storage-blob/12.18.0b1 Python/3.10.11 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Wed, 19 Jul 2023 20:05:53 GMT",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 200,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "50",
+        "Content-MD5": "u\u002Bxj56yWki/9bnZKdXbMkA==",
+        "Content-Type": "application/octet-stream",
+        "Date": "Wed, 19 Jul 2023 20:05:53 GMT",
+        "ETag": "\u00220x8DB88938E793371\u0022",
+        "Last-Modified": "Wed, 19 Jul 2023 20:05:53 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": "Origin",
+        "x-ms-access-tier": "Hot",
+        "x-ms-access-tier-inferred": "true",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-creation-time": "Wed, 19 Jul 2023 20:05:53 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-meta-Encryptiondata": "{\u0022WrappedContentKey\u0022: {\u0022KeyId\u0022: \u0022key1\u0022, \u0022EncryptedKey\u0022: \u0022pKv9VDfHXszxCTGxz66xW5QOMa9K9jgXfQVnFMxblFLf8B5KHyTH9xnfwtao7dW1\u0022, \u0022Algorithm\u0022: \u0022A256KW\u0022}, \u0022EncryptionAgent\u0022: {\u0022Protocol\u0022: \u00222.0\u0022, \u0022EncryptionAlgorithm\u0022: \u0022AES_GCM_256\u0022}, \u0022EncryptedRegionInfo\u0022: {\u0022DataLength\u0022: 4194304, \u0022NonceLength\u0022: 12}, \u0022KeyWrappingMetadata\u0022: {\u0022EncryptionLibrary\u0022: \u0022Python x.x.x\u0022}, \u0022EncryptionMode\u0022: \u0022FullBlob\u0022}",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": null
+    },
+    {
+      "RequestUri": "https://storagename.blob.core.windows.net/utcontainer6eb138ec/encryptionv2_blob6eb138ec",
+      "RequestMethod": "GET",
+      "RequestHeaders": {
+        "Accept": "application/xml",
+        "Accept-Encoding": "gzip, deflate",
+        "User-Agent": "azsdk-python-storage-blob/12.18.0b1 Python/3.10.11 (Windows-10-10.0.22621-SP0)",
+        "x-ms-date": "Wed, 19 Jul 2023 20:05:53 GMT",
+        "x-ms-range": "bytes=0-33554655",
+        "x-ms-version": "2023-01-03"
+      },
+      "RequestBody": null,
+      "StatusCode": 206,
+      "ResponseHeaders": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "50",
+        "Content-Range": "bytes 0-49/50",
+        "Content-Type": "application/octet-stream",
+        "Date": "Wed, 19 Jul 2023 20:05:53 GMT",
+        "ETag": "\u00220x8DB88938E793371\u0022",
+        "Last-Modified": "Wed, 19 Jul 2023 20:05:53 GMT",
+        "Server": [
+          "Windows-Azure-Blob/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Vary": "Origin",
+        "x-ms-blob-content-md5": "u\u002Bxj56yWki/9bnZKdXbMkA==",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-creation-time": "Wed, 19 Jul 2023 20:05:53 GMT",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-meta-Encryptiondata": "{\u0022WrappedContentKey\u0022: {\u0022KeyId\u0022: \u0022key1\u0022, \u0022EncryptedKey\u0022: \u0022pKv9VDfHXszxCTGxz66xW5QOMa9K9jgXfQVnFMxblFLf8B5KHyTH9xnfwtao7dW1\u0022, \u0022Algorithm\u0022: \u0022A256KW\u0022}, \u0022EncryptionAgent\u0022: {\u0022Protocol\u0022: \u00222.0\u0022, \u0022EncryptionAlgorithm\u0022: \u0022AES_GCM_256\u0022}, \u0022EncryptedRegionInfo\u0022: {\u0022DataLength\u0022: 4194304, \u0022NonceLength\u0022: 12}, \u0022KeyWrappingMetadata\u0022: {\u0022EncryptionLibrary\u0022: \u0022Python x.x.x\u0022}, \u0022EncryptionMode\u0022: \u0022FullBlob\u0022}",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2023-01-03"
+      },
+      "ResponseBody": "AAAAAAAAAAAAAAAAOlcuVv3gwmvUkhStCUEWyB4d15KQbGlZ\u002B60MZkel9dxgZYpxsfk="
+    }
+  ],
+  "Variables": {}
+}

--- a/sdk/storage/azure-storage-blob/tests/recordings/test_blob_encryption_v2_async.pyTestStorageBlobEncryptionV2Asynctest_case_insensitive_metadata_key.json
+++ b/sdk/storage/azure-storage-blob/tests/recordings/test_blob_encryption_v2_async.pyTestStorageBlobEncryptionV2Asynctest_case_insensitive_metadata_key.json
@@ -8,23 +8,27 @@
         "Accept-Encoding": "gzip, deflate",
         "Content-Length": "0",
         "User-Agent": "azsdk-python-storage-blob/12.18.0b1 Python/3.10.11 (Windows-10-10.0.22621-SP0)",
-        "x-ms-date": "Wed, 19 Jul 2023 20:05:52 GMT",
+        "x-ms-date": "Wed, 19 Jul 2023 20:51:37 GMT",
         "x-ms-version": "2023-01-03"
       },
       "RequestBody": null,
-      "StatusCode": 201,
+      "StatusCode": 409,
       "ResponseHeaders": {
-        "Content-Length": "0",
-        "Date": "Wed, 19 Jul 2023 20:05:53 GMT",
-        "ETag": "\u00220x8DB88938E56DC4F\u0022",
-        "Last-Modified": "Wed, 19 Jul 2023 20:05:53 GMT",
+        "Content-Length": "230",
+        "Content-Type": "application/xml",
+        "Date": "Wed, 19 Jul 2023 20:51:36 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
+        "x-ms-error-code": "ContainerAlreadyExists",
         "x-ms-version": "2023-01-03"
       },
-      "ResponseBody": null
+      "ResponseBody": [
+        "\uFEFF\u003C?xml version=\u00221.0\u0022 encoding=\u0022utf-8\u0022?\u003E\u003CError\u003E\u003CCode\u003EContainerAlreadyExists\u003C/Code\u003E\u003CMessage\u003EThe specified container already exists.\n",
+        "RequestId:0d680ef5-101e-005a-2f82-babc25000000\n",
+        "Time:2023-07-19T20:51:37.4165574Z\u003C/Message\u003E\u003C/Error\u003E"
+      ]
     },
     {
       "RequestUri": "https://storagename.blob.core.windows.net/utcontainer6eb138ec/encryptionv2_blob6eb138ec",
@@ -36,23 +40,23 @@
         "Content-Type": "application/octet-stream",
         "User-Agent": "azsdk-python-storage-blob/12.18.0b1 Python/3.10.11 (Windows-10-10.0.22621-SP0)",
         "x-ms-blob-type": "BlockBlob",
-        "x-ms-date": "Wed, 19 Jul 2023 20:05:53 GMT",
-        "x-ms-meta-encryptiondata": "{\u0022WrappedContentKey\u0022: {\u0022KeyId\u0022: \u0022key1\u0022, \u0022EncryptedKey\u0022: \u0022pKv9VDfHXszxCTGxz66xW5QOMa9K9jgXfQVnFMxblFLf8B5KHyTH9xnfwtao7dW1\u0022, \u0022Algorithm\u0022: \u0022A256KW\u0022}, \u0022EncryptionAgent\u0022: {\u0022Protocol\u0022: \u00222.0\u0022, \u0022EncryptionAlgorithm\u0022: \u0022AES_GCM_256\u0022}, \u0022EncryptedRegionInfo\u0022: {\u0022DataLength\u0022: 4194304, \u0022NonceLength\u0022: 12}, \u0022KeyWrappingMetadata\u0022: {\u0022EncryptionLibrary\u0022: \u0022Python x.x.x\u0022}, \u0022EncryptionMode\u0022: \u0022FullBlob\u0022}",
+        "x-ms-date": "Wed, 19 Jul 2023 20:51:37 GMT",
+        "x-ms-meta-encryptiondata": "{\u0022WrappedContentKey\u0022: {\u0022KeyId\u0022: \u0022key1\u0022, \u0022EncryptedKey\u0022: \u0022c3EwcBUQIku7ptntzfboaKwfdJmsOcVcOgfPAe30gAhEPkek8GsgMKRREXKhWZfG\u0022, \u0022Algorithm\u0022: \u0022A256KW\u0022}, \u0022EncryptionAgent\u0022: {\u0022Protocol\u0022: \u00222.0\u0022, \u0022EncryptionAlgorithm\u0022: \u0022AES_GCM_256\u0022}, \u0022EncryptedRegionInfo\u0022: {\u0022DataLength\u0022: 4194304, \u0022NonceLength\u0022: 12}, \u0022KeyWrappingMetadata\u0022: {\u0022EncryptionLibrary\u0022: \u0022Python x.x.x\u0022}, \u0022EncryptionMode\u0022: \u0022FullBlob\u0022}",
         "x-ms-version": "2023-01-03"
       },
-      "RequestBody": "AAAAAAAAAAAAAAAAOlcuVv3gwmvUkhStCUEWyB4d15KQbGlZ\u002B60MZkel9dxgZYpxsfk=",
+      "RequestBody": "AAAAAAAAAAAAAAAA36fti93e3c5nphghXMQznudhdD1KYf09pvx\u002BKjk2Jr24Vj20AEg=",
       "StatusCode": 201,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Content-MD5": "u\u002Bxj56yWki/9bnZKdXbMkA==",
-        "Date": "Wed, 19 Jul 2023 20:05:53 GMT",
-        "ETag": "\u00220x8DB88938E65D550\u0022",
-        "Last-Modified": "Wed, 19 Jul 2023 20:05:53 GMT",
+        "Content-MD5": "xG6OVIdph565MYIjlAzAkQ==",
+        "Date": "Wed, 19 Jul 2023 20:51:36 GMT",
+        "ETag": "\u00220x8DB8899F20ADDCD\u0022",
+        "Last-Modified": "Wed, 19 Jul 2023 20:51:37 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
-        "x-ms-content-crc64": "pBqwlEHg31I=",
+        "x-ms-content-crc64": "QlU2q8PhGGs=",
         "x-ms-request-server-encrypted": "true",
         "x-ms-version": "2023-01-03"
       },
@@ -65,7 +69,7 @@
         "Accept": "application/xml",
         "Accept-Encoding": "gzip, deflate",
         "User-Agent": "azsdk-python-storage-blob/12.18.0b1 Python/3.10.11 (Windows-10-10.0.22621-SP0)",
-        "x-ms-date": "Wed, 19 Jul 2023 20:05:53 GMT",
+        "x-ms-date": "Wed, 19 Jul 2023 20:51:37 GMT",
         "x-ms-version": "2023-01-03"
       },
       "RequestBody": null,
@@ -73,11 +77,11 @@
       "ResponseHeaders": {
         "Accept-Ranges": "bytes",
         "Content-Length": "50",
-        "Content-MD5": "u\u002Bxj56yWki/9bnZKdXbMkA==",
+        "Content-MD5": "xG6OVIdph565MYIjlAzAkQ==",
         "Content-Type": "application/octet-stream",
-        "Date": "Wed, 19 Jul 2023 20:05:53 GMT",
-        "ETag": "\u00220x8DB88938E65D550\u0022",
-        "Last-Modified": "Wed, 19 Jul 2023 20:05:53 GMT",
+        "Date": "Wed, 19 Jul 2023 20:51:36 GMT",
+        "ETag": "\u00220x8DB8899F20ADDCD\u0022",
+        "Last-Modified": "Wed, 19 Jul 2023 20:51:37 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
@@ -89,7 +93,7 @@
         "x-ms-creation-time": "Wed, 19 Jul 2023 20:05:53 GMT",
         "x-ms-lease-state": "available",
         "x-ms-lease-status": "unlocked",
-        "x-ms-meta-encryptiondata": "{\u0022WrappedContentKey\u0022: {\u0022KeyId\u0022: \u0022key1\u0022, \u0022EncryptedKey\u0022: \u0022pKv9VDfHXszxCTGxz66xW5QOMa9K9jgXfQVnFMxblFLf8B5KHyTH9xnfwtao7dW1\u0022, \u0022Algorithm\u0022: \u0022A256KW\u0022}, \u0022EncryptionAgent\u0022: {\u0022Protocol\u0022: \u00222.0\u0022, \u0022EncryptionAlgorithm\u0022: \u0022AES_GCM_256\u0022}, \u0022EncryptedRegionInfo\u0022: {\u0022DataLength\u0022: 4194304, \u0022NonceLength\u0022: 12}, \u0022KeyWrappingMetadata\u0022: {\u0022EncryptionLibrary\u0022: \u0022Python x.x.x\u0022}, \u0022EncryptionMode\u0022: \u0022FullBlob\u0022}",
+        "x-ms-meta-encryptiondata": "{\u0022WrappedContentKey\u0022: {\u0022KeyId\u0022: \u0022key1\u0022, \u0022EncryptedKey\u0022: \u0022c3EwcBUQIku7ptntzfboaKwfdJmsOcVcOgfPAe30gAhEPkek8GsgMKRREXKhWZfG\u0022, \u0022Algorithm\u0022: \u0022A256KW\u0022}, \u0022EncryptionAgent\u0022: {\u0022Protocol\u0022: \u00222.0\u0022, \u0022EncryptionAlgorithm\u0022: \u0022AES_GCM_256\u0022}, \u0022EncryptedRegionInfo\u0022: {\u0022DataLength\u0022: 4194304, \u0022NonceLength\u0022: 12}, \u0022KeyWrappingMetadata\u0022: {\u0022EncryptionLibrary\u0022: \u0022Python x.x.x\u0022}, \u0022EncryptionMode\u0022: \u0022FullBlob\u0022}",
         "x-ms-server-encrypted": "true",
         "x-ms-version": "2023-01-03"
       },
@@ -103,17 +107,17 @@
         "Accept-Encoding": "gzip, deflate",
         "Content-Length": "0",
         "User-Agent": "azsdk-python-storage-blob/12.18.0b1 Python/3.10.11 (Windows-10-10.0.22621-SP0)",
-        "x-ms-date": "Wed, 19 Jul 2023 20:05:53 GMT",
-        "x-ms-meta-Encryptiondata": "{\u0022WrappedContentKey\u0022: {\u0022KeyId\u0022: \u0022key1\u0022, \u0022EncryptedKey\u0022: \u0022pKv9VDfHXszxCTGxz66xW5QOMa9K9jgXfQVnFMxblFLf8B5KHyTH9xnfwtao7dW1\u0022, \u0022Algorithm\u0022: \u0022A256KW\u0022}, \u0022EncryptionAgent\u0022: {\u0022Protocol\u0022: \u00222.0\u0022, \u0022EncryptionAlgorithm\u0022: \u0022AES_GCM_256\u0022}, \u0022EncryptedRegionInfo\u0022: {\u0022DataLength\u0022: 4194304, \u0022NonceLength\u0022: 12}, \u0022KeyWrappingMetadata\u0022: {\u0022EncryptionLibrary\u0022: \u0022Python x.x.x\u0022}, \u0022EncryptionMode\u0022: \u0022FullBlob\u0022}",
+        "x-ms-date": "Wed, 19 Jul 2023 20:51:37 GMT",
+        "x-ms-meta-Encryptiondata": "{\u0022WrappedContentKey\u0022: {\u0022KeyId\u0022: \u0022key1\u0022, \u0022EncryptedKey\u0022: \u0022c3EwcBUQIku7ptntzfboaKwfdJmsOcVcOgfPAe30gAhEPkek8GsgMKRREXKhWZfG\u0022, \u0022Algorithm\u0022: \u0022A256KW\u0022}, \u0022EncryptionAgent\u0022: {\u0022Protocol\u0022: \u00222.0\u0022, \u0022EncryptionAlgorithm\u0022: \u0022AES_GCM_256\u0022}, \u0022EncryptedRegionInfo\u0022: {\u0022DataLength\u0022: 4194304, \u0022NonceLength\u0022: 12}, \u0022KeyWrappingMetadata\u0022: {\u0022EncryptionLibrary\u0022: \u0022Python x.x.x\u0022}, \u0022EncryptionMode\u0022: \u0022FullBlob\u0022}",
         "x-ms-version": "2023-01-03"
       },
       "RequestBody": null,
       "StatusCode": 200,
       "ResponseHeaders": {
         "Content-Length": "0",
-        "Date": "Wed, 19 Jul 2023 20:05:53 GMT",
-        "ETag": "\u00220x8DB88938E793371\u0022",
-        "Last-Modified": "Wed, 19 Jul 2023 20:05:53 GMT",
+        "Date": "Wed, 19 Jul 2023 20:51:36 GMT",
+        "ETag": "\u00220x8DB8899F21E3BE9\u0022",
+        "Last-Modified": "Wed, 19 Jul 2023 20:51:37 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
@@ -130,7 +134,7 @@
         "Accept": "application/xml",
         "Accept-Encoding": "gzip, deflate",
         "User-Agent": "azsdk-python-storage-blob/12.18.0b1 Python/3.10.11 (Windows-10-10.0.22621-SP0)",
-        "x-ms-date": "Wed, 19 Jul 2023 20:05:53 GMT",
+        "x-ms-date": "Wed, 19 Jul 2023 20:51:37 GMT",
         "x-ms-version": "2023-01-03"
       },
       "RequestBody": null,
@@ -138,11 +142,11 @@
       "ResponseHeaders": {
         "Accept-Ranges": "bytes",
         "Content-Length": "50",
-        "Content-MD5": "u\u002Bxj56yWki/9bnZKdXbMkA==",
+        "Content-MD5": "xG6OVIdph565MYIjlAzAkQ==",
         "Content-Type": "application/octet-stream",
-        "Date": "Wed, 19 Jul 2023 20:05:53 GMT",
-        "ETag": "\u00220x8DB88938E793371\u0022",
-        "Last-Modified": "Wed, 19 Jul 2023 20:05:53 GMT",
+        "Date": "Wed, 19 Jul 2023 20:51:36 GMT",
+        "ETag": "\u00220x8DB8899F21E3BE9\u0022",
+        "Last-Modified": "Wed, 19 Jul 2023 20:51:37 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
@@ -154,7 +158,7 @@
         "x-ms-creation-time": "Wed, 19 Jul 2023 20:05:53 GMT",
         "x-ms-lease-state": "available",
         "x-ms-lease-status": "unlocked",
-        "x-ms-meta-Encryptiondata": "{\u0022WrappedContentKey\u0022: {\u0022KeyId\u0022: \u0022key1\u0022, \u0022EncryptedKey\u0022: \u0022pKv9VDfHXszxCTGxz66xW5QOMa9K9jgXfQVnFMxblFLf8B5KHyTH9xnfwtao7dW1\u0022, \u0022Algorithm\u0022: \u0022A256KW\u0022}, \u0022EncryptionAgent\u0022: {\u0022Protocol\u0022: \u00222.0\u0022, \u0022EncryptionAlgorithm\u0022: \u0022AES_GCM_256\u0022}, \u0022EncryptedRegionInfo\u0022: {\u0022DataLength\u0022: 4194304, \u0022NonceLength\u0022: 12}, \u0022KeyWrappingMetadata\u0022: {\u0022EncryptionLibrary\u0022: \u0022Python x.x.x\u0022}, \u0022EncryptionMode\u0022: \u0022FullBlob\u0022}",
+        "x-ms-meta-Encryptiondata": "{\u0022WrappedContentKey\u0022: {\u0022KeyId\u0022: \u0022key1\u0022, \u0022EncryptedKey\u0022: \u0022c3EwcBUQIku7ptntzfboaKwfdJmsOcVcOgfPAe30gAhEPkek8GsgMKRREXKhWZfG\u0022, \u0022Algorithm\u0022: \u0022A256KW\u0022}, \u0022EncryptionAgent\u0022: {\u0022Protocol\u0022: \u00222.0\u0022, \u0022EncryptionAlgorithm\u0022: \u0022AES_GCM_256\u0022}, \u0022EncryptedRegionInfo\u0022: {\u0022DataLength\u0022: 4194304, \u0022NonceLength\u0022: 12}, \u0022KeyWrappingMetadata\u0022: {\u0022EncryptionLibrary\u0022: \u0022Python x.x.x\u0022}, \u0022EncryptionMode\u0022: \u0022FullBlob\u0022}",
         "x-ms-server-encrypted": "true",
         "x-ms-version": "2023-01-03"
       },
@@ -167,7 +171,7 @@
         "Accept": "application/xml",
         "Accept-Encoding": "gzip, deflate",
         "User-Agent": "azsdk-python-storage-blob/12.18.0b1 Python/3.10.11 (Windows-10-10.0.22621-SP0)",
-        "x-ms-date": "Wed, 19 Jul 2023 20:05:53 GMT",
+        "x-ms-date": "Wed, 19 Jul 2023 20:51:37 GMT",
         "x-ms-range": "bytes=0-33554655",
         "x-ms-version": "2023-01-03"
       },
@@ -178,24 +182,24 @@
         "Content-Length": "50",
         "Content-Range": "bytes 0-49/50",
         "Content-Type": "application/octet-stream",
-        "Date": "Wed, 19 Jul 2023 20:05:53 GMT",
-        "ETag": "\u00220x8DB88938E793371\u0022",
-        "Last-Modified": "Wed, 19 Jul 2023 20:05:53 GMT",
+        "Date": "Wed, 19 Jul 2023 20:51:37 GMT",
+        "ETag": "\u00220x8DB8899F21E3BE9\u0022",
+        "Last-Modified": "Wed, 19 Jul 2023 20:51:37 GMT",
         "Server": [
           "Windows-Azure-Blob/1.0",
           "Microsoft-HTTPAPI/2.0"
         ],
         "Vary": "Origin",
-        "x-ms-blob-content-md5": "u\u002Bxj56yWki/9bnZKdXbMkA==",
+        "x-ms-blob-content-md5": "xG6OVIdph565MYIjlAzAkQ==",
         "x-ms-blob-type": "BlockBlob",
         "x-ms-creation-time": "Wed, 19 Jul 2023 20:05:53 GMT",
         "x-ms-lease-state": "available",
         "x-ms-lease-status": "unlocked",
-        "x-ms-meta-Encryptiondata": "{\u0022WrappedContentKey\u0022: {\u0022KeyId\u0022: \u0022key1\u0022, \u0022EncryptedKey\u0022: \u0022pKv9VDfHXszxCTGxz66xW5QOMa9K9jgXfQVnFMxblFLf8B5KHyTH9xnfwtao7dW1\u0022, \u0022Algorithm\u0022: \u0022A256KW\u0022}, \u0022EncryptionAgent\u0022: {\u0022Protocol\u0022: \u00222.0\u0022, \u0022EncryptionAlgorithm\u0022: \u0022AES_GCM_256\u0022}, \u0022EncryptedRegionInfo\u0022: {\u0022DataLength\u0022: 4194304, \u0022NonceLength\u0022: 12}, \u0022KeyWrappingMetadata\u0022: {\u0022EncryptionLibrary\u0022: \u0022Python x.x.x\u0022}, \u0022EncryptionMode\u0022: \u0022FullBlob\u0022}",
+        "x-ms-meta-Encryptiondata": "{\u0022WrappedContentKey\u0022: {\u0022KeyId\u0022: \u0022key1\u0022, \u0022EncryptedKey\u0022: \u0022c3EwcBUQIku7ptntzfboaKwfdJmsOcVcOgfPAe30gAhEPkek8GsgMKRREXKhWZfG\u0022, \u0022Algorithm\u0022: \u0022A256KW\u0022}, \u0022EncryptionAgent\u0022: {\u0022Protocol\u0022: \u00222.0\u0022, \u0022EncryptionAlgorithm\u0022: \u0022AES_GCM_256\u0022}, \u0022EncryptedRegionInfo\u0022: {\u0022DataLength\u0022: 4194304, \u0022NonceLength\u0022: 12}, \u0022KeyWrappingMetadata\u0022: {\u0022EncryptionLibrary\u0022: \u0022Python x.x.x\u0022}, \u0022EncryptionMode\u0022: \u0022FullBlob\u0022}",
         "x-ms-server-encrypted": "true",
         "x-ms-version": "2023-01-03"
       },
-      "ResponseBody": "AAAAAAAAAAAAAAAAOlcuVv3gwmvUkhStCUEWyB4d15KQbGlZ\u002B60MZkel9dxgZYpxsfk="
+      "ResponseBody": "AAAAAAAAAAAAAAAA36fti93e3c5nphghXMQznudhdD1KYf09pvx\u002BKjk2Jr24Vj20AEg="
     }
   ],
   "Variables": {}

--- a/sdk/storage/azure-storage-blob/tests/test_blob_encryption_v2.py
+++ b/sdk/storage/azure-storage-blob/tests/test_blob_encryption_v2.py
@@ -394,6 +394,35 @@ class TestStorageBlobEncryptionV2(StorageRecordedTestCase):
     @BlobPreparer()
     @recorded_by_proxy
     @mock.patch('os.urandom', mock_urandom)
+    def test_case_insensitive_metadata_key(self, **kwargs):
+        storage_account_name = kwargs.pop("storage_account_name")
+        storage_account_key = kwargs.pop("storage_account_key")
+
+        self._setup(storage_account_name, storage_account_key)
+        kek = KeyWrapper('key1')
+        self.enable_encryption_v2(kek)
+
+        blob = self.bsc.get_blob_client(self.container_name, self._get_blob_reference())
+        content = b'Hello World Encrypted!'
+
+        # Upload blob with encryption V2
+        blob.upload_blob(content, overwrite=True)
+
+        # Change the case of the metadata key
+        metadata = blob.get_blob_properties().metadata
+        encryption_data = loads(metadata['encryptiondata'])
+        metadata = {'Encryptiondata': dumps(encryption_data)}
+        blob.set_blob_metadata(metadata)
+
+        # Act
+        data = blob.download_blob().readall()
+
+        # Assert
+        assert data == content
+
+    @BlobPreparer()
+    @recorded_by_proxy
+    @mock.patch('os.urandom', mock_urandom)
     def test_put_blob_empty(self, **kwargs):
         storage_account_name = kwargs.pop("storage_account_name")
         storage_account_key = kwargs.pop("storage_account_key")

--- a/sdk/storage/azure-storage-blob/tests/test_blob_encryption_v2.py
+++ b/sdk/storage/azure-storage-blob/tests/test_blob_encryption_v2.py
@@ -410,8 +410,8 @@ class TestStorageBlobEncryptionV2(StorageRecordedTestCase):
 
         # Change the case of the metadata key
         metadata = blob.get_blob_properties().metadata
-        encryption_data = loads(metadata['encryptiondata'])
-        metadata = {'Encryptiondata': dumps(encryption_data)}
+        encryption_data = metadata['encryptiondata']
+        metadata = {'Encryptiondata': encryption_data}
         blob.set_blob_metadata(metadata)
 
         # Act

--- a/sdk/storage/azure-storage-blob/tests/test_blob_encryption_v2_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_blob_encryption_v2_async.py
@@ -395,6 +395,34 @@ class TestStorageBlobEncryptionV2Async(AsyncStorageRecordedTestCase):
 
     @BlobPreparer()
     @recorded_by_proxy_async
+    async def test_case_insensitive_metadata_key(self, **kwargs):
+        storage_account_name = kwargs.pop("storage_account_name")
+        storage_account_key = kwargs.pop("storage_account_key")
+
+        await self._setup(storage_account_name, storage_account_key)
+        kek = KeyWrapper('key1')
+        self.enable_encryption_v2(kek)
+
+        blob = self.bsc.get_blob_client(self.container_name, self._get_blob_reference())
+        content = b'Hello World Encrypted!'
+
+        # Upload blob with encryption V2
+        await blob.upload_blob(content, overwrite=True)
+
+        # Change the case of the metadata key
+        metadata = (await blob.get_blob_properties()).metadata
+        encryption_data = loads(metadata['encryptiondata'])
+        metadata = {'Encryptiondata': dumps(encryption_data)}
+        await blob.set_blob_metadata(metadata)
+
+        # Act
+        data = await (await blob.download_blob()).readall()
+
+        # Assert
+        assert data == content
+
+    @BlobPreparer()
+    @recorded_by_proxy_async
     async def test_put_blob_empty(self, **kwargs):
         storage_account_name = kwargs.pop("storage_account_name")
         storage_account_key = kwargs.pop("storage_account_key")

--- a/sdk/storage/azure-storage-blob/tests/test_blob_encryption_v2_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_blob_encryption_v2_async.py
@@ -407,7 +407,8 @@ class TestStorageBlobEncryptionV2Async(AsyncStorageRecordedTestCase):
         content = b'Hello World Encrypted!'
 
         # Upload blob with encryption V2
-        await blob.upload_blob(content, overwrite=True)
+        with mock.patch('os.urandom', mock_urandom):
+            await blob.upload_blob(content, overwrite=True)
 
         # Change the case of the metadata key
         metadata = (await blob.get_blob_properties()).metadata

--- a/sdk/storage/azure-storage-blob/tests/test_blob_encryption_v2_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_blob_encryption_v2_async.py
@@ -411,8 +411,8 @@ class TestStorageBlobEncryptionV2Async(AsyncStorageRecordedTestCase):
 
         # Change the case of the metadata key
         metadata = (await blob.get_blob_properties()).metadata
-        encryption_data = loads(metadata['encryptiondata'])
-        metadata = {'Encryptiondata': dumps(encryption_data)}
+        encryption_data = metadata['encryptiondata']
+        metadata = {'Encryptiondata': encryption_data}
         await blob.set_blob_metadata(metadata)
 
         # Act

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_encryption.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_encryption.py
@@ -24,6 +24,7 @@ from cryptography.hazmat.primitives.ciphers.modes import CBC
 from cryptography.hazmat.primitives.padding import PKCS7
 
 from azure.core.exceptions import HttpResponseError
+from azure.core.utils import CaseInsensitiveDict
 
 from ._version import VERSION
 from ._shared import encode_base64, decode_base64_to_bytes
@@ -377,7 +378,9 @@ def parse_encryption_data(metadata: Dict[str, Any]) -> Optional[_EncryptionData]
     :rtype: Optional[_EncryptionData]
     """
     try:
-        return _dict_to_encryption_data(loads(metadata['encryptiondata']))
+        # Use case insensitive dict as key needs to be case-insensitive
+        case_insensitive_metadata = CaseInsensitiveDict(metadata)
+        return _dict_to_encryption_data(loads(case_insensitive_metadata['encryptiondata']))
     except:  # pylint: disable=bare-except
         return None
 
@@ -771,7 +774,7 @@ def decrypt_blob(  # pylint: disable=too-many-locals,too-many-statements
     except Exception as exc:  # pylint: disable=broad-except
         if require_encryption:
             raise ValueError(
-                'Encryption required, but received data does not contain appropriate metatadata.' + \
+                'Encryption required, but received data does not contain appropriate metadata.' + \
                 'Data was either not encrypted or metadata has been lost.') from exc
 
         return content


### PR DESCRIPTION
This change makes the encryption metadata key used for client-side encryption of blobs case insensitive. Uses `CaseInsensitiveDict` from `azure-core`.

There was one other place we were reading this metadata ([here](https://github.com/Azure/azure-sdk-for-python/blob/de249f1800c1f53056fe464646002547232057db/sdk/storage/azure-storage-blob/azure/storage/blob/_encryption.py#L770)) but that was reading directly from headers which are already kept in a case-insensitive collection.