### PR TITLE
Update autorest to `3.9.6` and modelerfour to `4.26.2`

### DIFF
--- a/swagger_to_sdk_config_autorest.json
+++ b/swagger_to_sdk_config_autorest.json
@@ -1,8 +1,8 @@
 {
   "meta": {
     "autorest_options": {
-      "version": "3.9.2",
-      "use": ["@autorest/python@6.6.0", "@autorest/modelerfour@4.24.3"],
+      "version": "3.9.6",
+      "use": ["@autorest/python@6.6.0", "@autorest/modelerfour@4.26.2"],
       "python": "",
       "sdkrel:python-sdks-folder": "./sdk/.",
       "version-tolerant": false,


### PR DESCRIPTION
- e-mail: `RE: ARM RPC - LRO response codes`
- test scenarios: [monitor](https://github.com/msyyc/azure-rest-api-specs/commit/1b75586c1d6301170a24094f60a9bafb074c0271#diff-666eb108547109b05474ce5113eb9357903fa07cf3ba503f3db45490266747ed) (with reference to https://github.com/mikekistler/azure-rest-api-specs/commit/69d8a92d6e2208399e4885ce4e9dfa3453717b1e)
- difference: https://github.com/msyyc/azure-sdk-for-python/commit/b06cda32936a13b0ece2c4b437fc11a7c3508250#diff-d6adafdf865c05a497c06bb11e5bbc2f4aa96960bb30ef59d22e85870b1f276a