### PR TITLE
[Cosmos] fix async query samples

### DIFF
--- a/sdk/cosmos/azure-cosmos/samples/examples_async.py
+++ b/sdk/cosmos/azure-cosmos/samples/examples_async.py
@@ -101,8 +101,7 @@ async def examples_async():
         import json
 
         async for item in container.query_items(
-                query='SELECT * FROM products p WHERE p.productModel <> "DISCONTINUED"',
-                enable_cross_partition_query=True,
+                query='SELECT * FROM products p WHERE p.productModel <> "DISCONTINUED"'
         ):
             print(json.dumps(item, indent=True))
         # [END query_items]

--- a/sdk/cosmos/azure-cosmos/samples/index_management_async.py
+++ b/sdk/cosmos/azure-cosmos/samples/index_management_async.py
@@ -119,7 +119,7 @@ async def fetch_all_databases(client):
 
 async def query_documents_with_custom_query(container, query_with_optional_parameters, message = "Document(s) found by query: "):
     try:
-        results = container.query_items(query_with_optional_parameters, enable_cross_partition_query=True)
+        results = container.query_items(query_with_optional_parameters)
         print(message)
         async for doc in results:
             print(doc)
@@ -377,8 +377,7 @@ async def range_scan_on_hash_index(db):
         # using the enableScanInQuery directive
         results = created_Container.query_items(
             query,
-            enable_scan_in_query=True,
-            enable_cross_partition_query=True
+            enable_scan_in_query=True
         )
         print("Printing documents queried by range by providing enableScanInQuery = True")
         async for doc in results: print(doc["id"])


### PR DESCRIPTION
Addressing https://github.com/Azure/azure-sdk-for-python/issues/30876 which pointed out we were wrongly using the `enable_cross_partition_query` in our async samples. 