### PR TITLE
[Cosmos] async `create_database_if_not_exists` method not working when passing `offer_throughput` bugfix

### DIFF
--- a/sdk/cosmos/azure-cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos/CHANGELOG.md
@@ -8,7 +8,7 @@
 #### Breaking Changes
 
 #### Bugs Fixed
-* Fixed bug with async `create_database_if_not_exists` method not working when passing `offer_throughput` as an option. See [PR](https://github.com/Azure/azure-sdk-for-python/pull/31189).
+* Fixed bug with async `create_database_if_not_exists` method not working when passing `offer_throughput` as an option. See [PR 31478](https://github.com/Azure/azure-sdk-for-python/pull/31478).
 
 #### Other Changes
 

--- a/sdk/cosmos/azure-cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos/CHANGELOG.md
@@ -8,6 +8,7 @@
 #### Breaking Changes
 
 #### Bugs Fixed
+* Fixed bug with async `create_database_if_not_exists` method not working when passing `offer_throughput` as an option. See [PR](https://github.com/Azure/azure-sdk-for-python/pull/31189).
 
 #### Other Changes
 

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_cosmos_client.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_cosmos_client.py
@@ -292,6 +292,7 @@ class CosmosClient(object):  # pylint: disable=client-accepts-api-version-keywor
         :returns: A DatabaseProxy instance representing the database.
         :rtype: ~azure.cosmos.DatabaseProxy
         """
+        offer_throughput = kwargs.pop("offerThroughput", None)
         try:
             database_proxy = self.get_database_client(id)
             await database_proxy.read(**kwargs)
@@ -299,6 +300,7 @@ class CosmosClient(object):  # pylint: disable=client-accepts-api-version-keywor
         except CosmosResourceNotFoundError:
             return await self.create_database(
                 id,
+                offer_throughput=offer_throughput,
                 **kwargs
             )
 


### PR DESCRIPTION
Title, basically we had a gap with this method not working out since the `read()` method would try to use the `offer_throughput` option passed.

Separately, created this issue here to track some test changes we should do as a result: https://github.com/Azure/azure-sdk-for-python/issues/31480