### PR TITLE
add tests.yml for azure-core

### DIFF
--- a/sdk/core/tests.yml
+++ b/sdk/core/tests.yml
@@ -1,0 +1,6 @@
+trigger: none
+
+stages:
+  - template: /eng/pipelines/templates/stages/archetype-sdk-tests.yml
+    parameters:
+      ServiceDirectory: core


### PR DESCRIPTION
Adds live and weekly test pipelines for azure-core. Main motivation is to get the typing/linting next checks from the weekly job to run on core regularly.