### PR TITLE
[ACS][CallAutomation] Adding ability to redirect request

### DIFF
--- a/sdk/communication/azure-communication-callautomation/azure/communication/callautomation/_call_automation_client.py
+++ b/sdk/communication/azure-communication-callautomation/azure/communication/callautomation/_call_automation_client.py
@@ -12,7 +12,7 @@ from ._call_connection_client import CallConnectionClient
 from ._generated._client import AzureCommunicationCallAutomationService
 from ._shared.auth_policy_utils import get_authentication_policy
 from ._shared.utils import parse_connection_str
-from ._credential.call_automation_auth_policy_utils import get_call_automation_authentication_policy
+from ._credential.call_automation_auth_policy_utils import get_call_automation_auth_policy
 from ._credential.credential_utils import get_custom_enabled, get_custom_url
 from ._generated.models import (
     CreateCallRequest,
@@ -102,7 +102,7 @@ class CallAutomationClient(object):
                 custom_url,
                 credential,
                 api_version=api_version or DEFAULT_VERSION,
-                authentication_policy=get_call_automation_authentication_policy(
+                authentication_policy=get_call_automation_auth_policy(
                 custom_url, credential, acs_url=endpoint),
                 sdk_moniker=SDK_MONIKER,
                 **kwargs)

--- a/sdk/communication/azure-communication-callautomation/azure/communication/callautomation/_call_automation_client.py
+++ b/sdk/communication/azure-communication-callautomation/azure/communication/callautomation/_call_automation_client.py
@@ -12,6 +12,8 @@ from ._call_connection_client import CallConnectionClient
 from ._generated._client import AzureCommunicationCallAutomationService
 from ._shared.auth_policy_utils import get_authentication_policy
 from ._shared.utils import parse_connection_str
+from ._credential.call_automation_auth_policy_utils import get_call_automation_authentication_policy
+from ._credential.credential_utils import get_custom_enabled, get_custom_url
 from ._generated.models import (
     CreateCallRequest,
     AnswerCallRequest,
@@ -93,14 +95,26 @@ class CallAutomationClient(object):
         if not parsed_url.netloc:
             raise ValueError(f"Invalid URL: {format(endpoint)}")
 
-        self._client = AzureCommunicationCallAutomationService(
-            endpoint,
-            credential,
-            api_version=api_version or DEFAULT_VERSION,
-            authentication_policy=get_authentication_policy(
-                endpoint, credential),
-            sdk_moniker=SDK_MONIKER,
-            **kwargs)
+        custom_enabled = get_custom_enabled()
+        custom_url = get_custom_url()
+        if custom_enabled and custom_url is not None:
+            self._client = AzureCommunicationCallAutomationService(
+                custom_url,
+                credential,
+                api_version=api_version or DEFAULT_VERSION,
+                authentication_policy=get_call_automation_authentication_policy(
+                custom_url, credential, acs_url=endpoint),
+                sdk_moniker=SDK_MONIKER,
+                **kwargs)
+        else:
+            self._client = AzureCommunicationCallAutomationService(
+                endpoint,
+                credential,
+                api_version=api_version or DEFAULT_VERSION,
+                authentication_policy=get_authentication_policy(
+                    endpoint, credential),
+                sdk_moniker=SDK_MONIKER,
+                **kwargs)
 
         self._call_recording_client = self._client.call_recording
         self._downloader = ContentDownloader(self._call_recording_client)

--- a/sdk/communication/azure-communication-callautomation/azure/communication/callautomation/_call_connection_client.py
+++ b/sdk/communication/azure-communication-callautomation/azure/communication/callautomation/_call_connection_client.py
@@ -40,6 +40,8 @@ from ._generated.models import (
 from ._generated.models._enums import RecognizeInputType
 from ._shared.auth_policy_utils import get_authentication_policy
 from ._shared.utils import parse_connection_str
+from ._credential.call_automation_auth_policy_utils import get_call_automation_authentication_policy
+from ._credential.credential_utils import get_custom_enabled, get_custom_url
 if TYPE_CHECKING:
     from ._call_automation_client import CallAutomationClient
     from ._models  import (
@@ -94,14 +96,27 @@ class CallConnectionClient(object): # pylint: disable=client-accepts-api-version
             parsed_url = urlparse(endpoint.rstrip('/'))
             if not parsed_url.netloc:
                 raise ValueError(f"Invalid URL: {format(endpoint)}")
-            self._client = AzureCommunicationCallAutomationService(
-                endpoint,
-                credential=credential,
-                api_version=api_version or DEFAULT_VERSION,
-                authentication_policy=get_authentication_policy(
-                    endpoint, credential),
-                sdk_moniker=SDK_MONIKER,
-                **kwargs)
+
+            custom_enabled = get_custom_enabled()
+            custom_url = get_custom_url()
+            if custom_enabled and custom_url is not None:
+                self._client = AzureCommunicationCallAutomationService(
+                    custom_url,
+                    credential,
+                    api_version=api_version or DEFAULT_VERSION,
+                    authentication_policy=get_call_automation_authentication_policy(
+                    custom_url, credential, acs_url=endpoint),
+                    sdk_moniker=SDK_MONIKER,
+                    **kwargs)
+            else:
+                self._client = AzureCommunicationCallAutomationService(
+                    endpoint,
+                    credential,
+                    api_version=api_version or DEFAULT_VERSION,
+                    authentication_policy=get_authentication_policy(
+                        endpoint, credential),
+                    sdk_moniker=SDK_MONIKER,
+                    **kwargs)
         else:
             self._client = call_automation_client
 

--- a/sdk/communication/azure-communication-callautomation/azure/communication/callautomation/_call_connection_client.py
+++ b/sdk/communication/azure-communication-callautomation/azure/communication/callautomation/_call_connection_client.py
@@ -40,7 +40,7 @@ from ._generated.models import (
 from ._generated.models._enums import RecognizeInputType
 from ._shared.auth_policy_utils import get_authentication_policy
 from ._shared.utils import parse_connection_str
-from ._credential.call_automation_auth_policy_utils import get_call_automation_authentication_policy
+from ._credential.call_automation_auth_policy_utils import get_call_automation_auth_policy
 from ._credential.credential_utils import get_custom_enabled, get_custom_url
 if TYPE_CHECKING:
     from ._call_automation_client import CallAutomationClient
@@ -104,7 +104,7 @@ class CallConnectionClient(object): # pylint: disable=client-accepts-api-version
                     custom_url,
                     credential,
                     api_version=api_version or DEFAULT_VERSION,
-                    authentication_policy=get_call_automation_authentication_policy(
+                    authentication_policy=get_call_automation_auth_policy(
                     custom_url, credential, acs_url=endpoint),
                     sdk_moniker=SDK_MONIKER,
                     **kwargs)

--- a/sdk/communication/azure-communication-callautomation/azure/communication/callautomation/_credential/__init__.py
+++ b/sdk/communication/azure-communication-callautomation/azure/communication/callautomation/_credential/__init__.py
@@ -1,0 +1,5 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------

--- a/sdk/communication/azure-communication-callautomation/azure/communication/callautomation/_credential/call_automation_auth_policy_utils.py
+++ b/sdk/communication/azure-communication-callautomation/azure/communication/callautomation/_credential/call_automation_auth_policy_utils.py
@@ -1,0 +1,57 @@
+# ------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# -------------------------------------------------------------------------
+
+from typing import Union
+from azure.core.credentials import TokenCredential, AzureKeyCredential
+from azure.core.credentials_async import AsyncTokenCredential
+from azure.core.pipeline.policies import (
+    AsyncBearerTokenCredentialPolicy,
+    BearerTokenCredentialPolicy,
+)
+from .._credential.call_automation_policy import CallAutomationHMACCredentialsPolicy
+
+def get_call_automation_authentication_policy(
+    endpoint: str,
+    credential: Union[TokenCredential, AsyncTokenCredential, AzureKeyCredential, str],
+    acs_url: str,
+    decode_url: bool = False,
+    is_async: bool = False
+):
+    # type: (...) -> Union[AsyncBearerTokenCredentialPolicy, BearerTokenCredentialPolicy, CallAutomationHMACCredentialsPolicy]
+    """Returns the correct authentication policy based on which credential is being passed.
+
+    :param endpoint: The endpoint to which we are authenticating to.
+    :type endpoint: str
+    :param credential: The credential we use to authenticate to the service
+    :type credential: Union[TokenCredential, AsyncTokenCredential, AzureKeyCredential, str]
+    :param acs_url: The endpoint of the Azure Communication Service.
+    :type acs_url: str
+    :param bool decode_url: `True` if there is a need to decode the url. Default value is `False`
+    :param bool is_async: For async clients there is a need to decode the url
+
+    :return: Either AsyncBearerTokenCredentialPolicy or BearerTokenCredentialPolicy or CallAutomationHMACCredentialsPolicy
+    :rtype: ~azure.core.pipeline.policies.AsyncBearerTokenCredentialPolicy or
+    ~azure.core.pipeline.policies.BearerTokenCredentialPolicy or
+    ~azure.communication.callautomation.credential.callautomationpolicy.CallAutomationHMACCredentialsPolicy
+    """
+
+    if credential is None:
+        raise ValueError("Parameter 'credential' must not be None.")
+    if hasattr(credential, "get_token"):
+        if is_async:
+            return AsyncBearerTokenCredentialPolicy(
+                credential, "https://communication.azure.com//.default"  # type: ignore
+            )
+        return BearerTokenCredentialPolicy(
+            credential, "https://communication.azure.com//.default"  # type: ignore
+        )
+    if isinstance(credential, (AzureKeyCredential, str)):
+        return CallAutomationHMACCredentialsPolicy(endpoint, acs_url, credential, decode_url=decode_url)
+
+    raise TypeError(
+        f"Unsupported credential: {format(type(credential))}. Use an access token string to use HMACCredentialsPolicy"
+        "or a token credential from azure.identity"
+    )

--- a/sdk/communication/azure-communication-callautomation/azure/communication/callautomation/_credential/call_automation_auth_policy_utils.py
+++ b/sdk/communication/azure-communication-callautomation/azure/communication/callautomation/_credential/call_automation_auth_policy_utils.py
@@ -13,14 +13,13 @@ from azure.core.pipeline.policies import (
 )
 from .._credential.call_automation_policy import CallAutomationHMACCredentialsPolicy
 
-def get_call_automation_authentication_policy(
+def get_call_automation_auth_policy(
     endpoint: str,
     credential: Union[TokenCredential, AsyncTokenCredential, AzureKeyCredential, str],
     acs_url: str,
     decode_url: bool = False,
     is_async: bool = False
 ):
-    # type: (...) -> Union[AsyncBearerTokenCredentialPolicy, BearerTokenCredentialPolicy, CallAutomationHMACCredentialsPolicy]
     """Returns the correct authentication policy based on which credential is being passed.
 
     :param endpoint: The endpoint to which we are authenticating to.
@@ -32,7 +31,8 @@ def get_call_automation_authentication_policy(
     :param bool decode_url: `True` if there is a need to decode the url. Default value is `False`
     :param bool is_async: For async clients there is a need to decode the url
 
-    :return: Either AsyncBearerTokenCredentialPolicy or BearerTokenCredentialPolicy or CallAutomationHMACCredentialsPolicy
+    :return: Either AsyncBearerTokenCredentialPolicy or BearerTokenCredentialPolicy
+     or CallAutomationHMACCredentialsPolicy
     :rtype: ~azure.core.pipeline.policies.AsyncBearerTokenCredentialPolicy or
     ~azure.core.pipeline.policies.BearerTokenCredentialPolicy or
     ~azure.communication.callautomation.credential.callautomationpolicy.CallAutomationHMACCredentialsPolicy

--- a/sdk/communication/azure-communication-callautomation/azure/communication/callautomation/_credential/call_automation_policy.py
+++ b/sdk/communication/azure-communication-callautomation/azure/communication/callautomation/_credential/call_automation_policy.py
@@ -1,0 +1,142 @@
+# ------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# -------------------------------------------------------------------------
+
+import hashlib
+import urllib
+import base64
+import hmac
+from urllib.parse import ParseResult, urlparse
+from typing import Union
+from azure.core.credentials import AzureKeyCredential
+from azure.core.pipeline.policies import SansIOHTTPPolicy
+from .._shared.utils import get_current_utc_time
+
+
+class CallAutomationHMACCredentialsPolicy(SansIOHTTPPolicy):
+    """Implementation of HMAC authentication policy.
+
+    :param str host: The host of the endpoint url for Azure Communication Service resource
+    :param access_key: The access key we use to authenticate to the service
+    :type access_key: str or AzureKeyCredential
+    :param bool decode_url: `True` if there is a need to decode the url. Default value is `False`
+    """
+
+    def __init__(
+        self,
+        host,  # type: str
+        acs_url,  # type: str
+        access_key,  # type: Union[str, AzureKeyCredential]
+        decode_url=False,  # type: bool
+    ):
+        # type: (...) -> None
+        super(CallAutomationHMACCredentialsPolicy, self).__init__()
+
+        if host.startswith("https://"):
+            self._host = host.replace("https://", "")
+
+        if host.startswith("http://"):
+            self._host = host.replace("http://", "")
+
+        self._access_key = access_key
+        self._decode_url = decode_url
+        self._acs_url = acs_url
+
+    def _compute_hmac(
+        self, value  # type: str
+    ):
+        if isinstance(self._access_key, AzureKeyCredential):
+            decoded_secret = base64.b64decode(self._access_key.key)
+        else:
+            decoded_secret = base64.b64decode(self._access_key)
+
+        digest = hmac.new(
+            decoded_secret, value.encode("utf-8"), hashlib.sha256
+        ).digest()
+
+        return base64.b64encode(digest).decode("utf-8")
+
+    def _sign_request(self, request):
+        verb = request.http_request.method.upper()
+
+        # Get the path and query from url, which looks like https://host/path/query
+        parsed_url: ParseResult = urlparse(request.http_request.url)
+        query_url = parsed_url.path
+        parsed_acs_url: ParseResult = urlparse(self._acs_url)
+
+        if parsed_url.query:
+            query_url += "?" + parsed_url.query
+
+        # Need URL() to get a correct encoded key value, from "%3A" to ":", when transport is in type AioHttpTransport.
+        # There's a similar scenario in azure-storage-blob and azure-appconfiguration, the check logic is from there.
+        try:
+            from yarl import URL
+            from azure.core.pipeline.transport import (  # pylint:disable=non-abstract-transport-import
+                AioHttpTransport,
+            )
+
+            if (
+                isinstance(request.context.transport, AioHttpTransport)
+                or isinstance(
+                    getattr(request.context.transport, "_transport", None),
+                    AioHttpTransport,
+                )
+                or isinstance(
+                    getattr(
+                        getattr(request.context.transport, "_transport", None),
+                        "_transport",
+                        None,
+                    ),
+                    AioHttpTransport,
+                )
+            ):
+                query_url = str(URL(query_url))
+        except (ImportError, TypeError):
+            pass
+
+        if self._decode_url:
+            query_url = urllib.parse.unquote(query_url)
+
+        signed_headers = "x-ms-date;host;x-ms-content-sha256"
+
+        utc_now = get_current_utc_time()
+        if request.http_request.body is None:
+            request.http_request.body = ""
+        content_digest = hashlib.sha256(
+            (request.http_request.body.encode("utf-8"))
+        ).digest()
+        content_hash = base64.b64encode(content_digest).decode("utf-8")
+
+        string_to_sign = (
+            verb
+            + "\n"
+            + query_url
+            + "\n"
+            + utc_now
+            + ";"
+            + parsed_acs_url.hostname
+            + ";"
+            + content_hash
+        )
+
+        signature = self._compute_hmac(string_to_sign)
+
+        signature_header = {
+            "x-ms-host": parsed_acs_url.hostname,
+            "x-ms-date": utc_now,
+            "x-ms-content-sha256": content_hash,
+            "x-ms-return-client-request-id": "true",
+            "Authorization": "HMAC-SHA256 SignedHeaders="
+            + signed_headers
+            + "&Signature="
+            + signature,
+        }
+
+        request.http_request.headers.update(signature_header)
+
+        return request
+
+    def on_request(self, request):
+        self._sign_request(request)

--- a/sdk/communication/azure-communication-callautomation/azure/communication/callautomation/_credential/credential_utils.py
+++ b/sdk/communication/azure-communication-callautomation/azure/communication/callautomation/_credential/credential_utils.py
@@ -1,0 +1,40 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+import os
+
+COMMUNICATION_CUSTOM_ENDPOINT_ENABLED = "COMMUNICATION_CUSTOM_ENDPOINT_ENABLED"
+COMMUNICATION_CUSTOM_URL = "COMMUNICATION_CUSTOM_URL"
+
+def get_custom_enabled():
+    """From environment variable, get whether to use a custom endpoint.
+    This is only for development purposes.
+
+    :return: custom_enabled
+    :rtype: bool
+    """
+    custom_enabled_str = get_environment_variable(COMMUNICATION_CUSTOM_ENDPOINT_ENABLED)
+
+    if custom_enabled_str is not None:
+        return custom_enabled_str.lower() == 'true'
+    return False
+
+def get_custom_url():
+    """From environment variable, get the acs endpoint to call.
+    This is only for development purposes.
+
+    :return: custom_url
+    :rtype: str
+    """
+    return get_environment_variable(COMMUNICATION_CUSTOM_URL)
+
+def get_environment_variable(variable_name):
+    """From environment variable, from variable name.
+    This is only for development purposes
+
+    :return: environment variable
+    :rtype: str
+    """
+    return os.environ.get(variable_name)

--- a/sdk/communication/azure-communication-callautomation/azure/communication/callautomation/_credential/credential_utils.py
+++ b/sdk/communication/azure-communication-callautomation/azure/communication/callautomation/_credential/credential_utils.py
@@ -34,7 +34,9 @@ def get_environment_variable(variable_name):
     """From environment variable, from variable name.
     This is only for development purposes
 
-    :return: environment variable
+    :param variable_name: key of the environment variable
+    :type variable_name: str
+    :return: environment variable value
     :rtype: str
     """
     return os.environ.get(variable_name)


### PR DESCRIPTION
This adds developer to add redirect feature. This is one of requested features.
Set COMMUNICATION_CUSTOM_ENDPOINT_ENABLED to true,
Set COMMUNICATION_CUSTOM_URL to redirect endpoint
in Environment variable.

if not set (or Enabled is false), it will just call method regularly. No API change is done.