### PR TITLE
App Configuration snapshot deserialization fix

### DIFF
--- a/sdk/appconfiguration/azure-appconfiguration/azure/appconfiguration/_models.py
+++ b/sdk/appconfiguration/azure-appconfiguration/azure/appconfiguration/_models.py
@@ -468,7 +468,8 @@ class Snapshot:  # pylint: disable=too-many-instance-attributes
         if generated.filters:
             for config_setting_filter in generated.filters:
                 filters.append(
-                    ConfigurationSettingFilter(key=config_setting_filter.key, label=config_setting_filter.label))
+                    ConfigurationSettingFilter(key=config_setting_filter.key, label=config_setting_filter.label)
+                )
         snapshot = cls(
             filters=filters,
             composition_type=cast(Optional[Literal["key", "key_label"]], generated.composition_type),
@@ -498,7 +499,8 @@ class Snapshot:  # pylint: disable=too-many-instance-attributes
         if deserialized.filters:
             for config_setting_filter in deserialized.filters:
                 filters.append(
-                    ConfigurationSettingFilter(key=config_setting_filter.key, label=config_setting_filter.label))
+                    ConfigurationSettingFilter(key=config_setting_filter.key, label=config_setting_filter.label)
+                )
         snapshot = cls(
             filters=filters,
             composition_type=cast(Optional[Literal["key", "key_label"]], deserialized.composition_type),


### PR DESCRIPTION
# Description

None check added before iterating filters property of snapshot response since the `filters` property in a Snapshot response could be `None` in the event where the `select` fields do not include `filters`. This causes `Snapshot` creation from response to fail when directly attempting to iterate a NoneType.

If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
