### PR TITLE
[Perf][EH/SB] Align test names with other SDKs

### DIFF
--- a/sdk/eventhub/perf-tests.yml
+++ b/sdk/eventhub/perf-tests.yml
@@ -11,7 +11,7 @@ PackageVersions:
   azure-eventhub: source
 
 Tests:
-- Test: send-event-batch
+- Test: send-events-batch
   Class: SendEventBatchTest
   Arguments:
   - --event-size 1024 --batch-size 100 --parallel 64

--- a/sdk/eventhub/perf.yml
+++ b/sdk/eventhub/perf.yml
@@ -10,7 +10,7 @@ parameters:
 - name: Tests
   displayName: Tests (regex of tests to run)
   type: string
-  default: '^(process-events-batch|send-event-batch)$'
+  default: '^(process-events-batch|send-events-batch)$'
 - name: Arguments
   displayName: Arguments (regex of arguments to run)
   type: string

--- a/sdk/servicebus/perf-tests.yml
+++ b/sdk/servicebus/perf-tests.yml
@@ -11,15 +11,15 @@ PackageVersions:
   azure-servicebus: source
 
 Tests:
-- Test: send-queue-message-batch
+- Test: send-queue-messages-batch
   Class: SendQueueMessageBatchTest
   Arguments:
-  - --message-size 1024 --batch-size 100  
+  - --message-size 1024 --batch-size 100
   - --message-size 1024 --batch-size 100 --uamqp-transport
   - --message-size 1024 --batch-size 100 --transport-type 1
   - --message-size 1024 --batch-size 100 --transport-type 1 --uamqp-transport
 
-- Test: receive-queue-message-batch
+- Test: receive-queue-messages-batch
   Class: ReceiveQueueMessageBatchTest
   Arguments:
   - --message-size 2000 --num-messages 50 --preload 10000
@@ -27,15 +27,15 @@ Tests:
   - --message-size 2000 --num-messages 50 --preload 10000 --transport-type 1
   - --message-size 2000 --num-messages 50 --preload 10000 --transport-type 1 --uamqp-transport
 
-- Test: send-subscription-message-batch
+- Test: send-subscription-messages-batch
   Class: SendTopicMessageBatchTest
   Arguments:
-  - --message-size 1024 --batch-size 100  
+  - --message-size 1024 --batch-size 100
   - --message-size 1024 --batch-size 100 --uamqp-transport
   - --message-size 1024 --batch-size 100 --transport-type 1
   - --message-size 1024 --batch-size 100 --transport-type 1 --uamqp-transport
 
-- Test: receive-subscription-message-batch
+- Test: receive-subscription-messages-batch
   Class: ReceiveSubscriptionMessageBatchTest
   Arguments:
   - --message-size 2000 --num-messages 50 --preload 10000

--- a/sdk/servicebus/perf.yml
+++ b/sdk/servicebus/perf.yml
@@ -10,7 +10,7 @@ parameters:
 - name: Tests
   displayName: Tests (regex of tests to run)
   type: string
-  default: '^(send-queue-message-batch|send-subscription-message-batch|receive-queue-message-batch|receive-subscription-message-batch)$'
+  default: '^(send-queue-messages-batch|send-subscription-messages-batch|receive-queue-messages-batch|receive-subscription-messages-batch)$'
 - name: Arguments
   displayName: Arguments (regex of arguments to run)
   type: string


### PR DESCRIPTION
This is so we can better compare similar AMQP SDK test runs among all the SDKs.

Related: https://github.com/Azure/azure-sdk-for-js/pull/26674