### PR TITLE
[Cosmos] api review changes

### DIFF
--- a/sdk/cosmos/azure-cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos/CHANGELOG.md
@@ -10,6 +10,7 @@
 #### Bugs Fixed
 
 #### Other Changes
+* Renamed `response_continuation_token_limit_in_kb` to `continuation_token_limit` for GA. See [PR 31532](https://github.com/Azure/azure-sdk-for-python/pull/31532).
 
 ### 4.4.1b1 (2023-07-25)
 

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_container.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_container.py
@@ -320,7 +320,7 @@ class ContainerProxy(object):
         :keyword dict[str, str] initial_headers: Initial headers to be sent as part of the request.
         :keyword response_hook: A callable invoked with the response metadata.
         :paramtype response_hook: Callable[[Dict[str, str], AsyncItemPaged[Dict[str, Any]]], None]
-        :keyword int response_continuation_token_limit_in_kb: **provisional keyword** The size limit in kb of the
+        :keyword int continuation_token_limit: **provisional keyword** The size limit in kb of the
         response continuation token in the query response. Valid values are positive integers.
         A value of 0 is the same as not passing a value (default no limit).
         :keyword int max_integrated_cache_staleness_in_ms: The max cache staleness for the integrated cache in
@@ -369,9 +369,9 @@ class ContainerProxy(object):
             feed_options["maxIntegratedCacheStaleness"] = max_integrated_cache_staleness_in_ms
         correlated_activity_id = GenerateGuidId()
         feed_options["correlatedActivityId"] = correlated_activity_id
-        response_continuation_token_limit_in_kb = kwargs.pop("response_continuation_token_limit_in_kb", None)
-        if response_continuation_token_limit_in_kb is not None:
-            feed_options["responseContinuationTokenLimitInKb"] = response_continuation_token_limit_in_kb
+        continuation_token_limit = kwargs.pop("continuation_token_limit", None)
+        if continuation_token_limit is not None:
+            feed_options["responseContinuationTokenLimitInKb"] = continuation_token_limit
         if hasattr(response_hook, "clear"):
             response_hook.clear()
 

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/container.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/container.py
@@ -354,7 +354,7 @@ class ContainerProxy(object):
         :keyword str session_token: Token for use with Session consistency.
         :keyword dict[str,str] initial_headers: Initial headers to be sent as part of the request.
         :keyword Callable response_hook: A callable invoked with the response metadata.
-        :keyword int response_continuation_token_limit_in_kb: **provisional keyword** The size limit in kb of the
+        :keyword int continuation_token_limit: **provisional keyword** The size limit in kb of the
         response continuation token in the query response. Valid values are positive integers.
         A value of 0 is the same as not passing a value (default no limit).
         :keyword int max_integrated_cache_staleness_in_ms: The max cache staleness for the integrated cache in
@@ -399,9 +399,9 @@ class ContainerProxy(object):
             feed_options["maxIntegratedCacheStaleness"] = max_integrated_cache_staleness_in_ms
         correlated_activity_id = GenerateGuidId()
         feed_options["correlatedActivityId"] = correlated_activity_id
-        response_continuation_token_limit_in_kb = kwargs.pop("response_continuation_token_limit_in_kb", None)
-        if response_continuation_token_limit_in_kb is not None:
-            feed_options["responseContinuationTokenLimitInKb"] = response_continuation_token_limit_in_kb
+        continuation_token_limit = kwargs.pop("continuation_token_limit", None)
+        if continuation_token_limit is not None:
+            feed_options["responseContinuationTokenLimitInKb"] = continuation_token_limit
         if hasattr(response_hook, "clear"):
             response_hook.clear()
 

--- a/sdk/cosmos/azure-cosmos/samples/document_management.py
+++ b/sdk/cosmos/azure-cosmos/samples/document_management.py
@@ -227,11 +227,11 @@ def query_items_with_continuation_token_size_limit(container, doc_id):
     sales_order = get_sales_order(doc_id)
     container.create_item(body=sales_order)
 
-    # set response_continuation_token_limit_in_kb to 8 to limit size to 8KB
+    # set continuation_token_limit to 8 to limit size to 8KB
     items = list(container.query_items(
         query="SELECT * FROM r",
         partition_key=doc_id,
-        response_continuation_token_limit_in_kb=size_limit_in_kb
+        continuation_token_limit=size_limit_in_kb
     ))
 
     print('Continuation Token size has been limited to {}KB.'.format(size_limit_in_kb))

--- a/sdk/cosmos/azure-cosmos/samples/document_management_async.py
+++ b/sdk/cosmos/azure-cosmos/samples/document_management_async.py
@@ -246,11 +246,11 @@ async def query_items_with_continuation_token_size_limit(container, doc_id):
     sales_order = get_sales_order(doc_id)
     await container.create_item(body=sales_order)
 
-    # set response_continuation_token_limit_in_kb to 8 to limit size to 8KB
+    # set continuation_token_limit to 8 to limit size to 8KB
     items = container.query_items(
         query="SELECT * FROM r",
         partition_key=doc_id,
-        response_continuation_token_limit_in_kb=size_limit_in_kb
+        continuation_token_limit=size_limit_in_kb
     )
 
     print('Continuation Token size has been limited to {}KB.'.format(size_limit_in_kb))

--- a/sdk/cosmos/azure-cosmos/test/test_query.py
+++ b/sdk/cosmos/azure-cosmos/test/test_query.py
@@ -736,7 +736,7 @@ class QueryTest(unittest.TestCase):
             container.create_item(body=dict(pk='123', id=str(i), some_value=str(i % 3)))
         query = "Select * from c where c.some_value='2'"
         response_query = container.query_items(query, partition_key='123', max_item_count=100,
-                                               response_continuation_token_limit_in_kb=1)
+                                               continuation_token_limit=1)
         pager = response_query.by_page()
         pager.next()
         token = pager.continuation_token

--- a/sdk/cosmos/azure-cosmos/test/test_query_async.py
+++ b/sdk/cosmos/azure-cosmos/test/test_query_async.py
@@ -733,7 +733,7 @@ class QueryTest(unittest.TestCase):
             await container.create_item(body=dict(pk='123', id=str(i), some_value=str(i % 3)))
         query = "Select * from c where c.some_value='2'"
         response_query = container.query_items(query, partition_key='123', max_item_count=100,
-                                               response_continuation_token_limit_in_kb=1)
+                                               continuation_token_limit=1)
         pager = response_query.by_page()
         await pager.__anext__()
         token = pager.continuation_token


### PR DESCRIPTION
Renaming the variable for its shorter variant - since it is a key word argument, users who use this option would have found it through our CHANGELOG or through the typehint explaining what it does, and as such we do not need the rest of the name.