### PR TITLE
[AppConfig] Fix a bug in creating FeatureFlagConfigurationSetting

### DIFF
--- a/sdk/appconfiguration/azure-appconfiguration/CHANGELOG.md
+++ b/sdk/appconfiguration/azure-appconfiguration/CHANGELOG.md
@@ -1,15 +1,10 @@
 # Release History
 
-## 1.5.0b2 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 1.5.0b2 (2023-08-02)
 
 ### Bugs Fixed
 - Fixed a bug in deserializing and serializing Snapshot when `filters` property is `None`.
-
-### Other Changes
+- Fixed a bug when creating `FeatureFlagConfigurationSetting` from SDK but having an error in portal.([#31326](https://github.com/Azure/azure-sdk-for-python/issues/31326))
 
 ## 1.5.0b1 (2023-07-11)
 

--- a/sdk/appconfiguration/azure-appconfiguration/assets.json
+++ b/sdk/appconfiguration/azure-appconfiguration/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "python",
   "TagPrefix": "python/appconfiguration/azure-appconfiguration",
-  "Tag": "python/appconfiguration/azure-appconfiguration_55ff13c98d"
+  "Tag": "python/appconfiguration/azure-appconfiguration_214d709db6"
 }

--- a/sdk/appconfiguration/azure-appconfiguration/azure/appconfiguration/_models.py
+++ b/sdk/appconfiguration/azure-appconfiguration/azure/appconfiguration/_models.py
@@ -29,21 +29,21 @@ class ConfigurationSetting(Model):
     """A configuration value.
     Variables are only populated by the server, and will be ignored when sending a request.
 
-    :ivar value: The value of the configuration setting
+    :ivar value: The value of the configuration setting.
     :vartype value: str
-    :ivar etag: Entity tag (etag) of the object
+    :ivar etag: Entity tag (etag) of the object.
     :vartype etag: str
-    :ivar key:
+    :ivar key: The key of the configuration setting.
     :vartype key: str
-    :ivar label:
+    :ivar label: The label of the configuration setting.
     :vartype label: str
-    :ivar content_type:
+    :ivar content_type: The content_type of the configuration setting.
     :vartype content_type: str
     :ivar last_modified:
     :vartype last_modified: datetime
     :ivar read_only:
     :vartype read_only: bool
-    :ivar tags:
+    :ivar tags: The tags assigned to the configuration setting.
     :vartype tags: dict[str, str]
     """
 
@@ -134,19 +134,19 @@ class FeatureFlagConfigurationSetting(ConfigurationSetting):  # pylint: disable=
     :paramtype enabled: bool
     :keyword filters: Filters that must run on the client and be evaluated as true for the feature to be considered enabled.
     :paramtype filters: list[dict[str, Any]]
-    :ivar label: A label used to group this configuration setting with others.
+    :ivar label: The label used to group this configuration setting with others.
     :vartype label: str
-    :ivar display_name: A name for the feature to use for display rather than the ID.
+    :ivar display_name: The name for the feature to use for display rather than the ID.
     :vartype display_name: str
-    :ivar description: A description of the feature.
+    :ivar description: The description of the feature.
     :vartype description: str
-    :ivar content_type:
+    :ivar content_type: The content_type of the configuration setting.
     :vartype content_type: str
     :ivar last_modified:
     :vartype last_modified: datetime
     :ivar read_only:
     :vartype read_only: bool
-    :ivar tags:
+    :ivar tags: The tags assigned to the configuration setting.
     :vartype tags: dict[str, str]
     """
 
@@ -265,15 +265,15 @@ class SecretReferenceConfigurationSetting(ConfigurationSetting):
     Variables are only populated by the server, and will be ignored when
     sending a request.
 
-    :ivar etag: Entity tag (etag) of the object
+    :ivar etag: Entity tag (etag) of the object.
     :vartype etag: str
-    :param key:
+    :param key: The key of the configuration setting.
     :type key: str
-    :param secret_id:
+    :param secret_id: The identity of the configuration setting.
     :type secret_id: str
-    :ivar label:
+    :ivar label: The label used to group this configuration setting with others.
     :vartype label: str
-    :ivar content_type:
+    :ivar content_type: The content_type of the configuration setting.
     :vartype content_type: str
     :ivar value: The value of the configuration setting
     :vartype value: dict[str, Any]
@@ -281,7 +281,7 @@ class SecretReferenceConfigurationSetting(ConfigurationSetting):
     :vartype last_modified: datetime
     :ivar read_only:
     :vartype read_only: bool
-    :ivar tags:
+    :ivar tags: The tags assigned to the configuration setting.
     :vartype tags: dict[str, str]
     """
 

--- a/sdk/appconfiguration/azure-appconfiguration/azure/appconfiguration/_models.py
+++ b/sdk/appconfiguration/azure-appconfiguration/azure/appconfiguration/_models.py
@@ -132,7 +132,8 @@ class FeatureFlagConfigurationSetting(ConfigurationSetting):  # pylint: disable=
     :keyword enabled: The value indicating whether the feature flag is enabled. A feature is OFF if enabled is false.
         If enabled is true, then the feature is ON if there are no conditions or if all conditions are satisfied.
     :paramtype enabled: bool
-    :keyword filters: Filters that must run on the client and be evaluated as true for the feature to be considered enabled.
+    :keyword filters: Filters that must run on the client and be evaluated as true for the feature
+        to be considered enabled.
     :paramtype filters: list[dict[str, Any]]
     :ivar label: The label used to group this configuration setting with others.
     :vartype label: str

--- a/sdk/appconfiguration/azure-appconfiguration/tests/test_azure_appconfiguration_client.py
+++ b/sdk/appconfiguration/azure-appconfiguration/tests/test_azure_appconfiguration_client.py
@@ -544,29 +544,43 @@ class TestAppConfigurationClient(AppConfigTestCase):
     def test_config_setting_feature_flag(self, appconfiguration_connection_string):
         client = self.create_client(appconfiguration_connection_string)
         feature_flag = FeatureFlagConfigurationSetting("test_feature", enabled=True)
-        set_flag = client.set_configuration_setting(feature_flag)
 
+        set_flag = client.set_configuration_setting(feature_flag)
         self._assert_same_keys(feature_flag, set_flag)
+        set_flag_value = json.loads(set_flag.value)
+        assert set_flag_value["id"] == "test_feature"
+        assert set_flag_value["enabled"] == True
+        assert set_flag_value["conditions"] != None
 
         set_flag.enabled = not set_flag.enabled
         changed_flag = client.set_configuration_setting(set_flag)
-
-        changed_flag.enabled = False
+        assert changed_flag.enabled == False
         temp = json.loads(changed_flag.value)
+        assert temp["id"] == set_flag_value["id"]
         assert temp["enabled"] == False
+        assert temp["conditions"] == set_flag_value["conditions"]
 
         c = json.loads(changed_flag.value)
         c["enabled"] = True
         changed_flag.value = json.dumps(c)
         assert changed_flag.enabled == True
+        temp = json.loads(changed_flag.value)
+        assert temp["id"] == set_flag_value["id"]
+        assert temp["enabled"] == True
+        assert temp["conditions"] == set_flag_value["conditions"]
 
         changed_flag.value = json.dumps({})
         assert changed_flag.enabled == None
-        assert changed_flag.value == json.dumps({"enabled": None, "conditions": {"client_filters": None}})
+        temp = json.loads(changed_flag.value)
+        assert temp["id"] == set_flag_value["id"]
+        assert temp["enabled"] == None
+        assert temp["conditions"] != None
+        assert temp["conditions"]["client_filters"] == None
 
         set_flag.value = "bad_value"
         assert set_flag.enabled == None
         assert set_flag.filters == None
+        assert set_flag.value == "bad_value"
 
         client.delete_configuration_setting(changed_flag.key)
 

--- a/sdk/appconfiguration/azure-appconfiguration/tests/test_azure_appconfiguration_client_aad_async.py
+++ b/sdk/appconfiguration/azure-appconfiguration/tests/test_azure_appconfiguration_client_aad_async.py
@@ -548,29 +548,43 @@ class TestAppConfigurationClientAADAsync(AsyncAppConfigTestCase):
     async def test_config_setting_feature_flag(self, appconfiguration_endpoint_string):
         async with self.create_aad_client(appconfiguration_endpoint_string) as client:
             feature_flag = FeatureFlagConfigurationSetting("test_feature", enabled=True)
-            set_flag = await client.set_configuration_setting(feature_flag)
 
+            set_flag = await client.set_configuration_setting(feature_flag)
             self._assert_same_keys(feature_flag, set_flag)
+            set_flag_value = json.loads(set_flag.value)
+            assert set_flag_value["id"] == "test_feature"
+            assert set_flag_value["enabled"] == True
+            assert set_flag_value["conditions"] != None
 
             set_flag.enabled = not set_flag.enabled
             changed_flag = await client.set_configuration_setting(set_flag)
-
-            changed_flag.enabled = False
+            assert changed_flag.enabled == False
             temp = json.loads(changed_flag.value)
+            assert temp["id"] == set_flag_value["id"]
             assert temp["enabled"] == False
+            assert temp["conditions"] == set_flag_value["conditions"]
 
-            c = json.loads(copy.deepcopy(changed_flag.value))
+            c = json.loads(changed_flag.value)
             c["enabled"] = True
             changed_flag.value = json.dumps(c)
             assert changed_flag.enabled == True
+            temp = json.loads(changed_flag.value)
+            assert temp["id"] == set_flag_value["id"]
+            assert temp["enabled"] == True
+            assert temp["conditions"] == set_flag_value["conditions"]
 
             changed_flag.value = json.dumps({})
             assert changed_flag.enabled == None
-            assert changed_flag.value == json.dumps({"enabled": None, "conditions": {"client_filters": None}})
+            temp = json.loads(changed_flag.value)
+            assert temp["id"] == set_flag_value["id"]
+            assert temp["enabled"] == None
+            assert temp["conditions"] != None
+            assert temp["conditions"]["client_filters"] == None
 
             set_flag.value = "bad_value"
             assert set_flag.enabled == None
             assert set_flag.filters == None
+            assert set_flag.value == "bad_value"
 
             await client.delete_configuration_setting(changed_flag.key)
 

--- a/sdk/appconfiguration/azure-appconfiguration/tests/test_azure_appconfiguration_client_async.py
+++ b/sdk/appconfiguration/azure-appconfiguration/tests/test_azure_appconfiguration_client_async.py
@@ -553,29 +553,43 @@ class TestAppConfigurationClientAsync(AsyncAppConfigTestCase):
     async def test_config_setting_feature_flag(self, appconfiguration_connection_string):
         async with self.create_client(appconfiguration_connection_string) as client:
             feature_flag = FeatureFlagConfigurationSetting("test_feature", enabled=True)
-            set_flag = await client.set_configuration_setting(feature_flag)
 
+            set_flag = await client.set_configuration_setting(feature_flag)
             self._assert_same_keys(feature_flag, set_flag)
+            set_flag_value = json.loads(set_flag.value)
+            assert set_flag_value["id"] == "test_feature"
+            assert set_flag_value["enabled"] == True
+            assert set_flag_value["conditions"] != None
 
             set_flag.enabled = not set_flag.enabled
             changed_flag = await client.set_configuration_setting(set_flag)
-
-            changed_flag.enabled = False
+            assert changed_flag.enabled == False
             temp = json.loads(changed_flag.value)
+            assert temp["id"] == set_flag_value["id"]
             assert temp["enabled"] == False
+            assert temp["conditions"] == set_flag_value["conditions"]
 
             c = json.loads(copy.deepcopy(changed_flag.value))
             c["enabled"] = True
             changed_flag.value = json.dumps(c)
             assert changed_flag.enabled == True
+            temp = json.loads(changed_flag.value)
+            assert temp["id"] == set_flag_value["id"]
+            assert temp["enabled"] == True
+            assert temp["conditions"] == set_flag_value["conditions"]
 
             changed_flag.value = json.dumps({})
             assert changed_flag.enabled == None
-            assert changed_flag.value == json.dumps({"enabled": None, "conditions": {"client_filters": None}})
+            temp = json.loads(changed_flag.value)
+            assert temp["id"] == set_flag_value["id"]
+            assert temp["enabled"] == None
+            assert temp["conditions"] != None
+            assert temp["conditions"]["client_filters"] == None
 
             set_flag.value = "bad_value"
             assert set_flag.enabled == None
             assert set_flag.filters == None
+            assert set_flag.value == "bad_value"
 
             await client.delete_configuration_setting(changed_flag.key)
 

--- a/sdk/appconfiguration/azure-appconfiguration/tests/testcase.py
+++ b/sdk/appconfiguration/azure-appconfiguration/tests/testcase.py
@@ -84,13 +84,12 @@ class AppConfigTestCase(AzureRecordedTestCase):
         assert key1.content_type == key2.content_type
         assert key1.tags == key2.tags
         assert key1.etag != key2.etag
+        assert key1.value == key2.value
         if isinstance(key1, FeatureFlagConfigurationSetting):
             assert key1.enabled == key2.enabled
             assert len(key1.filters) == len(key2.filters)
         elif isinstance(key1, SecretReferenceConfigurationSetting):
             assert key1.secret_id == key2.secret_id
-        else:
-            assert key1.value == key2.value
 
     def _assert_snapshots(self, snapshot: Snapshot, expected_snapshot: Snapshot):
         assert snapshot.composition_type == expected_snapshot.composition_type


### PR DESCRIPTION
Resolves https://github.com/Azure/azure-sdk-for-python/issues/31326

According to the definition of FeatureFlag schema([link](https://github.com/Azure/AppConfiguration/blob/main/docs/FeatureManagement/FeatureFlag.v1.1.0.schema.json#L7)), there's one required value "id" missing when creating `FeatureFlagConfigurationSetting`.