### PR TITLE
Azure-Core: Fix all typings that are not pipeline related

### DIFF
--- a/sdk/core/azure-core/azure/core/credentials_async.py
+++ b/sdk/core/azure-core/azure/core/credentials_async.py
@@ -3,14 +3,13 @@
 # Licensed under the MIT License.
 # ------------------------------------
 from __future__ import annotations
-from types import TracebackType
-from typing import Any, Optional, Type
+from typing import Any, Optional, AsyncContextManager
 from typing_extensions import Protocol, runtime_checkable
 from .credentials import AccessToken as _AccessToken
 
 
 @runtime_checkable
-class AsyncTokenCredential(Protocol):
+class AsyncTokenCredential(Protocol, AsyncContextManager["AsyncTokenCredential"]):
     """Protocol for classes able to provide OAuth tokens."""
 
     async def get_token(
@@ -31,15 +30,4 @@ class AsyncTokenCredential(Protocol):
         """
 
     async def close(self) -> None:
-        pass
-
-    async def __aenter__(self) -> AsyncTokenCredential:
-        pass
-
-    async def __aexit__(
-        self,
-        exception_type: Optional[Type[BaseException]],
-        exception_value: Optional[BaseException],
-        traceback: TracebackType,
-    ) -> None:
         pass

--- a/sdk/core/azure-core/azure/core/credentials_async.py
+++ b/sdk/core/azure-core/azure/core/credentials_async.py
@@ -2,7 +2,9 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
-from typing import Any, Optional
+from __future__ import annotations
+from types import TracebackType
+from typing import Any, Optional, Type
 from typing_extensions import Protocol, runtime_checkable
 from .credentials import AccessToken as _AccessToken
 
@@ -31,8 +33,13 @@ class AsyncTokenCredential(Protocol):
     async def close(self) -> None:
         pass
 
-    async def __aenter__(self):
+    async def __aenter__(self) -> AsyncTokenCredential:
         pass
 
-    async def __aexit__(self, exc_type, exc_value, traceback) -> None:
+    async def __aexit__(
+        self,
+        exception_type: Optional[Type[BaseException]],
+        exception_value: Optional[BaseException],
+        traceback: TracebackType,
+    ) -> None:
         pass

--- a/sdk/core/azure-core/azure/core/messaging.py
+++ b/sdk/core/azure-core/azure/core/messaging.py
@@ -4,6 +4,7 @@
 # Licensed under the MIT License. See License.txt in the project root for
 # license information.
 # --------------------------------------------------------------------------
+from __future__ import annotations
 import uuid
 from base64 import b64decode
 from datetime import datetime
@@ -139,7 +140,7 @@ class CloudEvent(Generic[DataType]):  # pylint:disable=too-many-instance-attribu
         )[:1024]
 
     @classmethod
-    def from_dict(cls, event: Dict[str, Any]) -> "CloudEvent":
+    def from_dict(cls, event: Dict[str, Any]) -> CloudEvent[DataType]:
         """Returns the deserialized CloudEvent object when a dict is provided.
 
         :param event: The dict representation of the event which needs to be deserialized.
@@ -214,7 +215,7 @@ class CloudEvent(Generic[DataType]):  # pylint:disable=too-many-instance-attribu
         return event_obj
 
     @classmethod
-    def from_json(cls, event: Any) -> "CloudEvent":
+    def from_json(cls, event: Any) -> CloudEvent[DataType]:
         """
         Returns the deserialized CloudEvent object when a json payload is provided.
         :param event: The json string that should be converted into a CloudEvent. This can also be

--- a/sdk/core/azure-core/azure/core/serialization.py
+++ b/sdk/core/azure-core/azure/core/serialization.py
@@ -6,7 +6,7 @@
 # --------------------------------------------------------------------------
 import base64
 from json import JSONEncoder
-from typing import Union, cast
+from typing import Union, cast, Any
 from datetime import datetime, date, time, timedelta
 from datetime import timezone
 
@@ -18,7 +18,7 @@ TZ_UTC = timezone.utc
 class _Null:
     """To create a Falsy object"""
 
-    def __bool__(self):
+    def __bool__(self) -> bool:
         return False
 
 
@@ -115,7 +115,7 @@ def _datetime_as_isostr(dt: Union[datetime, date, time, timedelta]) -> str:
 class AzureJSONEncoder(JSONEncoder):
     """A JSON encoder that's capable of serializing datetime objects and bytes."""
 
-    def default(self, o):  # pylint: disable=too-many-return-statements
+    def default(self, o: Any) -> Any:  # pylint: disable=too-many-return-statements
         if isinstance(o, (bytes, bytearray)):
             return base64.b64encode(o).decode()
         try:

--- a/sdk/core/azure-core/azure/core/tracing/_abstract_span.py
+++ b/sdk/core/azure-core/azure/core/tracing/_abstract_span.py
@@ -86,7 +86,7 @@ class AbstractSpan(Protocol):
         :type value: SpanKind
         """
 
-    def __enter__(self) -> "AbstractSpan":
+    def __enter__(self) -> AbstractSpan:
         """Start a span."""
 
     def __exit__(

--- a/sdk/core/azure-core/azure/core/tracing/_abstract_span.py
+++ b/sdk/core/azure-core/azure/core/tracing/_abstract_span.py
@@ -30,7 +30,7 @@ AttributeValue = Union[
     Sequence[int],
     Sequence[float],
 ]
-Attributes = Optional[Dict[str, AttributeValue]]
+Attributes = Dict[str, AttributeValue]
 
 
 class SpanKind(Enum):

--- a/sdk/core/azure-core/azure/core/tracing/_abstract_span.py
+++ b/sdk/core/azure-core/azure/core/tracing/_abstract_span.py
@@ -284,6 +284,6 @@ class Link:
     :type attributes: dict
     """
 
-    def __init__(self, headers: Dict[str, str], attributes: Optional["Attributes"] = None) -> None:
+    def __init__(self, headers: Dict[str, str], attributes: Optional[Attributes] = None) -> None:
         self.headers = headers
         self.attributes = attributes

--- a/sdk/core/azure-core/azure/core/tracing/common.py
+++ b/sdk/core/azure-core/azure/core/tracing/common.py
@@ -38,7 +38,7 @@ __all__ = [
 ]
 
 
-def get_function_and_class_name(func: Callable, *args) -> str:
+def get_function_and_class_name(func: Callable, *args: object) -> str:
     """
     Given a function and its unamed arguments, returns class_name.function_name. It assumes the first argument
     is `self`. If there are no arguments then it only returns the function name.

--- a/sdk/core/azure-core/azure/core/tracing/decorator.py
+++ b/sdk/core/azure-core/azure/core/tracing/decorator.py
@@ -50,7 +50,9 @@ def distributed_trace(  # pylint:disable=function-redefined
     pass
 
 
-def distributed_trace(__func: Optional[Callable[P, T]] = None, **kwargs: Any):  # pylint:disable=function-redefined
+def distributed_trace(
+    __func: Optional[Callable[P, T]] = None, **kwargs: Any
+) -> Any:  # pylint:disable=function-redefined
     """Decorator to apply to function to get traced automatically.
 
     Span will use the func name or "name_of_span".

--- a/sdk/core/azure-core/azure/core/tracing/decorator_async.py
+++ b/sdk/core/azure-core/azure/core/tracing/decorator_async.py
@@ -51,7 +51,7 @@ def distributed_trace_async(  # pylint:disable=function-redefined
 
 def distributed_trace_async(  # pylint:disable=function-redefined
     __func: Optional[Callable[P, Awaitable[T]]] = None, **kwargs: Any
-):
+) -> Any:
     """Decorator to apply to function to get traced automatically.
 
     Span will use the func name or "name_of_span".

--- a/sdk/core/azure-core/azure/core/utils/_utils.py
+++ b/sdk/core/azure-core/azure/core/utils/_utils.py
@@ -148,7 +148,7 @@ class CaseInsensitiveDict(MutableMapping[str, Any]):
     def __len__(self) -> int:
         return len(self._store)
 
-    def lowerkey_items(self):
+    def lowerkey_items(self) -> Iterator[Tuple[str, Any]]:
         return ((lower_case_key, pair[1]) for lower_case_key, pair in self._store.items())
 
     def __eq__(self, other: Any) -> bool:


### PR DESCRIPTION
Everything that is not pipeline (CloudEvent, serialization, AbstractSpan, etc.)
Brings the type score to 92.7%