### PR TITLE
[EH] Partition Last Received Event Updating Fix

### DIFF
--- a/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_consumer_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_consumer_async.py
@@ -14,7 +14,6 @@ from ._client_base_async import ConsumerProducerMixin
 from ._async_utils import get_dict_with_loop_if_needed
 from .._common import EventData
 from .._utils import create_properties, event_position_selector
-from ._transport._pyamqp_transport_async import PyamqpTransportAsync
 from .._constants import EPOCH_SYMBOL, TIMEOUT_SYMBOL, RECEIVER_RUNTIME_METRIC_SYMBOL
 
 if TYPE_CHECKING:

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_consumer_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_consumer_async.py
@@ -14,6 +14,7 @@ from ._client_base_async import ConsumerProducerMixin
 from ._async_utils import get_dict_with_loop_if_needed
 from .._common import EventData
 from .._utils import create_properties, event_position_selector
+from ._transport._pyamqp_transport_async import PyamqpTransportAsync
 from .._constants import EPOCH_SYMBOL, TIMEOUT_SYMBOL, RECEIVER_RUNTIME_METRIC_SYMBOL
 
 if TYPE_CHECKING:
@@ -182,7 +183,8 @@ class EventHubConsumer(
         # pylint:disable=protected-access
         message = self._message_buffer.popleft()
         event_data = EventData._from_message(message)
-        event_data._uamqp_message = message
+        if self._amqp_transport != PyamqpTransportAsync:
+            event_data._uamqp_message = message
         self._last_received_event = event_data
         return event_data
 

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_consumer_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_consumer_async.py
@@ -182,7 +182,7 @@ class EventHubConsumer(
         # pylint:disable=protected-access
         message = self._message_buffer.popleft()
         event_data = EventData._from_message(message)
-        if self._amqp_transport != PyamqpTransportAsync:
+        if self._amqp_transport.KIND == "uamqp":
             event_data._uamqp_message = message
         self._last_received_event = event_data
         return event_data

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_consumer_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_consumer_async.py
@@ -178,7 +178,6 @@ class EventHubConsumer(
     async def _open_with_retry(self) -> None:
         await self._do_retryable_operation(self._open, operation_need_param=False)
 
-    # only used by _uamqp_transport_async
     def _next_message_in_buffer(self):
         # pylint:disable=protected-access
         message = self._message_buffer.popleft()

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_transport/_pyamqp_transport_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_transport/_pyamqp_transport_async.py
@@ -228,65 +228,6 @@ class PyamqpTransportAsync(PyamqpTransport, AmqpTransportAsync):
         consumer._callback_task_run = True
         consumer._last_callback_called_time = time.time()
 
-
-        # max_retries = consumer._client._config.max_retries
-        # retried_times = 0
-        # running = True
-        # deadline = time.time() + (max_wait_time or 0)  # max_wait_time can be None
-        # has_not_fetched_once = True
-
-        # while len(consumer._message_buffer) < max_batch_size and (time.time() < deadline):
-        #     has_not_fetched_once = False
-
-        #     while retried_times <= max_retries and running:
-        #         try:
-        #             await consumer._open() # pylint: disable=protected-access
-        #             running = await cast(ReceiveClientAsync, consumer._handler).do_work_async(batch=consumer._prefetch)
-        #             break
-        #         except asyncio.CancelledError:  # pylint: disable=try-except-raise
-        #             raise
-        #         except Exception as exception:  # pylint: disable=broad-except
-        #             # If optional dependency is not installed, do not retry.
-        #             if isinstance(exception, ImportError):
-        #                 raise exception
-        #             if (
-        #                 isinstance(exception, errors.AMQPLinkError)
-        #                 and exception.condition == errors.ErrorCondition.LinkStolen  # pylint: disable=no-member
-        #             ):
-        #                 raise await consumer._handle_exception(exception)
-        #             if not consumer.running:  # exit by close
-        #                 return
-        #             if consumer._last_received_event:
-        #                 consumer._offset = consumer._last_received_event.offset
-        #             last_exception = await consumer._handle_exception(exception)
-        #             retried_times += 1
-        #             if retried_times > max_retries:
-        #                 _LOGGER.info(
-        #                     "%r operation has exhausted retry. Last exception: %r.",
-        #                     consumer._name,
-        #                     last_exception,
-        #                 )
-        #                 raise last_exception
-                    
-        # if consumer._message_buffer:
-        #     while consumer._message_buffer:
-        #         events = [
-        #             consumer._next_message_in_buffer() # pylint: disable=protected-access
-        #             for _ in range(min(max_batch_size, len(consumer._message_buffer))) # pylint: disable=protected-access
-        #         ]
-        #         now_time = time.time()
-        #         if len(events) > 0:
-        #             await consumer._on_event_received(events if batch else events[0]) # pylint: disable=protected-access
-        #             consumer._last_callback_called_time = now_time # pylint: disable=protected-access
-        #         else:
-        #             if max_wait_time and (now_time - consumer._last_callback_called_time) > max_wait_time: # pylint: disable=protected-access
-        #                 # no events received, and need to callback
-        #                 await consumer._on_event_received([] if batch else None) # pylint: disable=protected-access
-        #                 consumer._last_callback_called_time = now_time # pylint: disable=protected-access
-        #             # backoff a bit to avoid throttling CPU when no events are coming
-        #             await asyncio.sleep(0.05)
-
-
         callback_task = asyncio.create_task(
             PyamqpTransportAsync._callback_task(consumer, batch, max_batch_size, max_wait_time)
         )
@@ -300,7 +241,6 @@ class PyamqpTransportAsync(PyamqpTransport, AmqpTransportAsync):
             for t in tasks:
                 if not t.done():
                     await asyncio.wait([t], timeout=1)
-
 
     @staticmethod
     async def create_token_auth_async(auth_uri, get_token, token_type, config, **kwargs):

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_transport/_pyamqp_transport_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_transport/_pyamqp_transport_async.py
@@ -163,6 +163,7 @@ class PyamqpTransportAsync(PyamqpTransport, AmqpTransportAsync):
             events = [EventData._from_message(message) for message in messages] # pylint: disable=protected-access
             now_time = time.time()
             if len(events) > 0:
+                consumer._last_received_event = events[-1] # pylint: disable=protected-access
                 await consumer._on_event_received(events if batch else events[0]) # pylint: disable=protected-access
                 consumer._last_callback_called_time = now_time # pylint: disable=protected-access
             else:

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_transport/_pyamqp_transport_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_transport/_pyamqp_transport_async.py
@@ -156,14 +156,16 @@ class PyamqpTransportAsync(PyamqpTransport, AmqpTransportAsync):
     async def _callback_task(consumer, batch, max_batch_size, max_wait_time):
         while consumer._callback_task_run: # pylint: disable=protected-access
             async with consumer._message_buffer_lock: # pylint: disable=protected-access
-                messages = [
-                    consumer._message_buffer.popleft() # pylint: disable=protected-access
-                    for _ in range(min(max_batch_size, len(consumer._message_buffer))) # pylint: disable=protected-access
-                ]
+                # messages = [
+                #     consumer._message_buffer.popleft() # pylint: disable=protected-access
+                #     for _ in range(min(max_batch_size, len(consumer._message_buffer))) # pylint: disable=protected-access
+                # ]
+                messages  = consumer._next_message_in_buffer() # pylint: disable=protected-access
+
             events = [EventData._from_message(message) for message in messages] # pylint: disable=protected-access
             now_time = time.time()
             if len(events) > 0:
-                consumer._last_received_event = events[-1] # pylint: disable=protected-access
+                # consumer._last_received_event = events[-1] # pylint: disable=protected-access
                 await consumer._on_event_received(events if batch else events[0]) # pylint: disable=protected-access
                 consumer._last_callback_called_time = now_time # pylint: disable=protected-access
             else:

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_transport/_pyamqp_transport_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_transport/_pyamqp_transport_async.py
@@ -229,79 +229,77 @@ class PyamqpTransportAsync(PyamqpTransport, AmqpTransportAsync):
         consumer._last_callback_called_time = time.time()
 
 
-        max_retries = consumer._client._config.max_retries
-        retried_times = 0
-        running = True
-        deadline = time.time() + (max_wait_time or 0)  # max_wait_time can be None
-        has_not_fetched_once = True
+        # max_retries = consumer._client._config.max_retries
+        # retried_times = 0
+        # running = True
+        # deadline = time.time() + (max_wait_time or 0)  # max_wait_time can be None
+        # has_not_fetched_once = True
 
-        while len(consumer._message_buffer) < max_batch_size and (time.time() < deadline or has_not_fetched_once):
-            has_not_fetched_once = False
+        # while len(consumer._message_buffer) < max_batch_size and (time.time() < deadline):
+        #     has_not_fetched_once = False
 
-            while retried_times <= max_retries and running:
-                try:
-                    await consumer._open() # pylint: disable=protected-access
-                    running = await cast(ReceiveClientAsync, consumer._handler).do_work_async(batch=consumer._prefetch)
-                    break
-                except asyncio.CancelledError:  # pylint: disable=try-except-raise
-                    raise
-                except Exception as exception:  # pylint: disable=broad-except
-                    # If optional dependency is not installed, do not retry.
-                    if isinstance(exception, ImportError):
-                        raise exception
-                    if (
-                        isinstance(exception, errors.AMQPLinkError)
-                        and exception.condition == errors.ErrorCondition.LinkStolen  # pylint: disable=no-member
-                    ):
-                        raise await consumer._handle_exception(exception)
-                    if not consumer.running:  # exit by close
-                        return
-                    if consumer._last_received_event:
-                        consumer._offset = consumer._last_received_event.offset
-                    last_exception = await consumer._handle_exception(exception)
-                    retried_times += 1
-                    if retried_times > max_retries:
-                        _LOGGER.info(
-                            "%r operation has exhausted retry. Last exception: %r.",
-                            consumer._name,
-                            last_exception,
-                        )
-                        raise last_exception
+        #     while retried_times <= max_retries and running:
+        #         try:
+        #             await consumer._open() # pylint: disable=protected-access
+        #             running = await cast(ReceiveClientAsync, consumer._handler).do_work_async(batch=consumer._prefetch)
+        #             break
+        #         except asyncio.CancelledError:  # pylint: disable=try-except-raise
+        #             raise
+        #         except Exception as exception:  # pylint: disable=broad-except
+        #             # If optional dependency is not installed, do not retry.
+        #             if isinstance(exception, ImportError):
+        #                 raise exception
+        #             if (
+        #                 isinstance(exception, errors.AMQPLinkError)
+        #                 and exception.condition == errors.ErrorCondition.LinkStolen  # pylint: disable=no-member
+        #             ):
+        #                 raise await consumer._handle_exception(exception)
+        #             if not consumer.running:  # exit by close
+        #                 return
+        #             if consumer._last_received_event:
+        #                 consumer._offset = consumer._last_received_event.offset
+        #             last_exception = await consumer._handle_exception(exception)
+        #             retried_times += 1
+        #             if retried_times > max_retries:
+        #                 _LOGGER.info(
+        #                     "%r operation has exhausted retry. Last exception: %r.",
+        #                     consumer._name,
+        #                     last_exception,
+        #                 )
+        #                 raise last_exception
                     
-        if consumer._message_buffer:
-            while consumer._message_buffer:
-                events = [
-                    consumer._next_message_in_buffer() # pylint: disable=protected-access
-                    for _ in range(min(max_batch_size, len(consumer._message_buffer))) # pylint: disable=protected-access
-                ]
-                now_time = time.time()
-                if len(events) > 0:
-                    await consumer._on_event_received(events if batch else events[0]) # pylint: disable=protected-access
-                    consumer._last_callback_called_time = now_time # pylint: disable=protected-access
-                else:
-                    if max_wait_time and (now_time - consumer._last_callback_called_time) > max_wait_time: # pylint: disable=protected-access
-                        # no events received, and need to callback
-                        await consumer._on_event_received([] if batch else None) # pylint: disable=protected-access
-                        consumer._last_callback_called_time = now_time # pylint: disable=protected-access
-                    # backoff a bit to avoid throttling CPU when no events are coming
-                    await asyncio.sleep(0.05)
+        # if consumer._message_buffer:
+        #     while consumer._message_buffer:
+        #         events = [
+        #             consumer._next_message_in_buffer() # pylint: disable=protected-access
+        #             for _ in range(min(max_batch_size, len(consumer._message_buffer))) # pylint: disable=protected-access
+        #         ]
+        #         now_time = time.time()
+        #         if len(events) > 0:
+        #             await consumer._on_event_received(events if batch else events[0]) # pylint: disable=protected-access
+        #             consumer._last_callback_called_time = now_time # pylint: disable=protected-access
+        #         else:
+        #             if max_wait_time and (now_time - consumer._last_callback_called_time) > max_wait_time: # pylint: disable=protected-access
+        #                 # no events received, and need to callback
+        #                 await consumer._on_event_received([] if batch else None) # pylint: disable=protected-access
+        #                 consumer._last_callback_called_time = now_time # pylint: disable=protected-access
+        #             # backoff a bit to avoid throttling CPU when no events are coming
+        #             await asyncio.sleep(0.05)
 
 
+        callback_task = asyncio.create_task(
+            PyamqpTransportAsync._callback_task(consumer, batch, max_batch_size, max_wait_time)
+        )
+        receive_task = asyncio.create_task(PyamqpTransportAsync._receive_task(consumer))
 
-
-        # callback_task = asyncio.create_task(
-        #     PyamqpTransportAsync._callback_task(consumer, batch, max_batch_size, max_wait_time)
-        # )
-        # receive_task = asyncio.create_task(PyamqpTransportAsync._receive_task(consumer))
-
-        # tasks = [callback_task, receive_task]
-        # try:
-        #     await asyncio.gather(*tasks)
-        # finally:
-        #     consumer._callback_task_run = False
-        #     for t in tasks:
-        #         if not t.done():
-        #             await asyncio.wait([t], timeout=1)
+        tasks = [callback_task, receive_task]
+        try:
+            await asyncio.gather(*tasks)
+        finally:
+            consumer._callback_task_run = False
+            for t in tasks:
+                if not t.done():
+                    await asyncio.wait([t], timeout=1)
 
 
     @staticmethod

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_transport/_pyamqp_transport_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_transport/_pyamqp_transport_async.py
@@ -156,16 +156,12 @@ class PyamqpTransportAsync(PyamqpTransport, AmqpTransportAsync):
     async def _callback_task(consumer, batch, max_batch_size, max_wait_time):
         while consumer._callback_task_run: # pylint: disable=protected-access
             async with consumer._message_buffer_lock: # pylint: disable=protected-access
-                # messages = [
-                #     consumer._message_buffer.popleft() # pylint: disable=protected-access
-                #     for _ in range(min(max_batch_size, len(consumer._message_buffer))) # pylint: disable=protected-access
-                # ]
-                messages  = consumer._next_message_in_buffer() # pylint: disable=protected-access
-
-            events = [EventData._from_message(message) for message in messages] # pylint: disable=protected-access
+                events = [
+                    consumer._next_message_in_buffer() # pylint: disable=protected-access
+                    for _ in range(min(max_batch_size, len(consumer._message_buffer))) # pylint: disable=protected-access
+                ]
             now_time = time.time()
             if len(events) > 0:
-                # consumer._last_received_event = events[-1] # pylint: disable=protected-access
                 await consumer._on_event_received(events if batch else events[0]) # pylint: disable=protected-access
                 consumer._last_callback_called_time = now_time # pylint: disable=protected-access
             else:
@@ -229,80 +225,23 @@ class PyamqpTransportAsync(PyamqpTransport, AmqpTransportAsync):
         :param int or None max_wait_time: Max wait time.
         """
         # pylint:disable=protected-access
+        consumer._callback_task_run = True
+        consumer._last_callback_called_time = time.time()
 
-        max_retries = (
-            consumer._client._config.max_retries  # pylint:disable=protected-access
+        callback_task = asyncio.create_task(
+            PyamqpTransportAsync._callback_task(consumer, batch, max_batch_size, max_wait_time)
         )
-        has_not_fetched_once = True  # ensure one trip when max_wait_time is very small
-        deadline = time.time() + (max_wait_time or 0)  # max_wait_time can be None
-        while len(consumer._message_buffer) < max_batch_size and (
-            time.time() < deadline or has_not_fetched_once
-        ):
-            retried_times = 0
-            has_not_fetched_once = False
-            while retried_times <= max_retries and running and consumer._callback_task_run:
-                try:
-                    await consumer._open() # pylint: disable=protected-access
-                    running = await cast(ReceiveClientAsync, consumer._handler).do_work_async(batch=consumer._prefetch)
-                except asyncio.CancelledError:  # pylint: disable=try-except-raise
-                    raise
-                except Exception as exception:  # pylint: disable=broad-except
-                    # If optional dependency is not installed, do not retry.
-                    if isinstance(exception, ImportError):
-                        raise exception
-                    if (
-                        isinstance(exception, errors.AMQPLinkError)
-                        and exception.condition == errors.ErrorCondition.LinkStolen  # pylint: disable=no-member
-                    ):
-                        raise await consumer._handle_exception(exception)
-                    if not consumer.running:  # exit by close
-                        return
-                    if consumer._last_received_event:
-                        consumer._offset = consumer._last_received_event.offset
-                    last_exception = await consumer._handle_exception(exception)
-                    retried_times += 1
-                    if retried_times > max_retries:
-                        _LOGGER.info(
-                            "%r operation has exhausted retry. Last exception: %r.",
-                            consumer._name,
-                            last_exception,
-                        )
-                        raise last_exception
+        receive_task = asyncio.create_task(PyamqpTransportAsync._receive_task(consumer))
 
-        if consumer._message_buffer:
-            while consumer._message_buffer:
-                if batch:
-                    events_for_callback: List[EventData] = []
-                    for _ in range(min(max_batch_size, len(consumer._message_buffer))):
-                        events_for_callback.append(consumer._next_message_in_buffer())
-                    await consumer._on_event_received(events_for_callback)
-                else:
-                    await consumer._on_event_received(consumer._next_message_in_buffer())
-        elif max_wait_time:
-            if batch:
-                await consumer._on_event_received([])
-            else:
-                await consumer._on_event_received(None)
+        tasks = [callback_task, receive_task]
+        try:
+            await asyncio.gather(*tasks)
+        finally:
+            consumer._callback_task_run = False
+            for t in tasks:
+                if not t.done():
+                    await asyncio.wait([t], timeout=1)
 
-
-
-
-
-        # consumer._callback_task_run = True
-        # consumer._last_callback_called_time = time.time()
-        # callback_task = asyncio.create_task(
-        #     PyamqpTransportAsync._callback_task(consumer, batch, max_batch_size, max_wait_time)
-        # )
-        # receive_task = asyncio.create_task(PyamqpTransportAsync._receive_task(consumer))
-
-        # tasks = [callback_task, receive_task]
-        # try:
-        #     await asyncio.gather(*tasks)
-        # finally:
-        #     consumer._callback_task_run = False
-        #     for t in tasks:
-        #         if not t.done():
-        #             await asyncio.wait([t], timeout=1)
 
     @staticmethod
     async def create_token_auth_async(auth_uri, get_token, token_type, config, **kwargs):

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_transport/_pyamqp_transport_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_transport/_pyamqp_transport_async.py
@@ -228,19 +228,80 @@ class PyamqpTransportAsync(PyamqpTransport, AmqpTransportAsync):
         consumer._callback_task_run = True
         consumer._last_callback_called_time = time.time()
 
-        callback_task = asyncio.create_task(
-            PyamqpTransportAsync._callback_task(consumer, batch, max_batch_size, max_wait_time)
-        )
-        receive_task = asyncio.create_task(PyamqpTransportAsync._receive_task(consumer))
 
-        tasks = [callback_task, receive_task]
-        try:
-            await asyncio.gather(*tasks)
-        finally:
-            consumer._callback_task_run = False
-            for t in tasks:
-                if not t.done():
-                    await asyncio.wait([t], timeout=1)
+        max_retries = consumer._client._config.max_retries
+        retried_times = 0
+        running = True
+        deadline = time.time() + (max_wait_time or 0)  # max_wait_time can be None
+        has_not_fetched_once = True
+
+        while len(consumer._message_buffer) < max_batch_size and (time.time() < deadline or has_not_fetched_once):
+            has_not_fetched_once = False
+
+            while retried_times <= max_retries and running:
+                try:
+                    await consumer._open() # pylint: disable=protected-access
+                    running = await cast(ReceiveClientAsync, consumer._handler).do_work_async(batch=consumer._prefetch)
+                    break
+                except asyncio.CancelledError:  # pylint: disable=try-except-raise
+                    raise
+                except Exception as exception:  # pylint: disable=broad-except
+                    # If optional dependency is not installed, do not retry.
+                    if isinstance(exception, ImportError):
+                        raise exception
+                    if (
+                        isinstance(exception, errors.AMQPLinkError)
+                        and exception.condition == errors.ErrorCondition.LinkStolen  # pylint: disable=no-member
+                    ):
+                        raise await consumer._handle_exception(exception)
+                    if not consumer.running:  # exit by close
+                        return
+                    if consumer._last_received_event:
+                        consumer._offset = consumer._last_received_event.offset
+                    last_exception = await consumer._handle_exception(exception)
+                    retried_times += 1
+                    if retried_times > max_retries:
+                        _LOGGER.info(
+                            "%r operation has exhausted retry. Last exception: %r.",
+                            consumer._name,
+                            last_exception,
+                        )
+                        raise last_exception
+                    
+        if consumer._message_buffer:
+            while consumer._message_buffer:
+                events = [
+                    consumer._next_message_in_buffer() # pylint: disable=protected-access
+                    for _ in range(min(max_batch_size, len(consumer._message_buffer))) # pylint: disable=protected-access
+                ]
+                now_time = time.time()
+                if len(events) > 0:
+                    await consumer._on_event_received(events if batch else events[0]) # pylint: disable=protected-access
+                    consumer._last_callback_called_time = now_time # pylint: disable=protected-access
+                else:
+                    if max_wait_time and (now_time - consumer._last_callback_called_time) > max_wait_time: # pylint: disable=protected-access
+                        # no events received, and need to callback
+                        await consumer._on_event_received([] if batch else None) # pylint: disable=protected-access
+                        consumer._last_callback_called_time = now_time # pylint: disable=protected-access
+                    # backoff a bit to avoid throttling CPU when no events are coming
+                    await asyncio.sleep(0.05)
+
+
+
+
+        # callback_task = asyncio.create_task(
+        #     PyamqpTransportAsync._callback_task(consumer, batch, max_batch_size, max_wait_time)
+        # )
+        # receive_task = asyncio.create_task(PyamqpTransportAsync._receive_task(consumer))
+
+        # tasks = [callback_task, receive_task]
+        # try:
+        #     await asyncio.gather(*tasks)
+        # finally:
+        #     consumer._callback_task_run = False
+        #     for t in tasks:
+        #         if not t.done():
+        #             await asyncio.wait([t], timeout=1)
 
 
     @staticmethod

--- a/sdk/eventhub/azure-eventhub/dev_requirements.txt
+++ b/sdk/eventhub/azure-eventhub/dev_requirements.txt
@@ -6,3 +6,5 @@ azure-mgmt-resource==20.0.0
 aiohttp>=3.0,<4.0
 websocket-client==1.4.2
 -e ../../../tools/azure-devtools
+azure-eventhub-checkpointstoreblob-aio
+azure-eventhub-checkpointstoreblob

--- a/sdk/eventhub/azure-eventhub/dev_requirements.txt
+++ b/sdk/eventhub/azure-eventhub/dev_requirements.txt
@@ -4,7 +4,7 @@
 azure-mgmt-eventhub<=10.1.0
 azure-mgmt-resource==20.0.0
 aiohttp>=3.0,<4.0
-websocket-client==1.4.2
+websocket-client
 -e ../../../tools/azure-devtools
 azure-eventhub-checkpointstoreblob-aio
 azure-eventhub-checkpointstoreblob

--- a/sdk/eventhub/azure-eventhub/tests/conftest.py
+++ b/sdk/eventhub/azure-eventhub/tests/conftest.py
@@ -18,6 +18,8 @@ from azure.mgmt.eventhub import EventHubManagementClient
 from azure.eventhub import EventHubProducerClient
 from azure.eventhub._pyamqp import ReceiveClient
 from azure.eventhub._pyamqp.authentication import SASTokenAuth
+from azure.eventhub.extensions.checkpointstoreblob import BlobCheckpointStore
+from azure.eventhub.extensions.checkpointstoreblobaio import BlobCheckpointStore as BlobCheckpointStoreAsync
 try:
     import uamqp
     uamqp_transport_params = [True, False]
@@ -53,6 +55,20 @@ def sleep(request):
 @pytest.fixture(scope="session", params=uamqp_transport_params, ids=uamqp_transport_ids)
 def uamqp_transport(request):
     return request.param
+
+@pytest.fixture(scope="session")    
+def storage_connection_str():
+    return os.environ['AZURE_STORAGE_CONN_STR']
+
+@pytest.fixture()    
+def checkpoint_store(storage_connection_str):
+    checkpoint_store = BlobCheckpointStore.from_connection_string(storage_connection_str, "blobcontainer" + str(uuid.uuid4()))
+    return checkpoint_store
+
+@pytest.fixture()    
+def checkpoint_store_aio(storage_connection_str):
+    checkpoint_store = BlobCheckpointStoreAsync.from_connection_string(storage_connection_str, "blobcontainer" + str(uuid.uuid4()))
+    return checkpoint_store
 
 def get_logger(filename, level=logging.INFO):
     azure_logger = logging.getLogger("azure.eventhub")
@@ -179,6 +195,32 @@ def live_eventhub(resource_group, eventhub_namespace):  # pylint: disable=redefi
         except:
             warnings.warn(UserWarning("eventhub teardown failed"))
 
+@pytest.fixture()
+def schedule_update_properties(live_eventhub):  # pylint: disable=redefined-outer-name
+        try:
+            SUBSCRIPTION_ID = os.environ["AZURE_SUBSCRIPTION_ID"]
+        except KeyError:
+            pytest.skip('AZURE_SUBSCRIPTION_ID defined')
+            return
+        base_url = os.environ.get("EVENTHUB_RESOURCE_MANAGER_URL", "https://management.azure.com/")
+        credential_scopes = ["{}.default".format(base_url)]
+        resource_client = EventHubManagementClient(EnvironmentCredential(), SUBSCRIPTION_ID, base_url=base_url, credential_scopes=credential_scopes)
+        eventhub = resource_client.event_hubs.get(
+            live_eventhub["resource_group"],
+            live_eventhub["namespace"],
+            live_eventhub["event_hub"]
+        )
+        properties = eventhub.as_dict()
+        if properties["message_retention_in_days"] == 1:
+            properties["message_retention_in_days"] = 2
+        else:
+            properties["message_retention_in_days"] = 1
+        resource_client.event_hubs.create_or_update(
+            live_eventhub["resource_group"],
+            live_eventhub["namespace"],
+            live_eventhub["event_hub"],
+            properties
+        )
 
 @pytest.fixture()
 def connection_str(live_eventhub):

--- a/sdk/eventhub/azure-eventhub/tests/conftest.py
+++ b/sdk/eventhub/azure-eventhub/tests/conftest.py
@@ -58,7 +58,11 @@ def uamqp_transport(request):
 
 @pytest.fixture(scope="session")    
 def storage_connection_str():
-    return os.environ['AZURE_STORAGE_CONN_STR']
+    try:
+        return os.environ['AZURE_STORAGE_CONN_STR']
+    except KeyError:
+        pytest.skip('AZURE_STORAGE_CONN_STR undefined')
+        return
 
 @pytest.fixture()    
 def checkpoint_store(storage_connection_str):

--- a/sdk/eventhub/azure-eventhub/tests/conftest.py
+++ b/sdk/eventhub/azure-eventhub/tests/conftest.py
@@ -200,31 +200,16 @@ def live_eventhub(resource_group, eventhub_namespace):  # pylint: disable=redefi
             warnings.warn(UserWarning("eventhub teardown failed"))
 
 @pytest.fixture()
-def schedule_update_properties(live_eventhub):  # pylint: disable=redefined-outer-name
-        try:
-            SUBSCRIPTION_ID = os.environ["AZURE_SUBSCRIPTION_ID"]
-        except KeyError:
-            pytest.skip('AZURE_SUBSCRIPTION_ID defined')
-            return
-        base_url = os.environ.get("EVENTHUB_RESOURCE_MANAGER_URL", "https://management.azure.com/")
-        credential_scopes = ["{}.default".format(base_url)]
-        resource_client = EventHubManagementClient(EnvironmentCredential(), SUBSCRIPTION_ID, base_url=base_url, credential_scopes=credential_scopes)
-        eventhub = resource_client.event_hubs.get(
-            live_eventhub["resource_group"],
-            live_eventhub["namespace"],
-            live_eventhub["event_hub"]
-        )
-        properties = eventhub.as_dict()
-        if properties["message_retention_in_days"] == 1:
-            properties["message_retention_in_days"] = 2
-        else:
-            properties["message_retention_in_days"] = 1
-        resource_client.event_hubs.create_or_update(
-            live_eventhub["resource_group"],
-            live_eventhub["namespace"],
-            live_eventhub["event_hub"],
-            properties
-        )
+def resource_mgmt_client():
+    try:
+        SUBSCRIPTION_ID = os.environ["AZURE_SUBSCRIPTION_ID"]
+    except KeyError:
+        pytest.skip('AZURE_SUBSCRIPTION_ID defined')
+        return
+    base_url = os.environ.get("EVENTHUB_RESOURCE_MANAGER_URL", "https://management.azure.com/")
+    credential_scopes = ["{}.default".format(base_url)]
+    resource_client = EventHubManagementClient(EnvironmentCredential(), SUBSCRIPTION_ID, base_url=base_url, credential_scopes=credential_scopes)
+    yield resource_client
 
 @pytest.fixture()
 def connection_str(live_eventhub):

--- a/sdk/eventhub/azure-eventhub/tests/dev_requirements.txt
+++ b/sdk/eventhub/azure-eventhub/tests/dev_requirements.txt
@@ -1,2 +1,0 @@
-azure-eventhub-checkpointstoreblob-aio
-azure-eventhub-checkpointstoreblob

--- a/sdk/eventhub/azure-eventhub/tests/dev_requirements.txt
+++ b/sdk/eventhub/azure-eventhub/tests/dev_requirements.txt
@@ -1,0 +1,2 @@
+azure-eventhub-checkpointstoreblob-aio
+azure-eventhub-checkpointstoreblob

--- a/sdk/eventhub/azure-eventhub/tests/livetest/asynctests/test_consumer_client_async.py
+++ b/sdk/eventhub/azure-eventhub/tests/livetest/asynctests/test_consumer_client_async.py
@@ -54,6 +54,11 @@ async def test_receive_storage_checkpoint_async(connstr_senders, uamqp_transport
     assert len(sequence_numbers_0) == 10
     assert len(sequence_numbers_1) == 10
 
+    try:
+        await checkpoint_store_aio._container_client.delete_container()
+    except:
+        pass
+
 @pytest.mark.liveTest
 @pytest.mark.asyncio
 async def test_receive_no_partition_async(connstr_senders, uamqp_transport):

--- a/sdk/eventhub/azure-eventhub/tests/livetest/asynctests/test_consumer_client_async.py
+++ b/sdk/eventhub/azure-eventhub/tests/livetest/asynctests/test_consumer_client_async.py
@@ -1,6 +1,5 @@
 import pytest
 import asyncio
-import threading
 
 from azure.core.settings import settings
 from azure.core.tracing import SpanKind

--- a/sdk/eventhub/azure-eventhub/tests/livetest/asynctests/test_consumer_client_async.py
+++ b/sdk/eventhub/azure-eventhub/tests/livetest/asynctests/test_consumer_client_async.py
@@ -13,7 +13,7 @@ from azure.eventhub._constants import ALL_PARTITIONS
 
 @pytest.mark.liveTest
 @pytest.mark.asyncio
-async def test_receive_storage_checkpoint(connstr_senders, uamqp_transport, checkpoint_store_aio, schedule_update_properties):
+async def test_receive_storage_checkpoint_async(connstr_senders, uamqp_transport, checkpoint_store_aio, schedule_update_properties):
     connection_str, senders = connstr_senders
 
     for i in range(10):

--- a/sdk/eventhub/azure-eventhub/tests/livetest/synctests/test_consumer_client.py
+++ b/sdk/eventhub/azure-eventhub/tests/livetest/synctests/test_consumer_client.py
@@ -55,6 +55,11 @@ async def test_receive_storage_checkpoint(connstr_senders, uamqp_transport, chec
     assert len(sequence_numbers_0) == 10
     assert len(sequence_numbers_1) == 10
 
+    try:
+        checkpoint_store._container_client.delete_container()
+    except:
+        pass
+
 @pytest.mark.liveTest
 def test_receive_no_partition(connstr_senders, uamqp_transport):
     connection_str, senders = connstr_senders

--- a/sdk/eventhub/azure-eventhub/tests/livetest/synctests/test_consumer_client.py
+++ b/sdk/eventhub/azure-eventhub/tests/livetest/synctests/test_consumer_client.py
@@ -43,8 +43,7 @@ async def test_receive_storage_checkpoint(connstr_senders, uamqp_transport, chec
     with client:
         worker = threading.Thread(target=client.receive,
                                   args=(on_event,),
-                                  kwargs={"starting_position": "-1",
-                                          "partition_id": "0"})
+                                  kwargs={"starting_position": "-1"})
         worker.start()
 
         t = threading.Timer(2, schedule_update_properties)

--- a/sdk/eventhub/azure-eventhub/tests/livetest/synctests/test_consumer_client.py
+++ b/sdk/eventhub/azure-eventhub/tests/livetest/synctests/test_consumer_client.py
@@ -10,6 +10,50 @@ from azure.eventhub import EventHubConsumerClient
 from azure.eventhub._eventprocessor.in_memory_checkpoint_store import InMemoryCheckpointStore
 from azure.eventhub._constants import ALL_PARTITIONS
 
+@pytest.mark.liveTest
+@pytest.mark.asyncio
+async def test_receive_storage_checkpoint(connstr_senders, uamqp_transport, checkpoint_store, schedule_update_properties):
+    connection_str, senders = connstr_senders
+
+    for i in range(10):
+        senders[0].send(EventData("Test EventData"))
+        senders[1].send(EventData("Test EventData"))
+
+    try:
+        checkpoint_store._container_client.create_container()
+    except:
+        pass
+
+    client = EventHubConsumerClient.from_connection_string(connection_str, consumer_group='$default', checkpoint_store=checkpoint_store, uamqp_transport=uamqp_transport)
+
+    sequence_numbers_0 = []
+    sequence_numbers_1 = []
+    async def on_event(partition_context, event):
+        await partition_context.update_checkpoint(event)
+        sequence_num = event.sequence_number
+        if partition_context.partition_id == "0":
+            if sequence_num in sequence_numbers_0:
+                assert False
+            sequence_numbers_0.append(sequence_num)
+        else:
+            if sequence_num in sequence_numbers_1:
+                assert False
+            sequence_numbers_1.append(sequence_num)
+
+    with client:
+        worker = threading.Thread(target=client.receive,
+                                  args=(on_event,),
+                                  kwargs={"starting_position": "-1",
+                                          "partition_id": "0"})
+        worker.start()
+
+        t = threading.Timer(2, schedule_update_properties)
+        t.start()
+        time.sleep(10)
+
+ 
+    assert len(sequence_numbers_0) == 10
+    assert len(sequence_numbers_1) == 10
 
 @pytest.mark.liveTest
 def test_receive_no_partition(connstr_senders, uamqp_transport):

--- a/sdk/eventhub/azure-eventhub/tests/livetest/synctests/test_consumer_client.py
+++ b/sdk/eventhub/azure-eventhub/tests/livetest/synctests/test_consumer_client.py
@@ -28,8 +28,8 @@ async def test_receive_storage_checkpoint(connstr_senders, uamqp_transport, chec
 
     sequence_numbers_0 = []
     sequence_numbers_1 = []
-    async def on_event(partition_context, event):
-        await partition_context.update_checkpoint(event)
+    def on_event(partition_context, event):
+        partition_context.update_checkpoint(event)
         sequence_num = event.sequence_number
         if partition_context.partition_id == "0":
             if sequence_num in sequence_numbers_0:


### PR DESCRIPTION
This PR is to fix an issue that customers where seeing where upon an connection/EntityDisable/Detach/EntityUpdated error, the consumer would reprocesses the previously received events.

On the sync side of the code (for uamqp and pyamqp), we have a `_next_message_in_buffer` function that updates the Consumer's `_last_received_event` to be event data before the Checkpoint is called.  

On the async side of the code, we only had this function for uamqp.

PyAMQP did not do the same, instead it went into EventProcessor `on_event_received` where the `partition_context._last_received_event` was updated, but the `consumer._last_received_event` was never being updated. This meant that on an Exception in `receive_task` (pyamqp_transport_async), `consumer._offset` was never being updated to the latest offset. Therefore, we were reprocessing the old events. 


Decision to leave this as 2 tasks on pyAMQP for now, can revisit later
