### PR TITLE
[ML] Require `marshmallow` version lower than 3.20.0

### DIFF
--- a/sdk/ml/azure-ai-ml/dev_requirements.txt
+++ b/sdk/ml/azure-ai-ml/dev_requirements.txt
@@ -2,6 +2,7 @@
 ../../core/azure-core
 -e ../../../tools/azure-devtools
 ../../identity/azure-identity
+marshmallow<3.20
 marshmallow-jsonschema==0.10.0
 mock
 pytest-cov

--- a/sdk/ml/azure-ai-ml/setup.py
+++ b/sdk/ml/azure-ai-ml/setup.py
@@ -69,7 +69,7 @@ setup(
         "msrest>=0.6.18",
         "azure-core<2.0.0,>=1.23.0",
         "azure-mgmt-core<2.0.0,>=1.3.0",
-        "marshmallow<4.0.0,>=3.5",
+        "marshmallow<3.20.0,>=3.5",
         "jsonschema<5.0.0,>=4.0.0",
         "tqdm<5.0.0",
         # Used for PR 825138

--- a/sdk/ml/azure-ai-ml/setup.py
+++ b/sdk/ml/azure-ai-ml/setup.py
@@ -69,7 +69,7 @@ setup(
         "msrest>=0.6.18",
         "azure-core<2.0.0,>=1.23.0",
         "azure-mgmt-core<2.0.0,>=1.3.0",
-        "marshmallow<3.20.0,>=3.5",
+        "marshmallow<4.0.0,>=3.5",
         "jsonschema<5.0.0,>=4.0.0",
         "tqdm<5.0.0",
         # Used for PR 825138


### PR DESCRIPTION
# Description

`marshmallow` dropped support for Python 3.7 in version 3.20.0 (see [changelog](https://github.com/marshmallow-code/marshmallow/blob/dev/CHANGELOG.rst#3200-2023-07-20)). Given that `azure-ai-ml` still supports 3.7, this puts an upper bound on the `setup.py` requirement to avoid picking up the latest version.

Also, because of changes in 3.20.0+, ML CI runs have been failing on platforms using Python 3.8+ ([example](https://dev.azure.com/azure-sdk/public/_build/results?buildId=2935939&view=results)). These test failures seem to just be from body ordering changes, and would probably be fixed by re-recording -- something to note when we drop 3.7 support and the requirement can be raised again.

> Note: 3.20.0 adds "official" support for Python 3.11, but this just comes from adding the support classifier. Library owners state that 3.11 is already supported by `marshmallow` 3.19.0.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
