### PR TITLE
[engsys] fix: Dont skip code formatting validation when `pylint` is disabled.

### DIFF
--- a/eng/pipelines/templates/steps/run_black.yml
+++ b/eng/pipelines/templates/steps/run_black.yml
@@ -23,4 +23,4 @@ steps:
         --service_directory="${{ parameters.ServiceDirectory }}"
         --validate="${{ parameters.ValidateFormatting }}"
     env: ${{ parameters.EnvVars }}
-    condition: and(succeededOrFailed(), ne(variables['Skip.Pylint'],'true'))
+    condition: succeededOrFailed()

--- a/sdk/agrifood/azure-agrifood-farming/pyproject.toml
+++ b/sdk/agrifood/azure-agrifood-farming/pyproject.toml
@@ -1,6 +1,7 @@
 [tool.azure-sdk-build]
 mypy = false
 pylint = false
+black = false
 pyright = false
 type_check_samples = false
 verifytypes = false

--- a/sdk/anomalydetector/azure-ai-anomalydetector/pyproject.toml
+++ b/sdk/anomalydetector/azure-ai-anomalydetector/pyproject.toml
@@ -1,6 +1,7 @@
 [tool.azure-sdk-build]
 mypy = false
 pylint = false
+black = false
 pyright = false
 type_check_samples = false
 verifytypes = false

--- a/sdk/attestation/azure-security-attestation/pyproject.toml
+++ b/sdk/attestation/azure-security-attestation/pyproject.toml
@@ -1,6 +1,7 @@
 [tool.azure-sdk-build]
 mypy = false
 pylint = false
+black = false
 pyright = false
 type_check_samples = false
 verifytypes = false

--- a/sdk/batch/azure-batch/pyproject.toml
+++ b/sdk/batch/azure-batch/pyproject.toml
@@ -1,6 +1,7 @@
 [tool.azure-sdk-build]
 mypy = false
 pylint = false
+black = false
 pyright = false
 type_check_samples = false
 verifytypes = false

--- a/sdk/cognitiveservices/azure-cognitiveservices-anomalydetector/pyproject.toml
+++ b/sdk/cognitiveservices/azure-cognitiveservices-anomalydetector/pyproject.toml
@@ -1,2 +1,3 @@
 [tool.azure-sdk-build]
 pylint = false
+black = false

--- a/sdk/cognitiveservices/azure-cognitiveservices-knowledge-qnamaker/pyproject.toml
+++ b/sdk/cognitiveservices/azure-cognitiveservices-knowledge-qnamaker/pyproject.toml
@@ -1,2 +1,3 @@
 [tool.azure-sdk-build]
 pylint = false
+black = false

--- a/sdk/cognitiveservices/azure-cognitiveservices-language-luis/pyproject.toml
+++ b/sdk/cognitiveservices/azure-cognitiveservices-language-luis/pyproject.toml
@@ -1,2 +1,3 @@
 [tool.azure-sdk-build]
 pylint = false
+black = false

--- a/sdk/cognitiveservices/azure-cognitiveservices-language-spellcheck/pyproject.toml
+++ b/sdk/cognitiveservices/azure-cognitiveservices-language-spellcheck/pyproject.toml
@@ -1,2 +1,3 @@
 [tool.azure-sdk-build]
 pylint = false
+black = false

--- a/sdk/cognitiveservices/azure-cognitiveservices-language-textanalytics/pyproject.toml
+++ b/sdk/cognitiveservices/azure-cognitiveservices-language-textanalytics/pyproject.toml
@@ -1,2 +1,3 @@
 [tool.azure-sdk-build]
 pylint = false
+black = false

--- a/sdk/cognitiveservices/azure-cognitiveservices-personalizer/pyproject.toml
+++ b/sdk/cognitiveservices/azure-cognitiveservices-personalizer/pyproject.toml
@@ -1,2 +1,3 @@
 [tool.azure-sdk-build]
 pylint = false
+black = false

--- a/sdk/cognitiveservices/azure-cognitiveservices-search-autosuggest/pyproject.toml
+++ b/sdk/cognitiveservices/azure-cognitiveservices-search-autosuggest/pyproject.toml
@@ -1,2 +1,3 @@
 [tool.azure-sdk-build]
 pylint = false
+black = false

--- a/sdk/cognitiveservices/azure-cognitiveservices-search-customimagesearch/pyproject.toml
+++ b/sdk/cognitiveservices/azure-cognitiveservices-search-customimagesearch/pyproject.toml
@@ -1,2 +1,3 @@
 [tool.azure-sdk-build]
 pylint = false
+black = false

--- a/sdk/cognitiveservices/azure-cognitiveservices-search-customsearch/pyproject.toml
+++ b/sdk/cognitiveservices/azure-cognitiveservices-search-customsearch/pyproject.toml
@@ -1,2 +1,3 @@
 [tool.azure-sdk-build]
 pylint = false
+black = false

--- a/sdk/cognitiveservices/azure-cognitiveservices-search-entitysearch/pyproject.toml
+++ b/sdk/cognitiveservices/azure-cognitiveservices-search-entitysearch/pyproject.toml
@@ -1,2 +1,3 @@
 [tool.azure-sdk-build]
 pylint = false
+black = false

--- a/sdk/cognitiveservices/azure-cognitiveservices-search-imagesearch/pyproject.toml
+++ b/sdk/cognitiveservices/azure-cognitiveservices-search-imagesearch/pyproject.toml
@@ -1,2 +1,3 @@
 [tool.azure-sdk-build]
 pylint = false
+black = false

--- a/sdk/cognitiveservices/azure-cognitiveservices-search-newssearch/pyproject.toml
+++ b/sdk/cognitiveservices/azure-cognitiveservices-search-newssearch/pyproject.toml
@@ -1,2 +1,3 @@
 [tool.azure-sdk-build]
 pylint = false
+black = false

--- a/sdk/cognitiveservices/azure-cognitiveservices-search-videosearch/pyproject.toml
+++ b/sdk/cognitiveservices/azure-cognitiveservices-search-videosearch/pyproject.toml
@@ -1,2 +1,3 @@
 [tool.azure-sdk-build]
 pylint = false
+black = false

--- a/sdk/cognitiveservices/azure-cognitiveservices-search-visualsearch/pyproject.toml
+++ b/sdk/cognitiveservices/azure-cognitiveservices-search-visualsearch/pyproject.toml
@@ -1,2 +1,3 @@
 [tool.azure-sdk-build]
 pylint = false
+black = false

--- a/sdk/cognitiveservices/azure-cognitiveservices-search-websearch/pyproject.toml
+++ b/sdk/cognitiveservices/azure-cognitiveservices-search-websearch/pyproject.toml
@@ -1,2 +1,3 @@
 [tool.azure-sdk-build]
 pylint = false
+black = false

--- a/sdk/cognitiveservices/azure-cognitiveservices-vision-computervision/pyproject.toml
+++ b/sdk/cognitiveservices/azure-cognitiveservices-vision-computervision/pyproject.toml
@@ -1,2 +1,3 @@
 [tool.azure-sdk-build]
 pylint = false
+black = false

--- a/sdk/cognitiveservices/azure-cognitiveservices-vision-contentmoderator/pyproject.toml
+++ b/sdk/cognitiveservices/azure-cognitiveservices-vision-contentmoderator/pyproject.toml
@@ -1,2 +1,3 @@
 [tool.azure-sdk-build]
 pylint = false
+black = false

--- a/sdk/cognitiveservices/azure-cognitiveservices-vision-customvision/pyproject.toml
+++ b/sdk/cognitiveservices/azure-cognitiveservices-vision-customvision/pyproject.toml
@@ -1,2 +1,3 @@
 [tool.azure-sdk-build]
 pylint = false
+black = false

--- a/sdk/cognitiveservices/azure-cognitiveservices-vision-face/pyproject.toml
+++ b/sdk/cognitiveservices/azure-cognitiveservices-vision-face/pyproject.toml
@@ -1,2 +1,3 @@
 [tool.azure-sdk-build]
 pylint = false
+black = false

--- a/sdk/cosmos/azure-cosmos/pyproject.toml
+++ b/sdk/cosmos/azure-cosmos/pyproject.toml
@@ -4,3 +4,4 @@ pyright = false
 type_check_samples = false
 verifytypes = false
 pylint = false
+black = false

--- a/sdk/devcenter/azure-developer-devcenter/pyproject.toml
+++ b/sdk/devcenter/azure-developer-devcenter/pyproject.toml
@@ -1,5 +1,6 @@
 [tool.azure-sdk-build]
 pylint = false
+black = false
 pyright = false
 type_check_samples = false
 verifytypes = false

--- a/sdk/deviceupdate/azure-iot-deviceupdate/pyproject.toml
+++ b/sdk/deviceupdate/azure-iot-deviceupdate/pyproject.toml
@@ -1,6 +1,7 @@
 [tool.azure-sdk-build]
 mypy = false
 pylint = false
+black = false
 pyright = false
 type_check_samples = false
 verifytypes = false

--- a/sdk/eventhub/azure-eventhub-checkpointstoreblob-aio/pyproject.toml
+++ b/sdk/eventhub/azure-eventhub-checkpointstoreblob-aio/pyproject.toml
@@ -4,3 +4,4 @@ pyright = false
 type_check_samples = false
 verifytypes = false
 pylint = false
+black = false

--- a/sdk/eventhub/azure-eventhub-checkpointstoreblob/pyproject.toml
+++ b/sdk/eventhub/azure-eventhub-checkpointstoreblob/pyproject.toml
@@ -4,3 +4,4 @@ pyright = false
 type_check_samples = false
 verifytypes = false
 pylint = false
+black = false

--- a/sdk/eventhub/azure-eventhub-checkpointstoretable/pyproject.toml
+++ b/sdk/eventhub/azure-eventhub-checkpointstoretable/pyproject.toml
@@ -4,3 +4,4 @@ pyright = false
 type_check_samples = false
 verifytypes = false
 pylint = false
+black = false

--- a/sdk/eventhub/azure-eventhub/pyproject.toml
+++ b/sdk/eventhub/azure-eventhub/pyproject.toml
@@ -3,3 +3,4 @@ pyright = false
 type_check_samples = false
 verifytypes = false
 pylint = false
+black = false

--- a/sdk/iothub/azure-iot-deviceprovisioning/pyproject.toml
+++ b/sdk/iothub/azure-iot-deviceprovisioning/pyproject.toml
@@ -1,2 +1,3 @@
 [tool.azure-sdk-build]
 pylint = false
+black = false

--- a/sdk/keyvault/azure-keyvault/pyproject.toml
+++ b/sdk/keyvault/azure-keyvault/pyproject.toml
@@ -1,2 +1,3 @@
 [tool.azure-sdk-build]
 pylint = false
+black = false

--- a/sdk/loadtesting/azure-developer-loadtesting/pyproject.toml
+++ b/sdk/loadtesting/azure-developer-loadtesting/pyproject.toml
@@ -1,6 +1,7 @@
 [tool.azure-sdk-build]
 mypy = false
 pylint = false
+black = false
 pyright = false
 type_check_samples = false
 verifytypes = false

--- a/sdk/nspkg/azure-cognitiveservices-knowledge-nspkg/pyproject.toml
+++ b/sdk/nspkg/azure-cognitiveservices-knowledge-nspkg/pyproject.toml
@@ -1,2 +1,3 @@
 [tool.azure-sdk-build]
 pylint = false
+black = false

--- a/sdk/nspkg/azure-cognitiveservices-language-nspkg/pyproject.toml
+++ b/sdk/nspkg/azure-cognitiveservices-language-nspkg/pyproject.toml
@@ -1,2 +1,3 @@
 [tool.azure-sdk-build]
 pylint = false
+black = false

--- a/sdk/nspkg/azure-cognitiveservices-nspkg/pyproject.toml
+++ b/sdk/nspkg/azure-cognitiveservices-nspkg/pyproject.toml
@@ -1,2 +1,3 @@
 [tool.azure-sdk-build]
 pylint = false
+black = false

--- a/sdk/nspkg/azure-cognitiveservices-search-nspkg/pyproject.toml
+++ b/sdk/nspkg/azure-cognitiveservices-search-nspkg/pyproject.toml
@@ -1,2 +1,3 @@
 [tool.azure-sdk-build]
 pylint = false
+black = false

--- a/sdk/nspkg/azure-cognitiveservices-vision-nspkg/pyproject.toml
+++ b/sdk/nspkg/azure-cognitiveservices-vision-nspkg/pyproject.toml
@@ -1,2 +1,3 @@
 [tool.azure-sdk-build]
 pylint = false
+black = false

--- a/sdk/nspkg/azure-messaging-nspkg/pyproject.toml
+++ b/sdk/nspkg/azure-messaging-nspkg/pyproject.toml
@@ -1,2 +1,3 @@
 [tool.azure-sdk-build]
 pylint = false
+black = false

--- a/sdk/nspkg/azure-nspkg/pyproject.toml
+++ b/sdk/nspkg/azure-nspkg/pyproject.toml
@@ -1,2 +1,3 @@
 [tool.azure-sdk-build]
 pylint = false
+black = false

--- a/sdk/nspkg/azure-purview-nspkg/pyproject.toml
+++ b/sdk/nspkg/azure-purview-nspkg/pyproject.toml
@@ -1,2 +1,3 @@
 [tool.azure-sdk-build]
 pylint = false
+black = false

--- a/sdk/nspkg/azure-synapse-nspkg/pyproject.toml
+++ b/sdk/nspkg/azure-synapse-nspkg/pyproject.toml
@@ -1,2 +1,3 @@
 [tool.azure-sdk-build]
 pylint = false
+black = false

--- a/sdk/purview/azure-purview-administration/pyproject.toml
+++ b/sdk/purview/azure-purview-administration/pyproject.toml
@@ -1,6 +1,7 @@
 [tool.azure-sdk-build]
 mypy = false
 pylint = false
+black = false
 pyright = false
 type_check_samples = false
 verifytypes = false

--- a/sdk/purview/azure-purview-catalog/pyproject.toml
+++ b/sdk/purview/azure-purview-catalog/pyproject.toml
@@ -1,6 +1,7 @@
 [tool.azure-sdk-build]
 mypy = false
 pylint = false
+black = false
 pyright = false
 type_check_samples = false
 verifytypes = false

--- a/sdk/purview/azure-purview-scanning/pyproject.toml
+++ b/sdk/purview/azure-purview-scanning/pyproject.toml
@@ -1,6 +1,7 @@
 [tool.azure-sdk-build]
 mypy = false
 pylint = false
+black = false
 pyright = false
 type_check_samples = false
 verifytypes = false

--- a/sdk/purview/azure-purview-sharing/pyproject.toml
+++ b/sdk/purview/azure-purview-sharing/pyproject.toml
@@ -1,6 +1,7 @@
 [tool.azure-sdk-build]
 mypy = false
 pylint = false
+black = false
 pyright = false
 type_check_samples = false
 verifytypes = false

--- a/sdk/servicebus/azure-servicebus/pyproject.toml
+++ b/sdk/servicebus/azure-servicebus/pyproject.toml
@@ -3,3 +3,4 @@ pyright = false
 type_check_samples = false
 verifytypes = false
 pylint = false
+black = false

--- a/sdk/servicefabric/azure-servicefabric/pyproject.toml
+++ b/sdk/servicefabric/azure-servicefabric/pyproject.toml
@@ -1,2 +1,3 @@
 [tool.azure-sdk-build]
 pylint = false
+black = false

--- a/sdk/synapse/azure-synapse-accesscontrol/pyproject.toml
+++ b/sdk/synapse/azure-synapse-accesscontrol/pyproject.toml
@@ -1,6 +1,7 @@
 [tool.azure-sdk-build]
 mypy = false
 pylint = false
+black = false
 pyright = false
 type_check_samples = false
 verifytypes = false

--- a/sdk/synapse/azure-synapse-artifacts/pyproject.toml
+++ b/sdk/synapse/azure-synapse-artifacts/pyproject.toml
@@ -2,5 +2,6 @@
 mypy = false
 pylint = false
 pyright = false
+black = false
 type_check_samples = false
 verifytypes = false

--- a/sdk/synapse/azure-synapse-managedprivateendpoints/pyproject.toml
+++ b/sdk/synapse/azure-synapse-managedprivateendpoints/pyproject.toml
@@ -1,6 +1,7 @@
 [tool.azure-sdk-build]
 mypy = false
 pylint = false
+black = false
 pyright = false
 type_check_samples = false
 verifytypes = false

--- a/sdk/synapse/azure-synapse-monitoring/pyproject.toml
+++ b/sdk/synapse/azure-synapse-monitoring/pyproject.toml
@@ -2,5 +2,6 @@
 mypy = false
 pylint = false
 pyright = false
+black = false
 type_check_samples = false
 verifytypes = false

--- a/sdk/synapse/azure-synapse-spark/pyproject.toml
+++ b/sdk/synapse/azure-synapse-spark/pyproject.toml
@@ -1,6 +1,7 @@
 [tool.azure-sdk-build]
 mypy = false
 pylint = false
+black = false
 pyright = false
 type_check_samples = false
 verifytypes = false

--- a/sdk/synapse/azure-synapse/pyproject.toml
+++ b/sdk/synapse/azure-synapse/pyproject.toml
@@ -1,2 +1,3 @@
 [tool.azure-sdk-build]
 pylint = false
+black = false

--- a/sdk/translation/azure-ai-translation-text/pyproject.toml
+++ b/sdk/translation/azure-ai-translation-text/pyproject.toml
@@ -1,3 +1,4 @@
 [tool.azure-sdk-build]
 mypy = false
 pylint = false
+black = false

--- a/sdk/webpubsub/azure-messaging-webpubsubclient/pyproject.toml
+++ b/sdk/webpubsub/azure-messaging-webpubsubclient/pyproject.toml
@@ -1,6 +1,7 @@
 [tool.azure-sdk-build]
 mypy = false
 pylint = false
+black = false
 pyright = false
 type_check_samples = false
 verifytypes = false


### PR DESCRIPTION
# Description

This pull request

* Updates the pipeline definition `run_black.yml` to prevent it from getting skipped when `Skip.Pylint` is set
* Adds `black = false` to all `pyproject.toml`s that had `pylint = false`, to preserve the behavior that existed before this PR

# Background

The pipeline definition for code formatting will skip format validation if a package doesn't run pylint.

https://github.com/Azure/azure-sdk-for-python/blob/c816234b5bb722cc8007b1405b4f76b99dd0a602/eng/pipelines/templates/steps/run_black.yml#L26

This skip seems be longstanding (~2 years), which meant that disabling pylint for a package also disabled formatting validation.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.

---

cc: @l0lawrence , @kristapratico 