### PR TITLE
Update dev_requirements.txt for dev core/identity

### DIFF
--- a/sdk/cosmos/azure-cosmos/dev_requirements.txt
+++ b/sdk/cosmos/azure-cosmos/dev_requirements.txt
@@ -1,4 +1,4 @@
-azure-core
-azure-identity
+-e ../../core/azure-core
+-e ../../identity/azure-identity
 -e ../../../tools/azure-sdk-tools
 -e ../../../tools/azure-devtools


### PR DESCRIPTION
We didn't catch a change in azure-core that broke cosmos ([see this](https://github.com/Azure/azure-sdk-for-python/pull/31348)), because cosmos do not follow the guidance to install dev core, but install from PyPI instead.

This would have avoided any breakage in cosmos, as we would have caught it sooner.