### PR TITLE
not pass enable_cae

### DIFF
--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -1,16 +1,10 @@
 # Release History
 
-## 1.29.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 1.29.1 (2023-08-09)
 
 ### Bugs Fixed
 
 - Not pass `enabled_cae` unless it is explicitly enabled.
-
-### Other Changes
 
 ## 1.29.0 (2023-08-03)
 

--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Not pass `enabled_cae` unless it is explicitly enabled.
+
 ### Other Changes
 
 ## 1.29.0 (2023-08-03)

--- a/sdk/core/azure-core/azure/core/pipeline/policies/_authentication.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/_authentication.py
@@ -93,7 +93,10 @@ class BearerTokenCredentialPolicy(_BearerTokenCredentialPolicyBase, HTTPPolicy[H
         self._enforce_https(request)
 
         if self._token is None or self._need_new_token:
-            self._token = self._credential.get_token(*self._scopes, enable_cae=self._enable_cae)
+            if self._enable_cae:
+                self._token = self._credential.get_token(*self._scopes, enable_cae=self._enable_cae)
+            else:
+                self._token = self._credential.get_token(*self._scopes)
         self._update_headers(request.http_request.headers, self._token.token)
 
     def authorize_request(self, request: PipelineRequest[HTTPRequestType], *scopes: str, **kwargs) -> None:
@@ -105,7 +108,8 @@ class BearerTokenCredentialPolicy(_BearerTokenCredentialPolicyBase, HTTPPolicy[H
         :param ~azure.core.pipeline.PipelineRequest request: the request
         :param str scopes: required scopes of authentication
         """
-        kwargs.setdefault("enable_cae", self._enable_cae)
+        if self._enable_cae:
+            kwargs.setdefault("enable_cae", self._enable_cae)
         self._token = self._credential.get_token(*scopes, **kwargs)
         self._update_headers(request.http_request.headers, self._token.token)
 

--- a/sdk/core/azure-core/azure/core/pipeline/policies/_authentication_async.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/_authentication_async.py
@@ -56,9 +56,12 @@ class AsyncBearerTokenCredentialPolicy(AsyncHTTPPolicy[HTTPRequestType, AsyncHTT
             async with self._lock:
                 # double check because another coroutine may have acquired a token while we waited to acquire the lock
                 if self._token is None or self._need_new_token():
-                    self._token = await await_result(
-                        self._credential.get_token, *self._scopes, enable_cae=self._enable_cae
-                    )
+                    if self._enable_cae:
+                        self._token = await await_result(
+                            self._credential.get_token, *self._scopes, enable_cae=self._enable_cae
+                        )
+                    else:
+                        self._token = await await_result(self._credential.get_token, *self._scopes)
         request.http_request.headers["Authorization"] = "Bearer " + cast(AccessToken, self._token).token
 
     async def authorize_request(self, request: PipelineRequest[HTTPRequestType], *scopes: str, **kwargs: Any) -> None:
@@ -70,7 +73,8 @@ class AsyncBearerTokenCredentialPolicy(AsyncHTTPPolicy[HTTPRequestType, AsyncHTT
         :param ~azure.core.pipeline.PipelineRequest request: the request
         :param str scopes: required scopes of authentication
         """
-        kwargs.setdefault("enable_cae", self._enable_cae)
+        if self._enable_cae:
+            kwargs.setdefault("enable_cae", self._enable_cae)
         async with self._lock:
             self._token = await await_result(self._credential.get_token, *scopes, **kwargs)
         request.http_request.headers["Authorization"] = "Bearer " + cast(AccessToken, self._token).token

--- a/sdk/core/azure-core/tests/test_authentication.py
+++ b/sdk/core/azure-core/tests/test_authentication.py
@@ -152,7 +152,7 @@ def test_bearer_policy_default_context(http_request):
 
     pipeline.run(http_request("GET", "https://localhost"))
 
-    credential.get_token.assert_called_once_with(expected_scope, enable_cae=False)
+    credential.get_token.assert_called_once_with(expected_scope)
 
 
 @pytest.mark.parametrize("http_request", HTTP_REQUESTS)
@@ -222,7 +222,7 @@ def test_bearer_policy_cannot_complete_challenge(http_request):
 
     assert response.http_response is expected_response
     assert transport.send.call_count == 1
-    credential.get_token.assert_called_once_with(expected_scope, enable_cae=False)
+    credential.get_token.assert_called_once_with(expected_scope)
 
 
 @pytest.mark.parametrize("http_request", HTTP_REQUESTS)


### PR DESCRIPTION
Unfortunately, we have 
```py
result = self.acquire_token_silent_with_error(list(scopes), self._account, claims_challenge=claims, **kwargs)
```
in cli.

Changed to not pass in `enable_cae` unless it is explicitly on to make some time for cli to fix the code.