### PR TITLE
Update CODEOWNERS to add identity team to Identity PRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -44,7 +44,7 @@
 /sdk/agrifood/azure-agrifood-farming/                                @bhargav-kansagara
 
 # PRLabel: %Azure.Identity
-/sdk/identity/                                                       @pvaneck @schaabs @xiangyan99
+/sdk/identity/                                                       @pvaneck @xiangyan99 @Azure/azsdk-identity
 
 # PRLabel: %Event Hubs
 /sdk/eventhub/                                                       @annatisch @kashifkhan @swathipil @l0lawrence


### PR DESCRIPTION
This updates the CODEOWNERS file to add the identity feature crew to Identity-labeled PRs.

Similar PRs in other repos:

- https://github.com/Azure/azure-sdk-for-net/pull/37783/files
- https://github.com/Azure/azure-sdk-for-java/pull/36037/files
