### PR TITLE
upgrade sku for gpu-cluster

### DIFF
--- a/sdk/ml/test-resources.json
+++ b/sdk/ml/test-resources.json
@@ -758,7 +758,7 @@
             "minNodeCount": "[parameters('computeMinNodeCount')]",
             "maxNodeCount": "[parameters('computeMaxNodeCount')]"
           },
-          "vmSize": "[if(equals(parameters('location'), 'eastus2euap'), 'STANDARD_DS2_V2', 'STANDARD_NC6')]",
+          "vmSize": "[if(equals(parameters('location'), 'eastus2euap'), 'STANDARD_DS2_V2', 'STANDARD_NC6S_V3')]",
           "remoteLoginPortPublicAccess": "[parameters('remoteLoginPortPublicAccess')]"
         }
       }

--- a/sdk/ml/test-resources.json
+++ b/sdk/ml/test-resources.json
@@ -759,6 +759,7 @@
             "maxNodeCount": "[parameters('computeMaxNodeCount')]"
           },
           "vmSize": "[if(equals(parameters('location'), 'eastus2euap'), 'STANDARD_DS2_V2', 'STANDARD_NC6S_V3')]",
+          "vmPriority": "[if(equals(parameters('location'), 'eastus2euap'), 'Dedicated', 'LowPriority')]",
           "remoteLoginPortPublicAccess": "[parameters('remoteLoginPortPublicAccess')]"
         }
       }


### PR DESCRIPTION
# Description

The [sdkv2 e2e nightly test gate](https://dev.azure.com/azure-sdk/internal/_build?definitionId=5680&_a=summary) has been failing since July 12 due to failures in Deploy Test Resources step. Upon inspection of the logs and workspace, it seems the issue is that the compute called "gpu-cluster" fails in provisioning because it is of type STANDARD_NC6 which is being deprecated. This PR upgrades the sku to unblock the gate.

If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
