### PR TITLE
[Mgmt Core] Enable CAE in auth policy

### DIFF
--- a/sdk/core/azure-mgmt-core/azure/mgmt/core/policies/_authentication.py
+++ b/sdk/core/azure-mgmt-core/azure/mgmt/core/policies/_authentication.py
@@ -25,12 +25,14 @@
 # --------------------------------------------------------------------------
 import base64
 import time
-from typing import Optional, TypeVar
+from typing import Optional, TypeVar, TYPE_CHECKING, Any
 
 from azure.core.pipeline.policies import BearerTokenCredentialPolicy, SansIOHTTPPolicy
 from azure.core.pipeline import PipelineRequest, PipelineResponse
 from azure.core.exceptions import ServiceRequestError
 
+if TYPE_CHECKING:
+    from azure.core.credentials import TokenCredential
 
 HTTPRequestType = TypeVar("HTTPRequestType")
 HTTPResponseType = TypeVar("HTTPResponseType")
@@ -45,6 +47,11 @@ class ARMChallengeAuthenticationPolicy(BearerTokenCredentialPolicy):
     :param ~azure.core.credentials.TokenCredential credential: credential for authorizing requests
     :param str scopes: required authentication scopes
     """
+
+    def __init__(self, credential: "TokenCredential", *scopes: str, **kwargs: Any) -> None:
+        # ARM supports Continuous Access Evaluation (CAE). This policy will enable it by default.
+        kwargs.setdefault("enable_cae", True)
+        super().__init__(credential, *scopes, **kwargs)
 
     def on_challenge(
         self,

--- a/sdk/core/azure-mgmt-core/azure/mgmt/core/policies/_authentication_async.py
+++ b/sdk/core/azure-mgmt-core/azure/mgmt/core/policies/_authentication_async.py
@@ -23,7 +23,7 @@
 # IN THE SOFTWARE.
 #
 # --------------------------------------------------------------------------
-from typing import TypeVar, Awaitable, Optional
+from typing import TypeVar, Awaitable, Optional, TYPE_CHECKING, Any
 import inspect
 
 from azure.core.pipeline.policies import (
@@ -33,6 +33,9 @@ from azure.core.pipeline.policies import (
 from azure.core.pipeline import PipelineRequest, PipelineResponse
 
 from ._authentication import _parse_claims_challenge, _AuxiliaryAuthenticationPolicyBase
+
+if TYPE_CHECKING:
+    from azure.core.credentials_async import AsyncTokenCredential
 
 
 HTTPRequestType = TypeVar("HTTPRequestType")
@@ -62,6 +65,11 @@ class AsyncARMChallengeAuthenticationPolicy(AsyncBearerTokenCredentialPolicy):
     :param ~azure.core.credentials.TokenCredential credential: credential for authorizing requests
     :param str scopes: required authentication scopes
     """
+
+    def __init__(self, credential: "AsyncTokenCredential", *scopes: str, **kwargs: Any) -> None:
+        # ARM supports Continuous Access Evaluation (CAE). This policy will enable it by default.
+        kwargs.setdefault("enable_cae", True)
+        super().__init__(credential, *scopes, **kwargs)
 
     # pylint:disable=unused-argument
     async def on_challenge(

--- a/sdk/core/azure-mgmt-core/tests/asynctests/test_authentication_async.py
+++ b/sdk/core/azure-mgmt-core/tests/asynctests/test_authentication_async.py
@@ -89,6 +89,8 @@ async def test_claims_challenge():
     args, kwargs = credential.get_token.call_args
     assert expected_scope in args
     assert kwargs["claims"] == expected_claims
+    if "enable_cae" in kwargs:
+        assert kwargs["enable_cae"] == True
 
     with pytest.raises(StopIteration):
         next(tokens)

--- a/sdk/core/azure-mgmt-core/tests/test_authentication.py
+++ b/sdk/core/azure-mgmt-core/tests/test_authentication.py
@@ -150,6 +150,8 @@ def test_claims_challenge():
     args, kwargs = credential.get_token.call_args
     assert expected_scope in args
     assert kwargs["claims"] == expected_claims
+    if "enable_cae" in kwargs:
+        assert kwargs["enable_cae"] == True
 
     with pytest.raises(StopIteration):
         next(tokens)


### PR DESCRIPTION
With recent changes to [Identity](https://github.com/Azure/azure-sdk-for-python/pull/30777) and [Core](https://github.com/Azure/azure-sdk-for-python/pull/31012), requests for CAE tokens are now disabled by default. Since the ARM API endpoint and ARM SDK both support CAE (with the ARM policy containing logic for handling these CAE claims challenges), `ARMChallengeAuthenticationPolicy` and `AsyncARMChallengeAuthenticationPolicy` were updated to ensure that `enable_cae` is set to True.

Since the paradigm is now shifting towards enabling CAE per-request with CAE disabled by default, this change allows credentials to still get CAE-enabled tokens when interacting with ARM SDKs.

