### PR TITLE
update nlp tests to use prod components

### DIFF
--- a/sdk/ml/azure-ai-ml/tests/automl_job/e2etests/test_remote_text_classification.py
+++ b/sdk/ml/azure-ai-ml/tests/automl_job/e2etests/test_remote_text_classification.py
@@ -25,20 +25,13 @@ class TestTextClassification(AzureRecordedTestCase):
     ) -> None:
         training_data, validation_data, target_column_name = newsgroup
 
-        properties = get_automl_job_properties()
-        if components:
-            properties["_automl_subgraph_orchestration"] = "true"
-            properties["_pipeline_id_override"] = (
-                "azureml://registries/azmlft-dev-registry01/" "components/nlp_textclassification_multiclass"
-            )
-
         job = text_classification(
             training_data=training_data,
             validation_data=validation_data,
             target_column_name=target_column_name,
             compute="gpu-cluster",
             experiment_name="DPv2-text-classification",
-            properties=properties,
+            properties=get_automl_job_properties(),
         )
 
         # use component specific model name so that the test fails if components are not run

--- a/sdk/ml/azure-ai-ml/tests/automl_job/e2etests/test_remote_text_classification_multilabel.py
+++ b/sdk/ml/azure-ai-ml/tests/automl_job/e2etests/test_remote_text_classification_multilabel.py
@@ -25,20 +25,13 @@ class TestTextClassificationMultilabel(AzureRecordedTestCase):
     ) -> None:
         training_data, validation_data, target_column_name = paper_categorization
 
-        properties = get_automl_job_properties()
-        if components:
-            properties["_automl_subgraph_orchestration"] = "true"
-            properties[
-                "_pipeline_id_override"
-            ] = "azureml://registries/azmlft-dev-registry01/components/nlp_textclassification_multilabel"
-
         job = text_classification_multilabel(
             training_data=training_data,
             validation_data=validation_data,
             target_column_name=target_column_name,
             compute="gpu-cluster",
             experiment_name="DPv2-text-classification-multilabel",
-            properties=properties,
+            properties=get_automl_job_properties(),
         )
 
         # use component specific model name so that the test fails if components are not run

--- a/sdk/ml/azure-ai-ml/tests/automl_job/e2etests/test_remote_text_ner.py
+++ b/sdk/ml/azure-ai-ml/tests/automl_job/e2etests/test_remote_text_ner.py
@@ -23,19 +23,12 @@ class TestTextNer(AzureRecordedTestCase):
     def test_remote_run_text_ner(self, conll: Tuple[Input, Input], client: MLClient, components: bool) -> None:
         training_data, validation_data = conll
 
-        properties = get_automl_job_properties()
-        if components:
-            properties["_automl_subgraph_orchestration"] = "true"
-            properties[
-                "_pipeline_id_override"
-            ] = "azureml://registries/azmlft-dev-registry01/components/nlp_textclassification_ner"
-
         job = text_ner(
             training_data=training_data,
             validation_data=validation_data,
             compute="gpu-cluster",
             experiment_name="DPv2-text-ner",
-            properties=properties,
+            properties=get_automl_job_properties(),
         )
 
         # use component specific model name so that the test fails if components are not run


### PR DESCRIPTION
# Description

This PR removes the _pipeline_id_override flag because the JOS release that points to NLP prod components has progressed to prod regions. The tests will launch component runs because they use a huggingface model for component tests.

Test Runs:
**Scenario** | **Run**
--------------|----------
**Multilabel**|
runtime | [run](https://ml.azure.com/runs/placid_oyster_jq9r67k6p8?wsid=/subscriptions/dbd697c3-ef40-488f-83e6-5ad4dfb78f9b/resourceGroups/rbhimani-rg/providers/Microsoft.MachineLearningServices/workspaces/rbhimani-eastus&tid=72f988bf-86f1-41af-91ab-2d7cd011db47)
components | [run](https://ml.azure.com/runs/boring_longan_bl7snx298x?wsid=/subscriptions/dbd697c3-ef40-488f-83e6-5ad4dfb78f9b/resourceGroups/rbhimani-rg/providers/Microsoft.MachineLearningServices/workspaces/rbhimani-eastus&tid=72f988bf-86f1-41af-91ab-2d7cd011db47)
**Multiclass**|
runtime | [run](https://ml.azure.com/experiments/id/713d5f11-c914-4cb8-9a18-0297dd49216c/runs/hungry_lychee_8dxvttyr0z?wsid=/subscriptions/dbd697c3-ef40-488f-83e6-5ad4dfb78f9b/resourceGroups/rbhimani-rg/providers/Microsoft.MachineLearningServices/workspaces/rbhimani-eastus&tid=72f988bf-86f1-41af-91ab-2d7cd011db47)
components | [run](https://ml.azure.com/runs/khaki_nerve_b2dbd76wsn?wsid=/subscriptions/dbd697c3-ef40-488f-83e6-5ad4dfb78f9b/resourceGroups/rbhimani-rg/providers/Microsoft.MachineLearningServices/workspaces/rbhimani-eastus&tid=72f988bf-86f1-41af-91ab-2d7cd011db47)
**NER**|
runtime | [run](https://ml.azure.com/runs/nifty_beet_4qtvdr683h?wsid=/subscriptions/dbd697c3-ef40-488f-83e6-5ad4dfb78f9b/resourceGroups/rbhimani-rg/providers/Microsoft.MachineLearningServices/workspaces/rbhimani-eastus&tid=72f988bf-86f1-41af-91ab-2d7cd011db47)
components | [run](https://ml.azure.com/runs/ivory_steelpan_yj25mh2qc0?wsid=/subscriptions/dbd697c3-ef40-488f-83e6-5ad4dfb78f9b/resourceGroups/rbhimani-rg/providers/Microsoft.MachineLearningServices/workspaces/rbhimani-eastus&tid=72f988bf-86f1-41af-91ab-2d7cd011db47) <br> Note: this run fails because the ner preprocess component is unable to handle the data input. <br>This should be fixed on the component side and should not be a blocker for this PR, <br> because the correct component from azureml registry is picked up and the classification preprocess components are able to handle the data input.

If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
