### PR TITLE
[Test Proxy] Remove manual certificate setup instructions

### DIFF
--- a/doc/dev/test_proxy_migration_guide.md
+++ b/doc/dev/test_proxy_migration_guide.md
@@ -12,7 +12,6 @@ Please refer to the [troubleshooting guide][troubleshooting] if you have any iss
 - [Update existing tests](#update-existing-tests)
   - [Using resource preparers](#using-resource-preparers)
 - [Run tests](#run-tests)
-  - [Perform one-time setup](#perform-one-time-setup)
   - [Start the proxy server](#start-the-proxy-server)
   - [Record or play back tests](#record-or-play-back-tests)
   - [Register sanitizers](#register-sanitizers)
@@ -93,10 +92,6 @@ Resource preparers need a management client to function, so test classes that us
 [AzureMgmtRecordedTestCase][mgmt_recorded_test_case] instead of AzureRecordedTestCase.
 
 ## Run tests
-
-### Perform one-time setup
-
-The test proxy uses a self-signed certificate to communicate with HTTPS. Follow the general setup instructions [here][proxy_cert_docs] to trust this certificate locally.
 
 ### Start the proxy server
 

--- a/doc/dev/tests.md
+++ b/doc/dev/tests.md
@@ -15,7 +15,6 @@ testing infrastructure, and demonstrates how to write and run tests for a servic
     - [Tox](#tox)
     - [The `devtools_testutils` package](#the-devtools_testutils-package)
     - [Write or run tests](#write-or-run-tests)
-        - [Perform one-time test proxy setup](#perform-one-time-test-proxy-setup)
         - [Set up test resources](#set-up-test-resources)
         - [Configure credentials](#configure-credentials)
         - [Start the test proxy server](#start-the-test-proxy-server)
@@ -166,10 +165,6 @@ the
 Newer SDK tests utilize the [Azure SDK Tools Test Proxy][proxy_general_docs] to record and playback HTTP interactions.
 To migrate an existing test suite to use the test proxy, or to learn more about using the test proxy, refer to the
 [test proxy migration guide][proxy_migration_guide].
-
-### Perform one-time test proxy setup
-
-The test proxy uses a self-signed certificate to communicate with HTTPS. Follow the general setup instructions [here][proxy_cert_docs] to trust this certificate locally.
 
 ### Set up test resources
 


### PR DESCRIPTION
# Description

Now that https://github.com/Azure/azure-sdk-for-python/pull/30789 is merged, the test proxy is ready to go, on any platform, without any manual setup. The last manual setup -- trusting the proxy's certificate -- was obviated by automatic certificate setup and HTTP client reconfiguration.

This PR removes instructions in our test proxy documentation that asks users to do this manual setup.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
