### PR TITLE
Update tests

### DIFF
--- a/sdk/search/azure-search-documents/assets.json
+++ b/sdk/search/azure-search-documents/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "python",
   "TagPrefix": "python/search/azure-search-documents",
-  "Tag": "python/search/azure-search-documents_e0e666574f"
+  "Tag": "python/search/azure-search-documents_eb11ec363a"
 }

--- a/sdk/search/azure-search-documents/tests/async_tests/test_search_client_buffered_sender_live_async.py
+++ b/sdk/search/azure-search-documents/tests/async_tests/test_search_client_buffered_sender_live_async.py
@@ -21,8 +21,8 @@ class TestSearchIndexingBufferedSenderAsync(AzureRecordedTestCase):
     @search_decorator(schema="hotel_schema.json", index_batch="hotel_small.json")
     @recorded_by_proxy_async
     async def test_search_client_index_buffered_sender(self, endpoint, api_key, index_name):
-        client = SearchClient(endpoint, index_name, api_key)
-        batch_client = SearchIndexingBufferedSender(endpoint, index_name, api_key)
+        client = SearchClient(endpoint, index_name, api_key, retry_backoff_factor=60)
+        batch_client = SearchIndexingBufferedSender(endpoint, index_name, api_key, retry_backoff_factor=60)
         try:
             async with client:
                 async with batch_client:

--- a/sdk/search/azure-search-documents/tests/async_tests/test_search_client_index_document_live_async.py
+++ b/sdk/search/azure-search-documents/tests/async_tests/test_search_client_index_document_live_async.py
@@ -21,7 +21,7 @@ class TestSearchClientDocumentsAsync(AzureRecordedTestCase):
     @search_decorator(schema="hotel_schema.json", index_batch="hotel_small.json")
     @recorded_by_proxy_async
     async def test_search_client_index_document(self, endpoint, api_key, index_name):
-        client = SearchClient(endpoint, index_name, api_key)
+        client = SearchClient(endpoint, index_name, api_key, retry_backoff_factor=60)
         doc_count = 10
         async with client:
             doc_count = await self._test_upload_documents_new(client, doc_count)

--- a/sdk/search/azure-search-documents/tests/async_tests/test_search_client_search_live_async.py
+++ b/sdk/search/azure-search-documents/tests/async_tests/test_search_client_search_live_async.py
@@ -18,7 +18,7 @@ class TestClientTestAsync(AzureRecordedTestCase):
     @search_decorator(schema="hotel_schema.json", index_batch="hotel_small.json")
     @recorded_by_proxy_async
     async def test_search_client(self, endpoint, api_key, index_name):
-        client = SearchClient(endpoint, index_name, api_key)
+        client = SearchClient(endpoint, index_name, api_key, retry_backoff_factor=60)
         async with client:
             await self._test_get_search_simple(client)
             await self._test_get_search_simple_with_top(client)

--- a/sdk/search/azure-search-documents/tests/async_tests/test_search_index_client_alias_live_async.py
+++ b/sdk/search/azure-search-documents/tests/async_tests/test_search_index_client_alias_live_async.py
@@ -30,7 +30,7 @@ class TestSearchClientAlias(AzureRecordedTestCase):
     @search_decorator(schema="hotel_schema.json", index_batch="hotel_small.json")
     @recorded_by_proxy_async
     async def test_alias(self, endpoint, api_key):
-        client = SearchIndexClient(endpoint, api_key)
+        client = SearchIndexClient(endpoint, api_key, retry_backoff_factor=60)
         aliases = ["resort", "motel"]
 
         async with client:

--- a/sdk/search/azure-search-documents/tests/async_tests/test_search_index_client_data_source_live_async.py
+++ b/sdk/search/azure-search-documents/tests/async_tests/test_search_index_client_data_source_live_async.py
@@ -31,7 +31,7 @@ class TestSearchClientDataSourcesAsync(AzureRecordedTestCase):
     @recorded_by_proxy_async
     async def test_data_source(self, endpoint, api_key, **kwargs):
         storage_cs = kwargs.get("search_storage_connection_string")
-        client = SearchIndexerClient(endpoint, api_key)
+        client = SearchIndexerClient(endpoint, api_key, retry_backoff_factor=60)
         async with client:
             await self._test_create_datasource(client, storage_cs)
             await self._test_delete_datasource(client, storage_cs)

--- a/sdk/search/azure-search-documents/tests/async_tests/test_search_index_client_live_async.py
+++ b/sdk/search/azure-search-documents/tests/async_tests/test_search_index_client_live_async.py
@@ -27,7 +27,7 @@ class TestSearchIndexClientAsync(AzureRecordedTestCase):
     @search_decorator(schema=None, index_batch=None)
     @recorded_by_proxy_async
     async def test_search_index_client(self, api_key, endpoint, index_name):
-        client = SearchIndexClient(endpoint, api_key)
+        client = SearchIndexClient(endpoint, api_key, retry_backoff_factor=60)
         index_name = "hotels"
         async with client:
             await self._test_get_service_statistics(client)
@@ -84,7 +84,10 @@ class TestSearchIndexClientAsync(AzureRecordedTestCase):
 
     async def _test_get_index_statistics(self, client, index_name):
         result = await client.get_index_statistics(index_name)
-        assert set(result.keys()) == {"document_count", "storage_size"}
+        keys = set(result.keys())
+        assert "document_count" in keys
+        assert "storage_size" in keys
+        assert "vector_index_size" in keys
 
     async def _test_delete_indexes_if_unchanged(self, client):
         # First create an index

--- a/sdk/search/azure-search-documents/tests/async_tests/test_search_index_client_skillset_live_async.py
+++ b/sdk/search/azure-search-documents/tests/async_tests/test_search_index_client_skillset_live_async.py
@@ -29,7 +29,7 @@ class TestSearchClientSkillsets(AzureRecordedTestCase):
     @search_decorator(schema="hotel_schema.json", index_batch="hotel_small.json")
     @recorded_by_proxy_async
     async def test_skillset_crud(self, api_key, endpoint):
-        client = SearchIndexerClient(endpoint, api_key)
+        client = SearchIndexerClient(endpoint, api_key, retry_backoff_factor=60)
         async with client:
             await self._test_create_skillset(client)
             await self._test_get_skillset(client)

--- a/sdk/search/azure-search-documents/tests/async_tests/test_search_index_client_synonym_map_live_async.py
+++ b/sdk/search/azure-search-documents/tests/async_tests/test_search_index_client_synonym_map_live_async.py
@@ -21,7 +21,7 @@ class TestSearchClientSynonymMaps(AzureRecordedTestCase):
     @search_decorator(schema="hotel_schema.json", index_batch="hotel_small.json")
     @recorded_by_proxy_async
     async def test_synonym_map(self, endpoint, api_key):
-        client = SearchIndexClient(endpoint, api_key)
+        client = SearchIndexClient(endpoint, api_key, retry_backoff_factor=60)
         async with client:
             await self._test_create_synonym_map(client)
             await self._test_delete_synonym_map(client)

--- a/sdk/search/azure-search-documents/tests/async_tests/test_search_indexer_client_live_async.py
+++ b/sdk/search/azure-search-documents/tests/async_tests/test_search_indexer_client_live_async.py
@@ -27,8 +27,8 @@ class TestSearchIndexerClientTestAsync(AzureRecordedTestCase):
     async def test_search_indexers(self, endpoint, api_key, **kwargs):
         storage_cs = kwargs.get("search_storage_connection_string")
         container_name = kwargs.get("search_storage_container_name")
-        client = SearchIndexerClient(endpoint, api_key)
-        index_client = SearchIndexClient(endpoint, api_key)
+        client = SearchIndexerClient(endpoint, api_key, retry_backoff_factor=60)
+        index_client = SearchIndexClient(endpoint, api_key, retry_backoff_factor=60)
         async with client:
             async with index_client:
                 await self._test_create_indexer(client, index_client, storage_cs, container_name)

--- a/sdk/search/azure-search-documents/tests/test_search_client_basic_live.py
+++ b/sdk/search/azure-search-documents/tests/test_search_client_basic_live.py
@@ -18,14 +18,14 @@ class TestSearchClient(AzureRecordedTestCase):
     @search_decorator(schema="hotel_schema.json", index_batch="hotel_small.json")
     @recorded_by_proxy
     def test_get_document_count(self, endpoint, api_key, index_name):
-        client = SearchClient(endpoint, index_name, api_key)
+        client = SearchClient(endpoint, index_name, api_key, retry_backoff_factor=60)
         assert client.get_document_count() == 10
 
     @SearchEnvVarPreparer()
     @search_decorator(schema="hotel_schema.json", index_batch="hotel_small.json")
     @recorded_by_proxy
     def test_get_document(self, endpoint, api_key, index_name, index_batch):
-        client = SearchClient(endpoint, index_name, api_key)
+        client = SearchClient(endpoint, index_name, api_key, retry_backoff_factor=60)
         for hotel_id in range(1, 11):
             result = client.get_document(key=str(hotel_id))
             expected = index_batch["value"][hotel_id - 1]
@@ -37,6 +37,6 @@ class TestSearchClient(AzureRecordedTestCase):
     @search_decorator(schema="hotel_schema.json", index_batch="hotel_small.json")
     @recorded_by_proxy
     def test_get_document_missing(self, endpoint, api_key, index_name):
-        client = SearchClient(endpoint, index_name, api_key)
+        client = SearchClient(endpoint, index_name, api_key, retry_backoff_factor=60)
         with pytest.raises(HttpResponseError):
             client.get_document(key="1000")

--- a/sdk/search/azure-search-documents/tests/test_search_client_buffered_sender_live.py
+++ b/sdk/search/azure-search-documents/tests/test_search_client_buffered_sender_live.py
@@ -20,8 +20,8 @@ class TestSearchIndexingBufferedSender(AzureRecordedTestCase):
     @search_decorator(schema="hotel_schema.json", index_batch="hotel_small.json")
     @recorded_by_proxy
     def test_search_client_index_buffered_sender(self, endpoint, api_key, index_name):
-        client = SearchClient(endpoint, index_name, api_key)
-        batch_client = SearchIndexingBufferedSender(endpoint, index_name, api_key)
+        client = SearchClient(endpoint, index_name, api_key, retry_backoff_factor=60)
+        batch_client = SearchIndexingBufferedSender(endpoint, index_name, api_key, retry_backoff_factor=60)
         try:
             doc_count = 10
             doc_count = self._test_upload_documents_new(client, batch_client, doc_count)

--- a/sdk/search/azure-search-documents/tests/test_search_client_index_document_live.py
+++ b/sdk/search/azure-search-documents/tests/test_search_client_index_document_live.py
@@ -19,7 +19,7 @@ class TestSearchClientIndexDocument(AzureRecordedTestCase):
     @search_decorator(schema="hotel_schema.json", index_batch="hotel_small.json")
     @recorded_by_proxy
     def test_search_client_index_document(self, endpoint, api_key, index_name):
-        client = SearchClient(endpoint, index_name, api_key)
+        client = SearchClient(endpoint, index_name, api_key, retry_backoff_factor=60)
         doc_count = 10
         doc_count = self._test_upload_documents_new(client, doc_count)
         doc_count = self._test_upload_documents_existing(client, doc_count)

--- a/sdk/search/azure-search-documents/tests/test_search_client_search_live.py
+++ b/sdk/search/azure-search-documents/tests/test_search_client_search_live.py
@@ -15,7 +15,7 @@ class TestSearchClient(AzureRecordedTestCase):
     @search_decorator(schema="hotel_schema.json", index_batch="hotel_small.json")
     @recorded_by_proxy
     def test_search_client(self, endpoint, api_key, index_name):
-        client = SearchClient(endpoint, index_name, api_key)
+        client = SearchClient(endpoint, index_name, api_key, retry_backoff_factor=60)
         self._test_get_search_simple(client)
         self._test_get_search_simple_with_top(client)
         self._test_get_search_filter(client)

--- a/sdk/search/azure-search-documents/tests/test_search_index_client.py
+++ b/sdk/search/azure-search-documents/tests/test_search_index_client.py
@@ -24,7 +24,7 @@ class TestSearchIndexClient:
 
     def test_index_credential_roll(self):
         credential = AzureKeyCredential(key="old_api_key")
-        client = SearchIndexClient("endpoint", credential)
+        client = SearchIndexClient("endpoint", credential, retry_backoff_factor=60)
         assert client._headers == {
             "api-key": "old_api_key",
             "Accept": "application/json;odata.metadata=minimal",

--- a/sdk/search/azure-search-documents/tests/test_search_index_client_alias_live.py
+++ b/sdk/search/azure-search-documents/tests/test_search_index_client_alias_live.py
@@ -29,7 +29,7 @@ class TestSearchClientAlias(AzureRecordedTestCase):
     @search_decorator(schema="hotel_schema.json", index_batch="hotel_small.json")
     @recorded_by_proxy
     def test_alias(self, endpoint, api_key):
-        client = SearchIndexClient(endpoint, api_key)
+        client = SearchIndexClient(endpoint, api_key, retry_backoff_factor=60)
         aliases = ["resort", "motel"]
         index_name = next(client.list_index_names())
         self._test_list_aliases_empty(client)

--- a/sdk/search/azure-search-documents/tests/test_search_index_client_data_source_live.py
+++ b/sdk/search/azure-search-documents/tests/test_search_index_client_data_source_live.py
@@ -31,7 +31,7 @@ class TestSearchClientDataSources(AzureRecordedTestCase):
     @recorded_by_proxy
     def test_data_source(self, endpoint, api_key, **kwargs):
         storage_cs = kwargs.get("search_storage_connection_string")
-        client = SearchIndexerClient(endpoint, api_key)
+        client = SearchIndexerClient(endpoint, api_key, retry_backoff_factor=60)
         self._test_create_datasource(client, storage_cs)
         self._test_delete_datasource(client, storage_cs)
         self._test_get_datasource(client, storage_cs)

--- a/sdk/search/azure-search-documents/tests/test_search_index_client_live.py
+++ b/sdk/search/azure-search-documents/tests/test_search_index_client_live.py
@@ -25,7 +25,7 @@ class TestSearchIndexClient(AzureRecordedTestCase):
     @search_decorator(schema=None, index_batch=None)
     @recorded_by_proxy
     def test_search_index_client(self, api_key, endpoint, index_name):
-        client = SearchIndexClient(endpoint, api_key)
+        client = SearchIndexClient(endpoint, api_key, retry_backoff_factor=60)
         index_name = "hotels"
         self._test_get_service_statistics(client)
         self._test_list_indexes_empty(client)
@@ -63,7 +63,10 @@ class TestSearchIndexClient(AzureRecordedTestCase):
 
     def _test_get_index_statistics(self, client, index_name):
         result = client.get_index_statistics(index_name)
-        assert set(result.keys()) == {"document_count", "storage_size"}
+        keys = set(result.keys())
+        assert "document_count" in keys
+        assert "storage_size" in keys
+        assert "vector_index_size" in keys
 
     def _test_create_index(self, client, index_name):
         fields = [

--- a/sdk/search/azure-search-documents/tests/test_search_index_client_skillset_live.py
+++ b/sdk/search/azure-search-documents/tests/test_search_index_client_skillset_live.py
@@ -29,7 +29,7 @@ class TestSearchSkillset(AzureRecordedTestCase):
     @search_decorator(schema="hotel_schema.json", index_batch="hotel_small.json")
     @recorded_by_proxy
     def test_skillset_crud(self, api_key, endpoint):
-        client = SearchIndexerClient(endpoint, api_key)
+        client = SearchIndexerClient(endpoint, api_key, retry_backoff_factor=60)
         self._test_create_skillset_validation()
         self._test_create_skillset(client)
         self._test_get_skillset(client)

--- a/sdk/search/azure-search-documents/tests/test_search_index_client_synonym_map_live.py
+++ b/sdk/search/azure-search-documents/tests/test_search_index_client_synonym_map_live.py
@@ -20,7 +20,7 @@ class TestSearchClientSynonymMaps(AzureRecordedTestCase):
     @search_decorator(schema="hotel_schema.json", index_batch="hotel_small.json")
     @recorded_by_proxy
     def test_synonym_map(self, endpoint, api_key):
-        client = SearchIndexClient(endpoint, api_key)
+        client = SearchIndexClient(endpoint, api_key, retry_backoff_factor=60)
         self._test_create_synonym_map(client)
         self._test_delete_synonym_map(client)
         self._test_delete_synonym_map_if_unchanged(client)

--- a/sdk/search/azure-search-documents/tests/test_search_indexer_client_live.py
+++ b/sdk/search/azure-search-documents/tests/test_search_indexer_client_live.py
@@ -26,8 +26,8 @@ class TestSearchIndexerClientTest(AzureRecordedTestCase):
     def test_search_indexers(self, endpoint, api_key, **kwargs):
         storage_cs = kwargs.get("search_storage_connection_string")
         container_name = kwargs.get("search_storage_container_name")
-        client = SearchIndexerClient(endpoint, api_key)
-        index_client = SearchIndexClient(endpoint, api_key)
+        client = SearchIndexerClient(endpoint, api_key, retry_backoff_factor=60)
+        index_client = SearchIndexClient(endpoint, api_key, retry_backoff_factor=60)
         self._test_create_indexer(client, index_client, storage_cs, container_name)
         self._test_delete_indexer(client, index_client, storage_cs, container_name)
         self._test_get_indexer(client, index_client, storage_cs, container_name)


### PR DESCRIPTION
w/ the support of vector search on service side, now service returns 

"document_count", "vector_index_size", "storage_size"

rather than 

"document_count", "storage_size"

update the tests plus add retry delay to make tests more stable.