### PR TITLE
Update Python API review parser version to 0.3.8

### DIFF
--- a/eng/apiview_reqs.txt
+++ b/eng/apiview_reqs.txt
@@ -1,2 +1,2 @@
-apiview-stub-generator==0.3.7
+apiview-stub-generator==0.3.8
 azure-pylint-guidelines-checker==0.0.7


### PR DESCRIPTION
This PR is to update parser version to 0.3.8. This should be merged only after existing API reviews are upgraded to 0.3.8