### PR TITLE
[ML] fix(next-pylint): Resolve `arguments-differ` and `name-too-long`

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_internal/entities/runsettings/ai_super_computer_configuration.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_internal/entities/runsettings/ai_super_computer_configuration.py
@@ -19,7 +19,7 @@ class PascalCaseProperty(BaseProperty):
         return result
 
 
-class AISuperComputerStorageReferenceConfiguration(PascalCaseProperty):
+class AISuperComputerStorageReferenceConfiguration(PascalCaseProperty):  # pylint: disable=name-too-long
     _KEY_MAPPING = {
         "container_name": "ContainerName",
         "relative_path": "RelativePath",

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_deployment/batch/batch_pipeline_component_deployment_configurations_schema.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_deployment/batch/batch_pipeline_component_deployment_configurations_schema.py
@@ -22,7 +22,7 @@ from azure.ai.ml.constants._job.job import JobType
 
 module_logger = logging.getLogger(__name__)
 
-
+# pylint: disable-next=name-too-long
 class BatchPipelineComponentDeploymentConfiguarationsSchema(metaclass=PatchedSchemaMeta):
     component_id = fields.Str()
     job = UnionField(

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_feature_set/featureset_spec_properties_schema.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_feature_set/featureset_spec_properties_schema.py
@@ -13,6 +13,7 @@ from azure.ai.ml._schema.core.schema import YamlFileSchema, PatchedSchemaMeta
 from .source_metadata_schema import SourceMetadataSchema
 
 
+# pylint: disable-next=name-too-long
 class FeatureTransformationCodePropertiesSchema(metaclass=PatchedSchemaMeta):
     path = fields.Str(data_key="Path")
     transformer_class = fields.Str(data_key="TransformerClass")

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_utils/data_binding_expression.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_utils/data_binding_expression.py
@@ -58,7 +58,7 @@ def _add_data_binding_to_field(field, attrs_to_skip, schema_stack):
     return field
 
 
-def support_data_binding_expression_for_fields(
+def support_data_binding_expression_for_fields(  # pylint: disable=name-too-long
     schema: Union[PathAwareSchema, Schema], attrs_to_skip=None, schema_stack=None
 ):
     """Update fields inside schema to support data binding string.

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/automl/image_vertical/image_model_distribution_settings.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/automl/image_vertical/image_model_distribution_settings.py
@@ -33,26 +33,26 @@ from azure.ai.ml._schema.core.schema import PatchedSchemaMeta
 from azure.ai.ml._utils.utils import camel_to_snake
 
 
-def get_choice_schema_of_type(cls, **kwargs):
+def choice_schema_of_type(cls, **kwargs):
     class CustomChoiceSchema(ChoiceSchema):
         values = fields.List(cls(**kwargs))
 
     return CustomChoiceSchema()
 
 
-def get_choice_and_single_value_schema_of_type(cls, **kwargs):
+def choice_and_single_value_schema_of_type(cls, **kwargs):
     # Reshuffling the order of fields for allowing choice of booleans.
     # The reason is, while dumping [Bool, Choice[Bool]] is parsing even dict as True.
     # Since all unionFields are parsed sequentially, to avoid this, we are giving the "type" field at the end.
-    return UnionField([NestedField(get_choice_schema_of_type(cls, **kwargs)), cls(**kwargs)])
+    return UnionField([NestedField(choice_schema_of_type(cls, **kwargs)), cls(**kwargs)])
 
 
 FLOAT_SEARCH_SPACE_DISTRIBUTION_FIELD = UnionField(
     [
         fields.Float(),
         DumpableIntegerField(strict=True),
-        NestedField(get_choice_schema_of_type(DumpableIntegerField, strict=True)),
-        NestedField(get_choice_schema_of_type(fields.Float)),
+        NestedField(choice_schema_of_type(DumpableIntegerField, strict=True)),
+        NestedField(choice_schema_of_type(fields.Float)),
         NestedField(UniformSchema()),
         NestedField(QUniformSchema()),
         NestedField(NormalSchema()),
@@ -64,15 +64,15 @@ FLOAT_SEARCH_SPACE_DISTRIBUTION_FIELD = UnionField(
 INT_SEARCH_SPACE_DISTRIBUTION_FIELD = UnionField(
     [
         DumpableIntegerField(strict=True),
-        NestedField(get_choice_schema_of_type(DumpableIntegerField, strict=True)),
+        NestedField(choice_schema_of_type(DumpableIntegerField, strict=True)),
         NestedField(RandintSchema()),
         NestedField(IntegerQUniformSchema()),
         NestedField(IntegerQNormalSchema()),
     ]
 )
 
-STRING_SEARCH_SPACE_DISTRIBUTION_FIELD = get_choice_and_single_value_schema_of_type(DumpableStringField)
-BOOL_SEARCH_SPACE_DISTRIBUTION_FIELD = get_choice_and_single_value_schema_of_type(fields.Bool)
+STRING_SEARCH_SPACE_DISTRIBUTION_FIELD = choice_and_single_value_schema_of_type(DumpableStringField)
+BOOL_SEARCH_SPACE_DISTRIBUTION_FIELD = choice_and_single_value_schema_of_type(fields.Bool)
 
 model_size_enum_args = {"allowed_values": [o.value for o in ModelSize], "casing_transform": camel_to_snake}
 learning_rate_scheduler_enum_args = {
@@ -86,14 +86,12 @@ validation_metric_enum_args = {
 }
 
 
-MODEL_SIZE_DISTRIBUTION_FIELD = get_choice_and_single_value_schema_of_type(
-    StringTransformedEnum, **model_size_enum_args
-)
-LEARNING_RATE_SCHEDULER_DISTRIBUTION_FIELD = get_choice_and_single_value_schema_of_type(
+MODEL_SIZE_DISTRIBUTION_FIELD = choice_and_single_value_schema_of_type(StringTransformedEnum, **model_size_enum_args)
+LEARNING_RATE_SCHEDULER_DISTRIBUTION_FIELD = choice_and_single_value_schema_of_type(
     StringTransformedEnum, **learning_rate_scheduler_enum_args
 )
-OPTIMIZER_DISTRIBUTION_FIELD = get_choice_and_single_value_schema_of_type(StringTransformedEnum, **optimizer_enum_args)
-VALIDATION_METRIC_DISTRIBUTION_FIELD = get_choice_and_single_value_schema_of_type(
+OPTIMIZER_DISTRIBUTION_FIELD = choice_and_single_value_schema_of_type(StringTransformedEnum, **optimizer_enum_args)
+VALIDATION_METRIC_DISTRIBUTION_FIELD = choice_and_single_value_schema_of_type(
     StringTransformedEnum, **validation_metric_enum_args
 )
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/automl/image_vertical/image_model_distribution_settings.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/automl/image_vertical/image_model_distribution_settings.py
@@ -126,6 +126,7 @@ class ImageModelDistributionSettingsSchema(metaclass=PatchedSchemaMeta):
     weight_decay = FLOAT_SEARCH_SPACE_DISTRIBUTION_FIELD
 
 
+# pylint: disable-next=name-too-long
 class ImageModelDistributionSettingsClassificationSchema(ImageModelDistributionSettingsSchema):
     model_name = STRING_SEARCH_SPACE_DISTRIBUTION_FIELD
     training_crop_size = INT_SEARCH_SPACE_DISTRIBUTION_FIELD
@@ -161,6 +162,7 @@ class ImageModelDistributionSettingsClassificationSchema(ImageModelDistributionS
         return ImageClassificationSearchSpace(**data)
 
 
+# pylint: disable-next=name-too-long
 class ImageModelDistributionSettingsDetectionCommonSchema(ImageModelDistributionSettingsSchema):
     box_detections_per_image = INT_SEARCH_SPACE_DISTRIBUTION_FIELD
     box_score_threshold = FLOAT_SEARCH_SPACE_DISTRIBUTION_FIELD
@@ -204,9 +206,11 @@ class ImageModelDistributionSettingsDetectionCommonSchema(ImageModelDistribution
         return ImageObjectDetectionSearchSpace(**data)
 
 
+# pylint: disable-next=name-too-long
 class ImageModelDistributionSettingsObjectDetectionSchema(ImageModelDistributionSettingsDetectionCommonSchema):
     model_name = STRING_SEARCH_SPACE_DISTRIBUTION_FIELD
 
 
+# pylint: disable-next=name-too-long
 class ImageModelDistributionSettingsInstanceSegmentationSchema(ImageModelDistributionSettingsObjectDetectionSchema):
     model_name = STRING_SEARCH_SPACE_DISTRIBUTION_FIELD

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/automl/nlp_vertical/nlp_parameter_subspace.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/automl/nlp_vertical/nlp_parameter_subspace.py
@@ -26,23 +26,23 @@ from azure.ai.ml._schema.core.schema import PatchedSchemaMeta
 from azure.ai.ml._utils.utils import camel_to_snake
 
 
-def get_choice_schema_of_type(cls, **kwargs):
+def choice_schema_of_type(cls, **kwargs):
     class CustomChoiceSchema(ChoiceSchema):
         values = fields.List(cls(**kwargs))
 
     return CustomChoiceSchema()
 
 
-def get_choice_and_single_value_schema_of_type(cls, **kwargs):
-    return UnionField([cls(**kwargs), NestedField(get_choice_schema_of_type(cls, **kwargs))])
+def choice_and_single_value_schema_of_type(cls, **kwargs):
+    return UnionField([cls(**kwargs), NestedField(choice_schema_of_type(cls, **kwargs))])
 
 
 FLOAT_SEARCH_SPACE_DISTRIBUTION_FIELD = UnionField(
     [
         fields.Float(),
         DumpableIntegerField(strict=True),
-        NestedField(get_choice_schema_of_type(DumpableIntegerField, strict=True)),
-        NestedField(get_choice_schema_of_type(fields.Float)),
+        NestedField(choice_schema_of_type(DumpableIntegerField, strict=True)),
+        NestedField(choice_schema_of_type(fields.Float)),
         NestedField(UniformSchema()),
         NestedField(QUniformSchema()),
         NestedField(NormalSchema()),
@@ -54,19 +54,19 @@ FLOAT_SEARCH_SPACE_DISTRIBUTION_FIELD = UnionField(
 INT_SEARCH_SPACE_DISTRIBUTION_FIELD = UnionField(
     [
         DumpableIntegerField(strict=True),
-        NestedField(get_choice_schema_of_type(DumpableIntegerField, strict=True)),
+        NestedField(choice_schema_of_type(DumpableIntegerField, strict=True)),
         NestedField(RandintSchema()),
     ]
 )
 
-STRING_SEARCH_SPACE_DISTRIBUTION_FIELD = get_choice_and_single_value_schema_of_type(DumpableStringField)
-BOOL_SEARCH_SPACE_DISTRIBUTION_FIELD = get_choice_and_single_value_schema_of_type(fields.Bool)
+STRING_SEARCH_SPACE_DISTRIBUTION_FIELD = choice_and_single_value_schema_of_type(DumpableStringField)
+BOOL_SEARCH_SPACE_DISTRIBUTION_FIELD = choice_and_single_value_schema_of_type(fields.Bool)
 
 
 class NlpParameterSubspaceSchema(metaclass=PatchedSchemaMeta):
     gradient_accumulation_steps = INT_SEARCH_SPACE_DISTRIBUTION_FIELD
     learning_rate = FLOAT_SEARCH_SPACE_DISTRIBUTION_FIELD
-    learning_rate_scheduler = get_choice_and_single_value_schema_of_type(
+    learning_rate_scheduler = choice_and_single_value_schema_of_type(
         StringTransformedEnum,
         allowed_values=[obj.value for obj in NlpLearningRateScheduler],
         casing_transform=camel_to_snake,

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/component/data_transfer_component.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/component/data_transfer_component.py
@@ -157,6 +157,7 @@ class AnonymousDataTransferCopyComponentSchema(AnonymousAssetSchema, DataTransfe
         )
 
 
+# pylint: disable-next=name-too-long
 class AnonymousDataTransferImportComponentSchema(AnonymousAssetSchema, DataTransferImportComponentSchema):
     """Anonymous data transfer import component schema.
 
@@ -179,6 +180,7 @@ class AnonymousDataTransferImportComponentSchema(AnonymousAssetSchema, DataTrans
         )
 
 
+# pylint: disable-next=name-too-long
 class AnonymousDataTransferExportComponentSchema(AnonymousAssetSchema, DataTransferExportComponentSchema):
     """Anonymous data transfer export component schema.
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/core/fields.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/core/fields.py
@@ -38,7 +38,7 @@ from ...constants._common import (
     RESOURCE_ID_FORMAT,
     AzureMLResourceType,
 )
-from ...entities._job.pipeline._attr_dict import try_get_non_arbitrary_attr_for_potential_attr_dict
+from ...entities._job.pipeline._attr_dict import try_get_non_arbitrary_attr
 from ...exceptions import ValidationException
 from ..core.schema import PathAwareSchema
 
@@ -571,7 +571,7 @@ class TypeSensitiveUnionField(UnionField):
          * First Matched Error message if value has type and type matches atleast one field
         :rtype: Exception
         """
-        value_type = try_get_non_arbitrary_attr_for_potential_attr_dict(value, self.type_field_name)
+        value_type = try_get_non_arbitrary_attr(value, self.type_field_name)
         if value_type is None:
             # if value has no type field, raise original error
             return e
@@ -595,7 +595,7 @@ class TypeSensitiveUnionField(UnionField):
 
     def _serialize(self, value, attr, obj, **kwargs):
         union_fields = self._union_fields[:]
-        value_type = try_get_non_arbitrary_attr_for_potential_attr_dict(value, self.type_field_name)
+        value_type = try_get_non_arbitrary_attr(value, self.type_field_name)
         if value_type is not None and value_type in self.allowed_types:
             target_fields = self._type_sensitive_fields_dict[value_type]
             if len(target_fields) == 1:

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/monitoring/thresholds.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/monitoring/thresholds.py
@@ -76,6 +76,7 @@ class PredictionDriftMetricThresholdSchema(MetricThresholdSchema):
         return PredictionDriftMetricThreshold(**data)
 
 
+# pylint: disable-next=name-too-long
 class FeatureAttributionDriftMetricThresholdSchema(MetricThresholdSchema):
     @post_load
     def make(self, data, **kwargs):

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_utils/_feature_store_utils.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_utils/_feature_store_utils.py
@@ -28,12 +28,12 @@ if TYPE_CHECKING:
     from azure.ai.ml.operations._feature_store_entity_operations import FeatureStoreEntityOperations
 
 
-def read_feature_set_metadata_contents(*, path: str) -> Dict:
+def read_feature_set_metadata(*, path: str) -> Dict:
     metadata_path = str(Path(path, "FeatureSetSpec.yaml"))
     return load_yaml(metadata_path)
 
 
-def read_remote_feature_set_spec_metadata_contents(
+def read_remote_feature_set_spec_metadata(
     *,
     base_uri: str,
     datastore_operations: DatastoreOperations,

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_utils/utils.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_utils/utils.py
@@ -762,7 +762,7 @@ def is_on_disk_cache_enabled():
     return os.getenv(AZUREML_DISABLE_ON_DISK_CACHE_ENV_VAR) not in ["True", "true", True]
 
 
-def is_concurrent_component_registration_enabled():
+def is_concurrent_component_registration_enabled():  # pylint: disable=name-too-long
     return os.getenv(AZUREML_DISABLE_CONCURRENT_COMPONENT_REGISTRATION) not in ["True", "true", True]
 
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_utils/utils.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_utils/utils.py
@@ -404,12 +404,6 @@ def dict_eq(dict1: Dict[str, Any], dict2: Dict[str, Any]) -> bool:
     return dict1 == dict2
 
 
-def get_http_response_and_deserialized_from_pipeline_response(
-    pipeline_response: Any, deserialized: Any
-) -> Tuple[Any, Any]:
-    return pipeline_response.http_response, deserialized
-
-
 def xor(a: Any, b: Any) -> bool:
     return bool(a) != bool(b)
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_component/pipeline_component.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_component/pipeline_component.py
@@ -207,7 +207,7 @@ class PipelineComponent(Component):
                     component_binding_input = component_binding_input.path
                 if is_data_binding_expression(component_binding_input, ["parent"]):
                     # data binding may have more than one PipelineInput now
-                    for pipeline_input_name in PipelineExpression.parse_pipeline_input_names_from_data_binding(
+                    for pipeline_input_name in PipelineExpression.parse_pipeline_inputs_from_data_binding(
                         component_binding_input
                     ):
                         if pipeline_input_name not in self.inputs:

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_component/pipeline_component.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_component/pipeline_component.py
@@ -27,7 +27,7 @@ from azure.ai.ml.entities._inputs_outputs import GroupInput, Input
 from azure.ai.ml.entities._job.automl.automl_job import AutoMLJob
 from azure.ai.ml.entities._job.pipeline._attr_dict import (
     has_attr_safe,
-    try_get_non_arbitrary_attr_for_potential_attr_dict,
+    try_get_non_arbitrary_attr,
 )
 from azure.ai.ml.entities._job.pipeline._pipeline_expression import PipelineExpression
 from azure.ai.ml.entities._validation import MutableValidationResult
@@ -363,11 +363,7 @@ class PipelineComponent(Component):
             "settings": lambda val: val is not None and any(v is not None for v in val._to_dict().values()),
         }
         # Avoid new attr added by use `try_get_non...` instead of `hasattr` or `getattr` directly.
-        return [
-            k
-            for k, has_set in examine_mapping.items()
-            if has_set(try_get_non_arbitrary_attr_for_potential_attr_dict(obj, k))
-        ]
+        return [k for k, has_set in examine_mapping.items() if has_set(try_get_non_arbitrary_attr(obj, k))]
 
     def _get_telemetry_values(self, *args, **kwargs):
         telemetry_values = super()._get_telemetry_values()

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_endpoint/batch_endpoint.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_endpoint/batch_endpoint.py
@@ -89,19 +89,19 @@ class BatchEndpoint(Endpoint):
         return BatchEndpointData(location=location, tags=self.tags, properties=batch_endpoint)
 
     @classmethod
-    def _from_rest_object(cls, endpoint: BatchEndpointData):  # pylint: disable=arguments-renamed
+    def _from_rest_object(cls, obj: BatchEndpointData) -> "BatchEndpoint":
         return BatchEndpoint(
-            id=endpoint.id,
-            name=endpoint.name,
-            tags=endpoint.tags,
-            properties=endpoint.properties.properties,
-            auth_mode=camel_to_snake(endpoint.properties.auth_mode),
-            description=endpoint.properties.description,
-            location=endpoint.location,
-            defaults=endpoint.properties.defaults,
-            provisioning_state=endpoint.properties.provisioning_state,
-            scoring_uri=endpoint.properties.scoring_uri,
-            openapi_uri=endpoint.properties.swagger_uri,
+            id=obj.id,
+            name=obj.name,
+            tags=obj.tags,
+            properties=obj.properties.properties,
+            auth_mode=camel_to_snake(obj.properties.auth_mode),
+            description=obj.properties.description,
+            location=obj.location,
+            defaults=obj.properties.defaults,
+            provisioning_state=obj.properties.provisioning_state,
+            scoring_uri=obj.properties.scoring_uri,
+            openapi_uri=obj.properties.swagger_uri,
         )
 
     def dump(

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_endpoint/endpoint.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_endpoint/endpoint.py
@@ -114,8 +114,9 @@ class Endpoint(Resource):  # pylint: disable=too-many-instance-attributes
     def dump(self, dest: Optional[Union[str, PathLike, IO[AnyStr]]] = None, **kwargs) -> None:
         pass
 
+    @classmethod
     @abstractmethod
-    def _from_rest_object(self, obj: Any) -> Any:
+    def _from_rest_object(cls, obj: Any) -> Any:
         pass
 
     def _merge_with(self, other: "Endpoint") -> None:

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_endpoint/online_endpoint.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_endpoint/online_endpoint.py
@@ -213,46 +213,44 @@ class OnlineEndpoint(Endpoint):
         return switcher.get(yaml_auth_mode, yaml_auth_mode)
 
     @classmethod
-    def _from_rest_object(cls, resource: OnlineEndpointData):  # pylint: disable=arguments-renamed
-        auth_mode = cls._rest_auth_mode_to_yaml_auth_mode(resource.properties.auth_mode)
+    def _from_rest_object(cls, obj: OnlineEndpointData) -> "OnlineEndpoint":
+        auth_mode = cls._rest_auth_mode_to_yaml_auth_mode(obj.properties.auth_mode)
         # pylint: disable=protected-access
-        identity = (
-            IdentityConfiguration._from_online_endpoint_rest_object(resource.identity) if resource.identity else None
-        )
-        if resource.properties.compute:
+        identity = IdentityConfiguration._from_online_endpoint_rest_object(obj.identity) if obj.identity else None
+        if obj.properties.compute:
             endpoint = KubernetesOnlineEndpoint(
-                id=resource.id,
-                name=resource.name,
-                tags=resource.tags,
-                properties=resource.properties.properties,
-                compute=resource.properties.compute,
+                id=obj.id,
+                name=obj.name,
+                tags=obj.tags,
+                properties=obj.properties.properties,
+                compute=obj.properties.compute,
                 auth_mode=auth_mode,
-                description=resource.properties.description,
-                location=resource.location,
-                traffic=resource.properties.traffic,
-                provisioning_state=resource.properties.provisioning_state,
-                scoring_uri=resource.properties.scoring_uri,
-                openapi_uri=resource.properties.swagger_uri,
+                description=obj.properties.description,
+                location=obj.location,
+                traffic=obj.properties.traffic,
+                provisioning_state=obj.properties.provisioning_state,
+                scoring_uri=obj.properties.scoring_uri,
+                openapi_uri=obj.properties.swagger_uri,
                 identity=identity,
-                kind=resource.kind,
+                kind=obj.kind,
             )
         else:
             endpoint = ManagedOnlineEndpoint(
-                id=resource.id,
-                name=resource.name,
-                tags=resource.tags,
-                properties=resource.properties.properties,
+                id=obj.id,
+                name=obj.name,
+                tags=obj.tags,
+                properties=obj.properties.properties,
                 auth_mode=auth_mode,
-                description=resource.properties.description,
-                location=resource.location,
-                traffic=resource.properties.traffic,
-                mirror_traffic=resource.properties.mirror_traffic,
-                provisioning_state=resource.properties.provisioning_state,
-                scoring_uri=resource.properties.scoring_uri,
-                openapi_uri=resource.properties.swagger_uri,
+                description=obj.properties.description,
+                location=obj.location,
+                traffic=obj.properties.traffic,
+                mirror_traffic=obj.properties.mirror_traffic,
+                provisioning_state=obj.properties.provisioning_state,
+                scoring_uri=obj.properties.scoring_uri,
+                openapi_uri=obj.properties.swagger_uri,
                 identity=identity,
-                kind=resource.kind,
-                public_network_access=resource.properties.public_network_access,
+                kind=obj.kind,
+                public_network_access=obj.properties.public_network_access,
             )
 
         return endpoint

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/_input_output_helpers.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/_input_output_helpers.py
@@ -156,7 +156,7 @@ def validate_key_contains_allowed_characters(key: str) -> None:
         )
 
 
-def validate_pipeline_input_key_contains_allowed_characters(key: str) -> None:
+def validate_pipeline_input_key_characters(key: str) -> None:
     # Pipeline input allow '.' to support parameter group in key.
     # Note: ([a-zA-Z_]+[a-zA-Z0-9_]*) is a valid single key,
     # so a valid pipeline key is: ^{single_key}([.]{single_key})*$
@@ -191,7 +191,7 @@ def to_rest_dataset_literal_inputs(
     # Pack up the inputs into REST format
     for input_name, input_value in inputs.items():
         if job_type == JobType.PIPELINE:
-            validate_pipeline_input_key_contains_allowed_characters(input_name)
+            validate_pipeline_input_key_characters(input_name)
         elif job_type:
             # We pass job_type=None for pipeline node, and want skip this check for nodes.
             validate_key_contains_allowed_characters(input_name)

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/pipeline/_attr_dict.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/pipeline/_attr_dict.py
@@ -142,7 +142,7 @@ def has_attr_safe(obj, attr):
     return has_attr
 
 
-def try_get_non_arbitrary_attr_for_potential_attr_dict(obj, attr):
+def try_get_non_arbitrary_attr(obj, attr):
     """Try to get non-arbitrary attribute for potential attribute dict.
 
     Will not create target attribute if it is an arbitrary attribute in _AttrDict.

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/pipeline/_pipeline_expression.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/pipeline/_pipeline_expression.py
@@ -444,7 +444,7 @@ class PipelineExpression(PipelineExpressionMixin):
         return self._create_component()
 
     @staticmethod
-    def parse_pipeline_input_names_from_data_binding(data_binding: str) -> List[str]:
+    def parse_pipeline_inputs_from_data_binding(data_binding: str) -> List[str]:
         """Parse all PipelineInputs name from data binding expression.
 
         :param data_binding: Data binding expression

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_validation.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_validation.py
@@ -21,7 +21,7 @@ from marshmallow import Schema, ValidationError
 from .._schema import PathAwareSchema
 from .._vendor.azure_resources.models import Deployment, DeploymentProperties, DeploymentValidateResult, ErrorResponse
 from ..constants._common import BASE_PATH_CONTEXT_KEY, OperationStatus
-from ..entities._job.pipeline._attr_dict import try_get_non_arbitrary_attr_for_potential_attr_dict
+from ..entities._job.pipeline._attr_dict import try_get_non_arbitrary_attr
 from ..entities._util import convert_ordered_dict_to_dict, decorate_validation_error
 from ..exceptions import ErrorCategory, ErrorTarget, ValidationException
 from ._mixins import RestTranslatableMixin
@@ -403,8 +403,8 @@ class SchemaValidatableMixin:
         return type: str
         """
         return (
-            try_get_non_arbitrary_attr_for_potential_attr_dict(self, "base_path")
-            or try_get_non_arbitrary_attr_for_potential_attr_dict(self, "_base_path")
+            try_get_non_arbitrary_attr(self, "base_path")
+            or try_get_non_arbitrary_attr(self, "_base_path")
             or Path.cwd()
         )
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_component_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_component_operations.py
@@ -607,13 +607,13 @@ class ComponentOperations(_ScopeDependentOperations):
     @classmethod
     def _resolve_binding_on_supported_fields_for_node(cls, node):
         """Resolve all PipelineInput(binding from sdk) on supported fields to string."""
-        from azure.ai.ml.entities._job.pipeline._attr_dict import try_get_non_arbitrary_attr_for_potential_attr_dict
+        from azure.ai.ml.entities._job.pipeline._attr_dict import try_get_non_arbitrary_attr
         from azure.ai.ml.entities._job.pipeline._io import PipelineInput
 
         # compute binding to pipeline input is supported on node.
         supported_fields = ["compute", "compute_name"]
         for field_name in supported_fields:
-            val = try_get_non_arbitrary_attr_for_potential_attr_dict(node, field_name)
+            val = try_get_non_arbitrary_attr(node, field_name)
             if isinstance(val, PipelineInput):
                 # Put binding string to field
                 setattr(node, field_name, val._data_binding())

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_feature_set_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_feature_set_operations.py
@@ -29,8 +29,8 @@ from azure.ai.ml.operations._datastore_operations import DatastoreOperations
 from azure.ai.ml._telemetry import ActivityType, monitor_with_activity
 from azure.ai.ml._utils._feature_store_utils import (
     _archive_or_restore,
-    read_feature_set_metadata_contents,
-    read_remote_feature_set_spec_metadata_contents,
+    read_feature_set_metadata,
+    read_remote_feature_set_spec_metadata,
     _datetime_to_str,
 )
 from azure.ai.ml._utils._logger_utils import OpsLogger
@@ -406,7 +406,7 @@ class FeatureSetOperations(_ScopeDependentOperations):
         featureset_spec_path = str(featureset.specification.path)
         if is_url(featureset_spec_path):
             try:
-                featureset_spec_contents = read_remote_feature_set_spec_metadata_contents(
+                featureset_spec_contents = read_remote_feature_set_spec_metadata(
                     base_uri=featureset_spec_path,
                     datastore_operations=self._datastore_operation,
                 )
@@ -428,6 +428,6 @@ class FeatureSetOperations(_ScopeDependentOperations):
                 error_type=ValidationErrorType.FILE_OR_FOLDER_NOT_FOUND,
             )
 
-        featureset_spec_contents = read_feature_set_metadata_contents(path=featureset_spec_path)
+        featureset_spec_contents = read_feature_set_metadata(path=featureset_spec_path)
         featureset_spec_yaml_path = Path(featureset_spec_path, "FeatureSetSpec.yaml")
         return FeaturesetSpecMetadata._load(featureset_spec_contents, featureset_spec_yaml_path)

--- a/sdk/ml/azure-ai-ml/tests/pipeline_job/unittests/test_pipeline_job_schema.py
+++ b/sdk/ml/azure-ai-ml/tests/pipeline_job/unittests/test_pipeline_job_schema.py
@@ -31,7 +31,7 @@ from azure.ai.ml.entities._component.parallel_component import ParallelComponent
 from azure.ai.ml.entities._inputs_outputs import Input, Output
 from azure.ai.ml.entities._job._input_output_helpers import (
     INPUT_MOUNT_MAPPING_FROM_REST,
-    validate_pipeline_input_key_contains_allowed_characters,
+    validate_pipeline_input_key_characters,
 )
 from azure.ai.ml.entities._job.automl.search_space_utils import _convert_sweep_dist_dict_to_str_dict
 from azure.ai.ml.entities._job.job_service import (
@@ -55,10 +55,10 @@ class TestPipelineJobSchema:
     def test_validate_pipeline_job_keys(self):
         def validator(key, assert_valid=True):
             if assert_valid:
-                validate_pipeline_input_key_contains_allowed_characters(key)
+                validate_pipeline_input_key_characters(key)
                 return
             with pytest.raises(Exception):
-                validate_pipeline_input_key_contains_allowed_characters(key)
+                validate_pipeline_input_key_characters(key)
 
         validator("a.vsd2..", assert_valid=False)
         validator("a..b", assert_valid=False)


### PR DESCRIPTION
# Description

This pull request is part of a effort to ready the Azure ML Python SDK for an impending bump to the versions of pylint and azure-pylint-guidelines-checker that is used in our CI.

This pull request specifically resolves [`W0221` (arguments-differ)](https://pylint.pycqa.org/en/latest/user_guide/messages/warning/arguments-differ.html) and `name-too-long`

Validated with:

`pylint==2.15.8`
`azure-pylint-guidelines-checker=0.0.8`

`pylint --rcfile=../../../eng/pylintc --disable=all --enable=W0221,name-too-long azure/`


# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
