### PR TITLE
[multiapi combiner] adopt to new generated SDK

### DIFF
--- a/tools/azure-sdk-tools/packaging_tools/multiapi_combiner.py
+++ b/tools/azure-sdk-tools/packaging_tools/multiapi_combiner.py
@@ -524,7 +524,10 @@ class Serializer:
 
         imports += "\n".join(imports_to_add)
         try:
-            imports = modify_relative_imports(r"from (.*)_serialization import Serializer", imports)
+            if " Deserializer" in imports:
+                imports = modify_relative_imports(r"from (.*)_serialization import Deserializer", imports)
+            else:
+                imports = modify_relative_imports(r"from (.*)_serialization import Serializer", imports)
         except AttributeError:
             pass
         validation_relative = "..." if async_mode else ".."


### PR DESCRIPTION
for https://github.com/Azure/autorest.python/pull/2048.
Mainly for [this change](https://github.com/Azure/autorest.python/pull/2048/files#diff-f683bf88cf3ef3e713fda9ef92f2e792b5f8b43ddd794124179e01aa920d619e):
![image](https://github.com/Azure/azure-sdk-for-python/assets/70930885/9a56a7fc-183f-4689-af0f-54b14c55ec98)
