### PR TITLE
Use relative path in dev_requirements

### DIFF
--- a/sdk/agrifood/azure-agrifood-farming/dev_requirements.txt
+++ b/sdk/agrifood/azure-agrifood-farming/dev_requirements.txt
@@ -1,6 +1,6 @@
 aiohttp==3.8.3
 python-dateutil==2.8.2
-azure-core==1.26.3
-azure-identity==1.12.0
+-e ../../core/azure-core
+-e ../../identity/azure-identity
 -e ../../../tools/azure-sdk-tools
 -e ../../../tools/azure-devtools

--- a/sdk/appconfiguration/azure-appconfiguration-provider/dev_requirements.txt
+++ b/sdk/appconfiguration/azure-appconfiguration-provider/dev_requirements.txt
@@ -1,7 +1,7 @@
 -e ../../../tools/azure-devtools
-azure-core>=1.24.0
-azure-appconfiguration==1.4.0
-azure-identity
-azure-keyvault-secrets
+-e ../../core/azure-core
+-e ../../appconfiguration/azure-appconfiguration
+-e ../../identity/azure-identity
+-e ../../keyvault/azure-keyvault-secrets
 aiohttp>=3.0
 -e ../../../tools/azure-sdk-tools

--- a/sdk/servermanager/azure-mgmt-servermanager/MANIFEST.in
+++ b/sdk/servermanager/azure-mgmt-servermanager/MANIFEST.in
@@ -1,6 +1,8 @@
 include _meta.json
-recursive-include tests *.py *.yaml
+recursive-include tests *.py *.json
+recursive-include samples *.py *.md
 include *.md
 include azure/__init__.py
 include azure/mgmt/__init__.py
 include LICENSE
+include azure/mgmt/servermanager/py.typed

--- a/sdk/servermanager/azure-mgmt-servermanager/README.md
+++ b/sdk/servermanager/azure-mgmt-servermanager/README.md
@@ -1,26 +1,60 @@
 # Microsoft Azure SDK for Python
 
 This is the Microsoft Azure Server Manager Management Client Library.
-This package has been tested with Python 3.6+.
+This package has been tested with Python 3.7+.
 For a more complete view of Azure libraries, see the [azure sdk python release](https://aka.ms/azsdk/python/all).
 
 ## _Disclaimer_
 
 _Azure SDK Python packages support for Python 2.7 has ended 01 January 2022. For more information and questions, please refer to https://github.com/Azure/azure-sdk-for-python/issues/20691_
 
-# Usage
+## Getting started
+
+### Prerequisites
+
+- Python 3.7+ is required to use this package.
+- [Azure subscription](https://azure.microsoft.com/free/)
+
+### Install the package
+
+```bash
+pip install azure-mgmt-servermanager
+pip install azure-identity
+```
+
+### Authentication
+
+By default, [Azure Active Directory](https://aka.ms/awps/aad) token authentication depends on correct configure of following environment variables.
+
+- `AZURE_CLIENT_ID` for Azure client ID.
+- `AZURE_TENANT_ID` for Azure tenant ID.
+- `AZURE_CLIENT_SECRET` for Azure client secret.
+
+In addition, Azure subscription ID can be configured via environment variable `AZURE_SUBSCRIPTION_ID`.
+
+With above configuration, client can be authenticated by following code:
+
+```python
+from azure.identity import DefaultAzureCredential
+from azure.mgmt.servermanager import ServerManagement
+import os
+
+sub_id = os.getenv("AZURE_SUBSCRIPTION_ID")
+client = ServerManagement(credential=DefaultAzureCredential(), subscription_id=sub_id)
+```
+
+## Examples
+
+Code samples for this package can be found at:
+- [Search Server Manager Management](https://docs.microsoft.com/samples/browse/?languages=python&term=Getting%20started%20-%20Managing&terms=Getting%20started%20-%20Managing) on docs.microsoft.com
+- [Azure Python Mgmt SDK Samples Repo](https://aka.ms/azsdk/python/mgmt/samples)
 
 
-To learn how to use this package, see the [quickstart guide](https://aka.ms/azsdk/python/mgmt)
+## Troubleshooting
 
+## Next steps
 
- 
-For docs and references, see [Python SDK References](https://docs.microsoft.com/python/api/overview/azure/)
-Code samples for this package can be found at [Server Manager Management](https://docs.microsoft.com/samples/browse/?languages=python&term=Getting%20started%20-%20Managing&terms=Getting%20started%20-%20Managing) on docs.microsoft.com.
-Additional code samples for different Azure services are available at [Samples Repo](https://aka.ms/azsdk/python/mgmt/samples)
-
-
-# Provide Feedback
+## Provide Feedback
 
 If you encounter any bugs or have suggestions, please file an issue in the
 [Issues](https://github.com/Azure/azure-sdk-for-python/issues)

--- a/sdk/servermanager/azure-mgmt-servermanager/dev_requirements.txt
+++ b/sdk/servermanager/azure-mgmt-servermanager/dev_requirements.txt
@@ -1,4 +1,4 @@
 -e ../../../tools/azure-sdk-tools
 -e ../../../tools/azure-devtools
-azure-core
+../../core/azure-core
 ../../identity/azure-identity

--- a/sdk/servermanager/azure-mgmt-servermanager/setup.py
+++ b/sdk/servermanager/azure-mgmt-servermanager/setup.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See License.txt in the project root for
 # license information.
-#--------------------------------------------------------------------------
+# --------------------------------------------------------------------------
 
 import re
 import os.path
@@ -16,59 +16,68 @@ PACKAGE_NAME = "azure-mgmt-servermanager"
 PACKAGE_PPRINT_NAME = "Server Manager Management"
 
 # a-b-c => a/b/c
-package_folder_path = PACKAGE_NAME.replace('-', '/')
+package_folder_path = PACKAGE_NAME.replace("-", "/")
 # a-b-c => a.b.c
-namespace_name = PACKAGE_NAME.replace('-', '.')
+namespace_name = PACKAGE_NAME.replace("-", ".")
 
 # Version extraction inspired from 'requests'
-with open(os.path.join(package_folder_path, 'version.py')
-          if os.path.exists(os.path.join(package_folder_path, 'version.py'))
-          else os.path.join(package_folder_path, '_version.py'), 'r') as fd:
-    version = re.search(r'^VERSION\s*=\s*[\'"]([^\'"]*)[\'"]',
-                        fd.read(), re.MULTILINE).group(1)
+with open(
+    os.path.join(package_folder_path, "version.py")
+    if os.path.exists(os.path.join(package_folder_path, "version.py"))
+    else os.path.join(package_folder_path, "_version.py"),
+    "r",
+) as fd:
+    version = re.search(r'^VERSION\s*=\s*[\'"]([^\'"]*)[\'"]', fd.read(), re.MULTILINE).group(1)
 
 if not version:
-    raise RuntimeError('Cannot find version information')
+    raise RuntimeError("Cannot find version information")
 
-with open('README.md', encoding='utf-8') as f:
+with open("README.md", encoding="utf-8") as f:
     readme = f.read()
-with open('CHANGELOG.md', encoding='utf-8') as f:
+with open("CHANGELOG.md", encoding="utf-8") as f:
     changelog = f.read()
 
 setup(
     name=PACKAGE_NAME,
     version=version,
-    description='Microsoft Azure {} Client Library for Python'.format(PACKAGE_PPRINT_NAME),
-    long_description=readme + '\n\n' + changelog,
-    long_description_content_type='text/markdown',
-    license='MIT License',
-    author='Microsoft Corporation',
-    author_email='azpysdkhelp@microsoft.com',
-    url='https://github.com/Azure/azure-sdk-for-python',
+    description="Microsoft Azure {} Client Library for Python".format(PACKAGE_PPRINT_NAME),
+    long_description=readme + "\n\n" + changelog,
+    long_description_content_type="text/markdown",
+    license="MIT License",
+    author="Microsoft Corporation",
+    author_email="azpysdkhelp@microsoft.com",
+    url="https://github.com/Azure/azure-sdk-for-python",
     keywords="azure, azure sdk",  # update with search keywords relevant to the azure service / product
     classifiers=[
-        'Development Status :: 5 - Production/Stable',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 3 :: Only',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9',
-        'Programming Language :: Python :: 3.10',
-        'License :: OSI Approved :: MIT License',
+        "Development Status :: 5 - Production/Stable",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3 :: Only",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "License :: OSI Approved :: MIT License",
     ],
     zip_safe=False,
-    packages=find_packages(exclude=[
-        'tests',
-        # Exclude packages that will be covered by PEP420 or nspkg
-        'azure',
-        'azure.mgmt',
-    ]),
+    packages=find_packages(
+        exclude=[
+            "tests",
+            # Exclude packages that will be covered by PEP420 or nspkg
+            "azure",
+            "azure.mgmt",
+        ]
+    ),
+    include_package_data=True,
+    package_data={
+        "pytyped": ["py.typed"],
+    },
     install_requires=[
-        'msrest>=0.6.21',
-        'azure-common~=1.1',
-        'azure-mgmt-core>=1.3.0,<2.0.0',
+        "isodate<1.0.0,>=0.6.1",
+        "azure-common~=1.1",
+        "azure-mgmt-core>=1.3.2,<2.0.0",
+        "typing-extensions>=4.3.0; python_version<'3.8.0'",
     ],
-    python_requires=">=3.6"
+    python_requires=">=3.7",
 )

--- a/sdk/translation/azure-ai-translation-text/dev_requirements.txt
+++ b/sdk/translation/azure-ai-translation-text/dev_requirements.txt
@@ -1,3 +1,3 @@
 -e ../../../tools/azure-sdk-tools
 -e ../../../tools/azure-devtools
-azure-core
+-e ../../core/azure-core


### PR DESCRIPTION
We need to use relative path for core and identity in dev_requirements so we can make sure core/identity PRs do not introduce breaking changes.