### PR TITLE
Vivekmore msft/latest arb fixes

### DIFF
--- a/sdk/communication/azure-communication-callautomation/CHANGELOG.md
+++ b/sdk/communication/azure-communication-callautomation/CHANGELOG.md
@@ -8,6 +8,12 @@
 - Send DTMF tones to a participant in the call.
 - Mute participant in the call.
 
+### Other Changes
+- The models `ServerCallLocator` and `GroupCallLocator` have been deprecated, and the ID values can now be passed directly into `CallAutomationClient.start_recording` as keyword arguments.
+- The model `CallInvite` has been deprecated and now the target `CommunicationIdentifier` and associated properties can be passed directly into `create_call`, `redirect_call` and `add_participant`.
+- The method `CallAutomationClient.create_group_call` has been deprecated, this can now be achieved by passing a list of `CommunicationIdentifier`s into `create_call`.
+- The method `CallConnectionClient.play_media_to_all` has been deprecated, this can now be achieved as the default behaviour of `play_media`.
+
 ## 1.0.0 (2023-06-14)
 Call Automation enables developers to build call workflows. Personalise customer interactions by listening to call events and take actions based on your business logic. For more information, please see the [README][read_me].
 

--- a/sdk/communication/azure-communication-callautomation/README.md
+++ b/sdk/communication/azure-communication-callautomation/README.md
@@ -43,21 +43,17 @@ client = CallAutomationClient.from_connection_string(endpoint_url)
 ```Python
 from azure.communication.callautomation import (
     CallAutomationClient,
-    CallInvite,
     CommunicationUserIdentifier
 )
 
 # target endpoint for ACS User
 user = CommunicationUserIdentifier("8:acs:...")
 
-# make invitation
-call_invite = CallInvite(target=user)
-
 # callback url to receive callback events
 callback_url = "https://<MY-EVENT-HANDLER-URL>/events"
 
 # send out the invitation, creating call
-result = client.create_call(call_invite, callback_url)
+result = client.create_call(user, callback_url)
 
 # this id can be used to do further actions in the call
 call_connection_id = result.call_connection_id
@@ -70,7 +66,7 @@ call_connection = client.get_call_connection(call_connection_id)
 
 # from callconnection of result above, play media to all participants
 my_file = FileSource(url="https://<FILE-SOURCE>/<SOME-FILE>.wav")
-call_connection.play_to_all(my_file)
+call_connection.play_media(my_file)
 ```
 
 ## Troubleshooting

--- a/sdk/communication/azure-communication-callautomation/azure/communication/callautomation/__init__.py
+++ b/sdk/communication/azure-communication-callautomation/azure/communication/callautomation/__init__.py
@@ -114,4 +114,3 @@ def __getattr__(name):
         return ServerCallLocator
 
     raise AttributeError(f"module 'azure.communication.callautomation' has no attribute {name}")
-

--- a/sdk/communication/azure-communication-callautomation/azure/communication/callautomation/__init__.py
+++ b/sdk/communication/azure-communication-callautomation/azure/communication/callautomation/__init__.py
@@ -3,14 +3,13 @@
 # Licensed under the MIT License. See License.txt in the project root for
 # license information.
 # --------------------------------------------------------------------------
+import warnings
+
 from ._version import VERSION
 from ._call_automation_client import CallAutomationClient
 from ._call_connection_client import CallConnectionClient
 from ._models import (
     CallConnectionProperties,
-    CallInvite,
-    ServerCallLocator,
-    GroupCallLocator,
     FileSource,
     TextSource,
     SsmlSource,
@@ -51,9 +50,6 @@ __all__ = [
     "CallConnectionClient",
 
     # models for input
-    "CallInvite",
-    "ServerCallLocator",
-    "GroupCallLocator",
     "FileSource",
     "TextSource",
     "SsmlSource",
@@ -92,3 +88,30 @@ __all__ = [
     "VoiceKind"
 ]
 __version__ = VERSION
+
+
+def __getattr__(name):
+    if name == 'CallInvite':
+        warnings.warn(
+            "CallInvite is deprecated and should not be used. Please pass in keyword arguments directly.",
+            DeprecationWarning
+        )
+        from ._models import CallInvite
+        return CallInvite
+    if name == 'GroupCallLocator':
+        warnings.warn(
+            "GroupCallLocator is deprecated and should not be used. Please pass in 'group_call_id' directly.",
+            DeprecationWarning
+        )
+        from ._models import GroupCallLocator
+        return GroupCallLocator
+    if name == 'ServerCallLocator':
+        warnings.warn(
+            "ServerCallLocator is deprecated and should not be used. Please pass in 'server_call_id' directly.",
+            DeprecationWarning
+        )
+        from ._models import ServerCallLocator
+        return ServerCallLocator
+
+    raise AttributeError(f"module 'azure.communication.callautomation' has no attribute {name}")
+

--- a/sdk/communication/azure-communication-callautomation/azure/communication/callautomation/_call_automation_client.py
+++ b/sdk/communication/azure-communication-callautomation/azure/communication/callautomation/_call_automation_client.py
@@ -3,9 +3,12 @@
 # Licensed under the MIT License. See License.txt in the project root for
 # license information.
 # --------------------------------------------------------------------------
-from typing import List, Union, Optional, TYPE_CHECKING, Iterable
+from typing import List, Union, Optional, TYPE_CHECKING, Iterable, overload
 from urllib.parse import urlparse
+import warnings
+
 from azure.core.tracing.decorator import distributed_trace
+
 from ._version import SDK_MONIKER
 from ._api_versions import DEFAULT_VERSION
 from ._call_connection_client import CallConnectionClient
@@ -23,19 +26,21 @@ from ._generated.models import (
 )
 from ._models import (
     CallConnectionProperties,
-    RecordingProperties
+    RecordingProperties,
+    ChannelAffinity,
+    CallInvite
 )
 from ._content_downloader import ContentDownloader
 from ._utils import (
     get_repeatability_guid,
-    get_repeatability_timestamp,
     serialize_phone_identifier,
     serialize_identifier,
-    serialize_communication_user_identifier
+    serialize_communication_user_identifier,
+    build_call_locator,
+    process_repeatability_first_sent
 )
 if TYPE_CHECKING:
     from ._models  import (
-        CallInvite,
         ServerCallLocator,
         GroupCallLocator
     )
@@ -54,9 +59,9 @@ if TYPE_CHECKING:
         RecordingChannel,
         RecordingFormat
     )
-    from azure.core.exceptions import HttpResponseError
 
-class CallAutomationClient(object):
+
+class CallAutomationClient:
     """A client to interact with the AzureCommunicationService CallAutomation service.
     Call Automation provides developers the ability to build server-based,
     intelligent call workflows, and call recording for voice and PSTN channels.
@@ -121,7 +126,6 @@ class CallAutomationClient(object):
         :rtype: ~azure.communication.callautomation.CallAutomationClient
         """
         endpoint, access_key = parse_connection_str(conn_str)
-
         return cls(endpoint, access_key, **kwargs)
 
     def get_call_connection(
@@ -143,14 +147,17 @@ class CallAutomationClient(object):
         return CallConnectionClient._from_callautomation_client( #pylint:disable=protected-access
             callautomation_client=self._client,
             call_connection_id=call_connection_id,
-            **kwargs)
+            **kwargs
+        )
 
     @distributed_trace
     def create_call(
         self,
-        target_participant: 'CallInvite',
+        target_participant: Union['CommunicationIdentifier', List['CommunicationIdentifier']],
         callback_url: str,
         *,
+        source_caller_id_number: Optional['PhoneNumberIdentifier'] = None,
+        source_display_name: Optional[str] = None,
         operation_context: Optional[str] = None,
         cognitive_services_endpoint: Optional[str] = None,
         **kwargs
@@ -158,38 +165,52 @@ class CallAutomationClient(object):
         """Create a call connection request to a target identity.
 
         :param target_participant: Call invitee's information.
-        :type target_participant: ~azure.communication.callautomation.CallInvite
+        :type target_participant: ~azure.communication.callautomation.CommunicationIdentifier
+         or list[~azure.communication.callautomation.CommunicationIdentifier]
         :param callback_url: The call back url where callback events are sent.
         :type callback_url: str
         :keyword operation_context: Value that can be used to track the call and its associated events.
-        :paramtype operation_context: str
+        :paramtype operation_context: str or None
+        :keyword source_caller_id_number: The source caller Id, a phone number,
+         that's shown to the PSTN participant being invited.
+         Required only when calling a PSTN callee.
+        :paramtype source_caller_id_number: ~azure.communication.callautomation.PhoneNumberIdentifier or None
+        :keyword source_display_name: Display name of the caller.
+        :paramtype source_display_name: str or None
         :keyword cognitive_services_endpoint:
          The identifier of the Cognitive Service resource assigned to this call.
-        :paramtype cognitive_services_endpoint: str
+        :paramtype cognitive_services_endpoint: str or None
         :return: CallConnectionProperties
         :rtype: ~azure.communication.callautomation.CallConnectionProperties
         :raises ~azure.core.exceptions.HttpResponseError:
         """
+        # Backwards compatibility with old API signature
+        if isinstance(target_participant, CallInvite):
+            source_caller_id_number = source_caller_id_number or target_participant.source_caller_id_number
+            source_display_name = source_display_name or target_participant.source_display_name
+            target_participant = target_participant.target
+
+        try:
+            targets = [serialize_identifier(p) for p in target_participant]
+        except TypeError:
+            targets = [serialize_identifier(target_participant)]
         create_call_request = CreateCallRequest(
-            targets=[serialize_identifier(target_participant.target)],
+            targets=targets,
             callback_uri=callback_url,
-            source_caller_id_number=serialize_phone_identifier(
-                target_participant.source_caller_id_number) if target_participant.source_caller_id_number else None,
-            source_display_name=target_participant.source_display_name,
-            source=serialize_communication_user_identifier(
-                self.source) if self.source else None,
+            source_caller_id_number=serialize_phone_identifier(source_caller_id_number),
+            source_display_name=source_display_name,
+            source=serialize_communication_user_identifier(self.source),
             operation_context=operation_context,
             cognitive_services_endpoint=cognitive_services_endpoint
         )
 
+        process_repeatability_first_sent(kwargs)
         result = self._client.create_call(
             create_call_request=create_call_request,
-            repeatability_first_sent=get_repeatability_timestamp(),
             repeatability_request_id=get_repeatability_guid(),
-            **kwargs)
-
-        return CallConnectionProperties._from_generated(# pylint:disable=protected-access
-            result)
+            **kwargs
+        )
+        return CallConnectionProperties._from_generated(result)  # pylint:disable=protected-access
 
     @distributed_trace
     def create_group_call(
@@ -225,27 +246,20 @@ class CallAutomationClient(object):
         :rtype: ~azure.communication.callautomation.CallConnectionProperties
         :raises ~azure.core.exceptions.HttpResponseError:
         """
-        create_call_request = CreateCallRequest(
-            targets=[serialize_identifier(identifier)
-                     for identifier in target_participants],
-            callback_uri=callback_url,
-            source_caller_id_number=serialize_phone_identifier(
-                source_caller_id_number) if source_caller_id_number else None,
-            source_display_name=source_display_name,
-            source=serialize_identifier(
-                self.source) if self.source else None,
-            operation_context=operation_context,
-            cognitive_services_endpoint=cognitive_services_endpoint
+        warnings.warn(
+            "The method 'create_group_call' is deprecated. Please use 'create_call' instead.",
+            DeprecationWarning
         )
 
-        result = self._client.create_call(
-            create_call_request=create_call_request,
-            repeatability_first_sent=get_repeatability_timestamp(),
-            repeatability_request_id=get_repeatability_guid(),
-            **kwargs)
-
-        return CallConnectionProperties._from_generated(# pylint:disable=protected-access
-            result)
+        return self.create_call(
+            target_participant=target_participants,
+            callback_url=callback_url,
+            source_caller_id_number=source_caller_id_number,
+            source_display_name=source_display_name,
+            operation_context=operation_context,
+            cognitive_services_endpoint=cognitive_services_endpoint,
+            **kwargs
+        )
 
     @distributed_trace
     def answer_call(
@@ -283,20 +297,19 @@ class CallAutomationClient(object):
             operation_context=operation_context
         )
 
+        process_repeatability_first_sent(kwargs)
         result = self._client.answer_call(
             answer_call_request=answer_call_request,
-            repeatability_first_sent=get_repeatability_timestamp(),
             repeatability_request_id=get_repeatability_guid(),
-            **kwargs)
-
-        return CallConnectionProperties._from_generated(# pylint:disable=protected-access
-            result)
+            **kwargs
+        )
+        return CallConnectionProperties._from_generated(result)  # pylint:disable=protected-access
 
     @distributed_trace
     def redirect_call(
         self,
         incoming_call_context: str,
-        target_participant: 'CallInvite',
+        target_participant: 'CommunicationIdentifier',
         **kwargs
     ) -> None:
         """Redirect incoming call to a specific target.
@@ -305,21 +318,25 @@ class CallAutomationClient(object):
          Use this value to redirect incoming call.
         :type incoming_call_context: str
         :param target_participant: The target identity to redirect the call to.
-        :type target_participant: ~azure.communication.callautomation.CallInvite
+        :type target_participant: ~azure.communication.callautomation.CommunicationIdentifier
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
         """
+        # Backwards compatibility with old API signature
+        if isinstance(target_participant, CallInvite):
+            target_participant = target_participant.target
+
         redirect_call_request = RedirectCallRequest(
             incoming_call_context=incoming_call_context,
-            target=serialize_identifier(target_participant.target),
+            target=serialize_identifier(target_participant),
         )
-
+        process_repeatability_first_sent(kwargs)
         self._client.redirect_call(
             redirect_call_request=redirect_call_request,
-            repeatability_first_sent=get_repeatability_timestamp(),
             repeatability_request_id=get_repeatability_guid(),
-            **kwargs)
+            **kwargs
+        )
 
     @distributed_trace
     def reject_call(
@@ -345,17 +362,18 @@ class CallAutomationClient(object):
             call_reject_reason=call_reject_reason
         )
 
+        process_repeatability_first_sent(kwargs)
         self._client.reject_call(
             reject_call_request=reject_call_request,
-            repeatability_first_sent=get_repeatability_timestamp(),
             repeatability_request_id=get_repeatability_guid(),
-            **kwargs)
+            **kwargs
+        )
 
-    @distributed_trace
+    @overload
     def start_recording(
         self,
-        call_locator: Union['ServerCallLocator', 'GroupCallLocator'],
         *,
+        server_call_id: str,
         recording_state_callback_url: Optional[str] = None,
         recording_content_type: Optional[Union[str, 'RecordingContent']] = None,
         recording_channel_type: Optional[Union[str, 'RecordingChannel']] = None,
@@ -366,58 +384,107 @@ class CallAutomationClient(object):
     ) -> RecordingProperties:
         """Start recording for a ongoing call. Locate the call with call locator.
 
-        :param call_locator: The call locator to locate ongoing call.
-        :type call_locator: ~azure.communication.callautomation.ServerCallLocator
-         or ~azure.communication.callautomation.GroupCallLocator
+        :keyword str server_call_id: The server call ID to locate ongoing call.
         :keyword recording_state_callback_url: The url to send notifications to.
-        :paramtype recording_state_callback_url: str
+        :paramtype recording_state_callback_url: str or None
         :keyword recording_content_type: The content type of call recording.
-        :paramtype recording_content_type: str or ~azure.communication.callautomation.RecordingContent
+        :paramtype recording_content_type: str or ~azure.communication.callautomation.RecordingContent or None
         :keyword recording_channel_type: The channel type of call recording.
-        :paramtype recording_channel_type: str or ~azure.communication.callautomation.RecordingChannel
+        :paramtype recording_channel_type: str or ~azure.communication.callautomation.RecordingChannel or None
         :keyword recording_format_type: The format type of call recording.
-        :paramtype recording_format_type: str or ~azure.communication.callautomation.RecordingFormat
+        :paramtype recording_format_type: str or ~azure.communication.callautomation.RecordingFormat or None
         :keyword audio_channel_participant_ordering:
          The sequential order in which audio channels are assigned to participants in the unmixed recording.
          When 'recordingChannelType' is set to 'unmixed' and `audioChannelParticipantOrdering is not specified,
          the audio channel to participant mapping will be automatically assigned based on the order in
          which participant first audio was detected.
          Channel to participant mapping details can be found in the metadata of the recording.
-        :paramtype audio_channel_participant_ordering: list[~azure.communication.callautomation.CommunicationIdentifier]
+        :paramtype audio_channel_participant_ordering:
+         list[~azure.communication.callautomation.CommunicationIdentifier] or None
         :keyword channel_affinity: The channel affinity of call recording
          When 'recordingChannelType' is set to 'unmixed', if channelAffinity is not specified,
          'channel' will be automatically assigned.
          Channel-Participant mapping details can be found in the metadata of the recording.
-        :paramtype channel_affinity: list[~azure.communication.callautomation.ChannelAffinity]
+        :paramtype channel_affinity: list[~azure.communication.callautomation.ChannelAffinity] or None
         :return: RecordingProperties
         :rtype: ~azure.communication.callautomation.RecordingProperties
         :raises ~azure.core.exceptions.HttpResponseError:
         """
-        channel_affinity_internal = []
 
-        if channel_affinity:
-            for channel in channel_affinity:
-                channel_affinity_internal.append(channel._to_generated(# pylint:disable=protected-access
-                    ))
+    @overload
+    def start_recording(
+        self,
+        *,
+        group_call_id: str,
+        recording_state_callback_url: Optional[str] = None,
+        recording_content_type: Optional[Union[str, 'RecordingContent']] = None,
+        recording_channel_type: Optional[Union[str, 'RecordingChannel']] = None,
+        recording_format_type: Optional[Union[str, 'RecordingFormat']] = None,
+        audio_channel_participant_ordering: Optional[List['CommunicationIdentifier']] = None,
+        channel_affinity: Optional[List['ChannelAffinity']] = None,
+        **kwargs
+    ) -> RecordingProperties:
+        """Start recording for a ongoing call. Locate the call with call locator.
 
+        :keyword str group_call_id: The group call ID to locate ongoing call.
+        :keyword recording_state_callback_url: The url to send notifications to.
+        :paramtype recording_state_callback_url: str or None
+        :keyword recording_content_type: The content type of call recording.
+        :paramtype recording_content_type: str or ~azure.communication.callautomation.RecordingContent or None
+        :keyword recording_channel_type: The channel type of call recording.
+        :paramtype recording_channel_type: str or ~azure.communication.callautomation.RecordingChannel or None
+        :keyword recording_format_type: The format type of call recording.
+        :paramtype recording_format_type: str or ~azure.communication.callautomation.RecordingFormat or None
+        :keyword audio_channel_participant_ordering:
+         The sequential order in which audio channels are assigned to participants in the unmixed recording.
+         When 'recordingChannelType' is set to 'unmixed' and `audioChannelParticipantOrdering is not specified,
+         the audio channel to participant mapping will be automatically assigned based on the order in
+         which participant first audio was detected.
+         Channel to participant mapping details can be found in the metadata of the recording.
+        :paramtype audio_channel_participant_ordering:
+         list[~azure.communication.callautomation.CommunicationIdentifier] or None
+        :keyword channel_affinity: The channel affinity of call recording
+         When 'recordingChannelType' is set to 'unmixed', if channelAffinity is not specified,
+         'channel' will be automatically assigned.
+         Channel-Participant mapping details can be found in the metadata of the recording.
+        :paramtype channel_affinity: list[~azure.communication.callautomation.ChannelAffinity] or None
+        :return: RecordingProperties
+        :rtype: ~azure.communication.callautomation.RecordingProperties
+        :raises ~azure.core.exceptions.HttpResponseError:
+        """
+
+    @distributed_trace
+    def start_recording(
+        self,
+        *args: Union['ServerCallLocator', 'GroupCallLocator'],
+        **kwargs
+    ) -> RecordingProperties:
+        # pylint:disable=protected-access
+        channel_affinity: List[ChannelAffinity] = kwargs.pop("channel_affinity", None) or []
+        channel_affinity_internal = [c._to_generated() for c in channel_affinity]
+        call_locator = build_call_locator(
+            args,
+            kwargs.pop("call_locator", None),
+            kwargs.pop("server_call_id", None),
+            kwargs.pop("group_call_id", None)
+        )
         start_recording_request = StartCallRecordingRequest(
-            call_locator=call_locator._to_generated(# pylint:disable=protected-access
-            ),
-            recording_state_callback_uri = recording_state_callback_url,
-            recording_content_type = recording_content_type,
-            recording_channel_type = recording_channel_type,
-            recording_format_type = recording_format_type,
-            audio_channel_participant_ordering = audio_channel_participant_ordering,
-            channel_affinity = channel_affinity_internal,
-            repeatability_first_sent=get_repeatability_timestamp(),
-            repeatability_request_id=get_repeatability_guid()
+            call_locator=call_locator,
+            recording_state_callback_uri=kwargs.pop("recording_state_callback_url", None),
+            recording_content_type=kwargs.pop("recording_content_type", None),
+            recording_channel_type=kwargs.pop("recording_channel_type", None),
+            recording_format_type=kwargs.pop("recording_format_type", None),
+            audio_channel_participant_ordering=kwargs.pop("audio_channel_participant_ordering", None),
+            channel_affinity=channel_affinity_internal
         )
 
+        process_repeatability_first_sent(kwargs)
         recording_state_result = self._call_recording_client.start_recording(
-        start_call_recording = start_recording_request, **kwargs)
-
-        return RecordingProperties._from_generated(# pylint:disable=protected-access
-            recording_state_result)
+            start_call_recording=start_recording_request,
+            repeatability_request_id=get_repeatability_guid(),
+            **kwargs
+        )
+        return RecordingProperties._from_generated(recording_state_result)
 
     @distributed_trace
     def stop_recording(
@@ -433,7 +500,7 @@ class CallAutomationClient(object):
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
         """
-        self._call_recording_client.stop_recording(recording_id = recording_id, **kwargs)
+        self._call_recording_client.stop_recording(recording_id=recording_id, **kwargs)
 
     @distributed_trace
     def pause_recording(
@@ -449,7 +516,7 @@ class CallAutomationClient(object):
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
         """
-        self._call_recording_client.pause_recording(recording_id = recording_id, **kwargs)
+        self._call_recording_client.pause_recording(recording_id=recording_id, **kwargs)
 
     @distributed_trace
     def resume_recording(
@@ -465,7 +532,7 @@ class CallAutomationClient(object):
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
         """
-        self._call_recording_client.resume_recording(recording_id = recording_id, **kwargs)
+        self._call_recording_client.resume_recording(recording_id=recording_id, **kwargs)
 
     @distributed_trace
     def get_recording_properties(
@@ -482,9 +549,10 @@ class CallAutomationClient(object):
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         recording_state_result = self._call_recording_client.get_recording_properties(
-            recording_id = recording_id, **kwargs)
-        return RecordingProperties._from_generated(# pylint:disable=protected-access
-            recording_state_result)
+            recording_id=recording_id,
+            **kwargs
+        )
+        return RecordingProperties._from_generated(recording_state_result)  # pylint:disable=protected-access
 
     @distributed_trace
     def download_recording(
@@ -510,9 +578,9 @@ class CallAutomationClient(object):
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         stream = self._downloader.download_streaming(
-            source_location = recording_url,
-            offset = offset,
-            length = length,
+            source_location=recording_url,
+            offset=offset,
+            length=length,
             **kwargs
         )
         return stream
@@ -531,4 +599,14 @@ class CallAutomationClient(object):
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
         """
-        self._downloader.delete_recording(recording_location = recording_url, **kwargs)
+        self._downloader.delete_recording(recording_location=recording_url, **kwargs)
+
+    def __enter__(self) -> "CallAutomationClient":
+        self._client.__enter__()
+        return self
+
+    def __exit__(self, *args) -> None:
+        self.close()
+
+    def close(self) -> None:
+        self._client.__exit__()

--- a/sdk/communication/azure-communication-callautomation/azure/communication/callautomation/_call_connection_client.py
+++ b/sdk/communication/azure-communication-callautomation/azure/communication/callautomation/_call_connection_client.py
@@ -390,7 +390,7 @@ class CallConnectionClient:
     @distributed_trace
     def play_media_to_all(
         self,
-        play_source: Union['MediaSources', List['MediaSources']],
+        play_source: Union['FileSource', List['FileSource']],
         *,
         loop: bool = False,
         operation_context: Optional[str] = None,
@@ -400,11 +400,7 @@ class CallConnectionClient:
 
         :param play_source: A PlaySource representing the source to play.
         :type play_source: ~azure.communication.callautomation.FileSource or
-         ~azure.communication.callautomation.TextSource or
-         ~azure.communication.callautomation.SsmlSource or
-         list[~azure.communication.callautomation.FileSource or
-          ~azure.communication.callautomation.TextSource or
-          ~azure.communication.callautomation.SsmlSource]
+         list[~azure.communication.callautomation.FileSource]
         :keyword loop: Whether the media should be repeated until cancelled.
         :paramtype loop: bool
         :keyword operation_context: Value that can be used to track this call and its associated events.

--- a/sdk/communication/azure-communication-callautomation/azure/communication/callautomation/_call_connection_client.py
+++ b/sdk/communication/azure-communication-callautomation/azure/communication/callautomation/_call_connection_client.py
@@ -500,9 +500,6 @@ class CallConnectionClient:
         else:
             play_source_single = play_prompt
 
-        if not isinstance(input_type, RecognizeInputType):
-            input_type = RecognizeInputType[input_type.upper()]
-
         if input_type == RecognizeInputType.DTMF:
             dtmf_options = DtmfOptions(
                 inter_tone_timeout_in_seconds=dtmf_inter_tone_timeout,

--- a/sdk/communication/azure-communication-callautomation/azure/communication/callautomation/_call_connection_client.py
+++ b/sdk/communication/azure-communication-callautomation/azure/communication/callautomation/_call_connection_client.py
@@ -5,15 +5,20 @@
 # --------------------------------------------------------------------------
 from typing import TYPE_CHECKING, Optional, List, Union
 from urllib.parse import urlparse
+import warnings
+
+from typing_extensions import Literal
+
 from azure.core.paging import ItemPaged
 from azure.core.tracing.decorator import distributed_trace
+
 from ._version import SDK_MONIKER
 from ._api_versions import DEFAULT_VERSION
 from ._utils import (
     get_repeatability_guid,
-    get_repeatability_timestamp,
     serialize_phone_identifier,
-    serialize_identifier
+    serialize_identifier,
+    process_repeatability_first_sent
 )
 from ._models import (
     CallParticipant,
@@ -23,6 +28,7 @@ from ._models import (
     TransferCallResult,
     MuteParticipantResult,
     SendDtmfTonesResult,
+    CallInvite
 )
 from ._generated._client import AzureCommunicationCallAutomationService
 from ._generated.models import (
@@ -46,24 +52,26 @@ from ._shared.utils import (
 )
 if TYPE_CHECKING:
     from ._call_automation_client import CallAutomationClient
+    from ._generated.models._enums import DtmfTone
+    from ._shared.models import (
+        PhoneNumberIdentifier,
+        CommunicationIdentifier
+    )
     from ._models  import (
         FileSource,
         TextSource,
         SsmlSource,
-        CallInvite,
         RecognitionChoice
     )
     from azure.core.credentials import (
         TokenCredential,
         AzureKeyCredential
     )
-    from ._shared.models import (
-        CommunicationIdentifier,
-    )
-    from ._generated.models._enums import DtmfTone
-    from azure.core.exceptions import HttpResponseError
 
-class CallConnectionClient(object): # pylint: disable=client-accepts-api-version-keyword
+MediaSources = Union['FileSource', 'TextSource', 'SsmlSource']
+
+
+class CallConnectionClient:
     """A client to interact with ongoing call. This client can be used to do mid-call actions,
     such as Transfer and Play Media. Call must be estbalished to perform these actions.
 
@@ -77,7 +85,7 @@ class CallConnectionClient(object): # pylint: disable=client-accepts-api-version
     :keyword api_version: Azure Communication Call Automation API version.
     :paramtype api_version: str
     """
-    def __init__(# pylint: disable=missing-client-constructor-parameter-credential, missing-client-constructor-parameter-kwargs
+    def __init__(
         self,
         endpoint: str,
         credential: Union['TokenCredential', 'AzureKeyCredential'],
@@ -158,7 +166,6 @@ class CallConnectionClient(object): # pylint: disable=client-accepts-api-version
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         call_properties = self._call_connection_client.get_call(call_connection_id=self._call_connection_id, **kwargs)
-
         return CallConnectionProperties._from_generated(call_properties) # pylint:disable=protected-access
 
     @distributed_trace
@@ -171,16 +178,18 @@ class CallConnectionClient(object): # pylint: disable=client-accepts-api-version
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
         """
-
         if is_for_everyone:
+            process_repeatability_first_sent(kwargs)
             self._call_connection_client.terminate_call(
                 self._call_connection_id,
-                repeatability_first_sent=get_repeatability_timestamp(),
                 repeatability_request_id=get_repeatability_guid(),
-                **kwargs)
+                **kwargs
+            )
         else:
             self._call_connection_client.hangup_call(
-                self._call_connection_id, **kwargs)
+                self._call_connection_id,
+                **kwargs
+            )
 
     @distributed_trace
     def get_participant(
@@ -196,21 +205,26 @@ class CallConnectionClient(object): # pylint: disable=client-accepts-api-version
         :rtype: ~azure.communication.callautomation.CallParticipant
         :raises ~azure.core.exceptions.HttpResponseError:
         """
-
         participant = self._call_connection_client.get_participant(
-            self._call_connection_id, target_participant.raw_id, **kwargs)
-
+            self._call_connection_id,
+            target_participant.raw_id,
+            **kwargs
+        )
         return CallParticipant._from_generated(participant) # pylint:disable=protected-access
 
     @distributed_trace
     def list_participants(self, **kwargs) -> ItemPaged[CallParticipant]:
         """List all participants in this call.
 
-        :return: List of CallParticipant
-        :rtype: ItemPaged[azure.communication.callautomation.CallParticipant]
+        :return: An iterable of CallParticipant
+        :rtype: ~azure.core.paging.ItemPaged[azure.communication.callautomation.CallParticipant]
         :raises ~azure.core.exceptions.HttpResponseError:
         """
-        return self._call_connection_client.get_participants(self._call_connection_id, **kwargs)
+        return self._call_connection_client.get_participants(
+            self._call_connection_id,
+            cls=lambda participants: [CallParticipant._from_generated(p) for p in participants],  # pylint:disable=protected-access
+            **kwargs
+        )
 
     @distributed_trace
     def transfer_call_to_participant(
@@ -231,52 +245,70 @@ class CallConnectionClient(object): # pylint: disable=client-accepts-api-version
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         request = TransferToParticipantRequest(
-            target_participant=serialize_identifier(target_participant), operation_context=operation_context)
-
-        return self._call_connection_client.transfer_to_participant(
-            self._call_connection_id, request,
-            repeatability_first_sent=get_repeatability_timestamp(),
+            target_participant=serialize_identifier(target_participant),
+            operation_context=operation_context
+        )
+        process_repeatability_first_sent(kwargs)
+        result = self._call_connection_client.transfer_to_participant(
+            self._call_connection_id,
+            request,
             repeatability_request_id=get_repeatability_guid(),
-            **kwargs)
+            **kwargs
+        )
+        return TransferCallResult._from_generated(result)  # pylint:disable=protected-access
+
 
     @distributed_trace
     def add_participant(
         self,
-        target_participant: 'CallInvite',
+        target_participant: 'CommunicationIdentifier',
         *,
         invitation_timeout: Optional[int] = None,
         operation_context: Optional[str] = None,
+        source_caller_id_number: Optional['PhoneNumberIdentifier'] = None,
+        source_display_name: Optional[str] = None,
         **kwargs
     ) -> AddParticipantResult:
         """Add a participant to this call.
 
         :param target_participant: The participant being added.
-        :type target_participant: ~azure.communication.callautomation.CallInvite
+        :type target_participant: ~azure.communication.callautomation.CommunicationIdentifier
         :keyword invitation_timeout: Timeout to wait for the invited participant to pickup.
          The maximum value of this is 180 seconds.
-        :paramtype invitation_timeout: int
+        :paramtype invitation_timeout: int or None
         :keyword operation_context: Value that can be used to track this call and its associated events.
-        :paramtype operation_context: str
+        :paramtype operation_context: str or None
+        :keyword source_caller_id_number: The source caller Id, a phone number,
+         that's shown to the PSTN participant being invited.
+         Required only when calling a PSTN callee.
+        :paramtype source_caller_id_number: ~azure.communication.callautomation.PhoneNumberIdentifier or None
+        :keyword source_display_name: Display name of the caller.
+        :paramtype source_display_name: str or None
         :return: AddParticipantResult
         :rtype: ~azure.communication.callautomation.AddParticipantResult
         :raises ~azure.core.exceptions.HttpResponseError:
         """
-        add_participant_request = AddParticipantRequest(
-            participant_to_add=serialize_identifier(target_participant.target),
-            source_caller_id_number=serialize_phone_identifier(
-                target_participant.source_caller_id_number) if target_participant.source_caller_id_number else None,
-            source_display_name=target_participant.source_display_name,
-            invitation_timeout=invitation_timeout,
-            operation_context=operation_context)
+        # Backwards compatibility with old API signature
+        if isinstance(target_participant, CallInvite):
+            source_caller_id_number = source_caller_id_number or target_participant.source_caller_id_number
+            source_display_name = source_display_name or target_participant.source_display_name
+            target_participant = target_participant.target
 
+        add_participant_request = AddParticipantRequest(
+            participant_to_add=serialize_identifier(target_participant),
+            source_caller_id_number=serialize_phone_identifier(source_caller_id_number),
+            source_display_name=source_display_name,
+            invitation_timeout=invitation_timeout,
+            operation_context=operation_context
+        )
+        process_repeatability_first_sent(kwargs)
         response = self._call_connection_client.add_participant(
             self._call_connection_id,
             add_participant_request,
-            repeatability_first_sent=get_repeatability_timestamp(),
             repeatability_request_id=get_repeatability_guid(),
-            **kwargs)
-
-        return AddParticipantResult._from_generated(response) # pylint:disable=protected-access
+            **kwargs
+        )
+        return AddParticipantResult._from_generated(response)  # pylint:disable=protected-access
 
     @distributed_trace
     def remove_participant(
@@ -299,11 +331,10 @@ class CallConnectionClient(object): # pylint: disable=client-accepts-api-version
         remove_participant_request = RemoveParticipantRequest(
             participant_to_remove=serialize_identifier(target_participant),
             operation_context=operation_context)
-
+        process_repeatability_first_sent(kwargs)
         response = self._call_connection_client.remove_participant(
             self._call_connection_id,
             remove_participant_request,
-            repeatability_first_sent=get_repeatability_timestamp(),
             repeatability_request_id=get_repeatability_guid(),
             **kwargs)
 
@@ -312,9 +343,8 @@ class CallConnectionClient(object): # pylint: disable=client-accepts-api-version
     @distributed_trace
     def play_media(
         self,
-        play_source: Union['FileSource', 'TextSource', 'SsmlSource',
-                           List[Union['FileSource', 'TextSource', 'SsmlSource']]],
-        play_to: List['CommunicationIdentifier'],
+        play_source: Union[MediaSources, List[MediaSources]],
+        play_to: Union[Literal["all"], List['CommunicationIdentifier']] = 'all',
         *,
         loop: bool = False,
         operation_context: Optional[str] = None,
@@ -329,27 +359,28 @@ class CallConnectionClient(object): # pylint: disable=client-accepts-api-version
          list[~azure.communication.callautomation.FileSource or
           ~azure.communication.callautomation.TextSource or
           ~azure.communication.callautomation.SsmlSource]
-        :param play_to: The targets to play media to.
+        :param play_to: The targets to play media to. Default value is 'all', to play media
+         to all participants in the call.
         :type play_to: list[~azure.communication.callautomation.CommunicationIdentifier]
-        :keyword loop: if the media should be repeated until cancelled.
+        :keyword loop: Whether the media should be repeated until cancelled.
         :paramtype loop: bool
         :keyword operation_context: Value that can be used to track this call and its associated events.
-        :paramtype operation_context: str
+        :paramtype operation_context: str or None
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
         """
-        play_source_single: Union['FileSource', 'TextSource', 'SsmlSource'] = None
+        play_source_single: Optional[MediaSources] = None
         if isinstance(play_source, list):
             if play_source:  # Check if the list is not empty
                 play_source_single = play_source[0]
         else:
             play_source_single = play_source
 
+        audience = [] if play_to == "all" else [serialize_identifier(i) for i in play_to]
         play_request = PlayRequest(
-            play_sources=[play_source_single._to_generated()],#pylint:disable=protected-access
-            play_to=[serialize_identifier(identifier)
-                     for identifier in play_to],
+            play_sources=[play_source_single._to_generated()],  # pylint:disable=protected-access
+            play_to=audience,
             play_options=PlayOptions(loop=loop),
             operation_context=operation_context,
             **kwargs
@@ -359,8 +390,7 @@ class CallConnectionClient(object): # pylint: disable=client-accepts-api-version
     @distributed_trace
     def play_media_to_all(
         self,
-        play_source: Union['FileSource', 'TextSource', 'SsmlSource',
-                           List[Union['FileSource', 'TextSource', 'SsmlSource']]],
+        play_source: Union['MediaSources', List['MediaSources']],
         *,
         loop: bool = False,
         operation_context: Optional[str] = None,
@@ -375,26 +405,24 @@ class CallConnectionClient(object): # pylint: disable=client-accepts-api-version
          list[~azure.communication.callautomation.FileSource or
           ~azure.communication.callautomation.TextSource or
           ~azure.communication.callautomation.SsmlSource]
-        :keyword loop: if the media should be repeated until cancelled.
+        :keyword loop: Whether the media should be repeated until cancelled.
         :paramtype loop: bool
         :keyword operation_context: Value that can be used to track this call and its associated events.
-        :paramtype operation_context: str
+        :paramtype operation_context: str or None
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
         """
-        play_source_single: Union['FileSource', 'TextSource', 'SsmlSource'] = None
-        if isinstance(play_source, list):
-            if play_source:  # Check if the list is not empty
-                play_source_single = play_source[0]
-        else:
-            play_source_single = play_source
-
-        self.play_media(play_source=play_source_single,
-                        play_to=[],
-                        loop=loop,
-                        operation_context=operation_context,
-                        **kwargs)
+        warnings.warn(
+            "The method 'play_media_to_all' is deprecated. Please use 'play_media' instead.",
+            DeprecationWarning
+        )
+        self.play_media(
+            play_source=play_source,
+            loop=loop,
+            operation_context=operation_context,
+            **kwargs
+        )
 
     @distributed_trace
     def start_recognizing_media(
@@ -403,8 +431,7 @@ class CallConnectionClient(object): # pylint: disable=client-accepts-api-version
         target_participant: 'CommunicationIdentifier',
         *,
         initial_silence_timeout: Optional[int] = None,
-        play_prompt: Optional[Union['FileSource', 'TextSource', 'SsmlSource',
-                           List[Union['FileSource', 'TextSource', 'SsmlSource']]]] = None,
+        play_prompt: Optional[Union[MediaSources, List[MediaSources]]] = None,
         interrupt_call_media_operation: bool = False,
         operation_context: Optional[str] = None,
         interrupt_prompt: bool = False,
@@ -466,7 +493,7 @@ class CallConnectionClient(object): # pylint: disable=client-accepts-api-version
             speech_recognition_model_endpoint_id=speech_recognition_model_endpoint_id
         )
 
-        play_source_single: Union['FileSource', 'TextSource', 'SsmlSource'] = None
+        play_source_single: Optional[MediaSources] = None
         if isinstance(play_prompt, list):
             if play_prompt:  # Check if the list is not empty
                 play_source_single = play_prompt[0]
@@ -500,34 +527,30 @@ class CallConnectionClient(object): # pylint: disable=client-accepts-api-version
         elif input_type == RecognizeInputType.CHOICES:
             options.choices = [choice._to_generated() for choice in choices] #pylint:disable=protected-access
         else:
-            raise NotImplementedError(f"{type(input_type).__name__} is not supported")
+            raise ValueError(f"Input type '{input_type}' is not supported.")
 
         recognize_request = RecognizeRequest(
             recognize_input_type=input_type,
-            play_prompt=
-            play_source_single._to_generated() if play_source_single is not None else None,#pylint:disable=protected-access
+            play_prompt=play_source_single._to_generated() if play_source_single else None,  # pylint:disable=protected-access
             interrupt_call_media_operation=interrupt_call_media_operation,
             operation_context=operation_context,
-            recognize_options=options,
+            recognize_options=options
+        )
+        self._call_media_client.recognize(
+            self._call_connection_id,
+            recognize_request,
             **kwargs
         )
 
-        self._call_media_client.recognize(
-            self._call_connection_id, recognize_request)
-
     @distributed_trace
-    def cancel_all_media_operations(
-        self,
-        **kwargs
-    ) -> None:
+    def cancel_all_media_operations(self, **kwargs) -> None:
         """Cancels all the ongoing and queued media operations for this call.
 
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
         """
-        self._call_media_client.cancel_all_media_operations(
-            self._call_connection_id, **kwargs)
+        self._call_media_client.cancel_all_media_operations(self._call_connection_id, **kwargs)
 
     @distributed_trace
     def start_continuous_dtmf_recognition(
@@ -549,12 +572,13 @@ class CallConnectionClient(object): # pylint: disable=client-accepts-api-version
         """
         continuous_dtmf_recognition_request = ContinuousDtmfRecognitionRequest(
             target_participant=serialize_identifier(target_participant),
-            operation_context=operation_context)
-
+            operation_context=operation_context
+        )
         self._call_media_client.start_continuous_dtmf_recognition(
             self._call_connection_id,
             continuous_dtmf_recognition_request,
-            **kwargs)
+            **kwargs
+        )
 
     @distributed_trace
     def stop_continuous_dtmf_recognition(
@@ -576,12 +600,13 @@ class CallConnectionClient(object): # pylint: disable=client-accepts-api-version
         """
         continuous_dtmf_recognition_request = ContinuousDtmfRecognitionRequest(
             target_participant=serialize_identifier(target_participant),
-            operation_context=operation_context)
-
+            operation_context=operation_context
+        )
         self._call_media_client.stop_continuous_dtmf_recognition(
             self._call_connection_id,
             continuous_dtmf_recognition_request,
-            **kwargs)
+            **kwargs
+        )
 
     @distributed_trace
     def send_dtmf_tones(
@@ -607,14 +632,15 @@ class CallConnectionClient(object): # pylint: disable=client-accepts-api-version
         send_dtmf_tones_request = SendDtmfTonesRequest(
             tones=tones,
             target_participant=serialize_identifier(target_participant),
-            operation_context=operation_context)
-
+            operation_context=operation_context
+        )
+        process_repeatability_first_sent(kwargs)
         response = self._call_media_client.send_dtmf_tones(
             self._call_connection_id,
             send_dtmf_tones_request,
-            repeatability_first_sent=get_repeatability_timestamp(),
             repeatability_request_id=get_repeatability_guid(),
-            **kwargs)
+            **kwargs
+        )
 
         return SendDtmfTonesResult._from_generated(response)  # pylint:disable=protected-access
 
@@ -639,13 +665,12 @@ class CallConnectionClient(object): # pylint: disable=client-accepts-api-version
         """
         mute_participants_request = MuteParticipantsRequest(
             target_participants=[serialize_identifier(target_participant)],
-            operation_context=operation_context)
-
+            operation_context=operation_context
+        )
+        process_repeatability_first_sent(kwargs)
         response = self._call_connection_client.mute(
             self._call_connection_id,
             mute_participants_request,
-            repeatability_first_sent=get_repeatability_timestamp(),
             repeatability_request_id=get_repeatability_guid(),
             **kwargs)
-
-        return MuteParticipantResult._from_generated(response) # pylint:disable=protected-access
+        return MuteParticipantResult._from_generated(response)  # pylint:disable=protected-access

--- a/sdk/communication/azure-communication-callautomation/azure/communication/callautomation/_models.py
+++ b/sdk/communication/azure-communication-callautomation/azure/communication/callautomation/_models.py
@@ -43,7 +43,8 @@ if TYPE_CHECKING:
         SendDtmfTonesResult as SendDtmfTonesResultRest,
     )
 
-class CallInvite(object):
+
+class CallInvite:
     """Details of call invitation for outgoing call.
 
     :param target: Target's identity.
@@ -54,7 +55,6 @@ class CallInvite(object):
     :keyword source_display_name: Set display name for caller
     :paramtype source_display_name: str
     """
-
     target: CommunicationIdentifier
     """Target's identity."""
     source_caller_id_number: Optional[PhoneNumberIdentifier]
@@ -62,7 +62,7 @@ class CallInvite(object):
     source_display_name: Optional[str]
     """Display name for caller"""
 
-    def __init__(
+    def __init__(  # pylint: disable=unused-argument
         self,
         target: CommunicationIdentifier,
         *,
@@ -70,62 +70,58 @@ class CallInvite(object):
         source_display_name: Optional[str] = None,
         **kwargs
     ):
-        super().__init__(**kwargs)
         self.target = target
         self.source_caller_id_number = source_caller_id_number
         self.source_display_name = source_display_name
 
-class ServerCallLocator(object):
+
+class ServerCallLocator:
     """The locator to locate ongoing call, using server call id.
 
     :param server_call_id: The server call id of ongoing call.
     :type server_call_id: str
     """
-
     server_call_id: str
     """The server call id of ongoing call."""
     kind: str = "serverCallLocator"
     """This is for locating the call with server call id."""
 
-    def __init__(
+    def __init__(  # pylint: disable=unused-argument
         self,
         server_call_id: str,
         **kwargs
     ):
-        super().__init__(**kwargs)
         self.server_call_id = server_call_id
         self.kind = "serverCallLocator"
 
     def _to_generated(self):
-        return CallLocator(kind=self.kind,
-                           server_call_id=self.server_call_id)
+        return CallLocator(kind=self.kind, server_call_id=self.server_call_id)
 
-class GroupCallLocator(object):
+
+class GroupCallLocator:
     """The locator to locate ongoing call, using group call id.
 
     :param group_call_id: The group call id of ongoing call.
     :type group_call_id: str
     """
-
     group_call_id: str
     """The group call id of ongoing call."""
     kind: str = "groupCallLocator"
     """This is for locating the call with group call id."""
 
-    def __init__(
+    def __init__(  # pylint: disable=unused-argument
         self,
         group_call_id: str,
         **kwargs
     ):
-        super().__init__(**kwargs)
         self.group_call_id = group_call_id
         self.kind = "groupCallLocator"
 
     def _to_generated(self):
-        return CallLocator(kind=self.kind,
-                           group_call_id=self.group_call_id)
+        return CallLocator(kind=self.kind, group_call_id=self.group_call_id)
 
-class ChannelAffinity(object):
+
+class ChannelAffinity:
     """Channel affinity for a participant.
 
     All required parameters must be populated in order to send to Azure.
@@ -143,20 +139,19 @@ class ChannelAffinity(object):
     channel: int
     """ Channel number to which bitstream from a particular participant will be written."""
 
-    def __init__(
+    def __init__(  # pylint: disable=unused-argument
         self,
         target_participant: CommunicationIdentifier,
         channel: int,
         **kwargs
     ):
-        super().__init__(**kwargs)
         self.target_participant = target_participant
         self.channel = channel
 
     def _to_generated(self):
-        return ChannelAffinityInternal(participant= serialize_identifier(self.target_participant), channel=self.channel)
+        return ChannelAffinityInternal(participant=serialize_identifier(self.target_participant), channel=self.channel)
 
-class FileSource(object):
+class FileSource:
     """Media file source of URL to be played in action such as Play media.
 
     :param url: Url for the audio file to be played.
@@ -170,14 +165,13 @@ class FileSource(object):
     play_source_cache_id: Optional[str]
     """Cached source id of the play media, if it exists."""
 
-    def __init__(
+    def __init__(  # pylint: disable=unused-argument
         self,
         url: str,
         *,
         play_source_cache_id: Optional[str] = None,
         **kwargs
     ):
-        super().__init__(**kwargs)
         self.url = url
         self.play_source_cache_id = play_source_cache_id
 
@@ -188,7 +182,8 @@ class FileSource(object):
             play_source_cache_id=self.play_source_cache_id
         )
 
-class TextSource(object):
+
+class TextSource:
     """TextSource to be played in actions such as Play media.
 
     :param text: Text for the cognitive service to be played.
@@ -230,10 +225,8 @@ class TextSource(object):
             voice_kind: Optional[Union[str, 'VoiceKind']] = None,
             voice_name: Optional[str] = None,
             play_source_cache_id: Optional[str] = None,
-            custom_voice_endpoint_id: Optional[str] = None,
-            **kwargs
+            custom_voice_endpoint_id: Optional[str] = None
     ):
-        super().__init__(**kwargs)
         self.text = text
         self.source_locale = source_locale
         self.voice_kind = voice_kind
@@ -253,7 +246,7 @@ class TextSource(object):
             play_source_cache_id=self.play_source_cache_id
         )
 
-class SsmlSource(object):
+class SsmlSource:
     """SsmlSource to be played in actions such as Play media.
 
     :param ssml_text: Ssml string for the cognitive service to be played.
@@ -272,14 +265,12 @@ class SsmlSource(object):
     """Endpoint where the custom voice model was deployed."""
 
     def __init__(
-            self,
-            ssml_text: str,
-            *,
-            play_source_cache_id: Optional[str] = None,
-            custom_voice_endpoint_id: Optional[str] = None,
-            **kwargs
+        self,
+        ssml_text: str,
+        *,
+        play_source_cache_id: Optional[str] = None,
+        custom_voice_endpoint_id: Optional[str] = None
     ):
-        super().__init__(**kwargs)
         self.ssml_text = ssml_text
         self.play_source_cache_id = play_source_cache_id
         self.custom_voice_endpoint_id = custom_voice_endpoint_id
@@ -294,7 +285,8 @@ class SsmlSource(object):
         )
 
 
-class CallConnectionProperties(): # type: ignore # pylint: disable=too-many-instance-attributes
+
+class CallConnectionProperties:  # pylint: disable=too-many-instance-attributes
     """ Detailed properties of the call.
 
     :keyword call_connection_id: The call connection id of this call leg.
@@ -351,17 +343,14 @@ class CallConnectionProperties(): # type: ignore # pylint: disable=too-many-inst
         call_connection_id: Optional[str] = None,
         server_call_id: Optional[str] = None,
         targets: Optional[List[CommunicationIdentifier]] = None,
-        call_connection_state:
-        Optional[Union[str, 'CallConnectionState']] = None,
+        call_connection_state: Optional[Union[str, 'CallConnectionState']] = None,
         callback_url: Optional[str] = None,
         source_caller_id_number: Optional[PhoneNumberIdentifier] = None,
         source_display_name: Optional[str] = None,
         source: Optional[CommunicationIdentifier] = None,
         correlation_id: Optional[str] = None,
-        answered_by: Optional[CommunicationUserIdentifier] = None,
-        **kwargs
+        answered_by: Optional[CommunicationUserIdentifier] = None
     ):
-        super().__init__(**kwargs)
         self.call_connection_id = call_connection_id
         self.server_call_id = server_call_id
         self.targets = targets
@@ -398,9 +387,10 @@ class CallConnectionProperties(): # type: ignore # pylint: disable=too-many-inst
                 call_connection_properties_generated.answered_by)
             if call_connection_properties_generated.answered_by
             else None
-            )
+        )
 
-class RecordingProperties(object):
+
+class RecordingProperties:
     """Detailed recording properties of the call.
 
     :keyword recording_id: Id of this recording operation.
@@ -418,10 +408,8 @@ class RecordingProperties(object):
         self,
         *,
         recording_id: Optional[str] = None,
-        recording_state: Optional[Union[str,'RecordingState']] = None,
-        **kwargs
+        recording_state: Optional[Union[str,'RecordingState']] = None
     ):
-        super().__init__(**kwargs)
         self.recording_id = recording_id
         self.recording_state = recording_state
 
@@ -429,9 +417,11 @@ class RecordingProperties(object):
     def _from_generated(cls, recording_state_result: 'RecordingStateResultRest'):
         return cls(
             recording_id=recording_state_result.recording_id,
-            recording_state=recording_state_result.recording_state)
+            recording_state=recording_state_result.recording_state
+        )
 
-class CallParticipant(object):
+
+class CallParticipant:
     """Details of an Azure Communication Service call participant.
 
     :keyword identifier: Communication identifier of the participant.
@@ -449,10 +439,8 @@ class CallParticipant(object):
         self,
         *,
         identifier: Optional[CommunicationIdentifier] = None,
-        is_muted: bool = False,
-        **kwargs
+        is_muted: bool = False
     ):
-        super().__init__(**kwargs)
         self.identifier = identifier
         self.is_muted = is_muted
 
@@ -460,9 +448,11 @@ class CallParticipant(object):
     def _from_generated(cls, call_participant_generated: 'CallParticipantRest'):
         return cls(
             identifier=deserialize_identifier(call_participant_generated.identifier),
-            is_muted=call_participant_generated.is_muted)
+            is_muted=call_participant_generated.is_muted
+        )
 
-class AddParticipantResult(object):
+
+class AddParticipantResult:
     """ The result payload for adding participants to the call.
 
     :keyword participant: Participant that was added with this request.
@@ -480,20 +470,22 @@ class AddParticipantResult(object):
         self,
         *,
         participant: Optional[CallParticipant] = None,
-        operation_context: Optional[str] = None,
-        **kwargs
+        operation_context: Optional[str] = None
     ):
-        super().__init__(**kwargs)
         self.participant = participant
         self.operation_context = operation_context
 
     @classmethod
     def _from_generated(cls, add_participant_result_generated: 'AddParticipantResultRest'):
-        return cls(participant=CallParticipant._from_generated(# pylint:disable=protected-access
-            add_participant_result_generated.participant),
-            operation_context=add_participant_result_generated.operation_context)
+        return cls(
+            participant=CallParticipant._from_generated(  # pylint:disable=protected-access
+                add_participant_result_generated.participant
+            ),
+            operation_context=add_participant_result_generated.operation_context
+        )
 
-class RemoveParticipantResult(object):
+
+class RemoveParticipantResult:
     """The response payload for removing participants of the call.
 
     :keyword operation_context: The operation context provided by client.
@@ -506,17 +498,16 @@ class RemoveParticipantResult(object):
     def __init__(
         self,
         *,
-        operation_context: Optional[str] = None,
-        **kwargs
+        operation_context: Optional[str] = None
     ) -> None:
-        super().__init__(**kwargs)
         self.operation_context = operation_context
 
     @classmethod
     def _from_generated(cls, remove_participant_result_generated: 'RemoveParticipantResultRest'):
         return cls(operation_context=remove_participant_result_generated.operation_context)
 
-class TransferCallResult(object):
+
+class TransferCallResult:
     """The response payload for transferring the call.
 
     :keyword operation_context: The operation context provided by client.
@@ -529,17 +520,15 @@ class TransferCallResult(object):
     def __init__(
         self,
         *,
-        operation_context: Optional[str] = None,
-        **kwargs
+        operation_context: Optional[str] = None
     ) -> None:
-        super().__init__(**kwargs)
         self.operation_context = operation_context
 
     @classmethod
     def _from_generated(cls, transfer_result_generated: 'TransferParticipantResultRest'):
         return cls(operation_context=transfer_result_generated.operation_context)
 
-class RecognitionChoice(object):
+class RecognitionChoice:
     """
     An IVR choice for the recognize operation.
 
@@ -565,10 +554,8 @@ class RecognitionChoice(object):
             label: str,
             phrases: List[str],
             *,
-            tone: Optional[Union[str, 'DtmfTone']] = None,
-            **kwargs
+            tone: Optional[Union[str, 'DtmfTone']] = None
     ):
-        super().__init__(**kwargs)
         self.label = label
         self.phrases = phrases
         self.tone = tone
@@ -576,7 +563,7 @@ class RecognitionChoice(object):
     def _to_generated(self):
         return ChoiceInternal(label=self.label, phrases=self.phrases, tone=self.tone)
 
-class MuteParticipantResult(object):
+class MuteParticipantResult:
     """The result payload for muting participant from the call.
 
     :keyword operation_context: The operation context provided by client.
@@ -589,17 +576,15 @@ class MuteParticipantResult(object):
     def __init__(
         self,
         *,
-        operation_context: Optional[str] = None,
-        **kwargs
+        operation_context: Optional[str] = None
     ) -> None:
-        super().__init__(**kwargs)
         self.operation_context = operation_context
 
     @classmethod
     def _from_generated(cls, mute_participant_result_generated: 'MuteParticipantsResultRest'):
         return cls(operation_context=mute_participant_result_generated.operation_context)
 
-class SendDtmfTonesResult(object):
+class SendDtmfTonesResult:
     """The result payload for send Dtmf tones.
     :keyword operation_context: The operation context provided by client.
     :paramtype operation_context: str
@@ -611,10 +596,8 @@ class SendDtmfTonesResult(object):
     def __init__(
         self,
         *,
-        operation_context: Optional[str] = None,
-        **kwargs
+        operation_context: Optional[str] = None
     ) -> None:
-        super().__init__(**kwargs)
         self.operation_context = operation_context
 
     @classmethod

--- a/sdk/communication/azure-communication-callautomation/azure/communication/callautomation/_shared/models.py
+++ b/sdk/communication/azure-communication-callautomation/azure/communication/callautomation/_shared/models.py
@@ -2,8 +2,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
-# pylint: skip-file
-
 from enum import Enum
 from six import with_metaclass
 from typing import Mapping, Optional, Union, Any
@@ -75,7 +73,7 @@ ACS_USER_GCCH_CLOUD_PREFIX = "8:gcch-acs:"
 SPOOL_USER_PREFIX = "8:spool:"
 
 
-class CommunicationUserIdentifier(object):
+class CommunicationUserIdentifier:
     """Represents a user in Azure Communication Service.
 
     :ivar str raw_id: Optional raw ID of the identifier.
@@ -98,7 +96,7 @@ class CommunicationUserIdentifier(object):
     def __eq__(self, other):
         try:
             return self.raw_id == other.properties['id']
-        except Exception:
+        except Exception:  # pylint: disable=broad-except
             return False
 
 
@@ -114,7 +112,7 @@ PhoneNumberProperties = TypedDict(
 )
 
 
-class PhoneNumberIdentifier(object):
+class PhoneNumberIdentifier:
     """Represents a phone number.
 
     :ivar str raw_id: Optional raw ID of the identifier.
@@ -137,7 +135,7 @@ class PhoneNumberIdentifier(object):
     def __eq__(self, other):
         try:
             return self.raw_id == _phone_number_raw_id(other)
-        except Exception:
+        except Exception:  # pylint: disable=broad-except
             return False
 
 
@@ -150,7 +148,7 @@ def _phone_number_raw_id(identifier: PhoneNumberIdentifier) -> str:
     return f'{PHONE_NUMBER_PREFIX}{value}'
 
 
-class UnknownIdentifier(object):
+class UnknownIdentifier:
     """Represents an identifier of an unknown type.
 
     It will be encountered in communications with endpoints that are not
@@ -176,7 +174,7 @@ class UnknownIdentifier(object):
     def __eq__(self, other):
         try:
             return self.raw_id == other.raw_id
-        except Exception:
+        except Exception:  # pylint: disable=broad-except
             return False
 
 
@@ -188,7 +186,7 @@ MicrosoftTeamsUserProperties = TypedDict(
 )
 
 
-class MicrosoftTeamsUserIdentifier(object):
+class MicrosoftTeamsUserIdentifier:
     """Represents an identifier for a Microsoft Teams user.
 
     :ivar str raw_id: Optional raw ID of the identifier.
@@ -222,7 +220,7 @@ class MicrosoftTeamsUserIdentifier(object):
     def __eq__(self, other):
         try:
             return self.raw_id == _microsoft_teams_user_raw_id(other)
-        except Exception:
+        except Exception:  # pylint: disable=broad-except
             return False
 
 
@@ -235,9 +233,9 @@ def _microsoft_teams_user_raw_id(identifier: MicrosoftTeamsUserIdentifier) -> st
     cloud = identifier.properties['cloud']
     if cloud == CommunicationCloudEnvironment.DOD:
         return f'{TEAMS_USER_DOD_CLOUD_PREFIX}{user_id}'
-    elif cloud == CommunicationCloudEnvironment.GCCH:
+    if cloud == CommunicationCloudEnvironment.GCCH:
         return f'{TEAMS_USER_GCCH_CLOUD_PREFIX}{user_id}'
-    elif cloud == CommunicationCloudEnvironment.PUBLIC:
+    if cloud == CommunicationCloudEnvironment.PUBLIC:
         return f'{TEAMS_USER_PUBLIC_CLOUD_PREFIX}{user_id}'
     return f'{TEAMS_USER_PUBLIC_CLOUD_PREFIX}{user_id}'
 
@@ -250,7 +248,7 @@ MicrosoftBotProperties = TypedDict(
 )
 
 
-class MicrosoftBotIdentifier(object):
+class MicrosoftBotIdentifier:
     """Represents an identifier for a Microsoft bot.
 
     :ivar str raw_id: Optional raw ID of the identifier.
@@ -284,11 +282,11 @@ class MicrosoftBotIdentifier(object):
     def __eq__(self, other):
         try:
             return self.raw_id == _microsoft_bot_raw_id(other)
-        except Exception:
+        except Exception:  # pylint: disable=broad-except
             return False
 
 
-def _microsoft_bot_raw_id(identifier: MicrosoftBotIdentifier) -> str:
+def _microsoft_bot_raw_id(identifier: MicrosoftBotIdentifier) -> str:  # pylint: disable=too-many-return-statements
     if identifier.raw_id:
         return identifier.raw_id
     bot_id = identifier.properties['bot_id']
@@ -296,24 +294,26 @@ def _microsoft_bot_raw_id(identifier: MicrosoftBotIdentifier) -> str:
     if identifier.properties['is_resource_account_configured'] is False:
         if cloud == CommunicationCloudEnvironment.DOD:
             return f'{BOT_DOD_CLOUD_GLOBAL_PREFIX}{bot_id}'
-        elif cloud == CommunicationCloudEnvironment.GCCH:
+        if cloud == CommunicationCloudEnvironment.GCCH:
             return f'{BOT_GCCH_CLOUD_GLOBAL_PREFIX}{bot_id}'
         return f'{BOT_PREFIX}{bot_id}'
 
     if cloud == CommunicationCloudEnvironment.DOD:
         return f'{BOT_DOD_CLOUD_PREFIX}{bot_id}'
-    elif cloud == CommunicationCloudEnvironment.GCCH:
+    if cloud == CommunicationCloudEnvironment.GCCH:
         return f'{BOT_GCCH_CLOUD_PREFIX}{bot_id}'
     return f'{BOT_PUBLIC_CLOUD_PREFIX}{bot_id}'
 
 
-def identifier_from_raw_id(raw_id: str) -> CommunicationIdentifier:
+def identifier_from_raw_id(raw_id: str) -> CommunicationIdentifier:  # pylint: disable=too-many-return-statements
     """
     Creates a CommunicationIdentifier from a given raw ID.
 
     When storing raw IDs use this function to restore the identifier that was encoded in the raw ID.
 
     :param str raw_id: A raw ID to construct the CommunicationIdentifier from.
+    :return: The CommunicationIdentifier parsed from the raw_id.
+    :rtype: CommunicationIdentifier
     """
     if raw_id.startswith(PHONE_NUMBER_PREFIX):
         return PhoneNumberIdentifier(
@@ -340,61 +340,61 @@ def identifier_from_raw_id(raw_id: str) -> CommunicationIdentifier:
             is_anonymous=True,
             raw_id=raw_id
         )
-    elif prefix == TEAMS_USER_PUBLIC_CLOUD_PREFIX:
+    if prefix == TEAMS_USER_PUBLIC_CLOUD_PREFIX:
         return MicrosoftTeamsUserIdentifier(
             user_id=suffix,
             is_anonymous=False,
             cloud=CommunicationCloudEnvironment.PUBLIC,
             raw_id=raw_id
         )
-    elif prefix == TEAMS_USER_DOD_CLOUD_PREFIX:
+    if prefix == TEAMS_USER_DOD_CLOUD_PREFIX:
         return MicrosoftTeamsUserIdentifier(
             user_id=suffix,
             is_anonymous=False,
             cloud=CommunicationCloudEnvironment.DOD,
             raw_id=raw_id
         )
-    elif prefix == TEAMS_USER_GCCH_CLOUD_PREFIX:
+    if prefix == TEAMS_USER_GCCH_CLOUD_PREFIX:
         return MicrosoftTeamsUserIdentifier(
             user_id=suffix,
             is_anonymous=False,
             cloud=CommunicationCloudEnvironment.GCCH,
             raw_id=raw_id
         )
-    elif prefix in [ACS_USER_PREFIX, ACS_USER_DOD_CLOUD_PREFIX, ACS_USER_GCCH_CLOUD_PREFIX, SPOOL_USER_PREFIX]:
+    if prefix in [ACS_USER_PREFIX, ACS_USER_DOD_CLOUD_PREFIX, ACS_USER_GCCH_CLOUD_PREFIX, SPOOL_USER_PREFIX]:
         return CommunicationUserIdentifier(
             id=raw_id,
             raw_id=raw_id
         )
-    elif prefix == BOT_GCCH_CLOUD_GLOBAL_PREFIX:
+    if prefix == BOT_GCCH_CLOUD_GLOBAL_PREFIX:
         return MicrosoftBotIdentifier(
             bot_id=suffix,
             is_resource_account_configured=False,
             cloud=CommunicationCloudEnvironment.GCCH,
             raw_id=raw_id
         )
-    elif prefix == BOT_PUBLIC_CLOUD_PREFIX:
+    if prefix == BOT_PUBLIC_CLOUD_PREFIX:
         return MicrosoftBotIdentifier(
             bot_id=suffix,
             is_resource_account_configured=True,
             cloud=CommunicationCloudEnvironment.PUBLIC,
             raw_id=raw_id
         )
-    elif prefix == BOT_DOD_CLOUD_GLOBAL_PREFIX:
+    if prefix == BOT_DOD_CLOUD_GLOBAL_PREFIX:
         return MicrosoftBotIdentifier(
             bot_id=suffix,
             is_resource_account_configured=False,
             cloud=CommunicationCloudEnvironment.DOD,
             raw_id=raw_id
         )
-    elif prefix == BOT_GCCH_CLOUD_PREFIX:
+    if prefix == BOT_GCCH_CLOUD_PREFIX:
         return MicrosoftBotIdentifier(
             bot_id=suffix,
             is_resource_account_configured=True,
             cloud=CommunicationCloudEnvironment.GCCH,
             raw_id=raw_id
         )
-    elif prefix == BOT_DOD_CLOUD_PREFIX:
+    if prefix == BOT_DOD_CLOUD_PREFIX:
         return MicrosoftBotIdentifier(
             bot_id=suffix,
             is_resource_account_configured=True,

--- a/sdk/communication/azure-communication-callautomation/azure/communication/callautomation/_shared/models.py
+++ b/sdk/communication/azure-communication-callautomation/azure/communication/callautomation/_shared/models.py
@@ -2,6 +2,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
+# pylint: skip-file
 from enum import Enum
 from six import with_metaclass
 from typing import Mapping, Optional, Union, Any

--- a/sdk/communication/azure-communication-callautomation/azure/communication/callautomation/_utils.py
+++ b/sdk/communication/azure-communication-callautomation/azure/communication/callautomation/_utils.py
@@ -5,7 +5,7 @@
 # --------------------------------------------------------------------------
 from typing import TYPE_CHECKING, Dict, Any, List, Optional, Union
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime
 from ._shared.models import (
     CommunicationIdentifier,
     CommunicationUserIdentifier,

--- a/sdk/communication/azure-communication-callautomation/azure/communication/callautomation/_utils.py
+++ b/sdk/communication/azure-communication-callautomation/azure/communication/callautomation/_utils.py
@@ -3,7 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for
 # license information.
 # --------------------------------------------------------------------------
-from typing import Dict, Any, Union
+from typing import TYPE_CHECKING, Dict, Any, List, Optional, Union
 import uuid
 from datetime import datetime, timezone
 from ._shared.models import (
@@ -17,18 +17,80 @@ from ._shared.models import (
 from ._generated.models import (
     CommunicationIdentifierModel,
     CommunicationUserIdentifierModel,
-    PhoneNumberIdentifierModel
+    PhoneNumberIdentifierModel,
+    CallLocator
 )
+if TYPE_CHECKING:
+    from ._models import ServerCallLocator, GroupCallLocator
+
+
+def build_call_locator(
+    args: List[Union['ServerCallLocator', 'GroupCallLocator']],
+    call_locator: Optional[Union['ServerCallLocator', 'GroupCallLocator']],
+    server_call_id: Optional[str],
+    group_call_id: Optional[str]
+) -> CallLocator:
+    """Build the generated callLocator object from args in kwargs with support for legacy models.
+
+    :param args: Any positional parameters provided. This may include the legacy model. The new method signature
+     does not support positional params, so if there's anything here, it's the old model.
+    :type args: list[ServerCallLocator or GroupCallLocator]
+    :param call_locator: If the legacy call_locator was provided via keyword arg.
+    :type call_locator: ServerCallLocator or GroupCallLocator or None
+    :param server_call_id: If the new server_call_id was provided via keyword arg.
+    :type server_call_id: str or None
+    :param group_call_id: If the new group_call_id was provided via keyword arg.
+    :type group_call_id: str or None
+    :return: Generated CallLocator for the request body.
+    """
+    request: Optional[CallLocator] = None
+    if args:
+        if len(args) > 1:
+            raise TypeError(f"Unexpected positional arguments: {args[1:]}")
+        request = args[0]._to_generated()  # pylint:disable=protected-access
+
+    if call_locator:
+        if request is not None:
+            raise ValueError(
+                "Received multiple values for call_locator. "
+                "Please provide either 'group_call_id' or 'server_call_id'."
+            )
+        request = call_locator._to_generated()  # pylint:disable=protected-access
+    if group_call_id:
+        if request is not None:
+            raise ValueError(
+                "Received multiple values for call locator. "
+                "Please provide either 'group_call_id' or 'server_call_id'."
+            )
+        request = CallLocator(group_call_id=group_call_id, kind="groupCallLocator")
+    if server_call_id:
+        if request is not None:
+            raise ValueError(
+                "Received multiple values for call locator. "
+                "Please provide either 'group_call_id' or 'server_call_id'."
+            )
+        request = CallLocator(server_call_id=server_call_id, kind="serverCallLocator")
+    if request is None:
+        raise ValueError("Call locator required. Please provide either 'group_call_id' or 'server_call_id'.")
+    return request
+
+def process_repeatability_first_sent(keywords: Dict[str, Any]) -> None:
+    if 'headers' in keywords:
+        if 'Repeatability-First-Sent' not in keywords['headers']:
+            keywords['headers']['Repeatability-First-Sent'] = get_repeatability_timestamp()
+    else:
+        keywords['headers'] = {'Repeatability-First-Sent': get_repeatability_timestamp()}
+
 
 def get_repeatability_guid():
     return uuid.uuid4()
 
-def get_repeatability_timestamp():
-    return datetime.now(timezone.utc)
 
-def serialize_identifier(
-        identifier:CommunicationIdentifier
-        ) -> Dict[str, Any]:
+def get_repeatability_timestamp() -> str:
+    return datetime.utcnow().strftime('%a, %d %b %Y %H:%M:%S GMT')
+
+
+def serialize_identifier(identifier:CommunicationIdentifier) -> Dict[str, Any]:
     """Serialize the Communication identifier into CommunicationIdentifierModel
 
     :param identifier: Identifier object
@@ -37,53 +99,54 @@ def serialize_identifier(
     """
     try:
         request_model = {'raw_id': identifier.raw_id}
-
         if identifier.kind and identifier.kind != CommunicationIdentifierKind.UNKNOWN:
             request_model[identifier.kind] = dict(identifier.properties)
         return request_model
     except AttributeError:
-        raise TypeError("Unsupported identifier type " +
-                        identifier.__class__.__name__)
+        raise TypeError(f"Unsupported identifier type: {identifier.__class__.__name__}") from None
 
-def serialize_phone_identifier(
-        identifier:PhoneNumberIdentifier
-        ) -> PhoneNumberIdentifierModel:
+
+def serialize_phone_identifier(identifier: Optional[PhoneNumberIdentifier]) -> Optional[PhoneNumberIdentifierModel]:
     """Serialize the Communication identifier into CommunicationIdentifierModel
 
     :param identifier: PhoneNumberIdentifier
     :type identifier: PhoneNumberIdentifier
     :return: PhoneNumberIdentifierModel
     """
+    if identifier is None:
+        return None
     try:
         if identifier.kind and identifier.kind == CommunicationIdentifierKind.PHONE_NUMBER:
             request_model = PhoneNumberIdentifierModel(value=identifier.properties['value'])
             return request_model
-        raise AttributeError
     except AttributeError:
-        raise TypeError("Unsupported identifier type " +
-                        identifier.__class__.__name__)
+        pass
+    raise TypeError(f"Unsupported phone identifier type: {identifier.__class__.__name__}")
+
 
 def serialize_communication_user_identifier(
-        identifier:CommunicationUserIdentifier
-        ) -> CommunicationUserIdentifierModel:
+    identifier: Optional[CommunicationUserIdentifier]
+) -> Optional[CommunicationUserIdentifierModel]:
     """Serialize the CommunicationUserIdentifier into CommunicationUserIdentifierModel
 
     :param identifier: CommunicationUserIdentifier
     :type identifier: CommunicationUserIdentifier
     :return: CommunicationUserIdentifierModel
     """
+    if identifier is None:
+        return None
     try:
         if identifier.kind and identifier.kind == CommunicationIdentifierKind.COMMUNICATION_USER:
             request_model = CommunicationUserIdentifierModel(id=identifier.properties['id'])
             return request_model
-        raise AttributeError
     except AttributeError:
-        raise TypeError("Unsupported identifier type " +
-                        identifier.__class__.__name__)
+        pass
+    raise TypeError(f"Unsupported user identifier type: {identifier.__class__.__name__}")
+
 
 def deserialize_identifier(
-        identifier_model:CommunicationIdentifierModel
-        )->CommunicationIdentifier:
+    identifier_model: CommunicationIdentifierModel
+) -> CommunicationIdentifier:
     """
     Deserialize the CommunicationIdentifierModel into Communication Identifier
 
@@ -106,9 +169,10 @@ def deserialize_identifier(
         )
     return UnknownIdentifier(raw_id)
 
+
 def deserialize_phone_identifier(
-        identifier_model:PhoneNumberIdentifierModel
-        ) -> Union[PhoneNumberIdentifier, None]:
+    identifier_model:PhoneNumberIdentifierModel
+) -> Union[PhoneNumberIdentifier, None]:
     """
     Deserialize the PhoneNumberIdentifierModel into PhoneNumberIdentifier
 
@@ -120,9 +184,10 @@ def deserialize_phone_identifier(
         return PhoneNumberIdentifier(identifier_model.value)
     return None
 
+
 def deserialize_comm_user_identifier(
-        identifier_model:CommunicationUserIdentifierModel
-        ) -> Union[CommunicationUserIdentifierModel, None]:
+    identifier_model:CommunicationUserIdentifierModel
+) -> Union[CommunicationUserIdentifierModel, None]:
     """
     Deserialize the CommunicationUserIdentifierModel into CommunicationUserIdentifier
 

--- a/sdk/communication/azure-communication-callautomation/azure/communication/callautomation/aio/_call_automation_client_async.py
+++ b/sdk/communication/azure-communication-callautomation/azure/communication/callautomation/aio/_call_automation_client_async.py
@@ -3,8 +3,9 @@
 # Licensed under the MIT License. See License.txt in the project root for
 # license information.
 # --------------------------------------------------------------------------
-from typing import List, Union, Optional, TYPE_CHECKING, AsyncIterable
+from typing import List, Union, Optional, TYPE_CHECKING, AsyncIterable, Dict, overload
 from urllib.parse import urlparse
+import warnings
 from azure.core.tracing.decorator_async import distributed_trace_async
 from .._version import SDK_MONIKER
 from .._api_versions import DEFAULT_VERSION
@@ -23,19 +24,20 @@ from .._generated.models import (
 )
 from .._models import (
     CallConnectionProperties,
-    RecordingProperties
+    RecordingProperties,
+    CallInvite
 )
 from ._content_downloader_async import ContentDownloader
 from .._utils import (
     get_repeatability_guid,
-    get_repeatability_timestamp,
+    process_repeatability_first_sent,
     serialize_phone_identifier,
     serialize_identifier,
-    serialize_communication_user_identifier
+    serialize_communication_user_identifier,
+    build_call_locator,
 )
 if TYPE_CHECKING:
     from .._models  import (
-        CallInvite,
         ServerCallLocator,
         GroupCallLocator
     )
@@ -56,9 +58,9 @@ if TYPE_CHECKING:
         RecordingChannel,
         RecordingFormat
     )
-    from azure.core.exceptions import HttpResponseError
 
-class CallAutomationClient(object):
+
+class CallAutomationClient:
     """A client to interact with the AzureCommunicationService CallAutomation service.
     Call Automation provides developers the ability to build server-based,
     intelligent call workflows, and call recording for voice and PSTN channels.
@@ -75,13 +77,13 @@ class CallAutomationClient(object):
     :paramtype source: ~azure.communication.callautomation.CommunicationUserIdentifier
     """
     def __init__(
-            self,
-            endpoint: str,
-            credential: Union['AsyncTokenCredential', 'AzureKeyCredential'],
-            *,
-            api_version: Optional[str] = None,
-            source: Optional['CommunicationUserIdentifier'] = None,
-            **kwargs
+        self,
+        endpoint: str,
+        credential: Union['AsyncTokenCredential', 'AzureKeyCredential'],
+        *,
+        api_version: Optional[str] = None,
+        source: Optional['CommunicationUserIdentifier'] = None,
+        **kwargs
     ) -> None:
         if not credential:
             raise ValueError("credential can not be None")
@@ -123,7 +125,6 @@ class CallAutomationClient(object):
         :rtype: ~azure.communication.callautomation.CallAutomationClient
         """
         endpoint, access_key = parse_connection_str(conn_str)
-
         return cls(endpoint, access_key, **kwargs)
 
     def get_call_connection(
@@ -142,17 +143,20 @@ class CallAutomationClient(object):
         if not call_connection_id:
             raise ValueError("call_connection_id can not be None")
 
-        return CallConnectionClient._from_callautomation_client( #pylint:disable=protected-access
+        return CallConnectionClient._from_callautomation_client(  # pylint:disable=protected-access
             callautomation_client=self._client,
             call_connection_id=call_connection_id,
-            **kwargs)
+            **kwargs
+        )
 
     @distributed_trace_async
     async def create_call(
         self,
-        target_participant: 'CallInvite',
+        target_participant: Union['CommunicationIdentifier', List['CommunicationIdentifier']],
         callback_url: str,
         *,
+        source_caller_id_number: Optional['PhoneNumberIdentifier'] = None,
+        source_display_name: Optional[str] = None,
         operation_context: Optional[str] = None,
         cognitive_services_endpoint: Optional[str] = None,
         **kwargs
@@ -160,38 +164,52 @@ class CallAutomationClient(object):
         """Create a call connection request to a target identity.
 
         :param target_participant: Call invitee's information.
-        :type target_participant: ~azure.communication.callautomation.CallInvite
+        :type target_participant: ~azure.communication.callautomation.CommunicationIdentifier
+         or list[~azure.communication.callautomation.CommunicationIdentifier]
         :param callback_url: The call back url where callback events are sent.
         :type callback_url: str
         :keyword operation_context: Value that can be used to track the call and its associated events.
-        :paramtype operation_context: str
+        :paramtype operation_context: str or None
+        :keyword source_caller_id_number: The source caller Id, a phone number,
+         that's shown to the PSTN participant being invited.
+         Required only when calling a PSTN callee.
+        :paramtype source_caller_id_number: ~azure.communication.callautomation.PhoneNumberIdentifier or None
+        :keyword source_display_name: Display name of the caller.
+        :paramtype source_display_name: str or None
         :keyword cognitive_services_endpoint:
          The identifier of the Cognitive Service resource assigned to this call.
-        :paramtype cognitive_services_endpoint: str
+        :paramtype cognitive_services_endpoint: str or None
         :return: CallConnectionProperties
         :rtype: ~azure.communication.callautomation.CallConnectionProperties
         :raises ~azure.core.exceptions.HttpResponseError:
         """
+        # Backwards compatibility with old API signature
+        if isinstance(target_participant, CallInvite):
+            source_caller_id_number = source_caller_id_number or target_participant.source_caller_id_number
+            source_display_name = source_display_name or target_participant.source_display_name
+            target_participant = target_participant.target
+
+        try:
+            targets = [serialize_identifier(p) for p in target_participant]
+        except TypeError:
+            targets = [serialize_identifier(target_participant)]
+
         create_call_request = CreateCallRequest(
-            targets=[serialize_identifier(target_participant.target)],
+            targets=targets,
             callback_uri=callback_url,
-            source_caller_id_number=serialize_phone_identifier(
-                target_participant.source_caller_id_number) if target_participant.source_caller_id_number else None,
-            source_display_name=target_participant.source_display_name,
-            source=serialize_communication_user_identifier(
-                self.source) if self.source else None,
+            source_caller_id_number=serialize_phone_identifier(source_caller_id_number),
+            source_display_name=source_display_name,
+            source=serialize_communication_user_identifier(self.source),
             operation_context=operation_context,
             cognitive_services_endpoint=cognitive_services_endpoint
         )
-
+        process_repeatability_first_sent(kwargs)
         result = await self._client.create_call(
             create_call_request=create_call_request,
-            repeatability_first_sent=get_repeatability_timestamp(),
             repeatability_request_id=get_repeatability_guid(),
-            **kwargs)
-
-        return CallConnectionProperties._from_generated(# pylint:disable=protected-access
-            result)
+            **kwargs
+        )
+        return CallConnectionProperties._from_generated(result)  # pylint:disable=protected-access
 
     @distributed_trace_async
     async def create_group_call(
@@ -226,27 +244,20 @@ class CallAutomationClient(object):
         :rtype: ~azure.communication.callautomation.CallConnectionProperties
         :raises ~azure.core.exceptions.HttpResponseError:
         """
-        create_call_request = CreateCallRequest(
-            targets=[serialize_identifier(identifier)
-                     for identifier in target_participants],
-            callback_uri=callback_url,
-            source_caller_id_number=serialize_phone_identifier(
-                source_caller_id_number) if source_caller_id_number else None,
-            source_display_name=source_display_name,
-            source=serialize_identifier(
-                self.source) if self.source else None,
-            operation_context=operation_context,
-            cognitive_services_endpoint=cognitive_services_endpoint
+        warnings.warn(
+            "The method 'create_group_call' is deprecated. Please use 'create_call' instead.",
+            DeprecationWarning
         )
 
-        result = await self._client.create_call(
-            create_call_request=create_call_request,
-            repeatability_first_sent=get_repeatability_timestamp(),
-            repeatability_request_id=get_repeatability_guid(),
-            **kwargs)
-
-        return CallConnectionProperties._from_generated(# pylint:disable=protected-access
-            result)
+        return await self.create_call(
+            target_participant=target_participants,
+            callback_url=callback_url,
+            source_caller_id_number=source_caller_id_number,
+            source_display_name=source_display_name,
+            operation_context=operation_context,
+            cognitive_services_endpoint=cognitive_services_endpoint,
+            **kwargs
+        )
 
     @distributed_trace_async
     async def answer_call(
@@ -283,20 +294,19 @@ class CallAutomationClient(object):
             operation_context=operation_context
         )
 
+        process_repeatability_first_sent(kwargs)
         result = await self._client.answer_call(
             answer_call_request=answer_call_request,
-            repeatability_first_sent=get_repeatability_timestamp(),
             repeatability_request_id=get_repeatability_guid(),
-            **kwargs)
-
-        return CallConnectionProperties._from_generated(# pylint:disable=protected-access
-            result)
+            **kwargs
+        )
+        return CallConnectionProperties._from_generated(result)  # pylint:disable=protected-access
 
     @distributed_trace_async
     async def redirect_call(
         self,
         incoming_call_context: str,
-        target_participant: 'CallInvite',
+        target_participant: 'CommunicationIdentifier',
         **kwargs
     ) -> None:
         """Redirect incoming call to a specific target.
@@ -305,21 +315,27 @@ class CallAutomationClient(object):
          Use this value to redirect incoming call.
         :type incoming_call_context: str
         :param target_participant: The target identity to redirect the call to.
-        :type target_participant: ~azure.communication.callautomation.CallInvite
+        :type target_participant: ~azure.communication.callautomation.CommunicationIdentifier
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
         """
+
+        # Backwards compatibility with old API signature
+        if isinstance(target_participant, CallInvite):
+            target_participant = target_participant.target
+
         redirect_call_request = RedirectCallRequest(
             incoming_call_context=incoming_call_context,
-            target=serialize_identifier(target_participant.target)
+            target=serialize_identifier(target_participant),
         )
 
+        process_repeatability_first_sent(kwargs)
         await self._client.redirect_call(
             redirect_call_request=redirect_call_request,
-            repeatability_first_sent=get_repeatability_timestamp(),
             repeatability_request_id=get_repeatability_guid(),
-            **kwargs)
+            **kwargs
+        )
 
     @distributed_trace_async
     async def reject_call(
@@ -345,17 +361,18 @@ class CallAutomationClient(object):
             call_reject_reason=call_reject_reason
         )
 
+        process_repeatability_first_sent(kwargs)
         await self._client.reject_call(
             reject_call_request=reject_call_request,
-            repeatability_first_sent=get_repeatability_timestamp(),
             repeatability_request_id=get_repeatability_guid(),
-            **kwargs)
+            **kwargs
+        )
 
-    @distributed_trace_async
+    @overload
     async def start_recording(
         self,
-        call_locator: Union['ServerCallLocator', 'GroupCallLocator'],
         *,
+        server_call_id: str,
         recording_state_callback_url: Optional[str] = None,
         recording_content_type: Optional[Union[str, 'RecordingContent']] = None,
         recording_channel_type: Optional[Union[str, 'RecordingChannel']] = None,
@@ -366,58 +383,107 @@ class CallAutomationClient(object):
     ) -> RecordingProperties:
         """Start recording for a ongoing call. Locate the call with call locator.
 
-        :param call_locator: The call locator to locate ongoing call.
-        :type call_locator: ~azure.communication.callautomation.ServerCallLocator
-         or ~azure.communication.callautomation.GroupCallLocator
+        :keyword str server_call_id: The server call ID to locate ongoing call.
         :keyword recording_state_callback_url: The url to send notifications to.
-        :paramtype recording_state_callback_url: str
+        :paramtype recording_state_callback_url: str or None
         :keyword recording_content_type: The content type of call recording.
-        :paramtype recording_content_type: str or ~azure.communication.callautomation.RecordingContent
+        :paramtype recording_content_type: str or ~azure.communication.callautomation.RecordingContent or None
         :keyword recording_channel_type: The channel type of call recording.
-        :paramtype recording_channel_type: str or ~azure.communication.callautomation.RecordingChannel
+        :paramtype recording_channel_type: str or ~azure.communication.callautomation.RecordingChannel or None
         :keyword recording_format_type: The format type of call recording.
-        :paramtype recording_format_type: str or ~azure.communication.callautomation.RecordingFormat
+        :paramtype recording_format_type: str or ~azure.communication.callautomation.RecordingFormat or None
         :keyword audio_channel_participant_ordering:
          The sequential order in which audio channels are assigned to participants in the unmixed recording.
          When 'recordingChannelType' is set to 'unmixed' and `audioChannelParticipantOrdering is not specified,
          the audio channel to participant mapping will be automatically assigned based on the order in
          which participant first audio was detected.
          Channel to participant mapping details can be found in the metadata of the recording.
-        :paramtype audio_channel_participant_ordering: list[~azure.communication.callautomation.CommunicationIdentifier]
+        :paramtype audio_channel_participant_ordering:
+         list[~azure.communication.callautomation.CommunicationIdentifier] or None
         :keyword channel_affinity: The channel affinity of call recording
          When 'recordingChannelType' is set to 'unmixed', if channelAffinity is not specified,
          'channel' will be automatically assigned.
          Channel-Participant mapping details can be found in the metadata of the recording.
-        :paramtype channel_affinity: list[~azure.communication.callautomation.ChannelAffinity]
+        :paramtype channel_affinity: list[~azure.communication.callautomation.ChannelAffinity] or None
         :return: RecordingProperties
         :rtype: ~azure.communication.callautomation.RecordingProperties
         :raises ~azure.core.exceptions.HttpResponseError:
         """
-        channel_affinity_internal = []
 
-        if channel_affinity:
-            for channel in channel_affinity:
-                channel_affinity_internal.append(channel._to_generated(# pylint:disable=protected-access
-                    ))
+    @overload
+    async def start_recording(
+        self,
+        *,
+        group_call_id: str,
+        recording_state_callback_url: Optional[str] = None,
+        recording_content_type: Optional[Union[str, 'RecordingContent']] = None,
+        recording_channel_type: Optional[Union[str, 'RecordingChannel']] = None,
+        recording_format_type: Optional[Union[str, 'RecordingFormat']] = None,
+        audio_channel_participant_ordering: Optional[List['CommunicationIdentifier']] = None,
+        channel_affinity: Optional[List['ChannelAffinity']] = None,
+        **kwargs
+    ) -> RecordingProperties:
+        """Start recording for a ongoing call. Locate the call with call locator.
 
+        :keyword str group_call_id: The group call ID to locate ongoing call.
+        :keyword recording_state_callback_url: The url to send notifications to.
+        :paramtype recording_state_callback_url: str or None
+        :keyword recording_content_type: The content type of call recording.
+        :paramtype recording_content_type: str or ~azure.communication.callautomation.RecordingContent or None
+        :keyword recording_channel_type: The channel type of call recording.
+        :paramtype recording_channel_type: str or ~azure.communication.callautomation.RecordingChannel or None
+        :keyword recording_format_type: The format type of call recording.
+        :paramtype recording_format_type: str or ~azure.communication.callautomation.RecordingFormat or None
+        :keyword audio_channel_participant_ordering:
+         The sequential order in which audio channels are assigned to participants in the unmixed recording.
+         When 'recordingChannelType' is set to 'unmixed' and `audioChannelParticipantOrdering is not specified,
+         the audio channel to participant mapping will be automatically assigned based on the order in
+         which participant first audio was detected.
+         Channel to participant mapping details can be found in the metadata of the recording.
+        :paramtype audio_channel_participant_ordering:
+         list[~azure.communication.callautomation.CommunicationIdentifier] or None
+        :keyword channel_affinity: The channel affinity of call recording
+         When 'recordingChannelType' is set to 'unmixed', if channelAffinity is not specified,
+         'channel' will be automatically assigned.
+         Channel-Participant mapping details can be found in the metadata of the recording.
+        :paramtype channel_affinity: list[~azure.communication.callautomation.ChannelAffinity] or None
+        :return: RecordingProperties
+        :rtype: ~azure.communication.callautomation.RecordingProperties
+        :raises ~azure.core.exceptions.HttpResponseError:
+        """
+
+    @distributed_trace_async
+    async def start_recording(
+        self,
+        *args: Union['ServerCallLocator', 'GroupCallLocator'],
+        **kwargs
+    ) -> RecordingProperties:
+        # pylint:disable=protected-access
+        channel_affinity: List['ChannelAffinity'] = kwargs.pop("channel_affinity", None) or []
+        channel_affinity_internal = [c._to_generated() for c in channel_affinity]
+        call_locator = build_call_locator(
+            args,
+            kwargs.pop("call_locator", None),
+            kwargs.pop("server_call_id", None),
+            kwargs.pop("group_call_id", None)
+        )
         start_recording_request = StartCallRecordingRequest(
-            call_locator=call_locator._to_generated(# pylint:disable=protected-access
-            ),
-            recording_state_callback_uri = recording_state_callback_url,
-            recording_content_type = recording_content_type,
-            recording_channel_type = recording_channel_type,
-            recording_format_type = recording_format_type,
-            audio_channel_participant_ordering = audio_channel_participant_ordering,
-            channel_affinity = channel_affinity_internal,
-            repeatability_first_sent=get_repeatability_timestamp(),
-            repeatability_request_id=get_repeatability_guid()
+            call_locator=call_locator,
+            recording_state_callback_uri=kwargs.pop("recording_state_callback_url", None),
+            recording_content_type=kwargs.pop("recording_content_type", None),
+            recording_channel_type=kwargs.pop("recording_channel_type", None),
+            recording_format_type=kwargs.pop("recording_format_type", None),
+            audio_channel_participant_ordering=kwargs.pop("audio_channel_participant_ordering", None),
+            channel_affinity=channel_affinity_internal
         )
 
+        process_repeatability_first_sent(kwargs)
         recording_state_result = await self._call_recording_client.start_recording(
-        start_call_recording = start_recording_request, **kwargs)
-
-        return RecordingProperties._from_generated(# pylint:disable=protected-access
-            recording_state_result)
+            start_call_recording=start_recording_request,
+            repeatability_request_id=get_repeatability_guid()
+            **kwargs
+        )
+        return RecordingProperties._from_generated(recording_state_result)
 
     @distributed_trace_async
     async def stop_recording(
@@ -433,7 +499,7 @@ class CallAutomationClient(object):
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
         """
-        await self._call_recording_client.stop_recording(recording_id = recording_id, **kwargs)
+        await self._call_recording_client.stop_recording(recording_id=recording_id, **kwargs)
 
     @distributed_trace_async
     async def pause_recording(
@@ -449,7 +515,7 @@ class CallAutomationClient(object):
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
         """
-        await self._call_recording_client.pause_recording(recording_id = recording_id, **kwargs)
+        await self._call_recording_client.pause_recording(recording_id=recording_id, **kwargs)
 
     @distributed_trace_async
     async def resume_recording(
@@ -465,7 +531,7 @@ class CallAutomationClient(object):
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
         """
-        await self._call_recording_client.resume_recording(recording_id = recording_id, **kwargs)
+        await self._call_recording_client.resume_recording(recording_id=recording_id, **kwargs)
 
     @distributed_trace_async
     async def get_recording_properties(
@@ -482,9 +548,10 @@ class CallAutomationClient(object):
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         recording_state_result = await self._call_recording_client.get_recording_properties(
-            recording_id = recording_id, **kwargs)
-        return RecordingProperties._from_generated(# pylint:disable=protected-access
-            recording_state_result)
+            recording_id=recording_id,
+            **kwargs
+        )
+        return RecordingProperties._from_generated(recording_state_result)  # pylint:disable=protected-access
 
     @distributed_trace_async
     async def download_recording(
@@ -510,9 +577,9 @@ class CallAutomationClient(object):
         :raises ~azure.core.exceptions.HttpResponseError:
         """
         stream = await self._downloader.download_streaming(
-            source_location = recording_url,
-            offset = offset,
-            length = length,
+            source_location=recording_url,
+            offset=offset,
+            length=length,
             **kwargs
         )
         return stream
@@ -531,7 +598,7 @@ class CallAutomationClient(object):
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
         """
-        await self._downloader.delete_recording(recording_location = recording_url, **kwargs)
+        await self._downloader.delete_recording(recording_location=recording_url, **kwargs)
 
     async def __aenter__(self) -> "CallAutomationClient":
         await self._client.__aenter__()

--- a/sdk/communication/azure-communication-callautomation/azure/communication/callautomation/aio/_call_automation_client_async.py
+++ b/sdk/communication/azure-communication-callautomation/azure/communication/callautomation/aio/_call_automation_client_async.py
@@ -3,7 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for
 # license information.
 # --------------------------------------------------------------------------
-from typing import List, Union, Optional, TYPE_CHECKING, AsyncIterable, Dict, overload
+from typing import List, Union, Optional, TYPE_CHECKING, AsyncIterable, overload
 from urllib.parse import urlparse
 import warnings
 from azure.core.tracing.decorator_async import distributed_trace_async

--- a/sdk/communication/azure-communication-callautomation/azure/communication/callautomation/aio/_call_connection_client_async.py
+++ b/sdk/communication/azure-communication-callautomation/azure/communication/callautomation/aio/_call_connection_client_async.py
@@ -507,9 +507,6 @@ class CallConnectionClient:
         else:
             play_source_single = play_prompt
 
-        if not isinstance(input_type, RecognizeInputType):
-            input_type = RecognizeInputType[input_type.upper()]
-
         if input_type == RecognizeInputType.DTMF:
             dtmf_options = DtmfOptions(
                 inter_tone_timeout_in_seconds=dtmf_inter_tone_timeout,

--- a/sdk/communication/azure-communication-callautomation/azure/communication/callautomation/aio/_call_connection_client_async.py
+++ b/sdk/communication/azure-communication-callautomation/azure/communication/callautomation/aio/_call_connection_client_async.py
@@ -5,14 +5,19 @@
 # --------------------------------------------------------------------------
 from typing import TYPE_CHECKING, Optional, List, Union
 from urllib.parse import urlparse
+import warnings
+
+from typing_extensions import Literal
+
 from azure.core.async_paging import AsyncItemPaged
 from azure.core.tracing.decorator import distributed_trace
 from azure.core.tracing.decorator_async import distributed_trace_async
+
 from .._version import SDK_MONIKER
 from .._api_versions import DEFAULT_VERSION
 from .._utils import (
     get_repeatability_guid,
-    get_repeatability_timestamp,
+    process_repeatability_first_sent,
     serialize_phone_identifier,
     serialize_identifier
 )
@@ -24,6 +29,7 @@ from .._models import (
     TransferCallResult,
     MuteParticipantResult,
     SendDtmfTonesResult,
+    CallInvite
 )
 from .._generated.aio import AzureCommunicationCallAutomationService
 from .._generated.models import (
@@ -47,11 +53,15 @@ from .._shared.utils import (
 )
 if TYPE_CHECKING:
     from ._call_automation_client_async import CallAutomationClient
+    from .._generated.models._enums import DtmfTone
+    from .._shared.models import (
+        PhoneNumberIdentifier,
+        CommunicationIdentifier
+    )
     from .._models  import (
         FileSource,
         TextSource,
         SsmlSource,
-        CallInvite,
         RecognitionChoice
     )
     from azure.core.credentials_async import (
@@ -60,13 +70,11 @@ if TYPE_CHECKING:
     from azure.core.credentials import (
         AzureKeyCredential
     )
-    from .._shared.models import (
-        CommunicationIdentifier,
-    )
-    from .._generated.models._enums import DtmfTone
-    from azure.core.exceptions import HttpResponseError
 
-class CallConnectionClient(object): # pylint: disable=client-accepts-api-version-keyword
+MediaSources = Union['FileSource', 'TextSource', 'SsmlSource']
+
+
+class CallConnectionClient:
     """A client to interact with ongoing call. This client can be used to do mid-call actions,
     such as Transfer and Play Media. Call must be estbalished to perform these actions.
 
@@ -162,8 +170,8 @@ class CallConnectionClient(object): # pylint: disable=client-accepts-api-version
         """
         call_properties = await self._call_connection_client.get_call(
             call_connection_id=self._call_connection_id,
-            **kwargs)
-
+            **kwargs
+        )
         return CallConnectionProperties._from_generated(call_properties) # pylint:disable=protected-access
 
     @distributed_trace_async
@@ -176,16 +184,17 @@ class CallConnectionClient(object): # pylint: disable=client-accepts-api-version
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
         """
-
         if is_for_everyone:
+            process_repeatability_first_sent(kwargs)
             await self._call_connection_client.terminate_call(
                 self._call_connection_id,
-                repeatability_first_sent=get_repeatability_timestamp(),
                 repeatability_request_id=get_repeatability_guid(),
-                **kwargs)
+                **kwargs
+            )
         else:
             await self._call_connection_client.hangup_call(
-                self._call_connection_id, **kwargs)
+                self._call_connection_id, **kwargs
+            )
 
     @distributed_trace_async
     async def get_participant(
@@ -201,21 +210,26 @@ class CallConnectionClient(object): # pylint: disable=client-accepts-api-version
         :rtype: ~azure.communication.callautomation.CallParticipant
         :raises ~azure.core.exceptions.HttpResponseError:
         """
-
         participant = await self._call_connection_client.get_participant(
-            self._call_connection_id, target_participant.raw_id, **kwargs)
-
-        return CallParticipant._from_generated(participant) # pylint:disable=protected-access
+            self._call_connection_id,
+            target_participant.raw_id,
+            **kwargs
+        )
+        return CallParticipant._from_generated(participant)  # pylint:disable=protected-access
 
     @distributed_trace
     def list_participants(self, **kwargs) -> AsyncItemPaged[CallParticipant]:
         """List all participants from a call.
 
-        :return: List of CallParticipant
-        :rtype: ItemPaged[azure.communication.callautomation.CallParticipant]
+        :return: Async iterable of CallParticipant
+        :rtype: ~azure.core.async_paging.AsyncItemPaged[azure.communication.callautomation.CallParticipant]
         :raises ~azure.core.exceptions.HttpResponseError:
         """
-        return self._call_connection_client.get_participants(self._call_connection_id, **kwargs)
+        return self._call_connection_client.get_participants(
+            self._call_connection_id,
+            cls=lambda participants: [CallParticipant._from_generated(p) for p in participants],  # pylint:disable=protected-access
+            **kwargs
+        )
 
     @distributed_trace_async
     async def transfer_call_to_participant(
@@ -237,52 +251,70 @@ class CallConnectionClient(object): # pylint: disable=client-accepts-api-version
         """
         request = TransferToParticipantRequest(
             target_participant=serialize_identifier(target_participant),
-            operation_context=operation_context)
+            operation_context=operation_context
+        )
 
-        return await self._call_connection_client.transfer_to_participant(
-            self._call_connection_id, request,
-            repeatability_first_sent=get_repeatability_timestamp(),
+        process_repeatability_first_sent(kwargs)
+        result = await self._call_connection_client.transfer_to_participant(
+            self._call_connection_id,
+            request,
             repeatability_request_id=get_repeatability_guid(),
-            **kwargs)
+            **kwargs
+        )
+        return TransferCallResult._from_generated(result)  # pylint:disable=protected-access
 
     @distributed_trace_async
     async def add_participant(
         self,
-        target_participant: 'CallInvite',
+        target_participant: 'CommunicationIdentifier',
         *,
         invitation_timeout: Optional[int] = None,
         operation_context: Optional[str] = None,
+        source_caller_id_number: Optional['PhoneNumberIdentifier'] = None,
+        source_display_name: Optional[str] = None,
         **kwargs
     ) -> AddParticipantResult:
         """Add a participant to the call.
 
         :param target_participant: The participant being added.
-        :type target_participant: ~azure.communication.callautomation.CallInvite
+        :type target_participant: ~azure.communication.callautomation.CommunicationIdentifier
         :keyword invitation_timeout: Timeout to wait for the invited participant to pickup.
          The maximum value of this is 180 seconds.
-        :paramtype invitation_timeout: int
+        :paramtype invitation_timeout: int or None
         :keyword operation_context: Value that can be used to track the call and its associated events.
-        :paramtype operation_context: str
+        :paramtype operation_context: str or None
+        :keyword source_caller_id_number: The source caller Id, a phone number,
+         that's shown to the PSTN participant being invited.
+         Required only when calling a PSTN callee.
+        :paramtype source_caller_id_number: ~azure.communication.callautomation.PhoneNumberIdentifier or None
+        :keyword source_display_name: Display name of the caller.
+        :paramtype source_display_name: str or None
         :return: AddParticipantResult
         :rtype: ~azure.communication.callautomation.AddParticipantResult
         :raises ~azure.core.exceptions.HttpResponseError:
         """
-        add_participant_request = AddParticipantRequest(
-            participant_to_add=serialize_identifier(target_participant.target),
-            source_caller_id_number=serialize_phone_identifier(
-                target_participant.source_caller_id_number) if target_participant.source_caller_id_number else None,
-            source_display_name=target_participant.source_display_name,
-            invitation_timeout=invitation_timeout,
-            operation_context=operation_context)
+        # Backwards compatibility with old API signature
+        if isinstance(target_participant, CallInvite):
+            source_caller_id_number = source_caller_id_number or target_participant.source_caller_id_number
+            source_display_name = source_display_name or target_participant.source_display_name
+            target_participant = target_participant.target
 
+        add_participant_request = AddParticipantRequest(
+            participant_to_add=serialize_identifier(target_participant),
+            source_caller_id_number=serialize_phone_identifier(source_caller_id_number),
+            source_display_name=source_display_name,
+            invitation_timeout=invitation_timeout,
+            operation_context=operation_context
+        )
+
+        process_repeatability_first_sent(kwargs)
         response = await self._call_connection_client.add_participant(
             self._call_connection_id,
             add_participant_request,
-            repeatability_first_sent=get_repeatability_timestamp(),
             repeatability_request_id=get_repeatability_guid(),
-            **kwargs)
-
-        return AddParticipantResult._from_generated(response) # pylint:disable=protected-access
+            **kwargs
+        )
+        return AddParticipantResult._from_generated(response)  # pylint:disable=protected-access
 
     @distributed_trace_async
     async def remove_participant(
@@ -304,23 +336,23 @@ class CallConnectionClient(object): # pylint: disable=client-accepts-api-version
         """
         remove_participant_request = RemoveParticipantRequest(
             participant_to_remove=serialize_identifier(target_participant),
-            operation_context=operation_context)
+            operation_context=operation_context
+        )
 
+        process_repeatability_first_sent(kwargs)
         response = await self._call_connection_client.remove_participant(
             self._call_connection_id,
             remove_participant_request,
-            repeatability_first_sent=get_repeatability_timestamp(),
             repeatability_request_id=get_repeatability_guid(),
-            **kwargs)
-
-        return RemoveParticipantResult._from_generated(response) # pylint:disable=protected-access
+            **kwargs
+        )
+        return RemoveParticipantResult._from_generated(response)  # pylint:disable=protected-access
 
     @distributed_trace_async
     async def play_media(
         self,
-        play_source: Union['FileSource', 'TextSource', 'SsmlSource',
-                           List[Union['FileSource', 'TextSource', 'SsmlSource']]],
-        play_to: List['CommunicationIdentifier'],
+        play_source: Union[MediaSources, List[MediaSources]],
+        play_to: Union[Literal["all"], List['CommunicationIdentifier']] = 'all',
         *,
         loop: bool = False,
         operation_context: Optional[str] = None,
@@ -335,26 +367,28 @@ class CallConnectionClient(object): # pylint: disable=client-accepts-api-version
          list[~azure.communication.callautomation.FileSource or
           ~azure.communication.callautomation.TextSource or
           ~azure.communication.callautomation.SsmlSource]
+        :param play_to: The targets to play media to. Default value is 'all', to play media
+         to all participants in the call.
         :type play_to: list[~azure.communication.callautomation.CommunicationIdentifier]
-        :keyword loop: if the media should be repeated until cancelled.
+        :keyword loop: Whether the media should be repeated until cancelled.
         :paramtype loop: bool
         :keyword operation_context: Value that can be used to track this call and its associated events.
-        :paramtype operation_context: str
+        :paramtype operation_context: str or None
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
         """
-        play_source_single: Union['FileSource', 'TextSource', 'SsmlSource'] = None
+        play_source_single: Optional[MediaSources] = None
         if isinstance(play_source, list):
             if play_source:  # Check if the list is not empty
                 play_source_single = play_source[0]
         else:
             play_source_single = play_source
 
+        audience = [] if play_to == "all" else [serialize_identifier(i) for i in play_to]
         play_request = PlayRequest(
-            play_sources=[play_source_single._to_generated()],#pylint:disable=protected-access
-            play_to=[serialize_identifier(identifier)
-                     for identifier in play_to],
+            play_sources=[play_source_single._to_generated()],  # pylint:disable=protected-access
+            play_to=audience,
             play_options=PlayOptions(loop=loop),
             operation_context=operation_context,
             **kwargs
@@ -364,8 +398,7 @@ class CallConnectionClient(object): # pylint: disable=client-accepts-api-version
     @distributed_trace_async
     async def play_media_to_all(
         self,
-        play_source: Union['FileSource', 'TextSource', 'SsmlSource',
-                           List[Union['FileSource', 'TextSource', 'SsmlSource']]],
+        play_source: Union['MediaSources', List['MediaSources']],
         *,
         loop: bool = False,
         operation_context: Optional[str] = None,
@@ -383,22 +416,21 @@ class CallConnectionClient(object): # pylint: disable=client-accepts-api-version
         :keyword loop: if the media should be repeated until cancelled.
         :paramtype loop: bool
         :keyword operation_context: Value that can be used to track this call and its associated events.
-        :paramtype operation_context: str
+        :paramtype operation_context: str or None
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
         """
-        play_source_single: Union['FileSource', 'TextSource', 'SsmlSource'] = None
-        if isinstance(play_source, list):
-            if play_source:  # Check if the list is not empty
-                play_source_single = play_source[0]
-        else:
-            play_source_single = play_source
-
-        await self.play_media(play_source=play_source_single, play_to=[],
-                              loop=loop,
-                              operation_context=operation_context,
-                              **kwargs)
+        warnings.warn(
+            "The method 'play_media_to_all' is deprecated. Please use 'play_media' instead.",
+            DeprecationWarning
+        )
+        await self.play_media(
+            play_source=play_source,
+            loop=loop,
+            operation_context=operation_context,
+            **kwargs
+        )
 
     @distributed_trace_async
     async def start_recognizing_media(
@@ -407,8 +439,7 @@ class CallConnectionClient(object): # pylint: disable=client-accepts-api-version
         target_participant: 'CommunicationIdentifier',
         *,
         initial_silence_timeout: Optional[int] = None,
-        play_prompt: Optional[Union['FileSource', 'TextSource', 'SsmlSource',
-                           List[Union['FileSource', 'TextSource', 'SsmlSource']]]] = None,
+        play_prompt: Optional[Union[MediaSources, List[MediaSources]]] = None,
         interrupt_call_media_operation: bool = False,
         operation_context: Optional[str] = None,
         interrupt_prompt: bool = False,
@@ -469,8 +500,7 @@ class CallConnectionClient(object): # pylint: disable=client-accepts-api-version
             speech_language=speech_language,
             speech_recognition_model_endpoint_id=speech_recognition_model_endpoint_id
         )
-
-        play_source_single: Union['FileSource', 'TextSource', 'SsmlSource'] = None
+        play_source_single: Optional[MediaSources] = None
         if isinstance(play_prompt, list):
             if play_prompt:  # Check if the list is not empty
                 play_source_single = play_prompt[0]
@@ -504,33 +534,30 @@ class CallConnectionClient(object): # pylint: disable=client-accepts-api-version
         elif input_type == RecognizeInputType.CHOICES:
             options.choices = [choice._to_generated() for choice in choices] #pylint:disable=protected-access
         else:
-            raise NotImplementedError(f"{type(input_type).__name__} is not supported")
+            raise ValueError(f"Input type '{input_type}' is not supported.")
 
         recognize_request = RecognizeRequest(
             recognize_input_type=input_type,
-            play_prompt=play_source_single._to_generated() if play_source_single is not None else None,#pylint:disable=protected-access
+            play_prompt=play_source_single._to_generated() if play_source_single else None,  # pylint:disable=protected-access
             interrupt_call_media_operation=interrupt_call_media_operation,
             operation_context=operation_context,
             recognize_options=options,
             **kwargs
         )
-
         await self._call_media_client.recognize(
-            self._call_connection_id, recognize_request)
+            self._call_connection_id,
+            recognize_request
+        )
 
     @distributed_trace_async
-    async def cancel_all_media_operations(
-        self,
-        **kwargs
-    ) -> None:
+    async def cancel_all_media_operations(self, **kwargs) -> None:
         """ Cancels all the queued media operations.
 
         :return: None
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
         """
-        await self._call_media_client.cancel_all_media_operations(
-            self._call_connection_id, **kwargs)
+        await self._call_media_client.cancel_all_media_operations(self._call_connection_id, **kwargs)
 
     @distributed_trace_async
     async def start_continuous_dtmf_recognition(
@@ -552,12 +579,13 @@ class CallConnectionClient(object): # pylint: disable=client-accepts-api-version
         """
         continuous_dtmf_recognition_request = ContinuousDtmfRecognitionRequest(
             target_participant=serialize_identifier(target_participant),
-            operation_context=operation_context)
-
+            operation_context=operation_context
+        )
         await self._call_media_client.start_continuous_dtmf_recognition(
             self._call_connection_id,
             continuous_dtmf_recognition_request,
-            **kwargs)
+            **kwargs
+        )
 
     @distributed_trace_async
     async def stop_continuous_dtmf_recognition(
@@ -579,12 +607,13 @@ class CallConnectionClient(object): # pylint: disable=client-accepts-api-version
         """
         continuous_dtmf_recognition_request = ContinuousDtmfRecognitionRequest(
             target_participant=serialize_identifier(target_participant),
-            operation_context=operation_context)
-
+            operation_context=operation_context
+        )
         await self._call_media_client.stop_continuous_dtmf_recognition(
             self._call_connection_id,
             continuous_dtmf_recognition_request,
-            **kwargs)
+            **kwargs
+        )
 
     @distributed_trace_async
     async def send_dtmf_tones(
@@ -610,14 +639,15 @@ class CallConnectionClient(object): # pylint: disable=client-accepts-api-version
         send_dtmf_tones_request = SendDtmfTonesRequest(
             tones=tones,
             target_participant=serialize_identifier(target_participant),
-            operation_context=operation_context)
-
+            operation_context=operation_context
+        )
+        process_repeatability_first_sent(kwargs)
         response = await self._call_media_client.send_dtmf_tones(
             self._call_connection_id,
             send_dtmf_tones_request,
-            repeatability_first_sent=get_repeatability_timestamp(),
             repeatability_request_id=get_repeatability_guid(),
-            **kwargs)
+            **kwargs
+        )
 
         return SendDtmfTonesResult._from_generated(response)  # pylint:disable=protected-access
 
@@ -642,15 +672,15 @@ class CallConnectionClient(object): # pylint: disable=client-accepts-api-version
         """
         mute_participants_request = MuteParticipantsRequest(
             target_participants=[serialize_identifier(target_participant)],
-            operation_context=operation_context)
-
+            operation_context=operation_context
+        )
+        process_repeatability_first_sent(kwargs)
         response =  await self._call_connection_client.mute(
             self._call_connection_id,
             mute_participants_request,
-            repeatability_first_sent=get_repeatability_timestamp(),
             repeatability_request_id=get_repeatability_guid(),
-            **kwargs)
-
+            **kwargs
+        )
         return MuteParticipantResult._from_generated(response) # pylint:disable=protected-access
 
     async def __aenter__(self) -> "CallConnectionClient":

--- a/sdk/communication/azure-communication-callautomation/azure/communication/callautomation/aio/_call_connection_client_async.py
+++ b/sdk/communication/azure-communication-callautomation/azure/communication/callautomation/aio/_call_connection_client_async.py
@@ -398,7 +398,7 @@ class CallConnectionClient:
     @distributed_trace_async
     async def play_media_to_all(
         self,
-        play_source: Union['MediaSources', List['MediaSources']],
+        play_source: Union['FileSource', List['FileSource']],
         *,
         loop: bool = False,
         operation_context: Optional[str] = None,
@@ -408,11 +408,7 @@ class CallConnectionClient:
 
         :param play_source: A PlaySource representing the source to play.
         :type play_source: ~azure.communication.callautomation.FileSource or
-         ~azure.communication.callautomation.TextSource or
-         ~azure.communication.callautomation.SsmlSource or
-         list[~azure.communication.callautomation.FileSource or
-          ~azure.communication.callautomation.TextSource or
-          ~azure.communication.callautomation.SsmlSource]
+         list[~azure.communication.callautomation.FileSource]
         :keyword loop: if the media should be repeated until cancelled.
         :paramtype loop: bool
         :keyword operation_context: Value that can be used to track this call and its associated events.

--- a/sdk/communication/azure-communication-callautomation/setup.py
+++ b/sdk/communication/azure-communication-callautomation/setup.py
@@ -64,11 +64,9 @@ setup(
     install_requires=[
         "msrest>=0.7.1",
         "azure-core<2.0.0,>=1.24.0",
-        'six>=1.11.0'
+        'six>=1.11.0',
+        "typing-extensions>=4.3.0"
     ],
-    extras_require={
-        ":python_version<'3.8'": ["typing-extensions"]
-    },
     project_urls = {
         'Bug Reports': 'https://github.com/Azure/azure-sdk-for-python/issues',
         'Source': 'https://github.com/Azure/azure-sdk-for-python',

--- a/sdk/communication/azure-communication-callautomation/tests/test_call_connection_client.py
+++ b/sdk/communication/azure-communication-callautomation/tests/test_call_connection_client.py
@@ -14,6 +14,7 @@ from azure.communication.callautomation import (
     CallParticipant,
     TransferCallResult
 )
+from azure.core.paging import ItemPaged
 
 from unittest_helpers import mock_response
 
@@ -92,9 +93,7 @@ class TestCallConnectionClient(unittest.TestCase):
             transport=Mock(send=mock_send))
 
         response = call_connection.list_participants()
-        participants = [p for p in response]
-        for p in participants:
-            assert isinstance(p, CallParticipant)
+        assert isinstance(response, ItemPaged)
 
     def test_get_participants(self):
         def mock_send(_, **kwargs):

--- a/sdk/communication/azure-communication-callautomation/tests/test_call_media_client_e2e.py
+++ b/sdk/communication/azure-communication-callautomation/tests/test_call_media_client_e2e.py
@@ -98,7 +98,7 @@ class CallMediaClientAsyncAutomatedLiveTest(CallAutomationAutomatedLiveTestBase)
             caller_call_connection = CallConnectionClient.from_connection_string(self.connection_str, create_call_result.call_connection_id)
             file_source = FileSource(url=play_source_uri)
 
-            caller_call_connection.play_media_to_all(
+            caller_call_connection.play_media(
                 play_source=file_source
             )
 

--- a/sdk/communication/azure-communication-callautomation/tests/test_call_recording_client.py
+++ b/sdk/communication/azure-communication-callautomation/tests/test_call_recording_client.py
@@ -4,10 +4,15 @@
 # license information.
 # --------------------------------------------------------------------------
 import unittest
+import pytest
 
 from azure.core.credentials import AzureKeyCredential
 from azure.communication.callautomation import (
-    CallAutomationClient, ServerCallLocator, ChannelAffinity, CommunicationUserIdentifier
+    CallAutomationClient,
+    ServerCallLocator,
+    GroupCallLocator,
+    ChannelAffinity,
+    CommunicationUserIdentifier
 )
 from unittest_helpers import mock_response
 from unittest.mock import Mock
@@ -16,88 +21,72 @@ class TestCallRecordingClient(unittest.TestCase):
     recording_id = "123"
 
     def test_start_recording(self):
-        raised = False
-
-        def mock_send(*_, **__):
+        def mock_send(_, **kwargs):
+            kwargs.pop("stream", None)
+            if kwargs:
+                raise ValueError(f"Received unexpected kwargs in transport: {kwargs}")
             return mock_response(status_code=200, json_payload={
                 "recording_id": "1",
                 "recording_state": "2"
             })
 
         callautomation_client = CallAutomationClient("https://endpoint", AzureKeyCredential("fakeCredential=="), transport=Mock(send=mock_send))
-
-        call_locator = ServerCallLocator(server_call_id = "locatorId")
+        call_locator = ServerCallLocator(server_call_id="locatorId")
         target_participant = CommunicationUserIdentifier("testId")
         channel_affinity=ChannelAffinity(target_participant=target_participant, channel=0)
-        try:
-            callautomation_client.start_recording(call_locator=call_locator, channel_affinity=[channel_affinity])
-        except:
-            raised = True
-            raise
+        callautomation_client.start_recording(call_locator=call_locator, channel_affinity=[channel_affinity])
+        callautomation_client.start_recording(call_locator, channel_affinity=[channel_affinity])
+        callautomation_client.start_recording(group_call_id="locatorId", channel_affinity=[channel_affinity])
+        callautomation_client.start_recording(server_call_id="locatorId", channel_affinity=[channel_affinity])
 
-        self.assertFalse(raised, 'Expected is no excpetion raised')
-
+        with pytest.raises(ValueError):
+            call_locator = ServerCallLocator(server_call_id="locatorId")
+            callautomation_client.start_recording(call_locator, group_call_id="foo")
+        with pytest.raises(ValueError):
+            call_locator = GroupCallLocator(group_call_id="locatorId")
+            callautomation_client.start_recording(call_locator=call_locator, server_call_id="foo")
+        with pytest.raises(ValueError):
+            callautomation_client.start_recording(group_call_id="foo", server_call_id="bar")
 
     def test_stop_recording(self):
-        raised = False
-
-        def mock_send(*_, **__):
+        def mock_send(_, **kwargs):
+            kwargs.pop("stream", None)
+            if kwargs:
+                raise ValueError(f"Received unexpected kwargs in transport: {kwargs}")
             return mock_response(status_code=204)
 
         callautomation_client = CallAutomationClient("https://endpoint", AzureKeyCredential("fakeCredential=="), transport=Mock(send=mock_send))
-        try:
-            callautomation_client.stop_recording(recording_id=self.recording_id)
-        except:
-            raised = True
-            raise
-
-        self.assertFalse(raised, 'Expected is no excpetion raised')
+        callautomation_client.stop_recording(recording_id=self.recording_id)
 
     def test_resume_recording(self):
-        raised = False
-
-        def mock_send(*_, **__):
+        def mock_send(_, **kwargs):
+            kwargs.pop("stream", None)
+            if kwargs:
+                raise ValueError(f"Received unexpected kwargs in transport: {kwargs}")
             return mock_response(status_code=202)
 
         callautomation_client = CallAutomationClient("https://endpoint", AzureKeyCredential("fakeCredential=="), transport=Mock(send=mock_send))
-        try:
-            callautomation_client.resume_recording(recording_id=self.recording_id)
-        except:
-            raised = True
-            raise
-
-        self.assertFalse(raised, 'Expected is no excpetion raised')
+        callautomation_client.resume_recording(recording_id=self.recording_id)
 
     def test_pause_recording(self):
-        raised = False
-
-        def mock_send(*_, **__):
+        def mock_send(_, **kwargs):
+            kwargs.pop("stream", None)
+            if kwargs:
+                raise ValueError(f"Received unexpected kwargs in transport: {kwargs}")
             return mock_response(status_code=202)
 
         callautomation_client = CallAutomationClient("https://endpoint", AzureKeyCredential("fakeCredential=="), transport=Mock(send=mock_send))
-        try:
-            callautomation_client.pause_recording(recording_id=self.recording_id)
-        except:
-            raised = True
-            raise
-
-        self.assertFalse(raised, 'Expected is no excpetion raised')
-
+        callautomation_client.pause_recording(recording_id=self.recording_id)
 
     def test_get_recording_properties(self):
-        raised = False
-
-        def mock_send(*_, **__):
+        def mock_send(_, **kwargs):
+            kwargs.pop("stream", None)
+            if kwargs:
+                raise ValueError(f"Received unexpected kwargs in transport: {kwargs}")
             return mock_response(status_code=200, json_payload={
                 "recording_id": "1",
                 "recording_state": "2"
             })
 
         callautomation_client = CallAutomationClient("https://endpoint", AzureKeyCredential("fakeCredential=="), transport=Mock(send=mock_send))
-        try:
-            callautomation_client.get_recording_properties(recording_id=self.recording_id)
-        except:
-            raised = True
-            raise
-
-        self.assertFalse(raised, 'Expected is no excpetion raised')
+        callautomation_client.get_recording_properties(recording_id=self.recording_id)

--- a/sdk/communication/azure-communication-callautomation/tests/test_callautomation_client.py
+++ b/sdk/communication/azure-communication-callautomation/tests/test_callautomation_client.py
@@ -3,7 +3,9 @@
 # Licensed under the MIT License. See License.txt in the project root for
 # license information.
 # --------------------------------------------------------------------------
+import json
 import unittest
+import pytest
 
 from azure.core.credentials import AzureKeyCredential
 from azure.communication.callautomation import (
@@ -26,9 +28,12 @@ class TestCallAutomationClient(unittest.TestCase):
     incoming_call_context = "env2REDACTEDINCOMINGCALLCONTEXT"
 
     def test_create_call(self):
-        raised = False
-
-        def mock_send(*_, **__):
+        def mock_send(request, **kwargs):
+            kwargs.pop("stream", None)
+            if kwargs:
+                raise ValueError(f"Received unexpected kwargs in transport: {kwargs}")
+            body = json.loads(request.content)
+            assert body["sourceDisplayName"] == "baz", "Parameter value not as expected"
             return mock_response(status_code=201, json_payload={
                 "callConnectionId": self.call_connection_id,
                 "serverCallId": self.server_callI_id,
@@ -42,25 +47,47 @@ class TestCallAutomationClient(unittest.TestCase):
         user = CommunicationUserIdentifier(self.communication_user_id)
 
         # make invitation
-        call_invite = CallInvite(target=user)
+        call_invite = CallInvite(
+            target=user,
+            source_display_name="baz"
+        )
+        call_automation_client = CallAutomationClient(
+            "https://endpoint",
+            AzureKeyCredential("fakeCredential=="),
+            transport=Mock(send=mock_send)
+        )
+        call_connection_properties = call_automation_client.create_call(call_invite, self.callback_url)
+        self.assertEqual(self.call_connection_id, call_connection_properties.call_connection_id)
+        self.assertEqual(self.server_callI_id, call_connection_properties.server_call_id)
+        self.assertEqual(self.callback_url, call_connection_properties.callback_url)
 
-        call_automation_client = CallAutomationClient("https://endpoint", AzureKeyCredential("fakeCredential=="),
-                                                      transport=Mock(send=mock_send))
-        try:
-            call_connection_properties = call_automation_client.create_call(call_invite, self.callback_url)
-        except:
-            raised = True
-            raise
+        call_invite = CallInvite(
+            target=user,
+            source_display_name="WRONG"
+        )
+        call_connection_properties = call_automation_client.create_call(
+            target_participant=call_invite,
+            callback_url=self.callback_url,
+            source_display_name="baz"
+        )
+        self.assertEqual(self.call_connection_id, call_connection_properties.call_connection_id)
+        self.assertEqual(self.server_callI_id, call_connection_properties.server_call_id)
+        self.assertEqual(self.callback_url, call_connection_properties.callback_url)
 
-        self.assertFalse(raised, 'Expected is no exception raised')
+        call_connection_properties = call_automation_client.create_call(
+            target_participant=user,
+            callback_url=self.callback_url,
+            source_display_name="baz"
+        )
         self.assertEqual(self.call_connection_id, call_connection_properties.call_connection_id)
         self.assertEqual(self.server_callI_id, call_connection_properties.server_call_id)
         self.assertEqual(self.callback_url, call_connection_properties.callback_url)
 
     def test_create_group_call(self):
-        raised = False
-
-        def mock_send(*_, **__):
+        def mock_send(_, **kwargs):
+            kwargs.pop("stream", None)
+            if kwargs:
+                raise ValueError(f"Received unexpected kwargs in transport: {kwargs}")
             return mock_response(status_code=201, json_payload={
                 "callConnectionId": self.call_connection_id,
                 "serverCallId": self.server_callI_id,
@@ -75,22 +102,17 @@ class TestCallAutomationClient(unittest.TestCase):
 
         call_automation_client = CallAutomationClient("https://endpoint", AzureKeyCredential("fakeCredential=="),
                                                       transport=Mock(send=mock_send))
-        try:
-            call_connection_properties = call_automation_client.create_group_call([user], self.callback_url)
-        except:
-            raised = True
-            raise
-
-        self.assertFalse(raised, 'Expected is no exception raised')
+        call_connection_properties = call_automation_client.create_call([user], self.callback_url)
         self.assertEqual(self.call_connection_id, call_connection_properties.call_connection_id)
         self.assertEqual(self.server_callI_id, call_connection_properties.server_call_id)
         self.assertEqual(self.callback_url, call_connection_properties.callback_url)
 
-    def test_answer_call(self):
-        raised = False
-
-        def mock_send(*_, **__):
-            return mock_response(status_code=200, json_payload={
+    def test_create_group_call_back_compat(self):
+        def mock_send(_, **kwargs):
+            kwargs.pop("stream", None)
+            if kwargs:
+                raise ValueError(f"Received unexpected kwargs in transport: {kwargs}")
+            return mock_response(status_code=201, json_payload={
                 "callConnectionId": self.call_connection_id,
                 "serverCallId": self.server_callI_id,
                 "callbackUri": self.callback_url,
@@ -102,51 +124,74 @@ class TestCallAutomationClient(unittest.TestCase):
         # target endpoint for ACS User
         user = CommunicationUserIdentifier(self.communication_user_id)
 
+        call_automation_client = CallAutomationClient(
+            "https://endpoint",
+            AzureKeyCredential("fakeCredential=="),
+            transport=Mock(send=mock_send))
+        call_connection_properties = call_automation_client.create_group_call([user], self.callback_url)
+        self.assertEqual(self.call_connection_id, call_connection_properties.call_connection_id)
+        self.assertEqual(self.server_callI_id, call_connection_properties.server_call_id)
+        self.assertEqual(self.callback_url, call_connection_properties.callback_url)
+
+    def test_answer_call(self):
+        def mock_send(_, **kwargs):
+            kwargs.pop("stream", None)
+            if kwargs:
+                raise ValueError(f"Received unexpected kwargs in transport: {kwargs}")
+            return mock_response(status_code=200, json_payload={
+                "callConnectionId": self.call_connection_id,
+                "serverCallId": self.server_callI_id,
+                "callbackUri": self.callback_url,
+                "targets": [{"rawId": self.communication_user_id,
+                             "communicationUser": {"id": self.communication_user_id}}],
+                "sourceIdentity": {"rawId": self.communication_user_source_id,
+                                   "communicationUser": {"id": self.communication_user_source_id}}})
+
+        # target endpoint for ACS User
+        user = CommunicationUserIdentifier(self.communication_user_id)
         call_automation_client = CallAutomationClient("https://endpoint", AzureKeyCredential("fakeCredential=="),
                                                       transport=Mock(send=mock_send))
-        try:
-            call_connection_properties = call_automation_client.answer_call(self.incoming_call_context, self.callback_url)
-        except:
-            raised = True
-            raise
-
-        self.assertFalse(raised, 'Expected is no exception raised')
+        call_connection_properties = call_automation_client.answer_call(self.incoming_call_context, self.callback_url)
         self.assertEqual(self.call_connection_id, call_connection_properties.call_connection_id)
         self.assertEqual(self.server_callI_id, call_connection_properties.server_call_id)
         self.assertEqual(self.callback_url, call_connection_properties.callback_url)
 
     def test_redirect_call(self):
-        raised = False
-
-        def mock_send(*_, **__):
+        def mock_send(_, **kwargs):
+            kwargs.pop("stream", None)
+            if kwargs:
+                raise ValueError(f"Received unexpected kwargs in transport: {kwargs}")
             return mock_response(status_code=204)
 
         # target endpoint for ACS User
         user = CommunicationUserIdentifier(self.communication_user_id)
-        call_redirect_to = CallInvite(target=user)
+        call_redirect_to = CallInvite(
+            target=user,
+            source_display_name="baz"
+        )
 
-        call_automation_client = CallAutomationClient("https://endpoint", AzureKeyCredential("fakeCredential=="),
-                                                      transport=Mock(send=mock_send))
-        try:
-            call_automation_client.redirect_call(self.incoming_call_context, call_redirect_to)
-        except:
-            raised = True
-            raise
-
-        self.assertFalse(raised, 'Expected is no exception raised')
+        call_automation_client = CallAutomationClient(
+            "https://endpoint",
+            AzureKeyCredential("fakeCredential=="),
+            transport=Mock(send=mock_send)
+        )
+        call_automation_client.redirect_call(self.incoming_call_context, call_redirect_to)
+        call_automation_client.redirect_call(self.incoming_call_context, user)
+        with pytest.raises(ValueError) as e:
+            call_automation_client.redirect_call(
+                self.incoming_call_context,
+                user,
+                source_display_name="baz"
+            )
+        assert "unexpected kwargs" in str(e.value)
 
     def test_reject_call(self):
-        raised = False
-
-        def mock_send(*_, **__):
+        def mock_send(_, **kwargs):
+            kwargs.pop("stream", None)
+            if kwargs:
+                raise ValueError(f"Received unexpected kwargs in transport: {kwargs}")
             return mock_response(status_code=204)
 
         call_automation_client = CallAutomationClient("https://endpoint", AzureKeyCredential("fakeCredential=="),
                                                       transport=Mock(send=mock_send))
-        try:
-            call_automation_client.reject_call(self.incoming_call_context)
-        except:
-            raised = True
-            raise
-
-        self.assertFalse(raised, 'Expected is no exception raised')
+        call_automation_client.reject_call(self.incoming_call_context)


### PR DESCRIPTION
Added following changes as per ARB review
- The models `ServerCallLocator` and `GroupCallLocator` have been deprecated, and the ID values can now be passed directly into `CallAutomationClient.start_recording` as keyword arguments.
- The model `CallInvite` has been deprecated and now the target `CommunicationIdentifier` and associated properties can be passed directly into `create_call`, `redirect_call` and `add_participant`.
- The method `CallAutomationClient.create_group_call` has been deprecated, this can now be achieved by passing a list of `CommunicationIdentifier`s into `create_call`.
- The method `CallConnectionClient.play_media_to_all` has been deprecated, this can now be achieved as the default behaviour of `play_media`.