### PR TITLE
[Azure AMQP] Remove Deprecated SSL.Wrap_Socket

### DIFF
--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/_transport.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/_transport.py
@@ -580,7 +580,7 @@ class SSLTransport(_AbstractTransport):
                 exc.filename = {"ca_certs": ca_certs}
                 raise exc from None
         elif context.verify_mode != ssl.CERT_NONE:
-            # load the default system root CA certs. 
+            # load the default system root CA certs.
             context.load_default_certs(purpose=purpose)
 
         if certfile is not None:

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/_transport.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/_transport.py
@@ -510,7 +510,6 @@ class SSLTransport(_AbstractTransport):
     def _setup_transport(self):
         """Wrap the socket in an SSL object."""
         self.sock = self._wrap_socket(self.sock, **self.sslopts)
-        self.sock.do_handshake()
         self._quick_recv = self.sock.recv
 
     def _wrap_socket(self, sock, context=None, **sslopts):
@@ -535,7 +534,7 @@ class SSLTransport(_AbstractTransport):
         server_side=False,
         cert_reqs=ssl.CERT_REQUIRED,
         ca_certs=None,
-        do_handshake_on_connect=False,
+        do_handshake_on_connect=True,
         suppress_ragged_eofs=True,
         server_hostname=None,
         ciphers=None,

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/_transport.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/_transport.py
@@ -591,6 +591,9 @@ class SSLTransport(_AbstractTransport):
             context.set_ciphers(ciphers)
 
         # Set SNI headers if supported
+        # This order is maintained here because ssl.PROTOCOL_TLS_CLIENT sets check_hostname to True
+        # and verify_mode to CERT_REQUIRED. If verify_mode needs to be CERT_NONE, then check_hostname
+        # needs to be disabled first. https://docs.python.org/3/library/ssl.html#ssl.SSLContext.check_hostname
         try:
             context.check_hostname = ssl.HAS_SNI and server_hostname is not None
         except AttributeError:

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/_transport.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/_transport.py
@@ -547,7 +547,6 @@ class SSLTransport(_AbstractTransport):
         :param socket.socket sock: socket to wrap
         :param str or None keyfile: key file path
         :param str or None certfile: cert file path
-        :param bool or None server_side: server side socket
         :param int cert_reqs: cert requirements
         :param str or None ca_certs: ca certs file path
         :param bool do_handshake_on_connect: do handshake on connect

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/_transport.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/_transport.py
@@ -577,9 +577,6 @@ class SSLTransport(_AbstractTransport):
             try:
                 context.load_verify_locations(ca_certs)
             except FileNotFoundError as exc:
-                # FileNotFoundError does not have missing filename info, so adding it below.
-                # since this is the only file path that users can pass in
-                # (`connection_verify` in the EH/SB clients) through opts above.
                 exc.filename = {"ca_certs": ca_certs}
                 raise exc from None
         elif context.verify_mode != ssl.CERT_NONE:

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/_transport.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/_transport.py
@@ -531,7 +531,6 @@ class SSLTransport(_AbstractTransport):
         sock,
         keyfile=None,
         certfile=None,
-        server_side=False,
         cert_reqs=ssl.CERT_REQUIRED,
         ca_certs=None,
         do_handshake_on_connect=True,
@@ -562,12 +561,11 @@ class SSLTransport(_AbstractTransport):
         # Setup the right SSL version; default to optimal versions across
         # ssl implementations
         if ssl_version is None:
-            ssl_version = ssl.PROTOCOL_TLS_SERVER if server_side else ssl.PROTOCOL_TLS_CLIENT
-        purpose = ssl.Purpose.CLIENT_AUTH if server_side else ssl.Purpose.SERVER_AUTH
+            ssl_version = ssl.PROTOCOL_TLS_CLIENT
+        purpose = ssl.Purpose.SERVER_AUTH
 
         opts = {
             "sock": sock,
-            "server_side": server_side,
             "do_handshake_on_connect": do_handshake_on_connect,
             "suppress_ragged_eofs": suppress_ragged_eofs,
             "server_hostname": server_hostname,

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/_transport.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/_transport.py
@@ -590,18 +590,18 @@ class SSLTransport(_AbstractTransport):
         if ciphers is not None:
             context.set_ciphers(ciphers)
 
+        if ca_certs is None and context.verify_mode != ssl.CERT_NONE:
+            # attempt to load the system wide CA certs
+            # we want to load certs for server authentication on the client side. 
+            # https://docs.python.org/3/library/ssl.html#ssl.SSLContext.load_default_certs
+            purpose = ssl.Purpose.CLIENT_AUTH if server_side else ssl.Purpose.SERVER_AUTH
+            context.load_default_certs(purpose=purpose)
+
         # Set SNI headers if supported
         try:
             context.check_hostname = ssl.HAS_SNI and server_hostname is not None
         except AttributeError:
             pass
-
-        if cert_reqs is not None:
-            context.verify_mode = cert_reqs
-
-        if ca_certs is None and context.verify_mode != ssl.CERT_NONE:
-            purpose = ssl.Purpose.CLIENT_AUTH if server_side else ssl.Purpose.SERVER_AUTH
-            context.load_default_certs(purpose=purpose)
 
         sock = context.wrap_socket(**opts)
         return sock

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/_transport.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/_transport.py
@@ -590,18 +590,21 @@ class SSLTransport(_AbstractTransport):
         if ciphers is not None:
             context.set_ciphers(ciphers)
 
+        # Set SNI headers if supported
+        try:
+            context.check_hostname = ssl.HAS_SNI and server_hostname is not None
+        except AttributeError:
+            pass
+
+        if cert_reqs is not None:
+            context.verify_mode = cert_reqs
+
         if ca_certs is None and context.verify_mode != ssl.CERT_NONE:
             # attempt to load the system wide CA certs
             # we want to load certs for server authentication on the client side. 
             # https://docs.python.org/3/library/ssl.html#ssl.SSLContext.load_default_certs
             purpose = ssl.Purpose.CLIENT_AUTH if server_side else ssl.Purpose.SERVER_AUTH
             context.load_default_certs(purpose=purpose)
-
-        # Set SNI headers if supported
-        try:
-            context.check_hostname = ssl.HAS_SNI and server_hostname is not None
-        except AttributeError:
-            pass
 
         sock = context.wrap_socket(**opts)
         return sock

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_transport_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_transport_async.py
@@ -186,7 +186,7 @@ class AsyncTransportMixin:
             ssl_version = sslopts.get("ssl_version")
             if ssl_version is None:
                 ssl_version = ssl.PROTOCOL_TLS_CLIENT
-            
+
             context = ssl.SSLContext(ssl_version)
 
             purpose = ssl.Purpose.SERVER_AUTH
@@ -203,7 +203,7 @@ class AsyncTransportMixin:
                     exc.filename = {"ca_certs": ca_certs}
                     raise exc from None
             elif context.verify_mode != ssl.CERT_NONE:
-                # load the default system root CA certs. 
+                # load the default system root CA certs.
                 context.load_default_certs(purpose=purpose)
 
             certfile = sslopts.get("certfile")

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_transport_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_transport_async.py
@@ -214,7 +214,7 @@ class AsyncTransportMixin:
 
             server_hostname = sslopts.get("server_hostname")
             cert_reqs = sslopts.get("cert_reqs", ssl.CERT_REQUIRED)
-            
+
             if cert_reqs == ssl.CERT_NONE and server_hostname is None:
                 context.check_hostname = False
                 context.verify_mode = cert_reqs
@@ -245,7 +245,7 @@ class AsyncTransport(
         host,
         *,
         port=AMQP_PORT,
-        ssl_opts=False,
+        ssl_opts=None,
         socket_settings=None,
         raise_on_initial_eintr=True,
         **kwargs,  # pylint: disable=unused-argument
@@ -259,8 +259,8 @@ class AsyncTransport(
         self.host, self.port = to_host_port(host, port)
         self.socket_settings = socket_settings
         self.socket_lock = asyncio.Lock()
-        self.sslopts = ssl_opts
-        self.sslopts['server_hostname'] = self.host
+        self.sslopts = ssl_opts if isinstance(ssl_opts, dict) else {}
+        self.sslopts['server_hostname'] = host
         self.network_trace_params = kwargs.get('network_trace_params')
 
     async def connect(self):

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_transport_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_transport_async.py
@@ -214,7 +214,6 @@ class AsyncTransportMixin:
 
             server_hostname = sslopts.get("server_hostname")
             cert_reqs = sslopts.get("cert_reqs", ssl.CERT_REQUIRED)
-
             if cert_reqs == ssl.CERT_NONE and server_hostname is None:
                 context.check_hostname = False
                 context.verify_mode = cert_reqs

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_transport_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_transport_async.py
@@ -245,7 +245,7 @@ class AsyncTransport(
         host,
         *,
         port=AMQP_PORT,
-        ssl_opts=None,
+        ssl_opts=False,
         socket_settings=None,
         raise_on_initial_eintr=True,
         **kwargs,  # pylint: disable=unused-argument
@@ -259,8 +259,7 @@ class AsyncTransport(
         self.host, self.port = to_host_port(host, port)
         self.socket_settings = socket_settings
         self.socket_lock = asyncio.Lock()
-        self.sslopts = ssl_opts if isinstance(ssl_opts, dict) else {}
-        self.sslopts['server_hostname'] = host
+        self.sslopts = ssl_opts
         self.network_trace_params = kwargs.get('network_trace_params')
 
     async def connect(self):

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_transport_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_transport_async.py
@@ -185,7 +185,7 @@ class AsyncTransportMixin:
                 return self._build_ssl_context(**sslopts.pop("context"))
             ssl_version = sslopts.get("ssl_version")
             if ssl_version is None:
-                ssl_version = ssl.PROTOCOL_TLS
+                ssl_version = ssl.PROTOCOL_TLS_CLIENT
 
             # Set SNI headers if supported
             server_hostname = sslopts.get("server_hostname")

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/_transport.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/_transport.py
@@ -580,7 +580,7 @@ class SSLTransport(_AbstractTransport):
                 exc.filename = {"ca_certs": ca_certs}
                 raise exc from None
         elif context.verify_mode != ssl.CERT_NONE:
-            # load the default system root CA certs. 
+            # load the default system root CA certs.
             context.load_default_certs(purpose=purpose)
 
         if certfile is not None:

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/_transport.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/_transport.py
@@ -510,7 +510,6 @@ class SSLTransport(_AbstractTransport):
     def _setup_transport(self):
         """Wrap the socket in an SSL object."""
         self.sock = self._wrap_socket(self.sock, **self.sslopts)
-        self.sock.do_handshake()
         self._quick_recv = self.sock.recv
 
     def _wrap_socket(self, sock, context=None, **sslopts):
@@ -535,7 +534,7 @@ class SSLTransport(_AbstractTransport):
         server_side=False,
         cert_reqs=ssl.CERT_REQUIRED,
         ca_certs=None,
-        do_handshake_on_connect=False,
+        do_handshake_on_connect=True,
         suppress_ragged_eofs=True,
         server_hostname=None,
         ciphers=None,

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/_transport.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/_transport.py
@@ -547,7 +547,6 @@ class SSLTransport(_AbstractTransport):
         :param socket.socket sock: socket to wrap
         :param str or None keyfile: key file path
         :param str or None certfile: cert file path
-        :param bool or None server_side: server side socket
         :param int cert_reqs: cert requirements
         :param str or None ca_certs: ca certs file path
         :param bool do_handshake_on_connect: do handshake on connect

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/_transport.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/_transport.py
@@ -562,44 +562,48 @@ class SSLTransport(_AbstractTransport):
         # Setup the right SSL version; default to optimal versions across
         # ssl implementations
         if ssl_version is None:
-            ssl_version = ssl.PROTOCOL_TLS
+            ssl_version = ssl.PROTOCOL_TLS_SERVER if server_side else ssl.PROTOCOL_TLS_CLIENT
 
         opts = {
             "sock": sock,
-            "keyfile": keyfile,
-            "certfile": certfile,
             "server_side": server_side,
-            "cert_reqs": cert_reqs,
-            "ca_certs": ca_certs,
             "do_handshake_on_connect": do_handshake_on_connect,
             "suppress_ragged_eofs": suppress_ragged_eofs,
-            "ciphers": ciphers,
-            #'ssl_version': ssl_version
+            "server_hostname": server_hostname,
         }
 
-        # TODO: We need to refactor this.
-        try:
-            sock = ssl.wrap_socket(**opts)  # pylint: disable=deprecated-method
-        except FileNotFoundError as exc:
-            # FileNotFoundError does not have missing filename info, so adding it below.
-            # Assuming that this must be ca_certs, since this is the only file path that
-            # users can pass in (`connection_verify` in the EH/SB clients) through opts above.
-            # For uamqp exception parity. Remove later when resolving issue #27128.
-            exc.filename = {"ca_certs": ca_certs}
-            raise exc
+        context = ssl.SSLContext(ssl_version)
+
+        if certfile is not None:
+            context.load_cert_chain(certfile, keyfile)
+
+        if ca_certs is not None:
+            try:
+                context.load_verify_locations(ca_certs)
+            except FileNotFoundError as exc:
+                # FileNotFoundError does not have missing filename info, so adding it below.
+                # since this is the only file path that users can pass in
+                # (`connection_verify` in the EH/SB clients) through opts above.
+                exc.filename = {"ca_certs": ca_certs}
+                raise exc from None
+
+        if ciphers is not None:
+            context.set_ciphers(ciphers)
+
+        if ca_certs is None and context.verify_mode != ssl.CERT_NONE:
+            # attempt to load the system wide CA certs
+            # we want to load certs for server authentication on the client side. 
+            # https://docs.python.org/3/library/ssl.html#ssl.SSLContext.load_default_certs
+            purpose = ssl.Purpose.CLIENT_AUTH if server_side else ssl.Purpose.SERVER_AUTH
+            context.load_default_certs(purpose=purpose)
+
         # Set SNI headers if supported
-        if (
-            (server_hostname is not None)
-            and (hasattr(ssl, "HAS_SNI") and ssl.HAS_SNI)
-            and (hasattr(ssl, "SSLContext"))
-        ):
-            context = ssl.SSLContext(opts["ssl_version"])
-            context.verify_mode = cert_reqs
-            if cert_reqs != ssl.CERT_NONE:
-                context.check_hostname = True
-            if (certfile is not None) and (keyfile is not None):
-                context.load_cert_chain(certfile, keyfile)
-            sock = context.wrap_socket(sock, server_hostname=server_hostname)
+        try:
+            context.check_hostname = ssl.HAS_SNI and server_hostname is not None
+        except AttributeError:
+            pass
+
+        sock = context.wrap_socket(**opts)
         return sock
 
     def _shutdown_transport(self):

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/_transport.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/_transport.py
@@ -577,9 +577,6 @@ class SSLTransport(_AbstractTransport):
             try:
                 context.load_verify_locations(ca_certs)
             except FileNotFoundError as exc:
-                # FileNotFoundError does not have missing filename info, so adding it below.
-                # since this is the only file path that users can pass in
-                # (`connection_verify` in the EH/SB clients) through opts above.
                 exc.filename = {"ca_certs": ca_certs}
                 raise exc from None
         elif context.verify_mode != ssl.CERT_NONE:

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/_transport.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/_transport.py
@@ -531,7 +531,6 @@ class SSLTransport(_AbstractTransport):
         sock,
         keyfile=None,
         certfile=None,
-        server_side=False,
         cert_reqs=ssl.CERT_REQUIRED,
         ca_certs=None,
         do_handshake_on_connect=True,
@@ -562,12 +561,11 @@ class SSLTransport(_AbstractTransport):
         # Setup the right SSL version; default to optimal versions across
         # ssl implementations
         if ssl_version is None:
-            ssl_version = ssl.PROTOCOL_TLS_SERVER if server_side else ssl.PROTOCOL_TLS_CLIENT
-        purpose = ssl.Purpose.CLIENT_AUTH if server_side else ssl.Purpose.SERVER_AUTH
+            ssl_version = ssl.PROTOCOL_TLS_CLIENT
+        purpose = ssl.Purpose.SERVER_AUTH
 
         opts = {
             "sock": sock,
-            "server_side": server_side,
             "do_handshake_on_connect": do_handshake_on_connect,
             "suppress_ragged_eofs": suppress_ragged_eofs,
             "server_hostname": server_hostname,

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/_transport.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/_transport.py
@@ -501,6 +501,7 @@ class SSLTransport(_AbstractTransport):
         self, host, *, port=AMQPS_PORT, socket_timeout=None, ssl_opts=None, **kwargs
     ):
         self.sslopts = ssl_opts if isinstance(ssl_opts, dict) else {}
+        self.sslopts['server_hostname'] = host
         self._read_buffer = BytesIO()
         super(SSLTransport, self).__init__(
             host, port=port, socket_timeout=socket_timeout, **kwargs
@@ -563,6 +564,7 @@ class SSLTransport(_AbstractTransport):
         # ssl implementations
         if ssl_version is None:
             ssl_version = ssl.PROTOCOL_TLS_SERVER if server_side else ssl.PROTOCOL_TLS_CLIENT
+        purpose = ssl.Purpose.CLIENT_AUTH if server_side else ssl.Purpose.SERVER_AUTH
 
         opts = {
             "sock": sock,
@@ -574,9 +576,6 @@ class SSLTransport(_AbstractTransport):
 
         context = ssl.SSLContext(ssl_version)
 
-        if certfile is not None:
-            context.load_cert_chain(certfile, keyfile)
-
         if ca_certs is not None:
             try:
                 context.load_verify_locations(ca_certs)
@@ -586,25 +585,19 @@ class SSLTransport(_AbstractTransport):
                 # (`connection_verify` in the EH/SB clients) through opts above.
                 exc.filename = {"ca_certs": ca_certs}
                 raise exc from None
+        elif context.verify_mode != ssl.CERT_NONE:
+            # load the default system root CA certs. 
+            context.load_default_certs(purpose=purpose)
+
+        if certfile is not None:
+            context.load_cert_chain(certfile, keyfile)
 
         if ciphers is not None:
             context.set_ciphers(ciphers)
 
-        # Set SNI headers if supported
-        try:
-            context.check_hostname = ssl.HAS_SNI and server_hostname is not None
-        except AttributeError:
-            pass
-
-        if cert_reqs is not None:
+        if cert_reqs == ssl.CERT_NONE and server_hostname is None:
+            context.check_hostname = False
             context.verify_mode = cert_reqs
-
-        if ca_certs is None and context.verify_mode != ssl.CERT_NONE:
-            # attempt to load the system wide CA certs
-            # we want to load certs for server authentication on the client side. 
-            # https://docs.python.org/3/library/ssl.html#ssl.SSLContext.load_default_certs
-            purpose = ssl.Purpose.CLIENT_AUTH if server_side else ssl.Purpose.SERVER_AUTH
-            context.load_default_certs(purpose=purpose)
 
         sock = context.wrap_socket(**opts)
         return sock

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/_transport.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/_transport.py
@@ -590,18 +590,21 @@ class SSLTransport(_AbstractTransport):
         if ciphers is not None:
             context.set_ciphers(ciphers)
 
+        # Set SNI headers if supported
+        try:
+            context.check_hostname = ssl.HAS_SNI and server_hostname is not None
+        except AttributeError:
+            pass
+
+        if cert_reqs is not None:
+            context.verify_mode = cert_reqs
+
         if ca_certs is None and context.verify_mode != ssl.CERT_NONE:
             # attempt to load the system wide CA certs
             # we want to load certs for server authentication on the client side. 
             # https://docs.python.org/3/library/ssl.html#ssl.SSLContext.load_default_certs
             purpose = ssl.Purpose.CLIENT_AUTH if server_side else ssl.Purpose.SERVER_AUTH
             context.load_default_certs(purpose=purpose)
-
-        # Set SNI headers if supported
-        try:
-            context.check_hostname = ssl.HAS_SNI and server_hostname is not None
-        except AttributeError:
-            pass
 
         sock = context.wrap_socket(**opts)
         return sock

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_transport_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_transport_async.py
@@ -244,7 +244,7 @@ class AsyncTransport(
         host,
         *,
         port=AMQP_PORT,
-        ssl_opts=None,
+        ssl_opts=False,
         socket_settings=None,
         raise_on_initial_eintr=True,
         **kwargs,  # pylint: disable=unused-argument
@@ -258,8 +258,7 @@ class AsyncTransport(
         self.host, self.port = to_host_port(host, port)
         self.socket_settings = socket_settings
         self.socket_lock = asyncio.Lock()
-        self.sslopts = ssl_opts if isinstance(ssl_opts, dict) else {}
-        self.sslopts['server_hostname'] = host
+        self.sslopts = ssl_opts
         self.network_trace_params = kwargs.get('network_trace_params')
 
     async def connect(self):

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_transport_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_transport_async.py
@@ -186,7 +186,7 @@ class AsyncTransportMixin:
             ssl_version = sslopts.get("ssl_version")
             if ssl_version is None:
                 ssl_version = ssl.PROTOCOL_TLS_CLIENT
-            
+
             context = ssl.SSLContext(ssl_version)
 
             purpose = ssl.Purpose.SERVER_AUTH
@@ -203,7 +203,7 @@ class AsyncTransportMixin:
                     exc.filename = {"ca_certs": ca_certs}
                     raise exc from None
             elif context.verify_mode != ssl.CERT_NONE:
-                # load the default system root CA certs. 
+                # load the default system root CA certs.
                 context.load_default_certs(purpose=purpose)
 
             certfile = sslopts.get("certfile")

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_transport_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_transport_async.py
@@ -214,7 +214,6 @@ class AsyncTransportMixin:
 
             server_hostname = sslopts.get("server_hostname")
             cert_reqs = sslopts.get("cert_reqs", ssl.CERT_REQUIRED)
-            
             if cert_reqs == ssl.CERT_NONE and server_hostname is None:
                 context.check_hostname = False
                 context.verify_mode = cert_reqs
@@ -245,7 +244,7 @@ class AsyncTransport(
         host,
         *,
         port=AMQP_PORT,
-        ssl_opts=False,
+        ssl_opts=None,
         socket_settings=None,
         raise_on_initial_eintr=True,
         **kwargs,  # pylint: disable=unused-argument
@@ -259,8 +258,8 @@ class AsyncTransport(
         self.host, self.port = to_host_port(host, port)
         self.socket_settings = socket_settings
         self.socket_lock = asyncio.Lock()
-        self.sslopts = ssl_opts
-        self.sslopts['server_hostname'] = self.host
+        self.sslopts = ssl_opts if isinstance(ssl_opts, dict) else {}
+        self.sslopts['server_hostname'] = host
         self.network_trace_params = kwargs.get('network_trace_params')
 
     async def connect(self):

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_transport_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_transport_async.py
@@ -185,7 +185,7 @@ class AsyncTransportMixin:
                 return self._build_ssl_context(**sslopts.pop("context"))
             ssl_version = sslopts.get("ssl_version")
             if ssl_version is None:
-                ssl_version = ssl.PROTOCOL_TLS
+                ssl_version = ssl.PROTOCOL_TLS_CLIENT
 
             # Set SNI headers if supported
             server_hostname = sslopts.get("server_hostname")


### PR DESCRIPTION
Closes #25434

* This PR removes the deprecated [`ssl.wrap_socket`](https://docs.python.org/3/library/ssl.html#ssl.wrap_socket) and replaces it with [`SSLContext.wrap_socket`](https://docs.python.org/3/library/ssl.html#ssl.SSLContext.wrap_socket)
* `ssl_version` also now uses either `PROTOCOL_TLS_CLIENT` or `PROTOCOL_TLS_SERVER`. [`PROTOCOL_TLS`](https://docs.python.org/3/library/ssl.html#ssl.PROTOCOL_TLS) will be deprecated in py3.10 and its preferable to use the other values
* Refactored some of the custom ssl  context code to make it cleaner and be the same across sync / async.