### PR TITLE
[Tables] Update ci tests timeout setting

### DIFF
--- a/sdk/tables/tests.yml
+++ b/sdk/tables/tests.yml
@@ -5,6 +5,7 @@ stages:
     parameters:
       BuildTargetingString: azure-data-tables
       ServiceDirectory: tables
+      TestTimeoutInMinutes: 180
       SupportedClouds: 'Public,UsGov,China'
       CloudConfig:
         Public:


### PR DESCRIPTION
Tests are failing in China cloud in Ubuntu platforms due to timeout in the most recent weekly pipelines:
https://dev.azure.com/azure-sdk/internal/_build/results?buildId=2959886&view=results
https://dev.azure.com/azure-sdk/internal/_build/results?buildId=2959248&view=results

Extend tests running time to fix the issue.