### PR TITLE
Expose the parameters log_training_metrics and log_validation_loss for object detection and instance segmentation

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/automl/image_vertical/image_model_settings.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/automl/image_vertical/image_model_settings.py
@@ -86,6 +86,8 @@ class ImageModelSettingsObjectDetectionSchema(ImageModelSettingsSchema):
         allowed_values=[o.value for o in ValidationMetricType],
         casing_transform=camel_to_snake,
     )
+    log_training_metrics = fields.Str()
+    log_validation_loss = fields.Str()
 
     @post_load
     def make(self, data, **kwargs):

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/automl/image/automl_image_object_detection_base.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/automl/image/automl_image_object_detection_base.py
@@ -11,6 +11,8 @@ from azure.ai.ml._restclient.v2023_04_01_preview.models import (
     ModelSize,
     StochasticOptimizer,
     ValidationMetricType,
+    LogTrainingMetrics,
+    LogValidationLoss,
 )
 from azure.ai.ml._utils.utils import camel_to_snake
 from azure.ai.ml.entities._job.automl import SearchSpace
@@ -56,6 +58,8 @@ class AutoMLImageObjectDetectionBase(AutoMLImage):
                 learning_rate_scheduler=value.learning_rate_scheduler,
                 model_size=value.model_size,
                 validation_metric_type=value.validation_metric_type,
+                log_training_metrics=value.log_training_metrics,
+                log_validation_loss=value.log_validation_loss,
             )
         elif value is None:
             self._training_parameters = value
@@ -148,6 +152,8 @@ class AutoMLImageObjectDetectionBase(AutoMLImage):
         tile_predictions_nms_threshold: Optional[float] = None,
         validation_iou_threshold: Optional[float] = None,
         validation_metric_type: Optional[Union[str, ValidationMetricType]] = None,
+        log_training_metrics: Optional[Union[str, LogTrainingMetrics]] = None,
+        log_validation_loss: Optional[Union[str, LogValidationLoss]] = None,
     ) -> None:
         """Setting Image training parameters for for AutoML Image Object Detection and Image Instance Segmentation
         tasks.
@@ -431,6 +437,16 @@ class AutoMLImageObjectDetectionBase(AutoMLImage):
             ValidationMetricType[camel_to_snake(validation_metric_type)]
             if validation_metric_type is not None
             else self._training_parameters.validation_metric_type
+        )
+        self._training_parameters.log_training_metrics = (
+            LogTrainingMetrics[camel_to_snake(log_training_metrics)]
+            if log_training_metrics is not None
+            else self._training_parameters.log_training_metrics
+        )
+        self._training_parameters.log_validation_loss = (
+            LogValidationLoss[camel_to_snake(log_validation_loss)]
+            if log_validation_loss is not None
+            else self._training_parameters.log_validation_loss
         )
 
     # pylint: enable=too-many-locals

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/automl/image/automl_image_object_detection_base.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/automl/image/automl_image_object_detection_base.py
@@ -294,6 +294,12 @@ class AutoMLImageObjectDetectionBase(AutoMLImage):
         :keyword validation_metric_type: Metric computation method to use for validation metrics. Must
          be 'none', 'coco', 'voc', or 'coco_voc'.
         :type validation_metric_type: str or ~azure.mgmt.machinelearningservices.models.ValidationMetricType
+        :keyword log_training_metrics: indicates whether or not to log training metrics. Must
+         be 'Enable' or 'Disable'
+        :type log_training_metrics: str or ~azure.mgmt.machinelearningservices.models.LogTrainingMetrics
+        :keyword log_validation_loss: indicates whether or not to log validation loss. Must
+         be 'Enable' or 'Disable'
+        :type log_validation_loss: str or ~azure.mgmt.machinelearningservices.models.LogValidationLoss
         """
         self._training_parameters = self._training_parameters or ImageModelSettingsObjectDetection()
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/automl/image/image_model_settings.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/automl/image/image_model_settings.py
@@ -626,6 +626,12 @@ class ImageModelSettingsObjectDetection(ImageModelDistributionSettings):
      values include: "None", "Coco", "Voc", "CocoVoc".
     :type validation_metric_type: str or
      ~azure.mgmt.machinelearningservices.models.ValidationMetricType
+    :param log_training_metrics: indicates whether or not to log training metrics
+    :type log_training_metrics: str or
+     ~azure.mgmt.machinelearningservices.models.LogTrainingMetrics
+    :param log_validation_loss: indicates whether or not to log validation loss
+    :type log_validation_loss: str or
+     ~azure.mgmt.machinelearningservices.models.LogValidationLoss
     """
 
     def __init__(

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/automl/image/image_model_settings.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/automl/image/image_model_settings.py
@@ -16,6 +16,8 @@ from azure.ai.ml._restclient.v2023_04_01_preview.models import (
     ModelSize,
     StochasticOptimizer,
     ValidationMetricType,
+    LogTrainingMetrics,
+    LogValidationLoss,
 )
 from azure.ai.ml.entities._mixins import RestTranslatableMixin
 
@@ -672,8 +674,8 @@ class ImageModelSettingsObjectDetection(ImageModelDistributionSettings):
         tile_predictions_nms_threshold: Optional[float] = None,
         validation_iou_threshold: Optional[float] = None,
         validation_metric_type: Optional[ValidationMetricType] = None,
-        log_training_metrics: Optional[str] = None,
-        log_validation_loss: Optional[str] = None,
+        log_training_metrics: Optional[LogTrainingMetrics] = None,
+        log_validation_loss: Optional[LogValidationLoss] = None,
         **kwargs,
     ):
         super(ImageModelSettingsObjectDetection, self).__init__(

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/automl/image/image_model_settings.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/automl/image/image_model_settings.py
@@ -672,6 +672,8 @@ class ImageModelSettingsObjectDetection(ImageModelDistributionSettings):
         tile_predictions_nms_threshold: Optional[float] = None,
         validation_iou_threshold: Optional[float] = None,
         validation_metric_type: Optional[ValidationMetricType] = None,
+        log_training_metrics: Optional[str] = None,
+        log_validation_loss: Optional[str] = None,
         **kwargs,
     ):
         super(ImageModelSettingsObjectDetection, self).__init__(
@@ -720,11 +722,11 @@ class ImageModelSettingsObjectDetection(ImageModelDistributionSettings):
         self.tile_predictions_nms_threshold = tile_predictions_nms_threshold
         self.validation_iou_threshold = validation_iou_threshold
         self.validation_metric_type = validation_metric_type
+        self.log_training_metrics = log_training_metrics
+        self.log_validation_loss = log_validation_loss
 
     def _to_rest_object(self) -> RestImageModelSettingsObjectDetection:
         return RestImageModelSettingsObjectDetection(
-            # Temporary fix for https://msdata.visualstudio.com/Vienna/_workitems/edit/2385143
-            log_training_metrics="Disable",
             advanced_settings=self.advanced_settings,
             ams_gradient=self.ams_gradient,
             beta1=self.beta1,
@@ -768,6 +770,8 @@ class ImageModelSettingsObjectDetection(ImageModelDistributionSettings):
             tile_predictions_nms_threshold=self.tile_predictions_nms_threshold,
             validation_iou_threshold=self.validation_iou_threshold,
             validation_metric_type=self.validation_metric_type,
+            log_training_metrics=self.log_training_metrics,
+            log_validation_loss=self.log_validation_loss,
         )
 
     @classmethod
@@ -816,6 +820,8 @@ class ImageModelSettingsObjectDetection(ImageModelDistributionSettings):
             tile_predictions_nms_threshold=obj.tile_predictions_nms_threshold,
             validation_iou_threshold=obj.validation_iou_threshold,
             validation_metric_type=obj.validation_metric_type,
+            log_training_metrics=obj.log_training_metrics,
+            log_validation_loss=obj.log_validation_loss,
         )
 
     def __eq__(self, other: object) -> bool:
@@ -837,6 +843,8 @@ class ImageModelSettingsObjectDetection(ImageModelDistributionSettings):
             and self.tile_predictions_nms_threshold == other.tile_predictions_nms_threshold
             and self.validation_iou_threshold == other.validation_iou_threshold
             and self.validation_metric_type == other.validation_metric_type
+            and self.log_training_metrics == other.log_training_metrics
+            and self.log_validation_loss == other.log_validation_loss
         )
 
     def __ne__(self, other: object) -> bool:

--- a/sdk/ml/azure-ai-ml/tests/automl_job/unittests/test_automl_image_instance_segmentation.py
+++ b/sdk/ml/azure-ai-ml/tests/automl_job/unittests/test_automl_image_instance_segmentation.py
@@ -151,8 +151,17 @@ class TestAutoMLImageInstanceSegmentation:
                     LogValidationLoss.ENABLE,
                 ),
             ),
-            ((None, None, "coco_voc", "large", "enable", "enable"),
-             (None, None, ValidationMetricType.COCO_VOC, ModelSize.LARGE, LogTrainingMetrics.ENABLE, LogValidationLoss.ENABLE)),
+            (
+                (None, None, "coco_voc", "large", "enable", "enable"),
+                (
+                    None,
+                    None,
+                    ValidationMetricType.COCO_VOC,
+                    ModelSize.LARGE,
+                    LogTrainingMetrics.ENABLE,
+                    LogValidationLoss.ENABLE,
+                ),
+            ),
         ],
         ids=["snake case", "camel case", "with None"],
     )
@@ -167,7 +176,7 @@ class TestAutoMLImageInstanceSegmentation:
             validation_metric_type=settings[2],
             model_size=settings[3],
             log_training_metrics=settings[4],
-            log_validation_loss=settings[5]
+            log_validation_loss=settings[5],
         )
         assert image_instance_segmentation_job.training_parameters.optimizer == expected[0]
         assert image_instance_segmentation_job.training_parameters.learning_rate_scheduler == expected[1]
@@ -179,12 +188,12 @@ class TestAutoMLImageInstanceSegmentation:
     @pytest.mark.parametrize(
         "settings, expected",
         [
-            (("adamW", None, None, None, 'Enable', 'Enable'), pytest.raises(KeyError)),
-            ((None, "Warmup_Cosine", None, None, 'Enable', 'Enable'), pytest.raises(KeyError)),
-            ((None, None, "Coco_Voc", "large", 'Enable', 'Enable'), pytest.raises(KeyError)),
-            ((None, None, None, "Extra_Large", 'Enable', 'Enable'), pytest.raises(KeyError)),
-            ((None, None, None, None, 'false', 'Enable'), pytest.raises(KeyError)),
-            ((None, None, None, None, 'Enable', 'false'), pytest.raises(KeyError)),
+            (("adamW", None, None, None, "Enable", "Enable"), pytest.raises(KeyError)),
+            ((None, "Warmup_Cosine", None, None, "Enable", "Enable"), pytest.raises(KeyError)),
+            ((None, None, "Coco_Voc", "large", "Enable", "Enable"), pytest.raises(KeyError)),
+            ((None, None, None, "Extra_Large", "Enable", "Enable"), pytest.raises(KeyError)),
+            ((None, None, None, None, "false", "Enable"), pytest.raises(KeyError)),
+            ((None, None, None, None, "Enable", "false"), pytest.raises(KeyError)),
         ],
         ids=[
             "optimizer invalid",
@@ -192,7 +201,7 @@ class TestAutoMLImageInstanceSegmentation:
             "validation metric type invalid",
             "model size invalid",
             "log_training_metrics invalid",
-            "log_validation_loss invalid"
+            "log_validation_loss invalid",
         ],
     )
     def test_image_set_training_parameters_with_invalid_values(self, settings, expected):
@@ -207,7 +216,7 @@ class TestAutoMLImageInstanceSegmentation:
                 validation_metric_type=settings[2],
                 model_size=settings[3],
                 log_training_metrics=settings[4],
-                log_validation_loss=settings[5]
+                log_validation_loss=settings[5],
             )
 
     @pytest.mark.parametrize(
@@ -235,8 +244,17 @@ class TestAutoMLImageInstanceSegmentation:
                     LogValidationLoss.ENABLE,
                 ),
             ),
-            ((None, None, "coco_voc", "large", "enable", "enable"),
-             (None, None, ValidationMetricType.COCO_VOC, ModelSize.LARGE, LogTrainingMetrics.ENABLE, LogValidationLoss.ENABLE)),
+            (
+                (None, None, "coco_voc", "large", "enable", "enable"),
+                (
+                    None,
+                    None,
+                    ValidationMetricType.COCO_VOC,
+                    ModelSize.LARGE,
+                    LogTrainingMetrics.ENABLE,
+                    LogValidationLoss.ENABLE,
+                ),
+            ),
         ],
         ids=["snake case", "camel case", "with None"],
     )
@@ -247,7 +265,7 @@ class TestAutoMLImageInstanceSegmentation:
             validation_metric_type=settings[2],
             model_size=settings[3],
             log_training_metrics=settings[4],
-            log_validation_loss=settings[5]
+            log_validation_loss=settings[5],
         )
         image_instance_segmentation_job = image_instance_segmentation(
             training_data=Input(type=AssetTypes.MLTABLE, path="https://foo/bar/train.csv"),

--- a/sdk/ml/azure-ai-ml/tests/automl_job/unittests/test_automl_image_instance_segmentation.py
+++ b/sdk/ml/azure-ai-ml/tests/automl_job/unittests/test_automl_image_instance_segmentation.py
@@ -12,6 +12,8 @@ from azure.ai.ml._restclient.v2023_04_01_preview.models import (
     ModelSize,
     SamplingAlgorithmType,
     StochasticOptimizer,
+    LogTrainingMetrics,
+    LogValidationLoss,
 )
 from azure.ai.ml._restclient.v2023_04_01_preview.models import UserIdentity as RestUserIdentity
 from azure.ai.ml._restclient.v2023_04_01_preview.models import ValidationMetricType
@@ -128,24 +130,29 @@ class TestAutoMLImageInstanceSegmentation:
         "settings, expected",
         [
             (
-                ("adam", "warmup_cosine", "coco_voc", "large"),
+                ("adam", "warmup_cosine", "coco_voc", "large", "enable", "enable"),
                 (
                     StochasticOptimizer.ADAM,
                     LearningRateScheduler.WARMUP_COSINE,
                     ValidationMetricType.COCO_VOC,
                     ModelSize.LARGE,
+                    LogTrainingMetrics.ENABLE,
+                    LogValidationLoss.ENABLE,
                 ),
             ),
             (
-                ("Adam", "WarmupCosine", "CocoVoc", "Large"),
+                ("Adam", "WarmupCosine", "CocoVoc", "Large", "Enable", "Enable"),
                 (
                     StochasticOptimizer.ADAM,
                     LearningRateScheduler.WARMUP_COSINE,
                     ValidationMetricType.COCO_VOC,
                     ModelSize.LARGE,
+                    LogTrainingMetrics.ENABLE,
+                    LogValidationLoss.ENABLE,
                 ),
             ),
-            ((None, None, "coco_voc", "large"), (None, None, ValidationMetricType.COCO_VOC, ModelSize.LARGE)),
+            ((None, None, "coco_voc", "large", "enable", "enable"),
+             (None, None, ValidationMetricType.COCO_VOC, ModelSize.LARGE, LogTrainingMetrics.ENABLE, LogValidationLoss.ENABLE)),
         ],
         ids=["snake case", "camel case", "with None"],
     )
@@ -159,25 +166,33 @@ class TestAutoMLImageInstanceSegmentation:
             learning_rate_scheduler=settings[1],
             validation_metric_type=settings[2],
             model_size=settings[3],
+            log_training_metrics=settings[4],
+            log_validation_loss=settings[5]
         )
         assert image_instance_segmentation_job.training_parameters.optimizer == expected[0]
         assert image_instance_segmentation_job.training_parameters.learning_rate_scheduler == expected[1]
         assert image_instance_segmentation_job.training_parameters.validation_metric_type == expected[2]
         assert image_instance_segmentation_job.training_parameters.model_size == expected[3]
+        assert image_instance_segmentation_job.training_parameters.log_training_metrics == expected[4]
+        assert image_instance_segmentation_job.training_parameters.log_validation_loss == expected[5]
 
     @pytest.mark.parametrize(
         "settings, expected",
         [
-            (("adamW", None, None, None), pytest.raises(KeyError)),
-            ((None, "Warmup_Cosine", None, None), pytest.raises(KeyError)),
-            ((None, None, "Coco_Voc", "large"), pytest.raises(KeyError)),
-            ((None, None, None, "Extra_Large"), pytest.raises(KeyError)),
+            (("adamW", None, None, None, 'Enable', 'Enable'), pytest.raises(KeyError)),
+            ((None, "Warmup_Cosine", None, None, 'Enable', 'Enable'), pytest.raises(KeyError)),
+            ((None, None, "Coco_Voc", "large", 'Enable', 'Enable'), pytest.raises(KeyError)),
+            ((None, None, None, "Extra_Large", 'Enable', 'Enable'), pytest.raises(KeyError)),
+            ((None, None, None, None, 'false', 'Enable'), pytest.raises(KeyError)),
+            ((None, None, None, None, 'Enable', 'false'), pytest.raises(KeyError)),
         ],
         ids=[
             "optimizer invalid",
             "learning rate scheduler invalid",
             "validation metric type invalid",
             "model size invalid",
+            "log_training_metrics invalid",
+            "log_validation_loss invalid"
         ],
     )
     def test_image_set_training_parameters_with_invalid_values(self, settings, expected):
@@ -191,30 +206,37 @@ class TestAutoMLImageInstanceSegmentation:
                 learning_rate_scheduler=settings[1],
                 validation_metric_type=settings[2],
                 model_size=settings[3],
+                log_training_metrics=settings[4],
+                log_validation_loss=settings[5]
             )
 
     @pytest.mark.parametrize(
         "settings, expected",
         [
             (
-                ("adam", "warmup_cosine", "coco_voc", "large"),
+                ("adam", "warmup_cosine", "coco_voc", "large", "enable", "enable"),
                 (
                     StochasticOptimizer.ADAM,
                     LearningRateScheduler.WARMUP_COSINE,
                     ValidationMetricType.COCO_VOC,
                     ModelSize.LARGE,
+                    LogTrainingMetrics.ENABLE,
+                    LogValidationLoss.ENABLE,
                 ),
             ),
             (
-                ("Adam", "WarmupCosine", "CocoVoc", "Large"),
+                ("Adam", "WarmupCosine", "CocoVoc", "Large", "Enable", "Enable"),
                 (
                     StochasticOptimizer.ADAM,
                     LearningRateScheduler.WARMUP_COSINE,
                     ValidationMetricType.COCO_VOC,
                     ModelSize.LARGE,
+                    LogTrainingMetrics.ENABLE,
+                    LogValidationLoss.ENABLE,
                 ),
             ),
-            ((None, None, "coco_voc", "large"), (None, None, ValidationMetricType.COCO_VOC, ModelSize.LARGE)),
+            ((None, None, "coco_voc", "large", "enable", "enable"),
+             (None, None, ValidationMetricType.COCO_VOC, ModelSize.LARGE, LogTrainingMetrics.ENABLE, LogValidationLoss.ENABLE)),
         ],
         ids=["snake case", "camel case", "with None"],
     )
@@ -224,13 +246,18 @@ class TestAutoMLImageInstanceSegmentation:
             learning_rate_scheduler=settings[1],
             validation_metric_type=settings[2],
             model_size=settings[3],
+            log_training_metrics=settings[4],
+            log_validation_loss=settings[5]
         )
         image_instance_segmentation_job = image_instance_segmentation(
             training_data=Input(type=AssetTypes.MLTABLE, path="https://foo/bar/train.csv"),
             target_column_name="label",
             training_parameters=image_model_settings,
         )
+
         assert image_instance_segmentation_job.training_parameters.optimizer == expected[0]
         assert image_instance_segmentation_job.training_parameters.learning_rate_scheduler == expected[1]
         assert image_instance_segmentation_job.training_parameters.validation_metric_type == expected[2]
         assert image_instance_segmentation_job.training_parameters.model_size == expected[3]
+        assert image_instance_segmentation_job.training_parameters.log_training_metrics == expected[4]
+        assert image_instance_segmentation_job.training_parameters.log_validation_loss == expected[5]

--- a/sdk/ml/azure-ai-ml/tests/automl_job/unittests/test_automl_image_object_detection.py
+++ b/sdk/ml/azure-ai-ml/tests/automl_job/unittests/test_automl_image_object_detection.py
@@ -12,6 +12,8 @@ from azure.ai.ml._restclient.v2023_04_01_preview.models import (
     ObjectDetectionPrimaryMetrics,
     SamplingAlgorithmType,
     StochasticOptimizer,
+    LogTrainingMetrics,
+    LogValidationLoss,
 )
 from azure.ai.ml._restclient.v2023_04_01_preview.models import UserIdentity as RestUserIdentity
 from azure.ai.ml._restclient.v2023_04_01_preview.models import ValidationMetricType
@@ -136,24 +138,29 @@ class TestAutoMLImageObjectDetection:
         "settings, expected",
         [
             (
-                ("adam", "warmup_cosine", "coco_voc", "large"),
+                ("adam", "warmup_cosine", "coco_voc", "large", "enable", "enable"),
                 (
                     StochasticOptimizer.ADAM,
                     LearningRateScheduler.WARMUP_COSINE,
                     ValidationMetricType.COCO_VOC,
                     ModelSize.LARGE,
+                    LogTrainingMetrics.ENABLE,
+                    LogValidationLoss.ENABLE,
                 ),
             ),
             (
-                ("Adam", "WarmupCosine", "CocoVoc", "Large"),
+                ("Adam", "WarmupCosine", "CocoVoc", "Large", "Enable", "Enable"),
                 (
                     StochasticOptimizer.ADAM,
                     LearningRateScheduler.WARMUP_COSINE,
                     ValidationMetricType.COCO_VOC,
                     ModelSize.LARGE,
+                    LogTrainingMetrics.ENABLE,
+                    LogValidationLoss.ENABLE,
                 ),
             ),
-            ((None, None, "coco_voc", "large"), (None, None, ValidationMetricType.COCO_VOC, ModelSize.LARGE)),
+            ((None, None, "coco_voc", "large", "enable", "enable"),
+             (None, None, ValidationMetricType.COCO_VOC, ModelSize.LARGE, LogTrainingMetrics.ENABLE, LogValidationLoss.ENABLE)),
         ],
         ids=["snake case", "camel case", "with None"],
     )
@@ -167,25 +174,33 @@ class TestAutoMLImageObjectDetection:
             learning_rate_scheduler=settings[1],
             validation_metric_type=settings[2],
             model_size=settings[3],
+            log_training_metrics=settings[4],
+            log_validation_loss=settings[5]
         )
         assert image_object_detection_job.training_parameters.optimizer == expected[0]
         assert image_object_detection_job.training_parameters.learning_rate_scheduler == expected[1]
         assert image_object_detection_job.training_parameters.validation_metric_type == expected[2]
         assert image_object_detection_job.training_parameters.model_size == expected[3]
+        assert image_object_detection_job.training_parameters.log_training_metrics == expected[4]
+        assert image_object_detection_job.training_parameters.log_validation_loss == expected[5]
 
     @pytest.mark.parametrize(
         "settings, expected",
         [
-            (("adamW", None, None, None), pytest.raises(KeyError)),
-            ((None, "Warmup_Cosine", None, None), pytest.raises(KeyError)),
-            ((None, None, "Coco_Voc", "large"), pytest.raises(KeyError)),
-            ((None, None, None, "Extra_Large"), pytest.raises(KeyError)),
+            (("adamW", None, None, None, 'Enable', 'Enable'), pytest.raises(KeyError)),
+            ((None, "Warmup_Cosine", None, None, 'Enable', 'Enable'), pytest.raises(KeyError)),
+            ((None, None, "Coco_Voc", "large", 'Enable', 'Enable'), pytest.raises(KeyError)),
+            ((None, None, None, "Extra_Large", 'Enable', 'Enable'), pytest.raises(KeyError)),
+            ((None, None, None, None, 'false', 'Enable'), pytest.raises(KeyError)),
+            ((None, None, None, None, 'Enable', 'false'), pytest.raises(KeyError)),
         ],
         ids=[
             "optimizer invalid",
             "learning rate scheduler invalid",
             "validation metric type invalid",
             "model size invalid",
+            "log_training_metrics invalid",
+            "log_validation_loss invalid"
         ],
     )
     def test_image_set_training_parameters_with_invalid_values(self, settings, expected):
@@ -199,30 +214,37 @@ class TestAutoMLImageObjectDetection:
                 learning_rate_scheduler=settings[1],
                 validation_metric_type=settings[2],
                 model_size=settings[3],
+                log_training_metrics=settings[4],
+                log_validation_loss=settings[5]
             )
 
     @pytest.mark.parametrize(
         "settings, expected",
         [
             (
-                ("adam", "warmup_cosine", "coco_voc", "large"),
+                ("adam", "warmup_cosine", "coco_voc", "large", "enable", "enable"),
                 (
                     StochasticOptimizer.ADAM,
                     LearningRateScheduler.WARMUP_COSINE,
                     ValidationMetricType.COCO_VOC,
                     ModelSize.LARGE,
+                    LogTrainingMetrics.ENABLE,
+                    LogValidationLoss.ENABLE,
                 ),
             ),
             (
-                ("Adam", "WarmupCosine", "CocoVoc", "Large"),
+                ("Adam", "WarmupCosine", "CocoVoc", "Large", "Enable", "Enable"),
                 (
                     StochasticOptimizer.ADAM,
                     LearningRateScheduler.WARMUP_COSINE,
                     ValidationMetricType.COCO_VOC,
                     ModelSize.LARGE,
+                    LogTrainingMetrics.ENABLE,
+                    LogValidationLoss.ENABLE,
                 ),
             ),
-            ((None, None, "coco_voc", "large"), (None, None, ValidationMetricType.COCO_VOC, ModelSize.LARGE)),
+            ((None, None, "coco_voc", "large", "enable", "enable"),
+             (None, None, ValidationMetricType.COCO_VOC, ModelSize.LARGE, LogTrainingMetrics.ENABLE, LogValidationLoss.ENABLE)),
         ],
         ids=["snake case", "camel case", "with None"],
     )
@@ -232,6 +254,8 @@ class TestAutoMLImageObjectDetection:
             learning_rate_scheduler=settings[1],
             validation_metric_type=settings[2],
             model_size=settings[3],
+            log_training_metrics=settings[4],
+            log_validation_loss=settings[5]
         )
         image_object_detection_job = image_object_detection(
             training_data=Input(type=AssetTypes.MLTABLE, path="https://foo/bar/train.csv"),
@@ -242,3 +266,5 @@ class TestAutoMLImageObjectDetection:
         assert image_object_detection_job.training_parameters.learning_rate_scheduler == expected[1]
         assert image_object_detection_job.training_parameters.validation_metric_type == expected[2]
         assert image_object_detection_job.training_parameters.model_size == expected[3]
+        assert image_object_detection_job.training_parameters.log_training_metrics == expected[4]
+        assert image_object_detection_job.training_parameters.log_validation_loss == expected[5]

--- a/sdk/ml/azure-ai-ml/tests/automl_job/unittests/test_automl_image_object_detection.py
+++ b/sdk/ml/azure-ai-ml/tests/automl_job/unittests/test_automl_image_object_detection.py
@@ -159,8 +159,17 @@ class TestAutoMLImageObjectDetection:
                     LogValidationLoss.ENABLE,
                 ),
             ),
-            ((None, None, "coco_voc", "large", "enable", "enable"),
-             (None, None, ValidationMetricType.COCO_VOC, ModelSize.LARGE, LogTrainingMetrics.ENABLE, LogValidationLoss.ENABLE)),
+            (
+                (None, None, "coco_voc", "large", "enable", "enable"),
+                (
+                    None,
+                    None,
+                    ValidationMetricType.COCO_VOC,
+                    ModelSize.LARGE,
+                    LogTrainingMetrics.ENABLE,
+                    LogValidationLoss.ENABLE,
+                ),
+            ),
         ],
         ids=["snake case", "camel case", "with None"],
     )
@@ -175,7 +184,7 @@ class TestAutoMLImageObjectDetection:
             validation_metric_type=settings[2],
             model_size=settings[3],
             log_training_metrics=settings[4],
-            log_validation_loss=settings[5]
+            log_validation_loss=settings[5],
         )
         assert image_object_detection_job.training_parameters.optimizer == expected[0]
         assert image_object_detection_job.training_parameters.learning_rate_scheduler == expected[1]
@@ -187,12 +196,12 @@ class TestAutoMLImageObjectDetection:
     @pytest.mark.parametrize(
         "settings, expected",
         [
-            (("adamW", None, None, None, 'Enable', 'Enable'), pytest.raises(KeyError)),
-            ((None, "Warmup_Cosine", None, None, 'Enable', 'Enable'), pytest.raises(KeyError)),
-            ((None, None, "Coco_Voc", "large", 'Enable', 'Enable'), pytest.raises(KeyError)),
-            ((None, None, None, "Extra_Large", 'Enable', 'Enable'), pytest.raises(KeyError)),
-            ((None, None, None, None, 'false', 'Enable'), pytest.raises(KeyError)),
-            ((None, None, None, None, 'Enable', 'false'), pytest.raises(KeyError)),
+            (("adamW", None, None, None, "Enable", "Enable"), pytest.raises(KeyError)),
+            ((None, "Warmup_Cosine", None, None, "Enable", "Enable"), pytest.raises(KeyError)),
+            ((None, None, "Coco_Voc", "large", "Enable", "Enable"), pytest.raises(KeyError)),
+            ((None, None, None, "Extra_Large", "Enable", "Enable"), pytest.raises(KeyError)),
+            ((None, None, None, None, "false", "Enable"), pytest.raises(KeyError)),
+            ((None, None, None, None, "Enable", "false"), pytest.raises(KeyError)),
         ],
         ids=[
             "optimizer invalid",
@@ -200,7 +209,7 @@ class TestAutoMLImageObjectDetection:
             "validation metric type invalid",
             "model size invalid",
             "log_training_metrics invalid",
-            "log_validation_loss invalid"
+            "log_validation_loss invalid",
         ],
     )
     def test_image_set_training_parameters_with_invalid_values(self, settings, expected):
@@ -215,7 +224,7 @@ class TestAutoMLImageObjectDetection:
                 validation_metric_type=settings[2],
                 model_size=settings[3],
                 log_training_metrics=settings[4],
-                log_validation_loss=settings[5]
+                log_validation_loss=settings[5],
             )
 
     @pytest.mark.parametrize(
@@ -243,8 +252,17 @@ class TestAutoMLImageObjectDetection:
                     LogValidationLoss.ENABLE,
                 ),
             ),
-            ((None, None, "coco_voc", "large", "enable", "enable"),
-             (None, None, ValidationMetricType.COCO_VOC, ModelSize.LARGE, LogTrainingMetrics.ENABLE, LogValidationLoss.ENABLE)),
+            (
+                (None, None, "coco_voc", "large", "enable", "enable"),
+                (
+                    None,
+                    None,
+                    ValidationMetricType.COCO_VOC,
+                    ModelSize.LARGE,
+                    LogTrainingMetrics.ENABLE,
+                    LogValidationLoss.ENABLE,
+                ),
+            ),
         ],
         ids=["snake case", "camel case", "with None"],
     )
@@ -255,7 +273,7 @@ class TestAutoMLImageObjectDetection:
             validation_metric_type=settings[2],
             model_size=settings[3],
             log_training_metrics=settings[4],
-            log_validation_loss=settings[5]
+            log_validation_loss=settings[5],
         )
         image_object_detection_job = image_object_detection(
             training_data=Input(type=AssetTypes.MLTABLE, path="https://foo/bar/train.csv"),

--- a/sdk/ml/azure-ai-ml/tests/automl_job/unittests/test_automl_image_schema.py
+++ b/sdk/ml/azure-ai-ml/tests/automl_job/unittests/test_automl_image_schema.py
@@ -148,7 +148,6 @@ def expected_image_model_settings_classification() -> RestImageModelSettingsClas
 @pytest.fixture
 def expected_image_model_settings_object_detection() -> RestImageModelSettingsObjectDetection:
     return RestImageModelSettingsObjectDetection(
-        log_training_metrics="Disable",
         checkpoint_frequency=1,
         early_stopping=True,
         early_stopping_delay=2,


### PR DESCRIPTION
# Description

Expose the parameters log_training_metrics and log_validation_loss for object detection and instance segmentation

The test runs below use the JOS and azureml-automl-dnn-vision changes for exposing and setting these parameters.

Tests:
**Scenario** | **Run** | **Notes**
--------------|----------|------------
**OD**| | 
individual 'Enable' | [run](https://ml.azure.com/experiments/id/e1bd4ec3-b8ea-449a-bc60-2f50186bb27e/runs/tender_pea_lvhjkkp9wk?wsid=/subscriptions/381b38e9-9840-4719-a5a0-61d9585e1e91/resourceGroups/automlimage_eastus2_rg/providers/Microsoft.MachineLearningServices/workspaces/rbhimani-jos2&tid=72f988bf-86f1-41af-91ab-2d7cd011db47) | both params set to 'Enable'
individual 'enable' | [run](https://ml.azure.com/experiments/id/e1bd4ec3-b8ea-449a-bc60-2f50186bb27e/runs/lime_bell_dttw85h5fd?wsid=/subscriptions/381b38e9-9840-4719-a5a0-61d9585e1e91/resourceGroups/automlimage_eastus2_rg/providers/Microsoft.MachineLearningServices/workspaces/rbhimani-jos2&tid=72f988bf-86f1-41af-91ab-2d7cd011db47) | both params set to 'enable', in HD driver script they appear as 'Enable'
individual 'Disable' | [run](https://ml.azure.com/experiments/id/e1bd4ec3-b8ea-449a-bc60-2f50186bb27e/runs/witty_feijoa_ssv938gb2q?wsid=/subscriptions/381b38e9-9840-4719-a5a0-61d9585e1e91/resourceGroups/automlimage_eastus2_rg/providers/Microsoft.MachineLearningServices/workspaces/rbhimani-jos2&tid=72f988bf-86f1-41af-91ab-2d7cd011db47) | both params set to 'Disable
individual 'disable' | [run](https://ml.azure.com/experiments/id/e1bd4ec3-b8ea-449a-bc60-2f50186bb27e/runs/dreamy_garage_vkkh5v62rh?wsid=/subscriptions/381b38e9-9840-4719-a5a0-61d9585e1e91/resourceGroups/automlimage_eastus2_rg/providers/Microsoft.MachineLearningServices/workspaces/rbhimani-jos2&tid=72f988bf-86f1-41af-91ab-2d7cd011db47) | both params set to 'disable', in HD driver script they appear as 'Disable'
individual don't specify params | [run]() | the params are not specified through SDK, so the MFE defaults are picked up: log_training_metrics == 'Enable' and log_validation_loss == 'Disable as in the HD driver script
Automode | [run](https://ml.azure.com/runs/lime_bottle_dq73fy290p?wsid=/subscriptions/381b38e9-9840-4719-a5a0-61d9585e1e91/resourcegroups/automlimage_eastus2_rg/workspaces/rbhimani-jos2&tid=72f988bf-86f1-41af-91ab-2d7cd011db47) | both params are not present in the HD script, so they pick up the runtime defaults: log_training_metrics == 'Disable' and log_validation_loss == 'Enable'
**IS**| | 
individual 'Enable' | [run](https://ml.azure.com/runs/orange_guava_zbc6tx9qym?wsid=/subscriptions/381b38e9-9840-4719-a5a0-61d9585e1e91/resourcegroups/automlimage_eastus2_rg/workspaces/rbhimani-jos2&tid=72f988bf-86f1-41af-91ab-2d7cd011db47) | both params set to 'Enable'
individual 'enable' | [run](https://ml.azure.com/runs/ashy_market_vgnr3ybmhb?wsid=/subscriptions/381b38e9-9840-4719-a5a0-61d9585e1e91/resourcegroups/automlimage_eastus2_rg/workspaces/rbhimani-jos2&tid=72f988bf-86f1-41af-91ab-2d7cd011db47) | both params set to 'enable', in HD driver script they appear as 'Enable'
individual 'Disable' | [run](https://ml.azure.com/runs/brave_iron_hfnys9szs6?wsid=/subscriptions/381b38e9-9840-4719-a5a0-61d9585e1e91/resourcegroups/automlimage_eastus2_rg/workspaces/rbhimani-jos2&tid=72f988bf-86f1-41af-91ab-2d7cd011db47) | both params set to 'Disable
individual 'disable' | [run](https://ml.azure.com/runs/loyal_parrot_hcqmsd1q6q?wsid=/subscriptions/381b38e9-9840-4719-a5a0-61d9585e1e91/resourcegroups/automlimage_eastus2_rg/workspaces/rbhimani-jos2&tid=72f988bf-86f1-41af-91ab-2d7cd011db47) | both params set to 'disable', in HD driver script they appear as 'Disable'
individual don't specify params | [run](https://ml.azure.com/runs/maroon_wing_s6qh51kv0j?wsid=/subscriptions/381b38e9-9840-4719-a5a0-61d9585e1e91/resourcegroups/automlimage_eastus2_rg/workspaces/rbhimani-jos2&tid=72f988bf-86f1-41af-91ab-2d7cd011db47) | the params are not specified through SDK, so the MFE defaults are picked up: log_training_metrics == 'Enable' and log_validation_loss == 'Disable as in the HD driver script
Automode | [run](https://ml.azure.com/runs/stoic_music_ths9r1ftdj?wsid=/subscriptions/381b38e9-9840-4719-a5a0-61d9585e1e91/resourcegroups/automlimage_eastus2_rg/workspaces/rbhimani-jos2&tid=72f988bf-86f1-41af-91ab-2d7cd011db47) | both params are not present in the HD script, so they pick up the runtime defaults: log_training_metrics == 'Disable' and log_validation_loss == 'Enable'


If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
