### PR TITLE
[Identity] Small improvements

### DIFF
--- a/sdk/identity/azure-identity/CHANGELOG.md
+++ b/sdk/identity/azure-identity/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 - Ensure `AzurePowershellCredential` calls PowerShell with the `-NoProfile` flag to avoid loading user profiles for more consistent behavior.  ([#31682](https://github.com/Azure/azure-sdk-for-python/pull/31682))
 - Fixed an issue with subprocess-based developer credentials (such as AzureCliCredential) where the process would sometimes hang waiting for user input.  ([#31534](https://github.com/Azure/azure-sdk-for-python/pull/31534))
+- Fixed an issue with `ClientAssertionCredential` not properly checking if CAE should be enabled.  ([#31544](https://github.com/Azure/azure-sdk-for-python/pull/31544))
 
 ### Other Changes
 

--- a/sdk/identity/azure-identity/azure/identity/_internal/aad_client.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/aad_client.py
@@ -43,7 +43,7 @@ class AadClient(AadClientBase):
         return self._run_pipeline(request, **kwargs)
 
     def obtain_token_by_jwt_assertion(self, scopes: Iterable[str], assertion: str, **kwargs: Any) -> AccessToken:
-        request = self._get_jwt_assertion_request(scopes, assertion)
+        request = self._get_jwt_assertion_request(scopes, assertion, **kwargs)
         return self._run_pipeline(request, **kwargs)
 
     def obtain_token_by_refresh_token(self, scopes: Iterable[str], refresh_token: str, **kwargs: Any) -> AccessToken:
@@ -68,6 +68,7 @@ class AadClient(AadClientBase):
         # tenant_id is already part of `request` at this point
         kwargs.pop("tenant_id", None)
         kwargs.pop("claims", None)
+        enable_cae = kwargs.pop("enable_cae", False)
         now = int(time.time())
         response = self._pipeline.run(request, retry_on_methods=self._POST, **kwargs)
-        return self._process_response(response, now, **kwargs)
+        return self._process_response(response, now, enable_cae=enable_cae, **kwargs)

--- a/sdk/identity/azure-identity/azure/identity/_internal/client_credential_base.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/client_credential_base.py
@@ -20,6 +20,7 @@ class ClientCredentialBase(MsalCredential, GetTokenMixin):
     def _acquire_token_silently(self, *scopes: str, **kwargs: Any) -> Optional[AccessToken]:
         app = self._get_app(**kwargs)
         request_time = int(time.time())
+        kwargs.pop("enable_cae", None)
         result = app.acquire_token_silent_with_error(
             list(scopes), account=None, claims_challenge=kwargs.pop("claims", None), **kwargs
         )

--- a/sdk/identity/azure-identity/azure/identity/_internal/client_credential_base.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/client_credential_base.py
@@ -3,7 +3,7 @@
 # Licensed under the MIT License.
 # ------------------------------------
 import time
-from typing import Any, Optional
+from typing import Any, Optional, Dict
 
 from azure.core.credentials import AccessToken
 from azure.core.exceptions import ClientAuthenticationError
@@ -13,6 +13,12 @@ from . import wrap_exceptions
 from .msal_credentials import MsalCredential
 
 
+def _get_known_kwargs(kwargs: Dict[str, Any]):
+    # Remove kwargs not expected by MSAL. These aren't typically passed by users, but this is a precaution.
+    known_kwargs = {"force_refresh", "authority", "correlation_id", "data"}
+    return {k: v for k, v in kwargs.items() if k in known_kwargs}
+
+
 class ClientCredentialBase(MsalCredential, GetTokenMixin):
     """Base class for credentials authenticating a service principal with a certificate or secret"""
 
@@ -20,9 +26,8 @@ class ClientCredentialBase(MsalCredential, GetTokenMixin):
     def _acquire_token_silently(self, *scopes: str, **kwargs: Any) -> Optional[AccessToken]:
         app = self._get_app(**kwargs)
         request_time = int(time.time())
-        kwargs.pop("enable_cae", None)
         result = app.acquire_token_silent_with_error(
-            list(scopes), account=None, claims_challenge=kwargs.pop("claims", None), **kwargs
+            list(scopes), account=None, claims_challenge=kwargs.pop("claims", None), **_get_known_kwargs(kwargs)
         )
         if result and "access_token" in result and "expires_in" in result:
             return AccessToken(result["access_token"], request_time + int(result["expires_in"]))

--- a/sdk/identity/azure-identity/azure/identity/aio/_internal/aad_client.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_internal/aad_client.py
@@ -48,7 +48,7 @@ class AadClient(AadClientBase):
         return await self._run_pipeline(request, **kwargs)
 
     async def obtain_token_by_jwt_assertion(self, scopes: Iterable[str], assertion: str, **kwargs) -> AccessToken:
-        request = self._get_jwt_assertion_request(scopes, assertion)
+        request = self._get_jwt_assertion_request(scopes, assertion, **kwargs)
         return await self._run_pipeline(request, stream=False, **kwargs)
 
     async def obtain_token_by_refresh_token(self, scopes: Iterable[str], refresh_token: str, **kwargs) -> AccessToken:


### PR DESCRIPTION
- Ensure the `enable_cae` isn't passed in to msal through kwargs. There was only one spot where this was the case.
- Ensure kwargs are passed through to _get_jwt_assertion_request so that enable_cae can be properly detected.
- Pop `enable_cae` for sync pipeline runner. This mirrors the behavior of the async pipeline runner.