### PR TITLE
Add a type in identity

### DIFF
--- a/sdk/identity/azure-identity/azure/identity/_internal/pipeline.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/pipeline.py
@@ -26,7 +26,7 @@ def _get_config(**kwargs) -> Configuration:
     :return: A configuration object.
     :rtype: ~azure.core.configuration.Configuration
     """
-    config = Configuration(**kwargs)
+    config: Configuration = Configuration(**kwargs)
     config.custom_hook_policy = CustomHookPolicy(**kwargs)
     config.headers_policy = HeadersPolicy(**kwargs)
     config.http_logging_policy = HttpLoggingPolicy(**kwargs)


### PR DESCRIPTION
Somehow https://github.com/Azure/azure-sdk-for-python/pull/31422 requires this to be happy. Otherwise:

```
azure/identity/_internal/pipeline.py:29: error: Need type annotation for "config"  [var-annotated]
```