### PR TITLE
[ML] fix(next-pylint): Resolve `docstring-should-be-keyword`

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_artifacts/_blob_storage_helper.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_artifacts/_blob_storage_helper.py
@@ -259,7 +259,7 @@ class BlobStorageClient:
         blobs = self.container_client.list_blobs(name_starts_with=starts_with)
         return [blob.name for blob in blobs]
 
-    def exists(self, blobpath: str, delimeter: str = "/") -> bool:
+    def exists(self, blobpath: str, delimiter: str = "/") -> bool:
         """Returns whether there exists a blob named `blobpath`, or if there exists a virtual directory given path
         delimeter `delimeter`
 
@@ -281,11 +281,11 @@ class BlobStorageClient:
         if self.container_client.get_blob_client(blobpath).exists():
             return True
 
-        ensure_delimeter = delimeter if not blobpath.endswith(delimeter) else ""
+        ensure_delimeter = delimiter if not blobpath.endswith(delimiter) else ""
 
         # Virtual directory only exists if there is atleast one blob with it
         result = next(
-            self.container_client.walk_blobs(name_starts_with=blobpath + ensure_delimeter, delimiter=delimeter),
+            self.container_client.walk_blobs(name_starts_with=blobpath + ensure_delimeter, delimiter=delimiter),
             None,
         )
         return result is not None

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_local_endpoints/dockerfile_resolver.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_local_endpoints/dockerfile_resolver.py
@@ -143,8 +143,8 @@ class DockerfileResolver(object):
 
         :param directory_path: absolute path of local directory to write Dockerfile.
         :type directory_path: str
-        :param name: name of Dockerfile prefix
-        :type name: str
+        :param file_prefix: name of Dockerfile prefix
+        :type file_prefix: str
         """
         file_name = f"{file_prefix}.Dockerfile" if file_prefix else "Dockerfile"
         self._local_dockerfile_path = str(Path(directory_path, file_name).resolve())

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_local_endpoints/endpoint_stub.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_local_endpoints/endpoint_stub.py
@@ -23,7 +23,7 @@ class EndpointStub:
     def create_or_update(self, endpoint: OnlineEndpoint):
         """Create or update a local endpoint.
 
-        :param endpoint OnlineEndpoint: OnlineEndpoint entity to create or update.
+        :param OnlineEndpoint endpoint: OnlineEndpoint entity to create or update.
         """
         self._create_endpoint_cache(endpoint=endpoint)
         return endpoint
@@ -31,7 +31,7 @@ class EndpointStub:
     def get(self, endpoint_name: str):
         """Get a local endpoint.
 
-        :param endpoint_name str: Name of local endpoint to get.
+        :param str endpoint_name: Name of local endpoint to get.
         """
         endpoint_path = self._get_endpoint_cache_file(endpoint_name=endpoint_name)
         if endpoint_path.exists():
@@ -49,7 +49,7 @@ class EndpointStub:
     def delete(self, endpoint_name: str):
         """Delete a local endpoint.
 
-        :param endpoint_name str: Name of local endpoint to delete.
+        :param str endpoint_name: Name of local endpoint to delete.
         """
         build_directory = self._get_build_directory(endpoint_name=endpoint_name)
         shutil.rmtree(build_directory)
@@ -67,7 +67,7 @@ class EndpointStub:
     def _create_endpoint_cache(self, endpoint: OnlineEndpoint):
         """Create or update a local endpoint cache.
 
-        :param endpoint OnlineEndpoint: OnlineEndpoint entity to create or update.
+        :param OnlineEndpoint endpoint: OnlineEndpoint entity to create or update.
         """
         endpoint_cache_path = self._get_endpoint_cache_file(endpoint_name=endpoint.name)
         endpoint_metadata = json.dumps(endpoint.dump())
@@ -77,7 +77,7 @@ class EndpointStub:
     def _get_endpoint_cache_file(self, endpoint_name: str) -> Path:
         """Get a local endpoint cache Path. Idempotent.
 
-        :param endpoint_name str: Name of local endpoint to get local cache.
+        :param str endpoint_name: Name of local endpoint to get local cache.
         :returns Path: path to cached endpoint file.
         """
         build_directory = self._create_build_directory(endpoint_name=endpoint_name)
@@ -86,7 +86,7 @@ class EndpointStub:
     def _create_build_directory(self, endpoint_name: str) -> Path:
         """Create or update a local endpoint build directory.
 
-        :param endpoint_name str: Name of local endpoint to get local directory.
+        :param str endpoint_name: Name of local endpoint to get local directory.
         :returns Path: path to endpoint build directory.
         """
         build_directory = self._get_build_directory(endpoint_name=endpoint_name)
@@ -96,7 +96,7 @@ class EndpointStub:
     def _get_build_directory(self, endpoint_name: str) -> Path:
         """Get a local endpoint build directory. Idempotent.
 
-        :param endpoint_name str: Name of local endpoint to get local directory.
+        :param str endpoint_name: Name of local endpoint to get local directory.
         :returns Path: path to endpoint build directory.
         """
         return Path(self._get_inferencing_cache_dir(), endpoint_name)

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_ml_client.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_ml_client.py
@@ -545,11 +545,11 @@ class MLClient:
 
         :param credential: The credential object for the workspace.
         :type credential: ~azure.core.credentials.TokenCredential
-        :param path: The path to the config file or starting directory to search.
+        :keyword path: The path to the config file or starting directory to search.
             The parameter defaults to starting the search in the current directory.
             Defaults to None
         :type path: typing.Union[os.PathLike, str]
-        :param file_name: Allows overriding the config file name to search for when path is a directory path.
+        :keyword file_name: Allows overriding the config file name to search for when path is a directory path.
             (Default value = None)
         :type file_name: str
         :keyword str cloud: The cloud name to use. Defaults to AzureCloud.

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/core/fields.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/core/fields.py
@@ -641,7 +641,7 @@ class TypeSensitiveUnionField(UnionField):
 
 def ComputeField(**kwargs):
     """
-    :param required : if set to True, it is not possible to pass None
+    :keyword required: if set to True, it is not possible to pass None
     :type required: bool
     """
     return UnionField(
@@ -658,7 +658,7 @@ def ComputeField(**kwargs):
 
 def CodeField(**kwargs):
     """
-    :param required : if set to True, it is not possible to pass None
+    :keyword required: if set to True, it is not possible to pass None
     :type required: bool
     """
     return UnionField(

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_telemetry/logging_handler.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_telemetry/logging_handler.py
@@ -84,15 +84,15 @@ def get_appinsights_log_handler(
 
     :param user_agent: Information about the user's browser.
     :type user_agent: Dict[str, str]
-    :param instrumentation_key: The Application Insights instrumentation key.
-    :type instrumentation_key: str
-    :param component_name: The component name.
-    :type component_name: str
-    :param enable_telemetry: Whether to enable telemetry. Will be overriden to False if not in a Jupyter Notebook.
-    :type enable_telemetry: bool
     :param args: Optional arguments for formatting messages.
     :type args: list
-    :param kwargs: Optional keyword arguments for adding additional information to messages.
+    :keyword instrumentation_key: The Application Insights instrumentation key.
+    :type instrumentation_key: str
+    :keyword component_name: The component name.
+    :type component_name: str
+    :keyword enable_telemetry: Whether to enable telemetry. Will be overriden to False if not in a Jupyter Notebook.
+    :type enable_telemetry: bool
+    :keyword kwargs: Optional keyword arguments for adding additional information to messages.
     :type kwargs: dict
     :return: The logging handler.
     :rtype: AzureMLSDKLogHandler

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_utils/_endpoint_utils.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_utils/_endpoint_utils.py
@@ -90,7 +90,7 @@ def local_endpoint_polling_wrapper(func: Callable, message: str, **kwargs) -> An
 
     :param Callable func: Name of the endpoint.
     :param str message: Message to print out before starting operation write-out.
-    :param dict kwargs: kwargs to be passed to the func
+    :keyword dict kwargs: kwargs to be passed to the func
     :return: The type returned by Func
     """
     pool = concurrent.futures.ThreadPoolExecutor()

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_utils/_http_utils.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_utils/_http_utils.py
@@ -48,7 +48,7 @@ def _request_function(f: Callable[["HttpPipeline"], None]):
             Accepts the same parameters as azure.core.rest.HttpRequest, except for the method.
             All other kwargs are forwarded to azure.core.Pipeline.run
 
-            :param bool stream: Whether to stream the response, defaults to False
+            :keyword bool stream: Whether to stream the response, defaults to False
             :return HttpResponse:
             """
             request = HttpRequest(

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_utils/utils.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_utils/utils.py
@@ -246,8 +246,10 @@ def load_yaml(source: Optional[Union[AnyStr, PathLike, IO]]) -> Dict:
     # via CLI, which is then populated through CLArgs.
     """Load a local YAML file.
 
-    :param file_path: The relative or absolute path to the local file.
-    :type file_path: str
+    :param source: Either
+       * The relative or absolute path to the local file.
+       * A readable File-like object
+    :type source: Optional[Union[AnyStr, PathLike, IO]]
     :raises ~azure.ai.ml.exceptions.ValidationException: Raised if file or folder cannot be successfully loaded.
         Details will be provided in the error message.
     :return: A dictionary representation of the local file's contents.
@@ -775,7 +777,8 @@ def try_enable_internal_components(*, force=False):
     """Try to enable internal components for the current process. This is the only function outside _internal that
     references _internal.
 
-    :param force: Force enable internal components even if enabled before.
+    :keyword force: Force enable internal components even if enabled before.
+    :type force: bool
     """
     if is_internal_components_enabled():
         from azure.ai.ml._internal import enable_internal_components_in_pipeline
@@ -972,7 +975,7 @@ def get_valid_dot_keys_with_wildcard(
     :type root: Dict[str, Any]
     :param dot_key_wildcard: Dot key with wildcard, e.g. "a.*.c".
     :type dot_key_wildcard: str
-    :param validate_func: Validation function. It takes two parameters: the root node and the dot key parts.
+    :keyword validate_func: Validation function. It takes two parameters: the root node and the dot key parts.
     If None, no validation will be performed.
     :type validate_func: Optional[Callable[[List[str], Dict[str, Any]], bool]]
     :return: List of valid dot keys.

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/automl/_automl_image.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/automl/_automl_image.py
@@ -53,12 +53,12 @@ def image_classification(
 ) -> ImageClassificationJob:
     """Creates an object for AutoML Image multi-class Classification job.
 
-    :param training_data:  The training data to be used within the experiment.
+    :keyword training_data:  The training data to be used within the experiment.
     :type training_data: Input
-    :param target_column_name: The name of the label column.
+    :keyword target_column_name: The name of the label column.
             This parameter is applicable to ``training_data`` and ``validation_data`` parameters.
     :type target_column_name: str
-    :param primary_metric: The metric that Automated Machine Learning will optimize for model selection.
+    :keyword primary_metric: The metric that Automated Machine Learning will optimize for model selection.
             Automated Machine Learning collects more metrics than it can optimize.
             For more information on how metrics are calculated, see
             https://docs.microsoft.com/azure/machine-learning/how-to-configure-auto-train#primary-metric.
@@ -67,9 +67,9 @@ def image_classification(
             and precision_score_weighted
             Defaults to accuracy.
     :type primary_metric: Union[str, ClassificationPrimaryMetrics]
-    :param validation_data: The validation data to be used within the experiment.
+    :keyword validation_data: The validation data to be used within the experiment.
     :type validation_data: Input, optional
-    :param validation_data_size:  What fraction of the data to hold out for validation when user validation data
+    :keyword validation_data_size:  What fraction of the data to hold out for validation when user validation data
             is not specified. This should be between 0.0 and 1.0 non-inclusive.
 
             Specify ``validation_data`` to provide validation data, otherwise set ``validation_data_size``
@@ -77,7 +77,7 @@ def image_classification(
 
             Defaults to .2
     :type validation_data_size: float, optional
-    :param kwargs: A dictionary of additional configuration parameters.
+    :keyword kwargs: A dictionary of additional configuration parameters.
     :type kwargs: dict
 
     :return: Image classification job object that can be submitted to an Azure ML compute for execution.
@@ -106,12 +106,12 @@ def image_classification_multilabel(
 ) -> ImageClassificationMultilabelJob:
     """Creates an object for AutoML Image multi-label Classification job.
 
-    :param training_data:  The training data to be used within the experiment.
+    :keyword training_data:  The training data to be used within the experiment.
     :type training_data: Input
-    :param target_column_name: The name of the label column.
+    :keyword target_column_name: The name of the label column.
             This parameter is applicable to ``training_data`` and ``validation_data`` parameters.
     :type target_column_name: str
-    :param primary_metric: The metric that Automated Machine Learning will optimize for model selection.
+    :keyword primary_metric: The metric that Automated Machine Learning will optimize for model selection.
             Automated Machine Learning collects more metrics than it can optimize.
             For more information on how metrics are calculated, see
             https://docs.microsoft.com/azure/machine-learning/how-to-configure-auto-train#primary-metric.
@@ -120,9 +120,9 @@ def image_classification_multilabel(
             precision_score_weighted, and Iou
             Defaults to Iou.
     :type primary_metric: Union[str, ClassificationMultilabelPrimaryMetrics]
-    :param validation_data: The validation data to be used within the experiment.
+    :keyword validation_data: The validation data to be used within the experiment.
     :type validation_data: Input, optional
-    :param validation_data_size:  What fraction of the data to hold out for validation when user validation data
+    :keyword validation_data_size:  What fraction of the data to hold out for validation when user validation data
             is not specified. This should be between 0.0 and 1.0 non-inclusive.
 
             Specify ``validation_data`` to provide validation data, otherwise set ``validation_data_size``
@@ -130,7 +130,7 @@ def image_classification_multilabel(
 
             Defaults to .2
     :type validation_data_size: float, optional
-    :param kwargs: A dictionary of additional configuration parameters.
+    :keyword kwargs: A dictionary of additional configuration parameters.
     :type kwargs: dict
 
     :return: Image multi-label classification job object that can be submitted to an Azure ML compute for execution.
@@ -159,12 +159,12 @@ def image_object_detection(
 ) -> ImageObjectDetectionJob:
     """Creates an object for AutoML Image Object Detection job.
 
-    :param training_data:  The training data to be used within the experiment.
+    :keyword training_data:  The training data to be used within the experiment.
     :type training_data: Input
-    :param target_column_name: The name of the label column.
+    :keyword target_column_name: The name of the label column.
             This parameter is applicable to ``training_data`` and ``validation_data`` parameters.
     :type target_column_name: str
-    :param primary_metric: The metric that Automated Machine Learning will optimize for model selection.
+    :keyword primary_metric: The metric that Automated Machine Learning will optimize for model selection.
             Automated Machine Learning collects more metrics than it can optimize.
             For more information on how metrics are calculated, see
             https://docs.microsoft.com/azure/machine-learning/how-to-configure-auto-train#primary-metric.
@@ -172,9 +172,9 @@ def image_object_detection(
             Acceptable values: MeanAveragePrecision
             Defaults to MeanAveragePrecision.
     :type primary_metric: Union[str, ObjectDetectionPrimaryMetrics]
-    :param validation_data: The validation data to be used within the experiment.
+    :keyword validation_data: The validation data to be used within the experiment.
     :type validation_data: Input, optional
-    :param validation_data_size:  What fraction of the data to hold out for validation when user validation data
+    :keyword validation_data_size:  What fraction of the data to hold out for validation when user validation data
             is not specified. This should be between 0.0 and 1.0 non-inclusive.
 
             Specify ``validation_data`` to provide validation data, otherwise set ``validation_data_size``
@@ -182,7 +182,7 @@ def image_object_detection(
 
             Defaults to .2
     :type validation_data_size: float, optional
-    :param kwargs: A dictionary of additional configuration parameters.
+    :keyword kwargs: A dictionary of additional configuration parameters.
     :type kwargs: dict
 
     :return: Image object detection job object that can be submitted to an Azure ML compute for execution.
@@ -211,12 +211,12 @@ def image_instance_segmentation(
 ) -> ImageInstanceSegmentationJob:
     """Creates an object for AutoML Image Instance Segmentation job.
 
-    :param training_data:  The training data to be used within the experiment.
+    :keyword training_data:  The training data to be used within the experiment.
     :type training_data: Input
-    :param target_column_name: The name of the label column.
+    :keyword target_column_name: The name of the label column.
             This parameter is applicable to ``training_data`` and ``validation_data`` parameters.
     :type target_column_name: str
-    :param primary_metric: The metric that Automated Machine Learning will optimize for model selection.
+    :keyword primary_metric: The metric that Automated Machine Learning will optimize for model selection.
             Automated Machine Learning collects more metrics than it can optimize.
             For more information on how metrics are calculated, see
             https://docs.microsoft.com/azure/machine-learning/how-to-configure-auto-train#primary-metric.
@@ -224,9 +224,9 @@ def image_instance_segmentation(
             Acceptable values: MeanAveragePrecision
             Defaults to MeanAveragePrecision.
     :type primary_metric: Union[str, InstanceSegmentationPrimaryMetrics]
-    :param validation_data: The validation data to be used within the experiment.
+    :keyword validation_data: The validation data to be used within the experiment.
     :type validation_data: Input, optional
-    :param validation_data_size:  What fraction of the data to hold out for validation when user validation data
+    :keyword validation_data_size:  What fraction of the data to hold out for validation when user validation data
             is not specified. This should be between 0.0 and 1.0 non-inclusive.
 
             Specify ``validation_data`` to provide validation data, otherwise set ``validation_data_size``
@@ -234,7 +234,7 @@ def image_instance_segmentation(
 
             Defaults to .2
     :type validation_data_size: float, optional
-    :param kwargs: A dictionary of additional configuration parameters.
+    :keyword kwargs: A dictionary of additional configuration parameters.
     :type kwargs: dict
 
     :return: Image instance segmentation job

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/automl/_automl_nlp.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/automl/_automl_nlp.py
@@ -28,20 +28,20 @@ def text_classification(
     A text classification job is used to train a model that can predict the class/category of a text data.
     Input training data should include a target column that classifies the text into exactly one class.
 
-    :param training_data: The training data to be used within the experiment.
+    :keyword training_data: The training data to be used within the experiment.
             It should contain both training features and a target column.
     :type training_data: Input
-    :param target_column_name: Name of the target column.
+    :keyword target_column_name: Name of the target column.
     :type target_column_name: str
-    :param validation_data: The validation data to be used within the experiment.
+    :keyword validation_data: The validation data to be used within the experiment.
             It should contain both training features and a target column.
     :type validation_data: Input
-    :param primary_metric: Primary metric for the task.
+    :keyword primary_metric: Primary metric for the task.
             Acceptable values: accuracy, AUC_weighted, precision_score_weighted
     :type primary_metric: Union[str, ClassificationPrimaryMetrics]
-    :param log_verbosity: Log verbosity level.
+    :keyword log_verbosity: Log verbosity level.
     :type log_verbosity: str
-    :param kwargs: A dictionary of additional configuration parameters.
+    :keyword kwargs: A dictionary of additional configuration parameters.
     :type kwargs: dict
 
     :return: The TextClassificationJob object.
@@ -76,20 +76,20 @@ def text_classification_multilabel(
     For more information on format of multilabel data, refer to:
     https://docs.microsoft.com/en-us/azure/machine-learning/how-to-auto-train-nlp-models#multi-label
 
-    :param training_data: The training data to be used within the experiment.
+    :keyword training_data: The training data to be used within the experiment.
             It should contain both training features and a target column.
     :type training_data: Input
-    :param target_column_name: Name of the target column.
+    :keyword target_column_name: Name of the target column.
     :type target_column_name: str
-    :param validation_data: The validation data to be used within the experiment.
+    :keyword validation_data: The validation data to be used within the experiment.
             It should contain both training features and a target column.
     :type validation_data: Input
-    :param primary_metric: Primary metric for the task.
+    :keyword primary_metric: Primary metric for the task.
             Acceptable values: accuracy
     :type primary_metric: str
-    :param log_verbosity: Log verbosity level.
+    :keyword log_verbosity: Log verbosity level.
     :type log_verbosity: str
-    :param kwargs: A dictionary of additional configuration parameters.
+    :keyword kwargs: A dictionary of additional configuration parameters.
     :type kwargs: dict
 
     :return: The TextClassificationMultilabelJob object.
@@ -123,18 +123,18 @@ def text_ner(
     refer to:
     https://docs.microsoft.com/en-us/azure/machine-learning/how-to-auto-train-nlp-models#named-entity-recognition-ner
 
-    :param training_data: The training data to be used within the experiment.
+    :keyword training_data: The training data to be used within the experiment.
             It should contain both training features and a target column.
     :type training_data: Input
-    :param validation_data: The validation data to be used within the experiment.
+    :keyword validation_data: The validation data to be used within the experiment.
             It should contain both training features and a target column.
     :type validation_data: Input
-    :param primary_metric: Primary metric for the task.
+    :keyword primary_metric: Primary metric for the task.
             Acceptable values: accuracy
     :type primary_metric: str
-    :param log_verbosity: Log verbosity level.
+    :keyword log_verbosity: Log verbosity level.
     :type log_verbosity: str
-    :param kwargs: A dictionary of additional configuration parameters.
+    :keyword kwargs: A dictionary of additional configuration parameters.
     :type kwargs: dict
 
     :return: The TextNerJob object.

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/automl/_automl_tabular.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/automl/_automl_tabular.py
@@ -37,13 +37,13 @@ def classification(
     Various models are trained using the training data. The model with the best performance on the validation data
     based on the primary metric is selected as the final model.
 
-    :param training_data: The training data to be used within the experiment.
+    :keyword training_data: The training data to be used within the experiment.
             It should contain both training features and a label column (optionally a sample weights column).
     :type training_data: Input
-    :param target_column_name: The name of the label column.
+    :keyword target_column_name: The name of the label column.
             This parameter is applicable to ``training_data``, ``validation_data`` and ``test_data`` parameters
     :type target_column_name: str
-    :param primary_metric: The metric that Automated Machine Learning will optimize for model selection.
+    :keyword primary_metric: The metric that Automated Machine Learning will optimize for model selection.
             Automated Machine Learning collects more metrics than it can optimize.
             For more information on how metrics are calculated, see
             https://docs.microsoft.com/azure/machine-learning/how-to-configure-auto-train#primary-metric.
@@ -52,25 +52,25 @@ def classification(
             and precision_score_weighted
             Defaults to accuracy
     :type primary_metric: str, optional
-    :param enable_model_explainability: Whether to enable explaining the best AutoML model at the end of all AutoML
+    :keyword enable_model_explainability: Whether to enable explaining the best AutoML model at the end of all AutoML
             training iterations.
             The default is None. For more information, see
             `Interpretability: model explanations in automated machine learning
             <https://docs.microsoft.com/azure/machine-learning/how-to-machine-learning-interpretability-automl>`__.
     :type enable_model_explainability: bool, optional
-    :param weight_column_name: The name of the sample weight column. Automated ML supports a weighted column
+    :keyword weight_column_name: The name of the sample weight column. Automated ML supports a weighted column
             as an input, causing rows in the data to be weighted up or down.
             If the input data is from a pandas.DataFrame which doesn't have column names,
             column indices can be used instead, expressed as integers.
 
             This parameter is applicable to ``training_data`` and ``validation_data`` parameters
     :type weight_column_name: str, optional
-    :param validation_data: The validation data to be used within the experiment.
+    :keyword validation_data: The validation data to be used within the experiment.
             It should contain both training features and label column (optionally a sample weights column).
 
             Defaults to None
     :type validation_data: Input, optional
-    :param validation_data_size: What fraction of the data to hold out for validation when user validation data
+    :keyword validation_data_size: What fraction of the data to hold out for validation when user validation data
             is not specified. This should be between 0.0 and 1.0 non-inclusive.
 
             Specify ``validation_data`` to provide validation data, otherwise set ``n_cross_validations`` or
@@ -83,7 +83,7 @@ def classification(
 
             Defaults to None
     :type validation_data_size: float, optional
-    :param n_cross_validations: How many cross validations to perform when user validation data is not specified.
+    :keyword n_cross_validations: How many cross validations to perform when user validation data is not specified.
 
             Specify ``validation_data`` to provide validation data, otherwise set ``n_cross_validations`` or
             ``validation_data_size`` to extract validation data out of the specified training data.
@@ -95,13 +95,13 @@ def classification(
 
             Defaults to None
     :type n_cross_validations: Union[str, int], optional
-    :param cv_split_column_names: List of names of the columns that contain custom cross validation split.
+    :keyword cv_split_column_names: List of names of the columns that contain custom cross validation split.
             Each of the CV split columns represents one CV split where each row are either marked
             1 for training or 0 for validation.
 
             Defaults to None
     :type cv_split_column_names: List[str], optional
-    :param test_data: The Model Test feature using test datasets or test data splits is a feature in
+    :keyword test_data: The Model Test feature using test datasets or test data splits is a feature in
             Preview state and might change at any time.
             The test data to be used for a test run that will automatically be started after
             model training is complete. The test run will get predictions using the best model
@@ -114,7 +114,7 @@ def classification(
 
             Defaults to None
     :type test_data: Input, optional
-    :param test_data_size: The Model Test feature using test datasets or test data splits is a feature in
+    :keyword test_data_size: The Model Test feature using test datasets or test data splits is a feature in
             Preview state and might change at any time.
             What fraction of the training data to hold out for test data for a test run that will
             automatically be started after model training is complete. The test run will get
@@ -179,13 +179,13 @@ def regression(
     based on the primary metric is selected as the final model.
 
 
-    :param training_data: The training data to be used within the experiment.
+    :keyword training_data: The training data to be used within the experiment.
             It should contain both training features and a label column (optionally a sample weights column).
     :type training_data: Input
-    :param target_column_name: The name of the label column.
+    :keyword target_column_name: The name of the label column.
             This parameter is applicable to ``training_data``, ``validation_data`` and ``test_data`` parameters
     :type target_column_name: str
-    :param primary_metric: The metric that Automated Machine Learning will optimize for model selection.
+    :keyword primary_metric: The metric that Automated Machine Learning will optimize for model selection.
             Automated Machine Learning collects more metrics than it can optimize.
             For more information on how metrics are calculated, see
             https://docs.microsoft.com/azure/machine-learning/how-to-configure-auto-train#primary-metric.
@@ -194,25 +194,25 @@ def regression(
             normalized_root_mean_squared_error.
             Defaults to normalized_root_mean_squared_error
     :type primary_metric: str, optional
-    :param enable_model_explainability: Whether to enable explaining the best AutoML model at the end of all AutoML
+    :keyword enable_model_explainability: Whether to enable explaining the best AutoML model at the end of all AutoML
             training iterations.
             The default is None. For more information, see
             `Interpretability: model explanations in automated machine learning
             <https://docs.microsoft.com/azure/machine-learning/how-to-machine-learning-interpretability-automl>`__.
     :type enable_model_explainability: bool, optional
-    :param weight_column_name: The name of the sample weight column. Automated ML supports a weighted column
+    :keyword weight_column_name: The name of the sample weight column. Automated ML supports a weighted column
             as an input, causing rows in the data to be weighted up or down.
             If the input data is from a pandas.DataFrame which doesn't have column names,
             column indices can be used instead, expressed as integers.
 
             This parameter is applicable to ``training_data`` and ``validation_data`` parameters
     :type weight_column_name: str, optional
-    :param validation_data: The validation data to be used within the experiment.
+    :keyword validation_data: The validation data to be used within the experiment.
             It should contain both training features and label column (optionally a sample weights column).
 
             Defaults to None
     :type validation_data: Input, optional
-    :param validation_data_size: What fraction of the data to hold out for validation when user validation data
+    :keyword validation_data_size: What fraction of the data to hold out for validation when user validation data
             is not specified. This should be between 0.0 and 1.0 non-inclusive.
 
             Specify ``validation_data`` to provide validation data, otherwise set ``n_cross_validations`` or
@@ -225,7 +225,7 @@ def regression(
 
             Defaults to None
     :type validation_data_size: float, optional
-    :param n_cross_validations: How many cross validations to perform when user validation data is not specified.
+    :keyword n_cross_validations: How many cross validations to perform when user validation data is not specified.
 
             Specify ``validation_data`` to provide validation data, otherwise set ``n_cross_validations`` or
             ``validation_data_size`` to extract validation data out of the specified training data.
@@ -237,13 +237,13 @@ def regression(
 
             Defaults to None
     :type n_cross_validations: Union[str, int], optional
-    :param cv_split_column_names: List of names of the columns that contain custom cross validation split.
+    :keyword cv_split_column_names: List of names of the columns that contain custom cross validation split.
             Each of the CV split columns represents one CV split where each row are either marked
             1 for training or 0 for validation.
 
             Defaults to None
     :type cv_split_column_names: List[str], optional
-    :param test_data: The Model Test feature using test datasets or test data splits is a feature in
+    :keyword test_data: The Model Test feature using test datasets or test data splits is a feature in
             Preview state and might change at any time.
             The test data to be used for a test run that will automatically be started after
             model training is complete. The test run will get predictions using the best model
@@ -256,7 +256,7 @@ def regression(
 
             Defaults to None
     :type test_data: Input, optional
-    :param test_data_size: The Model Test feature using test datasets or test data splits is a feature in
+    :keyword test_data_size: The Model Test feature using test datasets or test data splits is a feature in
             Preview state and might change at any time.
             What fraction of the training data to hold out for test data for a test run that will
             automatically be started after model training is complete. The test run will get
@@ -321,13 +321,13 @@ def forecasting(
     Various models are trained using the training data. The model with the best performance on the validation data
     based on the primary metric is selected as the final model.
 
-    :param training_data: The training data to be used within the experiment.
+    :keyword training_data: The training data to be used within the experiment.
             It should contain both training features and a label column (optionally a sample weights column).
     :type training_data: Input
-    :param target_column_name: The name of the label column.
+    :keyword target_column_name: The name of the label column.
             This parameter is applicable to ``training_data``, ``validation_data`` and ``test_data`` parameters
     :type target_column_name: str
-    :param primary_metric: The metric that Automated Machine Learning will optimize for model selection.
+    :keyword primary_metric: The metric that Automated Machine Learning will optimize for model selection.
             Automated Machine Learning collects more metrics than it can optimize.
             For more information on how metrics are calculated, see
             https://docs.microsoft.com/azure/machine-learning/how-to-configure-auto-train#primary-metric.
@@ -335,25 +335,25 @@ def forecasting(
             Acceptable values: r2_score, normalized_mean_absolute_error, normalized_root_mean_squared_error
             Defaults to normalized_root_mean_squared_error
     :type primary_metric: str, optional
-    :param enable_model_explainability: Whether to enable explaining the best AutoML model at the end of all AutoML
+    :keyword enable_model_explainability: Whether to enable explaining the best AutoML model at the end of all AutoML
             training iterations.
             The default is None. For more information, see
             `Interpretability: model explanations in automated machine learning
             <https://docs.microsoft.com/azure/machine-learning/how-to-machine-learning-interpretability-automl>`__.
     :type enable_model_explainability: bool, optional
-    :param weight_column_name: The name of the sample weight column. Automated ML supports a weighted column
+    :keyword weight_column_name: The name of the sample weight column. Automated ML supports a weighted column
             as an input, causing rows in the data to be weighted up or down.
             If the input data is from a pandas.DataFrame which doesn't have column names,
             column indices can be used instead, expressed as integers.
 
             This parameter is applicable to ``training_data`` and ``validation_data`` parameters
     :type weight_column_name: str, optional
-    :param validation_data: The validation data to be used within the experiment.
+    :keyword validation_data: The validation data to be used within the experiment.
             It should contain both training features and label column (optionally a sample weights column).
 
             Defaults to None
     :type validation_data: Input, optional
-    :param validation_data_size: What fraction of the data to hold out for validation when user validation data
+    :keyword validation_data_size: What fraction of the data to hold out for validation when user validation data
             is not specified. This should be between 0.0 and 1.0 non-inclusive.
 
             Specify ``validation_data`` to provide validation data, otherwise set ``n_cross_validations`` or
@@ -366,7 +366,7 @@ def forecasting(
 
             Defaults to None
     :type validation_data_size: float, optional
-    :param n_cross_validations: How many cross validations to perform when user validation data is not specified.
+    :keyword n_cross_validations: How many cross validations to perform when user validation data is not specified.
 
             Specify ``validation_data`` to provide validation data, otherwise set ``n_cross_validations`` or
             ``validation_data_size`` to extract validation data out of the specified training data.
@@ -378,13 +378,13 @@ def forecasting(
 
             Defaults to None
     :type n_cross_validations: Union[str, int], optional
-    :param cv_split_column_names: List of names of the columns that contain custom cross validation split.
+    :keyword cv_split_column_names: List of names of the columns that contain custom cross validation split.
             Each of the CV split columns represents one CV split where each row are either marked
             1 for training or 0 for validation.
 
             Defaults to None
     :type cv_split_column_names: List[str], optional
-    :param test_data: The Model Test feature using test datasets or test data splits is a feature in
+    :keyword test_data: The Model Test feature using test datasets or test data splits is a feature in
             Preview state and might change at any time.
             The test data to be used for a test run that will automatically be started after
             model training is complete. The test run will get predictions using the best model
@@ -397,7 +397,7 @@ def forecasting(
 
             Defaults to None
     :type test_data: Input, optional
-    :param test_data_size: The Model Test feature using test datasets or test data splits is a feature in
+    :keyword test_data_size: The Model Test feature using test datasets or test data splits is a feature in
             Preview state and might change at any time.
             What fraction of the training data to hold out for test data for a test run that will
             automatically be started after model training is complete. The test run will get
@@ -419,7 +419,7 @@ def forecasting(
 
             Defaults to None
     :type test_data_size: float, optional
-    :param forecasting_settings: The settings for the forecasting task
+    :keyword forecasting_settings: The settings for the forecasting task
     :type forecasting_settings: ForecastingSettings, optional
     :return: A job object that can be submitted to an Azure ML compute for execution.
     :rtype: ForecastingJob

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/dsl/_condition.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/dsl/_condition.py
@@ -40,9 +40,9 @@ def condition(
         The value could be a boolean type control output, a node with exactly one boolean type output
         or a pipeline expression.
     :type condition: Union[str, bool, InputOutputBase, BaseNode, PipelineExpression]
-    :param true_block: Block to be executed if condition resolved result is true.
+    :keyword true_block: Block to be executed if condition resolved result is true.
     :type true_block: BaseNode
-    :param false_block: Block to be executed if condition resolved result is false.
+    :keyword false_block: Block to be executed if condition resolved result is false.
     :type false_block:  BaseNode
     :return: The condition node.
     :rtype: ConditionNode

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/dsl/_load_import.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/dsl/_load_import.py
@@ -29,9 +29,9 @@ def to_component(*, job: ComponentTranslatableMixin, **kwargs) -> Callable[..., 
         # Consuming the component func
         component = component_func(param1=xxx, param2=xxx)
 
-    :param job: Job load from local or remote.
+    :keyword job: Job load from local or remote.
     :type job: ~azure.ai.ml.entities._job.pipeline._component_translatable.ComponentTranslatableMixin
-    :param kwargs: A dictionary of additional configuration parameters.
+    :keyword kwargs: A dictionary of additional configuration parameters.
     :type kwargs: dict
 
     :return: Wrapped function call.

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/dsl/_parallel_for.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/dsl/_parallel_for.py
@@ -40,9 +40,9 @@ def parallel_for(*, body, items, **kwargs):
                     input=loop_node.outputs.output,
                 )
 
-    :param body: Node to execute as the loop body.
+    :keyword body: Node to execute as the loop body.
     :type body: BaseNode
-    :param items: The loop body's input which will bind to the loop node.
+    :keyword items: The loop body's input which will bind to the loop node.
     :type items: Union[list, dict, str, PipelineInput, NodeOutput]
     """
     parallel_for_node = ParallelFor(

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/dsl/_pipeline_component_builder.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/dsl/_pipeline_component_builder.py
@@ -154,9 +154,9 @@ class PipelineComponentBuilder:
     ) -> PipelineComponent:
         """Build a pipeline component from current pipeline builder.
 
-        :param user_provided_kwargs: The kwargs user provided to dsl pipeline function. None if not provided.
-        :param non_pipeline_inputs_dict: The non-pipeline input provided key-value. None if not exist.
-        :param non_pipeline_inputs: List of non-pipeline input name. None if not exist.
+        :keyword user_provided_kwargs: The kwargs user provided to dsl pipeline function. None if not provided.
+        :keyword non_pipeline_inputs_dict: The non-pipeline input provided key-value. None if not exist.
+        :keyword non_pipeline_inputs: List of non-pipeline input name. None if not exist.
         """
         if user_provided_kwargs is None:
             user_provided_kwargs = {}

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/dsl/_pipeline_decorator.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/dsl/_pipeline_decorator.py
@@ -93,21 +93,21 @@ def pipeline(
                 ml_client.jobs.create_or_update(pipeline_job, experiment_name="pipeline_samples")
 
     :param func: The user pipeline function to be decorated.
-    :param func: types.FunctionType
-    :param name: The name of pipeline component, defaults to function name.
+    :type func: types.FunctionType
+    :keyword name: The name of pipeline component, defaults to function name.
     :type name: str
-    :param version: The version of pipeline component, defaults to "1".
+    :keyword version: The version of pipeline component, defaults to "1".
     :type version: str
-    :param display_name: The display name of pipeline component, defaults to function name.
+    :keyword display_name: The display name of pipeline component, defaults to function name.
     :type display_name: str
-    :param description: The description of the built pipeline.
+    :keyword description: The description of the built pipeline.
     :type description: str
-    :param experiment_name: Name of the experiment the job will be created under, \
+    :keyword experiment_name: Name of the experiment the job will be created under, \
                 if None is provided, experiment will be set to current directory.
     :type experiment_name: str
-    :param tags: The tags of pipeline component.
+    :keyword tags: The tags of pipeline component.
     :type tags: dict[str, str]
-    :param kwargs: A dictionary of additional configuration parameters.
+    :keyword kwargs: A dictionary of additional configuration parameters.
     :type kwargs: dict
     """
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/dsl/_settings.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/dsl/_settings.py
@@ -113,10 +113,10 @@ def set_pipeline_settings(
 
     This function should be called inside a `dsl.pipeline` decorated function, otherwise will raise exception.
 
-    :param on_init: On_init job node or name. On init job will be executed before all other jobs, \
+    :keyword on_init: On_init job node or name. On init job will be executed before all other jobs, \
                 it should not have data connections to regular nodes.
     :type on_init: Union[BaseNode, str]
-    :param on_finalize: On_finalize job node or name. On finalize job will be executed after pipeline run \
+    :keyword on_finalize: On_finalize job node or name. On finalize job will be executed after pipeline run \
                 finishes (completed/failed/canceled), it should not have data connections to regular nodes.
     :type on_finalize: Union[BaseNode, str]
     :return:

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_assets/_artifacts/_package/model_package.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_assets/_artifacts/_package/model_package.py
@@ -248,8 +248,10 @@ class ModelPackage(Resource, PackageRequest):
     ) -> None:
         """Dump the model package spec into a file in yaml format.
 
-        :param path: Path to a local file as the target, new file will be created, raises exception if the file exists.
-        :type path: str
+        :param dest: Either
+          * A path to a local file
+          * A writeable file-like object
+        :type dest: Union[str, PathLike, IO[AnyStr]]
         """
         yaml_serialized = self._to_dict()
         dump_yaml_to_file(dest, yaml_serialized, default_flow_style=False)

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_assets/federated_learning_silo.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_assets/federated_learning_silo.py
@@ -54,8 +54,10 @@ class FederatedLearningSilo:
     ) -> None:
         """Dump the Federated Learning Silo spec into a file in yaml format.
 
-        :param path: Path to a local file as the target, new file will be created, raises exception if the file exists.
-        :type path: str
+        :param dest: Either
+          * A path to a local file
+          * A writeable file-like object
+        :type dest: Union[str, PathLike, IO[AnyStr]]
         """
         yaml_serialized = self._to_dict()
         dump_yaml_to_file(dest, yaml_serialized, default_flow_style=False)

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_builders/command.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_builders/command.py
@@ -480,20 +480,20 @@ class Command(BaseNode, NodeWithGroupInputMixin):
     ) -> None:
         """Set resources for Command.
 
-        :param instance_type: The type of compute instance to run the job on. If not specified, the job will run on
+        :keyword instance_type: The type of compute instance to run the job on. If not specified, the job will run on
             the default compute target.
         :type instance_type: Union[str, list[str]]
-        :param instance_count: The number of instances to run the job on. If not specified, the job will run on a
+        :keyword instance_count: The number of instances to run the job on. If not specified, the job will run on a
             single instance.
         :type instance_count: int
-        :param locations: The list of locations where the job will run. If not specified, the job will run on the
+        :keyword locations: The list of locations where the job will run. If not specified, the job will run on the
             default compute target.
         :type locations: list[str]
-        :param properties: The properties of the job.
+        :keyword properties: The properties of the job.
         :type properties: dict
-        :param docker_args: The Docker arguments for the job.
+        :keyword docker_args: The Docker arguments for the job.
         :type docker_args: str
-        :param shm_size: The size of the docker container's shared memory block. This should be in the
+        :keyword shm_size: The size of the docker container's shared memory block. This should be in the
             format of (number)(unit) where the number has to be greater than 0 and the unit can be one of
             b(bytes), k(kilobytes), m(megabytes), or g(gigabytes).
         :type shm_size: str
@@ -531,7 +531,7 @@ class Command(BaseNode, NodeWithGroupInputMixin):
     def set_limits(self, *, timeout: int, **kwargs) -> None:  # pylint: disable=unused-argument
         """Set limits for Command.
 
-        :param timeout: The timeout for the job in seconds.
+        :keyword timeout: The timeout for the job in seconds.
         :type timeout: int
 
         .. admonition:: Example:
@@ -552,9 +552,9 @@ class Command(BaseNode, NodeWithGroupInputMixin):
     def set_queue_settings(self, *, job_tier: Optional[str] = None, priority: Optional[str] = None) -> None:
         """Set QueueSettings for the job.
 
-        :param job_tier: The job tier. Accepted values are "Spot", "Basic", "Standard", or "Premium".
+        :keyword job_tier: The job tier. Accepted values are "Spot", "Basic", "Standard", or "Premium".
         :type job_tier: str
-        :param priority:  The priority of the job on the compute. Defaults to "Medium".
+        :keyword priority:  The priority of the job on the compute. Defaults to "Medium".
         :type priority: str
 
         .. admonition:: Example:
@@ -604,43 +604,43 @@ class Command(BaseNode, NodeWithGroupInputMixin):
         in the current Command node will be used as its trial component. A command node can sweep
         multiple times, and the generated sweep node will share the same trial component.
 
-        :param primary_metric: The primary metric of the sweep objective - e.g. AUC (Area Under the Curve).
+        :keyword primary_metric: The primary metric of the sweep objective - e.g. AUC (Area Under the Curve).
         The metric must be logged while running the trial component.
         :type primary_metric: str
-        :param goal: The goal of the Sweep objective. Accepted values are "minimize" or "maximize".
+        :keyword goal: The goal of the Sweep objective. Accepted values are "minimize" or "maximize".
         :type goal: str
-        :param sampling_algorithm: The sampling algorithm to use inside the search space. Defaults to "random".
+        :keyword sampling_algorithm: The sampling algorithm to use inside the search space. Defaults to "random".
         Acceptable values are "random", "grid", or "bayesian".
         :type sampling_algorithm: str
-        :param compute: The target compute to run the node on. If not specified, the current node's compute
+        :keyword compute: The target compute to run the node on. If not specified, the current node's compute
         will be used.
         :type compute: str
-        :param max_total_trials: The maximum number of trials to run. This value will overwrite value in
+        :keyword max_total_trials: The maximum number of trials to run. This value will overwrite value in
         CommandJob.limits if specified.
         :type max_total_trials: int
-        :param max_concurrent_trials: The maximum number of concurrent trials for the Sweep job.
+        :keyword max_concurrent_trials: The maximum number of concurrent trials for the Sweep job.
         :type max_concurrent_trials: int
-        :param max_total_trials: The maximum number of total trials for the Sweep Job.
+        :keyword max_total_trials: The maximum number of total trials for the Sweep Job.
         :type max_total_trials: int
-        :param timeout: The maximum run duration in seconds, after which the job will be cancelled.
+        :keyword timeout: The maximum run duration in seconds, after which the job will be cancelled.
         :type timeout: int
-        :param trial_timeout: The Sweep Job trial timeout value in seconds.
+        :keyword trial_timeout: The Sweep Job trial timeout value in seconds.
         :type trial_timeout: int
-        :param early_termination_policy: The early termination policy of the sweep node. Acceptable
+        :keyword early_termination_policy: The early termination policy of the sweep node. Acceptable
         values are "bandit", "median_stopping", or "truncation_selection".
         :type early_termination_policy: Union[~azure.ai.ml.sweep.BanditPolicy,
         ~azure.ai.ml.sweep.TruncationSelectionPolicy, ~azure.ai.ml.sweep.MedianStoppingPolicy, str]
-        :param identity: The identity that the job will use while running on compute.
+        :keyword identity: The identity that the job will use while running on compute.
         :type identity: Union[
             ~azure.ai.ml.ManagedIdentityConfiguration,
             ~azure.ai.ml.AmlTokenConfiguration,
             ~azure.ai.ml.UserIdentityConfiguration]
-        :param queue_settings: The queue settings for the job.
+        :keyword queue_settings: The queue settings for the job.
         :type queue_settings: ~azure.ai.ml.entities.QueueSettings
-        :param job_tier: **Experimental** The job tier. Accepted values are "Spot", "Basic",
+        :keyword job_tier: **Experimental** The job tier. Accepted values are "Spot", "Basic",
         "Standard", or "Premium".
         :type job_tier: str
-        :param priority: **Experimental** The compute priority. Accepted values are "low",
+        :keyword priority: **Experimental** The compute priority. Accepted values are "low",
         "medium", and "high".
         :type priority: str
         :return: A Sweep node with the component from current Command node as its trial component.

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_builders/command_func.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_builders/command_func.py
@@ -147,32 +147,32 @@ def command(
 ) -> Command:
     """Creates a Command object which can be used inside a dsl.pipeline function or used as a standalone Command job.
 
-    :param name: The name of the Command job or component.
+    :keyword name: The name of the Command job or component.
     :type name: str
-    :param description: The description of the Command.
+    :keyword description: The description of the Command.
     :type description: str
-    :param tags: Tag dictionary. Tags can be added, removed, and updated.
+    :keyword tags: Tag dictionary. Tags can be added, removed, and updated.
     :type tags: dict[str, str]
-    :param properties: The job property dictionary.
+    :keyword properties: The job property dictionary.
     :type properties: dict[str, str]
-    :param display_name: The display name of the job.
+    :keyword display_name: The display name of the job.
     :type display_name: str
-    :param command: The command to be executed.
+    :keyword command: The command to be executed.
     :type command: str
-    :param experiment_name: The name of the experiment the job will be created under. Defaults to current directory
+    :keyword experiment_name: The name of the experiment the job will be created under. Defaults to current directory
         name.
     :type experiment_name: str
-    :param environment: The environment that the job will run in.
+    :keyword environment: The environment that the job will run in.
     :type environment: Union[str, ~azure.ai.ml.entities.Environment]
-    :param environment_variables:  A dictionary of environment variable names and values.
+    :keyword environment_variables:  A dictionary of environment variable names and values.
         These environment variables are set on the process where user script is being executed.
     :type environment_variables: dict[str, str]
-    :param distribution: The configuration for distributed jobs.
+    :keyword distribution: The configuration for distributed jobs.
     :type distribution: Union[dict, ~azure.ai.ml.PyTorchDistribution, ~azure.ai.ml.MpiDistribution,
         ~azure.ai.ml.TensorFlowDistribution, ~azure.ai.ml.RayDistribution]
-    :param compute: The compute target the job will run on.
+    :keyword compute: The compute target the job will run on.
     :type compute: str
-    :param inputs: A mapping of input names to input data sources used in the job.
+    :keyword inputs: A mapping of input names to input data sources used in the job.
     :type inputs: dict[str, Union[
         ~azure.ai.ml.Input,
         str,
@@ -182,46 +182,46 @@ def command(
         Enum,
         ]
     ]
-    :param outputs: A mapping of output names to output data sources used in the job.
+    :keyword outputs: A mapping of output names to output data sources used in the job.
     :type outputs: dict[str, Union[str, ~azure.ai.ml.Output]]
-    :param instance_count: The number of instances or nodes to be used by the compute target. Defaults to 1.
+    :keyword instance_count: The number of instances or nodes to be used by the compute target. Defaults to 1.
     :type instance_count: int
-    :param instance_type: The type of VM to be used by the compute target.
+    :keyword instance_type: The type of VM to be used by the compute target.
     :type instance_type: str
-    :param locations: The list of locations where the job will run.
+    :keyword locations: The list of locations where the job will run.
     :type locations: list[str]
-    :param docker_args: Extra arguments to pass to the Docker run command. This would override any
+    :keyword docker_args: Extra arguments to pass to the Docker run command. This would override any
      parameters that have already been set by the system, or in this section. This parameter is only
      supported for Azure ML compute types.
     :type docker_args: str
-    :param shm_size: The size of the Docker container's shared memory block. This should be in the
+    :keyword shm_size: The size of the Docker container's shared memory block. This should be in the
      format of (number)(unit) where the number has to be greater than 0 and the unit can be one of
      b(bytes), k(kilobytes), m(megabytes), or g(gigabytes).
     :type shm_size: str
-    :param timeout: The number, in seconds, after which the job will be cancelled.
+    :keyword timeout: The number, in seconds, after which the job will be cancelled.
     :type timeout: int
-    :param code: The source code to run the job. Can be a local path or "http:", "https:", or "azureml:" url
+    :keyword code: The source code to run the job. Can be a local path or "http:", "https:", or "azureml:" url
         pointing to a remote location.
     :type code: Union[str, os.PathLike]
-    :param identity: The identity that the command job will use while running on compute.
+    :keyword identity: The identity that the command job will use while running on compute.
     :type identity: Union[
         ~azure.ai.ml.entities.ManagedIdentityConfiguration,
         ~azure.ai.ml.entities.AmlTokenConfiguration,
         ~azure.ai.ml.entities.UserIdentityConfiguration]
-    :param is_deterministic: Specifies whether the Command will return the same output given the same input.
+    :keyword is_deterministic: Specifies whether the Command will return the same output given the same input.
         Defaults to True.
         When True, if a Command Component is deterministic and has been run before in the current workspace
         with the same input and settings, it will reuse results from a previously submitted job when used as a
         node or step in a pipeline. In that scenario, no compute resources will be used.
     :type is_deterministic: bool
-    :param services: The interactive services for the node. This is an experimental parameter, and may change at
+    :keyword services: The interactive services for the node. This is an experimental parameter, and may change at
         any time. Please see https://aka.ms/azuremlexperimental for more information.
     :type services: dict[str, Union[~azure.ai.ml.entities.JobService, ~azure.ai.ml.entities.JupyterLabJobService,
         ~azure.ai.ml.entities.SshJobService, ~azure.ai.ml.entities.TensorBoardJobService,
         ~azure.ai.ml.entities.VsCodeJobService]]
-    :param job_tier: The job tier. Accepted values are "Spot", "Basic", "Standard", or "Premium".
+    :keyword job_tier: The job tier. Accepted values are "Spot", "Basic", "Standard", or "Premium".
     :type job_tier: str
-    :param priority: The priority of the job on the compute. Defaults to "Medium".
+    :keyword priority: The priority of the job on the compute. Defaults to "Medium".
     :type priority: str
     :return: A Command object.
     :rtype: ~azure.ai.ml.entities.Command

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_builders/data_transfer_func.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_builders/data_transfer_func.py
@@ -135,29 +135,29 @@ def copy_data(
 ) -> DataTransferCopy:
     """Create a DataTransferCopy object which can be used inside dsl.pipeline as a function.
 
-    :param name: The name of the job.
+    :keyword name: The name of the job.
     :type name: str
-    :param description: Description of the job.
+    :keyword description: Description of the job.
     :type description: str
-    :param tags: Tag dictionary. Tags can be added, removed, and updated.
+    :keyword tags: Tag dictionary. Tags can be added, removed, and updated.
     :type tags: dict[str, str]
-    :param display_name: Display name of the job.
+    :keyword display_name: Display name of the job.
     :type display_name: str
-    :param experiment_name:  Name of the experiment the job will be created under.
+    :keyword experiment_name:  Name of the experiment the job will be created under.
     :type experiment_name: str
-    :param compute: The compute resource the job runs on.
+    :keyword compute: The compute resource the job runs on.
     :type compute: str
-    :param inputs: Mapping of inputs data bindings used in the job.
+    :keyword inputs: Mapping of inputs data bindings used in the job.
     :type inputs: dict
-    :param outputs: Mapping of outputs data bindings used in the job.
+    :keyword outputs: Mapping of outputs data bindings used in the job.
     :type outputs: dict
-    :param is_deterministic: Specify whether the command will return same output given same input.
+    :keyword is_deterministic: Specify whether the command will return same output given same input.
         If a command (component) is deterministic, when use it as a node/step in a pipeline,
         it will reuse results from a previous submitted job in current workspace which has same inputs and settings.
         In this case, this step will not use any compute resource.
         Default to be True, specify is_deterministic=False if you would like to avoid such reuse behavior.
     :type is_deterministic: bool
-    :param data_copy_mode: data copy mode in copy task, possible value is "merge_with_overwrite", "fail_if_conflict".
+    :keyword data_copy_mode: data copy mode in copy task, possible value is "merge_with_overwrite", "fail_if_conflict".
     :type data_copy_mode: str
     """
     inputs = inputs or {}
@@ -212,21 +212,21 @@ def import_data(
 ) -> DataTransferImport:
     """Create a DataTransferImport object which can be used inside dsl.pipeline.
 
-    :param name: The name of the job.
+    :keyword name: The name of the job.
     :type name: str
-    :param description: Description of the job.
+    :keyword description: Description of the job.
     :type description: str
-    :param tags: Tag dictionary. Tags can be added, removed, and updated.
+    :keyword tags: Tag dictionary. Tags can be added, removed, and updated.
     :type tags: dict[str, str]
-    :param display_name: Display name of the job.
+    :keyword display_name: Display name of the job.
     :type display_name: str
-    :param experiment_name:  Name of the experiment the job will be created under.
+    :keyword experiment_name:  Name of the experiment the job will be created under.
     :type experiment_name: str
-    :param compute: The compute resource the job runs on.
+    :keyword compute: The compute resource the job runs on.
     :type compute: str
-    :param source: The data source of file system or database
+    :keyword source: The data source of file system or database
     :type source: Union[Dict, Database, FileSystem]
-    :param outputs: Mapping of outputs data bindings used in the job, default will be an output port with key "sink"
+    :keyword outputs: Mapping of outputs data bindings used in the job, default will be an output port with key "sink"
     and type "mltable".
     :type outputs: dict
     """
@@ -278,21 +278,21 @@ def export_data(
 ) -> DataTransferExport:
     """Create a DataTransferExport object which can be used inside dsl.pipeline.
 
-    :param name: The name of the job.
+    :keyword name: The name of the job.
     :type name: str
-    :param description: Description of the job.
+    :keyword description: Description of the job.
     :type description: str
-    :param tags: Tag dictionary. Tags can be added, removed, and updated.
+    :keyword tags: Tag dictionary. Tags can be added, removed, and updated.
     :type tags: dict[str, str]
-    :param display_name: Display name of the job.
+    :keyword display_name: Display name of the job.
     :type display_name: str
-    :param experiment_name:  Name of the experiment the job will be created under.
+    :keyword experiment_name:  Name of the experiment the job will be created under.
     :type experiment_name: str
-    :param compute: The compute resource the job runs on.
+    :keyword compute: The compute resource the job runs on.
     :type compute: str
-    :param sink: The sink of external data and databases.
+    :keyword sink: The sink of external data and databases.
     :type sink: Union[Dict, Database, FileSystem]
-    :param inputs: Mapping of inputs data bindings used in the job.
+    :keyword inputs: Mapping of inputs data bindings used in the job.
     :type inputs: dict
     """
     sink = _build_source_sink(sink)

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_builders/import_func.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_builders/import_func.py
@@ -30,22 +30,22 @@ def import_job(
     """Create a Import object which can be used inside dsl.pipeline as a
     function and can also be created as a standalone import job.
 
-    :param name: Name of the import job or component created
+    :keyword name: Name of the import job or component created
     :type name: str
-    :param description: a friendly description of the import
+    :keyword description: a friendly description of the import
     :type description: str
-    :param tags: Tags to be attached to this import
+    :keyword tags: Tags to be attached to this import
     :type tags: Dict
-    :param display_name: a friendly name
+    :keyword display_name: a friendly name
     :type display_name: str
-    :param experiment_name:  Name of the experiment the job will be created under,
+    :keyword experiment_name:  Name of the experiment the job will be created under,
         if None is provided, default will be set to current directory name. Will be ignored as a pipeline step.
     :type experiment_name: str
-    :param source: input source parameters used by this import.
+    :keyword source: input source parameters used by this import.
     :type source: ImportSource
-    :param output: the output of this import
+    :keyword output: the output of this import
     :type output: Output
-    :param is_deterministic: Specify whether the command will return same output given same input.
+    :keyword is_deterministic: Specify whether the command will return same output given same input.
         If a command (component) is deterministic, when use it as a node/step in a pipeline,
         it will reuse results from a previous submitted job in current workspace which has same inputs and settings.
         In this case, this step will not use any compute resource.

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_builders/parallel_func.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_builders/parallel_func.py
@@ -99,76 +99,76 @@ def parallel_run_function(
             ),
         )
 
-    :param name: Name of the parallel job or component created
+    :keyword name: Name of the parallel job or component created
     :type name: str
-    :param description: a friendly description of the parallel
+    :keyword description: a friendly description of the parallel
     :type description: str
-    :param tags: Tags to be attached to this parallel
+    :keyword tags: Tags to be attached to this parallel
     :type tags: Dict
-    :param properties: The asset property dictionary.
+    :keyword properties: The asset property dictionary.
     :type properties: dict[str, str]
-    :param display_name: a friendly name
+    :keyword display_name: a friendly name
     :type display_name: str
-    :param experiment_name: Name of the experiment the job will be created under,
+    :keyword experiment_name: Name of the experiment the job will be created under,
         if None is provided, default will be set to current directory name. Will be ignored as a pipeline step.
     :type experiment_name: str
-    :param compute: the name of the compute where the parallel job is executed(
+    :keyword compute: the name of the compute where the parallel job is executed(
         will not be used if the parallel is used as a component/function)
     :type compute: str
-    :param retry_settings: parallel component run failed retry
+    :keyword retry_settings: parallel component run failed retry
     :type retry_settings: BatchRetrySettings
-    :param environment_variables:  A dictionary of environment variables names and values.
+    :keyword environment_variables:  A dictionary of environment variables names and values.
         These environment variables are set on the process where user script is being executed.
     :type environment_variables: Dict[str, str]
-    :param logging_level: A string of the logging level name, which is defined in 'logging'.
+    :keyword logging_level: A string of the logging level name, which is defined in 'logging'.
         Possible values are 'WARNING', 'INFO', and 'DEBUG'. (optional, default value is 'INFO'.)
         This value could be set through PipelineParameter.
     :type logging_level: str
-    :param max_concurrency_per_instance: The max parallellism that each compute instance has.
+    :keyword max_concurrency_per_instance: The max parallellism that each compute instance has.
     :type max_concurrency_per_instance: int
-    :param error_threshold: The number of record failures for Tabular Dataset
+    :keyword error_threshold: The number of record failures for Tabular Dataset
         and file failures for File Dataset that should be ignored during
         processing. If the error count goes above this value, then the job will be aborted. Error
         threshold is for the entire input rather than the individual mini-batch sent to run() method.
         The range is [-1, int.max]. -1 indicates ignore all failures during processing.
     :type error_threshold: int
-    :param mini_batch_error_threshold: The number of mini batch processing failures should be ignored.
+    :keyword mini_batch_error_threshold: The number of mini batch processing failures should be ignored.
     :type mini_batch_error_threshold: int
-    :param task: The parallel task.
+    :keyword task: The parallel task.
     :type task: RunFunction
-    :param mini_batch_size: For FileDataset input, this field is the number of files a user script can process
+    :keyword mini_batch_size: For FileDataset input, this field is the number of files a user script can process
         in one run() call. For TabularDataset input, this field is the approximate size of data the user script
         can process in one run() call. Example values are 1024, 1024KB, 10MB, and 1GB.
         (optional, default value is 10 files for FileDataset and 1MB for TabularDataset.) This value could be set
         through PipelineParameter.
     :type mini_batch_size: str
-    :param partition_keys: The keys used to partition dataset into mini-batches.
+    :keyword partition_keys: The keys used to partition dataset into mini-batches.
         If specified, the data with the same key will be partitioned into the same mini-batch.
         If both partition_keys and mini_batch_size are specified, the partition keys will take effect.
         The input(s) must be partitioned dataset(s),
         and the partition_keys must be a subset of the keys of every input dataset for this to work.
     :type partition_keys: List
-    :param input_data: The input data.
+    :keyword input_data: The input data.
     :type input_data: str
-    :param inputs: a dict of inputs used by this parallel.
+    :keyword inputs: a dict of inputs used by this parallel.
     :type inputs: Dict
-    :param outputs: the outputs of this parallel
+    :keyword outputs: the outputs of this parallel
     :type outputs: Dict
-    :param instance_count: Optional number of instances or nodes used by the compute target. Defaults to 1.
+    :keyword instance_count: Optional number of instances or nodes used by the compute target. Defaults to 1.
     :type instance_count: int
-    :param instance_type: Optional type of VM used as supported by the compute target.
+    :keyword instance_type: Optional type of VM used as supported by the compute target.
     :type instance_type: str
-    :param docker_args: Extra arguments to pass to the Docker run command. This would override any
+    :keyword docker_args: Extra arguments to pass to the Docker run command. This would override any
      parameters that have already been set by the system, or in this section. This parameter is only
      supported for Azure ML compute types.
     :type docker_args: str
-    :param shm_size: Size of the docker container's shared memory block. This should be in the
+    :keyword shm_size: Size of the docker container's shared memory block. This should be in the
      format of (number)(unit) where number as to be greater than 0 and the unit can be one of
      b(bytes), k(kilobytes), m(megabytes), or g(gigabytes).
     :type shm_size: str
-    :param identity: Identity that training job will use while running on compute.
+    :keyword identity: Identity that training job will use while running on compute.
     :type identity: Union[ManagedIdentity, AmlToken]
-    :param is_deterministic: Specify whether the parallel will return same output given same input.
+    :keyword is_deterministic: Specify whether the parallel will return same output given same input.
         If a parallel (component) is deterministic, when use it as a node/step in a pipeline,
         it will reuse results from a previous submitted job in current workspace which has same inputs and settings.
         In this case, this step will not use any compute resource.

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_builders/spark_func.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_builders/spark_func.py
@@ -110,69 +110,69 @@ def spark(
 ) -> Spark:
     """Creates a Spark object which can be used inside a dsl.pipeline function or used as a standalone Spark job.
 
-    :param experiment_name:  The name of the experiment the job will be created under.
+    :keyword experiment_name:  The name of the experiment the job will be created under.
     :type experiment_name: str
-    :param name: The name of the job.
+    :keyword name: The name of the job.
     :type name: str
-    :param display_name: The job display name.
+    :keyword display_name: The job display name.
     :type display_name: str
-    :param description: The description of the job.
+    :keyword description: The description of the job.
     :type description: str
-    :param tags: The dictionary of tags for the job. Tags can be added, removed, and updated.
+    :keyword tags: The dictionary of tags for the job. Tags can be added, removed, and updated.
     :type tags: dict[str, str]
-    :param code: The source code to run the job. Can be a local path or "http:", "https:", or "azureml:" url pointing
+    :keyword code: The source code to run the job. Can be a local path or "http:", "https:", or "azureml:" url pointing
         to a remote location.
     :type code: Union[str, os.PathLike]
-    :param entry: The file or class entry point.
+    :keyword entry: The file or class entry point.
     :type entry: Union[dict[str, str], ~azure.ai.ml.entities.SparkJobEntry]
-    :param py_files: The list of .zip, .egg or .py files to place on the PYTHONPATH for Python apps.
+    :keyword py_files: The list of .zip, .egg or .py files to place on the PYTHONPATH for Python apps.
     :type py_files: list[str]
-    :param jars: The list of .JAR files to include on the driver and executor classpaths.
+    :keyword jars: The list of .JAR files to include on the driver and executor classpaths.
     :type jars: list[str]
-    :param files: The list of files to be placed in the working directory of each executor.
+    :keyword files: The list of files to be placed in the working directory of each executor.
     :type files: list[str]
-    :param archives: The list of archives to be extracted into the working directory of each executor.
+    :keyword archives: The list of archives to be extracted into the working directory of each executor.
     :type archives: list[str]
-    :param identity: The identity that the Spark job will use while running on compute.
+    :keyword identity: The identity that the Spark job will use while running on compute.
     :type identity: Union[
         dict[str, str],
         ~azure.ai.ml.entities.ManagedIdentityConfiguration,
         ~azure.ai.ml.entities.AmlTokenConfiguration,
         ~azure.ai.ml.entities.UserIdentityConfiguration]
-    :param driver_cores: The number of cores to use for the driver process, only in cluster mode.
+    :keyword driver_cores: The number of cores to use for the driver process, only in cluster mode.
     :type driver_cores: int
-    :param driver_memory: The amount of memory to use for the driver process, formatted as strings with a size unit
+    :keyword driver_memory: The amount of memory to use for the driver process, formatted as strings with a size unit
         suffix ("k", "m", "g" or "t") (e.g. "512m", "2g").
     :type driver_memory: str
-    :param executor_cores: The number of cores to use on each executor.
+    :keyword executor_cores: The number of cores to use on each executor.
     :type executor_cores: int
-    :param executor_memory: The amount of memory to use per executor process, formatted as strings with a size unit
+    :keyword executor_memory: The amount of memory to use per executor process, formatted as strings with a size unit
         suffix ("k", "m", "g" or "t") (e.g. "512m", "2g").
     :type executor_memory: str
-    :param executor_instances: The initial number of executors.
+    :keyword executor_instances: The initial number of executors.
     :type executor_instances: int
-    :param dynamic_allocation_enabled: Whether to use dynamic resource allocation, which scales the number of executors
+    :keyword dynamic_allocation_enabled: Whether to use dynamic resource allocation, which scales the number of executors
         registered with this application up and down based on the workload.
     :type dynamic_allocation_enabled: bool
-    :param dynamic_allocation_min_executors: The lower bound for the number of executors if dynamic allocation is
+    :keyword dynamic_allocation_min_executors: The lower bound for the number of executors if dynamic allocation is
         enabled.
     :type dynamic_allocation_min_executors: int
-    :param dynamic_allocation_max_executors: The upper bound for the number of executors if dynamic allocation is
+    :keyword dynamic_allocation_max_executors: The upper bound for the number of executors if dynamic allocation is
         enabled.
     :type dynamic_allocation_max_executors: int
-    :param conf: A dictionary with pre-defined Spark configurations key and values.
+    :keyword conf: A dictionary with pre-defined Spark configurations key and values.
     :type conf: dict[str, str]
-    :param environment: The Azure ML environment to run the job in.
+    :keyword environment: The Azure ML environment to run the job in.
     :type environment: Union[str, ~azure.ai.ml.entities.Environment]
-    :param inputs: A mapping of input names to input data used in the job.
+    :keyword inputs: A mapping of input names to input data used in the job.
     :type inputs: dict[str, ~azure.ai.ml.Input]
-    :param outputs: A mapping of output names to output data used in the job.
+    :keyword outputs: A mapping of output names to output data used in the job.
     :type outputs: dict[str, ~azure.ai.ml.Output]
-    :param args: The arguments for the job.
+    :keyword args: The arguments for the job.
     :type args: str
-    :param compute: The compute resource the job runs on.
+    :keyword compute: The compute resource the job runs on.
     :type compute: str
-    :param resources: The compute resource configuration for the job.
+    :keyword resources: The compute resource configuration for the job.
     :type resources: Union[dict, ~azure.ai.ml.entities.SparkResourceConfiguration]
 
     .. admonition:: Example:

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_component/component_factory.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_component/component_factory.py
@@ -125,11 +125,11 @@ class _ComponentFactory:
     def load_from_dict(cls, *, data: Dict, context: Dict, _type: Optional[str] = None, **kwargs) -> Component:
         """Load a component from a yaml dict.
 
-        :param data: the yaml dict.
+        :keyword data: the yaml dict.
         :type data: Dict
-        :param context: the context of the yaml dict.
+        :keyword context: the context of the yaml dict.
         :type context: Dict
-        :param _type: the type name of the component. When None, it will be inferred from the yaml dict.
+        :keyword _type: the type name of the component. When None, it will be inferred from the yaml dict.
         :type _type: str
         """
 
@@ -144,9 +144,9 @@ class _ComponentFactory:
     def load_from_rest(cls, *, obj: ComponentVersion, _type: Optional[str] = None) -> Component:
         """Load a component from a rest object.
 
-        :param obj: The rest object.
+        :keyword obj: The rest object.
         :type obj: ComponentVersion
-        :param _type: the type name of the component. When None, it will be inferred from the rest object.
+        :keyword _type: the type name of the component. When None, it will be inferred from the rest object.
         :type _type: str
         """
         if _type is not None:

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_inputs_outputs/input.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_inputs_outputs/input.py
@@ -313,7 +313,7 @@ class Input(_InputOutputBase):  # pylint: disable=too-many-instance-attributes
     def _parse_and_validate(self, val):
         """Parse the val passed from the command line and validate the value.
 
-        :param str_val: The input string value from the command line.
+        :param val: The input string value from the command line.
         :return: The parsed value, an exception will be raised if the value is invalid.
         """
         if self._is_primitive_type:

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/_input_output_helpers.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/_input_output_helpers.py
@@ -183,7 +183,7 @@ def to_rest_dataset_literal_inputs(
     :type inputs: Dict[str, Union[int, str, float, bool, JobInput]]
     :return: A dictionary mapping input name to a ComponentJobInput or PipelineInput
     :rtype: Dict[str, Union[ComponentJobInput, PipelineInput]]
-    :param job_type: When job_type is pipeline, enable dot('.') in parameter keys to support parameter group.
+    :keyword job_type: When job_type is pipeline, enable dot('.') in parameter keys to support parameter group.
         TODO: Remove this after move name validation to Job's customized validate.
     :type job_type: str
     """

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/automl/image/automl_image.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/automl/image/automl_image.py
@@ -111,7 +111,7 @@ class AutoMLImage(AutoMLVertical, ABC):
     ) -> None:
         """Limit settings for all AutoML Image Verticals.
 
-        :param timeout_minutes: AutoML job timeout.
+        :keyword timeout_minutes: AutoML job timeout.
         :type timeout_minutes: ~datetime.timedelta
         """
         self._limits = self._limits or ImageLimitSettings()
@@ -131,12 +131,12 @@ class AutoMLImage(AutoMLVertical, ABC):
     ) -> None:
         """Sweep settings for all AutoML Image Verticals.
 
-        :param sampling_algorithm: Required. [Required] Type of the hyperparameter sampling
+        :keyword sampling_algorithm: Required. [Required] Type of the hyperparameter sampling
          algorithms. Possible values include: "Grid", "Random", "Bayesian".
         :type sampling_algorithm: Union[str, ~azure.mgmt.machinelearningservices.models.SamplingAlgorithmType.RANDOM,
         ~azure.mgmt.machinelearningservices.models.SamplingAlgorithmType.GRID,
         ~azure.mgmt.machinelearningservices.models.SamplingAlgorithmType.BAYESIAN]
-        :param early_termination: Type of early termination policy.
+        :keyword early_termination: Type of early termination policy.
         :type early_termination: Union[
         ~azure.mgmt.machinelearningservices.models.BanditPolicy,
         ~azure.mgmt.machinelearningservices.models.MedianStoppingPolicy,

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/automl/image/automl_image_classification_base.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/automl/image/automl_image_classification_base.py
@@ -132,103 +132,103 @@ class AutoMLImageClassificationBase(AutoMLImage):
     ) -> None:
         """Setting Image training parameters for AutoML Image Classification and Image Classification Multilabel tasks.
 
-        :param advanced_settings: Settings for advanced scenarios.
+        :keyword advanced_settings: Settings for advanced scenarios.
         :type advanced_settings: str
-        :param ams_gradient: Enable AMSGrad when optimizer is 'adam' or 'adamw'.
+        :keyword ams_gradient: Enable AMSGrad when optimizer is 'adam' or 'adamw'.
         :type ams_gradient: bool
-        :param beta1: Value of 'beta1' when optimizer is 'adam' or 'adamw'. Must be a float in the
+        :keyword beta1: Value of 'beta1' when optimizer is 'adam' or 'adamw'. Must be a float in the
          range [0, 1].
         :type beta1: float
-        :param beta2: Value of 'beta2' when optimizer is 'adam' or 'adamw'. Must be a float in the
+        :keyword beta2: Value of 'beta2' when optimizer is 'adam' or 'adamw'. Must be a float in the
          range [0, 1].
         :type beta2: float
-        :param checkpoint_frequency: Frequency to store model checkpoints. Must be a positive
+        :keyword checkpoint_frequency: Frequency to store model checkpoints. Must be a positive
          integer.
         :type checkpoint_frequency: int
-        :param checkpoint_run_id: The id of a previous run that has a pretrained checkpoint for
+        :keyword checkpoint_run_id: The id of a previous run that has a pretrained checkpoint for
          incremental training.
         :type checkpoint_run_id: str
-        :param distributed: Whether to use distributed training.
+        :keyword distributed: Whether to use distributed training.
         :type distributed: bool
-        :param early_stopping: Enable early stopping logic during training.
+        :keyword early_stopping: Enable early stopping logic during training.
         :type early_stopping: bool
-        :param early_stopping_delay: Minimum number of epochs or validation evaluations to wait
+        :keyword early_stopping_delay: Minimum number of epochs or validation evaluations to wait
          before primary metric improvement
          is tracked for early stopping. Must be a positive integer.
         :type early_stopping_delay: int
-        :param early_stopping_patience: Minimum number of epochs or validation evaluations with no
+        :keyword early_stopping_patience: Minimum number of epochs or validation evaluations with no
          primary metric improvement before
          the run is stopped. Must be a positive integer.
         :type early_stopping_patience: int
-        :param enable_onnx_normalization: Enable normalization when exporting ONNX model.
+        :keyword enable_onnx_normalization: Enable normalization when exporting ONNX model.
         :type enable_onnx_normalization: bool
-        :param evaluation_frequency: Frequency to evaluate validation dataset to get metric scores.
+        :keyword evaluation_frequency: Frequency to evaluate validation dataset to get metric scores.
          Must be a positive integer.
         :type evaluation_frequency: int
-        :param gradient_accumulation_step: Gradient accumulation means running a configured number of
+        :keyword gradient_accumulation_step: Gradient accumulation means running a configured number of
          "GradAccumulationStep" steps without
          updating the model weights while accumulating the gradients of those steps, and then using
          the accumulated gradients to compute the weight updates. Must be a positive integer.
         :type gradient_accumulation_step: int
-        :param layers_to_freeze: Number of layers to freeze for the model. Must be a positive
+        :keyword layers_to_freeze: Number of layers to freeze for the model. Must be a positive
          integer.
          For instance, passing 2 as value for 'seresnext' means
          freezing layer0 and layer1. For a full list of models supported and details on layer freeze,
          please
          see: https://docs.microsoft.com/en-us/azure/machine-learning/reference-automl-images-hyperparameters#model-agnostic-hyperparameters.   # pylint: disable=line-too-long
         :type layers_to_freeze: int
-        :param learning_rate: Initial learning rate. Must be a float in the range [0, 1].
+        :keyword learning_rate: Initial learning rate. Must be a float in the range [0, 1].
         :type learning_rate: float
-        :param learning_rate_scheduler: Type of learning rate scheduler. Must be 'warmup_cosine' or
+        :keyword learning_rate_scheduler: Type of learning rate scheduler. Must be 'warmup_cosine' or
          'step'. Possible values include: "None", "WarmupCosine", "Step".
         :type learning_rate_scheduler: str or
          ~azure.mgmt.machinelearningservices.models.LearningRateScheduler
-        :param model_name: Name of the model to use for training.
+        :keyword model_name: Name of the model to use for training.
          For more information on the available models please visit the official documentation:
          https://docs.microsoft.com/en-us/azure/machine-learning/how-to-auto-train-image-models.
         :type model_name: str
-        :param momentum: Value of momentum when optimizer is 'sgd'. Must be a float in the range [0,
+        :keyword momentum: Value of momentum when optimizer is 'sgd'. Must be a float in the range [0,
          1].
         :type momentum: float
-        :param nesterov: Enable nesterov when optimizer is 'sgd'.
+        :keyword nesterov: Enable nesterov when optimizer is 'sgd'.
         :type nesterov: bool
-        :param number_of_epochs: Number of training epochs. Must be a positive integer.
+        :keyword number_of_epochs: Number of training epochs. Must be a positive integer.
         :type number_of_epochs: int
-        :param number_of_workers: Number of data loader workers. Must be a non-negative integer.
+        :keyword number_of_workers: Number of data loader workers. Must be a non-negative integer.
         :type number_of_workers: int
-        :param optimizer: Type of optimizer. Possible values include: "None", "Sgd", "Adam", "Adamw".
+        :keyword optimizer: Type of optimizer. Possible values include: "None", "Sgd", "Adam", "Adamw".
         :type optimizer: str or ~azure.mgmt.machinelearningservices.models.StochasticOptimizer
-        :param random_seed: Random seed to be used when using deterministic training.
+        :keyword random_seed: Random seed to be used when using deterministic training.
         :type random_seed: int
-        :param step_lr_gamma: Value of gamma when learning rate scheduler is 'step'. Must be a float
+        :keyword step_lr_gamma: Value of gamma when learning rate scheduler is 'step'. Must be a float
          in the range [0, 1].
         :type step_lr_gamma: float
-        :param step_lr_step_size: Value of step size when learning rate scheduler is 'step'. Must be
+        :keyword step_lr_step_size: Value of step size when learning rate scheduler is 'step'. Must be
          a positive integer.
         :type step_lr_step_size: int
-        :param training_batch_size: Training batch size. Must be a positive integer.
+        :keyword training_batch_size: Training batch size. Must be a positive integer.
         :type training_batch_size: int
-        :param validation_batch_size: Validation batch size. Must be a positive integer.
+        :keyword validation_batch_size: Validation batch size. Must be a positive integer.
         :type validation_batch_size: int
-        :param warmup_cosine_lr_cycles: Value of cosine cycle when learning rate scheduler is
+        :keyword warmup_cosine_lr_cycles: Value of cosine cycle when learning rate scheduler is
          'warmup_cosine'. Must be a float in the range [0, 1].
         :type warmup_cosine_lr_cycles: float
-        :param warmup_cosine_lr_warmup_epochs: Value of warmup epochs when learning rate scheduler is
+        :keyword warmup_cosine_lr_warmup_epochs: Value of warmup epochs when learning rate scheduler is
          'warmup_cosine'. Must be a positive integer.
         :type warmup_cosine_lr_warmup_epochs: int
-        :param weight_decay: Value of weight decay when optimizer is 'sgd', 'adam', or 'adamw'. Must
+        :keyword weight_decay: Value of weight decay when optimizer is 'sgd', 'adam', or 'adamw'. Must
          be a float in the range[0, 1].
         :type weight_decay: float
-        :param training_crop_size: Image crop size that is input to the neural network for the
+        :keyword training_crop_size: Image crop size that is input to the neural network for the
          training dataset. Must be a positive integer.
         :type training_crop_size: int
-        :param validation_crop_size: Image crop size that is input to the neural network for the
+        :keyword validation_crop_size: Image crop size that is input to the neural network for the
          validation dataset. Must be a positive integer.
         :type validation_crop_size: int
-        :param validation_resize_size: Image size to which to resize before cropping for validation
+        :keyword validation_resize_size: Image size to which to resize before cropping for validation
          dataset. Must be a positive integer.
         :type validation_resize_size: int
-        :param weighted_loss: Weighted loss. The accepted values are 0 for no weighted loss.
+        :keyword weighted_loss: Weighted loss. The accepted values are 0 for no weighted loss.
          1 for weighted loss with sqrt.(class_weights). 2 for weighted loss with class_weights. Must be
          0 or 1 or 2.
         :type weighted_loss: int

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/automl/image/automl_image_object_detection_base.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/automl/image/automl_image_object_detection_base.py
@@ -152,140 +152,140 @@ class AutoMLImageObjectDetectionBase(AutoMLImage):
         """Setting Image training parameters for for AutoML Image Object Detection and Image Instance Segmentation
         tasks.
 
-        :param advanced_settings: Settings for advanced scenarios.
+        :keyword advanced_settings: Settings for advanced scenarios.
         :type advanced_settings: str
-        :param ams_gradient: Enable AMSGrad when optimizer is 'adam' or 'adamw'.
+        :keyword ams_gradient: Enable AMSGrad when optimizer is 'adam' or 'adamw'.
         :type ams_gradient: bool
-        :param beta1: Value of 'beta1' when optimizer is 'adam' or 'adamw'. Must be a float in the
+        :keyword beta1: Value of 'beta1' when optimizer is 'adam' or 'adamw'. Must be a float in the
          range [0, 1].
         :type beta1: float
-        :param beta2: Value of 'beta2' when optimizer is 'adam' or 'adamw'. Must be a float in the
+        :keyword beta2: Value of 'beta2' when optimizer is 'adam' or 'adamw'. Must be a float in the
          range [0, 1].
         :type beta2: float
-        :param checkpoint_frequency: Frequency to store model checkpoints. Must be a positive
+        :keyword checkpoint_frequency: Frequency to store model checkpoints. Must be a positive
          integer.
         :type checkpoint_frequency: int
-        :param checkpoint_run_id: The id of a previous run that has a pretrained checkpoint for
+        :keyword checkpoint_run_id: The id of a previous run that has a pretrained checkpoint for
          incremental training.
         :type checkpoint_run_id: str
-        :param distributed: Whether to use distributed training.
+        :keyword distributed: Whether to use distributed training.
         :type distributed: bool
-        :param early_stopping: Enable early stopping logic during training.
+        :keyword early_stopping: Enable early stopping logic during training.
         :type early_stopping: bool
-        :param early_stopping_delay: Minimum number of epochs or validation evaluations to wait
+        :keyword early_stopping_delay: Minimum number of epochs or validation evaluations to wait
          before primary metric improvement
          is tracked for early stopping. Must be a positive integer.
         :type early_stopping_delay: int
-        :param early_stopping_patience: Minimum number of epochs or validation evaluations with no
+        :keyword early_stopping_patience: Minimum number of epochs or validation evaluations with no
          primary metric improvement before
          the run is stopped. Must be a positive integer.
         :type early_stopping_patience: int
-        :param enable_onnx_normalization: Enable normalization when exporting ONNX model.
+        :keyword enable_onnx_normalization: Enable normalization when exporting ONNX model.
         :type enable_onnx_normalization: bool
-        :param evaluation_frequency: Frequency to evaluate validation dataset to get metric scores.
+        :keyword evaluation_frequency: Frequency to evaluate validation dataset to get metric scores.
          Must be a positive integer.
         :type evaluation_frequency: int
-        :param gradient_accumulation_step: Gradient accumulation means running a configured number of
+        :keyword gradient_accumulation_step: Gradient accumulation means running a configured number of
          "GradAccumulationStep" steps without
          updating the model weights while accumulating the gradients of those steps, and then using
          the accumulated gradients to compute the weight updates. Must be a positive integer.
         :type gradient_accumulation_step: int
-        :param layers_to_freeze: Number of layers to freeze for the model. Must be a positive
+        :keyword layers_to_freeze: Number of layers to freeze for the model. Must be a positive
          integer.
          For instance, passing 2 as value for 'seresnext' means
          freezing layer0 and layer1. For a full list of models supported and details on layer freeze,
          please
          see: https://docs.microsoft.com/en-us/azure/machine-learning/reference-automl-images-hyperparameters#model-agnostic-hyperparameters.   # pylint: disable=line-too-long
         :type layers_to_freeze: int
-        :param learning_rate: Initial learning rate. Must be a float in the range [0, 1].
+        :keyword learning_rate: Initial learning rate. Must be a float in the range [0, 1].
         :type learning_rate: float
-        :param learning_rate_scheduler: Type of learning rate scheduler. Must be 'warmup_cosine' or
+        :keyword learning_rate_scheduler: Type of learning rate scheduler. Must be 'warmup_cosine' or
          'step'. Possible values include: "None", "WarmupCosine", "Step".
         :type learning_rate_scheduler: str or
          ~azure.mgmt.machinelearningservices.models.LearningRateScheduler
-        :param model_name: Name of the model to use for training.
+        :keyword model_name: Name of the model to use for training.
          For more information on the available models please visit the official documentation:
          https://docs.microsoft.com/en-us/azure/machine-learning/how-to-auto-train-image-models.
         :type model_name: str
-        :param momentum: Value of momentum when optimizer is 'sgd'. Must be a float in the range [0,
+        :keyword momentum: Value of momentum when optimizer is 'sgd'. Must be a float in the range [0,
          1].
         :type momentum: float
-        :param nesterov: Enable nesterov when optimizer is 'sgd'.
+        :keyword nesterov: Enable nesterov when optimizer is 'sgd'.
         :type nesterov: bool
-        :param number_of_epochs: Number of training epochs. Must be a positive integer.
+        :keyword number_of_epochs: Number of training epochs. Must be a positive integer.
         :type number_of_epochs: int
-        :param number_of_workers: Number of data loader workers. Must be a non-negative integer.
+        :keyword number_of_workers: Number of data loader workers. Must be a non-negative integer.
         :type number_of_workers: int
-        :param optimizer: Type of optimizer. Possible values include: "None", "Sgd", "Adam", "Adamw".
+        :keyword optimizer: Type of optimizer. Possible values include: "None", "Sgd", "Adam", "Adamw".
         :type optimizer: str or ~azure.mgmt.machinelearningservices.models.StochasticOptimizer
-        :param random_seed: Random seed to be used when using deterministic training.
+        :keyword random_seed: Random seed to be used when using deterministic training.
         :type random_seed: int
-        :param step_lr_gamma: Value of gamma when learning rate scheduler is 'step'. Must be a float
+        :keyword step_lr_gamma: Value of gamma when learning rate scheduler is 'step'. Must be a float
          in the range [0, 1].
         :type step_lr_gamma: float
-        :param step_lr_step_size: Value of step size when learning rate scheduler is 'step'. Must be
+        :keyword step_lr_step_size: Value of step size when learning rate scheduler is 'step'. Must be
          a positive integer.
         :type step_lr_step_size: int
-        :param training_batch_size: Training batch size. Must be a positive integer.
+        :keyword training_batch_size: Training batch size. Must be a positive integer.
         :type training_batch_size: int
-        :param validation_batch_size: Validation batch size. Must be a positive integer.
+        :keyword validation_batch_size: Validation batch size. Must be a positive integer.
         :type validation_batch_size: int
-        :param warmup_cosine_lr_cycles: Value of cosine cycle when learning rate scheduler is
+        :keyword warmup_cosine_lr_cycles: Value of cosine cycle when learning rate scheduler is
          'warmup_cosine'. Must be a float in the range [0, 1].
         :type warmup_cosine_lr_cycles: float
-        :param warmup_cosine_lr_warmup_epochs: Value of warmup epochs when learning rate scheduler is
+        :keyword warmup_cosine_lr_warmup_epochs: Value of warmup epochs when learning rate scheduler is
          'warmup_cosine'. Must be a positive integer.
         :type warmup_cosine_lr_warmup_epochs: int
-        :param weight_decay: Value of weight decay when optimizer is 'sgd', 'adam', or 'adamw'. Must
+        :keyword weight_decay: Value of weight decay when optimizer is 'sgd', 'adam', or 'adamw'. Must
          be a float in the range[0, 1].
         :type weight_decay: float
-        :param box_detections_per_image: Maximum number of detections per image, for all classes.
+        :keyword box_detections_per_image: Maximum number of detections per image, for all classes.
          Must be a positive integer.
          Note: This settings is not supported for the 'yolov5' algorithm.
         :type box_detections_per_image: int
-        :param box_score_threshold: During inference, only return proposals with a classification
+        :keyword box_score_threshold: During inference, only return proposals with a classification
          score greater than
          BoxScoreThreshold. Must be a float in the range[0, 1].
         :type box_score_threshold: float
-        :param image_size: Image size for training and validation. Must be a positive integer.
+        :keyword image_size: Image size for training and validation. Must be a positive integer.
          Note: The training run may get into CUDA OOM if the size is too big.
          Note: This settings is only supported for the 'yolov5' algorithm.
         :type image_size: int
-        :param max_size: Maximum size of the image to be rescaled before feeding it to the backbone.
+        :keyword max_size: Maximum size of the image to be rescaled before feeding it to the backbone.
          Must be a positive integer. Note: training run may get into CUDA OOM if the size is too big.
          Note: This settings is not supported for the 'yolov5' algorithm.
         :type max_size: int
-        :param min_size: Minimum size of the image to be rescaled before feeding it to the backbone.
+        :keyword min_size: Minimum size of the image to be rescaled before feeding it to the backbone.
          Must be a positive integer. Note: training run may get into CUDA OOM if the size is too big.
          Note: This settings is not supported for the 'yolov5' algorithm.
         :type min_size: int
-        :param model_size: Model size. Must be 'small', 'medium', 'large', or 'extra_large'.
+        :keyword model_size: Model size. Must be 'small', 'medium', 'large', or 'extra_large'.
          Note: training run may get into CUDA OOM if the model size is too big.
          Note: This settings is only supported for the 'yolov5' algorithm.
         :type model_size: str or ~azure.mgmt.machinelearningservices.models.ModelSize
-        :param multi_scale: Enable multi-scale image by varying image size by +/- 50%.
+        :keyword multi_scale: Enable multi-scale image by varying image size by +/- 50%.
          Note: training run may get into CUDA OOM if no sufficient GPU memory.
          Note: This settings is only supported for the 'yolov5' algorithm.
         :type multi_scale: bool
-        :param nms_iou_threshold: IOU threshold used during inference in NMS post processing. Must be
+        :keyword nms_iou_threshold: IOU threshold used during inference in NMS post processing. Must be
          float in the range [0, 1].
         :type nms_iou_threshold: float
-        :param tile_grid_size: The grid size to use for tiling each image. Note: TileGridSize must
+        :keyword tile_grid_size: The grid size to use for tiling each image. Note: TileGridSize must
          not be
          None to enable small object detection logic. A string containing two integers in mxn format.
         :type tile_grid_size: str
-        :param tile_overlap_ratio: Overlap ratio between adjacent tiles in each dimension. Must be
+        :keyword tile_overlap_ratio: Overlap ratio between adjacent tiles in each dimension. Must be
          float in the range [0, 1).
         :type tile_overlap_ratio: float
-        :param tile_predictions_nms_threshold: The IOU threshold to use to perform NMS while merging
+        :keyword tile_predictions_nms_threshold: The IOU threshold to use to perform NMS while merging
          predictions from tiles and image.
          Used in validation/ inference. Must be float in the range [0, 1].
          NMS: Non-maximum suppression.
         :type tile_predictions_nms_threshold: str
-        :param validation_iou_threshold: IOU threshold to use when computing validation metric. Must
+        :keyword validation_iou_threshold: IOU threshold to use when computing validation metric. Must
          be float in the range [0, 1].
         :type validation_iou_threshold: float
-        :param validation_metric_type: Metric computation method to use for validation metrics. Must
+        :keyword validation_metric_type: Metric computation method to use for validation metrics. Must
          be 'none', 'coco', 'voc', or 'coco_voc'.
         :type validation_metric_type: str or ~azure.mgmt.machinelearningservices.models.ValidationMetricType
         """

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/automl/nlp/automl_nlp_job.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/automl/nlp/automl_nlp_job.py
@@ -209,9 +209,9 @@ class AutoMLNLPJob(AutoMLVertical, ABC):
     ):
         """Sweep settings for all AutoML NLP tasks.
 
-        :param sampling_algorithm: Required. Specifies type of hyperparameter sampling algorithm.
+        :keyword sampling_algorithm: Required. Specifies type of hyperparameter sampling algorithm.
         Possible values include: "Grid", "Random", and "Bayesian".
-        :param early_termination: Optional early termination policy to end poorly performing training candidates.
+        :keyword early_termination: Optional early termination policy to end poorly performing training candidates.
         :return: None.
         """
         if self._sweep:
@@ -236,21 +236,21 @@ class AutoMLNLPJob(AutoMLVertical, ABC):
     ) -> None:
         """Fix certain training parameters throughout the training procedure for all candidates.
 
-        :param gradient_accumulation_steps: number of steps over which to accumulate gradients before a backward
+        :keyword gradient_accumulation_steps: number of steps over which to accumulate gradients before a backward
         pass. This must be a positive integer.
-        :param learning_rate: initial learning rate. Must be a float in (0, 1).
-        :param learning_rate_scheduler: the type of learning rate scheduler. Must choose from 'linear', 'cosine',
+        :keyword learning_rate: initial learning rate. Must be a float in (0, 1).
+        :keyword learning_rate_scheduler: the type of learning rate scheduler. Must choose from 'linear', 'cosine',
         'cosine_with_restarts', 'polynomial', 'constant', and 'constant_with_warmup'.
-        :param model_name: the model name to use during training. Must choose from 'bert-base-cased',
+        :keyword model_name: the model name to use during training. Must choose from 'bert-base-cased',
         'bert-base-uncased', 'bert-base-multilingual-cased', 'bert-base-german-cased', 'bert-large-cased',
         'bert-large-uncased', 'distilbert-base-cased', 'distilbert-base-uncased', 'roberta-base', 'roberta-large',
         'distilroberta-base', 'xlm-roberta-base', 'xlm-roberta-large', xlnet-base-cased', and 'xlnet-large-cased'.
-        :param number_of_epochs: the number of epochs to train with. Must be a positive integer.
-        :param training_batch_size: the batch size during training. Must be a positive integer.
-        :param validation_batch_size: the batch size during validation. Must be a positive integer.
-        :param warmup_ratio: ratio of total training steps used for a linear warmup from 0 to learning_rate.
+        :keyword number_of_epochs: the number of epochs to train with. Must be a positive integer.
+        :keyword training_batch_size: the batch size during training. Must be a positive integer.
+        :keyword validation_batch_size: the batch size during validation. Must be a positive integer.
+        :keyword warmup_ratio: ratio of total training steps used for a linear warmup from 0 to learning_rate.
         Must be a float in [0, 1].
-        :param weight_decay: value of weight decay when optimizer is sgd, adam, or adamw. This must be a float in
+        :keyword weight_decay: value of weight decay when optimizer is sgd, adam, or adamw. This must be a float in
         the range [0, 1].
         :return: None.
         """

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/automl/tabular/forecasting_job.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/automl/tabular/forecasting_job.py
@@ -103,11 +103,11 @@ class ForecastingJob(AutoMLTabular):
     ) -> None:
         """Manage parameters used by forecasting tasks.
 
-        :param time_column_name:
+        :keyword time_column_name:
             The name of the time column. This parameter is required when forecasting to specify the datetime
             column in the input data used for building the time series and inferring its frequency.
         :type time_column_name: str
-        :param forecast_horizon:
+        :keyword forecast_horizon:
             The desired maximum forecast horizon in units of time-series frequency. The default value is 1.
 
             Units are based on the time interval of your training data, e.g., monthly, weekly that the forecaster
@@ -115,13 +115,13 @@ class ForecastingJob(AutoMLTabular):
             setting forecasting parameters, see `Auto-train a time-series forecast model <https://docs.microsoft.com/
             azure/machine-learning/how-to-auto-train-forecast>`_.
         :type forecast_horizon: int or str
-        :param time_series_id_column_names:
+        :keyword time_series_id_column_names:
             The names of columns used to group a timeseries.
             It can be used to create multiple series. If time series id column names is not defined or
             the identifier columns specified do not identify all the series in the dataset, the time series identifiers
             will be automatically created for your dataset.
         :type time_series_id_column_names: str or list(str)
-        :param target_lags:
+        :keyword target_lags:
             The number of past periods to lag from the target column. By default the lags are turned off.
 
             When forecasting, this parameter represents the number of rows to lag the target values based
@@ -153,9 +153,9 @@ class ForecastingJob(AutoMLTabular):
                auto correlation will designate the lag. If first significant element (value correlate with
                itself) is followed by insignificant, the lag will be 0 and we will not use look back features.
         :type target_lags: int, str, or list(int)
-        :param feature_lags: Flag for generating lags for the numeric features with 'auto' or None.
+        :keyword feature_lags: Flag for generating lags for the numeric features with 'auto' or None.
         :type feature_lags: str or None
-        :param target_rolling_window_size:
+        :keyword target_rolling_window_size:
             The number of past periods used to create a rolling window average of the target column.
 
             When forecasting, this parameter represents `n` historical periods to use to generate forecasted values,
@@ -164,18 +164,18 @@ class ForecastingJob(AutoMLTabular):
             If set to 'auto', rolling window will be estimated as the last
             value where the PACF is more then the significance threshold. Please see target_lags section for details.
         :type target_rolling_window_size: int, str or None
-        :param country_or_region_for_holidays: The country/region used to generate holiday features.
+        :keyword country_or_region_for_holidays: The country/region used to generate holiday features.
             These should be ISO 3166 two-letter country/region codes, for example 'US' or 'GB'.
         :type country_or_region_for_holidays: str or None
-        :param use_stl: Configure STL Decomposition of the time-series target column.
+        :keyword use_stl: Configure STL Decomposition of the time-series target column.
                     use_stl can take three values: None (default) - no stl decomposition, 'season' - only generate
                     season component and season_trend - generate both season and trend components.
         :type use_stl: str or None
-        :param seasonality: Set time series seasonality as an integer multiple of the series frequency.
+        :keyword seasonality: Set time series seasonality as an integer multiple of the series frequency.
                     If seasonality is set to 'auto', it will be inferred.
                     If set to None, the time series is assumed non-seasonal which is equivalent to seasonality=1.
         :type seasonality: int, str or None
-        :param short_series_handling_config:
+        :keyword short_series_handling_config:
             The parameter defining how if AutoML should handle short time series.
 
             Possible values: 'auto' (default), 'pad', 'drop' and None.
@@ -237,7 +237,7 @@ class ForecastingJob(AutoMLTabular):
             +-----------+------------------------+--------------------+----------------------------------+
 
         :type short_series_handling_config: str or None
-        :param frequency: Forecast frequency.
+        :keyword frequency: Forecast frequency.
 
             When forecasting, this parameter represents the period with which the forecast is desired,
             for example daily, weekly, yearly, etc. The forecast frequency is dataset frequency by default.
@@ -248,7 +248,7 @@ class ForecastingJob(AutoMLTabular):
             Please refer to pandas documentation for more information:
             https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#dateoffset-objects
         :type frequency: str or None
-        :param target_aggregate_function: The function to be used to aggregate the time series target
+        :keyword target_aggregate_function: The function to be used to aggregate the time series target
                                             column to conform to a user specified frequency. If the
                                             target_aggregation_function is set, but the freq parameter
                                             is not set, the error is raised. The possible target
@@ -283,7 +283,7 @@ class ForecastingJob(AutoMLTabular):
                 +----------------+-----------------------------+---------------------------------------------+
 
         :type target_aggregate_function: str or None
-        :param cv_step_size:
+        :keyword cv_step_size:
             Number of periods between the origin_time of one CV fold and the next fold. For
             example, if `n_step` = 3 for daily data, the origin time for each fold will be
             three days apart.

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/command_job.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/command_job.py
@@ -241,7 +241,7 @@ class CommandJob(Job, ParameterizedCommand, JobIOMixin):
         """Translate a command job to component.
 
         :param context: Context of command job YAML file.
-        :param kwargs: Extra arguments.
+        :keyword kwargs: Extra arguments.
         :return: Translated command component.
         """
         from azure.ai.ml.entities import CommandComponent
@@ -268,7 +268,7 @@ class CommandJob(Job, ParameterizedCommand, JobIOMixin):
         """Translate a command job to a pipeline node.
 
         :param context: Context of command job YAML file.
-        :param kwargs: Extra arguments.
+        :keyword kwargs: Extra arguments.
         :return: Translated command component.
         """
         from azure.ai.ml.entities._builders import Command

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/data_transfer/data_transfer_job.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/data_transfer/data_transfer_job.py
@@ -65,7 +65,7 @@ class DataTransferJob(Job, JobIOMixin):
     :type task: str
     :param data_copy_mode: data copy mode in copy task, possible value is "merge_with_overwrite", "fail_if_conflict".
     :type data_copy_mode: str
-    :param kwargs: A dictionary of additional configuration parameters.
+    :keyword kwargs: A dictionary of additional configuration parameters.
     :type kwargs: dict
     """
 
@@ -179,7 +179,7 @@ class DataTransferCopyJob(DataTransferJob):
         """Translate a data transfer copy job to component.
 
         :param context: Context of data transfer job YAML file.
-        :param kwargs: Extra arguments.
+        :keyword kwargs: Extra arguments.
         :return: Translated data transfer copy component.
         """
         from azure.ai.ml.entities._component.datatransfer_component import (
@@ -204,7 +204,7 @@ class DataTransferCopyJob(DataTransferJob):
         """Translate a data transfer copy job to a pipeline node.
 
         :param context: Context of data transfer job YAML file.
-        :param kwargs: Extra arguments.
+        :keyword kwargs: Extra arguments.
         :return: Translated data transfer component.
         """
         from azure.ai.ml.entities._builders import DataTransferCopy
@@ -249,7 +249,7 @@ class DataTransferImportJob(DataTransferJob):
         """Translate a data transfer import job to component.
 
         :param context: Context of data transfer job YAML file.
-        :param kwargs: Extra arguments.
+        :keyword kwargs: Extra arguments.
         :return: Translated data transfer import component.
         """
 
@@ -264,7 +264,7 @@ class DataTransferImportJob(DataTransferJob):
         """Translate a data transfer import job to a pipeline node.
 
         :param context: Context of data transfer job YAML file.
-        :param kwargs: Extra arguments.
+        :keyword kwargs: Extra arguments.
         :return: Translated data transfer import node.
         """
         from azure.ai.ml.entities._builders import DataTransferImport
@@ -309,7 +309,7 @@ class DataTransferExportJob(DataTransferJob):
         """Translate a data transfer export job to component.
 
         :param context: Context of data transfer job YAML file.
-        :param kwargs: Extra arguments.
+        :keyword kwargs: Extra arguments.
         :return: Translated data transfer export component.
         """
         if self.sink.type == ExternalDataType.DATABASE:
@@ -328,7 +328,7 @@ class DataTransferExportJob(DataTransferJob):
         """Translate a data transfer export job to a pipeline node.
 
         :param context: Context of data transfer job YAML file.
-        :param kwargs: Extra arguments.
+        :keyword kwargs: Extra arguments.
         :return: Translated data transfer export node.
         """
         from azure.ai.ml.entities._builders import DataTransferExport

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/import_job.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/import_job.py
@@ -214,7 +214,7 @@ class ImportJob(Job, JobIOMixin):
         """Translate a import job to component.
 
         :param context: Context of import job YAML file.
-        :param kwargs: Extra arguments.
+        :keyword kwargs: Extra arguments.
         :return: Translated import component.
         """
         from azure.ai.ml.entities._component.import_component import ImportComponent
@@ -238,7 +238,7 @@ class ImportJob(Job, JobIOMixin):
         """Translate a import job to a pipeline node.
 
         :param context: Context of import job YAML file.
-        :param kwargs: Extra arguments.
+        :keyword kwargs: Extra arguments.
         :return: Translated import node.
         """
         from azure.ai.ml.entities._builders import Import

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/job.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/job.py
@@ -252,7 +252,7 @@ class Job(Resource, ComponentTranslatableMixin, TelemetryMixin):
         :param params_override: Fields to overwrite on top of the yaml file.
             Format is [{"field1": "value1"}, {"field2": "value2"}], defaults to None
         :type params_override: List[Dict], optional
-        :param kwargs: A dictionary of additional configuration parameters.
+        :keyword kwargs: A dictionary of additional configuration parameters.
         :type kwargs: dict
         :raises Exception: An exception
         :return: Loaded job object.

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/parallel/parallel_job.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/parallel/parallel_job.py
@@ -97,7 +97,7 @@ class ParallelJob(Job, ParameterizedParallel, JobIOMixin):
         """Translate a parallel job to component job.
 
         :param context: Context of parallel job YAML file.
-        :param kwargs: Extra arguments.
+        :keyword kwargs: Extra arguments.
         :return: Translated parallel component.
         """
         from azure.ai.ml.entities._component.parallel_component import ParallelComponent
@@ -126,7 +126,7 @@ class ParallelJob(Job, ParameterizedParallel, JobIOMixin):
         """Translate a parallel job to a pipeline node.
 
         :param context: Context of parallel job YAML file.
-        :param kwargs: Extra arguments.
+        :keyword kwargs: Extra arguments.
         :return: Translated parallel component.
         """
         from azure.ai.ml.entities._builders import Parallel

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/pipeline/_component_translatable.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/pipeline/_component_translatable.py
@@ -345,7 +345,7 @@ class ComponentTranslatableMixin:
     def _to_node(self, context: Optional[Dict] = None, **kwargs) -> "BaseNode":
         """Translate to pipeline node.
 
-        :param kwargs:
+        :keyword kwargs:
         :return: Translated node.
         """
         # Note: Source of translated component should be same with Job

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/pipeline/_io/mixin.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/pipeline/_io/mixin.py
@@ -415,7 +415,6 @@ class PipelineJobIOMixin(NodeWithGroupInputMixin):
         """Build an output object for pipeline and copy settings from source output.
 
         :param name: Output name.
-        :param meta: Output metadata.
         :param data: Output data.
         :return: Built output object.
         """

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/pipeline/_io/mixin.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/pipeline/_io/mixin.py
@@ -93,7 +93,7 @@ class NodeIOMixin:
         accessing attribute, eg: node1.inputs.xxx.
 
         :param inputs: Provided kwargs when parameterizing component func.
-        :param input_definition_dict: Static input definition dict. If not provided, will build inputs without meta.
+        :keyword input_definition_dict: Static input definition dict. If not provided, will build inputs without meta.
         :return: Built dynamic input attribute dict.
         """
         if input_definition_dict is not None:
@@ -360,7 +360,7 @@ class NodeWithGroupInputMixin(NodeIOMixin):
         """Build an input attribute dict so user can get/set inputs by
         accessing attribute, eg: node1.inputs.xxx.
 
-        :param input_definition_dict: Input definition dict from component entity.
+        :keyword input_definition_dict: Input definition dict from component entity.
         :param inputs: Provided kwargs when parameterizing component func.
         :return: Built input attribute dict.
         """
@@ -401,7 +401,7 @@ class PipelineJobIOMixin(NodeWithGroupInputMixin):
         """Build an input attribute dict so user can get/set inputs by
         accessing attribute, eg: node1.inputs.xxx.
 
-        :param input_definition_dict: Input definition dict from component entity.
+        :keyword input_definition_dict: Input definition dict from component entity.
         :param inputs: Provided kwargs when parameterizing component func.
         :return: Built input attribute dict.
         """

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/pipeline/_load_component.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/pipeline/_load_component.py
@@ -167,12 +167,12 @@ class _PipelineNodeFactory:
 
         :param _type: The type of the node.
         :type _type: str
-        :param create_instance_func: A function to create a new instance of the node, defaults to None
+        :keyword create_instance_func: A function to create a new instance of the node, defaults to None
         :type create_instance_func: typing.Optional[typing.Callable[..., typing.Union[BaseNode, AutoMLJob]]]
-        :param load_from_rest_object_func: A function to load a node from a rest object, defaults to None
+        :keyword load_from_rest_object_func: A function to load a node from a rest object, defaults to None
         :type load_from_rest_object_func: typing.Optional[typing.Callable[[Any], typing.Union[BaseNode, AutoMLJob\
             , ControlFlowNode]]]
-        :param nested_schema: schema/schemas of corresponding nested field, will be used in \
+        :keyword nested_schema: schema/schemas of corresponding nested field, will be used in \
             PipelineJobSchema.jobs.value, defaults to None
         :type nested_schema: typing.Optional[typing.Union[NestedField, List[NestedField]]]
         """
@@ -199,9 +199,9 @@ class _PipelineNodeFactory:
     def load_from_dict(self, *, data: dict, _type: Optional[str] = None) -> Union[BaseNode, AutoMLJob]:
         """Load a node from a dict.
 
-        :param data: A dict containing the node's data.
+        :keyword data: A dict containing the node's data.
         :type data: dict
-        :param _type: The type of the node. If not specified, it will be inferred from the data.
+        :keyword _type: The type of the node. If not specified, it will be inferred from the data.
         :type _type: str
         """
         if _type is None:
@@ -231,9 +231,9 @@ class _PipelineNodeFactory:
     ) -> Union[BaseNode, AutoMLJob, ControlFlowNode]:
         """Load a node from a rest object.
 
-        :param obj: A rest object containing the node's data.
+        :keyword obj: A rest object containing the node's data.
         :type obj: dict
-        :param _type: The type of the node. If not specified, it will be inferred from the data.
+        :keyword _type: The type of the node. If not specified, it will be inferred from the data.
         :type _type: str
         """
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/pipeline/pipeline_job.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/pipeline/pipeline_job.py
@@ -438,7 +438,7 @@ class PipelineJob(Job, YamlTranslatableMixin, PipelineJobIOMixin, SchemaValidata
         (Write a pipeline job as node in yaml is not supported presently.)
 
         :param context: Context of command job YAML file.
-        :param kwargs: Extra arguments.
+        :keyword kwargs: Extra arguments.
         :return: Translated command component.
         """
         component = self._to_component(context, **kwargs)
@@ -632,7 +632,7 @@ class PipelineJob(Job, YamlTranslatableMixin, PipelineJobIOMixin, SchemaValidata
         """Translate a pipeline job to pipeline component.
 
         :param context: Context of pipeline job YAML file.
-        :param kwargs: Extra arguments.
+        :keyword kwargs: Extra arguments.
         :return: Translated pipeline component.
         """
         ignored_keys = PipelineComponent._check_ignored_keys(self)

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/spark_job.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/spark_job.py
@@ -328,7 +328,7 @@ class SparkJob(Job, ParameterizedSpark, JobIOMixin, SparkJobEntryMixin):
         """Translate a spark job to component.
 
         :param context: Context of spark job YAML file.
-        :param kwargs: Extra arguments.
+        :keyword kwargs: Extra arguments.
         :return: Translated spark component.
         """
         from azure.ai.ml.entities import SparkComponent
@@ -368,7 +368,7 @@ class SparkJob(Job, ParameterizedSpark, JobIOMixin, SparkJobEntryMixin):
         """Translate a spark job to a pipeline node.
 
         :param context: Context of spark job YAML file.
-        :param kwargs: Extra arguments.
+        :keyword kwargs: Extra arguments.
         :return: Translated spark component.
         """
         from azure.ai.ml.entities._builders import Spark

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/sweep/early_termination_policy.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/sweep/early_termination_policy.py
@@ -2,7 +2,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 from abc import ABC
-from typing import Optional
 
 from azure.ai.ml._restclient.v2023_04_01_preview.models import BanditPolicy as RestBanditPolicy
 from azure.ai.ml._restclient.v2023_04_01_preview.models import EarlyTerminationPolicy as RestEarlyTerminationPolicy

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/sweep/parameterized_sweep.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/sweep/parameterized_sweep.py
@@ -138,13 +138,13 @@ class ParameterizedSweep:
     ) -> None:
         """Set limits for Sweep node. Leave parameters as None if you don't want to update corresponding values.
 
-        :param max_concurrent_trials: maximum concurrent trial number.
+        :keyword max_concurrent_trials: maximum concurrent trial number.
         :type max_concurrent_trials: int
-        :param max_total_trials: maximum total trial number.
+        :keyword max_total_trials: maximum total trial number.
         :type max_total_trials: int
-        :param timeout: total timeout in seconds for sweep node
+        :keyword timeout: total timeout in seconds for sweep node
         :type timeout: int
-        :param trial_timeout: timeout in seconds for each trial
+        :keyword trial_timeout: timeout in seconds for each trial
         :type trial_timeout: int
         """
         if self._limits is None:
@@ -167,10 +167,10 @@ class ParameterizedSweep:
     def set_objective(self, *, goal: Optional[str] = None, primary_metric: Optional[str] = None) -> None:
         """Set the sweep object.. Leave parameters as None if you don't want to update corresponding values.
 
-        :param goal: Defines supported metric goals for hyperparameter tuning. Acceptable values are:
+        :keyword goal: Defines supported metric goals for hyperparameter tuning. Acceptable values are:
         "minimize", "maximize".
         :type goal: str
-        :param primary_metric: Name of the metric to optimize.
+        :keyword primary_metric: Name of the metric to optimize.
         :type primary_metric: str
         """
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_load_functions.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_load_functions.py
@@ -63,7 +63,7 @@ def load_common(
         Must be provided, and is assumed to be assigned by other internal
         functions that call this.
     :type relative_origin: str
-    :param params_override: _description_, defaults to None
+    :keyword params_override: _description_, defaults to None
     :type params_override: list, optional
     :return: _description_
     :rtype: Resource
@@ -161,12 +161,12 @@ def load_job(
         If the source is an open file, the file will be read directly,
         and an exception is raised if the file is not readable.
     :type source: Union[PathLike, str, io.TextIOWrapper]
-    :param relative_origin: The origin to be used when deducing
+    :keyword relative_origin: The origin to be used when deducing
         the relative locations of files referenced in the parsed yaml.
         Defaults to the inputted source's directory if it is a file or file path input.
         Defaults to "./" if the source is a stream input with no name value.
     :type relative_origin: str
-    :param params_override: Fields to overwrite on top of the yaml file.
+    :keyword params_override: Fields to overwrite on top of the yaml file.
         Format is [{"field1": "value1"}, {"field2": "value2"}]
     :type params_override: List[Dict]
     :raises ~azure.ai.ml.exceptions.ValidationException: Raised if Job cannot be successfully validated.
@@ -192,12 +192,12 @@ def load_workspace(
         If the source is an open file, the file will be read directly,
         and an exception is raised if the file is not readable.
     :type source: Union[PathLike, str, io.TextIOWrapper]
-    :param relative_origin: The origin to be used when deducing
+    :keyword relative_origin: The origin to be used when deducing
         the relative locations of files referenced in the parsed yaml.
         Defaults to the inputted source's directory if it is a file or file path input.
         Defaults to "./" if the source is a stream input with no name value.
     :type relative_origin: str
-    :param params_override: Fields to overwrite on top of the yaml file.
+    :keyword params_override: Fields to overwrite on top of the yaml file.
         Format is [{"field1": "value1"}, {"field2": "value2"}]
     :type params_override: List[Dict]
 
@@ -222,12 +222,12 @@ def load_registry(
         If the source is an open file, the file will be read directly,
         and an exception is raised if the file is not readable.
     :type source: Union[PathLike, str, io.TextIOWrapper]
-    :param relative_origin: The origin to be used when deducing
+    :keyword relative_origin: The origin to be used when deducing
         the relative locations of files referenced in the parsed yaml.
         Defaults to the inputted source's directory if it is a file or file path input.
         Defaults to "./" if the source is a stream input with no name value.
     :type relative_origin: str
-    :param params_override: Fields to overwrite on top of the yaml file.
+    :keyword params_override: Fields to overwrite on top of the yaml file.
         Format is [{"field1": "value1"}, {"field2": "value2"}]
     :type params_override: List[Dict]
 
@@ -252,12 +252,12 @@ def load_datastore(
         If the source is an open file, the file will be read directly,
         and an exception is raised if the file is not readable.
     :type source: Union[PathLike, str, io.TextIOWrapper]
-    :param relative_origin: The origin to be used when deducing
+    :keyword relative_origin: The origin to be used when deducing
         the relative locations of files referenced in the parsed yaml.
         Defaults to the inputted source's directory if it is a file or file path input.
         Defaults to "./" if the source is a stream input with no name value.
     :type relative_origin: str
-    :param params_override: Fields to overwrite on top of the yaml file.
+    :keyword params_override: Fields to overwrite on top of the yaml file.
         Format is [{"field1": "value1"}, {"field2": "value2"}]
     :type params_override: List[Dict]
     :raises ~azure.ai.ml.exceptions.ValidationException: Raised if Datastore cannot be successfully validated.
@@ -283,12 +283,12 @@ def load_code(
         If the source is an open file, the file will be read directly,
         and an exception is raised if the file is not readable.
     :type source: Union[PathLike, str, io.TextIOWrapper]
-    :param relative_origin: The origin to be used when deducing
+    :keyword relative_origin: The origin to be used when deducing
         the relative locations of files referenced in the parsed yaml.
         Defaults to the inputted source's directory if it is a file or file path input.
         Defaults to "./" if the source is a stream input with no name value.
     :type relative_origin: str
-    :param params_override: Fields to overwrite on top of the yaml file.
+    :keyword params_override: Fields to overwrite on top of the yaml file.
         Format is [{"field1": "value1"}, {"field2": "value2"}]
     :type params_override: List[Dict]
     :raises ~azure.ai.ml.exceptions.ValidationException: Raised if Code cannot be successfully validated.
@@ -314,12 +314,12 @@ def load_compute(
         If the source is an open file, the file will be read directly,
         and an exception is raised if the file is not readable.
     :type source: Union[PathLike, str, io.TextIOWrapper]
-    :param relative_origin: The origin to be used when deducing
+    :keyword relative_origin: The origin to be used when deducing
         the relative locations of files referenced in the parsed yaml.
         Defaults to the inputted source's directory if it is a file or file path input.
         Defaults to "./" if the source is a stream input with no name value.
     :type relative_origin: str
-    :param params_override: Fields to overwrite on top of the yaml file.
+    :keyword params_override: Fields to overwrite on top of the yaml file.
         Format is [{"field1": "value1"}, {"field2": "value2"}]
     :type params_override: List[Dict]
 
@@ -356,21 +356,21 @@ def load_component(
         If the source is an open file, the file will be read directly,
         and an exception is raised if the file is not readable.
     :type source: Union[PathLike, str, io.TextIOWrapper]
-    :param relative_origin: The origin to be used when deducing
+    :keyword relative_origin: The origin to be used when deducing
         the relative locations of files referenced in the parsed yaml.
         Defaults to the inputted source's directory if it is a file or file path input.
         Defaults to "./" if the source is a stream input with no name value.
     :type relative_origin: str
-    :param params_override: Fields to overwrite on top of the yaml file.
+    :keyword params_override: Fields to overwrite on top of the yaml file.
         Format is [{"field1": "value1"}, {"field2": "value2"}]
     :type params_override: List[Dict]
-    :param client: An MLClient instance.
+    :keyword client: An MLClient instance.
     :type client: MLClient
-    :param name: Name of the component.
+    :keyword name: Name of the component.
     :type name: str
-    :param version: Version of the component.
+    :keyword version: Version of the component.
     :type version: str
-    :param kwargs: A dictionary of additional configuration parameters.
+    :keyword kwargs: A dictionary of additional configuration parameters.
     :type kwargs: dict
 
     :return: A function that can be called with parameters to get a `azure.ai.ml.entities.Component`
@@ -412,12 +412,12 @@ def load_model(
         If the source is an open file, the file will be read directly,
         and an exception is raised if the file is not readable.
     :type source: Union[PathLike, str, io.TextIOWrapper]
-    :param relative_origin: The origin to be used when deducing
+    :keyword relative_origin: The origin to be used when deducing
         the relative locations of files referenced in the parsed yaml.
         Defaults to the inputted source's directory if it is a file or file path input.
         Defaults to "./" if the source is a stream input with no name value.
     :type relative_origin: str
-    :param params_override: Fields to overwrite on top of the yaml file.
+    :keyword params_override: Fields to overwrite on top of the yaml file.
         Format is [{"field1": "value1"}, {"field2": "value2"}]
     :type params_override: List[Dict]
     :raises ~azure.ai.ml.exceptions.ValidationException: Raised if Model cannot be successfully validated.
@@ -443,12 +443,12 @@ def load_data(
         If the source is an open file, the file will be read directly,
         and an exception is raised if the file is not readable.
     :type source: Union[PathLike, str, io.TextIOWrapper]
-    :param relative_origin: The origin to be used when deducing
+    :keyword relative_origin: The origin to be used when deducing
         the relative locations of files referenced in the parsed yaml.
         Defaults to the inputted source's directory if it is a file or file path input.
         Defaults to "./" if the source is a stream input with no name value.
     :type relative_origin: str
-    :param params_override: Fields to overwrite on top of the yaml file.
+    :keyword params_override: Fields to overwrite on top of the yaml file.
         Format is [{"field1": "value1"}, {"field2": "value2"}]
     :type params_override: List[Dict]
     :raises ~azure.ai.ml.exceptions.ValidationException: Raised if Data cannot be successfully validated.
@@ -474,12 +474,12 @@ def load_environment(
         If the source is an open file, the file will be read directly,
         and an exception is raised if the file is not readable.
     :type source: Union[PathLike, str, io.TextIOWrapper]
-    :param relative_origin: The origin to be used when deducing
+    :keyword relative_origin: The origin to be used when deducing
         the relative locations of files referenced in the parsed yaml.
         Defaults to the inputted source's directory if it is a file or file path input.
         Defaults to "./" if the source is a stream input with no name value.
     :type relative_origin: str
-    :param params_override: Fields to overwrite on top of the yaml file.
+    :keyword params_override: Fields to overwrite on top of the yaml file.
         Format is [{"field1": "value1"}, {"field2": "value2"}]
     :type params_override: List[Dict]
     :raises ~azure.ai.ml.exceptions.ValidationException: Raised if Environment cannot be successfully validated.
@@ -505,12 +505,12 @@ def load_online_deployment(
         If the source is an open file, the file will be read directly,
         and an exception is raised if the file is not readable.
     :type source: Union[PathLike, str, io.TextIOWrapper]
-    :param relative_origin: The origin to be used when deducing
+    :keyword relative_origin: The origin to be used when deducing
         the relative locations of files referenced in the parsed yaml.
         Defaults to the inputted source's directory if it is a file or file path input.
         Defaults to "./" if the source is a stream input with no name value.
     :type relative_origin: str
-    :param params_override: Fields to overwrite on top of the yaml file.
+    :keyword params_override: Fields to overwrite on top of the yaml file.
         Format is [{"field1": "value1"}, {"field2": "value2"}]
     :type params_override: List[Dict]
     :raises ~azure.ai.ml.exceptions.ValidationException: Raised if Online Deployment cannot be successfully validated.
@@ -536,12 +536,12 @@ def load_batch_deployment(
         If the source is an open file, the file will be read directly,
         and an exception is raised if the file is not readable.
     :type source: Union[PathLike, str, io.TextIOWrapper]
-    :param relative_origin: The origin to be used when deducing
+    :keyword relative_origin: The origin to be used when deducing
         the relative locations of files referenced in the parsed yaml.
         Defaults to the inputted source's directory if it is a file or file path input.
         Defaults to "./" if the source is a stream input with no name value.
     :type relative_origin: str
-    :param params_override: Fields to overwrite on top of the yaml file.
+    :keyword params_override: Fields to overwrite on top of the yaml file.
         Format is [{"field1": "value1"}, {"field2": "value2"}]
     :type params_override: List[Dict]
 
@@ -566,12 +566,12 @@ def load_model_batch_deployment(
         If the source is an open file, the file will be read directly,
         and an exception is raised if the file is not readable.
     :type source: Union[PathLike, str, io.TextIOWrapper]
-    :param relative_origin: The origin to be used when deducing
+    :keyword relative_origin: The origin to be used when deducing
         the relative locations of files referenced in the parsed yaml.
         Defaults to the inputted source's directory if it is a file or file path input.
         Defaults to "./" if the source is a stream input with no name value.
     :type relative_origin: str
-    :param params_override: Fields to overwrite on top of the yaml file.
+    :keyword params_override: Fields to overwrite on top of the yaml file.
         Format is [{"field1": "value1"}, {"field2": "value2"}]
     :type params_override: List[Dict]
 
@@ -596,12 +596,12 @@ def load_pipeline_component_batch_deployment(
         If the source is an open file, the file will be read directly,
         and an exception is raised if the file is not readable.
     :type source: Union[PathLike, str, io.TextIOWrapper]
-    :param relative_origin: The origin to be used when deducing
+    :keyword relative_origin: The origin to be used when deducing
         the relative locations of files referenced in the parsed yaml.
         Defaults to the inputted source's directory if it is a file or file path input.
         Defaults to "./" if the source is a stream input with no name value.
     :type relative_origin: str
-    :param params_override: Fields to overwrite on top of the yaml file.
+    :keyword params_override: Fields to overwrite on top of the yaml file.
         Format is [{"field1": "value1"}, {"field2": "value2"}]
     :type params_override: List[Dict]
 
@@ -626,12 +626,12 @@ def load_online_endpoint(
         If the source is an open file, the file will be read directly,
         and an exception is raised if the file is not readable.
     :type source: Union[PathLike, str, io.TextIOWrapper]
-    :param relative_origin: The origin to be used when deducing
+    :keyword relative_origin: The origin to be used when deducing
         the relative locations of files referenced in the parsed yaml.
         Defaults to the inputted source's directory if it is a file or file path input.
         Defaults to "./" if the source is a stream input with no name value.
     :type relative_origin: str
-    :param params_override: Fields to overwrite on top of the yaml file.
+    :keyword params_override: Fields to overwrite on top of the yaml file.
         Format is [{"field1": "value1"}, {"field2": "value2"}]
     :type params_override: List[Dict]
     :raises ~azure.ai.ml.exceptions.ValidationException: Raised if Online Endpoint cannot be successfully validated.
@@ -661,7 +661,7 @@ def load_batch_endpoint(
         Defaults to the inputted source's directory if it is a file or file path input.
         Defaults to "./" if the source is a stream input with no name value.
     :type relative_origin: str
-    :param params_override: Fields to overwrite on top of the yaml file.
+    :keyword params_override: Fields to overwrite on top of the yaml file.
         Format is [{"field1": "value1"}, {"field2": "value2"}]
     :type params_override: List[Dict]
 
@@ -686,12 +686,12 @@ def load_workspace_connection(
         If the source is an open file, the file will be read directly,
         and an exception is raised if the file is not readable.
     :type source: Union[PathLike, str, io.TextIOWrapper]
-    :param relative_origin: The origin to be used when deducing
+    :keyword relative_origin: The origin to be used when deducing
         the relative locations of files referenced in the parsed yaml.
         Defaults to the inputted source's directory if it is a file or file path input.
         Defaults to "./" if the source is a stream input with no name value.
     :type relative_origin: str
-    :param params_override: Fields to overwrite on top of the yaml file.
+    :keyword params_override: Fields to overwrite on top of the yaml file.
         Format is [{"field1": "value1"}, {"field2": "value2"}]
     :type params_override: List[Dict]
 
@@ -720,7 +720,7 @@ def load_schedule(
         Defaults to the inputted source's directory if it is a file or file path input.
         Defaults to "./" if the source is a stream input with no name value.
     :type relative_origin: str
-    :param params_override: Fields to overwrite on top of the yaml file.
+    :keyword params_override: Fields to overwrite on top of the yaml file.
         Format is [{"field1": "value1"}, {"field2": "value2"}]
     :type params_override: List[Dict]
 
@@ -744,12 +744,12 @@ def load_feature_store(
         If the source is an open file, the file will be read directly,
         and an exception is raised if the file is not readable.
     :type source: Union[PathLike, str, io.TextIOWrapper]
-    :param relative_origin: The origin to be used when deducing
+    :keyword relative_origin: The origin to be used when deducing
         the relative locations of files referenced in the parsed yaml.
         Defaults to the inputted source's directory if it is a file or file path input.
         Defaults to "./" if the source is a stream input with no name value.
     :type relative_origin: str
-    :param params_override: Fields to overwrite on top of the yaml file.
+    :keyword params_override: Fields to overwrite on top of the yaml file.
         Format is [{"field1": "value1"}, {"field2": "value2"}]
     :type params_override: List[Dict]
     :return: Loaded feature store object.
@@ -773,12 +773,12 @@ def load_feature_set(
         If the source is an open file, the file will be read directly,
         and an exception is raised if the file is not readable.
     :type source: Union[PathLike, str, io.TextIOWrapper]
-    :param relative_origin: The origin to be used when deducing
+    :keyword relative_origin: The origin to be used when deducing
         the relative locations of files referenced in the parsed yaml.
         Defaults to the inputted source's directory if it is a file or file path input.
         Defaults to "./" if the source is a stream input with no name value.
     :type relative_origin: str
-    :param params_override: Fields to overwrite on top of the yaml file.
+    :keyword params_override: Fields to overwrite on top of the yaml file.
         Format is [{"field1": "value1"}, {"field2": "value2"}]
     :type params_override: List[Dict]
     :raises ~azure.ai.ml.exceptions.ValidationException: Raised if FeatureSet cannot be successfully validated.
@@ -804,12 +804,12 @@ def load_feature_store_entity(
         If the source is an open file, the file will be read directly,
         and an exception is raised if the file is not readable.
     :type source: Union[PathLike, str, io.TextIOWrapper]
-    :param relative_origin: The origin to be used when deducing
+    :keyword relative_origin: The origin to be used when deducing
         the relative locations of files referenced in the parsed yaml.
         Defaults to the inputted source's directory if it is a file or file path input.
         Defaults to "./" if the source is a stream input with no name value.
     :type relative_origin: str
-    :param params_override: Fields to overwrite on top of the yaml file.
+    :keyword params_override: Fields to overwrite on top of the yaml file.
         Format is [{"field1": "value1"}, {"field2": "value2"}]
     :type params_override: List[Dict]
     :raises ~azure.ai.ml.exceptions.ValidationException: Raised if FeatureStoreEntity cannot be successfully validated.

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_registry/registry.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_registry/registry.py
@@ -90,8 +90,8 @@ class Registry(Resource):
     ) -> None:
         """Dump the registry spec into a file in yaml format.
 
-        :param path: Path to a local file as the target, new file will be created, raises exception if the file exists.
-        :type path: str
+        :param dest: Path to a local file as the target, new file will be created, raises exception if the file exists.
+        :type dest: str
         """
         yaml_serialized = self._to_dict()
         dump_yaml_to_file(dest, yaml_serialized, default_flow_style=False)

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_resource.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_resource.py
@@ -163,7 +163,7 @@ class Resource(abc.ABC):
         :type yaml_path: typing.Optional[typing.Union[typing.PathLike, str]]
         :param params_override: Parameters to override, defaults to None
         :type params_override: typing.Optional[list]
-        :param kwargs: A dictionary of additional configuration parameters.
+        :keyword kwargs: A dictionary of additional configuration parameters.
         :type kwargs: dict
         :return: Resource
         :rtype: Resource
@@ -176,7 +176,7 @@ class Resource(abc.ABC):
     ):
         """Get arm resource.
 
-        :param kwargs: A dictionary of additional configuration parameters.
+        :keyword kwargs: A dictionary of additional configuration parameters.
         :type kwargs: dict
 
         :return: Resource
@@ -193,7 +193,7 @@ class Resource(abc.ABC):
     def _get_arm_resource_and_params(self, **kwargs):
         """Get arm resource and parameters.
 
-        :param kwargs: A dictionary of additional configuration parameters.
+        :keyword kwargs: A dictionary of additional configuration parameters.
         :type kwargs: dict
 
         :return: Resource and parameters

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_batch_deployment_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_batch_deployment_operations.py
@@ -234,7 +234,7 @@ class BatchDeploymentOperations(_ScopeDependentOperations):
 
         :param endpoint_name: Name of endpoint.
         :type endpoint_name: str
-        :param name: (Optional) Name of deployment.
+        :keyword name: (Optional) Name of deployment.
         :type name: str
         :raise: Exception if endpoint_type is not BATCH_ENDPOINT_TYPE
         :return: List of jobs

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_batch_endpoint_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_batch_endpoint_operations.py
@@ -212,10 +212,10 @@ class BatchEndpointOperations(_ScopeDependentOperations):
 
         :param endpoint_name: The endpoint name.
         :type endpoint_name: str
-        :param deployment_name: (Optional) The name of a specific deployment to invoke. This is optional.
+        :keyword deployment_name: (Optional) The name of a specific deployment to invoke. This is optional.
             By default requests are routed to any of the deployments according to the traffic rules.
         :type deployment_name: str
-        :param inputs: (Optional) A dictionary of existing data asset, public uri file or folder
+        :keyword inputs: (Optional) A dictionary of existing data asset, public uri file or folder
             to use with the deployment
         :type inputs: Dict[str, Input]
         :raises ~azure.ai.ml.exceptions.ValidationException: Raised if deployment cannot be successfully validated.

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_component_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_component_operations.py
@@ -129,7 +129,7 @@ class ComponentOperations(_ScopeDependentOperations):
 
         :param name: Component name, if not set, list all components of the workspace
         :type name: Optional[str]
-        :param list_view_type: View type for including/excluding (for example) archived components.
+        :keyword list_view_type: View type for including/excluding (for example) archived components.
             Default: ACTIVE_ONLY.
         :type list_view_type: Optional[ListViewType]
         :return: An iterator like instance of component objects
@@ -323,7 +323,7 @@ class ComponentOperations(_ScopeDependentOperations):
         :type component: Union[Component, types.FunctionType]
         :param version: The component version to override.
         :type version: str
-        :param skip_validation: whether to skip validation before creating/updating the component
+        :keyword skip_validation: whether to skip validation before creating/updating the component
         :type skip_validation: bool
         :raises ~azure.ai.ml.exceptions.ValidationException: Raised if Component cannot be successfully validated.
             Details will be provided in the error message.
@@ -799,7 +799,7 @@ class ComponentOperations(_ScopeDependentOperations):
         :type component: Union[Component, str]
         :param resolver: The resolver to resolve the dependencies.
         :type resolver: Callable
-        :param resolve_inputs: Whether to resolve inputs.
+        :keyword resolve_inputs: Whether to resolve inputs.
         :type resolve_inputs: bool
         """
         if not isinstance(component, PipelineComponent) or not component.jobs:

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_compute_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_compute_operations.py
@@ -48,7 +48,7 @@ class ComputeOperations(_ScopeDependentOperations):
     def list(self, *, compute_type: Optional[str] = None) -> Iterable[Compute]:
         """List computes of the workspace.
 
-        :param compute_type: the type of the compute to be listed, defaults to amlcompute
+        :keyword compute_type: the type of the compute to be listed, defaults to amlcompute
         :type compute_type: str
         :return: An iterator like instance of Compute objects
         :rtype: ~azure.core.paging.ItemPaged[Compute]
@@ -183,7 +183,7 @@ class ComputeOperations(_ScopeDependentOperations):
 
         :param name: The name of the compute.
         :type name: str
-        :param action: Action to perform. Possible values: ["Delete", "Detach"]. Defaults to "Delete".
+        :keyword action: Action to perform. Possible values: ["Delete", "Detach"]. Defaults to "Delete".
         :type action: Optional[str]
         :return: A poller to track the operation status.
         :rtype: ~azure.core.polling.LROPoller[None]
@@ -250,7 +250,7 @@ class ComputeOperations(_ScopeDependentOperations):
     def list_usage(self, *, location: Optional[str] = None) -> Iterable[Usage]:
         """Gets the current usage information as well as limits for AML resources for given subscription and location.
 
-        :param location: The location for which resource usage is queried.
+        :keyword location: The location for which resource usage is queried.
             If location not provided , defaults to workspace location
         :type location: str
         :return: An iterator over current usage info
@@ -268,7 +268,7 @@ class ComputeOperations(_ScopeDependentOperations):
     def list_sizes(self, *, location: Optional[str] = None, compute_type: Optional[str] = None) -> Iterable[VmSize]:
         """Returns supported VM Sizes in a location.
 
-        :param location: The location upon which virtual-machine-sizes is queried.
+        :keyword location: The location upon which virtual-machine-sizes is queried.
             If location not provided, defaults to workspace location.
         :type location: str
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_data_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_data_operations.py
@@ -118,7 +118,7 @@ class DataOperations(_ScopeDependentOperations):
 
         :param name: Name of a specific data asset, optional.
         :type name: Optional[str]
-        :param list_view_type: View type for including/excluding (for example) archived data assets.
+        :keyword list_view_type: View type for including/excluding (for example) archived data assets.
             Default: ACTIVE_ONLY.
         :type list_view_type: Optional[ListViewType]
         :return: An iterator like instance of Data objects
@@ -434,7 +434,7 @@ class DataOperations(_ScopeDependentOperations):
 
         :param name: name of asset being created by the materialization jobs.
         :type name: str
-        :param list_view_type: View type for including/excluding (for example) archived jobs. Default: ACTIVE_ONLY.
+        :keyword list_view_type: View type for including/excluding (for example) archived jobs. Default: ACTIVE_ONLY.
         :type list_view_type: Optional[ListViewType]
         :return: An iterator like instance of Job objects.
         :rtype: ~azure.core.paging.ItemPaged[PipelineJob]
@@ -593,11 +593,11 @@ class DataOperations(_ScopeDependentOperations):
         :type name: str
         :param version: Version of data asset.
         :type version: str
-        :param share_with_name: Name of data asset to share with.
+        :keyword share_with_name: Name of data asset to share with.
         :type share_with_name: str
-        :param share_with_version: Version of data asset to share with.
+        :keyword share_with_version: Version of data asset to share with.
         :type share_with_version: str
-        :param registry_name: Name of the destination registry.
+        :keyword registry_name: Name of the destination registry.
         :type registry_name: str
         :return: Data asset object.
         :rtype: ~azure.ai.ml.entities.Data

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_datastore_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_datastore_operations.py
@@ -50,7 +50,7 @@ class DatastoreOperations(_ScopeDependentOperations):
     def list(self, *, include_secrets: bool = False) -> Iterable[Datastore]:
         """Lists all datastores and associated information within a workspace.
 
-        :param include_secrets: Include datastore secrets in returned datastores, defaults to False
+        :keyword include_secrets: Include datastore secrets in returned datastores, defaults to False
         :type include_secrets: bool, optional
         :return: An iterator like instance of Datastore objects
         :rtype: ~azure.core.paging.ItemPaged[Datastore]
@@ -99,7 +99,7 @@ class DatastoreOperations(_ScopeDependentOperations):
 
         :param name: Datastore name
         :type name: str
-        :param include_secrets: Include datastore secrets in the returned datastore, defaults to False
+        :keyword include_secrets: Include datastore secrets in the returned datastore, defaults to False
         :type include_secrets: bool, optional
         :return: Datastore with the specified name.
         :rtype: Datastore
@@ -128,7 +128,7 @@ class DatastoreOperations(_ScopeDependentOperations):
     def get_default(self, *, include_secrets: bool = False) -> Datastore:
         """Returns the workspace's default datastore.
 
-        :param include_secrets: Include datastore secrets in the returned datastore, defaults to False
+        :keyword include_secrets: Include datastore secrets in the returned datastore, defaults to False
         :type include_secrets: bool, optional
         :return: The default datastore.
         :rtype: Datastore

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_environment_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_environment_operations.py
@@ -264,7 +264,7 @@ class EnvironmentOperations(_ScopeDependentOperations):
 
         :param name: Name of the environment.
         :type name: Optional[str]
-        :param list_view_type: View type for including/excluding (for example) archived environments.
+        :keyword list_view_type: View type for including/excluding (for example) archived environments.
             Default: ACTIVE_ONLY.
         :type list_view_type: Optional[ListViewType]
         :return: An iterator like instance of Environment objects.
@@ -379,18 +379,20 @@ class EnvironmentOperations(_ScopeDependentOperations):
 
     @monitor_with_activity(logger, "Environment.Share", ActivityType.PUBLICAPI)
     @experimental
-    def share(self, name, version, *, share_with_name, share_with_version, registry_name) -> Environment:
+    def share(
+        self, name: str, version: str, *, share_with_name: str, share_with_version: str, registry_name: str
+    ) -> Environment:
         """Share a environment asset from workspace to registry.
 
         :param name: Name of environment asset.
         :type name: str
         :param version: Version of environment asset.
         :type version: str
-        :param share_with_name: Name of environment asset to share with.
+        :keyword share_with_name: Name of environment asset to share with.
         :type share_with_name: str
-        :param share_with_version: Version of environment asset to share with.
+        :keyword share_with_version: Version of environment asset to share with.
         :type share_with_version: str
-        :param registry_name: Name of the destination registry.
+        :keyword registry_name: Name of the destination registry.
         :type registry_name: str
         :return: Environment asset object.
         :rtype: ~azure.ai.ml.entities.Environment

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_feature_set_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_feature_set_operations.py
@@ -86,7 +86,7 @@ class FeatureSetOperations(_ScopeDependentOperations):
 
         :param name: Name of a specific FeatureSet asset, optional.
         :type name: Optional[str]
-        :param list_view_type: View type for including/excluding (for example) archived FeatureSet assets.
+        :keyword list_view_type: View type for including/excluding (for example) archived FeatureSet assets.
         Default: ACTIVE_ONLY.
         :type list_view_type: Optional[ListViewType]
         :return: An iterator like instance of FeatureSet objects
@@ -189,23 +189,23 @@ class FeatureSetOperations(_ScopeDependentOperations):
     ) -> LROPoller[FeatureSetBackfillMetadata]:
         """Backfill.
 
-        :param name: Feature set name. This is case-sensitive.
+        :keyword name: Feature set name. This is case-sensitive.
         :type name: str
-        :param version: Version identifier. This is case-sensitive.
+        :keyword version: Version identifier. This is case-sensitive.
         :type version: str
-        :param feature_window_start_time: Start time of the feature window to be materialized.
+        :keyword feature_window_start_time: Start time of the feature window to be materialized.
         :type feature_window_start_time: datetime
-        :param feature_window_end_time: End time of the feature window to be materialized.
+        :keyword feature_window_end_time: End time of the feature window to be materialized.
         :type feature_window_end_time: datetime
-        :param display_name: Specifies description.
+        :keyword display_name: Specifies description.
         :type display_name: str
-        :param description: Specifies description.
+        :keyword description: Specifies description.
         :type description: str
-        :param tags: A set of tags. Specifies the tags.
+        :keyword tags: A set of tags. Specifies the tags.
         :type tags: dict[str, str]
-        :param compute_resource: Specifies the compute resource settings.
+        :keyword compute_resource: Specifies the compute resource settings.
         :type compute_resource: ~azure.ai.ml.entities.MaterializationComputeResource
-        :param spark_configuration: Specifies the spark compute settings.
+        :keyword spark_configuration: Specifies the spark compute settings.
         :type spark_configuration: dict[str, str]
         :return: An instance of LROPoller that returns ~azure.ai.ml.entities.FeatureSetBackfillMetadata
         """
@@ -248,11 +248,11 @@ class FeatureSetOperations(_ScopeDependentOperations):
         :type name: str
         :param version: Feature set version.
         :type version: str
-        :param feature_window_start_time: Start time of the feature window to filter materialization jobs.
+        :keyword feature_window_start_time: Start time of the feature window to filter materialization jobs.
         :type feature_window_start_time: Union[str, datetime]
-        :param feature_window_end_time: End time of the feature window to filter materialization jobs.
+        :keyword feature_window_end_time: End time of the feature window to filter materialization jobs.
         :type feature_window_end_time: Union[str, datetime]
-        :param filters: Comma-separated list of tag names (and optionally values). Example: tag1,tag2=value2.
+        :keyword filters: Comma-separated list of tag names (and optionally values). Example: tag1,tag2=value2.
         :type filters: str
         :return: An iterator like instance of ~azure.ai.ml.entities.FeatureSetMaterializationMetadata objects
         :rtype: ~azure.core.paging.ItemPaged[FeatureSetMaterializationMetadata]
@@ -290,11 +290,11 @@ class FeatureSetOperations(_ScopeDependentOperations):
         :type feature_set_name: str
         :param version: Feature set version.
         :type version: str
-        :param feature_name: feature name.
+        :keyword feature_name: feature name.
         :type feature_name: str
-        :param description: Description of the featureset.
+        :keyword description: Description of the featureset.
         :type description: str
-        :param tags: Comma-separated list of tag names (and optionally values). Example: tag1,tag2=value2.
+        :keyword tags: Comma-separated list of tag names (and optionally values). Example: tag1,tag2=value2.
         :type tags: str
         :return: An iterator like instance of Feature objects
         :rtype: ~azure.core.paging.ItemPaged[Feature]
@@ -321,9 +321,9 @@ class FeatureSetOperations(_ScopeDependentOperations):
         :type feature_set_name: str
         :param version: Feature set version.
         :type version: str
-        :param feature_name. This is case-sensitive.
+        :keyword feature_name. This is case-sensitive.
         :type feature_name: str
-        :param tags: Comma-separated list of tag names (and optionally values). Example: tag1,tag2=value2.
+        :keyword tags: Comma-separated list of tag names (and optionally values). Example: tag1,tag2=value2.
         :type tags: str
         :return: Feature object
         :rtype: ~azure.ai.ml.entities.Feature

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_feature_store_entity_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_feature_store_entity_operations.py
@@ -64,7 +64,7 @@ class FeatureStoreEntityOperations(_ScopeDependentOperations):
 
         :param name: Name of a specific FeatureStoreEntity asset, optional.
         :type name: Optional[str]
-        :param list_view_type: View type for including/excluding (for example) archived FeatureStoreEntity assets.
+        :keyword list_view_type: View type for including/excluding (for example) archived FeatureStoreEntity assets.
         Default: ACTIVE_ONLY.
         :type list_view_type: Optional[ListViewType]
         :return: An iterator like instance of FeatureStoreEntity objects

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_feature_store_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_feature_store_operations.py
@@ -181,8 +181,8 @@ class FeatureStoreOperations(WorkspaceOperationsBase):
 
         Returns the feature store if already exists.
 
-        :param feature store: FeatureStore definition.
-        :type feature store: FeatureStore
+        :param feature_store: FeatureStore definition.
+        :type feature_store: FeatureStore
         :type update_dependent_resources: boolean
         :return: An instance of LROPoller that returns a FeatureStore.
         :rtype: ~azure.core.polling.LROPoller[~azure.ai.ml.entities.FeatureStore]
@@ -232,7 +232,8 @@ class FeatureStoreOperations(WorkspaceOperationsBase):
     ) -> LROPoller[FeatureStore]:
         """Update friendly name, description, materialization identities or tags of a feature store.
 
-        :param feature store: FeatureStore resource.
+        :param feature_store: FeatureStore resource.
+        :type feature_store: FeatureStore
         :param update_dependent_resources: gives your consent to update the feature store dependent resources.
             Note that updating the feature store attached Azure Container Registry resource may break lineage
             of previous jobs or your ability to rerun earlier jobs in this feature store.
@@ -242,7 +243,6 @@ class FeatureStoreOperations(WorkspaceOperationsBase):
             Azure Container Registry and Azure Application Insights will fail.
         :param application_insights: Application insights resource for feature store.
         :param container_registry: Container registry resource for feature store.
-        :type feature store: FeatureStore
         :return: An instance of LROPoller that returns a FeatureStore.
         :rtype: ~azure.core.polling.LROPoller[~azure.ai.ml.entities.FeatureStore]
         """

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_feature_store_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_feature_store_operations.py
@@ -72,7 +72,7 @@ class FeatureStoreOperations(WorkspaceOperationsBase):
         """List all feature stores that the user has access to in the current
         resource group or subscription.
 
-        :param scope: scope of the listing, "resource_group" or "subscription", defaults to "resource_group"
+        :keyword scope: scope of the listing, "resource_group" or "subscription", defaults to "resource_group"
         :type scope: str, optional
         :return: An iterator like instance of FeatureStore objects
         :rtype: ~azure.core.paging.ItemPaged[FeatureStore]
@@ -234,15 +234,15 @@ class FeatureStoreOperations(WorkspaceOperationsBase):
 
         :param feature_store: FeatureStore resource.
         :type feature_store: FeatureStore
-        :param update_dependent_resources: gives your consent to update the feature store dependent resources.
+        :keyword update_dependent_resources: gives your consent to update the feature store dependent resources.
             Note that updating the feature store attached Azure Container Registry resource may break lineage
             of previous jobs or your ability to rerun earlier jobs in this feature store.
             Also, updating the feature store attached Azure Application Insights resource may break lineage of
             deployed inference endpoints this feature store. Only set this argument if you are sure that you want
             to perform this operation. If this argument is not set, the command to update
             Azure Container Registry and Azure Application Insights will fail.
-        :param application_insights: Application insights resource for feature store.
-        :param container_registry: Container registry resource for feature store.
+        :keyword application_insights: Application insights resource for feature store.
+        :keyword container_registry: Container registry resource for feature store.
         :return: An instance of LROPoller that returns a FeatureStore.
         :rtype: ~azure.core.polling.LROPoller[~azure.ai.ml.entities.FeatureStore]
         """
@@ -386,7 +386,7 @@ class FeatureStoreOperations(WorkspaceOperationsBase):
 
         :param name: Name of the FeatureStore
         :type name: str
-        :param delete_dependent_resources: Whether to delete resources associated with the feature store,
+        :keyword delete_dependent_resources: Whether to delete resources associated with the feature store,
             i.e., container registry, storage account, key vault, and application insights.
             The default is False. Set to True to delete these resources.
         :type delete_dependent_resources: bool

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_job_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_job_operations.py
@@ -675,10 +675,6 @@ class JobOperations(_ScopeDependentOperations):
     ) -> None:
         """Download logs and output of a job.
 
-        :param str name: Name of a job.
-        :param Union[PathLike, str] download_path: Local path as download destination, defaults to '.'.
-        :param str output_name: Named output to download, defaults to None.
-        :param bool all: Whether to download logs and all named outputs, defaults to False.
         :param name: Name of a job.
         :type name: str
         :param download_path: Local path as download destination, defaults to '.'.

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_job_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_job_operations.py
@@ -241,9 +241,9 @@ class JobOperations(_ScopeDependentOperations):
     ) -> Iterable[Job]:
         """List jobs of the workspace.
 
-        :param parent_job_name: When provided, returns children of named job.
+        :keyword parent_job_name: When provided, returns children of named job.
         :type parent_job_name: Optional[str]
-        :param list_view_type: View type for including/excluding (for example) archived jobs. Default: ACTIVE_ONLY.
+        :keyword list_view_type: View type for including/excluding (for example) archived jobs. Default: ACTIVE_ONLY.
         :type list_view_type: Optional[ListViewType]
         :return: An iterator like instance of Job objects.
         :rtype: ~azure.core.paging.ItemPaged[Job]
@@ -414,7 +414,7 @@ class JobOperations(_ScopeDependentOperations):
 
         :param job: Job object to be validated.
         :type job: Job
-        :param raise_on_failure: Whether raise error when there are validation errors.
+        :keyword raise_on_failure: Whether raise error when there are validation errors.
         :type raise_on_failure: bool
         :return: a ValidationResult object containing all found errors.
         :rtype: ValidationResult
@@ -489,16 +489,16 @@ class JobOperations(_ScopeDependentOperations):
         Environment, Code, they'll be created together with the job.
 
         :param Job job: Job definition or object which can be translate to a job.
-        :param description: Description to overwrite when submitting the pipeline.
+        :keyword description: Description to overwrite when submitting the pipeline.
         :type description: str
-        :param compute: Compute target to overwrite when submitting the pipeline.
+        :keyword compute: Compute target to overwrite when submitting the pipeline.
         :type compute: str
-        :param tags: Tags to overwrite when submitting the pipeline.
+        :keyword tags: Tags to overwrite when submitting the pipeline.
         :type tags: dict
-        :param experiment_name: Name of the experiment the job will be created under, if None is provided,
+        :keyword experiment_name: Name of the experiment the job will be created under, if None is provided,
             job will be created under experiment 'Default'.
         :type experiment_name: str
-        :param skip_validation: whether to skip validation before creating/updating the job. Note that dependent
+        :keyword skip_validation: whether to skip validation before creating/updating the job. Note that dependent
             resources like anonymous component won't skip their validation in creating.
         :type skip_validation: bool
         :raises [~azure.ai.ml.exceptions.UserErrorException, ~azure.ai.ml.exceptions.ValidationException]: Raised if
@@ -677,11 +677,11 @@ class JobOperations(_ScopeDependentOperations):
 
         :param name: Name of a job.
         :type name: str
-        :param download_path: Local path as download destination, defaults to '.'.
+        :keyword download_path: Local path as download destination, defaults to '.'.
         :type download_path: Union[PathLike, str]
-        :param output_name: Named output to download, defaults to None.
+        :keyword output_name: Named output to download, defaults to None.
         :type output_name: str
-        :param all: Whether to download logs and all named outputs, defaults to False.
+        :keyword all: Whether to download logs and all named outputs, defaults to False.
         :type all: bool
         :raises ~azure.ai.ml.exceptions.JobException: Raised if Job is not yet in a terminal state.
             Details will be provided in the error message.

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_job_ops_helper.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_job_ops_helper.py
@@ -40,8 +40,6 @@ def _get_sorted_filtered_logs(
 ) -> List[str]:
     """Filters log file names, sorts, and returns list starting with where we left off last iteration.
 
-    :param run_details:
-    :type run_details: dict
     :param processed_logs: dictionary tracking the state of how many lines of each file have been written out
     :type processed_logs: dict[str, int]
     :param job_type: the job type to filter log files

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_local_deployment_helper.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_local_deployment_helper.py
@@ -166,10 +166,10 @@ class _LocalDeploymentHelper(object):
     ):
         """Create deployment locally using Docker.
 
-        :param endpoint: OnlineDeployment object with information from user yaml.
-        :type endpoint: OnlineDeployment
+        :param endpoint_name: OnlineDeployment object with information from user yaml.
+        :type endpoint_name: str
         :param deployment: Deployment to create
-        :type deployment: Deployment entity
+        :type deployment: OnlineDeployment
         :param local_endpoint_mode: Mode for local endpoint.
         :type local_endpoint_mode: LocalEndpointMode
         :param local_enable_gpu: enable local container to access gpu

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_local_endpoint_helper.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_local_endpoint_helper.py
@@ -45,8 +45,6 @@ class _LocalEndpointHelper(object):
 
         :param endpoint: OnlineEndpoint object with information from user yaml.
         :type endpoint: OnlineEndpoint
-        :param operation_message: Output string for operation messages.
-        :type operation_message: str
         """
         try:
             if endpoint is None:
@@ -145,8 +143,6 @@ class _LocalEndpointHelper(object):
 
         :param name: Name of endpoint to delete.
         :type name: str
-        :param deployment_name: Name of specific deployment to delete.
-        :type deployment_name: str
         """
         endpoint_stub = self._endpoint_stub.get(endpoint_name=name)
         if endpoint_stub:

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_local_endpoint_helper.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_local_endpoint_helper.py
@@ -97,8 +97,8 @@ class _LocalEndpointHelper(object):
     def get(self, endpoint_name: str) -> OnlineEndpoint:
         """Get a local endpoint.
 
-        :param name: Name of endpoint.
-        :type name: str
+        :param endpoint_name: Name of endpoint.
+        :type endpoint_name: str
         :return OnlineEndpoint:
         """
         endpoint = self._endpoint_stub.get(endpoint_name=endpoint_name)

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_model_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_model_operations.py
@@ -425,7 +425,7 @@ class ModelOperations(_ScopeDependentOperations):
 
         :param name: Name of the model.
         :type name: Optional[str]
-        :param list_view_type: View type for including/excluding (for example) archived models. Default: ACTIVE_ONLY.
+        :keyword list_view_type: View type for including/excluding (for example) archived models. Default: ACTIVE_ONLY.
         :type list_view_type: Optional[ListViewType]
         :return: An iterator like instance of Model objects
         :rtype: ~azure.core.paging.ItemPaged[Model]
@@ -474,11 +474,11 @@ class ModelOperations(_ScopeDependentOperations):
         :type name: str
         :param version: Version of model asset.
         :type version: str
-        :param share_with_name: Name of model asset to share with.
+        :keyword share_with_name: Name of model asset to share with.
         :type share_with_name: str
-        :param share_with_version: Version of model asset to share with.
+        :keyword share_with_version: Version of model asset to share with.
         :type share_with_version: str
-        :param registry_name: Name of the destination registry.
+        :keyword registry_name: Name of the destination registry.
         :type registry_name: str
         :return: Model asset object.
         :rtype: ~azure.ai.ml.entities.Model

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_online_deployment_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_online_deployment_operations.py
@@ -93,11 +93,11 @@ class OnlineDeploymentOperations(_ScopeDependentOperations):
 
         :param deployment: the deployment entity
         :type deployment: ~azure.ai.ml.entities.OnlineDeployment
-        :param local: Whether deployment should be created locally, defaults to False
+        :keyword local: Whether deployment should be created locally, defaults to False
         :type local: bool, optional
-        :param vscode_debug: Whether to open VSCode instance to debug local deployment, defaults to False
+        :keyword vscode_debug: Whether to open VSCode instance to debug local deployment, defaults to False
         :type vscode_debug: bool, optional
-        :param local_enable_gpu: enable local container to access gpu
+        :keyword local_enable_gpu: enable local container to access gpu
         :type local_enable_gpu: bool, optional
         :raises ~azure.ai.ml.exceptions.ValidationException: Raised if OnlineDeployment cannot
             be successfully validated. Details will be provided in the error message.
@@ -224,7 +224,7 @@ class OnlineDeploymentOperations(_ScopeDependentOperations):
         :type name: str
         :param endpoint_name: The name of the endpoint
         :type endpoint_name: str
-        :param local: Whether deployment should be retrieved from local docker environment, defaults to False
+        :keyword local: Whether deployment should be retrieved from local docker environment, defaults to False
         :type local: Optional[bool]
         :raises ~azure.ai.ml.exceptions.LocalEndpointNotFoundError: Raised if local endpoint resource does not exist.
         :return: a deployment entity
@@ -255,7 +255,7 @@ class OnlineDeploymentOperations(_ScopeDependentOperations):
         :type name: str
         :param endpoint_name: The name of the endpoint
         :type endpoint_name: str
-        :param local: Whether deployment should be retrieved from local docker environment, defaults to False
+        :keyword local: Whether deployment should be retrieved from local docker environment, defaults to False
         :type local: Optional[bool]
         :raises ~azure.ai.ml.exceptions.LocalEndpointNotFoundError: Raised if local endpoint resource does not exist.
         :return: A poller to track the operation status
@@ -290,10 +290,10 @@ class OnlineDeploymentOperations(_ScopeDependentOperations):
         :type endpoint_name: str
         :param lines: The maximum number of lines to tail
         :type lines: int
-        :param container_type: The type of container to retrieve logs from. Possible values include:
+        :keyword container_type: The type of container to retrieve logs from. Possible values include:
             "StorageInitializer", "InferenceServer", defaults to None
         :type container_type: Optional[str], optional
-        :param local: [description], defaults to False
+        :keyword local: [description], defaults to False
         :type local: bool, optional
         :return: the logs
         :rtype: str
@@ -321,7 +321,7 @@ class OnlineDeploymentOperations(_ScopeDependentOperations):
 
         :param endpoint_name: The name of the endpoint
         :type endpoint_name: str
-        :param local: Whether deployment should be retrieved from local docker environment, defaults to False
+        :keyword local: Whether deployment should be retrieved from local docker environment, defaults to False
         :type local: bool, optional
         :return: an iterator of deployment entities
         :rtype: Iterable[~azure.ai.ml.entities.OnlineDeployment]

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_online_endpoint_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_online_endpoint_operations.py
@@ -80,7 +80,7 @@ class OnlineEndpointOperations(_ScopeDependentOperations):
     def list(self, *, local: bool = False) -> ItemPaged[OnlineEndpoint]:
         """List endpoints of the workspace.
 
-        :param local: (Optional) Flag to indicate whether to interact with endpoints in local Docker environment.
+        :keyword local: (Optional) Flag to indicate whether to interact with endpoints in local Docker environment.
             Default: False
         :type local: bool
         :return: A list of endpoints
@@ -120,7 +120,7 @@ class OnlineEndpointOperations(_ScopeDependentOperations):
 
         :param name: Name of the endpoint.
         :type name: str
-        :param local: Indicates whether to interact with endpoints in local Docker environment. Defaults to False.
+        :keyword local: Indicates whether to interact with endpoints in local Docker environment. Defaults to False.
         :type local: Optional[bool]
         :raises ~azure.ai.ml.exceptions.LocalEndpointNotFoundError: Raised if local endpoint resource does not exist.
         :return: Endpoint object retrieved from the service.
@@ -163,7 +163,7 @@ class OnlineEndpointOperations(_ScopeDependentOperations):
 
         :param name: Name of the endpoint.
         :type name: str
-        :param local: Whether to interact with the endpoint in local Docker environment. Defaults to False.
+        :keyword local: Whether to interact with the endpoint in local Docker environment. Defaults to False.
         :type local: bool
         :raises ~azure.ai.ml.exceptions.LocalEndpointNotFoundError: Raised if local endpoint resource does not exist.
         :return: A poller to track the operation status if remote, else returns None if local.
@@ -199,7 +199,7 @@ class OnlineEndpointOperations(_ScopeDependentOperations):
 
         :param endpoint: The endpoint entity.
         :type endpoint: ~azure.ai.ml.entities.OnlineEndpoint
-        :param local: Whether to interact with the endpoint in local Docker environment. Defaults to False.
+        :keyword local: Whether to interact with the endpoint in local Docker environment. Defaults to False.
         :type local: bool
         :raises ~azure.ai.ml.exceptions.ValidationException: Raised if OnlineEndpoint cannot be successfully validated.
             Details will be provided in the error message.
@@ -267,7 +267,7 @@ class OnlineEndpointOperations(_ScopeDependentOperations):
 
         :param name: The endpoint name.
         :type name: The endpoint type. Defaults to ONLINE_ENDPOINT_TYPE.
-        :param key_type: One of "primary", "secondary". Defaults to "primary".
+        :keyword key_type: One of "primary", "secondary". Defaults to "primary".
         :type key_type: str
         :return: A poller to track the operation status.
         :rtype: ~azure.core.polling.LROPoller[None]
@@ -307,14 +307,14 @@ class OnlineEndpointOperations(_ScopeDependentOperations):
 
         :param endpoint_name: The endpoint name
         :type endpoint_name: str
-        :param request_file: File containing the request payload. This is only valid for online endpoint.
+        :keyword request_file: File containing the request payload. This is only valid for online endpoint.
         :type request_file: Optional[str]
-        :param deployment_name: Name of a specific deployment to invoke. This is optional.
+        :keyword deployment_name: Name of a specific deployment to invoke. This is optional.
             By default requests are routed to any of the deployments according to the traffic rules.
         :type deployment_name: Optional[str]
-        :param input_data: To use a pre-registered data asset, pass str in format
+        :keyword input_data: To use a pre-registered data asset, pass str in format
         :type input_data: Optional[Union[str, Data]]
-        :param local: Indicates whether to interact with endpoints in local Docker environment. Defaults to False.
+        :keyword local: Indicates whether to interact with endpoints in local Docker environment. Defaults to False.
         :type local: Optional[bool]
         :raises ~azure.ai.ml.exceptions.LocalEndpointNotFoundError: Raised if local endpoint resource does not exist.
         :raises ~azure.ai.ml.exceptions.MultipleLocalDeploymentsFoundError: Raised if there are multiple deployments

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_operation_orchestrator.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_operation_orchestrator.py
@@ -122,8 +122,6 @@ class OperationOrchestrator(object):
         :type register_asset: Optional[bool]
         :param sub_workspace_resource:
         :type sub_workspace_resource: Optional[bool]
-        :param arm_id_cache_dict: A dict to cache the ARM id of input asset.
-        :type arm_id_cache_dict: Optional[Dict[str, str]]
         :raises ~azure.ai.ml.exceptions.ValidationException: Raised if asset's ID cannot be converted
             or asset cannot be successfully registered.
         :return: The ARM Id or entity object

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_registry_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_registry_operations.py
@@ -52,7 +52,7 @@ class RegistryOperations:
     def list(self, *, scope: str = Scope.RESOURCE_GROUP) -> Iterable[Registry]:
         """List all registries that the user has access to in the current resource group or subscription.
 
-        :param scope: scope of the listing, "resource_group" or "subscription", defaults to "resource_group"
+        :keyword scope: scope of the listing, "resource_group" or "subscription", defaults to "resource_group"
         :type scope: str, optional
         :return: An iterator like instance of Registry objects
         :rtype: ~azure.core.paging.ItemPaged[Registry]
@@ -142,7 +142,7 @@ class RegistryOperations:
     def begin_delete(self, *, name: str, **kwargs: Dict) -> LROPoller[None]:
         """Delete a registry if it exists. Returns nothing on a successful operation.
 
-        :param name: Name of the registry
+        :keyword name: Name of the registry
         :type name: str
         :return: A poller to track the operation status.
         :rtype: LROPoller

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_schedule_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_schedule_operations.py
@@ -118,7 +118,7 @@ class ScheduleOperations(_ScopeDependentOperations):
     ) -> Iterable[Schedule]:
         """List schedules in specified workspace.
 
-        :param list_view_type: View type for including/excluding (for example)
+        :keyword list_view_type: View type for including/excluding (for example)
             archived schedules. Default: ENABLED_ONLY.
         :type list_view_type: Optional[ScheduleListViewType]
         :return: An iterator to list Schedule.

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_virtual_cluster_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_virtual_cluster_operations.py
@@ -68,7 +68,7 @@ class VirtualClusterOperations:
     def list(self, *, scope: Optional[str] = None) -> Iterable[Dict]:
         """List virtual clusters a user has access to.
 
-        :param scope: scope of the listing, "subscription" or None, defaults to None.
+        :keyword scope: scope of the listing, "subscription" or None, defaults to None.
             If None, list virtual clusters across all subscriptions a customer has access to.
         :type scope: str, optional
         :return: An iterator like instance of dictionaries.

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_workspace_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_workspace_operations.py
@@ -62,7 +62,7 @@ class WorkspaceOperations(WorkspaceOperationsBase):
     def list(self, *, scope: str = Scope.RESOURCE_GROUP) -> Iterable[Workspace]:
         """List all workspaces that the user has access to in the current resource group or subscription.
 
-        :param scope: scope of the listing, "resource_group" or "subscription", defaults to "resource_group"
+        :keyword scope: scope of the listing, "resource_group" or "subscription", defaults to "resource_group"
         :type scope: str, optional
         :return: An iterator like instance of Workspace objects
         :rtype: ~azure.core.paging.ItemPaged[Workspace]
@@ -135,7 +135,7 @@ class WorkspaceOperations(WorkspaceOperationsBase):
         """Triggers the workspace to provision the managed network. Specifying spark enabled
         as true prepares the workspace managed network for supporting Spark.
 
-        :param workspace_name: Name of the workspace.
+        :keyword workspace_name: Name of the workspace.
         :type workspace_name: str
         :return: An instance of LROPoller.
         :rtype: ~azure.core.polling.LROPoller[~azure.ai.ml.entities.ManagedNetworkProvisionStatus]
@@ -195,11 +195,11 @@ class WorkspaceOperations(WorkspaceOperationsBase):
 
         :param name: Name of the workspace
         :type name: str
-        :param delete_dependent_resources: Whether to delete resources associated with the workspace,
+        :keyword delete_dependent_resources: Whether to delete resources associated with the workspace,
             i.e., container registry, storage account, key vault, and application insights.
             The default is False. Set to True to delete these resources.
         :type delete_dependent_resources: bool
-        :param permanently_delete: Workspaces are soft-deleted state by default to allow recovery of workspace data.
+        :keyword permanently_delete: Workspaces are soft-deleted state by default to allow recovery of workspace data.
             Set this flag to override the soft-delete behavior and permanently delete your workspace.
         :type permanently_delete: bool
         :return: A poller to track the operation status.


### PR DESCRIPTION
# Description

This pull request is part of a effort to ready the Azure ML Python SDK for an impending bump to the versions of pylint and azure-pylint-guidelines-checker that is used in our CI.

This pull request specifically resolves `docstring-should-be-keyword` from [azure-pylint-guidelines-checker](https://github.com/Azure/azure-sdk-tools/tree/main/tools/pylint-extensions/azure-pylint-guidelines-checker#rules-list)

Validated with:

`pylint==2.15.8`
`azure-pylint-guidelines-checker=0.0.8`

`pylint --rcfile=../../../eng/pylintc --disable=all --enable=docstring-should-be-keyword azure/`

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
