### PR TITLE
[Identity] Enable black formatting in CI

### DIFF
--- a/sdk/identity/azure-identity/azure/identity/_credentials/browser.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/browser.py
@@ -159,6 +159,7 @@ class InteractiveBrowserCredential(InteractiveCredential):
         # base class will raise for other errors
         return result
 
+
 def _open_browser(url):
     opened = webbrowser.open(url)
     if not opened:

--- a/sdk/identity/ci.yml
+++ b/sdk/identity/ci.yml
@@ -35,6 +35,7 @@ extends:
         Path: sdk/identity/platform-matrix.json
         Selection: sparse
         GenerateVMJobs: true
+    ValidateFormatting: true
     TestProxy: true
     Artifacts:
      - name: azure-identity


### PR DESCRIPTION
With the recent black reformatting to azure-identity, let's keep the formatting in check by enabling it in the CI.

