### PR TITLE
fix: Resolve ApiVIEW comments about `, optional` and `:paramtype:`

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_artifacts/_artifact_utilities.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_artifacts/_artifact_utilities.py
@@ -217,17 +217,17 @@ def upload_artifact(
     :param datastore_name: The datastore name
     :type datastore_name: Optional[str]
     :param asset_hash: The asset hash
-    :type asset_hash: Optional[str], optional
+    :type asset_hash: Optional[str]
     :param show_progress: Whether to show progress on the console. Defaults to True.
-    :type show_progress: bool, optional
+    :type show_progress: bool
     :param asset_name: The asset name
-    :type asset_name: Optional[str], optional
+    :type asset_name: Optional[str]
     :param asset_version: The asset version
-    :type asset_version: Optional[str], optional
+    :type asset_version: Optional[str]
     :param ignore_file: The IgnoreFile determining which, if any, files to ignore when uploading
-    :type ignore_file: IgnoreFile, optional
+    :type ignore_file: IgnoreFile
     :param sas_uri: The sas uri to use for uploading
-    :type sas_uri: Optional[str], optional
+    :type sas_uri: Optional[str]
     :return: The artifact storage info
     :rtype: ArtifactStorageInfo
     """
@@ -280,7 +280,7 @@ def download_artifact(
     :param datastore_name: name of datastore
     :type datastore_name: Optional[str]
     :param datastore_info: the return value of invoking get_datastore_info
-    :type datastore_info: Optional[Dict], optional
+    :type datastore_info: Optional[Dict]
     :return: Path that files were written to
     :rtype: str
     """
@@ -465,13 +465,13 @@ def _check_and_upload_path(
     :param artifact_type: The artifact type
     :type artifact_type: str
     :param datastore_name: the name of the datastore to upload to
-    :type datastore_name: Optional[str], optional
+    :type datastore_name: Optional[str]
     :param sas_uri: the sas uri to use for uploading
-    :type sas_uri: Optional[str], optional
+    :type sas_uri: Optional[str]
     :param show_progress: Whether to show progress on the console. Defaults to True.
-    :type show_progress: bool, optional
+    :type show_progress: bool
     :param blob_uri: The storage account uri
-    :type blob_uri: Optional[str], optional
+    :type blob_uri: Optional[str]
     :return: A 2-tuple of the uploaded artifact, and the indicator file.
     :rtype: Tuple[T, Optional[str]]
     """

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_artifacts/_artifact_utilities.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_artifacts/_artifact_utilities.py
@@ -79,7 +79,7 @@ def get_datastore_info(
     :keyword credential: Local credential to use for authentication. If not provided, will try to get
         credentials from the datastore, which requires authorization to perform action
         'Microsoft.MachineLearningServices/workspaces/datastores/listSecrets/action' over target datastore.
-    :type credential: str
+    :paramtype credential: str
     :return: The dictionary with datastore info
     :rtype: Dict[Literal["storage_type", "storage_account", "account_url", "container_name"], str]
     """

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_artifacts/_blob_storage_helper.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_artifacts/_blob_storage_helper.py
@@ -81,11 +81,11 @@ class BlobStorageClient:
         :param version: The asset version
         :type version: str
         :param ignore_file: The IgnoreFile that specifies which files, if any, to ignore when uploading files
-        :type ignore_file: IgnoreFile, optional
+        :type ignore_file: IgnoreFile
         :param asset_hash: The asset hash
-        :type asset_hash: Optional[str], optional
+        :type asset_hash: Optional[str]
         :param show_progress: Whether to show progress on the console. Defaults to True.
-        :type show_progress: bool, optional
+        :type show_progress: bool
         :return: A dictionary containing info of the uploaded artifact
         :rtype: Dict[Literal["remote path", "name", "version", "indicator file"], str]
         """

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_artifacts/_fileshare_storage_helper.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_artifacts/_fileshare_storage_helper.py
@@ -80,11 +80,11 @@ class FileStorageClient:
         :param version: The asset version
         :type version: str
         :param ignore_file: The IgnoreFile that specifies which files, if any, to ignore when uploading files
-        :type ignore_file: IgnoreFile, optional
+        :type ignore_file: IgnoreFile
         :param asset_hash: The asset hash
-        :type asset_hash: Optional[str], optional
+        :type asset_hash: Optional[str]
         :param show_progress: Whether to show progress on the console. Defaults to True.
-        :type show_progress: bool, optional
+        :type show_progress: bool
         :return: A dictionary containing info of the uploaded artifact
         :rtype: Dict[Literal["remote path", "name", "version"], str]
         """
@@ -148,17 +148,17 @@ class FileStorageClient:
         :param dest: The destination in the fileshare to upload to
         :type dest: str
         :param show_progress: Whether to show progress on the console. Defaults to False.
-        :type show_progress: bool, optional
+        :type show_progress: bool
         :param msg: Message to display on progress bar. Defaults to None.
-        :type msg: Optional[str], optional
+        :type msg: Optional[str]
         :param in_directory: Whether this function is being called by :attr:`FileStorageClient.upload_dir`. Defaults
             to False.
-        :type in_directory: bool, optional
+        :type in_directory: bool
         :param subdirectory_client: The subdirectory client.
-        :type subdirectory_client: Optional[ShareDirectoryClient], optional
+        :type subdirectory_client: Optional[ShareDirectoryClient]
         :param callback: A callback that receives the raw requests returned by the service during the upload process.
             Only used if `in_directory` and `show_progress` are True.
-        :type callback: Optional[Callable[[Dict], None]], optional
+        :type callback: Optional[Callable[[Dict], None]]
         """
         validate_content = os.stat(source).st_size > 0  # don't do checksum for empty files
 
@@ -294,11 +294,11 @@ class FileStorageClient:
         """Downloads all contents inside a specified fileshare directory.
 
         :param starts_with: The prefix used to filter files to download
-        :type starts_with: str, optional
+        :type starts_with: str
         :param destination: The destination to download to. Default to user's home directory.
-        :type destination: str, optional
+        :type destination: str
         :param max_concurrency: The maximum number of concurrent downloads. Defaults to 4.
-        :type max_concurrency: int, optional
+        :type max_concurrency: int
         """
         recursive_download(
             client=self.directory_client,
@@ -394,7 +394,7 @@ def recursive_download(
     :param max_concurrency: The maximum number of concurrent downloads
     :type max_concurrency: int
     :param starts_with: The prefix used to filter files to download. Defaults to ""
-    :type starts_with: str, optional
+    :type starts_with: str
     """
     try:
         items = list(client.list_directories_and_files(name_starts_with=starts_with))

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_artifacts/_gen2_storage_helper.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_artifacts/_gen2_storage_helper.py
@@ -71,11 +71,11 @@ class Gen2StorageClient:
         :param version: The asset version
         :type version: str
         :param ignore_file: The IgnoreFile that specifies which files, if any, to ignore when uploading files
-        :type ignore_file: IgnoreFile, optional
+        :type ignore_file: IgnoreFile
         :param asset_hash: The asset hash
-        :type asset_hash: Optional[str], optional
+        :type asset_hash: Optional[str]
         :param show_progress: Whether to show progress on the console. Defaults to True.
-        :type show_progress: bool, optional
+        :type show_progress: bool
         :return: A dictionary containing info of the uploaded artifact
         :rtype: Dict[Literal["remote path", "name", "version", "indicator file"], str]
         """

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_azure_environments.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_azure_environments.py
@@ -123,9 +123,9 @@ def _get_base_url_from_metadata(cloud_name: Optional[str] = None, is_local_mfe: 
     """Retrieve the base url for a cloud from the metadata in SDK.
 
     :param cloud_name: cloud name
-    :type cloud_name: Optional[str], optional
+    :type cloud_name: Optional[str]
     :param is_local_mfe: Whether is local Management Front End. Defaults to False.
-    :type is_local_mfe: bool, optional
+    :type is_local_mfe: bool
     :return: base url for a cloud
     :rtype: str
     """
@@ -142,7 +142,7 @@ def _get_aml_resource_id_from_metadata(cloud_name: Optional[str] = None) -> str:
     """Retrieve the aml_resource_id for a cloud from the metadata in SDK.
 
     :param cloud_name: cloud name
-    :type cloud_name: str, optional
+    :type cloud_name: str
     :return: aml_resource_id for a cloud
     :rtype: str
     """
@@ -155,7 +155,7 @@ def _get_active_directory_url_from_metadata(cloud_name: Optional[str] = None) ->
     """Retrieve the active_directory_url for a cloud from the metadata in SDK.
 
     :param cloud_name: cloud name
-    :type cloud_name: str, optional
+    :type cloud_name: str
     :return: active_directory for a cloud
     :rtype: str
     """
@@ -168,7 +168,7 @@ def _get_storage_endpoint_from_metadata(cloud_name: Optional[str] = None) -> str
     """Retrieve the storage_endpoint for a cloud from the metadata in SDK.
 
     :param cloud_name: cloud name
-    :type cloud_name: str, optional
+    :type cloud_name: str
     :return: storage_endpoint for a cloud
     :rtype: str
     """
@@ -181,7 +181,7 @@ def _get_azure_portal_id_from_metadata(cloud_name: Optional[str] = None) -> str:
     """Retrieve the azure_portal_id for a cloud from the metadata in SDK.
 
     :param cloud_name: cloud name
-    :type cloud_name: str, optional
+    :type cloud_name: str
     :return: azure_portal_id for a cloud
     :rtype: str
     """
@@ -194,7 +194,7 @@ def _get_cloud_information_from_metadata(cloud_name: Optional[str] = None, **kwa
     """Retrieve the cloud information from the metadata in SDK.
 
     :param cloud_name: cloud name
-    :type cloud_name: str, optional
+    :type cloud_name: str
     :return: A dictionary of additional configuration parameters required for passing in cloud information.
     :rtype: Dict
     """
@@ -213,7 +213,7 @@ def _get_registry_discovery_endpoint_from_metadata(cloud_name: Optional[str] = N
     """Retrieve the registry_discovery_endpoint for a cloud from the metadata in SDK.
 
     :param cloud_name: cloud name
-    :type cloud_name: str, optional
+    :type cloud_name: str
     :return: registry_discovery_endpoint for a cloud
     :rtype: str
     """

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_exception_helper.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_exception_helper.py
@@ -240,9 +240,9 @@ def format_create_validation_error(
     :param yaml_operation: Whether the exception was caused by yaml validation.
     :type yaml_operation: bool
     :param cli: Whether is invoked from Azure CLI AzureML Extension. Defaults to False
-    :type cli: bool, optional
+    :type cli: bool
     :param raw_error: The raw exception message
-    :type raw_error: Optional[str], optional
+    :type raw_error: Optional[str]
     :return: Formatted error message
     :rtype: str
     """

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_local_endpoints/dockerfile_resolver.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_local_endpoints/dockerfile_resolver.py
@@ -82,7 +82,7 @@ class DockerfileResolver(object):
         Constructs the Dockerfile instructions based on properties.
 
         :param install_debugpy: Whether to install debugpy. Defaults to False.
-        :type install_debugpy: bool, optional
+        :type install_debugpy: bool
         """
         self._instructions = []
         if self._docker_base_image:

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_ml_client.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_ml_client.py
@@ -113,12 +113,12 @@ class MLClient:
     :type registry_name: Optional[str]
     :keyword show_progress: Specifies whether or not to display progress bars for long-running operations (e.g.
         customers may consider setting this to False if not using this SDK in an interactive setup). Defaults to True.
-    :type show_progress: Optional[bool]
+    :paramtype show_progress: Optional[bool]
     :keyword enable_telemetry: Specifies whether or not to enable telemetry. Will be overridden to False if not in a
         Jupyter Notebook. Defaults to True if in a Jupyter Notebook.
-    :type enable_telemetry: Optional[bool]
+    :paramtype enable_telemetry: Optional[bool]
     :keyword cloud: The cloud name to use. Defaults to "AzureCloud".
-    :type cloud: Optional[str]
+    :paramtype cloud: Optional[str]
     :raises ValueError: Raised if credential is None.
     :raises ~azure.ai.ml.ValidationException: Raised if both workspace_name and registry_name are provided.
 
@@ -547,12 +547,12 @@ class MLClient:
         :type credential: ~azure.core.credentials.TokenCredential
         :keyword path: The path to the configuration file or starting directory to search for the configuration file
             within. Defaults to None, indicating the current directory will be used.
-        :type path: Optional[Union[os.PathLike, str]]
+        :paramtype path: Optional[Union[os.PathLike, str]]
         :keyword file_name: The configuration file name to search for when path is a directory path. Defaults to
             "config.json".
-        :type file_name: Optional[str]
+        :paramtype file_name: Optional[str]
         :keyword cloud: The cloud name to use. Defaults to "AzureCloud".
-        :type cloud: Optional[str]
+        :paramtype cloud: Optional[str]
         :raises ~azure.ai.ml.exceptions.ValidationException: Raised if "config.json", or file_name if overridden,
             cannot be found in directory. Details will be provided in the error message.
         :returns: The client for an existing Azure ML Workspace.

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/core/fields.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/core/fields.py
@@ -648,7 +648,7 @@ class TypeSensitiveUnionField(UnionField):
 def ComputeField(**kwargs) -> Field:
     """
     :keyword required: if set to True, it is not possible to pass None
-    :type required: bool
+    :paramtype required: bool
     :return: The compute field
     :rtype: Field
     """
@@ -667,7 +667,7 @@ def ComputeField(**kwargs) -> Field:
 def CodeField(**kwargs) -> Field:
     """
     :keyword required: if set to True, it is not possible to pass None
-    :type required: bool
+    :paramtype required: bool
     :return: The code field
     :rtype: Field
     """

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_telemetry/_customtraceback.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_telemetry/_customtraceback.py
@@ -143,9 +143,9 @@ def format_exc(limit: Optional[int] = None, chain: bool = True) -> str:
     """Like print_exc() but return a string.
 
     :param limit: None to include all frames or the number of frames to include.
-    :type limit: Optional[int], optional
+    :type limit: Optional[int]
     :param chain: Whether to format __cause__ and __context__. Defaults to True
-    :type chain: bool, optional
+    :type chain: bool
     :return: The formatted exception string
     :rtype: str
     """
@@ -170,9 +170,9 @@ def format_exception(  # pylint: disable=unused-argument
     :param tb: The exception traceback
     :type tb: types.TracebackType
     :param limit: None to include all frames or the number of frames to include.
-    :type limit: Optional[int], optional
+    :type limit: Optional[int]
     :param chain: Whether to format __cause__ and __context__. Defaults to True
-    :type chain: bool, optional
+    :type chain: bool
     :return: A list of strings, each ending in a newline and some containing internal newlines.
       When these lines are concatenated and printed, exactly the same text is printed as does print_exception().
     :rtype: List[str]

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_telemetry/logging_handler.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_telemetry/logging_handler.py
@@ -97,13 +97,13 @@ def get_appinsights_log_handler(
     :param args: Optional arguments for formatting messages.
     :type args: list
     :keyword instrumentation_key: The Application Insights instrumentation key.
-    :type instrumentation_key: str
+    :paramtype instrumentation_key: str
     :keyword component_name: The component name.
-    :type component_name: str
+    :paramtype component_name: str
     :keyword enable_telemetry: Whether to enable telemetry. Will be overriden to False if not in a Jupyter Notebook.
-    :type enable_telemetry: bool
+    :paramtype enable_telemetry: bool
     :keyword kwargs: Optional keyword arguments for adding additional information to messages.
-    :type kwargs: dict
+    :paramtype kwargs: dict
     :return: The logging handler.
     :rtype: AzureMLSDKLogHandler
     """

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_utils/_artifact_utils.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_utils/_artifact_utils.py
@@ -231,7 +231,7 @@ class ArtifactCache:
         :param feed: The download feed
         :type feed: str
         :param max_retries: The number of times to retry the download. Defaults to 3
-        :type max_retries: int, optional
+        :type max_retries: int
         """
         retries = 0
         while retries <= max_retries:
@@ -307,9 +307,9 @@ class ArtifactCache:
         :param scope: Scope of the feed: 'project' if the feed was created in a project, and 'organization' otherwise.
         :type scope: Literal["project", "organization"]
         :param organization: Azure DevOps organization URL.
-        :type organization: str, optional
+        :type organization: str
         :param project: Name or ID of the project.
-        :type project: str, optional
+        :type project: str
         :param resolve: Whether download package when package does not exist in local.
         :type resolve: bool
         :return artifact_package_path: Cache path of the artifact package
@@ -373,9 +373,9 @@ class ArtifactCache:
         :param scope: Scope of the feed: 'project' if the feed was created in a project, and 'organization' otherwise.
         :type scope: Literal["project", "organization"]
         :param organization: Azure DevOps organization URL.
-        :type organization: str, optional
+        :type organization: str
         :param project: Name or ID of the project.
-        :type project: str, optional
+        :type project: str
         :return artifact_package_path: Cache path of the artifact package
         :rtype: Path
         """

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_utils/_asset_utils.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_utils/_asset_utils.py
@@ -327,7 +327,7 @@ def get_content_hash(path: Union[str, os.PathLike], ignore_file: IgnoreFile = Ig
     :param path: The directory to calculate the size of
     :type path: Union[str, os.PathLike]
     :param ignore_file: An ignore file that specifies files to ignore when computing the size
-    :type ignore_file: IgnoreFile, optional
+    :type ignore_file: IgnoreFile
     :return: The content hash if the content is a link, directory, or file. None otherwise
     :rtype: Optional[str]
     """
@@ -458,7 +458,7 @@ def get_directory_size(
     :param root: The directory to calculate the size of
     :type root: Union[str, os.PathLike]
     :param ignore_file: An ignore file that specifies files to ignore when computing the size
-    :type ignore_file: IgnoreFile, optional
+    :type ignore_file: IgnoreFile
     :return: The computed size of the directory, and the sizes of the child paths
     :rtype: Tuple[int, Dict[str, int]]
     """
@@ -816,11 +816,11 @@ def _get_latest(
     :param resource_group_name: The resource group name
     :type resource_group_name: str
     :param workspace_name: The workspace name
-    :type workspace_name: Optional[str], optional
+    :type workspace_name: Optional[str]
     :param registry_name: The registry name
-    :type registry_name: Optional[str], optional
+    :type registry_name: Optional[str]
     :param order_by: Specifies how to order the results. Defaults to :attr:`OrderString.CREATED_AT_DESC`
-    :type order_by: Literal[OrderString.CREATED_AT, OrderString.CREATED_AT_DESC], optional
+    :type order_by: Literal[OrderString.CREATED_AT, OrderString.CREATED_AT_DESC]
     :return: The latest version of the requested asset
     :rtype: Union[ModelVersionData, DataVersionBaseData]
     """

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_utils/_asset_utils.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_utils/_asset_utils.py
@@ -404,9 +404,9 @@ def traverse_directory(  # pylint: disable=unused-argument
     :param files: List of all file paths in the directory
     :type files: List[str]
     :keyword prefix: Remote upload path for project directory (e.g. LocalUpload/<guid>/project_dir)
-    :type prefix: str
+    :paramtype prefix: str
     :keyword ignore_file: The .amlignore or .gitignore file in the project directory
-    :type ignore_file: azure.ai.ml._utils._asset_utils.IgnoreFile
+    :paramtype ignore_file: azure.ai.ml._utils._asset_utils.IgnoreFile
     :return: Zipped list of tuples representing the local path and remote destination path for each file
     :rtype: Iterable[Tuple[str, Union[str, Any]]]
     """

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_utils/_func_utils.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_utils/_func_utils.py
@@ -360,7 +360,7 @@ try:
             :param instructions: The instructions to split
             :type instructions: List[instr]
             :keyword remove_mock_body: Whether to remove the mock body. Defaults to False
-            :type remove_mock_body: bool
+            :paramtype remove_mock_body: bool
             :return: The split instructions
             :rtype: List[List[Instr]]
             """

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_utils/_func_utils.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_utils/_func_utils.py
@@ -360,7 +360,7 @@ try:
             :param instructions: The instructions to split
             :type instructions: List[instr]
             :keyword remove_mock_body: Whether to remove the mock body. Defaults to False
-            :type remove_mock_body: bool, optional
+            :type remove_mock_body: bool
             :return: The split instructions
             :rtype: List[List[Instr]]
             """

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_utils/_pathspec.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_utils/_pathspec.py
@@ -562,7 +562,7 @@ def normalize_file(file: Union[str, os.PathLike], separators: Optional[Iterable[
     :param separators: The path separators to normalize. This does not need to include the POSIX path separator
         (``'/'``), but including it will not affect the results. Default is :data:`None` for
         :data:`NORMALIZE_PATH_SEPS`. To prevent normalization, pass an empty container (e.g., an empty tuple ``()``).
-    :type separators: Optional[Iterable[str]], optional
+    :type separators: Optional[Iterable[str]]
     :return: The normalized file path.
     :rtype: str
     """

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_utils/_storage_utils.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_utils/_storage_utils.py
@@ -139,11 +139,11 @@ def get_storage_client(
     :param storage_account: The storage_account name
     :type storage_account: str
     :param storage_type: The storage type
-    :type storage_type: Union[DatastoreType, str], optional
+    :type storage_type: Union[DatastoreType, str]
     :param account_url: The account url
-    :type account_url: Optional[str], optional
+    :type account_url: Optional[str]
     :param container_name: The container name
-    :type container_name: Optional[str], optional
+    :type container_name: Optional[str]
     :return: The storage client
     :rtype: Union[BlobStorageClient, FileStorageClient, Gen2StorageClient]
     """

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_utils/utils.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_utils/utils.py
@@ -130,7 +130,7 @@ def create_requests_pipeline_with_retry(*, requests_pipeline: HttpPipeline, retr
     :keyword requests_pipeline: Pipeline to base new one off of.
     :type requests_pipeline: HttpPipeline
     :keyword retry: Number of retries. Defaults to 3
-    :type retry: int, optional
+    :type retry: int
     :return: Pipeline identical to provided one, except with a new retry policy
     :rtype: HttpPipeline
     """
@@ -170,7 +170,7 @@ def download_text_from_url(
     :param timeout: One of
       * float that specifies the connect and read time outs
       * a 2-tuple that specifies the connect and read time out in that order
-    :type timeout: Union[float, Tuple[float, float]], optional
+    :type timeout: Union[float, Tuple[float, float]]
     :return: The Response text
     :rtype: str
     """

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_utils/utils.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_utils/utils.py
@@ -128,9 +128,9 @@ def create_requests_pipeline_with_retry(*, requests_pipeline: HttpPipeline, retr
     but overwrites the retry policy.
 
     :keyword requests_pipeline: Pipeline to base new one off of.
-    :type requests_pipeline: HttpPipeline
+    :paramtype requests_pipeline: HttpPipeline
     :keyword retry: Number of retries. Defaults to 3
-    :type retry: int
+    :paramtype retry: int
     :return: Pipeline identical to provided one, except with a new retry policy
     :rtype: HttpPipeline
     """
@@ -802,7 +802,7 @@ def try_enable_internal_components(*, force=False):
     references _internal.
 
     :keyword force: Force enable internal components even if enabled before.
-    :type force: bool
+    :paramtype force: bool
     """
     if is_internal_components_enabled():
         from azure.ai.ml._internal import enable_internal_components_in_pipeline
@@ -1028,7 +1028,7 @@ def get_valid_dot_keys_with_wildcard(
     :type dot_key_wildcard: str
     :keyword validate_func: Validation function. It takes two parameters: the root node and the dot key parts.
     If None, no validation will be performed.
-    :type validate_func: Optional[Callable[[List[str], Dict[str, Any]], bool]]
+    :paramtype validate_func: Optional[Callable[[List[str], Dict[str, Any]], bool]]
     :return: List of valid dot keys.
     :rtype: List[str]
     """

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/automl/_automl_image.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/automl/_automl_image.py
@@ -41,11 +41,11 @@ def _create_image_job(
     :param target_column_name: The target column name
     :type target_column_name: str
     :param primary_metric: The primary metric
-    :type primary_metric: Optional[Union[str, ClassificationPrimaryMetrics]], optional
+    :type primary_metric: Optional[Union[str, ClassificationPrimaryMetrics]]
     :param validation_data: The validation data
-    :type validation_data: Optional[Input], optional
+    :type validation_data: Optional[Input]
     :param validation_data_size: The validation data size
-    :type validation_data_size: Optional[float], optional
+    :type validation_data_size: Optional[float]
     :return: An AutoML Image Job
     :rtype: TImageJob
     """
@@ -87,7 +87,7 @@ def image_classification(
             Defaults to accuracy.
     :type primary_metric: Union[str, ClassificationPrimaryMetrics]
     :keyword validation_data: The validation data to be used within the experiment.
-    :type validation_data: Input, optional
+    :type validation_data: Input
     :keyword validation_data_size:  What fraction of the data to hold out for validation when user validation data
             is not specified. This should be between 0.0 and 1.0 non-inclusive.
 
@@ -95,7 +95,7 @@ def image_classification(
             to extract validation data out of the specified training data.
 
             Defaults to .2
-    :type validation_data_size: float, optional
+    :type validation_data_size: float
     :keyword kwargs: A dictionary of additional configuration parameters.
     :type kwargs: dict
 
@@ -140,7 +140,7 @@ def image_classification_multilabel(
             Defaults to Iou.
     :type primary_metric: Union[str, ClassificationMultilabelPrimaryMetrics]
     :keyword validation_data: The validation data to be used within the experiment.
-    :type validation_data: Input, optional
+    :type validation_data: Input
     :keyword validation_data_size:  What fraction of the data to hold out for validation when user validation data
             is not specified. This should be between 0.0 and 1.0 non-inclusive.
 
@@ -148,7 +148,7 @@ def image_classification_multilabel(
             to extract validation data out of the specified training data.
 
             Defaults to .2
-    :type validation_data_size: float, optional
+    :type validation_data_size: float
     :keyword kwargs: A dictionary of additional configuration parameters.
     :type kwargs: dict
 
@@ -192,7 +192,7 @@ def image_object_detection(
             Defaults to MeanAveragePrecision.
     :type primary_metric: Union[str, ObjectDetectionPrimaryMetrics]
     :keyword validation_data: The validation data to be used within the experiment.
-    :type validation_data: Input, optional
+    :type validation_data: Input
     :keyword validation_data_size:  What fraction of the data to hold out for validation when user validation data
             is not specified. This should be between 0.0 and 1.0 non-inclusive.
 
@@ -200,7 +200,7 @@ def image_object_detection(
             to extract validation data out of the specified training data.
 
             Defaults to .2
-    :type validation_data_size: float, optional
+    :type validation_data_size: float
     :keyword kwargs: A dictionary of additional configuration parameters.
     :type kwargs: dict
 
@@ -244,7 +244,7 @@ def image_instance_segmentation(
             Defaults to MeanAveragePrecision.
     :type primary_metric: Union[str, InstanceSegmentationPrimaryMetrics]
     :keyword validation_data: The validation data to be used within the experiment.
-    :type validation_data: Input, optional
+    :type validation_data: Input
     :keyword validation_data_size:  What fraction of the data to hold out for validation when user validation data
             is not specified. This should be between 0.0 and 1.0 non-inclusive.
 
@@ -252,7 +252,7 @@ def image_instance_segmentation(
             to extract validation data out of the specified training data.
 
             Defaults to .2
-    :type validation_data_size: float, optional
+    :type validation_data_size: float
     :keyword kwargs: A dictionary of additional configuration parameters.
     :type kwargs: dict
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/automl/_automl_image.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/automl/_automl_image.py
@@ -73,10 +73,10 @@ def image_classification(
     """Creates an object for AutoML Image multi-class Classification job.
 
     :keyword training_data:  The training data to be used within the experiment.
-    :type training_data: Input
+    :paramtype training_data: Input
     :keyword target_column_name: The name of the label column.
             This parameter is applicable to ``training_data`` and ``validation_data`` parameters.
-    :type target_column_name: str
+    :paramtype target_column_name: str
     :keyword primary_metric: The metric that Automated Machine Learning will optimize for model selection.
             Automated Machine Learning collects more metrics than it can optimize.
             For more information on how metrics are calculated, see
@@ -87,7 +87,7 @@ def image_classification(
             Defaults to accuracy.
     :type primary_metric: Union[str, ClassificationPrimaryMetrics]
     :keyword validation_data: The validation data to be used within the experiment.
-    :type validation_data: Input
+    :paramtype validation_data: Input
     :keyword validation_data_size:  What fraction of the data to hold out for validation when user validation data
             is not specified. This should be between 0.0 and 1.0 non-inclusive.
 
@@ -95,9 +95,9 @@ def image_classification(
             to extract validation data out of the specified training data.
 
             Defaults to .2
-    :type validation_data_size: float
+    :paramtype validation_data_size: float
     :keyword kwargs: A dictionary of additional configuration parameters.
-    :type kwargs: dict
+    :paramtype kwargs: dict
 
     :return: Image classification job object that can be submitted to an Azure ML compute for execution.
     :rtype: ImageClassificationJob
@@ -126,10 +126,10 @@ def image_classification_multilabel(
     """Creates an object for AutoML Image multi-label Classification job.
 
     :keyword training_data:  The training data to be used within the experiment.
-    :type training_data: Input
+    :paramtype training_data: Input
     :keyword target_column_name: The name of the label column.
             This parameter is applicable to ``training_data`` and ``validation_data`` parameters.
-    :type target_column_name: str
+    :paramtype target_column_name: str
     :keyword primary_metric: The metric that Automated Machine Learning will optimize for model selection.
             Automated Machine Learning collects more metrics than it can optimize.
             For more information on how metrics are calculated, see
@@ -140,7 +140,7 @@ def image_classification_multilabel(
             Defaults to Iou.
     :type primary_metric: Union[str, ClassificationMultilabelPrimaryMetrics]
     :keyword validation_data: The validation data to be used within the experiment.
-    :type validation_data: Input
+    :paramtype validation_data: Input
     :keyword validation_data_size:  What fraction of the data to hold out for validation when user validation data
             is not specified. This should be between 0.0 and 1.0 non-inclusive.
 
@@ -148,9 +148,9 @@ def image_classification_multilabel(
             to extract validation data out of the specified training data.
 
             Defaults to .2
-    :type validation_data_size: float
+    :paramtype validation_data_size: float
     :keyword kwargs: A dictionary of additional configuration parameters.
-    :type kwargs: dict
+    :paramtype kwargs: dict
 
     :return: Image multi-label classification job object that can be submitted to an Azure ML compute for execution.
     :rtype: ImageClassificationMultilabelJob
@@ -179,10 +179,10 @@ def image_object_detection(
     """Creates an object for AutoML Image Object Detection job.
 
     :keyword training_data:  The training data to be used within the experiment.
-    :type training_data: Input
+    :paramtype training_data: Input
     :keyword target_column_name: The name of the label column.
             This parameter is applicable to ``training_data`` and ``validation_data`` parameters.
-    :type target_column_name: str
+    :paramtype target_column_name: str
     :keyword primary_metric: The metric that Automated Machine Learning will optimize for model selection.
             Automated Machine Learning collects more metrics than it can optimize.
             For more information on how metrics are calculated, see
@@ -192,7 +192,7 @@ def image_object_detection(
             Defaults to MeanAveragePrecision.
     :type primary_metric: Union[str, ObjectDetectionPrimaryMetrics]
     :keyword validation_data: The validation data to be used within the experiment.
-    :type validation_data: Input
+    :paramtype validation_data: Input
     :keyword validation_data_size:  What fraction of the data to hold out for validation when user validation data
             is not specified. This should be between 0.0 and 1.0 non-inclusive.
 
@@ -200,9 +200,9 @@ def image_object_detection(
             to extract validation data out of the specified training data.
 
             Defaults to .2
-    :type validation_data_size: float
+    :paramtype validation_data_size: float
     :keyword kwargs: A dictionary of additional configuration parameters.
-    :type kwargs: dict
+    :paramtype kwargs: dict
 
     :return: Image object detection job object that can be submitted to an Azure ML compute for execution.
     :rtype: ImageObjectDetectionJob
@@ -231,10 +231,10 @@ def image_instance_segmentation(
     """Creates an object for AutoML Image Instance Segmentation job.
 
     :keyword training_data:  The training data to be used within the experiment.
-    :type training_data: Input
+    :paramtype training_data: Input
     :keyword target_column_name: The name of the label column.
             This parameter is applicable to ``training_data`` and ``validation_data`` parameters.
-    :type target_column_name: str
+    :paramtype target_column_name: str
     :keyword primary_metric: The metric that Automated Machine Learning will optimize for model selection.
             Automated Machine Learning collects more metrics than it can optimize.
             For more information on how metrics are calculated, see
@@ -244,7 +244,7 @@ def image_instance_segmentation(
             Defaults to MeanAveragePrecision.
     :type primary_metric: Union[str, InstanceSegmentationPrimaryMetrics]
     :keyword validation_data: The validation data to be used within the experiment.
-    :type validation_data: Input
+    :paramtype validation_data: Input
     :keyword validation_data_size:  What fraction of the data to hold out for validation when user validation data
             is not specified. This should be between 0.0 and 1.0 non-inclusive.
 
@@ -252,9 +252,9 @@ def image_instance_segmentation(
             to extract validation data out of the specified training data.
 
             Defaults to .2
-    :type validation_data_size: float
+    :paramtype validation_data_size: float
     :keyword kwargs: A dictionary of additional configuration parameters.
-    :type kwargs: dict
+    :paramtype kwargs: dict
 
     :return: Image instance segmentation job
     :rtype: ImageInstanceSegmentationJob

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/automl/_automl_nlp.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/automl/_automl_nlp.py
@@ -30,19 +30,19 @@ def text_classification(
 
     :keyword training_data: The training data to be used within the experiment.
             It should contain both training features and a target column.
-    :type training_data: Input
+    :paramtype training_data: Input
     :keyword target_column_name: Name of the target column.
-    :type target_column_name: str
+    :paramtype target_column_name: str
     :keyword validation_data: The validation data to be used within the experiment.
             It should contain both training features and a target column.
-    :type validation_data: Input
+    :paramtype validation_data: Input
     :keyword primary_metric: Primary metric for the task.
             Acceptable values: accuracy, AUC_weighted, precision_score_weighted
-    :type primary_metric: Union[str, ClassificationPrimaryMetrics]
+    :paramtype primary_metric: Union[str, ClassificationPrimaryMetrics]
     :keyword log_verbosity: Log verbosity level.
-    :type log_verbosity: str
+    :paramtype log_verbosity: str
     :keyword kwargs: A dictionary of additional configuration parameters.
-    :type kwargs: dict
+    :paramtype kwargs: dict
 
     :return: The TextClassificationJob object.
     :rtype: TextClassificationJob
@@ -79,19 +79,19 @@ def text_classification_multilabel(
 
     :keyword training_data: The training data to be used within the experiment.
             It should contain both training features and a target column.
-    :type training_data: Input
+    :paramtype training_data: Input
     :keyword target_column_name: Name of the target column.
-    :type target_column_name: str
+    :paramtype target_column_name: str
     :keyword validation_data: The validation data to be used within the experiment.
             It should contain both training features and a target column.
-    :type validation_data: Input
+    :paramtype validation_data: Input
     :keyword primary_metric: Primary metric for the task.
             Acceptable values: accuracy
-    :type primary_metric: str
+    :paramtype primary_metric: str
     :keyword log_verbosity: Log verbosity level.
-    :type log_verbosity: str
+    :paramtype log_verbosity: str
     :keyword kwargs: A dictionary of additional configuration parameters.
-    :type kwargs: dict
+    :paramtype kwargs: dict
 
     :return: The TextClassificationMultilabelJob object.
     :rtype: TextClassificationMultilabelJob
@@ -127,17 +127,17 @@ def text_ner(
 
     :keyword training_data: The training data to be used within the experiment.
             It should contain both training features and a target column.
-    :type training_data: Input
+    :paramtype training_data: Input
     :keyword validation_data: The validation data to be used within the experiment.
             It should contain both training features and a target column.
-    :type validation_data: Input
+    :paramtype validation_data: Input
     :keyword primary_metric: Primary metric for the task.
             Acceptable values: accuracy
-    :type primary_metric: str
+    :paramtype primary_metric: str
     :keyword log_verbosity: Log verbosity level.
-    :type log_verbosity: str
+    :paramtype log_verbosity: str
     :keyword kwargs: A dictionary of additional configuration parameters.
-    :type kwargs: dict
+    :paramtype kwargs: dict
 
     :return: The TextNerJob object.
     :rtype: TextNerJob

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/automl/_automl_tabular.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/automl/_automl_tabular.py
@@ -39,10 +39,10 @@ def classification(
 
     :keyword training_data: The training data to be used within the experiment.
             It should contain both training features and a label column (optionally a sample weights column).
-    :type training_data: Input
+    :paramtype training_data: Input
     :keyword target_column_name: The name of the label column.
             This parameter is applicable to ``training_data``, ``validation_data`` and ``test_data`` parameters
-    :type target_column_name: str
+    :paramtype target_column_name: str
     :keyword primary_metric: The metric that Automated Machine Learning will optimize for model selection.
             Automated Machine Learning collects more metrics than it can optimize.
             For more information on how metrics are calculated, see
@@ -57,19 +57,19 @@ def classification(
             The default is None. For more information, see
             `Interpretability: model explanations in automated machine learning
             <https://docs.microsoft.com/azure/machine-learning/how-to-machine-learning-interpretability-automl>`__.
-    :type enable_model_explainability: bool
+    :paramtype enable_model_explainability: bool
     :keyword weight_column_name: The name of the sample weight column. Automated ML supports a weighted column
             as an input, causing rows in the data to be weighted up or down.
             If the input data is from a pandas.DataFrame which doesn't have column names,
             column indices can be used instead, expressed as integers.
 
             This parameter is applicable to ``training_data`` and ``validation_data`` parameters
-    :type weight_column_name: str
+    :paramtype weight_column_name: str
     :keyword validation_data: The validation data to be used within the experiment.
             It should contain both training features and label column (optionally a sample weights column).
 
             Defaults to None
-    :type validation_data: Input
+    :paramtype validation_data: Input
     :keyword validation_data_size: What fraction of the data to hold out for validation when user validation data
             is not specified. This should be between 0.0 and 1.0 non-inclusive.
 
@@ -82,7 +82,7 @@ def classification(
             /azure/machine-learning/how-to-configure-cross-validation-data-splits>`__.
 
             Defaults to None
-    :type validation_data_size: float
+    :paramtype validation_data_size: float
     :keyword n_cross_validations: How many cross validations to perform when user validation data is not specified.
 
             Specify ``validation_data`` to provide validation data, otherwise set ``n_cross_validations`` or
@@ -94,13 +94,13 @@ def classification(
             /azure/machine-learning/how-to-configure-cross-validation-data-splits>`__.
 
             Defaults to None
-    :type n_cross_validations: Union[str, int]
+    :paramtype n_cross_validations: Union[str, int]
     :keyword cv_split_column_names: List of names of the columns that contain custom cross validation split.
             Each of the CV split columns represents one CV split where each row are either marked
             1 for training or 0 for validation.
 
             Defaults to None
-    :type cv_split_column_names: List[str]
+    :paramtype cv_split_column_names: List[str]
     :keyword test_data: The Model Test feature using test datasets or test data splits is a feature in
             Preview state and might change at any time.
             The test data to be used for a test run that will automatically be started after
@@ -113,7 +113,7 @@ def classification(
             If ``test_data`` is specified then the ``target_column_name`` parameter must be specified.
 
             Defaults to None
-    :type test_data: Input
+    :paramtype test_data: Input
     :keyword test_data_size: The Model Test feature using test datasets or test data splits is a feature in
             Preview state and might change at any time.
             What fraction of the training data to hold out for test data for a test run that will
@@ -134,7 +134,7 @@ def classification(
             no test run will be executed automatically after model training is completed.
 
             Defaults to None
-    :type test_data_size: float
+    :paramtype test_data_size: float
     :return: A job object that can be submitted to an Azure ML compute for execution.
     :rtype: ClassificationJob
     """
@@ -181,10 +181,10 @@ def regression(
 
     :keyword training_data: The training data to be used within the experiment.
             It should contain both training features and a label column (optionally a sample weights column).
-    :type training_data: Input
+    :paramtype training_data: Input
     :keyword target_column_name: The name of the label column.
             This parameter is applicable to ``training_data``, ``validation_data`` and ``test_data`` parameters
-    :type target_column_name: str
+    :paramtype target_column_name: str
     :keyword primary_metric: The metric that Automated Machine Learning will optimize for model selection.
             Automated Machine Learning collects more metrics than it can optimize.
             For more information on how metrics are calculated, see
@@ -199,19 +199,19 @@ def regression(
             The default is None. For more information, see
             `Interpretability: model explanations in automated machine learning
             <https://docs.microsoft.com/azure/machine-learning/how-to-machine-learning-interpretability-automl>`__.
-    :type enable_model_explainability: bool
+    :paramtype enable_model_explainability: bool
     :keyword weight_column_name: The name of the sample weight column. Automated ML supports a weighted column
             as an input, causing rows in the data to be weighted up or down.
             If the input data is from a pandas.DataFrame which doesn't have column names,
             column indices can be used instead, expressed as integers.
 
             This parameter is applicable to ``training_data`` and ``validation_data`` parameters
-    :type weight_column_name: str
+    :paramtype weight_column_name: str
     :keyword validation_data: The validation data to be used within the experiment.
             It should contain both training features and label column (optionally a sample weights column).
 
             Defaults to None
-    :type validation_data: Input
+    :paramtype validation_data: Input
     :keyword validation_data_size: What fraction of the data to hold out for validation when user validation data
             is not specified. This should be between 0.0 and 1.0 non-inclusive.
 
@@ -224,7 +224,7 @@ def regression(
             /azure/machine-learning/how-to-configure-cross-validation-data-splits>`__.
 
             Defaults to None
-    :type validation_data_size: float
+    :paramtype validation_data_size: float
     :keyword n_cross_validations: How many cross validations to perform when user validation data is not specified.
 
             Specify ``validation_data`` to provide validation data, otherwise set ``n_cross_validations`` or
@@ -236,13 +236,13 @@ def regression(
             /azure/machine-learning/how-to-configure-cross-validation-data-splits>`__.
 
             Defaults to None
-    :type n_cross_validations: Union[str, int]
+    :paramtype n_cross_validations: Union[str, int]
     :keyword cv_split_column_names: List of names of the columns that contain custom cross validation split.
             Each of the CV split columns represents one CV split where each row are either marked
             1 for training or 0 for validation.
 
             Defaults to None
-    :type cv_split_column_names: List[str]
+    :paramtype cv_split_column_names: List[str]
     :keyword test_data: The Model Test feature using test datasets or test data splits is a feature in
             Preview state and might change at any time.
             The test data to be used for a test run that will automatically be started after
@@ -255,7 +255,7 @@ def regression(
             If ``test_data`` is specified then the ``target_column_name`` parameter must be specified.
 
             Defaults to None
-    :type test_data: Input
+    :paramtype test_data: Input
     :keyword test_data_size: The Model Test feature using test datasets or test data splits is a feature in
             Preview state and might change at any time.
             What fraction of the training data to hold out for test data for a test run that will
@@ -277,7 +277,7 @@ def regression(
             no test run will be executed automatically after model training is completed.
 
             Defaults to None
-    :type test_data_size: float
+    :paramtype test_data_size: float
     :return: A job object that can be submitted to an Azure ML compute for execution.
     :rtype: RegressionJob
     """
@@ -323,10 +323,10 @@ def forecasting(
 
     :keyword training_data: The training data to be used within the experiment.
             It should contain both training features and a label column (optionally a sample weights column).
-    :type training_data: Input
+    :paramtype training_data: Input
     :keyword target_column_name: The name of the label column.
             This parameter is applicable to ``training_data``, ``validation_data`` and ``test_data`` parameters
-    :type target_column_name: str
+    :paramtype target_column_name: str
     :keyword primary_metric: The metric that Automated Machine Learning will optimize for model selection.
             Automated Machine Learning collects more metrics than it can optimize.
             For more information on how metrics are calculated, see
@@ -340,19 +340,19 @@ def forecasting(
             The default is None. For more information, see
             `Interpretability: model explanations in automated machine learning
             <https://docs.microsoft.com/azure/machine-learning/how-to-machine-learning-interpretability-automl>`__.
-    :type enable_model_explainability: bool
+    :paramtype enable_model_explainability: bool
     :keyword weight_column_name: The name of the sample weight column. Automated ML supports a weighted column
             as an input, causing rows in the data to be weighted up or down.
             If the input data is from a pandas.DataFrame which doesn't have column names,
             column indices can be used instead, expressed as integers.
 
             This parameter is applicable to ``training_data`` and ``validation_data`` parameters
-    :type weight_column_name: str
+    :paramtype weight_column_name: str
     :keyword validation_data: The validation data to be used within the experiment.
             It should contain both training features and label column (optionally a sample weights column).
 
             Defaults to None
-    :type validation_data: Input
+    :paramtype validation_data: Input
     :keyword validation_data_size: What fraction of the data to hold out for validation when user validation data
             is not specified. This should be between 0.0 and 1.0 non-inclusive.
 
@@ -365,7 +365,7 @@ def forecasting(
             /azure/machine-learning/how-to-configure-cross-validation-data-splits>`__.
 
             Defaults to None
-    :type validation_data_size: float
+    :paramtype validation_data_size: float
     :keyword n_cross_validations: How many cross validations to perform when user validation data is not specified.
 
             Specify ``validation_data`` to provide validation data, otherwise set ``n_cross_validations`` or
@@ -377,13 +377,13 @@ def forecasting(
             /azure/machine-learning/how-to-configure-cross-validation-data-splits>`__.
 
             Defaults to None
-    :type n_cross_validations: Union[str, int]
+    :paramtype n_cross_validations: Union[str, int]
     :keyword cv_split_column_names: List of names of the columns that contain custom cross validation split.
             Each of the CV split columns represents one CV split where each row are either marked
             1 for training or 0 for validation.
 
             Defaults to None
-    :type cv_split_column_names: List[str]
+    :paramtype cv_split_column_names: List[str]
     :keyword test_data: The Model Test feature using test datasets or test data splits is a feature in
             Preview state and might change at any time.
             The test data to be used for a test run that will automatically be started after
@@ -396,7 +396,7 @@ def forecasting(
             If ``test_data`` is specified then the ``target_column_name`` parameter must be specified.
 
             Defaults to None
-    :type test_data: Input
+    :paramtype test_data: Input
     :keyword test_data_size: The Model Test feature using test datasets or test data splits is a feature in
             Preview state and might change at any time.
             What fraction of the training data to hold out for test data for a test run that will
@@ -418,9 +418,9 @@ def forecasting(
             no test run will be executed automatically after model training is completed.
 
             Defaults to None
-    :type test_data_size: float
+    :paramtype test_data_size: float
     :keyword forecasting_settings: The settings for the forecasting task
-    :type forecasting_settings: ForecastingSettings
+    :paramtype forecasting_settings: ForecastingSettings
     :return: A job object that can be submitted to an Azure ML compute for execution.
     :rtype: ForecastingJob
     """

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/automl/_automl_tabular.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/automl/_automl_tabular.py
@@ -51,25 +51,25 @@ def classification(
             Acceptable values: accuracy, AUC_weighted, norm_macro_recall, average_precision_score_weighted,
             and precision_score_weighted
             Defaults to accuracy
-    :type primary_metric: str, optional
+    :type primary_metric: str
     :keyword enable_model_explainability: Whether to enable explaining the best AutoML model at the end of all AutoML
             training iterations.
             The default is None. For more information, see
             `Interpretability: model explanations in automated machine learning
             <https://docs.microsoft.com/azure/machine-learning/how-to-machine-learning-interpretability-automl>`__.
-    :type enable_model_explainability: bool, optional
+    :type enable_model_explainability: bool
     :keyword weight_column_name: The name of the sample weight column. Automated ML supports a weighted column
             as an input, causing rows in the data to be weighted up or down.
             If the input data is from a pandas.DataFrame which doesn't have column names,
             column indices can be used instead, expressed as integers.
 
             This parameter is applicable to ``training_data`` and ``validation_data`` parameters
-    :type weight_column_name: str, optional
+    :type weight_column_name: str
     :keyword validation_data: The validation data to be used within the experiment.
             It should contain both training features and label column (optionally a sample weights column).
 
             Defaults to None
-    :type validation_data: Input, optional
+    :type validation_data: Input
     :keyword validation_data_size: What fraction of the data to hold out for validation when user validation data
             is not specified. This should be between 0.0 and 1.0 non-inclusive.
 
@@ -82,7 +82,7 @@ def classification(
             /azure/machine-learning/how-to-configure-cross-validation-data-splits>`__.
 
             Defaults to None
-    :type validation_data_size: float, optional
+    :type validation_data_size: float
     :keyword n_cross_validations: How many cross validations to perform when user validation data is not specified.
 
             Specify ``validation_data`` to provide validation data, otherwise set ``n_cross_validations`` or
@@ -94,13 +94,13 @@ def classification(
             /azure/machine-learning/how-to-configure-cross-validation-data-splits>`__.
 
             Defaults to None
-    :type n_cross_validations: Union[str, int], optional
+    :type n_cross_validations: Union[str, int]
     :keyword cv_split_column_names: List of names of the columns that contain custom cross validation split.
             Each of the CV split columns represents one CV split where each row are either marked
             1 for training or 0 for validation.
 
             Defaults to None
-    :type cv_split_column_names: List[str], optional
+    :type cv_split_column_names: List[str]
     :keyword test_data: The Model Test feature using test datasets or test data splits is a feature in
             Preview state and might change at any time.
             The test data to be used for a test run that will automatically be started after
@@ -113,7 +113,7 @@ def classification(
             If ``test_data`` is specified then the ``target_column_name`` parameter must be specified.
 
             Defaults to None
-    :type test_data: Input, optional
+    :type test_data: Input
     :keyword test_data_size: The Model Test feature using test datasets or test data splits is a feature in
             Preview state and might change at any time.
             What fraction of the training data to hold out for test data for a test run that will
@@ -134,7 +134,7 @@ def classification(
             no test run will be executed automatically after model training is completed.
 
             Defaults to None
-    :type test_data_size: float, optional
+    :type test_data_size: float
     :return: A job object that can be submitted to an Azure ML compute for execution.
     :rtype: ClassificationJob
     """
@@ -193,25 +193,25 @@ def regression(
             Acceptable values: spearman_correlation, r2_score, normalized_mean_absolute_error,
             normalized_root_mean_squared_error.
             Defaults to normalized_root_mean_squared_error
-    :type primary_metric: str, optional
+    :type primary_metric: str
     :keyword enable_model_explainability: Whether to enable explaining the best AutoML model at the end of all AutoML
             training iterations.
             The default is None. For more information, see
             `Interpretability: model explanations in automated machine learning
             <https://docs.microsoft.com/azure/machine-learning/how-to-machine-learning-interpretability-automl>`__.
-    :type enable_model_explainability: bool, optional
+    :type enable_model_explainability: bool
     :keyword weight_column_name: The name of the sample weight column. Automated ML supports a weighted column
             as an input, causing rows in the data to be weighted up or down.
             If the input data is from a pandas.DataFrame which doesn't have column names,
             column indices can be used instead, expressed as integers.
 
             This parameter is applicable to ``training_data`` and ``validation_data`` parameters
-    :type weight_column_name: str, optional
+    :type weight_column_name: str
     :keyword validation_data: The validation data to be used within the experiment.
             It should contain both training features and label column (optionally a sample weights column).
 
             Defaults to None
-    :type validation_data: Input, optional
+    :type validation_data: Input
     :keyword validation_data_size: What fraction of the data to hold out for validation when user validation data
             is not specified. This should be between 0.0 and 1.0 non-inclusive.
 
@@ -224,7 +224,7 @@ def regression(
             /azure/machine-learning/how-to-configure-cross-validation-data-splits>`__.
 
             Defaults to None
-    :type validation_data_size: float, optional
+    :type validation_data_size: float
     :keyword n_cross_validations: How many cross validations to perform when user validation data is not specified.
 
             Specify ``validation_data`` to provide validation data, otherwise set ``n_cross_validations`` or
@@ -236,13 +236,13 @@ def regression(
             /azure/machine-learning/how-to-configure-cross-validation-data-splits>`__.
 
             Defaults to None
-    :type n_cross_validations: Union[str, int], optional
+    :type n_cross_validations: Union[str, int]
     :keyword cv_split_column_names: List of names of the columns that contain custom cross validation split.
             Each of the CV split columns represents one CV split where each row are either marked
             1 for training or 0 for validation.
 
             Defaults to None
-    :type cv_split_column_names: List[str], optional
+    :type cv_split_column_names: List[str]
     :keyword test_data: The Model Test feature using test datasets or test data splits is a feature in
             Preview state and might change at any time.
             The test data to be used for a test run that will automatically be started after
@@ -255,7 +255,7 @@ def regression(
             If ``test_data`` is specified then the ``target_column_name`` parameter must be specified.
 
             Defaults to None
-    :type test_data: Input, optional
+    :type test_data: Input
     :keyword test_data_size: The Model Test feature using test datasets or test data splits is a feature in
             Preview state and might change at any time.
             What fraction of the training data to hold out for test data for a test run that will
@@ -277,7 +277,7 @@ def regression(
             no test run will be executed automatically after model training is completed.
 
             Defaults to None
-    :type test_data_size: float, optional
+    :type test_data_size: float
     :return: A job object that can be submitted to an Azure ML compute for execution.
     :rtype: RegressionJob
     """
@@ -334,25 +334,25 @@ def forecasting(
 
             Acceptable values: r2_score, normalized_mean_absolute_error, normalized_root_mean_squared_error
             Defaults to normalized_root_mean_squared_error
-    :type primary_metric: str, optional
+    :type primary_metric: str
     :keyword enable_model_explainability: Whether to enable explaining the best AutoML model at the end of all AutoML
             training iterations.
             The default is None. For more information, see
             `Interpretability: model explanations in automated machine learning
             <https://docs.microsoft.com/azure/machine-learning/how-to-machine-learning-interpretability-automl>`__.
-    :type enable_model_explainability: bool, optional
+    :type enable_model_explainability: bool
     :keyword weight_column_name: The name of the sample weight column. Automated ML supports a weighted column
             as an input, causing rows in the data to be weighted up or down.
             If the input data is from a pandas.DataFrame which doesn't have column names,
             column indices can be used instead, expressed as integers.
 
             This parameter is applicable to ``training_data`` and ``validation_data`` parameters
-    :type weight_column_name: str, optional
+    :type weight_column_name: str
     :keyword validation_data: The validation data to be used within the experiment.
             It should contain both training features and label column (optionally a sample weights column).
 
             Defaults to None
-    :type validation_data: Input, optional
+    :type validation_data: Input
     :keyword validation_data_size: What fraction of the data to hold out for validation when user validation data
             is not specified. This should be between 0.0 and 1.0 non-inclusive.
 
@@ -365,7 +365,7 @@ def forecasting(
             /azure/machine-learning/how-to-configure-cross-validation-data-splits>`__.
 
             Defaults to None
-    :type validation_data_size: float, optional
+    :type validation_data_size: float
     :keyword n_cross_validations: How many cross validations to perform when user validation data is not specified.
 
             Specify ``validation_data`` to provide validation data, otherwise set ``n_cross_validations`` or
@@ -377,13 +377,13 @@ def forecasting(
             /azure/machine-learning/how-to-configure-cross-validation-data-splits>`__.
 
             Defaults to None
-    :type n_cross_validations: Union[str, int], optional
+    :type n_cross_validations: Union[str, int]
     :keyword cv_split_column_names: List of names of the columns that contain custom cross validation split.
             Each of the CV split columns represents one CV split where each row are either marked
             1 for training or 0 for validation.
 
             Defaults to None
-    :type cv_split_column_names: List[str], optional
+    :type cv_split_column_names: List[str]
     :keyword test_data: The Model Test feature using test datasets or test data splits is a feature in
             Preview state and might change at any time.
             The test data to be used for a test run that will automatically be started after
@@ -396,7 +396,7 @@ def forecasting(
             If ``test_data`` is specified then the ``target_column_name`` parameter must be specified.
 
             Defaults to None
-    :type test_data: Input, optional
+    :type test_data: Input
     :keyword test_data_size: The Model Test feature using test datasets or test data splits is a feature in
             Preview state and might change at any time.
             What fraction of the training data to hold out for test data for a test run that will
@@ -418,9 +418,9 @@ def forecasting(
             no test run will be executed automatically after model training is completed.
 
             Defaults to None
-    :type test_data_size: float, optional
+    :type test_data_size: float
     :keyword forecasting_settings: The settings for the forecasting task
-    :type forecasting_settings: ForecastingSettings, optional
+    :type forecasting_settings: ForecastingSettings
     :return: A job object that can be submitted to an Azure ML compute for execution.
     :rtype: ForecastingJob
     """

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/dsl/_condition.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/dsl/_condition.py
@@ -48,11 +48,11 @@ def condition(
     :keyword true_block: The block to be executed if the condition resolves to True.
     :type true_block: Union[
         ~azure.ai.ml.entities._builders.BaseNode,
-        List[~azure.ai.ml.entities._builders.BaseNode]], optional
+        List[~azure.ai.ml.entities._builders.BaseNode]]
     :keyword false_block: The block to be executed if the condition resolves to False.
     :type false_block: Union[
         ~azure.ai.ml.entities._builders.BaseNode,
-        List[~azure.ai.ml.entities._builders.BaseNode]], optional
+        List[~azure.ai.ml.entities._builders.BaseNode]]
     :return: The condition node.
     :rtype: ConditionNode
     :raises UserErrorException: Raised if the condition node has an incorrect number of outputs.

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/dsl/_condition.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/dsl/_condition.py
@@ -46,11 +46,11 @@ def condition(
         ~azure.ai.ml.entities._builders.BaseNode,
         ~azure.ai.ml.entities._job.pipeline._pipeline_expression.PipelineExpression]
     :keyword true_block: The block to be executed if the condition resolves to True.
-    :type true_block: Union[
+    :paramtype true_block: Union[
         ~azure.ai.ml.entities._builders.BaseNode,
         List[~azure.ai.ml.entities._builders.BaseNode]]
     :keyword false_block: The block to be executed if the condition resolves to False.
-    :type false_block: Union[
+    :paramtype false_block: Union[
         ~azure.ai.ml.entities._builders.BaseNode,
         List[~azure.ai.ml.entities._builders.BaseNode]]
     :return: The condition node.

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/dsl/_do_while.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/dsl/_do_while.py
@@ -51,7 +51,7 @@ def do_while(body, mapping, max_iteration_count: int, condition=None):
     :param condition: The name of a boolean output of the body.
         The do-while loop stops if its value is evaluated to be negative.
         If not specified, it handles as a while-true loop.
-    :type condition:  ~azure.ai.ml.entities.Output, optional
+    :type condition:  ~azure.ai.ml.entities.Output
     :return: The do-while node.
     :rtype: ~azure.ai.ml.entities._builders.do_while.DoWhile
     """

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/dsl/_dynamic.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/dsl/_dynamic.py
@@ -19,11 +19,11 @@ class KwParameter(Parameter):
     :type name: str
     :param default: The default value of the parameter.
     :param annotation: The annotation type of the parameter, defaults to `Parameter.empty`.
-    :type annotation: Any, optional
+    :type annotation: Any
     :param _type: The type of the parameter, defaults to "str".
-    :type _type: str, optional
+    :type _type: str
     :param _optional: Indicates if the parameter is optional, defaults to False.
-    :type _optional: bool, optional
+    :type _optional: bool
     """
 
     def __init__(self, name, default, annotation=Parameter.empty, _type="str", _optional=False) -> None:

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/dsl/_fl_scatter_gather_node.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/dsl/_fl_scatter_gather_node.py
@@ -97,28 +97,28 @@ def fl_scatter_gather(
         ~azure.ai.ml.entities.PipelineJob,
         ~azure.ai.ml.entities.CommandComponent]
     :keyword aggregation_compute: The name of the compute that the aggregation component will use.
-    :type aggregation_compute: str, optional
+    :type aggregation_compute: str
     :keyword aggregation_datastore: The name of the datastore that the aggregation component will use.
-    :type aggregation_datastore: str, optional
+    :type aggregation_datastore: str
     :keyword shared_silo_kwargs: A dictionary of string keywords to component inputs. This dictionary is treated
         like kwargs and is injected into ALL executed silo components.
-    :type shared_silo_kwargs: Dict, optional
+    :type shared_silo_kwargs: Dict
     :keyword aggregation_kwargs: A dictionary of string keywords to component inputs. This dictionary is treated
         like kwargs and is injected into ALL executed aggregation components.
-    :type aggregation_kwargs: Dict, optional
+    :type aggregation_kwargs: Dict
     :keyword silo_to_aggregation_argument_map: A dictionary specifying the mapping of outputs from the silo step to
         inputs in the aggregation step. The keys should be output names from the silo step, and the values should be
         input names in the aggregation step. This allows for customization of the mapping between the steps.
-    :type silo_to_aggregation_argument_map: Dict, optional
+    :type silo_to_aggregation_argument_map: Dict
     :keyword aggregation_to_silo_argument_map: A dictionary specifying the mapping of outputs from the aggregation step
         to inputs in the silo step. The keys should be output names from the aggregation step, and the values should be
         input names in the silo step. This allows for customization of the mapping between the steps.
-    :type aggregation_to_silo_argument_map: Dict, optional
+    :type aggregation_to_silo_argument_map: Dict
     :keyword max_iterations: The maximum number of scatter gather iterations that should be performed.
-    :type max_iterations: int, optional
+    :type max_iterations: int
     :keyword _create_default_mappings_if_needed:
         If True, try to automatically create input/output mappings if they're unset.
-    :type _create_default_mappings_if_needed: bool, optional
+    :type _create_default_mappings_if_needed: bool
     :return: The federated learning scatter-gather subgraph node.
     :rtype: ~azure.ai.ml.entities._builders.fl_scatter_gather.FLScatterGather
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/dsl/_fl_scatter_gather_node.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/dsl/_fl_scatter_gather_node.py
@@ -84,41 +84,41 @@ def fl_scatter_gather(
     :keyword silo_configs: A list of FederatedLearningSilo objects,
         which contain the necessary data to reconfigure components to run on specific computes and datastores,
         while also targeting specific inputs located on the aforementioned datastores.
-    :type silo_configs: List[~azure.ai.ml.entities._assets.federated_learning_silo.FederatedLearningSilo]
+    :paramtype silo_configs: List[~azure.ai.ml.entities._assets.federated_learning_silo.FederatedLearningSilo]
     :keyword silo_component: A pipeline step that will be run multiple times across different silos, as specified
         by the silo_configs input. In a typical horizontal federated learning context, this step is what will perform
         model training using siloed subsets of data. Can be either a PipelineJob or a CommandComponent.
-    :type silo_component: Union[~azure.ai.ml.entities.PipelineJob, ~azure.ai.ml.entities.CommandComponent]
+    :paramtype silo_component: Union[~azure.ai.ml.entities.PipelineJob, ~azure.ai.ml.entities.CommandComponent]
     :keyword aggregation_component: A pipeline step which receives inputs from the myriad executed silo components,
         and does something with them. In a typical horizontal federated learning context, this component will merge
         the models that were independently trained on each silo's data in a single model. Can be either a
         PipelineJob or a CommandComponent.
-    :type aggregation_component: Union[
+    :paramtype aggregation_component: Union[
         ~azure.ai.ml.entities.PipelineJob,
         ~azure.ai.ml.entities.CommandComponent]
     :keyword aggregation_compute: The name of the compute that the aggregation component will use.
-    :type aggregation_compute: str
+    :paramtype aggregation_compute: str
     :keyword aggregation_datastore: The name of the datastore that the aggregation component will use.
-    :type aggregation_datastore: str
+    :paramtype aggregation_datastore: str
     :keyword shared_silo_kwargs: A dictionary of string keywords to component inputs. This dictionary is treated
         like kwargs and is injected into ALL executed silo components.
-    :type shared_silo_kwargs: Dict
+    :paramtype shared_silo_kwargs: Dict
     :keyword aggregation_kwargs: A dictionary of string keywords to component inputs. This dictionary is treated
         like kwargs and is injected into ALL executed aggregation components.
-    :type aggregation_kwargs: Dict
+    :paramtype aggregation_kwargs: Dict
     :keyword silo_to_aggregation_argument_map: A dictionary specifying the mapping of outputs from the silo step to
         inputs in the aggregation step. The keys should be output names from the silo step, and the values should be
         input names in the aggregation step. This allows for customization of the mapping between the steps.
-    :type silo_to_aggregation_argument_map: Dict
+    :paramtype silo_to_aggregation_argument_map: Dict
     :keyword aggregation_to_silo_argument_map: A dictionary specifying the mapping of outputs from the aggregation step
         to inputs in the silo step. The keys should be output names from the aggregation step, and the values should be
         input names in the silo step. This allows for customization of the mapping between the steps.
-    :type aggregation_to_silo_argument_map: Dict
+    :paramtype aggregation_to_silo_argument_map: Dict
     :keyword max_iterations: The maximum number of scatter gather iterations that should be performed.
-    :type max_iterations: int
+    :paramtype max_iterations: int
     :keyword _create_default_mappings_if_needed:
         If True, try to automatically create input/output mappings if they're unset.
-    :type _create_default_mappings_if_needed: bool
+    :paramtype _create_default_mappings_if_needed: bool
     :return: The federated learning scatter-gather subgraph node.
     :rtype: ~azure.ai.ml.entities._builders.fl_scatter_gather.FLScatterGather
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/dsl/_group_decorator.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/dsl/_group_decorator.py
@@ -161,11 +161,11 @@ def group(_cls: Type[T]) -> Type[T]:
         :param body: The source code of the body of the new function
         :type body: List[str]
         :keyword globals: The global variables to make available to the new function.
-        :type globals: Dict[str, Any]
+        :paramtype globals: Dict[str, Any]
         :keyword locals: The local variables to make available to the new function
-        :type locals: Dict[str, Any]
+        :paramtype locals: Dict[str, Any]
         :keyword return_type: The return type of the new function
-        :type return_type: Type[T2]
+        :paramtype return_type: Type[T2]
         :return: The created function
         :rtype: Callable[..., T2]
         """

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/dsl/_group_decorator.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/dsl/_group_decorator.py
@@ -161,9 +161,9 @@ def group(_cls: Type[T]) -> Type[T]:
         :param body: The source code of the body of the new function
         :type body: List[str]
         :keyword globals: The global variables to make available to the new function.
-        :type globals: Dict[str, Any], optional
+        :type globals: Dict[str, Any]
         :keyword locals: The local variables to make available to the new function
-        :type locals: Dict[str, Any], optional
+        :type locals: Dict[str, Any]
         :keyword return_type: The return type of the new function
         :type return_type: Type[T2]
         :return: The created function

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/dsl/_load_import.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/dsl/_load_import.py
@@ -30,9 +30,9 @@ def to_component(*, job: ComponentTranslatableMixin, **kwargs) -> Callable[..., 
         component = component_func(param1=xxx, param2=xxx)
 
     :keyword job: Job load from local or remote.
-    :type job: ~azure.ai.ml.entities._job.pipeline._component_translatable.ComponentTranslatableMixin
+    :paramtype job: ~azure.ai.ml.entities._job.pipeline._component_translatable.ComponentTranslatableMixin
     :keyword kwargs: A dictionary of additional configuration parameters.
-    :type kwargs: dict
+    :paramtype kwargs: dict
 
     :return: Wrapped function call.
     :rtype: typing.Callable[..., ~azure.ai.ml.entities._builders.command.Command]

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/dsl/_parallel_for.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/dsl/_parallel_for.py
@@ -41,9 +41,9 @@ def parallel_for(*, body, items, **kwargs):
                 )
 
     :keyword body: Node to execute as the loop body.
-    :type body: ~azure.ai.ml.entities._builders.BaseNode
+    :paramtype body: ~azure.ai.ml.entities._builders.BaseNode
     :keyword items: The loop body's input which will bind to the loop node.
-    :type items: Union[
+    :paramtype items: Union[
         list,
         dict,
         str,

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/dsl/_pipeline_decorator.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/dsl/_pipeline_decorator.py
@@ -102,20 +102,20 @@ def pipeline(
     :param func: The user pipeline function to be decorated.
     :type func: types.FunctionType
     :keyword name: The name of pipeline component, defaults to function name.
-    :type name: str
+    :paramtype name: str
     :keyword version: The version of pipeline component, defaults to "1".
-    :type version: str
+    :paramtype version: str
     :keyword display_name: The display name of pipeline component, defaults to function name.
-    :type display_name: str
+    :paramtype display_name: str
     :keyword description: The description of the built pipeline.
-    :type description: str
+    :paramtype description: str
     :keyword experiment_name: Name of the experiment the job will be created under, \
                 if None is provided, experiment will be set to current directory.
-    :type experiment_name: str
+    :paramtype experiment_name: str
     :keyword tags: The tags of pipeline component.
-    :type tags: dict[str, str]
+    :paramtype tags: dict[str, str]
     :keyword kwargs: A dictionary of additional configuration parameters.
-    :type kwargs: dict
+    :paramtype kwargs: dict
 
     .. admonition:: Example:
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/dsl/_settings.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/dsl/_settings.py
@@ -115,10 +115,10 @@ def set_pipeline_settings(
 
     :keyword on_init: On_init job node or name. On init job will be executed before all other jobs, \
                 it should not have data connections to regular nodes.
-    :type on_init: Union[BaseNode, str]
+    :paramtype on_init: Union[BaseNode, str]
     :keyword on_finalize: On_finalize job node or name. On finalize job will be executed after pipeline run \
                 finishes (completed/failed/canceled), it should not have data connections to regular nodes.
-    :type on_finalize: Union[BaseNode, str]
+    :paramtype on_finalize: Union[BaseNode, str]
     :return:
     """
     dsl_settings = _dsl_settings_stack.top()

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/dsl/_utils.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/dsl/_utils.py
@@ -105,7 +105,7 @@ def _relative_to(
     :param basedir: The base path to compute `path` relative to
     :type basedir: Union[str, os.PathLike]
     :param raises_if_impossible: Whether to raise if :attr:`pathlib.Path.relative_to` throws. Defaults to False.
-    :type raises_if_impossible: bool, optional
+    :type raises_if_impossible: bool
     :return:
         * None if raises_if_impossible is False and basedir is not a parent of path
         * path.relative_to(basedir) otherwise
@@ -150,7 +150,7 @@ def _change_working_dir(path: Union[str, os.PathLike], mkdir: bool = True) -> It
     :param path: The path to change to
     :type path: Union[str, os.PathLike]
     :param mkdir: Whether to ensure `path` exists, creating it if it doesn't exists. Defaults to True.
-    :type mkdir: bool, optional
+    :type mkdir: bool
     """
 
     saved_path = os.getcwd()

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_assets/asset.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_assets/asset.py
@@ -31,7 +31,7 @@ class Asset(Resource):
     :param properties: The asset property dictionary. Defaults to None.
     :type properties: Optional[dict[str, str]]
     :keyword kwargs: A dictionary of additional configuration parameters.
-    :type kwargs: Optional[dict]
+    :paramtype kwargs: Optional[dict]
     """
 
     def __init__(
@@ -117,7 +117,7 @@ class Asset(Resource):
             If dest is an open file, the file will be written to directly.
         :type dest: Union[PathLike, str, IO[AnyStr]]
         :keyword kwargs: Additional arguments to pass to the YAML serializer.
-        :type kwargs: dict
+        :paramtype kwargs: dict
         :raises FileExistsError: Raised if dest is a file path and the file already exists.
         :raises IOError: Raised if dest is an open file and the file is not writable.
         """

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_assets/federated_learning_silo.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_assets/federated_learning_silo.py
@@ -106,10 +106,10 @@ class FederatedLearningSilo:
 
         :keyword yaml_path: A path leading to a local YAML file which contains a list of
             FederatedLearningSilo objects.
-        :type yaml_path: Optional[Union[PathLike, str]]
+        :paramtype yaml_path: Optional[Union[PathLike, str]]
         :keyword list_arg: A string that names the top-level value which contains the list
             of FL silos.
-        :type list_arg: str
+        :paramtype list_arg: str
         :return: The list of federated learning silos
         :rtype: List[FederatedLearningSilo]
         """

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_assets/intellectual_property.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_assets/intellectual_property.py
@@ -15,10 +15,10 @@ class IntellectualProperty(RestTranslatableMixin):
     """Intellectual property settings definition.
 
     :keyword publisher: The publisher's name.
-    :type publisher: Optional[str]
+    :paramtype publisher: Optional[str]
     :keyword protection_level: Asset Protection Level. Accepted values are IPProtectionLevel.ALL ("all") and
         IPProtectionLevel.NONE ("none"). Defaults to IPProtectionLevel.ALL ("all").
-    :type protection_level: Optional[Union[str, ~azure.ai.ml.constants.IPProtectionLevel]]
+    :paramtype protection_level: Optional[Union[str, ~azure.ai.ml.constants.IPProtectionLevel]]
 
     .. admonition:: Example:
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_builders/command.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_builders/command.py
@@ -95,40 +95,40 @@ class Command(BaseNode, NodeWithGroupInputMixin):
     You should not instantiate this class directly. Instead, you should create it using the builder function: command().
 
     :keyword component: The ID or instance of the command component or job to be run for the step.
-    :type component: Union[str, ~azure.ai.ml.entities.CommandComponent]
+    :paramtype component: Union[str, ~azure.ai.ml.entities.CommandComponent]
     :keyword compute: The compute target the job will run on.
-    :type compute: Optional[str]
+    :paramtype compute: Optional[str]
     :keyword inputs: A mapping of input names to input data sources used in the job.
-    :type inputs: Optional[dict[str, Union[
+    :paramtype inputs: Optional[dict[str, Union[
         ~azure.ai.ml.Input, str, bool, int, float, Enum]]]
     :keyword outputs: A mapping of output names to output data sources used in the job.
-    :type outputs: Optional[dict[str, Union[str, ~azure.ai.ml.Output]]]
+    :paramtype outputs: Optional[dict[str, Union[str, ~azure.ai.ml.Output]]]
     :keyword limits: The limits for the command component or job.
-    :type limits: ~azure.ai.ml.entities.CommandJobLimits
+    :paramtype limits: ~azure.ai.ml.entities.CommandJobLimits
     :keyword identity: The identity that the command job will use while running on compute.
-    :type identity: Optional[Union[
+    :paramtype identity: Optional[Union[
         dict[str, str],
         ~azure.ai.ml.entities.ManagedIdentityConfiguration,
         ~azure.ai.ml.entities.AmlTokenConfiguration,
         ~azure.ai.ml.entities.UserIdentityConfiguration]]
     :keyword distribution: The configuration for distributed jobs.
-    :type distribution: Optional[Union[dict, ~azure.ai.ml.PyTorchDistribution, ~azure.ai.ml.MpiDistribution,
+    :paramtype distribution: Optional[Union[dict, ~azure.ai.ml.PyTorchDistribution, ~azure.ai.ml.MpiDistribution,
         ~azure.ai.ml.TensorFlowDistribution, ~azure.ai.ml.RayDistribution]]
     :keyword environment: The environment that the job will run in.
-    :type environment: Optional[Union[str, ~azure.ai.ml.entities.Environment]]
+    :paramtype environment: Optional[Union[str, ~azure.ai.ml.entities.Environment]]
     :keyword environment_variables:  A dictionary of environment variable names and values.
         These environment variables are set on the process where the user script is being executed.
-    :type environment_variables: Optional[dict[str, str]]
+    :paramtype environment_variables: Optional[dict[str, str]]
     :keyword resources: The compute resource configuration for the command.
-    :type resources: Optional[~azure.ai.ml.entities.JobResourceConfiguration]
+    :paramtype resources: Optional[~azure.ai.ml.entities.JobResourceConfiguration]
     :keyword services: The interactive services for the node. This is an experimental parameter, and may change at any
         time. Please see https://aka.ms/azuremlexperimental for more information.
-    :type services: Optional[dict[str, Union[~azure.ai.ml.entities.JobService,
+    :paramtype services: Optional[dict[str, Union[~azure.ai.ml.entities.JobService,
         ~azure.ai.ml.entities.JupyterLabJobService,
         ~azure.ai.ml.entities.SshJobService, ~azure.ai.ml.entities.TensorBoardJobService,
         ~azure.ai.ml.entities.VsCodeJobService]]]
     :keyword queue_settings: Queue settings for the job.
-    :type queue_settings: Optional[~azure.ai.ml.entities.QueueSettings]
+    :paramtype queue_settings: Optional[~azure.ai.ml.entities.QueueSettings]
     :raises ~azure.ai.ml.exceptions.ValidationException: Raised if Command cannot be successfully validated.
         Details will be provided in the error message.
     """
@@ -462,21 +462,21 @@ class Command(BaseNode, NodeWithGroupInputMixin):
 
         :keyword instance_type: The type of compute instance to run the job on. If not specified, the job will run on
             the default compute target.
-        :type instance_type: Optional[Union[str, list[str]]]
+        :paramtype instance_type: Optional[Union[str, list[str]]]
         :keyword instance_count: The number of instances to run the job on. If not specified, the job will run on a
             single instance.
-        :type instance_count: Optional[int]
+        :paramtype instance_count: Optional[int]
         :keyword locations: The list of locations where the job will run. If not specified, the job will run on the
             default compute target.
-        :type locations: Optional[list[str]]
+        :paramtype locations: Optional[list[str]]
         :keyword properties: The properties of the job.
-        :type properties: Optional[dict]
+        :paramtype properties: Optional[dict]
         :keyword docker_args: The Docker arguments for the job.
-        :type docker_args: Optional[str]
+        :paramtype docker_args: Optional[str]
         :keyword shm_size: The size of the docker container's shared memory block. This should be in the
             format of (number)(unit) where the number has to be greater than 0 and the unit can be one of
             b(bytes), k(kilobytes), m(megabytes), or g(gigabytes).
-        :type shm_size: Optional[str]
+        :paramtype shm_size: Optional[str]
 
         .. admonition:: Example:
 
@@ -512,7 +512,7 @@ class Command(BaseNode, NodeWithGroupInputMixin):
         """Set limits for Command.
 
         :keyword timeout: The timeout for the job in seconds.
-        :type timeout: int
+        :paramtype timeout: int
 
         .. admonition:: Example:
 
@@ -533,9 +533,9 @@ class Command(BaseNode, NodeWithGroupInputMixin):
         """Set QueueSettings for the job.
 
         :keyword job_tier: The job tier. Accepted values are "Spot", "Basic", "Standard", or "Premium".
-        :type job_tier: Optional[str]
+        :paramtype job_tier: Optional[str]
         :keyword priority:  The priority of the job on the compute. Defaults to "Medium".
-        :type priority: Optional[str]
+        :paramtype priority: Optional[str]
 
         .. admonition:: Example:
 
@@ -586,41 +586,41 @@ class Command(BaseNode, NodeWithGroupInputMixin):
 
         :keyword primary_metric: The primary metric of the sweep objective - e.g. AUC (Area Under the Curve).
             The metric must be logged while running the trial component.
-        :type primary_metric: str
+        :paramtype primary_metric: str
         :keyword goal: The goal of the Sweep objective. Accepted values are "minimize" or "maximize".
-        :type goal: str
+        :paramtype goal: str
         :keyword sampling_algorithm: The sampling algorithm to use inside the search space.
             Acceptable values are "random", "grid", or "bayesian". Defaults to "random".
-        :type sampling_algorithm: str
+        :paramtype sampling_algorithm: str
         :keyword compute: The target compute to run the node on. If not specified, the current node's compute
             will be used.
-        :type compute: Optional[str]
+        :paramtype compute: Optional[str]
         :keyword max_total_trials: The maximum number of total trials to run. This value will overwrite the value in
             CommandJob.limits if specified.
-        :type max_total_trials: Optional[int]
+        :paramtype max_total_trials: Optional[int]
         :keyword max_concurrent_trials: The maximum number of concurrent trials for the Sweep job.
-        :type max_concurrent_trials: Optional[int]
+        :paramtype max_concurrent_trials: Optional[int]
         :keyword timeout: The maximum run duration in seconds, after which the job will be cancelled.
-        :type timeout: Optional[int]
+        :paramtype timeout: Optional[int]
         :keyword trial_timeout: The Sweep Job trial timeout value, in seconds.
-        :type trial_timeout: Optional[int]
+        :paramtype trial_timeout: Optional[int]
         :keyword early_termination_policy: The early termination policy of the sweep node. Acceptable
             values are "bandit", "median_stopping", or "truncation_selection". Defaults to None.
-        :type early_termination_policy: Optional[Union[~azure.ai.ml.sweep.BanditPolicy,
+        :paramtype early_termination_policy: Optional[Union[~azure.ai.ml.sweep.BanditPolicy,
             ~azure.ai.ml.sweep.TruncationSelectionPolicy, ~azure.ai.ml.sweep.MedianStoppingPolicy, str]]
         :keyword identity: The identity that the job will use while running on compute.
-        :type identity: Optional[Union[
+        :paramtype identity: Optional[Union[
             ~azure.ai.ml.ManagedIdentityConfiguration,
             ~azure.ai.ml.AmlTokenConfiguration,
             ~azure.ai.ml.UserIdentityConfiguration]]
         :keyword queue_settings: The queue settings for the job.
-        :type queue_settings: Optional[~azure.ai.ml.entities.QueueSettings]
+        :paramtype queue_settings: Optional[~azure.ai.ml.entities.QueueSettings]
         :keyword job_tier: **Experimental** The job tier. Accepted values are "Spot", "Basic",
             "Standard", or "Premium".
-        :type job_tier: Optional[str]
+        :paramtype job_tier: Optional[str]
         :keyword priority: **Experimental** The compute priority. Accepted values are "low",
             "medium", and "high".
-        :type priority: Optional[str]
+        :paramtype priority: Optional[str]
         :return: A Sweep node with the component from current Command node as its trial component.
         :rtype: ~azure.ai.ml.entities.Sweep
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_builders/command_func.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_builders/command_func.py
@@ -148,56 +148,56 @@ def command(
     """Creates a Command object which can be used inside a dsl.pipeline function or used as a standalone Command job.
 
     :keyword name: The name of the Command job or component.
-    :type name: Optional[str]
+    :paramtype name: Optional[str]
     :keyword description: The description of the Command. Defaults to None.
-    :type description: Optional[str]
+    :paramtype description: Optional[str]
     :keyword tags: Tag dictionary. Tags can be added, removed, and updated. Defaults to None.
-    :type tags: Optional[dict[str, str]]
+    :paramtype tags: Optional[dict[str, str]]
     :keyword properties: The job property dictionary. Defaults to None.
-    :type properties: Optional[dict[str, str]]
+    :paramtype properties: Optional[dict[str, str]]
     :keyword display_name: The display name of the job. Defaults to a randomly generated name.
-    :type display_name: Optional[str]
+    :paramtype display_name: Optional[str]
     :keyword command: The command to be executed. Defaults to None.
-    :type command: Optional[str]
+    :paramtype command: Optional[str]
     :keyword experiment_name: The name of the experiment that the job will be created under. Defaults to current
         directory name.
-    :type experiment_name: Optional[str]
+    :paramtype experiment_name: Optional[str]
     :keyword environment: The environment that the job will run in.
-    :type environment: Optional[Union[str, ~azure.ai.ml.entities.Environment]]
+    :paramtype environment: Optional[Union[str, ~azure.ai.ml.entities.Environment]]
     :keyword environment_variables: A dictionary of environment variable names and values.
         These environment variables are set on the process where user script is being executed.
         Defaults to None.
-    :type environment_variables: Optional[dict[str, str]]
+    :paramtype environment_variables: Optional[dict[str, str]]
     :keyword distribution: The configuration for distributed jobs. Defaults to None.
-    :type distribution: Optional[Union[dict, ~azure.ai.ml.PyTorchDistribution, ~azure.ai.ml.MpiDistribution,
+    :paramtype distribution: Optional[Union[dict, ~azure.ai.ml.PyTorchDistribution, ~azure.ai.ml.MpiDistribution,
         ~azure.ai.ml.TensorFlowDistribution, ~azure.ai.ml.RayDistribution]]
     :keyword compute: The compute target the job will run on. Defaults to default compute.
-    :type compute: Optional[str]
+    :paramtype compute: Optional[str]
     :keyword inputs: A mapping of input names to input data sources used in the job. Defaults to None.
-    :type inputs: Optional[dict[str, Union[~azure.ai.ml.Input, str, bool, int, float, Enum]]]
+    :paramtype inputs: Optional[dict[str, Union[~azure.ai.ml.Input, str, bool, int, float, Enum]]]
     :keyword outputs: A mapping of output names to output data sources used in the job. Defaults to None.
-    :type outputs: Optional[dict[str, Union[str, ~azure.ai.ml.Output]]]
+    :paramtype outputs: Optional[dict[str, Union[str, ~azure.ai.ml.Output]]]
     :keyword instance_count: The number of instances or nodes to be used by the compute target. Defaults to 1.
-    :type instance_count: Optional[int]
+    :paramtype instance_count: Optional[int]
     :keyword instance_type: The type of VM to be used by the compute target.
-    :type instance_type: Optional[str]
+    :paramtype instance_type: Optional[str]
     :keyword locations: The list of locations where the job will run.
-    :type locations: Optional[list[str]]
+    :paramtype locations: Optional[list[str]]
     :keyword docker_args: Extra arguments to pass to the Docker run command. This would override any
         parameters that have already been set by the system, or in this section. This parameter is only
         supported for Azure ML compute types. Defaults to None.
-    :type docker_args: Optional[str]
+    :paramtype docker_args: Optional[str]
     :keyword shm_size: The size of the Docker container's shared memory block. This should be in the
         format of (number)(unit) where the number has to be greater than 0 and the unit can be one of
         b(bytes), k(kilobytes), m(megabytes), or g(gigabytes).
-    :type shm_size: Optional[str]
+    :paramtype shm_size: Optional[str]
     :keyword timeout: The number, in seconds, after which the job will be cancelled.
-    :type timeout: Optional[int]
+    :paramtype timeout: Optional[int]
     :keyword code: The source code to run the job. Can be a local path or "http:", "https:", or "azureml:" url
         pointing to a remote location.
-    :type code: Optional[Union[str, os.PathLike]]
+    :paramtype code: Optional[Union[str, os.PathLike]]
     :keyword identity: The identity that the command job will use while running on compute.
-    :type identity: Optional[Union[
+    :paramtype identity: Optional[Union[
         ~azure.ai.ml.entities.ManagedIdentityConfiguration,
         ~azure.ai.ml.entities.AmlTokenConfiguration,
         ~azure.ai.ml.entities.UserIdentityConfiguration]]
@@ -205,17 +205,17 @@ def command(
         Defaults to True. When True, if a Command Component is deterministic and has been run before in the
         current workspace with the same input and settings, it will reuse results from a previously submitted
         job when used as a node or step in a pipeline. In that scenario, no compute resources will be used.
-    :type is_deterministic: bool
+    :paramtype is_deterministic: bool
     :keyword services: The interactive services for the node. Defaults to None. This is an experimental parameter,
         and may change at any time. Please see https://aka.ms/azuremlexperimental for more information.
-    :type services: Optional[dict[str, Union[~azure.ai.ml.entities.JobService,
+    :paramtype services: Optional[dict[str, Union[~azure.ai.ml.entities.JobService,
         ~azure.ai.ml.entities.JupyterLabJobService, ~azure.ai.ml.entities.SshJobService,
         ~azure.ai.ml.entities.TensorBoardJobService, ~azure.ai.ml.entities.VsCodeJobService]]]
     :keyword job_tier: The job tier. Accepted values are "Spot", "Basic", "Standard", or "Premium".
-    :type job_tier: Optional[str]
+    :paramtype job_tier: Optional[str]
     :keyword priority: The priority of the job on the compute. Accepted values are "low", "medium", and "high".
         Defaults to "medium".
-    :type priority: Optional[str]
+    :paramtype priority: Optional[str]
     :return: A Command object.
     :rtype: ~azure.ai.ml.entities.Command
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_builders/data_transfer_func.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_builders/data_transfer_func.py
@@ -123,29 +123,29 @@ def copy_data(
     """Create a DataTransferCopy object which can be used inside dsl.pipeline as a function.
 
     :keyword name: The name of the job.
-    :type name: str
+    :paramtype name: str
     :keyword description: Description of the job.
-    :type description: str
+    :paramtype description: str
     :keyword tags: Tag dictionary. Tags can be added, removed, and updated.
-    :type tags: dict[str, str]
+    :paramtype tags: dict[str, str]
     :keyword display_name: Display name of the job.
-    :type display_name: str
+    :paramtype display_name: str
     :keyword experiment_name:  Name of the experiment the job will be created under.
-    :type experiment_name: str
+    :paramtype experiment_name: str
     :keyword compute: The compute resource the job runs on.
-    :type compute: str
+    :paramtype compute: str
     :keyword inputs: Mapping of inputs data bindings used in the job.
-    :type inputs: dict
+    :paramtype inputs: dict
     :keyword outputs: Mapping of outputs data bindings used in the job.
-    :type outputs: dict
+    :paramtype outputs: dict
     :keyword is_deterministic: Specify whether the command will return same output given same input.
         If a command (component) is deterministic, when use it as a node/step in a pipeline,
         it will reuse results from a previous submitted job in current workspace which has same inputs and settings.
         In this case, this step will not use any compute resource.
         Default to be True, specify is_deterministic=False if you would like to avoid such reuse behavior.
-    :type is_deterministic: bool
+    :paramtype is_deterministic: bool
     :keyword data_copy_mode: data copy mode in copy task, possible value is "merge_with_overwrite", "fail_if_conflict".
-    :type data_copy_mode: str
+    :paramtype data_copy_mode: str
     :return: A DataTransferCopy object.
     :rtype: ~azure.ai.ml.entities._component.datatransfer_component.DataTransferCopyComponent
     """
@@ -202,23 +202,23 @@ def import_data(
     """Create a DataTransferImport object which can be used inside dsl.pipeline.
 
     :keyword name: The name of the job.
-    :type name: str
+    :paramtype name: str
     :keyword description: Description of the job.
-    :type description: str
+    :paramtype description: str
     :keyword tags: Tag dictionary. Tags can be added, removed, and updated.
-    :type tags: dict[str, str]
+    :paramtype tags: dict[str, str]
     :keyword display_name: Display name of the job.
-    :type display_name: str
+    :paramtype display_name: str
     :keyword experiment_name: Name of the experiment the job will be created under.
-    :type experiment_name: str
+    :paramtype experiment_name: str
     :keyword compute: The compute resource the job runs on.
-    :type compute: str
+    :paramtype compute: str
     :keyword source: The data source of file system or database.
-    :type source: Union[Dict, ~azure.ai.ml.entities._inputs_outputs.external_data.Database,
+    :paramtype source: Union[Dict, ~azure.ai.ml.entities._inputs_outputs.external_data.Database,
         ~azure.ai.ml.entities._inputs_outputs.external_data.FileSystem]
     :keyword outputs: Mapping of outputs data bindings used in the job.
         The default will be an output port with the key "sink" and type "mltable".
-    :type outputs: dict
+    :paramtype outputs: dict
     :return: A DataTransferImport object.
     :rtype: ~azure.ai.ml.entities._job.pipeline._component_translatable.DataTransferImport
     """
@@ -271,24 +271,24 @@ def export_data(
     """Create a DataTransferExport object which can be used inside dsl.pipeline.
 
     :keyword name: The name of the job.
-    :type name: str
+    :paramtype name: str
     :keyword description: Description of the job.
-    :type description: str
+    :paramtype description: str
     :keyword tags: Tag dictionary. Tags can be added, removed, and updated.
-    :type tags: dict[str, str]
+    :paramtype tags: dict[str, str]
     :keyword display_name: Display name of the job.
-    :type display_name: str
+    :paramtype display_name: str
     :keyword experiment_name: Name of the experiment the job will be created under.
-    :type experiment_name: str
+    :paramtype experiment_name: str
     :keyword compute: The compute resource the job runs on.
-    :type compute: str
+    :paramtype compute: str
     :keyword sink: The sink of external data and databases.
-    :type sink: Union[
+    :paramtype sink: Union[
         Dict,
         ~azure.ai.ml.entities._inputs_outputs.external_data.Database,
         ~azure.ai.ml.entities._inputs_outputs.external_data.FileSystem]
     :keyword inputs: Mapping of inputs data bindings used in the job.
-    :type inputs: dict
+    :paramtype inputs: dict
     :return: A DataTransferExport object.
     :rtype: ~azure.ai.ml.entities._job.pipeline._component_translatable.DataTransferExport
     :raises ValidationException: If sink is not provided or exporting file system is not supported.

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_builders/do_while.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_builders/do_while.py
@@ -37,7 +37,7 @@ class DoWhile(LoopNode):
     :type mapping: dict[Union[str, ~azure.ai.ml.entities.Output],
         Union[str, ~azure.ai.ml.entities.Input, list]]
     :param limits: Limits in running the do-while node.
-    :type limits: Union[dict, ~azure.ai.ml.entities._job.job_limits.DoWhileJobLimits], optional
+    :type limits: Union[dict, ~azure.ai.ml.entities._job.job_limits.DoWhileJobLimits]
     :raises ValidationError: If the initialization parameters are not of valid types.
     """
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_builders/do_while.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_builders/do_while.py
@@ -205,7 +205,7 @@ class DoWhile(LoopNode):
         The range of the iteration count is (0, 1000].
 
         :keyword max_iteration_count: The maximum iteration count for the do-while job.
-        :type max_iteration_count: int
+        :paramtype max_iteration_count: int
         """
         if isinstance(self.limits, DoWhileJobLimits):
             self.limits._max_iteration_count = max_iteration_count  # pylint: disable=protected-access

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_builders/fl_scatter_gather.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_builders/fl_scatter_gather.py
@@ -55,21 +55,21 @@ class FLScatterGather(ControlFlowNode, NodeIOMixin):
     :param aggregation_component: Component representing the aggregation step.
     :type aggregation_component: ~azure.ai.ml.entities.Component
     :param aggregation_compute: The compute resource for the aggregation step.
-    :type aggregation_compute: str, optional
+    :type aggregation_compute: str
     :param aggregation_datastore: The datastore for the aggregation step.
-    :type aggregation_datastore: str, optional
+    :type aggregation_datastore: str
     :param shared_silo_kwargs: Keyword arguments shared across all silos.
-    :type shared_silo_kwargs: dict, optional
+    :type shared_silo_kwargs: dict
     :param aggregation_kwargs: Keyword arguments specific to the aggregation step.
-    :type aggregation_kwargs: dict, optional
+    :type aggregation_kwargs: dict
     :param silo_to_aggregation_argument_map: Mapping of silo to aggregation arguments.
-    :type silo_to_aggregation_argument_map: dict, optional
+    :type silo_to_aggregation_argument_map: dict
     :param aggregation_to_silo_argument_map: Mapping of aggregation to silo arguments.
-    :type aggregation_to_silo_argument_map: dict, optional
+    :type aggregation_to_silo_argument_map: dict
     :param max_iterations: The maximum number of iterations for the scatter-gather loop.
-    :type max_iterations: int, optional
+    :type max_iterations: int
     :param create_default_mappings_if_needed: Whether to create default argument mappings if needed.
-    :type create_default_mappings_if_needed: bool, optional
+    :type create_default_mappings_if_needed: bool
     """
 
     # See node class for input descriptions, no point maintaining
@@ -377,7 +377,7 @@ class FLScatterGather(ControlFlowNode, NodeIOMixin):
             'real' output anchoring.
         :type orchestrator_datastore: str
         :param iteration: The current iteration number in the scatter gather loop. Defaults to 0.
-        :type iteration: Optional[int], optional
+        :type iteration: Optional[int]
         :param _path: for recursive anchoring, codes the "path" inside the pipeline for messaging
         :type _path: str
         :return: A validation result containing any issues that were uncovered during anchoring. This function adds

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_builders/fl_scatter_gather.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_builders/fl_scatter_gather.py
@@ -488,27 +488,27 @@ class FLScatterGather(ControlFlowNode, NodeIOMixin):
         """Validates the inputs for the scatter-gather node.
 
         :keyword silo_configs: List of federated learning silo configurations.
-        :type silo_configs: List[~azure.ai.ml.entities._assets.federated_learning_silo.FederatedLearningSilo]
+        :paramtype silo_configs: List[~azure.ai.ml.entities._assets.federated_learning_silo.FederatedLearningSilo]
         :keyword silo_component: Component representing the silo for federated learning.
-        :type silo_component: ~azure.ai.ml.entities.Component
+        :paramtype silo_component: ~azure.ai.ml.entities.Component
         :keyword aggregation_component: Component representing the aggregation step.
-        :type aggregation_component: ~azure.ai.ml.entities.Component
+        :paramtype aggregation_component: ~azure.ai.ml.entities.Component
         :keyword shared_silo_kwargs: Keyword arguments shared across all silos.
-        :type shared_silo_kwargs: Dict
+        :paramtype shared_silo_kwargs: Dict
         :keyword aggregation_compute: The compute resource for the aggregation step.
-        :type aggregation_compute: str
+        :paramtype aggregation_compute: str
         :keyword aggregation_datastore: The datastore for the aggregation step.
-        :type aggregation_datastore: str
+        :paramtype aggregation_datastore: str
         :keyword aggregation_kwargs: Keyword arguments specific to the aggregation step.
-        :type aggregation_kwargs: Dict
+        :paramtype aggregation_kwargs: Dict
         :keyword silo_to_aggregation_argument_map: Mapping of silo to aggregation arguments.
-        :type silo_to_aggregation_argument_map: Dict
+        :paramtype silo_to_aggregation_argument_map: Dict
         :keyword aggregation_to_silo_argument_map: Mapping of aggregation to silo arguments.
-        :type aggregation_to_silo_argument_map: Dict
+        :paramtype aggregation_to_silo_argument_map: Dict
         :keyword max_iterations: The maximum number of iterations for the scatter-gather loop.
-        :type max_iterations: int
+        :paramtype max_iterations: int
         :keyword raise_error: Whether to raise an exception if validation fails. Defaults to False.
-        :type raise_error: bool
+        :paramtype raise_error: bool
         :return: The validation result.
         :rtype: ~azure.ai.ml.entities._validation.MutableValidationResult
         """

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_builders/import_func.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_builders/import_func.py
@@ -31,28 +31,28 @@ def import_job(
     and can also be created as a standalone import job.
 
     :keyword name: Name of the import job or component created.
-    :type name: str
+    :paramtype name: str
     :keyword description: A friendly description of the import.
-    :type description: str
+    :paramtype description: str
     :keyword tags: Tags to be attached to this import.
-    :type tags: Dict
+    :paramtype tags: Dict
     :keyword display_name: A friendly name.
-    :type display_name: str
+    :paramtype display_name: str
     :keyword experiment_name: Name of the experiment the job will be created under.
         If None is provided, the default will be set to the current directory name.
         Will be ignored as a pipeline step.
-    :type experiment_name: str
+    :paramtype experiment_name: str
     :keyword source: Input source parameters used by this import.
-    :type source: ~azure.ai.ml.entities._job.import_job.ImportSource
+    :paramtype source: ~azure.ai.ml.entities._job.import_job.ImportSource
     :keyword output: The output of this import.
-    :type output: ~azure.ai.ml.entities.Output
+    :paramtype output: ~azure.ai.ml.entities.Output
     :keyword is_deterministic: Specify whether the command will return the same output given the same input.
         If a command (component) is deterministic, when used as a node/step in a pipeline,
         it will reuse results from a previously submitted job in the current workspace
         which has the same inputs and settings.
         In this case, this step will not use any compute resource.
         Defaults to True.
-    :type is_deterministic: bool
+    :paramtype is_deterministic: bool
     :returns: The Import object.
     :rtype: ~azure.ai.ml.entities._builders.import_node.Import
     """

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_builders/import_func.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_builders/import_func.py
@@ -31,21 +31,21 @@ def import_job(
     and can also be created as a standalone import job.
 
     :keyword name: Name of the import job or component created.
-    :type name: str, optional
+    :type name: str
     :keyword description: A friendly description of the import.
-    :type description: str, optional
+    :type description: str
     :keyword tags: Tags to be attached to this import.
-    :type tags: Dict, optional
+    :type tags: Dict
     :keyword display_name: A friendly name.
-    :type display_name: str, optional
+    :type display_name: str
     :keyword experiment_name: Name of the experiment the job will be created under.
         If None is provided, the default will be set to the current directory name.
         Will be ignored as a pipeline step.
-    :type experiment_name: str, optional
+    :type experiment_name: str
     :keyword source: Input source parameters used by this import.
-    :type source: ~azure.ai.ml.entities._job.import_job.ImportSource, optional
+    :type source: ~azure.ai.ml.entities._job.import_job.ImportSource
     :keyword output: The output of this import.
-    :type output: ~azure.ai.ml.entities.Output, optional
+    :type output: ~azure.ai.ml.entities.Output
     :keyword is_deterministic: Specify whether the command will return the same output given the same input.
         If a command (component) is deterministic, when used as a node/step in a pipeline,
         it will reuse results from a previously submitted job in the current workspace

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_builders/import_node.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_builders/import_node.py
@@ -37,18 +37,18 @@ class Import(BaseNode):
     :param component: Id or instance of the import component/job to be run for the step.
     :type component: ~azure.ai.ml.entities._component.import_component.ImportComponent
     :param inputs: Input parameters to the import.
-    :type inputs: Dict[str, str], optional
+    :type inputs: Dict[str, str]
     :param outputs: Mapping of output data bindings used in the job.
-    :type outputs: Dict[str, Union[str, ~azure.ai.ml.entities.Output]], optional
+    :type outputs: Dict[str, Union[str, ~azure.ai.ml.entities.Output]]
     :param name: Name of the import.
     :type name: str
     :param description: Description of the import.
-    :type description: str, optional
+    :type description: str
     :param display_name: Display name of the job.
-    :type display_name: str, optional
+    :type display_name: str
     :param experiment_name: Name of the experiment the job will be created under,
         if None is provided, the default will be set to the current directory name.
-    :type experiment_name: str, optional
+    :type experiment_name: str
     """
 
     def __init__(

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_builders/parallel.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_builders/parallel.py
@@ -278,15 +278,15 @@ class Parallel(BaseNode, NodeWithGroupInputMixin):
         """Set the resources for the parallel job.
 
         :keyword instance_type: The instance type or a list of instance types used as supported by the compute target.
-        :type instance_type: str or list[str]
+        :paramtype instance_type: str or list[str]
         :keyword instance_count: The number of instances or nodes used by the compute target.
-        :type instance_count: int
+        :paramtype instance_count: int
         :keyword properties: The property dictionary for the resources.
-        :type properties: dict
+        :paramtype properties: dict
         :keyword docker_args: Extra arguments to pass to the Docker run command.
-        :type docker_args: str
+        :paramtype docker_args: str
         :keyword shm_size: Size of the Docker container's shared memory block.
-        :type shm_size: str
+        :paramtype shm_size: str
         """
         if self.resources is None:
             self.resources = JobResourceConfiguration()

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_builders/parallel.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_builders/parallel.py
@@ -39,27 +39,27 @@ class Parallel(BaseNode, NodeWithGroupInputMixin):
     :param component: Id or instance of the parallel component/job to be run for the step
     :type component: ~azure.ai.ml.entities._component.parallel_component.parallelComponent
     :param name: Name of the parallel
-    :type name: str, optional
+    :type name: str
     :param description: Description of the commad
-    :type description: str, optional
+    :type description: str
     :param tags: Tag dictionary. Tags can be added, removed, and updated
-    :type tags: dict[str, str], optional
+    :type tags: dict[str, str]
     :param properties: The job property dictionary
-    :type properties: dict[str, str], optional
+    :type properties: dict[str, str]
     :param display_name: Display name of the job
-    :type display_name: str, optional
+    :type display_name: str
     :param retry_settings: Parallel job run failed retry
-    :type retry_settings: BatchRetrySettings, optional
+    :type retry_settings: BatchRetrySettings
     :param logging_level: A string of the logging level name
-    :type logging_level: str, optional
+    :type logging_level: str
     :param max_concurrency_per_instance: The max parallellism that each compute instance has
-    :type max_concurrency_per_instance: int, optional
+    :type max_concurrency_per_instance: int
     :param error_threshold: The number of item processing failures should be ignored
-    :type error_threshold: int, optional
+    :type error_threshold: int
     :param mini_batch_error_threshold: The number of mini batch processing failures should be ignored
-    :type mini_batch_error_threshold: int, optional
+    :type mini_batch_error_threshold: int
     :param task: The parallel task
-    :type task: ParallelTask, optional
+    :type task: ParallelTask
     :param mini_batch_size: For FileDataset input, this field is the number of files
                             a user script can process in one run() call.
                             For TabularDataset input, this field is the approximate size of data
@@ -67,20 +67,20 @@ class Parallel(BaseNode, NodeWithGroupInputMixin):
                             Example values are 1024, 1024KB, 10MB, and 1GB. (optional, default value is 10 files
                             for FileDataset and 1MB for TabularDataset.)
                             This value could be set through PipelineParameter
-    :type mini_batch_size: str, optional
+    :type mini_batch_size: str
     :param partition_keys: The keys used to partition dataset into mini-batches. If specified,
                            the data with the same key will be partitioned into the same mini-batch.
                            If both partition_keys and mini_batch_size are specified,
                            the partition keys will take effect.
                            The input(s) must be partitioned dataset(s),
                            and the partition_keys must be a subset of the keys of every input dataset for this to work.
-    :type partition_keys: List, optional
+    :type partition_keys: List
     :param input_data: The input data
-    :type input_data: str, optional
+    :type input_data: str
     :param inputs: Inputs of the component/job
-    :type inputs: dict, optional
+    :type inputs: dict
     :param outputs: Outputs of the component/job
-    :type outputs: dict, optional
+    :type outputs: dict
     """
 
     # pylint: disable=too-many-instance-attributes
@@ -278,15 +278,15 @@ class Parallel(BaseNode, NodeWithGroupInputMixin):
         """Set the resources for the parallel job.
 
         :keyword instance_type: The instance type or a list of instance types used as supported by the compute target.
-        :type instance_type: str or list[str], optional
+        :type instance_type: str or list[str]
         :keyword instance_count: The number of instances or nodes used by the compute target.
-        :type instance_count: int, optional
+        :type instance_count: int
         :keyword properties: The property dictionary for the resources.
-        :type properties: dict, optional
+        :type properties: dict
         :keyword docker_args: Extra arguments to pass to the Docker run command.
-        :type docker_args: str, optional
+        :type docker_args: str
         :keyword shm_size: Size of the Docker container's shared memory block.
-        :type shm_size: str, optional
+        :type shm_size: str
         """
         if self.resources is None:
             self.resources = JobResourceConfiguration()

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_builders/parallel_for.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_builders/parallel_for.py
@@ -33,7 +33,7 @@ class ParallelFor(LoopNode, NodeIOMixin):
         ~azure.ai.ml.entities._job.pipeline._io.PipelineInput]
     :param max_concurrency: Maximum number of concurrent iterations to run. All loop body nodes will be executed
         in parallel if not specified.
-    :type max_concurrency: int, optional
+    :type max_concurrency: int
     """
 
     OUT_TYPE_MAPPING = {

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_builders/parallel_func.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_builders/parallel_func.py
@@ -100,45 +100,45 @@ def parallel_run_function(
         )
 
     :keyword name: Name of the parallel job or component created.
-    :type name: str, optional
+    :type name: str
     :keyword description: A friendly description of the parallel.
-    :type description: str, optional
+    :type description: str
     :keyword tags: Tags to be attached to this parallel.
-    :type tags: Dict, optional
+    :type tags: Dict
     :keyword properties: The asset property dictionary.
-    :type properties: Dict, optional
+    :type properties: Dict
     :keyword display_name: A friendly name.
-    :type display_name: str, optional
+    :type display_name: str
     :keyword experiment_name: Name of the experiment the job will be created under,
                             if None is provided, default will be set to current directory name.
                             Will be ignored as a pipeline step.
-    :type experiment_name: str, optional
+    :type experiment_name: str
     :keyword compute: The name of the compute where the parallel job is executed (will not be used
                     if the parallel is used as a component/function).
-    :type compute: str, optional
+    :type compute: str
     :keyword retry_settings: Parallel component run failed retry
-    :type retry_settings: ~azure.ai.ml.entities._deployment.deployment_settings.BatchRetrySettings, optional
+    :type retry_settings: ~azure.ai.ml.entities._deployment.deployment_settings.BatchRetrySettings
     :keyword environment_variables: A dictionary of environment variables names and values.
                                   These environment variables are set on the process
                                   where user script is being executed.
-    :type environment_variables: Dict[str, str], optional
+    :type environment_variables: Dict[str, str]
     :keyword logging_level: A string of the logging level name, which is defined in 'logging'.
                           Possible values are 'WARNING', 'INFO', and 'DEBUG'. (optional, default value is 'INFO'.)
                           This value could be set through PipelineParameter.
-    :type logging_level: str, optional
+    :type logging_level: str
     :keyword max_concurrency_per_instance: The max parallellism that each compute instance has.
-    :type max_concurrency_per_instance: int, optional
+    :type max_concurrency_per_instance: int
     :keyword error_threshold: The number of record failures for Tabular Dataset and file failures for File Dataset
                             that should be ignored during processing.
                             If the error count goes above this value, then the job will be aborted.
                             Error threshold is for the entire input rather
                             than the individual mini-batch sent to run() method.
                             The range is [-1, int.max]. -1 indicates ignore all failures during processing
-    :type error_threshold: int, optional
+    :type error_threshold: int
     :keyword mini_batch_error_threshold: The number of mini batch processing failures should be ignored
-    :type mini_batch_error_threshold: int, optional
+    :type mini_batch_error_threshold: int
     :keyword task: The parallel task
-    :type task: ~azure.ai.ml.entities._job.parallel.run_function.RunFunction, optional
+    :type task: ~azure.ai.ml.entities._job.parallel.run_function.RunFunction
     :keyword mini_batch_size: For FileDataset input,
                             this field is the number of files a user script can process in one run() call.
                             For TabularDataset input, this field is the approximate size of data
@@ -146,38 +146,38 @@ def parallel_run_function(
                             Example values are 1024, 1024KB, 10MB, and 1GB.
                             (optional, default value is 10 files for FileDataset and 1MB for TabularDataset.)
                             This value could be set through PipelineParameter.
-    :type mini_batch_size: str, optional
+    :type mini_batch_size: str
     :keyword partition_keys: The keys used to partition dataset into mini-batches. If specified,
                            the data with the same key will be partitioned into the same mini-batch.
                            If both partition_keys and mini_batch_size are specified,
                            the partition keys will take effect.
                            The input(s) must be partitioned dataset(s),
                            and the partition_keys must be a subset of the keys of every input dataset for this to work
-    :type partition_keys: List, optional
+    :type partition_keys: List
     :keyword input_data: The input data.
-    :type input_data: str, optional
+    :type input_data: str
     :keyword inputs: A dict of inputs used by this parallel.
-    :type inputs: Dict, optional
+    :type inputs: Dict
     :keyword outputs: The outputs of this parallel
-    :type outputs: Dict, optional
+    :type outputs: Dict
     :keyword instance_count: Optional number of instances or nodes used by the compute target.
                            Defaults to 1
-    :type instance_count: int, optional
+    :type instance_count: int
     :keyword instance_type: Optional type of VM used as supported by the compute target..
-    :type instance_type: str, optional
+    :type instance_type: str
     :keyword docker_args: Extra arguments to pass to the Docker run command.
                         This would override any parameters that have already been set by the system,
                         or in this section.
                         This parameter is only supported for Azure ML compute types.
-    :type docker_args: str, optional
+    :type docker_args: str
     :keyword shm_size: Size of the docker container's shared memory block.
                      This should be in the format of (number)(unit) where number as to be greater than 0
                      and the unit can be one of b(bytes), k(kilobytes), m(megabytes), or g(gigabytes).
-    :type shm_size: str, optional
+    :type shm_size: str
     :keyword identity: Identity that training job will use while running on compute.
     :type identity: Union[
                     ~azure.ai.ml._restclient.v2022_02_01_preview.models.ManagedIdentity,
-                    ~azure.ai.ml._restclient.v2022_02_01_preview.models.AmlToken], optional
+                    ~azure.ai.ml._restclient.v2022_02_01_preview.models.AmlToken]
     :keyword is_deterministic: Specify whether the parallel will return same output given same input.
                              If a parallel (component) is deterministic, when use it as a node/step in a pipeline,
                              it will reuse results from a previous submitted job in current workspace

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_builders/parallel_func.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_builders/parallel_func.py
@@ -100,45 +100,45 @@ def parallel_run_function(
         )
 
     :keyword name: Name of the parallel job or component created.
-    :type name: str
+    :paramtype name: str
     :keyword description: A friendly description of the parallel.
-    :type description: str
+    :paramtype description: str
     :keyword tags: Tags to be attached to this parallel.
-    :type tags: Dict
+    :paramtype tags: Dict
     :keyword properties: The asset property dictionary.
-    :type properties: Dict
+    :paramtype properties: Dict
     :keyword display_name: A friendly name.
-    :type display_name: str
+    :paramtype display_name: str
     :keyword experiment_name: Name of the experiment the job will be created under,
                             if None is provided, default will be set to current directory name.
                             Will be ignored as a pipeline step.
-    :type experiment_name: str
+    :paramtype experiment_name: str
     :keyword compute: The name of the compute where the parallel job is executed (will not be used
                     if the parallel is used as a component/function).
-    :type compute: str
+    :paramtype compute: str
     :keyword retry_settings: Parallel component run failed retry
-    :type retry_settings: ~azure.ai.ml.entities._deployment.deployment_settings.BatchRetrySettings
+    :paramtype retry_settings: ~azure.ai.ml.entities._deployment.deployment_settings.BatchRetrySettings
     :keyword environment_variables: A dictionary of environment variables names and values.
                                   These environment variables are set on the process
                                   where user script is being executed.
-    :type environment_variables: Dict[str, str]
+    :paramtype environment_variables: Dict[str, str]
     :keyword logging_level: A string of the logging level name, which is defined in 'logging'.
                           Possible values are 'WARNING', 'INFO', and 'DEBUG'. (optional, default value is 'INFO'.)
                           This value could be set through PipelineParameter.
-    :type logging_level: str
+    :paramtype logging_level: str
     :keyword max_concurrency_per_instance: The max parallellism that each compute instance has.
-    :type max_concurrency_per_instance: int
+    :paramtype max_concurrency_per_instance: int
     :keyword error_threshold: The number of record failures for Tabular Dataset and file failures for File Dataset
                             that should be ignored during processing.
                             If the error count goes above this value, then the job will be aborted.
                             Error threshold is for the entire input rather
                             than the individual mini-batch sent to run() method.
                             The range is [-1, int.max]. -1 indicates ignore all failures during processing
-    :type error_threshold: int
+    :paramtype error_threshold: int
     :keyword mini_batch_error_threshold: The number of mini batch processing failures should be ignored
-    :type mini_batch_error_threshold: int
+    :paramtype mini_batch_error_threshold: int
     :keyword task: The parallel task
-    :type task: ~azure.ai.ml.entities._job.parallel.run_function.RunFunction
+    :paramtype task: ~azure.ai.ml.entities._job.parallel.run_function.RunFunction
     :keyword mini_batch_size: For FileDataset input,
                             this field is the number of files a user script can process in one run() call.
                             For TabularDataset input, this field is the approximate size of data
@@ -146,36 +146,36 @@ def parallel_run_function(
                             Example values are 1024, 1024KB, 10MB, and 1GB.
                             (optional, default value is 10 files for FileDataset and 1MB for TabularDataset.)
                             This value could be set through PipelineParameter.
-    :type mini_batch_size: str
+    :paramtype mini_batch_size: str
     :keyword partition_keys: The keys used to partition dataset into mini-batches. If specified,
                            the data with the same key will be partitioned into the same mini-batch.
                            If both partition_keys and mini_batch_size are specified,
                            the partition keys will take effect.
                            The input(s) must be partitioned dataset(s),
                            and the partition_keys must be a subset of the keys of every input dataset for this to work
-    :type partition_keys: List
+    :paramtype partition_keys: List
     :keyword input_data: The input data.
-    :type input_data: str
+    :paramtype input_data: str
     :keyword inputs: A dict of inputs used by this parallel.
-    :type inputs: Dict
+    :paramtype inputs: Dict
     :keyword outputs: The outputs of this parallel
-    :type outputs: Dict
+    :paramtype outputs: Dict
     :keyword instance_count: Optional number of instances or nodes used by the compute target.
                            Defaults to 1
-    :type instance_count: int
+    :paramtype instance_count: int
     :keyword instance_type: Optional type of VM used as supported by the compute target..
-    :type instance_type: str
+    :paramtype instance_type: str
     :keyword docker_args: Extra arguments to pass to the Docker run command.
                         This would override any parameters that have already been set by the system,
                         or in this section.
                         This parameter is only supported for Azure ML compute types.
-    :type docker_args: str
+    :paramtype docker_args: str
     :keyword shm_size: Size of the docker container's shared memory block.
                      This should be in the format of (number)(unit) where number as to be greater than 0
                      and the unit can be one of b(bytes), k(kilobytes), m(megabytes), or g(gigabytes).
-    :type shm_size: str
+    :paramtype shm_size: str
     :keyword identity: Identity that training job will use while running on compute.
-    :type identity: Union[
+    :paramtype identity: Union[
                     ~azure.ai.ml._restclient.v2022_02_01_preview.models.ManagedIdentity,
                     ~azure.ai.ml._restclient.v2022_02_01_preview.models.AmlToken]
     :keyword is_deterministic: Specify whether the parallel will return same output given same input.
@@ -185,7 +185,7 @@ def parallel_run_function(
                              In this case, this step will not use any compute resource. Defaults to True,
                              specify is_deterministic=False if you would like to avoid such reuse behavior,
                              defaults to True.
-    :type is_deterministic: bool
+    :paramtype is_deterministic: bool
     :return: The parallel node
     :rtype: ~azure.ai.ml._builders.parallel.Parallel
     """

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_builders/spark_func.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_builders/spark_func.py
@@ -111,71 +111,71 @@ def spark(
     """Creates a Spark object which can be used inside a dsl.pipeline function or used as a standalone Spark job.
 
     :keyword experiment_name:  The name of the experiment the job will be created under.
-    :type experiment_name: Optional[str]
+    :paramtype experiment_name: Optional[str]
     :keyword name: The name of the job.
-    :type name: Optional[str]
+    :paramtype name: Optional[str]
     :keyword display_name: The job display name.
-    :type display_name: Optional[str]
+    :paramtype display_name: Optional[str]
     :keyword description: The description of the job. Defaults to None.
-    :type description: Optional[str]
+    :paramtype description: Optional[str]
     :keyword tags: The dictionary of tags for the job. Tags can be added, removed, and updated. Defaults to None.
-    :type tags: Optional[dict[str, str]]
+    :paramtype tags: Optional[dict[str, str]]
     :keyword code: The source code to run the job. Can be a local path or "http:", "https:", or "azureml:" url
         pointing to a remote location.
     :type code: Optional[Union[str, os.PathLike]]
     :keyword entry: The file or class entry point.
-    :type entry: Optional[Union[dict[str, str], ~azure.ai.ml.entities.SparkJobEntry]]
+    :paramtype entry: Optional[Union[dict[str, str], ~azure.ai.ml.entities.SparkJobEntry]]
     :keyword py_files: The list of .zip, .egg or .py files to place on the PYTHONPATH for Python apps.
         Defaults to None.
-    :type py_files: Optional[list[str]]
+    :paramtype py_files: Optional[list[str]]
     :keyword jars: The list of .JAR files to include on the driver and executor classpaths. Defaults to None.
-    :type jars: Optional[list[str]]
+    :paramtype jars: Optional[list[str]]
     :keyword files: The list of files to be placed in the working directory of each executor. Defaults to None.
-    :type files: Optional[list[str]]
+    :paramtype files: Optional[list[str]]
     :keyword archives: The list of archives to be extracted into the working directory of each executor.
         Defaults to None.
-    :type archives: Optional[list[str]]
+    :paramtype archives: Optional[list[str]]
     :keyword identity: The identity that the Spark job will use while running on compute.
-    :type identity: Optional[Union[
+    :paramtype identity: Optional[Union[
         dict[str, str],
         ~azure.ai.ml.entities.ManagedIdentityConfiguration,
         ~azure.ai.ml.entities.AmlTokenConfiguration,
         ~azure.ai.ml.entities.UserIdentityConfiguration]]
     :keyword driver_cores: The number of cores to use for the driver process, only in cluster mode.
-    :type driver_cores: Optional[int]
+    :paramtype driver_cores: Optional[int]
     :keyword driver_memory: The amount of memory to use for the driver process, formatted as strings with a size unit
         suffix ("k", "m", "g" or "t") (e.g. "512m", "2g").
-    :type driver_memory: Optional[str]
+    :paramtype driver_memory: Optional[str]
     :keyword executor_cores: The number of cores to use on each executor.
-    :type executor_cores: Optional[int]
+    :paramtype executor_cores: Optional[int]
     :keyword executor_memory: The amount of memory to use per executor process, formatted as strings with a size unit
         suffix ("k", "m", "g" or "t") (e.g. "512m", "2g").
-    :type executor_memory: Optional[str]
+    :paramtype executor_memory: Optional[str]
     :keyword executor_instances: The initial number of executors.
-    :type executor_instances: Optional[int]
+    :paramtype executor_instances: Optional[int]
     :keyword dynamic_allocation_enabled: Whether to use dynamic resource allocation, which scales the number of
         executors registered with this application up and down based on the workload.
-    :type dynamic_allocation_enabled: Optional[bool]
+    :paramtype dynamic_allocation_enabled: Optional[bool]
     :keyword dynamic_allocation_min_executors: The lower bound for the number of executors if dynamic allocation is
         enabled.
-    :type dynamic_allocation_min_executors: Optional[int]
+    :paramtype dynamic_allocation_min_executors: Optional[int]
     :keyword dynamic_allocation_max_executors: The upper bound for the number of executors if dynamic allocation is
         enabled.
-    :type dynamic_allocation_max_executors: Optional[int]
+    :paramtype dynamic_allocation_max_executors: Optional[int]
     :keyword conf: A dictionary with pre-defined Spark configurations key and values. Defaults to None.
-    :type conf: Optional[dict[str, str]]
+    :paramtype conf: Optional[dict[str, str]]
     :keyword environment: The Azure ML environment to run the job in.
-    :type environment: Optional[Union[str, ~azure.ai.ml.entities.Environment]]
+    :paramtype environment: Optional[Union[str, ~azure.ai.ml.entities.Environment]]
     :keyword inputs: A mapping of input names to input data used in the job. Defaults to None.
-    :type inputs: Optional[dict[str, ~azure.ai.ml.Input]]
+    :paramtype inputs: Optional[dict[str, ~azure.ai.ml.Input]]
     :keyword outputs: A mapping of output names to output data used in the job. Defaults to None.
-    :type outputs: Optional[dict[str, ~azure.ai.ml.Output]]
+    :paramtype outputs: Optional[dict[str, ~azure.ai.ml.Output]]
     :keyword args: The arguments for the job.
-    :type args: Optional[str]
+    :paramtype args: Optional[str]
     :keyword compute: The compute resource the job runs on.
-    :type compute: Optional[str]
+    :paramtype compute: Optional[str]
     :keyword resources: The compute resource configuration for the job.
-    :type resources: Optional[Union[dict, ~azure.ai.ml.entities.SparkResourceConfiguration]]
+    :paramtype resources: Optional[Union[dict, ~azure.ai.ml.entities.SparkResourceConfiguration]]
     :return: A Spark object.
     :rtype: ~azure.ai.ml.entities.Spark
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_component/_additional_includes.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_component/_additional_includes.py
@@ -34,7 +34,7 @@ class AdditionalIncludes:
     :param base_path: The base path for origin code path and additional include configs.
     :type base_path: Path
     :param configs: The additional include configs.
-    :type configs: List[Union[str, dict]], optional
+    :type configs: List[Union[str, dict]]
     """
 
     def __init__(
@@ -309,7 +309,7 @@ class AdditionalIncludes:
         :param local_path: The local path
         :type local_path: str
         :param config_info: The config info
-        :type config_info: Optional[str], optional
+        :type config_info: Optional[str]
         :return: The validation result.
         :rtype: ~azure.ai.ml.entities._validation.MutableValidationResult
         """

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_component/code.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_component/code.py
@@ -22,11 +22,11 @@ class ComponentIgnoreFile(IgnoreFile):
     :param directory_path: The directory path for the ignore file.
     :type directory_path: Union[str, Path]
     :param additional_includes_file_name: Name of the additional includes file in the root directory to be ignored.
-    :type additional_includes_file_name: str, optional
+    :type additional_includes_file_name: str
     :param skip_ignore_file: Whether to skip the ignore file, defaults to False.
-    :type skip_ignore_file: bool, optional
+    :type skip_ignore_file: bool
     :param extra_ignore_list: List of additional ignore files to be considered during file exclusion.
-    :type extra_ignore_list: List[~azure.ai.ml._utils._asset_utils.IgnoreFile], optional
+    :type extra_ignore_list: List[~azure.ai.ml._utils._asset_utils.IgnoreFile]
     :raises ValueError: If additional include file is not found.
     :return: The ComponentIgnoreFile object.
     :rtype: ComponentIgnoreFile

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_component/command_component.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_component/command_component.py
@@ -36,29 +36,29 @@ class CommandComponent(Component, ParameterizedCommand, AdditionalIncludesMixin)
     """Command component version, used to define a Command Component or Job.
 
     :keyword name: The name of the Command job or component.
-    :type name: Optional[str]
+    :paramtype name: Optional[str]
     :keyword version: The version of the Command job or component.
-    :type version: Optional[str]
+    :paramtype version: Optional[str]
     :keyword description: The description of the component. Defaults to None.
-    :type description: Optional[str]
+    :paramtype description: Optional[str]
     :keyword tags: Tag dictionary. Tags can be added, removed, and updated. Defaults to None.
-    :type tags: Optional[dict]
+    :paramtype tags: Optional[dict]
     :keyword display_name: The display name of the component.
-    :type display_name: Optional[str]
+    :paramtype display_name: Optional[str]
     :keyword command: The command to be executed.
-    :type command: Optional[str]
+    :paramtype command: Optional[str]
     :keyword code: The source code to run the job. Can be a local path or "http:", "https:", or "azureml:" url pointing
         to a remote location.
     :type code: Optional[str]
     :keyword environment: The environment that the job will run in.
-    :type environment: Optional[Union[str, ~azure.ai.ml.entities.Environment]]
+    :paramtype environment: Optional[Union[str, ~azure.ai.ml.entities.Environment]]
     :keyword distribution: The configuration for distributed jobs. Defaults to None.
-    :type distribution: Optional[Union[~azure.ai.ml.PyTorchDistribution, ~azure.ai.ml.MpiDistribution,
+    :paramtype distribution: Optional[Union[~azure.ai.ml.PyTorchDistribution, ~azure.ai.ml.MpiDistribution,
         ~azure.ai.ml.TensorFlowDistribution, ~azure.ai.ml.RayDistribution]]
     :keyword resources: The compute resource configuration for the command.
-    :type resources: Optional[~azure.ai.ml.entities.JobResourceConfiguration]
+    :paramtype resources: Optional[~azure.ai.ml.entities.JobResourceConfiguration]
     :keyword inputs: A mapping of input names to input data sources used in the job. Defaults to None.
-    :type inputs: Optional[dict[str, Union[
+    :paramtype inputs: Optional[dict[str, Union[
         ~azure.ai.ml.Input,
         str,
         bool,
@@ -67,18 +67,18 @@ class CommandComponent(Component, ParameterizedCommand, AdditionalIncludesMixin)
         Enum,
         ]]]
     :keyword outputs: A mapping of output names to output data sources used in the job. Defaults to None.
-    :type outputs: Optional[dict[str, Union[str, ~azure.ai.ml.Output]]]
+    :paramtype outputs: Optional[dict[str, Union[str, ~azure.ai.ml.Output]]]
     :keyword instance_count: The number of instances or nodes to be used by the compute target. Defaults to 1.
-    :type instance_count: Optional[int]
+    :paramtype instance_count: Optional[int]
     :keyword is_deterministic: Specifies whether the Command will return the same output given the same input.
         Defaults to True. When True, if a Command (component) is deterministic and has been run before in the
         current workspace with the same input and settings, it will reuse results from a previous submitted job
         when used as a node or step in a pipeline. In that scenario, no compute resources will be used.
-    :type is_deterministic: Optional[bool]
+    :paramtype is_deterministic: Optional[bool]
     :keyword additional_includes: A list of shared additional files to be included in the component. Defaults to None.
-    :type additional_includes: Optional[list[str]]
+    :paramtype additional_includes: Optional[list[str]]
     :keyword properties: The job property dictionary. Defaults to None.
-    :type properties: Optional[dict[str, str]]
+    :paramtype properties: Optional[dict[str, str]]
     :raises ~azure.ai.ml.exceptions.ValidationException: Raised if CommandComponent cannot be successfully validated.
         Details will be provided in the error message.
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_component/component.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_component/component.py
@@ -290,7 +290,7 @@ class Component(
         :param io_names: The names to validate
         :type io_names: Iterable[str]
         :param raise_error: Whether to raise if validation fails. Defaults to False
-        :type raise_error: bool, optional
+        :type raise_error: bool
         :return: The validation result
         :rtype: MutableValidationResult
         """
@@ -476,7 +476,7 @@ class Component(
         """Return the hash of component.
 
         :param keys_to_omit: An iterable of keys to omit when computing the component hash
-        :type keys_to_omit: Optional[Iterable[str]], optional
+        :type keys_to_omit: Optional[Iterable[str]]
         :return: The component hash
         :rtype: str
         """

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_component/component_factory.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_component/component_factory.py
@@ -134,11 +134,11 @@ class _ComponentFactory:
         """Load a component from a YAML dict.
 
         :keyword data: The YAML dict.
-        :type data: dict
+        :paramtype data: dict
         :keyword context: The context of the YAML dict.
-        :type context: dict
+        :paramtype context: dict
         :keyword _type: The type name of the component. When None, it will be inferred from the YAML dict.
-        :type _type: str
+        :paramtype _type: str
         :return: The loaded component.
         :rtype: ~azure.ai.ml.entities.Component
         """
@@ -155,9 +155,9 @@ class _ComponentFactory:
         """Load a component from a REST object.
 
         :keyword obj: The REST object.
-        :type obj: ComponentVersion
+        :paramtype obj: ComponentVersion
         :keyword _type: The type name of the component. When None, it will be inferred from the REST object.
-        :type _type: str
+        :paramtype _type: str
         :return: The loaded component.
         :rtype: ~azure.ai.ml.entities.Component
         """

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_component/datatransfer_component.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_component/datatransfer_component.py
@@ -28,11 +28,11 @@ class DataTransferComponent(Component):  # pylint: disable=too-many-instance-att
 
     :param task: Task type in the data transfer component. Possible values are "copy_data",
                  "import_data", and "export_data".
-    :type task: str, optional
+    :type task: str
     :param inputs: Mapping of input data bindings used in the job.
-    :type inputs: dict, optional
+    :type inputs: dict
     :param outputs: Mapping of output data bindings used in the job.
-    :type outputs: dict, optional
+    :type outputs: dict
     :param kwargs: Additional parameters for the data transfer component.
     :raises ~azure.ai.ml.exceptions.ValidationException: Raised if the component cannot be successfully validated.
         Details will be provided in the error message.
@@ -132,11 +132,11 @@ class DataTransferCopyComponent(DataTransferComponent):
 
     :param data_copy_mode: Data copy mode in the copy task.
                            Possible values are "merge_with_overwrite" and "fail_if_conflict".
-    :type data_copy_mode: str, optional
+    :type data_copy_mode: str
     :param inputs: Mapping of input data bindings used in the job.
-    :type inputs: dict, optional
+    :type inputs: dict
     :param outputs: Mapping of output data bindings used in the job.
-    :type outputs: dict, optional
+    :type outputs: dict
     :param kwargs: Additional parameters for the data transfer copy component.
     :raises ~azure.ai.ml.exceptions.ValidationException: Raised if the component cannot be successfully validated.
         Details will be provided in the error message.
@@ -228,10 +228,10 @@ class DataTransferImportComponent(DataTransferComponent):
     """DataTransfer import component version, used to define a data transfer import component.
 
     :param source: The data source of the file system or database.
-    :type source: dict, optional
+    :type source: dict
     :param outputs: Mapping of output data bindings used in the job.
                     Default value is an output port with the key "sink" and the type "mltable".
-    :type outputs: dict, optional
+    :type outputs: dict
     :param kwargs: Additional parameters for the data transfer import component.
     :raises ~azure.ai.ml.exceptions.ValidationException: Raised if the component cannot be successfully validated.
         Details will be provided in the error message.
@@ -276,9 +276,9 @@ class DataTransferExportComponent(DataTransferComponent):  # pylint: disable=too
     """DataTransfer export component version, used to define a data transfer export component.
 
     :param sink: The sink of external data and databases.
-    :type sink: Union[Dict, Database, FileSystem], optional
+    :type sink: Union[Dict, Database, FileSystem]
     :param inputs: Mapping of input data bindings used in the job.
-    :type inputs: dict, optional
+    :type inputs: dict
     :param kwargs: Additional parameters for the data transfer export component.
     :raises ~azure.ai.ml.exceptions.ValidationException: Raised if the component cannot be successfully validated.
         Details will be provided in the error message.

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_component/import_component.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_component/import_component.py
@@ -20,19 +20,19 @@ class ImportComponent(Component):
     """Import component version, used to define an import component.
 
     :param name: Name of the component.
-    :type name: str, optional
+    :type name: str
     :param version: Version of the component.
-    :type version: str, optional
+    :type version: str
     :param description: Description of the component.
-    :type description: str, optional
+    :type description: str
     :param tags: Tag dictionary. Tags can be added, removed, and updated.
-    :type tags: dict, optional
+    :type tags: dict
     :param display_name: Display name of the component.
-    :type display_name: str, optional
+    :type display_name: str
     :param source: Input source parameters of the component.
-    :type source: dict, optional
+    :type source: dict
     :param output: Output of the component.
-    :type output: dict, optional
+    :type output: dict
     :param is_deterministic: Whether the command component is deterministic. Defaults to True.
     :type is_deterministic: bool
     :param kwargs: Additional parameters for the import component.

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_component/parallel_component.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_component/parallel_component.py
@@ -32,53 +32,53 @@ class ParallelComponent(
     """Parallel component version, used to define a parallel component.
 
     :param name: Name of the component. Defaults to None
-    :type name: str , optional
+    :type name: str
     :param version: Version of the component. Defaults to None
-    :type version: str, optional
+    :type version: str
     :param description: Description of the component. Defaults to None
-    :type description: str, optional
+    :type description: str
     :param tags: Tag dictionary. Tags can be added, removed, and updated. Defaults to None
-    :type tags: dict, optional
+    :type tags: dict
     :param display_name: Display name of the component. Defaults to None
-    :type display_name: str, optional
+    :type display_name: str
     :param retry_settings: parallel component run failed retry. Defaults to None
     :type retry_settings: BatchRetrySettings
     :param logging_level: A string of the logging level name. Defaults to None
-    :type logging_level: str, optional
+    :type logging_level: str
     :param max_concurrency_per_instance: The max parallellism that each compute instance has. Defaults to None
-    :type max_concurrency_per_instance: int, optional
+    :type max_concurrency_per_instance: int
     :param error_threshold: The number of item processing failures should be ignored. Defaults to None
-    :type error_threshold: int, optional
+    :type error_threshold: int
     :param mini_batch_error_threshold: The number of mini batch processing failures should be ignored. Defaults to None
-    :type mini_batch_error_threshold: int, optional
+    :type mini_batch_error_threshold: int
     :param task: The parallel task. Defaults to None
-    :type task: ParallelTask, optional
+    :type task: ParallelTask
     :param mini_batch_size: For FileDataset input, this field is the number of files a user script can process
         in one run() call. For TabularDataset input, this field is the approximate size of data the user script
         can process in one run() call. Example values are 1024, 1024KB, 10MB, and 1GB.
         (optional, default value is 10 files for FileDataset and 1MB for TabularDataset.) This value could be set
         through PipelineParameter.
-    :type mini_batch_size: str, optional
+    :type mini_batch_size: str
     :param partition_keys:  The keys used to partition dataset into mini-batches. Defaults to None
         If specified, the data with the same key will be partitioned into the same mini-batch.
         If both partition_keys and mini_batch_size are specified, partition_keys will take effect.
         The input(s) must be partitioned dataset(s),
         and the partition_keys must be a subset of the keys of every input dataset for this to work.
-    :type partition_keys: list, optional
+    :type partition_keys: list
     :param input_data: The input data. Defaults to None
-    :type input_data: str, optional
+    :type input_data: str
     :param resources: Compute Resource configuration for the component. Defaults to None
-    :type resources: Union[dict, ~azure.ai.ml.entities.JobResourceConfiguration], optional
+    :type resources: Union[dict, ~azure.ai.ml.entities.JobResourceConfiguration]
     :param inputs: Inputs of the component. Defaults to None
-    :type inputs: dict, optional
+    :type inputs: dict
     :param outputs: Outputs of the component. Defaults to None
-    :type outputs: dict, optional
+    :type outputs: dict
     :param code: promoted property from task.code
-    :type code: str, optional
+    :type code: str
     :param instance_count: promoted property from resources.instance_count. Defaults to None
-    :type instance_count: int, optional
+    :type instance_count: int
     :param is_deterministic: Whether the parallel component is deterministic. Defaults to True
-    :type is_deterministic: bool, optional
+    :type is_deterministic: bool
     :raises ~azure.ai.ml.exceptions.ValidationException: Raised if ParallelComponent cannot be successfully validated.
         Details will be provided in the error message.
     """

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_component/spark_component.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_component/spark_component.py
@@ -30,43 +30,43 @@ class SparkComponent(
         to a remote location. Defaults to ".", indicating the current directory.
     :type code: Union[str, os.PathLike]
     :keyword entry: The file or class entry point.
-    :type entry: Optional[Union[dict[str, str], ~azure.ai.ml.entities.SparkJobEntry]]
+    :paramtype entry: Optional[Union[dict[str, str], ~azure.ai.ml.entities.SparkJobEntry]]
     :keyword py_files: The list of .zip, .egg or .py files to place on the PYTHONPATH for Python apps. Defaults to None.
-    :type py_files: Optional[list[str]]
+    :paramtype py_files: Optional[list[str]]
     :keyword jars: The list of .JAR files to include on the driver and executor classpaths. Defaults to None.
-    :type jars: Optional[list[str]]
+    :paramtype jars: Optional[list[str]]
     :keyword files: The list of files to be placed in the working directory of each executor. Defaults to None.
-    :type files: Optional[list[str]]
+    :paramtype files: Optional[list[str]]
     :keyword archives: The list of archives to be extracted into the working directory of each executor.
         Defaults to None.
-    :type archives: Optional[list[str]]
+    :paramtype archives: Optional[list[str]]
     :keyword driver_cores: The number of cores to use for the driver process, only in cluster mode.
-    :type driver_cores: Optional[int]
+    :paramtype driver_cores: Optional[int]
     :keyword driver_memory: The amount of memory to use for the driver process, formatted as strings with a size unit
         suffix ("k", "m", "g" or "t") (e.g. "512m", "2g").
-    :type driver_memory: Optional[str]
+    :paramtype driver_memory: Optional[str]
     :keyword executor_cores: The number of cores to use on each executor.
-    :type executor_cores: Optional[int]
+    :paramtype executor_cores: Optional[int]
     :keyword executor_memory: The amount of memory to use per executor process, formatted as strings with a size unit
         suffix ("k", "m", "g" or "t") (e.g. "512m", "2g").
-    :type executor_memory: Optional[str]
+    :paramtype executor_memory: Optional[str]
     :keyword executor_instances: The initial number of executors.
-    :type executor_instances: Optional[int]
+    :paramtype executor_instances: Optional[int]
     :keyword dynamic_allocation_enabled: Whether to use dynamic resource allocation, which scales the number of
         executors registered with this application up and down based on the workload. Defaults to False.
-    :type dynamic_allocation_enabled: Optional[bool]
+    :paramtype dynamic_allocation_enabled: Optional[bool]
     :keyword dynamic_allocation_min_executors: The lower bound for the number of executors if dynamic allocation is
         enabled.
-    :type dynamic_allocation_min_executors: Optional[int]
+    :paramtype dynamic_allocation_min_executors: Optional[int]
     :keyword dynamic_allocation_max_executors: The upper bound for the number of executors if dynamic allocation is
         enabled.
-    :type dynamic_allocation_max_executors: Optional[int]
+    :paramtype dynamic_allocation_max_executors: Optional[int]
     :keyword conf: A dictionary with pre-defined Spark configurations key and values. Defaults to None.
-    :type conf: Optional[dict[str, str]]
+    :paramtype conf: Optional[dict[str, str]]
     :keyword environment: The Azure ML environment to run the job in.
-    :type environment: Optional[Union[str, ~azure.ai.ml.entities.Environment]]
+    :paramtype environment: Optional[Union[str, ~azure.ai.ml.entities.Environment]]
     :keyword inputs: A mapping of input names to input data sources used in the job. Defaults to None.
-    :type inputs: Optional[dict[str, Union[
+    :paramtype inputs: Optional[dict[str, Union[
         ~azure.ai.ml.entities._job.pipeline._io.NodeOutput,
         ~azure.ai.ml.Input,
         str,
@@ -76,9 +76,9 @@ class SparkComponent(
         Enum,
         ]]]
     :keyword outputs: A mapping of output names to output data sources used in the job. Defaults to None.
-    :type outputs: Optional[dict[str, Union[str, ~azure.ai.ml.Output]]]
+    :paramtype outputs: Optional[dict[str, Union[str, ~azure.ai.ml.Output]]]
     :keyword args: The arguments for the job. Defaults to None.
-    :type args: Optional[str]
+    :paramtype args: Optional[str]
 
     .. admonition:: Example:
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_compute/_setup_scripts.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_compute/_setup_scripts.py
@@ -16,11 +16,11 @@ class ScriptReference(RestTranslatableMixin):
     """Script reference.
 
     :keyword path: The location of scripts in workspace storage.
-    :type path: Optional[str]
+    :paramtype path: Optional[str]
     :keyword command: Command line arguments passed to the script to run.
-    :type command: Optional[str]
+    :paramtype command: Optional[str]
     :keyword timeout_minutes: Timeout, in minutes, for the script to run.
-    :type timeout_minutes: Optional[int]
+    :paramtype timeout_minutes: Optional[int]
     """
 
     def __init__(
@@ -56,9 +56,9 @@ class SetupScripts(RestTranslatableMixin):
     """Customized setup scripts.
 
     :keyword startup_script: The script to be run every time the compute is started.
-    :type startup_script: Optional[~azure.ai.ml.entities.ScriptReference]
+    :paramtype startup_script: Optional[~azure.ai.ml.entities.ScriptReference]
     :keyword creation_script: The script to be run only when the compute is created.
-    :type creation_script: Optional[~azure.ai.ml.entities.ScriptReference]
+    :paramtype creation_script: Optional[~azure.ai.ml.entities.ScriptReference]
     """
 
     def __init__(

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_compute/_usage.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_compute/_usage.py
@@ -78,7 +78,7 @@ class Usage(RestTranslatableMixin):
             If dest is an open file, the file will be written to directly.
         :type dest: Union[PathLike, str, IO[AnyStr]]
         :keyword kwargs: Additional arguments to pass to the YAML serializer.
-        :type kwargs: dict
+        :paramtype kwargs: dict
         :raises: FileExistsError if dest is a file path and the file already exists.
         :raises: IOError if dest is an open file and the file is not writable.
         """

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_compute/aml_compute.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_compute/aml_compute.py
@@ -46,10 +46,10 @@ class AmlComputeSshSettings:
         :param admin_username: SSH user name
         :type admin_username: str
         :param admin_password: SSH user password, defaults to None
-        :type admin_password: str, optional
+        :type admin_password: str
         :param ssh_key_value:  Specifies the SSH rsa private key as a string. Use "ssh-keygen -t
             rsa -b 2048" to generate your SSH key pairs. Defaults to None
-        :type ssh_key_value: Optional[str], optional
+        :type ssh_key_value: Optional[str]
         """
         self.admin_username = admin_username
         self.admin_password = admin_password
@@ -77,37 +77,37 @@ class AmlCompute(Compute):
     :param name: Name of the compute
     :type name: str
     :param description: Description of the resource.
-    :type description: str, optional
+    :type description: str
     :param size: Compute Size, defaults to None.
-    :type size: str, optional
+    :type size: str
     :param tags: A set of tags. Contains resource tags defined as key/value pairs.
     :type tags: Optional[dict[str, str]]
     :param ssh_settings: SSH settings to access the AzureML compute cluster.
-    :type ssh_settings: AmlComputeSshSettings, optional
+    :type ssh_settings: AmlComputeSshSettings
     :param network_settings: Virtual network settings for the AzureML compute cluster.
-    :type network_settings: NetworkSettings, optional
+    :type network_settings: NetworkSettings
     :param idle_time_before_scale_down: Node Idle Time before scaling down amlCompute. Defaults to None.
-    :type idle_time_before_scale_down: int, optional
+    :type idle_time_before_scale_down: int
     :param identity:  The identity configuration, identities that are associated with the compute cluster.
-    :type identity: IdentityConfiguration, optional
+    :type identity: IdentityConfiguration
     :param tier: Virtual Machine tier. Possible values include: "Dedicated", "LowPriority". Defaults to None.
-    :type tier: str, optional
+    :type tier: str
     :param min_instances: Minimum number of instances. Defaults to None.
-    :type min_instances: int, optional
+    :type min_instances: int
     :param max_instances: Maximum number of instances. Defaults to None.
-    :type max_instances: int, optional
+    :type max_instances: int
     :param ssh_public_access_enabled: State of the public SSH port. Possible values are:
      False - Indicates that the public ssh port is closed on all nodes of the cluster. True -
      Indicates that the public ssh port is open on all nodes of the cluster. None -
      Indicates that the public ssh port is closed on all nodes of the cluster if VNet is defined,
      else is open all public nodes. It can be default only during cluster creation time, after
      creation it will be either True or False. Possible values include: True, False, None. Default value: None.
-     :type ssh_public_access_enabled: bool, optional
+     :type ssh_public_access_enabled: bool
     :param enable_node_public_ip: Enable or disable node public IP address provisioning. Possible values are:
      True - Indicates that the compute nodes will have public IPs provisioned.
      False - Indicates that the compute nodes will have a private endpoint and no public IPs.
      Default Value: True.
-    :type enable_node_public_ip: Optional[bool], optional
+    :type enable_node_public_ip: Optional[bool]
     """
 
     def __init__(

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_compute/compute.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_compute/compute.py
@@ -29,11 +29,11 @@ class Compute(Resource, RestTranslatableMixin):
     :param name: Name of the compute
     :type name: str
     :param location: The resource location, defaults to workspace location.
-    :type location: Optional[str], optional
+    :type location: Optional[str]
     :param description: Description of the resource.
-    :type description: Optional[str], optional
+    :type description: Optional[str]
     :param resource_id: ARM resource id of the underlying compute.
-    :type resource_id: str, optional
+    :type resource_id: str
     :param tags: A set of tags. Contains resource tags defined as key/value pairs.
     :type tags: Optional[dict[str, str]]
     """
@@ -212,9 +212,9 @@ class NetworkSettings:
         """Network settings for a compute.
 
         :param vnet_name: The virtual network name, defaults to None
-        :type vnet_name: str, optional
+        :type vnet_name: str
         :param subnet: The subnet name, defaults to None
-        :type subnet: str, optional
+        :type subnet: str
         """
         self.vnet_name = vnet_name
         self.subnet = subnet

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_compute/compute_instance.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_compute/compute_instance.py
@@ -98,25 +98,25 @@ class ComputeInstance(Compute):
     :param name: Name of the compute
     :type name: str
     :param location: The resource location, defaults to None
-    :type location: Optional[str], optional
+    :type location: Optional[str]
     :param description: Description of the resource.
-    :type description: Optional[str], optional
+    :type description: Optional[str]
     :param size: Compute Size, defaults to None
-    :type size: Optional[str], optional
+    :type size: Optional[str]
     :param tags: A set of tags. Contains resource tags defined as key/value pairs.
     :type tags: Optional[dict[str, str]]
     :param create_on_behalf_of: defaults to None
-    :type create_on_behalf_of: Optional[AssignedUserConfiguration], optional
+    :type create_on_behalf_of: Optional[AssignedUserConfiguration]
     :ivar state: defaults to None
-    :type state: Optional[str], optional
+    :type state: Optional[str]
     :ivar last_operation: defaults to None
-    :type last_operation: Optional[Dict[str, str]], optional
+    :type last_operation: Optional[Dict[str, str]]
     :ivar applications: defaults to None
-    :type applications: Optional[List[Dict[str, str]]], optional
+    :type applications: Optional[List[Dict[str, str]]]
     :param network_settings: defaults to None
-    :type network_settings: Optional[NetworkSettings], optional
+    :type network_settings: Optional[NetworkSettings]
     :param ssh_settings: defaults to None
-    :type ssh_settings: Optional[ComputeInstanceSshSettings], optional
+    :type ssh_settings: Optional[ComputeInstanceSshSettings]
     :param ssh_public_access_enabled: State of the public SSH port. Possible values are: ["False", "True", "None"]
         False - Indicates that the public ssh port is closed on all nodes of the cluster.
         True - Indicates that the public ssh port is open on all nodes of the cluster.
@@ -125,28 +125,28 @@ class ComputeInstance(Compute):
         creation it will be either True or False. Possible values include: True, False, None.
         Default value: None.
 
-    :type ssh_public_access_enabled: Optional[bool], optional
+    :type ssh_public_access_enabled: Optional[bool]
     :param schedules: Compute instance schedules, defaults to None
-    :type schedules: Optional[ComputeSchedules], optional
+    :type schedules: Optional[ComputeSchedules]
     :param identity:  The identity configuration, identities that are associated with the compute cluster.
-    :type identity: IdentityConfiguration, optional
+    :type identity: IdentityConfiguration
     :param idle_time_before_shutdown: Deprecated. Use the `idle_time_before_shutdown_minutes` parameter instead.
         Stops compute instance after user defined period of inactivity.
         Time is defined in ISO8601 format. Minimum is 15 minutes, maximum is 3 days.
-    :type idle_time_before_shutdown: Optional[str], optional
+    :type idle_time_before_shutdown: Optional[str]
     :param idle_time_before_shutdown_minutes: Stops compute instance after a user defined period of
         inactivity in minutes. Minimum is 15 minutes, maximum is 3 days.
-    :type idle_time_before_shutdown_minutes: Optional[int], optional
+    :type idle_time_before_shutdown_minutes: Optional[int]
     :param enable_node_public_ip: Enable or disable node public IP address provisioning. Possible values are:
         True - Indicates that the compute nodes will have public IPs provisioned.
         False - Indicates that the compute nodes will have a private endpoint and no public IPs.
         Default Value: True.
-    :type enable_node_public_ip: Optional[bool], optional
+    :type enable_node_public_ip: Optional[bool]
     :param setup_scripts: Details of customized scripts to execute for setting up the cluster.
-    :type setup_scripts: Optional[SetupScripts], optional
+    :type setup_scripts: Optional[SetupScripts]
     :param custom_applications: List of custom applications and their endpoints
         for the compute instance.
-    :type custom_applications: Optional[List[CustomApplications]], optional
+    :type custom_applications: Optional[List[CustomApplications]]
     """
 
     def __init__(

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_compute/kubernetes_compute.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_compute/kubernetes_compute.py
@@ -21,23 +21,23 @@ class KubernetesCompute(Compute):
     :param name: Name of the compute
     :type name: str
     :param location: The resource location, defaults to None
-    :type location: Optional[str], optional
+    :type location: Optional[str]
     :param description: Description of the resource.
-    :type description: Optional[str], optional
+    :type description: Optional[str]
     :param tags: A set of tags. Contains resource tags defined as key/value pairs.
     :type tags: Optional[dict[str, str]]
     :param resource_id: ARM resource id of the underlying compute, defaults to None
-    :type resource_id: Optional[str], optional
+    :type resource_id: Optional[str]
     :param created_on: defaults to None
-    :type created_on: Optional[~datetime.datetime], optional
+    :type created_on: Optional[~datetime.datetime]
     :param provisioning_state: defaults to None
-    :type provisioning_state: Optional[str], optional
+    :type provisioning_state: Optional[str]
     :param namespace: Namespace of the KubernetesCompute
-    :type namespace: Optional[str], optional
+    :type namespace: Optional[str]
     :param properties: KubernetesProperties, defaults to None
-    :type properties: Optional[Dict], optional
+    :type properties: Optional[Dict]
     :param identity:  The identity configuration, identities that are associated with the compute cluster.
-    :type identity: IdentityConfiguration, optional
+    :type identity: IdentityConfiguration
     """
 
     def __init__(

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_compute/synapsespark_compute.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_compute/synapsespark_compute.py
@@ -22,11 +22,11 @@ class AutoScaleSettings:
     """Auto-scale settings for Synapse Spark compute.
 
     :keyword min_node_count: The minimum compute node count.
-    :type min_node_count: Optional[int]
+    :paramtype min_node_count: Optional[int]
     :keyword max_node_count: The maximum compute node count.
-    :type max_node_count: Optional[int]
+    :paramtype max_node_count: Optional[int]
     :keyword enabled: Specifies if auto-scale is enabled.
-    :type enabled: Optional[bool]
+    :paramtype enabled: Optional[bool]
 
     .. admonition:: Example:
 
@@ -71,9 +71,9 @@ class AutoPauseSettings:
     """Auto pause settings for Synapse Spark compute.
 
     :keyword delay_in_minutes: The time delay in minutes before pausing cluster.
-    :type delay_in_minutes: Optional[int]
+    :paramtype delay_in_minutes: Optional[int]
     :keyword enabled: Specifies if auto-pause is enabled.
-    :type enabled: Optional[bool]
+    :paramtype enabled: Optional[bool]
 
     .. admonition:: Example:
 
@@ -109,27 +109,27 @@ class SynapseSparkCompute(Compute):
     """SynapseSpark Compute resource.
 
     :keyword name: The name of the compute.
-    :type name: str
+    :paramtype name: str
     :keyword description: The description of the resource. Defaults to None.
-    :type description: Optional[str]
+    :paramtype description: Optional[str]
     :keyword tags: The set of resource tags defined as key/value pairs. Defaults to None.
-    :type tags: Optional[[dict[str, str]]
+    :paramtype tags: Optional[[dict[str, str]]
     :keyword node_count: The number of nodes in the compute.
-    :type node_count: Optional[int]
+    :paramtype node_count: Optional[int]
     :keyword node_family: The node family of the compute.
-    :type node_family: Optional[str]
+    :paramtype node_family: Optional[str]
     :keyword node_size: The size of the node.
-    :type node_size: Optional[str]
+    :paramtype node_size: Optional[str]
     :keyword spark_version: The version of Spark to use.
-    :type spark_version: Optional[str]
+    :paramtype spark_version: Optional[str]
     :keyword identity: The configuration of identities that are associated with the compute cluster.
-    :type identity: Optional[~azure.ai.ml.entities.IdentityConfiguration]
+    :paramtype identity: Optional[~azure.ai.ml.entities.IdentityConfiguration]
     :keyword scale_settings: The scale settings for the compute.
-    :type scale_settings: Optional[~azure.ai.ml.entities.AutoScaleSettings]
+    :paramtype scale_settings: Optional[~azure.ai.ml.entities.AutoScaleSettings]
     :keyword auto_pause_settings: The auto pause settings for the compute.
-    :type auto_pause_settings: Optional[~azure.ai.ml.entities.AutoPauseSettings]
+    :paramtype auto_pause_settings: Optional[~azure.ai.ml.entities.AutoPauseSettings]
     :keyword kwargs: Additional keyword arguments passed to the parent class.
-    :type kwargs: Optional[dict]
+    :paramtype kwargs: Optional[dict]
 
     .. admonition:: Example:
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_compute/virtual_machine_compute.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_compute/virtual_machine_compute.py
@@ -32,13 +32,13 @@ class VirtualMachineSshSettings:
         :type admin_username: str, required
         :param admin_password: Describes the admin user password.
             Defaults to None. Required if ssh_private_key_file is not specified.
-        :type admin_password: str, optional
+        :type admin_password: str
         :param ssh_port: The ssh port number. Default is 22.
-        :type ssh_port: str, optional
+        :type ssh_port: str
         :param ssh_private_key_file: Specifies the file containing SSH rsa private key.
             Use "ssh-keygen -t rsa -b 2048" to generate your SSH key pairs.
             Required if admin_password is not specified.
-        :type ssh_private_key_file: str, optional
+        :type ssh_private_key_file: str
         """
         self.admin_username = admin_username
         self.admin_password = admin_password
@@ -52,13 +52,13 @@ class VirtualMachineCompute(Compute):
     :param name: Name of the compute
     :type name: str
     :param description: Description of the resource.
-    :type description: Optional[str], optional
+    :type description: Optional[str]
     :param resource_id: ARM resource id of the underlying compute
     :type resource_id: str
     :param tags: A set of tags. Contains resource tags defined as key/value pairs.
     :type tags: Optional[dict[str, str]]
     :param ssh_settings: SSH settings.
-    :type ssh_settings: VirtualMachineSshSettings, optional
+    :type ssh_settings: VirtualMachineSshSettings
     """
 
     def __init__(

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_credentials.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_credentials.py
@@ -241,7 +241,7 @@ class ServicePrincipalConfiguration(BaseTenantCredentials):
     :param client_secret: The client secret.
     :type client_secret: str
     :keyword kwargs: Additional arguments to pass to the parent class.
-    :type kwargs: Optional[dict]
+    :paramtype kwargs: Optional[dict]
     """
 
     def __init__(
@@ -417,13 +417,13 @@ class ManagedIdentityConfiguration(_BaseIdentityConfiguration):
     """Managed Identity credential configuration.
 
     :keyword client_id: The client ID of the managed identity.
-    :type client_id: Optional[str]
+    :paramtype client_id: Optional[str]
     :keyword resource_id: The resource ID of the managed identity.
-    :type resource_id: Optional[str]
+    :paramtype resource_id: Optional[str]
     :keyword object_id: The object ID.
-    :type object_id: Optional[str]
+    :paramtype object_id: Optional[str]
     :keyword principal_id: The principal ID.
-    :type principal_id: Optional[str]
+    :paramtype principal_id: Optional[str]
     """
 
     def __init__(

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_deployment/batch_deployment.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_deployment/batch_deployment.py
@@ -37,17 +37,17 @@ class BatchDeployment(Deployment):  # pylint: disable=too-many-instance-attribut
     :param name: the name of the batch deployment
     :type name: str
     :param description: Description of the resource.
-    :type description: str, optional
+    :type description: str
     :param tags: Tag dictionary. Tags can be added, removed, and updated.
     :type tags: dict[str, str]
     :param properties: The asset property dictionary.
     :type properties: dict[str, str]
     :param model: Model entity for the endpoint deployment, defaults to None
-    :type model: Union[str, Model], optional
+    :type model: Union[str, Model]
     :param code_configuration: defaults to None
-    :type code_configuration: CodeConfiguration, optional
+    :type code_configuration: CodeConfiguration
     :param environment: Environment entity for the endpoint deployment., defaults to None
-    :type environment: Union[str, Environment], optional
+    :type environment: Union[str, Environment]
     :param compute: Compute target for batch inference operation.
     :type compute: str
     :param output_action: Indicates how the output will be organized. Possible values include:
@@ -63,23 +63,23 @@ class BatchDeployment(Deployment):  # pylint: disable=too-many-instance-attribut
         -1 value indicates, ignore all failures during batch inference
         For FileDataset count of file failures
         For TabularDataset, this is the count of record failures, defaults to -1
-    :type error_threshold: int, optional
+    :type error_threshold: int
     :param retry_settings: Retry settings for a batch inference operation, defaults to None
-    :type retry_settings: BatchRetrySettings, optional
+    :type retry_settings: BatchRetrySettings
     :param resources: Indicates compute configuration for the job.
     :type resources: ~azure.mgmt.machinelearningservices.models.ResourceConfiguration
     :param logging_level: Logging level for batch inference operation, defaults to "info"
-    :type logging_level: str, optional
+    :type logging_level: str
     :param mini_batch_size: Size of the mini-batch passed to each batch invocation, defaults to 10
-    :type mini_batch_size: int, optional
+    :type mini_batch_size: int
     :param environment_variables: Environment variables that will be set in deployment.
-    :type environment_variables: dict, optional
+    :type environment_variables: dict
     :param code_path: Folder path to local code assets. Equivalent to code_configuration.code.
-    :type code_path: Union[str, PathLike], optional
+    :type code_path: Union[str, PathLike]
     :param scoring_script: Scoring script name. Equivalent to code_configuration.code.scoring_script.
-    :type scoring_script: Union[str, PathLike], optional
+    :type scoring_script: Union[str, PathLike]
     :param instance_count: Number of instances the interfering will run on. Equivalent to resources.instance_count.
-    :type instance_count: int, optional
+    :type instance_count: int
     :raises ~azure.ai.ml.exceptions.ValidationException: Raised if BatchDeployment cannot be successfully validated.
         Details will be provided in the error message.
     """

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_deployment/data_collector.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_deployment/data_collector.py
@@ -20,11 +20,11 @@ class DataCollector:
     :param collections: Mapping dictionary of strings mapped to DeploymentCollection entities.
     :type collections: Mapping[str, DeploymentCollection]
     :param rolling_rate: The rolling rate of mdc files, possible values: ["minute", "hour", "day"].
-    :type rolling_rate: str, optional
+    :type rolling_rate: str
     :param sampling_rate: The sampling rate of mdc files, possible values: [0.0, 1.0].
-    :type sampling_rate: float, optional
+    :type sampling_rate: float
     :param request_logging: Logging of request payload parameters.
-    :type request_logging: RequestLogging, optional
+    :type request_logging: RequestLogging
     """
 
     def __init__(

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_deployment/deployment.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_deployment/deployment.py
@@ -34,27 +34,27 @@ class Deployment(Resource, RestTranslatableMixin):
     :param name: Name of the deployment resource, defaults to None
     :type name: typing.Optional[str]
     :keyword endpoint_name: Name of the Endpoint resource, defaults to None
-    :type endpoint_name: typing.Optional[str]
+    :paramtype endpoint_name: typing.Optional[str]
     :keyword description: Description of the deployment resource, defaults to None
-    :type description: typing.Optional[str]
+    :paramtype description: typing.Optional[str]
     :keyword tags: Tag dictionary. Tags can be added, removed, and updated, defaults to None
-    :type tags: typing.Optional[typing.Dict[str, typing.Any]]
+    :paramtype tags: typing.Optional[typing.Dict[str, typing.Any]]
     :keyword properties: The asset property dictionary, defaults to None
-    :type properties: typing.Optional[typing.Dict[str, typing.Any]]
+    :paramtype properties: typing.Optional[typing.Dict[str, typing.Any]]
     :keyword model: The Model entity, defaults to None
-    :type model: typing.Optional[typing.Union[str, ~azure.ai.ml.entities.Model]]
+    :paramtype model: typing.Optional[typing.Union[str, ~azure.ai.ml.entities.Model]]
     :keyword code_configuration: Code Configuration, defaults to None
-    :type code_configuration: typing.Optional[CodeConfiguration]
+    :paramtype code_configuration: typing.Optional[CodeConfiguration]
     :keyword environment: The Environment entity, defaults to None
-    :type environment: typing.Optional[typing.Union[str, ~azure.ai.ml.entities.Environment]]
+    :paramtype environment: typing.Optional[typing.Union[str, ~azure.ai.ml.entities.Environment]]
     :keyword environment_variables: Environment variables that will be set in deployment, defaults to None
-    :type environment_variables: typing.Optional[typing.Dict[str, str]]
+    :paramtype environment_variables: typing.Optional[typing.Dict[str, str]]
     :keyword code_path: Folder path to local code assets. Equivalent to code_configuration.code.path
         , defaults to None
-    :type code_path: typing.Optional[typing.Union[str, PathLike]]
+    :paramtype code_path: typing.Optional[typing.Union[str, PathLike]]
     :keyword scoring_script: Scoring script name. Equivalent to code_configuration.code.scoring_script
         , defaults to None
-    :type scoring_script: typing.Optional[typing.Union[str, PathLike]]
+    :paramtype scoring_script: typing.Optional[typing.Union[str, PathLike]]
     :raises ~azure.ai.ml.exceptions.ValidationException: Raised if Deployment cannot be successfully validated.
         Exception details will be provided in the error message.
     """
@@ -82,27 +82,27 @@ class Deployment(Resource, RestTranslatableMixin):
         :param name: Name of the deployment resource, defaults to None
         :type name: typing.Optional[str]
         :keyword endpoint_name: Name of the Endpoint resource, defaults to None
-        :type endpoint_name: typing.Optional[str]
+        :paramtype endpoint_name: typing.Optional[str]
         :keyword description: Description of the deployment resource, defaults to None
-        :type description: typing.Optional[str]
+        :paramtype description: typing.Optional[str]
         :keyword tags: Tag dictionary. Tags can be added, removed, and updated, defaults to None
-        :type tags: typing.Optional[typing.Dict[str, typing.Any]]
+        :paramtype tags: typing.Optional[typing.Dict[str, typing.Any]]
         :keyword properties: The asset property dictionary, defaults to None
-        :type properties: typing.Optional[typing.Dict[str, typing.Any]]
+        :paramtype properties: typing.Optional[typing.Dict[str, typing.Any]]
         :keyword model: The Model entity, defaults to None
-        :type model: typing.Optional[typing.Union[str, ~azure.ai.ml.entities.Model]]
+        :paramtype model: typing.Optional[typing.Union[str, ~azure.ai.ml.entities.Model]]
         :keyword code_configuration: Code Configuration, defaults to None
-        :type code_configuration: typing.Optional[CodeConfiguration]
+        :paramtype code_configuration: typing.Optional[CodeConfiguration]
         :keyword environment: The Environment entity, defaults to None
-        :type environment: typing.Optional[typing.Union[str, ~azure.ai.ml.entities.Environment]]
+        :paramtype environment: typing.Optional[typing.Union[str, ~azure.ai.ml.entities.Environment]]
         :keyword environment_variables: Environment variables that will be set in deployment, defaults to None
-        :type environment_variables: typing.Optional[typing.Dict[str, str]]
+        :paramtype environment_variables: typing.Optional[typing.Dict[str, str]]
         :keyword code_path: Folder path to local code assets. Equivalent to code_configuration.code.path
             , defaults to None
-        :type code_path: typing.Optional[typing.Union[str, PathLike]]
+        :paramtype code_path: typing.Optional[typing.Union[str, PathLike]]
         :keyword scoring_script: Scoring script name. Equivalent to code_configuration.code.scoring_script
             , defaults to None
-        :type scoring_script: typing.Optional[typing.Union[str, PathLike]]
+        :paramtype scoring_script: typing.Optional[typing.Union[str, PathLike]]
         :raises ~azure.ai.ml.exceptions.ValidationException: Raised if Deployment cannot be successfully validated.
             Exception details will be provided in the error message.
         """

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_deployment/deployment_collection.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_deployment/deployment_collection.py
@@ -15,11 +15,11 @@ class DeploymentCollection:
     """Collection entity
 
     :param enabled: Is logging for this collection enabled.
-    :type enabled: str, optional
+    :type enabled: str
     :param data: Data asset id associated with collection logging.
-    :type data: str, optional
+    :type data: str
     :param client_id: Client ID associated with collection logging.
-    :type client_id: str, optional
+    :type client_id: str
 
     """
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_deployment/deployment_settings.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_deployment/deployment_settings.py
@@ -25,9 +25,9 @@ class BatchRetrySettings(RestTranslatableMixin):
     """Retry settings for batch deployment.
 
     :param max_retries: Number of retries in failure, defaults to 3
-    :type max_retries: int, optional
+    :type max_retries: int
     :param timeout: Timeout in seconds, defaults to 30
-    :type timeout: int, optional
+    :type timeout: int
     """
 
     def __init__(self, *, max_retries: Optional[int] = None, timeout: Optional[int] = None):
@@ -61,11 +61,11 @@ class OnlineRequestSettings(RestTranslatableMixin):
     """Request Settings entity.
 
     :param request_timeout_ms: defaults to 5000
-    :type request_timeout_ms: int, optional
+    :type request_timeout_ms: int
     :param max_concurrent_requests_per_instance: defaults to 1
-    :type max_concurrent_requests_per_instance: int, optional
+    :type max_concurrent_requests_per_instance: int
     :param max_queue_wait_ms: defaults to 500
-    :type max_queue_wait_ms: int, optional
+    :type max_queue_wait_ms: int
     """
 
     def __init__(
@@ -134,15 +134,15 @@ class ProbeSettings(RestTranslatableMixin):
         """Settings on how to probe an endpoint.
 
         :param failure_threshold: Threshold for probe failures, defaults to 30
-        :type failure_threshold: int, optional
+        :type failure_threshold: int
         :param success_threshold: Threshold for probe success, defaults to 1
-        :type success_threshold: int, optional
+        :type success_threshold: int
         :param timeout: timeout in seconds, defaults to 2
-        :type timeout: int, optional
+        :type timeout: int
         :param period: [description], defaults to 10
-        :type period: int, optional
+        :type period: int
         :param initial_delay: How to to wait for the first probe, defaults to 10
-        :type initial_delay: int, optional
+        :type initial_delay: int
         """
 
         self.failure_threshold = failure_threshold

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_deployment/model_batch_deployment_settings.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_deployment/model_batch_deployment_settings.py
@@ -16,9 +16,9 @@ class ModelBatchDeploymentSettings:
     """Model Batch Deployment Settings entity.
 
     :param mini_batch_size: Size of the mini-batch passed to each batch invocation, defaults to 10
-    :type mini_batch_size: int, optional
+    :type mini_batch_size: int
     :param instance_count: Number of instances the interfering will run on. Equivalent to resources.instance_count.
-    :type instance_count: int, optional
+    :type instance_count: int
     :param output_action: Indicates how the output will be organized. Possible values include:
      "summary_only", "append_row". Defaults to "append_row"
     :type output_action: str or ~azure.ai.ml.constants._deployment.BatchDeploymentOutputAction
@@ -27,18 +27,18 @@ class ModelBatchDeploymentSettings:
     :param max_concurrency_per_instance: Indicates maximum number of parallelism per instance, defaults to 1
     :type max_concurrency_per_instance: int
     :param retry_settings: Retry settings for a batch inference operation, defaults to None
-    :type retry_settings: BatchRetrySettings, optional
+    :type retry_settings: BatchRetrySettings
     :param environment_variables: Environment variables that will be set in deployment.
-    :type environment_variables: dict, optional
+    :type environment_variables: dict
     :param error_threshold: Error threshold, if the error count for the entire input goes above
         this value,
         the batch inference will be aborted. Range is [-1, int.MaxValue]
         -1 value indicates, ignore all failures during batch inference
         For FileDataset count of file failures
         For TabularDataset, this is the count of record failures, defaults to -1
-    :type error_threshold: int, optional
+    :type error_threshold: int
     :param logging_level: Logging level for batch inference operation, defaults to "info"
-    :type logging_level: str, optional
+    :type logging_level: str
     """
 
     def __init__(

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_deployment/payload_response.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_deployment/payload_response.py
@@ -11,7 +11,7 @@ class PayloadResponse:
     """Response deployment entity
 
     :param enabled: Is response logging enabled.
-    :type enabled: str, optional
+    :type enabled: str
 
     """
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_deployment/scale_settings.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_deployment/scale_settings.py
@@ -96,9 +96,9 @@ class TargetUtilizationScaleSettings(OnlineScaleSettings):
     """Auto scale settings.
 
     :param min_instances: Minimum number of the instances
-    :type min_instances: int, optional
+    :type min_instances: int
     :param max_instances: Maximum number of the instances
-    :type max_instances: int, optional
+    :type max_instances: int
     :param polling_interval: The polling interval in ISO 8691 format. Only supports duration with
      precision as low as Seconds.
     :type polling_interval: str

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_endpoint/batch_endpoint.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_endpoint/batch_endpoint.py
@@ -30,19 +30,19 @@ class BatchEndpoint(Endpoint):
     :param properties: The asset property dictionary.
     :type properties: dict[str, str]
     :param auth_mode: Possible values include: "AMLToken", "Key", "AADToken", defaults to None
-    :type auth_mode: str, optional
+    :type auth_mode: str
     :param description: Description of the inference endpoint, defaults to None
-    :type description: str, optional
+    :type description: str
     :param location: defaults to None
-    :type location: str, optional
+    :type location: str
     :param defaults:  Traffic rules on how the traffic will be routed across deployments, defaults to {}
-    :type defaults: Dict[str, str], optional
+    :type defaults: Dict[str, str]
     :param default_deployment_name:  Equivalent to defaults.default_deployment, will be ignored if defaults is present.
-    :type default_deployment_name: str, optional
+    :type default_deployment_name: str
     :param scoring_uri: URI to use to perform a prediction, readonly.
-    :type scoring_uri: str, optional
+    :type scoring_uri: str
     :param openapi_uri: URI to check the open API definition of the endpoint.
-    :type openapi_uri: str, optional
+    :type openapi_uri: str
     """
 
     def __init__(

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_endpoint/endpoint.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_endpoint/endpoint.py
@@ -29,13 +29,13 @@ class Endpoint(Resource):  # pylint: disable=too-many-instance-attributes
     :param description: Description of the resource.
     :type description: typing.Optional[str]
     :keyword traffic: Traffic rules on how the traffic will be routed across deployments, defaults to {}
-    :type traffic: typing.Optional[typing.Dict[str, int]]
+    :paramtype traffic: typing.Optional[typing.Dict[str, int]]
     :keyword scoring_uri: str, Endpoint URI, readonly
-    :type scoring_uri: typing.Optional[str]
+    :paramtype scoring_uri: typing.Optional[str]
     :keyword openapi_uri: str, Endpoint Open API URI, readonly
-    :type openapi_uri: typing.Optional[str]
+    :paramtype openapi_uri: typing.Optional[str]
     :keyword provisioning_state: str, provisioning state, readonly
-    :type provisioning_state: typing.Optional[str]
+    :paramtype provisioning_state: typing.Optional[str]
     """
 
     def __init__(
@@ -65,13 +65,13 @@ class Endpoint(Resource):  # pylint: disable=too-many-instance-attributes
         :param description: Description of the resource.
         :type description: typing.Optional[str]
         :keyword traffic: Traffic rules on how the traffic will be routed across deployments, defaults to {}
-        :type traffic: typing.Optional[typing.Dict[str, int]]
+        :paramtype traffic: typing.Optional[typing.Dict[str, int]]
         :keyword scoring_uri: str, Endpoint URI, readonly
-        :type scoring_uri: typing.Optional[str]
+        :paramtype scoring_uri: typing.Optional[str]
         :keyword openapi_uri: str, Endpoint Open API URI, readonly
-        :type openapi_uri: typing.Optional[str]
+        :paramtype openapi_uri: typing.Optional[str]
         :keyword provisioning_state: str, provisioning state, readonly
-        :type provisioning_state: typing.Optional[str]
+        :paramtype provisioning_state: typing.Optional[str]
         """
         # MFE is case-insensitive for Name. So convert the name into lower case here.
         if name:

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_endpoint/online_endpoint.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_endpoint/online_endpoint.py
@@ -40,31 +40,31 @@ class OnlineEndpoint(Endpoint):
     """Online endpoint entity.
 
     :keyword name: Name of the resource, defaults to None
-    :type name: typing.Optional[str]
+    :paramtype name: typing.Optional[str]
     :keyword tags: Tag dictionary. Tags can be added, removed, and updated. defaults to None
-    :type tags: typing.Optional[typing.Dict[str, typing.Any]]
+    :paramtype tags: typing.Optional[typing.Dict[str, typing.Any]]
     :keyword properties: The asset property dictionary, defaults to None
-    :type properties: typing.Optional[typing.Dict[str, typing.Any]]
+    :paramtype properties: typing.Optional[typing.Dict[str, typing.Any]]
     :keyword auth_mode: Possible values include: "aml_token", "key", defaults to KEY
     :type auth_mode: typing.Optional[str]
     :keyword description: Description of the inference endpoint, defaults to None
-    :type description: typing.Optional[str]
+    :paramtype description: typing.Optional[str]
     :keyword location: Location of the resource, defaults to None
-    :type location: typing.Optional[str]
+    :paramtype location: typing.Optional[str]
     :keyword traffic: Traffic rules on how the traffic will be routed across deployments, defaults to None
-    :type traffic: typing.Optional[typing.Dict[str, int]]
+    :paramtype traffic: typing.Optional[typing.Dict[str, int]]
     :keyword mirror_traffic: Duplicated live traffic used to inference a single deployment, defaults to None
-    :type mirror_traffic: typing.Optional[typing.Dict[str, int]]
+    :paramtype mirror_traffic: typing.Optional[typing.Dict[str, int]]
     :keyword identity: Identity Configuration, defaults to SystemAssigned
-    :type identity: typing.Optional[IdentityConfiguration]
+    :paramtype identity: typing.Optional[IdentityConfiguration]
     :keyword scoring_uri: Scoring URI, defaults to None
-    :type scoring_uri: typing.Optional[str]
+    :paramtype scoring_uri: typing.Optional[str]
     :keyword openapi_uri: OpenAPI URI, defaults to None
-    :type openapi_uri: typing.Optional[str]
+    :paramtype openapi_uri: typing.Optional[str]
     :keyword provisioning_state: Provisioning state of an endpoint, defaults to None
-    :type provisioning_state: typing.Optional[str]
+    :paramtype provisioning_state: typing.Optional[str]
     :keyword kind: Kind of the resource, we have two kinds: K8s and Managed online endpoints, defaults to None
-    :type kind: typing.Optional[str]
+    :paramtype kind: typing.Optional[str]
     """
 
     def __init__(
@@ -90,29 +90,29 @@ class OnlineEndpoint(Endpoint):
         Constructor for an Online endpoint entity.
 
         :keyword name: Name of the resource, defaults to None
-        :type name: typing.Optional[str]
+        :paramtype name: typing.Optional[str]
         :keyword tags: Tag dictionary. Tags can be added, removed, and updated. defaults to None
-        :type tags: typing.Optional[typing.Dict[str, typing.Any]]
+        :paramtype tags: typing.Optional[typing.Dict[str, typing.Any]]
         :keyword properties: The asset property dictionary, defaults to None
-        :type properties: typing.Optional[typing.Dict[str, typing.Any]]
+        :paramtype properties: typing.Optional[typing.Dict[str, typing.Any]]
         :keyword auth_mode: Possible values include: "aml_token", "key", defaults to KEY
         :type auth_mode: typing.Optional[str]
         :keyword description: Description of the inference endpoint, defaults to None
-        :type description: typing.Optional[str]
+        :paramtype description: typing.Optional[str]
         :keyword location: Location of the resource, defaults to None
-        :type location: typing.Optional[str]
+        :paramtype location: typing.Optional[str]
         :keyword traffic: Traffic rules on how the traffic will be routed across deployments, defaults to None
-        :type traffic: typing.Optional[typing.Dict[str, int]]
+        :paramtype traffic: typing.Optional[typing.Dict[str, int]]
         :keyword mirror_traffic: Duplicated live traffic used to inference a single deployment, defaults to None
-        :type mirror_traffic: typing.Optional[typing.Dict[str, int]]
+        :paramtype mirror_traffic: typing.Optional[typing.Dict[str, int]]
         :keyword identity: Identity Configuration, defaults to SystemAssigned
-        :type identity: typing.Optional[IdentityConfiguration]
+        :paramtype identity: typing.Optional[IdentityConfiguration]
         :keyword scoring_uri: Scoring URI, defaults to None
-        :type scoring_uri: typing.Optional[str]
+        :paramtype scoring_uri: typing.Optional[str]
         :keyword openapi_uri: OpenAPI URI, defaults to None
-        :type openapi_uri: typing.Optional[str]
+        :paramtype openapi_uri: typing.Optional[str]
         :keyword provisioning_state: Provisioning state of an endpoint, defaults to None
-        :type provisioning_state: typing.Optional[str]
+        :paramtype provisioning_state: typing.Optional[str]
         :keyword kind: Kind of the resource, we have two kinds: K8s and Managed online endpoints, defaults to None
         :type kind: typing.Optional[str]
         """
@@ -297,27 +297,27 @@ class KubernetesOnlineEndpoint(OnlineEndpoint):
     """K8s Online endpoint entity.
 
     :keyword name: Name of the resource, defaults to None
-    :type name: typing.Optional[str]
+    :paramtype name: typing.Optional[str]
     :keyword tags: Tag dictionary. Tags can be added, removed, and updated, defaults to None
-    :type tags: typing.Optional[typing.Dict[str, typing.Any]]
+    :paramtype tags: typing.Optional[typing.Dict[str, typing.Any]]
     :keyword properties: The asset property dictionary, defaults to None
-    :type properties: typing.Optional[typing.Dict[str, typing.Any]]
+    :paramtype properties: typing.Optional[typing.Dict[str, typing.Any]]
     :keyword auth_mode: Possible values include: "aml_token", "key", defaults to KEY
     :type auth_mode: typing.Optional[str]
     :keyword description: Description of the inference endpoint, defaults to None
-    :type description: typing.Optional[str]
+    :paramtype description: typing.Optional[str]
     :keyword location: Location of the resource, defaults to None
-    :type location: typing.Optional[str]
+    :paramtype location: typing.Optional[str]
     :keyword traffic: Traffic rules on how the traffic will be routed across deployments, defaults to None
-    :type traffic: typing.Optional[typing.Dict[str, int]]
+    :paramtype traffic: typing.Optional[typing.Dict[str, int]]
     :keyword mirror_traffic: Duplicated live traffic used to inference a single deployment, defaults to None
-    :type mirror_traffic: typing.Optional[typing.Dict[str, int]]
+    :paramtype mirror_traffic: typing.Optional[typing.Dict[str, int]]
     :keyword compute: Compute cluster id, defaults to None
-    :type compute: typing.Optional[str]
+    :paramtype compute: typing.Optional[str]
     :keyword identity: Identity Configuration, defaults to SystemAssigned
-    :type identity: typing.Optional[IdentityConfiguration]
+    :paramtype identity: typing.Optional[IdentityConfiguration]
     :keyword kind: Kind of the resource, we have two kinds: K8s and Managed online endpoints, defaults to None
-    :type kind: typing.Optional[str]
+    :paramtype kind: typing.Optional[str]
     """
 
     def __init__(
@@ -341,25 +341,25 @@ class KubernetesOnlineEndpoint(OnlineEndpoint):
         Constructor for K8s Online endpoint entity.
 
         :keyword name: Name of the resource, defaults to None
-        :type name: typing.Optional[str]
+        :paramtype name: typing.Optional[str]
         :keyword tags: Tag dictionary. Tags can be added, removed, and updated, defaults to None
-        :type tags: typing.Optional[typing.Dict[str, typing.Any]]
+        :paramtype tags: typing.Optional[typing.Dict[str, typing.Any]]
         :keyword properties: The asset property dictionary, defaults to None
-        :type properties: typing.Optional[typing.Dict[str, typing.Any]]
+        :paramtype properties: typing.Optional[typing.Dict[str, typing.Any]]
         :keyword auth_mode: Possible values include: "aml_token", "key", defaults to KEY
         :type auth_mode: typing.Optional[str]
         :keyword description: Description of the inference endpoint, defaults to None
-        :type description: typing.Optional[str]
+        :paramtype description: typing.Optional[str]
         :keyword location: Location of the resource, defaults to None
-        :type location: typing.Optional[str]
+        :paramtype location: typing.Optional[str]
         :keyword traffic: Traffic rules on how the traffic will be routed across deployments, defaults to None
-        :type traffic: typing.Optional[typing.Dict[str, int]]
+        :paramtype traffic: typing.Optional[typing.Dict[str, int]]
         :keyword mirror_traffic: Duplicated live traffic used to inference a single deployment, defaults to None
-        :type mirror_traffic: typing.Optional[typing.Dict[str, int]]
+        :paramtype mirror_traffic: typing.Optional[typing.Dict[str, int]]
         :keyword compute: Compute cluster id, defaults to None
-        :type compute: typing.Optional[str]
+        :paramtype compute: typing.Optional[str]
         :keyword identity: Identity Configuration, defaults to SystemAssigned
-        :type identity: typing.Optional[IdentityConfiguration]
+        :paramtype identity: typing.Optional[IdentityConfiguration]
         :keyword kind: Kind of the resource, we have two kinds: K8s and Managed online endpoints, defaults to None
         :type kind: typing.Optional[str]
         """
@@ -419,25 +419,25 @@ class ManagedOnlineEndpoint(OnlineEndpoint):
     """Managed Online endpoint entity.
 
     :keyword name: Name of the resource, defaults to None
-    :type name: typing.Optional[str]
+    :paramtype name: typing.Optional[str]
     :keyword tags: Tag dictionary. Tags can be added, removed, and updated, defaults to None
-    :type tags: typing.Optional[typing.Dict[str, typing.Any]]
+    :paramtype tags: typing.Optional[typing.Dict[str, typing.Any]]
     :keyword properties: The asset property dictionary, defaults to None
-    :type properties: typing.Optional[typing.Dict[str, typing.Any]]
+    :paramtype properties: typing.Optional[typing.Dict[str, typing.Any]]
     :keyword auth_mode: Possible values include: "aml_token", "key", defaults to KEY
     :type auth_mode: str
     :keyword description: Description of the inference endpoint, defaults to None
-    :type description: typing.Optional[str]
+    :paramtype description: typing.Optional[str]
     :keyword location: Location of the resource, defaults to None
-    :type location: typing.Optional[str]
+    :paramtype location: typing.Optional[str]
     :keyword traffic: Traffic rules on how the traffic will be routed across deployments, defaults to None
-    :type traffic: typing.Optional[typing.Dict[str, int]]
+    :paramtype traffic: typing.Optional[typing.Dict[str, int]]
     :keyword mirror_traffic: Duplicated live traffic used to inference a single deployment, defaults to None
-    :type mirror_traffic: typing.Optional[typing.Dict[str, int]]
+    :paramtype mirror_traffic: typing.Optional[typing.Dict[str, int]]
     :keyword identity: Identity Configuration, defaults to SystemAssigned
-    :type identity: typing.Optional[IdentityConfiguration]
+    :paramtype identity: typing.Optional[IdentityConfiguration]
     :keyword kind: Kind of the resource, we have two kinds: K8s and Managed online endpoints, defaults to None.
-    :type kind: typing.Optional[str]
+    :paramtype kind: typing.Optional[str]
     :keyword public_network_access: Whether to allow public endpoint connectivity, defaults to None
         Allowed values are: "enabled", "disabled"
     :type public_network_access: typing.Optional[str]
@@ -464,23 +464,23 @@ class ManagedOnlineEndpoint(OnlineEndpoint):
         Constructor for Managed Online endpoint entity.
 
         :keyword name: Name of the resource, defaults to None
-        :type name: typing.Optional[str]
+        :paramtype name: typing.Optional[str]
         :keyword tags: Tag dictionary. Tags can be added, removed, and updated, defaults to None
-        :type tags: typing.Optional[typing.Dict[str, typing.Any]]
+        :paramtype tags: typing.Optional[typing.Dict[str, typing.Any]]
         :keyword properties: The asset property dictionary, defaults to None
-        :type properties: typing.Optional[typing.Dict[str, typing.Any]]
+        :paramtype properties: typing.Optional[typing.Dict[str, typing.Any]]
         :keyword auth_mode: Possible values include: "aml_token", "key", defaults to KEY
         :type auth_mode: str
         :keyword description: Description of the inference endpoint, defaults to None
-        :type description: typing.Optional[str]
+        :paramtype description: typing.Optional[str]
         :keyword location: Location of the resource, defaults to None
-        :type location: typing.Optional[str]
+        :paramtype location: typing.Optional[str]
         :keyword traffic: Traffic rules on how the traffic will be routed across deployments, defaults to None
-        :type traffic: typing.Optional[typing.Dict[str, int]]
+        :paramtype traffic: typing.Optional[typing.Dict[str, int]]
         :keyword mirror_traffic: Duplicated live traffic used to inference a single deployment, defaults to None
-        :type mirror_traffic: typing.Optional[typing.Dict[str, int]]
+        :paramtype mirror_traffic: typing.Optional[typing.Dict[str, int]]
         :keyword identity: Identity Configuration, defaults to SystemAssigned
-        :type identity: typing.Optional[IdentityConfiguration]
+        :paramtype identity: typing.Optional[IdentityConfiguration]
         :keyword kind: Kind of the resource, we have two kinds: K8s and Managed online endpoints, defaults to None.
         :type kind: typing.Optional[str]
         :keyword public_network_access: Whether to allow public endpoint connectivity, defaults to None

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_feature_set/materialization_settings.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_feature_set/materialization_settings.py
@@ -18,17 +18,17 @@ class MaterializationSettings(RestTranslatableMixin):
     """Defines materialization settings.
 
     :keyword schedule: The schedule details.
-    :type schedule: Optional[~azure.ai.ml.entities.RecurrenceTrigger]
+    :paramtype schedule: Optional[~azure.ai.ml.entities.RecurrenceTrigger]
     :keyword offline_enabled: Specifies if offline store is enabled.
-    :type offline_enabled: Optional[bool]
+    :paramtype offline_enabled: Optional[bool]
     :keyword online_enabled: Specifies if online store is enabled.
-    :type online_enabled: Optional[bool]
+    :paramtype online_enabled: Optional[bool]
     :keyword notification: The notification details.
-    :type notification: Optional[~azure.ai.ml.entities.Notification]
+    :paramtype notification: Optional[~azure.ai.ml.entities.Notification]
     :keyword resource: The compute resource settings.
-    :type resource: Optional[~azure.ai.ml.entities.MaterializationComputeResource]
+    :paramtype resource: Optional[~azure.ai.ml.entities.MaterializationComputeResource]
     :keyword spark_configuration: The spark compute settings.
-    :type spark_configuration: Optional[dict[str, str]]
+    :paramtype spark_configuration: Optional[dict[str, str]]
 
     .. admonition:: Example:
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_inputs_outputs/enum_input.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_inputs_outputs/enum_input.py
@@ -24,11 +24,11 @@ class EnumInput(Input):
         """Enum parameter parse the value according to its enum values.
 
         :param enum: Enum values.
-        :type enum: Union[EnumMeta, Sequence[str]], optional
+        :type enum: Union[EnumMeta, Sequence[str]]
         :param default: Default value of the parameter
-        :type default: Any, optional
+        :type default: Any
         :param description: Description of the parameter
-        :type description: str, optional
+        :type description: str
         """
         enum_values = self._assert_enum_valid(enum)
         # This is used to parse enum class instead of enum str value if a enum class is provided.

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_inputs_outputs/external_data.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_inputs_outputs/external_data.py
@@ -13,11 +13,11 @@ class StoredProcedureParameter(DictMixin, RestTranslatableMixin):
     """Define a stored procedure parameter class for DataTransfer import database task.
 
     :keyword name: The name of the database stored procedure.
-    :type name: str
+    :paramtype name: str
     :keyword value: The value of the database stored procedure.
-    :type value: str
+    :paramtype value: str
     :keyword type: The type of the database stored procedure.
-    :type type: str
+    :paramtype type: str
     """
 
     def __init__(
@@ -36,16 +36,16 @@ class Database(DictMixin, RestTranslatableMixin):  # pylint: disable=too-many-in
     """Define a database class for a DataTransfer Component or Job.
 
     :keyword query: The SQL query to retrieve data from the database.
-    :type query: str
+    :paramtype query: str
     :keyword table_name: The name of the database table.
-    :type table_name: str
+    :paramtype table_name: str
     :keyword stored_procedure: The name of the stored procedure.
-    :type stored_procedure: str
+    :paramtype stored_procedure: str
     :keyword stored_procedure_params: The parameters for the stored procedure.
-    :type stored_procedure_params: List[dict, StoredProcedureParameter]
+    :paramtype stored_procedure_params: List[dict, StoredProcedureParameter]
     :keyword connection: The connection string for the database.
         The credential information should be stored in the workspace connection.
-    :type connection: str
+    :paramtype connection: str
     :raises ~azure.ai.ml.exceptions.ValidationException: Raised if the Database object cannot be successfully validated.
         Details will be provided in the error message.
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_inputs_outputs/external_data.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_inputs_outputs/external_data.py
@@ -13,11 +13,11 @@ class StoredProcedureParameter(DictMixin, RestTranslatableMixin):
     """Define a stored procedure parameter class for DataTransfer import database task.
 
     :keyword name: The name of the database stored procedure.
-    :type name: str, optional
+    :type name: str
     :keyword value: The value of the database stored procedure.
-    :type value: str, optional
+    :type value: str
     :keyword type: The type of the database stored procedure.
-    :type type: str, optional
+    :type type: str
     """
 
     def __init__(
@@ -36,16 +36,16 @@ class Database(DictMixin, RestTranslatableMixin):  # pylint: disable=too-many-in
     """Define a database class for a DataTransfer Component or Job.
 
     :keyword query: The SQL query to retrieve data from the database.
-    :type query: str, optional
+    :type query: str
     :keyword table_name: The name of the database table.
-    :type table_name: str, optional
+    :type table_name: str
     :keyword stored_procedure: The name of the stored procedure.
-    :type stored_procedure: str, optional
+    :type stored_procedure: str
     :keyword stored_procedure_params: The parameters for the stored procedure.
-    :type stored_procedure_params: List[dict, StoredProcedureParameter], optional
+    :type stored_procedure_params: List[dict, StoredProcedureParameter]
     :keyword connection: The connection string for the database.
         The credential information should be stored in the workspace connection.
-    :type connection: str, optional
+    :type connection: str
     :raises ~azure.ai.ml.exceptions.ValidationException: Raised if the Database object cannot be successfully validated.
         Details will be provided in the error message.
 
@@ -84,7 +84,7 @@ class Database(DictMixin, RestTranslatableMixin):  # pylint: disable=too-many-in
         """Convert the Source object to a dict.
 
         :param remove_name: Whether to remove the `name` key from the  dict representation. Defaults to True.
-        :type remove_name: bool, optional
+        :type remove_name: bool
         :return: The dictionary representation of the class
         :rtype: Dict
         """
@@ -120,7 +120,7 @@ class Database(DictMixin, RestTranslatableMixin):  # pylint: disable=too-many-in
         """Get or set the parameters for the stored procedure.
 
         :return: The parameters for the stored procedure.
-        :rtype: List[StoredProcedureParameter], optional
+        :rtype: List[StoredProcedureParameter]
         """
 
         return self._stored_procedure_params
@@ -149,10 +149,10 @@ class FileSystem(DictMixin, RestTranslatableMixin):  # pylint: disable=too-many-
     e.g. source_s3 = FileSystem(path='s3://my_bucket/my_folder', connection='azureml:my_s3_connection')
 
     :param path: The path to which the input is pointing. Could be pointing to the path of file system. Default is None.
-    :type path: str, optional
+    :type path: str
     :param connection: Connection is workspace, we didn't support storage connection here, need leverage workspace
         connection to store these credential info. Default is None.
-    :type connection: str, optional
+    :type connection: str
     :raises ~azure.ai.ml.exceptions.ValidationException: Raised if Source cannot be successfully validated.
         Details will be provided in the error message.
     """
@@ -180,7 +180,7 @@ class FileSystem(DictMixin, RestTranslatableMixin):  # pylint: disable=too-many-
         """Convert the Source object to a dict.
 
         :param remove_name: Whether to remove the `name` key from the  dict representation. Defaults to True.
-        :type remove_name: bool, optional
+        :type remove_name: bool
         :return: The dictionary representation of the object
         :rtype: Dict
         """

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_inputs_outputs/group_input.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_inputs_outputs/group_input.py
@@ -127,7 +127,7 @@ class GroupInput(Input):
         :param value: The value to convert.
         :type value: any
         :param group_names: The names of the parent groups.
-        :type group_names: list, optional
+        :type group_names: list
         :return: The converted value as a GroupAttrDict.
         :rtype: GroupAttrDict or any
         """

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_inputs_outputs/input.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_inputs_outputs/input.py
@@ -31,31 +31,31 @@ class Input(_InputOutputBase):  # pylint: disable=too-many-instance-attributes
     :keyword type: The type of the data input. Accepted values are
         'uri_folder', 'uri_file', 'mltable', 'mlflow_model', 'custom_model', 'integer', 'number', 'string', and
         'boolean'.
-    :type type: str
+    :paramtype type: str
     :keyword path: The path to the input data. Paths can be local paths, remote data uris, or a registered AzureML asset
         ID.
-    :type path: Optional[str]
+    :paramtype path: Optional[str]
     :keyword mode: The access mode of the data input. Accepted values are:
         * 'ro_mount': Mount the data to the compute target as read-only,
         * 'download': Download the data to the compute target,
         * 'direct': Pass in the URI as a string to be accessed at runtime
-    :type mode: Optional[str]
+    :paramtype mode: Optional[str]
     :keyword default: The default value of the input. If a default is set, the input data will be optional.
-    :type default: Union[str, int, float, bool]
+    :paramtype default: Union[str, int, float, bool]
     :keyword min: The minimum value for the input. If a value smaller than the minimum is passed to the job, the job
         execution will fail.
-    :type min: Union[int, float]
+    :paramtype min: Union[int, float]
     :keyword max: The maximum value for the input. If a value larger than the maximum is passed to a job, the job
         execution will fail.
-    :type max: Union[integer, float]
+    :paramtype max: Union[integer, float]
     :keyword optional: Specifies if the input is optional.
-    :type optional: Optional[bool]
+    :paramtype optional: Optional[bool]
     :keyword description: Description of the input
-    :type description: Optional[str]
+    :paramtype description: Optional[str]
     :keyword datastore: The datastore to upload local files to.
-    :type datastore: str
+    :paramtype datastore: str
     :keyword intellectual_property: Intellectual property for the input.
-    :type intellectual_property: IntellectualProperty
+    :paramtype intellectual_property: IntellectualProperty
     :raises ~azure.ai.ml.exceptions.ValidationException: Raised if Input cannot be successfully validated.
         Details will be provided in the error message.
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_inputs_outputs/input.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_inputs_outputs/input.py
@@ -31,7 +31,7 @@ class Input(_InputOutputBase):  # pylint: disable=too-many-instance-attributes
     :keyword type: The type of the data input. Accepted values are
         'uri_folder', 'uri_file', 'mltable', 'mlflow_model', 'custom_model', 'integer', 'number', 'string', and
         'boolean'.
-    :type type: str, optional
+    :type type: str
     :keyword path: The path to the input data. Paths can be local paths, remote data uris, or a registered AzureML asset
         ID.
     :type path: Optional[str]
@@ -53,9 +53,9 @@ class Input(_InputOutputBase):  # pylint: disable=too-many-instance-attributes
     :keyword description: Description of the input
     :type description: Optional[str]
     :keyword datastore: The datastore to upload local files to.
-    :type datastore: str, optional
+    :type datastore: str
     :keyword intellectual_property: Intellectual property for the input.
-    :type intellectual_property: IntellectualProperty, optional
+    :type intellectual_property: IntellectualProperty
     :raises ~azure.ai.ml.exceptions.ValidationException: Raised if Input cannot be successfully validated.
         Details will be provided in the error message.
 
@@ -180,11 +180,11 @@ class Input(_InputOutputBase):  # pylint: disable=too-many-instance-attributes
         :param type: The type of the data input. Can only be set to "string".
         :type type: str
         :param default: The default value of this input. When a `default` is set, the input will be optional.
-        :type default: str, optional
+        :type default: str
         :param optional: Determine if this input is optional.
-        :type optional: bool, optional
+        :type optional: bool
         :param description: Description of the input.
-        :type description: str, optional
+        :type description: str
         :raises ~azure.ai.ml.exceptions.ValidationException: Raised if Input cannot be successfully validated.
             Details will be provided in the error message.
         """

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_inputs_outputs/output.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_inputs_outputs/output.py
@@ -22,7 +22,7 @@ class Output(_InputOutputBase):
 
     :keyword type: The type of the data output. Accepted values are 'uri_folder', 'uri_file', 'mltable', 'mlflow_model',
         'custom_model', and user-defined types.
-    :type type: str, optional
+    :type type: str
     :keyword path: The remote path where the output should be stored.
     :type path: Optional[str]
     :keyword mode: The access mode of the data output. Accepted values are
@@ -39,14 +39,14 @@ class Output(_InputOutputBase):
         when name is set.
     :type version: str
     :keyword is_control: Determine if the output is a control output.
-    :type is_control: bool, optional
+    :type is_control: bool
     :keyword early_available: Mark the output for early node orchestration.
-    :type early_available: bool, optional
+    :type early_available: bool
     :keyword intellectual_property: Intellectual property associated with the output.
         It can be an instance of `IntellectualProperty` or a dictionary that will be used to create an instance.
     :type intellectual_property: Union[
         ~azure.ai.ml.entities._assets.intellectual_property.IntellectualProperty,
-        dict], optional
+        dict]
 
     .. admonition:: Example:
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_inputs_outputs/output.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_inputs_outputs/output.py
@@ -22,29 +22,29 @@ class Output(_InputOutputBase):
 
     :keyword type: The type of the data output. Accepted values are 'uri_folder', 'uri_file', 'mltable', 'mlflow_model',
         'custom_model', and user-defined types.
-    :type type: str
+    :paramtype type: str
     :keyword path: The remote path where the output should be stored.
-    :type path: Optional[str]
+    :paramtype path: Optional[str]
     :keyword mode: The access mode of the data output. Accepted values are
         * 'rw_mount': Read-write mount the data
         * 'upload': Upload the data from the compute target
         * 'direct': Pass in the URI as a string
-    :type mode: Optional[str]
+    :paramtype mode: Optional[str]
     :keyword description: The description of the output.
-    :type description: Optional[str]
+    :paramtype description: Optional[str]
     :keyword name: The name to be used to register the output as a Data or Model asset. A name can be set without
         setting a version.
-    :type name: str
+    :paramtype name: str
     :keyword version: The version used to register the output as a Data or Model asset. A version can be set only
         when name is set.
-    :type version: str
+    :paramtype version: str
     :keyword is_control: Determine if the output is a control output.
-    :type is_control: bool
+    :paramtype is_control: bool
     :keyword early_available: Mark the output for early node orchestration.
-    :type early_available: bool
+    :paramtype early_available: bool
     :keyword intellectual_property: Intellectual property associated with the output.
         It can be an instance of `IntellectualProperty` or a dictionary that will be used to create an instance.
-    :type intellectual_property: Union[
+    :paramtype intellectual_property: Union[
         ~azure.ai.ml.entities._assets.intellectual_property.IntellectualProperty,
         dict]
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_inputs_outputs/utils.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_inputs_outputs/utils.py
@@ -83,9 +83,9 @@ def _get_param_with_standard_annotation(
     :param cls_or_func: Either a class or a function
     :type cls_or_func: Union[Callable, Type]
     :param is_func: Whether `cls_or_func` is a function. Defaults to False.
-    :type is_func: bool, optional
+    :type is_func: bool
     :param skip_params:
-    :type skip_params: Optional[List[str]], optional
+    :type skip_params: Optional[List[str]]
     :return: A dictionary of field annotations
     :rtype: Dict[str, Union[Annotation, "Input", "Output"]]
     """

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/_input_output_helpers.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/_input_output_helpers.py
@@ -196,7 +196,7 @@ def to_rest_dataset_literal_inputs(
     :rtype: Dict[str, Union[ComponentJobInput, PipelineInput]]
     :keyword job_type: When job_type is pipeline, enable dot('.') in parameter keys to support parameter group.
         TODO: Remove this after move name validation to Job's customized validate.
-    :type job_type: str
+    :paramtype job_type: str
     """
     rest_inputs = {}
     # Pack up the inputs into REST format

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/automl/image/automl_image.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/automl/image/automl_image.py
@@ -112,7 +112,7 @@ class AutoMLImage(AutoMLVertical, ABC):
         """Limit settings for all AutoML Image Verticals.
 
         :keyword timeout_minutes: AutoML job timeout.
-        :type timeout_minutes: ~datetime.timedelta
+        :paramtype timeout_minutes: ~datetime.timedelta
         """
         self._limits = self._limits or ImageLimitSettings()
         self._limits.max_concurrent_trials = (
@@ -137,7 +137,7 @@ class AutoMLImage(AutoMLVertical, ABC):
         ~azure.mgmt.machinelearningservices.models.SamplingAlgorithmType.GRID,
         ~azure.mgmt.machinelearningservices.models.SamplingAlgorithmType.BAYESIAN]
         :keyword early_termination: Type of early termination policy.
-        :type early_termination: Union[
+        :paramtype early_termination: Union[
         ~azure.mgmt.machinelearningservices.models.BanditPolicy,
         ~azure.mgmt.machinelearningservices.models.MedianStoppingPolicy,
         ~azure.mgmt.machinelearningservices.models.TruncationSelectionPolicy]

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/automl/image/automl_image_classification_base.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/automl/image/automl_image_classification_base.py
@@ -133,43 +133,43 @@ class AutoMLImageClassificationBase(AutoMLImage):
         """Setting Image training parameters for AutoML Image Classification and Image Classification Multilabel tasks.
 
         :keyword advanced_settings: Settings for advanced scenarios.
-        :type advanced_settings: str
+        :paramtype advanced_settings: str
         :keyword ams_gradient: Enable AMSGrad when optimizer is 'adam' or 'adamw'.
-        :type ams_gradient: bool
+        :paramtype ams_gradient: bool
         :keyword beta1: Value of 'beta1' when optimizer is 'adam' or 'adamw'. Must be a float in the
          range [0, 1].
-        :type beta1: float
+        :paramtype beta1: float
         :keyword beta2: Value of 'beta2' when optimizer is 'adam' or 'adamw'. Must be a float in the
          range [0, 1].
-        :type beta2: float
+        :paramtype beta2: float
         :keyword checkpoint_frequency: Frequency to store model checkpoints. Must be a positive
          integer.
-        :type checkpoint_frequency: int
+        :paramtype checkpoint_frequency: int
         :keyword checkpoint_run_id: The id of a previous run that has a pretrained checkpoint for
          incremental training.
-        :type checkpoint_run_id: str
+        :paramtype checkpoint_run_id: str
         :keyword distributed: Whether to use distributed training.
-        :type distributed: bool
+        :paramtype distributed: bool
         :keyword early_stopping: Enable early stopping logic during training.
-        :type early_stopping: bool
+        :paramtype early_stopping: bool
         :keyword early_stopping_delay: Minimum number of epochs or validation evaluations to wait
          before primary metric improvement
          is tracked for early stopping. Must be a positive integer.
-        :type early_stopping_delay: int
+        :paramtype early_stopping_delay: int
         :keyword early_stopping_patience: Minimum number of epochs or validation evaluations with no
          primary metric improvement before
          the run is stopped. Must be a positive integer.
-        :type early_stopping_patience: int
+        :paramtype early_stopping_patience: int
         :keyword enable_onnx_normalization: Enable normalization when exporting ONNX model.
-        :type enable_onnx_normalization: bool
+        :paramtype enable_onnx_normalization: bool
         :keyword evaluation_frequency: Frequency to evaluate validation dataset to get metric scores.
          Must be a positive integer.
-        :type evaluation_frequency: int
+        :paramtype evaluation_frequency: int
         :keyword gradient_accumulation_step: Gradient accumulation means running a configured number of
          "GradAccumulationStep" steps without
          updating the model weights while accumulating the gradients of those steps, and then using
          the accumulated gradients to compute the weight updates. Must be a positive integer.
-        :type gradient_accumulation_step: int
+        :paramtype gradient_accumulation_step: int
         :keyword layers_to_freeze: Number of layers to freeze for the model. Must be a positive
          integer.
          For instance, passing 2 as value for 'seresnext' means
@@ -178,7 +178,7 @@ class AutoMLImageClassificationBase(AutoMLImage):
          see: https://docs.microsoft.com/en-us/azure/machine-learning/reference-automl-images-hyperparameters#model-agnostic-hyperparameters.   # pylint: disable=line-too-long
         :type layers_to_freeze: int
         :keyword learning_rate: Initial learning rate. Must be a float in the range [0, 1].
-        :type learning_rate: float
+        :paramtype learning_rate: float
         :keyword learning_rate_scheduler: Type of learning rate scheduler. Must be 'warmup_cosine' or
          'step'. Possible values include: "None", "WarmupCosine", "Step".
         :type learning_rate_scheduler: str or
@@ -189,49 +189,49 @@ class AutoMLImageClassificationBase(AutoMLImage):
         :type model_name: str
         :keyword momentum: Value of momentum when optimizer is 'sgd'. Must be a float in the range [0,
          1].
-        :type momentum: float
+        :paramtype momentum: float
         :keyword nesterov: Enable nesterov when optimizer is 'sgd'.
-        :type nesterov: bool
+        :paramtype nesterov: bool
         :keyword number_of_epochs: Number of training epochs. Must be a positive integer.
-        :type number_of_epochs: int
+        :paramtype number_of_epochs: int
         :keyword number_of_workers: Number of data loader workers. Must be a non-negative integer.
-        :type number_of_workers: int
+        :paramtype number_of_workers: int
         :keyword optimizer: Type of optimizer. Possible values include: "None", "Sgd", "Adam", "Adamw".
         :type optimizer: str or ~azure.mgmt.machinelearningservices.models.StochasticOptimizer
         :keyword random_seed: Random seed to be used when using deterministic training.
-        :type random_seed: int
+        :paramtype random_seed: int
         :keyword step_lr_gamma: Value of gamma when learning rate scheduler is 'step'. Must be a float
          in the range [0, 1].
-        :type step_lr_gamma: float
+        :paramtype step_lr_gamma: float
         :keyword step_lr_step_size: Value of step size when learning rate scheduler is 'step'. Must be
          a positive integer.
-        :type step_lr_step_size: int
+        :paramtype step_lr_step_size: int
         :keyword training_batch_size: Training batch size. Must be a positive integer.
-        :type training_batch_size: int
+        :paramtype training_batch_size: int
         :keyword validation_batch_size: Validation batch size. Must be a positive integer.
-        :type validation_batch_size: int
+        :paramtype validation_batch_size: int
         :keyword warmup_cosine_lr_cycles: Value of cosine cycle when learning rate scheduler is
          'warmup_cosine'. Must be a float in the range [0, 1].
-        :type warmup_cosine_lr_cycles: float
+        :paramtype warmup_cosine_lr_cycles: float
         :keyword warmup_cosine_lr_warmup_epochs: Value of warmup epochs when learning rate scheduler is
          'warmup_cosine'. Must be a positive integer.
-        :type warmup_cosine_lr_warmup_epochs: int
+        :paramtype warmup_cosine_lr_warmup_epochs: int
         :keyword weight_decay: Value of weight decay when optimizer is 'sgd', 'adam', or 'adamw'. Must
          be a float in the range[0, 1].
-        :type weight_decay: float
+        :paramtype weight_decay: float
         :keyword training_crop_size: Image crop size that is input to the neural network for the
          training dataset. Must be a positive integer.
-        :type training_crop_size: int
+        :paramtype training_crop_size: int
         :keyword validation_crop_size: Image crop size that is input to the neural network for the
          validation dataset. Must be a positive integer.
-        :type validation_crop_size: int
+        :paramtype validation_crop_size: int
         :keyword validation_resize_size: Image size to which to resize before cropping for validation
          dataset. Must be a positive integer.
-        :type validation_resize_size: int
+        :paramtype validation_resize_size: int
         :keyword weighted_loss: Weighted loss. The accepted values are 0 for no weighted loss.
          1 for weighted loss with sqrt.(class_weights). 2 for weighted loss with class_weights. Must be
          0 or 1 or 2.
-        :type weighted_loss: int
+        :paramtype weighted_loss: int
         """
         self._training_parameters = self._training_parameters or ImageModelSettingsClassification()
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/automl/image/automl_image_object_detection_base.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/automl/image/automl_image_object_detection_base.py
@@ -159,43 +159,43 @@ class AutoMLImageObjectDetectionBase(AutoMLImage):
         tasks.
 
         :keyword advanced_settings: Settings for advanced scenarios.
-        :type advanced_settings: str
+        :paramtype advanced_settings: str
         :keyword ams_gradient: Enable AMSGrad when optimizer is 'adam' or 'adamw'.
-        :type ams_gradient: bool
+        :paramtype ams_gradient: bool
         :keyword beta1: Value of 'beta1' when optimizer is 'adam' or 'adamw'. Must be a float in the
          range [0, 1].
-        :type beta1: float
+        :paramtype beta1: float
         :keyword beta2: Value of 'beta2' when optimizer is 'adam' or 'adamw'. Must be a float in the
          range [0, 1].
-        :type beta2: float
+        :paramtype beta2: float
         :keyword checkpoint_frequency: Frequency to store model checkpoints. Must be a positive
          integer.
-        :type checkpoint_frequency: int
+        :paramtype checkpoint_frequency: int
         :keyword checkpoint_run_id: The id of a previous run that has a pretrained checkpoint for
          incremental training.
-        :type checkpoint_run_id: str
+        :paramtype checkpoint_run_id: str
         :keyword distributed: Whether to use distributed training.
-        :type distributed: bool
+        :paramtype distributed: bool
         :keyword early_stopping: Enable early stopping logic during training.
-        :type early_stopping: bool
+        :paramtype early_stopping: bool
         :keyword early_stopping_delay: Minimum number of epochs or validation evaluations to wait
          before primary metric improvement
          is tracked for early stopping. Must be a positive integer.
-        :type early_stopping_delay: int
+        :paramtype early_stopping_delay: int
         :keyword early_stopping_patience: Minimum number of epochs or validation evaluations with no
          primary metric improvement before
          the run is stopped. Must be a positive integer.
-        :type early_stopping_patience: int
+        :paramtype early_stopping_patience: int
         :keyword enable_onnx_normalization: Enable normalization when exporting ONNX model.
-        :type enable_onnx_normalization: bool
+        :paramtype enable_onnx_normalization: bool
         :keyword evaluation_frequency: Frequency to evaluate validation dataset to get metric scores.
          Must be a positive integer.
-        :type evaluation_frequency: int
+        :paramtype evaluation_frequency: int
         :keyword gradient_accumulation_step: Gradient accumulation means running a configured number of
          "GradAccumulationStep" steps without
          updating the model weights while accumulating the gradients of those steps, and then using
          the accumulated gradients to compute the weight updates. Must be a positive integer.
-        :type gradient_accumulation_step: int
+        :paramtype gradient_accumulation_step: int
         :keyword layers_to_freeze: Number of layers to freeze for the model. Must be a positive
          integer.
          For instance, passing 2 as value for 'seresnext' means
@@ -204,7 +204,7 @@ class AutoMLImageObjectDetectionBase(AutoMLImage):
          see: https://docs.microsoft.com/en-us/azure/machine-learning/reference-automl-images-hyperparameters#model-agnostic-hyperparameters.   # pylint: disable=line-too-long
         :type layers_to_freeze: int
         :keyword learning_rate: Initial learning rate. Must be a float in the range [0, 1].
-        :type learning_rate: float
+        :paramtype learning_rate: float
         :keyword learning_rate_scheduler: Type of learning rate scheduler. Must be 'warmup_cosine' or
          'step'. Possible values include: "None", "WarmupCosine", "Step".
         :type learning_rate_scheduler: str or
@@ -215,36 +215,36 @@ class AutoMLImageObjectDetectionBase(AutoMLImage):
         :type model_name: str
         :keyword momentum: Value of momentum when optimizer is 'sgd'. Must be a float in the range [0,
          1].
-        :type momentum: float
+        :paramtype momentum: float
         :keyword nesterov: Enable nesterov when optimizer is 'sgd'.
-        :type nesterov: bool
+        :paramtype nesterov: bool
         :keyword number_of_epochs: Number of training epochs. Must be a positive integer.
-        :type number_of_epochs: int
+        :paramtype number_of_epochs: int
         :keyword number_of_workers: Number of data loader workers. Must be a non-negative integer.
-        :type number_of_workers: int
+        :paramtype number_of_workers: int
         :keyword optimizer: Type of optimizer. Possible values include: "None", "Sgd", "Adam", "Adamw".
         :type optimizer: str or ~azure.mgmt.machinelearningservices.models.StochasticOptimizer
         :keyword random_seed: Random seed to be used when using deterministic training.
-        :type random_seed: int
+        :paramtype random_seed: int
         :keyword step_lr_gamma: Value of gamma when learning rate scheduler is 'step'. Must be a float
          in the range [0, 1].
-        :type step_lr_gamma: float
+        :paramtype step_lr_gamma: float
         :keyword step_lr_step_size: Value of step size when learning rate scheduler is 'step'. Must be
          a positive integer.
-        :type step_lr_step_size: int
+        :paramtype step_lr_step_size: int
         :keyword training_batch_size: Training batch size. Must be a positive integer.
-        :type training_batch_size: int
+        :paramtype training_batch_size: int
         :keyword validation_batch_size: Validation batch size. Must be a positive integer.
-        :type validation_batch_size: int
+        :paramtype validation_batch_size: int
         :keyword warmup_cosine_lr_cycles: Value of cosine cycle when learning rate scheduler is
          'warmup_cosine'. Must be a float in the range [0, 1].
-        :type warmup_cosine_lr_cycles: float
+        :paramtype warmup_cosine_lr_cycles: float
         :keyword warmup_cosine_lr_warmup_epochs: Value of warmup epochs when learning rate scheduler is
          'warmup_cosine'. Must be a positive integer.
-        :type warmup_cosine_lr_warmup_epochs: int
+        :paramtype warmup_cosine_lr_warmup_epochs: int
         :keyword weight_decay: Value of weight decay when optimizer is 'sgd', 'adam', or 'adamw'. Must
          be a float in the range[0, 1].
-        :type weight_decay: float
+        :paramtype weight_decay: float
         :keyword box_detections_per_image: Maximum number of detections per image, for all classes.
          Must be a positive integer.
          Note: This settings is not supported for the 'yolov5' algorithm.
@@ -252,7 +252,7 @@ class AutoMLImageObjectDetectionBase(AutoMLImage):
         :keyword box_score_threshold: During inference, only return proposals with a classification
          score greater than
          BoxScoreThreshold. Must be a float in the range[0, 1].
-        :type box_score_threshold: float
+        :paramtype box_score_threshold: float
         :keyword image_size: Image size for training and validation. Must be a positive integer.
          Note: The training run may get into CUDA OOM if the size is too big.
          Note: This settings is only supported for the 'yolov5' algorithm.
@@ -275,14 +275,14 @@ class AutoMLImageObjectDetectionBase(AutoMLImage):
         :type multi_scale: bool
         :keyword nms_iou_threshold: IOU threshold used during inference in NMS post processing. Must be
          float in the range [0, 1].
-        :type nms_iou_threshold: float
+        :paramtype nms_iou_threshold: float
         :keyword tile_grid_size: The grid size to use for tiling each image. Note: TileGridSize must
          not be
          None to enable small object detection logic. A string containing two integers in mxn format.
         :type tile_grid_size: str
         :keyword tile_overlap_ratio: Overlap ratio between adjacent tiles in each dimension. Must be
          float in the range [0, 1).
-        :type tile_overlap_ratio: float
+        :paramtype tile_overlap_ratio: float
         :keyword tile_predictions_nms_threshold: The IOU threshold to use to perform NMS while merging
          predictions from tiles and image.
          Used in validation/ inference. Must be float in the range [0, 1].
@@ -290,16 +290,16 @@ class AutoMLImageObjectDetectionBase(AutoMLImage):
         :type tile_predictions_nms_threshold: str
         :keyword validation_iou_threshold: IOU threshold to use when computing validation metric. Must
          be float in the range [0, 1].
-        :type validation_iou_threshold: float
+        :paramtype validation_iou_threshold: float
         :keyword validation_metric_type: Metric computation method to use for validation metrics. Must
          be 'none', 'coco', 'voc', or 'coco_voc'.
-        :type validation_metric_type: str or ~azure.mgmt.machinelearningservices.models.ValidationMetricType
+        :paramtype validation_metric_type: str or ~azure.mgmt.machinelearningservices.models.ValidationMetricType
         :keyword log_training_metrics: indicates whether or not to log training metrics. Must
          be 'Enable' or 'Disable'
-        :type log_training_metrics: str or ~azure.mgmt.machinelearningservices.models.LogTrainingMetrics
+        :paramtype log_training_metrics: str or ~azure.mgmt.machinelearningservices.models.LogTrainingMetrics
         :keyword log_validation_loss: indicates whether or not to log validation loss. Must
          be 'Enable' or 'Disable'
-        :type log_validation_loss: str or ~azure.mgmt.machinelearningservices.models.LogValidationLoss
+        :paramtype log_validation_loss: str or ~azure.mgmt.machinelearningservices.models.LogValidationLoss
         """
         self._training_parameters = self._training_parameters or ImageModelSettingsObjectDetection()
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/automl/nlp/nlp_limit_settings.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/automl/nlp/nlp_limit_settings.py
@@ -13,11 +13,11 @@ class NlpLimitSettings(RestTranslatableMixin):
     """Limit settings for all AutoML NLP Verticals.
 
     :param max_concurrent_trials: Maximum number of concurrent AutoML iterations.
-    :type max_concurrent_trials: int, optional
+    :type max_concurrent_trials: int
     :param max_trials: Maximum number of AutoML iterations.
-    :type max_trials: int, optional
+    :type max_trials: int
     :param timeout_minutes: AutoML job timeout.
-    :type timeout_minutes: int, optional
+    :type timeout_minutes: int
     """
 
     def __init__(

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/automl/tabular/forecasting_job.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/automl/tabular/forecasting_job.py
@@ -39,9 +39,9 @@ class ForecastingJob(AutoMLTabular):
         """Initialize a new AutoML Forecasting task.
 
         :param primary_metric: The primary metric to use for optimization
-        :type primary_metric: str, optional
+        :type primary_metric: str
         :param forecasting_settings: The settings for the forecasting task
-        :type forecasting_settings: ForecastingSettings, optional
+        :type forecasting_settings: ForecastingSettings
         :param kwargs: Job-specific arguments
         :type kwargs: dict
         """
@@ -107,7 +107,7 @@ class ForecastingJob(AutoMLTabular):
         :keyword time_column_name:
             The name of the time column. This parameter is required when forecasting to specify the datetime
             column in the input data used for building the time series and inferring its frequency.
-        :type time_column_name: Optional[str], optional
+        :type time_column_name: Optional[str]
         :keyword forecast_horizon:
             The desired maximum forecast horizon in units of time-series frequency. The default value is 1.
 
@@ -115,13 +115,13 @@ class ForecastingJob(AutoMLTabular):
             should predict out. When task type is forecasting, this parameter is required. For more information on
             setting forecasting parameters, see `Auto-train a time-series forecast model <https://docs.microsoft.com/
             azure/machine-learning/how-to-auto-train-forecast>`_.
-        :type forecast_horizon: Optional[Union[str, int]], optional
+        :type forecast_horizon: Optional[Union[str, int]]
         :keyword time_series_id_column_names:
             The names of columns used to group a timeseries.
             It can be used to create multiple series. If time series id column names is not defined or
             the identifier columns specified do not identify all the series in the dataset, the time series identifiers
             will be automatically created for your dataset.
-        :type time_series_id_column_names: Optional[Union[str, List[str]]], optional
+        :type time_series_id_column_names: Optional[Union[str, List[str]]]
         :keyword target_lags:
             The number of past periods to lag from the target column. By default the lags are turned off.
 
@@ -153,9 +153,9 @@ class ForecastingJob(AutoMLTabular):
             #. We scan the PACF values from the beginning and the value before the first insignificant
                auto correlation will designate the lag. If first significant element (value correlate with
                itself) is followed by insignificant, the lag will be 0 and we will not use look back features.
-        :type target_lags: Optional[Union[str, int, List[int]]], optional
+        :type target_lags: Optional[Union[str, int, List[int]]]
         :keyword feature_lags: Flag for generating lags for the numeric features with 'auto' or None.
-        :type feature_lags: Optional[str], optional
+        :type feature_lags: Optional[str]
         :keyword target_rolling_window_size:
             The number of past periods used to create a rolling window average of the target column.
 
@@ -164,18 +164,18 @@ class ForecastingJob(AutoMLTabular):
             when you only want to consider a certain amount of history when training the model.
             If set to 'auto', rolling window will be estimated as the last
             value where the PACF is more then the significance threshold. Please see target_lags section for details.
-        :type target_rolling_window_size: Optional[Union[int, str]], optional
+        :type target_rolling_window_size: Optional[Union[int, str]]
         :keyword country_or_region_for_holidays: The country/region used to generate holiday features.
             These should be ISO 3166 two-letter country/region codes, for example 'US' or 'GB'.
-        :type country_or_region_for_holidays: Optional[str], optional
+        :type country_or_region_for_holidays: Optional[str]
         :keyword use_stl: Configure STL Decomposition of the time-series target column.
                     use_stl can take three values: None (default) - no stl decomposition, 'season' - only generate
                     season component and season_trend - generate both season and trend components.
-        :type use_stl: Optional[str], optional
+        :type use_stl: Optional[str]
         :keyword seasonality: Set time series seasonality as an integer multiple of the series frequency.
                     If seasonality is set to 'auto', it will be inferred.
                     If set to None, the time series is assumed non-seasonal which is equivalent to seasonality=1.
-        :type seasonality: Optional[Union[int, str], optional
+        :type seasonality: Optional[Union[int, str]
         :keyword short_series_handling_config:
             The parameter defining how if AutoML should handle short time series.
 
@@ -237,7 +237,7 @@ class ForecastingJob(AutoMLTabular):
             | False     | None                   | False              | None                             |
             +-----------+------------------------+--------------------+----------------------------------+
 
-        :type short_series_handling_config: Optional[str], optional
+        :type short_series_handling_config: Optional[str]
         :keyword frequency: Forecast frequency.
 
             When forecasting, this parameter represents the period with which the forecast is desired,
@@ -248,7 +248,7 @@ class ForecastingJob(AutoMLTabular):
             The frequency needs to be a pandas offset alias.
             Please refer to pandas documentation for more information:
             https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#dateoffset-objects
-        :type frequency: Optional[str], optional
+        :type frequency: Optional[str]
         :keyword target_aggregate_function: The function to be used to aggregate the time series target
                                             column to conform to a user specified frequency. If the
                                             target_aggregation_function is set, but the freq parameter
@@ -283,15 +283,15 @@ class ForecastingJob(AutoMLTabular):
                 |                |                             | aggregation function.                       |
                 +----------------+-----------------------------+---------------------------------------------+
 
-        :type target_aggregate_function: Optional[str], optional
+        :type target_aggregate_function: Optional[str]
         :keyword cv_step_size:
             Number of periods between the origin_time of one CV fold and the next fold. For
             example, if `n_step` = 3 for daily data, the origin time for each fold will be
             three days apart.
-        :type cv_step_size: Optional[int], optional
+        :type cv_step_size: Optional[int]
         :keyword features_unknown_at_forecast_time:
             The column of features/regressors that are available at training time but unknown at forecast time.
-        :type features_unknown_at_forecast_time: Optional[Union[str, List[str]]], optional
+        :type features_unknown_at_forecast_time: Optional[Union[str, List[str]]]
         """
         self._forecasting_settings = self._forecasting_settings or ForecastingSettings()
 
@@ -370,17 +370,17 @@ class ForecastingJob(AutoMLTabular):
             Whether to enable or disable enforcing the ONNX-compatible models.
             The default is False. For more information about Open Neural Network Exchange (ONNX) and Azure Machine
             Learning, see this `article <https://docs.microsoft.com/azure/machine-learning/concept-onnx>`__.
-        :type enable_onnx_compatible: Optional[bool], optional
+        :type enable_onnx_compatible: Optional[bool]
         :keyword enable_dnn_training:
             Whether to include DNN based models during model selection.
             However, the default is True for DNN NLP tasks, and it's False for all other AutoML tasks.
-        :type enable_dnn_training: Optional[bool], optional
+        :type enable_dnn_training: Optional[bool]
         :keyword enable_model_explainability:
             Whether to enable explaining the best AutoML model at the end of all AutoML training iterations.
             For more information, see `Interpretability: model explanations in automated machine learning
             <https://docs.microsoft.com/azure/machine-learning/how-to-machine-learning-interpretability-automl>`__.
             , defaults to None
-        :type enable_model_explainability: Optional[bool], optional
+        :type enable_model_explainability: Optional[bool]
         :keyword enable_stack_ensemble:
             Whether to enable/disable StackEnsemble iteration.
             If `enable_onnx_compatible_models` flag is being set, then StackEnsemble iteration will be disabled.
@@ -389,16 +389,16 @@ class ForecastingJob(AutoMLTabular):
             For more information about ensembles, see `Ensemble configuration
             <https://docs.microsoft.com/azure/machine-learning/how-to-configure-auto-train#ensemble>`__
             , defaults to None
-        :type enable_stack_ensemble: Optional[bool], optional
+        :type enable_stack_ensemble: Optional[bool]
         :keyword enable_vote_ensemble:
             Whether to enable/disable VotingEnsemble iteration.
             For more information about ensembles, see `Ensemble configuration
             <https://docs.microsoft.com/azure/machine-learning/how-to-configure-auto-train#ensemble>`__
             , defaults to None
-        :type enable_vote_ensemble: Optional[bool], optional
+        :type enable_vote_ensemble: Optional[bool]
         :keyword stack_ensemble_settings:
             Settings for StackEnsemble iteration, defaults to None
-        :type stack_ensemble_settings: Optional[StackEnsembleSettings], optional
+        :type stack_ensemble_settings: Optional[StackEnsembleSettings]
         :keyword ensemble_model_download_timeout:
             During VotingEnsemble and StackEnsemble model generation,
             multiple fitted models from the previous child runs are downloaded. Configure this parameter with a
@@ -408,10 +408,10 @@ class ForecastingJob(AutoMLTabular):
             A list of model names to search for an experiment. If not specified,
             then all models supported for the task are used minus any specified in ``blocked_training_algorithms``
             or deprecated TensorFlow models, defaults to None
-        :type allowed_training_algorithms: Optional[List[str]], optional
+        :type allowed_training_algorithms: Optional[List[str]]
         :keyword blocked_training_algorithms:
             A list of algorithms to ignore for an experiment, defaults to None
-        :type blocked_training_algorithms: Optional[List[str]], optional
+        :type blocked_training_algorithms: Optional[List[str]]
         :keyword training_mode:
             [Experimental] The training mode to use.
             The possible values are-
@@ -423,7 +423,7 @@ class ForecastingJob(AutoMLTabular):
             * auto- Currently, it is same as non_distributed. In future, this might change.
 
             Note: This parameter is in public preview and may change in future.
-        :type training_mode: Optional[Union[~azure.ai.ml.constants.TabularTrainingMode, str]], optional
+        :type training_mode: Optional[Union[~azure.ai.ml.constants.TabularTrainingMode, str]]
         """
         super().set_training(
             enable_onnx_compatible_models=enable_onnx_compatible_models,

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/automl/tabular/forecasting_job.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/automl/tabular/forecasting_job.py
@@ -107,7 +107,7 @@ class ForecastingJob(AutoMLTabular):
         :keyword time_column_name:
             The name of the time column. This parameter is required when forecasting to specify the datetime
             column in the input data used for building the time series and inferring its frequency.
-        :type time_column_name: Optional[str]
+        :paramtype time_column_name: Optional[str]
         :keyword forecast_horizon:
             The desired maximum forecast horizon in units of time-series frequency. The default value is 1.
 
@@ -121,7 +121,7 @@ class ForecastingJob(AutoMLTabular):
             It can be used to create multiple series. If time series id column names is not defined or
             the identifier columns specified do not identify all the series in the dataset, the time series identifiers
             will be automatically created for your dataset.
-        :type time_series_id_column_names: Optional[Union[str, List[str]]]
+        :paramtype time_series_id_column_names: Optional[Union[str, List[str]]]
         :keyword target_lags:
             The number of past periods to lag from the target column. By default the lags are turned off.
 
@@ -155,7 +155,7 @@ class ForecastingJob(AutoMLTabular):
                itself) is followed by insignificant, the lag will be 0 and we will not use look back features.
         :type target_lags: Optional[Union[str, int, List[int]]]
         :keyword feature_lags: Flag for generating lags for the numeric features with 'auto' or None.
-        :type feature_lags: Optional[str]
+        :paramtype feature_lags: Optional[str]
         :keyword target_rolling_window_size:
             The number of past periods used to create a rolling window average of the target column.
 
@@ -164,10 +164,10 @@ class ForecastingJob(AutoMLTabular):
             when you only want to consider a certain amount of history when training the model.
             If set to 'auto', rolling window will be estimated as the last
             value where the PACF is more then the significance threshold. Please see target_lags section for details.
-        :type target_rolling_window_size: Optional[Union[int, str]]
+        :paramtype target_rolling_window_size: Optional[Union[int, str]]
         :keyword country_or_region_for_holidays: The country/region used to generate holiday features.
             These should be ISO 3166 two-letter country/region codes, for example 'US' or 'GB'.
-        :type country_or_region_for_holidays: Optional[str]
+        :paramtype country_or_region_for_holidays: Optional[str]
         :keyword use_stl: Configure STL Decomposition of the time-series target column.
                     use_stl can take three values: None (default) - no stl decomposition, 'season' - only generate
                     season component and season_trend - generate both season and trend components.
@@ -175,7 +175,7 @@ class ForecastingJob(AutoMLTabular):
         :keyword seasonality: Set time series seasonality as an integer multiple of the series frequency.
                     If seasonality is set to 'auto', it will be inferred.
                     If set to None, the time series is assumed non-seasonal which is equivalent to seasonality=1.
-        :type seasonality: Optional[Union[int, str]
+        :paramtype seasonality: Optional[Union[int, str]
         :keyword short_series_handling_config:
             The parameter defining how if AutoML should handle short time series.
 
@@ -288,10 +288,10 @@ class ForecastingJob(AutoMLTabular):
             Number of periods between the origin_time of one CV fold and the next fold. For
             example, if `n_step` = 3 for daily data, the origin time for each fold will be
             three days apart.
-        :type cv_step_size: Optional[int]
+        :paramtype cv_step_size: Optional[int]
         :keyword features_unknown_at_forecast_time:
             The column of features/regressors that are available at training time but unknown at forecast time.
-        :type features_unknown_at_forecast_time: Optional[Union[str, List[str]]]
+        :paramtype features_unknown_at_forecast_time: Optional[Union[str, List[str]]]
         """
         self._forecasting_settings = self._forecasting_settings or ForecastingSettings()
 
@@ -374,7 +374,7 @@ class ForecastingJob(AutoMLTabular):
         :keyword enable_dnn_training:
             Whether to include DNN based models during model selection.
             However, the default is True for DNN NLP tasks, and it's False for all other AutoML tasks.
-        :type enable_dnn_training: Optional[bool]
+        :paramtype enable_dnn_training: Optional[bool]
         :keyword enable_model_explainability:
             Whether to enable explaining the best AutoML model at the end of all AutoML training iterations.
             For more information, see `Interpretability: model explanations in automated machine learning
@@ -398,20 +398,20 @@ class ForecastingJob(AutoMLTabular):
         :type enable_vote_ensemble: Optional[bool]
         :keyword stack_ensemble_settings:
             Settings for StackEnsemble iteration, defaults to None
-        :type stack_ensemble_settings: Optional[StackEnsembleSettings]
+        :paramtype stack_ensemble_settings: Optional[StackEnsembleSettings]
         :keyword ensemble_model_download_timeout:
             During VotingEnsemble and StackEnsemble model generation,
             multiple fitted models from the previous child runs are downloaded. Configure this parameter with a
             higher value than 300 secs, if more time is needed, defaults to None
-        :type ensemble_model_download_timeout: Optional[int]
+        :paramtype ensemble_model_download_timeout: Optional[int]
         :keyword allowed_training_algorithms:
             A list of model names to search for an experiment. If not specified,
             then all models supported for the task are used minus any specified in ``blocked_training_algorithms``
             or deprecated TensorFlow models, defaults to None
-        :type allowed_training_algorithms: Optional[List[str]]
+        :paramtype allowed_training_algorithms: Optional[List[str]]
         :keyword blocked_training_algorithms:
             A list of algorithms to ignore for an experiment, defaults to None
-        :type blocked_training_algorithms: Optional[List[str]]
+        :paramtype blocked_training_algorithms: Optional[List[str]]
         :keyword training_mode:
             [Experimental] The training mode to use.
             The possible values are-

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/automl/tabular/limit_settings.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/automl/tabular/limit_settings.py
@@ -14,13 +14,13 @@ class TabularLimitSettings(RestTranslatableMixin):
 
     :param enable_early_termination: Whether to enable early termination if the score is not improving in
         the short term. The default is True.
-    :type enable_early_termination: bool, optional
+    :type enable_early_termination: bool
     :param exit_score: Target score for experiment. The experiment terminates after this score is reached.
-    :type exit_score: float, optional
+    :type exit_score: float
     :param max_concurrent_trials: Maximum number of concurrent AutoML iterations.
-    :type max_concurrent_trials: int, optional
+    :type max_concurrent_trials: int
     :param max_cores_per_trial: The maximum number of threads to use for a given training iteration.
-    :type max_cores_per_trial: int, optional
+    :type max_cores_per_trial: int
     :param max_nodes: [Experimental] The maximum number of nodes to use for distributed training.
 
         * For forecasting, each model is trained using max(2, int(max_nodes / max_concurrent_trials)) nodes.
@@ -28,13 +28,13 @@ class TabularLimitSettings(RestTranslatableMixin):
         * For classification/regression, each model is trained using max_nodes nodes.
 
         Note- This parameter is in public preview and might change in future.
-    :type max_nodes: int, optional
+    :type max_nodes: int
     :param max_trials: Maximum number of AutoML iterations.
-    :type max_trials: int, optional
+    :type max_trials: int
     :param timeout_minutes: AutoML job timeout.
-    :type timeout_minutes: int, optional
+    :type timeout_minutes: int
     :param trial_timeout_minutes: AutoML job timeout.
-    :type trial_timeout_minutes: int, optional
+    :type trial_timeout_minutes: int
     """
 
     def __init__(

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/automl/tabular/regression_job.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/automl/tabular/regression_job.py
@@ -34,7 +34,7 @@ class RegressionJob(AutoMLTabular):
         """Initialize a new AutoML Regression task.
 
         :param primary_metric: The primary metric to use for optimization
-        :type primary_metric: str, optional
+        :type primary_metric: str
         :param kwargs: Job-specific arguments
         :type kwargs: dict
         """

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/command_job.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/command_job.py
@@ -236,7 +236,7 @@ class CommandJob(Job, ParameterizedCommand, JobIOMixin):
         """Translate a command job to component.
 
         :param context: Context of command job YAML file.
-        :type context: dict, optional
+        :type context: dict
         :keyword kwargs: Extra arguments.
         :return: Translated command component.
         :rtype: CommandComponent
@@ -265,7 +265,7 @@ class CommandJob(Job, ParameterizedCommand, JobIOMixin):
         """Translate a command job to a pipeline node.
 
         :param context: Context of command job YAML file.
-        :type context: dict, optional
+        :type context: dict
         :keyword kwargs: Extra arguments.
         :return: Translated command component.
         :rtype: Command

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/command_job.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/command_job.py
@@ -56,44 +56,44 @@ class CommandJob(Job, ParameterizedCommand, JobIOMixin):
     """Command job.
 
     :keyword name: The name of the job.
-    :type name: str
+    :paramtype name: str
     :keyword description: The job description.
-    :type description: str
+    :paramtype description: str
     :keyword tags: Tag dictionary. Tags can be added, removed, and updated.
-    :type tags: dict[str, str]
+    :paramtype tags: dict[str, str]
     :keyword display_name: The job display name.
-    :type display_name: str
+    :paramtype display_name: str
     :keyword properties: A dictionary of properties for the job.
-    :type properties: dict[str, str]
+    :paramtype properties: dict[str, str]
     :keyword experiment_name: The name of the experiment that the job will be created under. Defaults to current
         directory name.
-    :type experiment_name: str
+    :paramtype experiment_name: str
     :keyword services: Read-only information on services associated with the job.
-    :type services: Optional[dict[str, ~azure.ai.ml.entities.JobService]]
+    :paramtype services: Optional[dict[str, ~azure.ai.ml.entities.JobService]]
     :keyword inputs: Mapping of output data bindings used in the command.
-    :type inputs: Optional[dict[str, Union[~azure.ai.ml.Input, str, bool, int, float]]]
+    :paramtype inputs: Optional[dict[str, Union[~azure.ai.ml.Input, str, bool, int, float]]]
     :keyword outputs: Mapping of output data bindings used in the job.
-    :type outputs: Optional[dict[str, ~azure.ai.ml.Output]]
+    :paramtype outputs: Optional[dict[str, ~azure.ai.ml.Output]]
     :keyword command: The command to be executed.
-    :type command: str
+    :paramtype command: str
     :keyword compute: The compute target the job runs on.
-    :type compute: str
+    :paramtype compute: str
     :keyword resources: The compute resource configuration for the job.
-    :type resources: ~azure.ai.ml.entities.ResourceConfiguration
+    :paramtype resources: ~azure.ai.ml.entities.ResourceConfiguration
     :keyword code: A local path or "http:", "https:", or "azureml:" url pointing to a remote location.
     :type code: str
     :keyword distribution: The distribution configuration for distributed jobs.
-    :type distribution: Union[~azure.ai.ml.PyTorchDistribution, ~azure.ai.ml.MpiDistribution,
+    :paramtype distribution: Union[~azure.ai.ml.PyTorchDistribution, ~azure.ai.ml.MpiDistribution,
         ~azure.ai.ml.TensorFlowDistribution, ~azure.ai.ml.RayDistribution]
     :keyword environment: The environment that the job will run in.
-    :type environment: Union[~azure.ai.ml.entities.Environment, str]
+    :paramtype environment: Union[~azure.ai.ml.entities.Environment, str]
     :keyword identity: The identity that the job will use while running on compute.
-    :type identity: Optional[Union[~azure.ai.ml.ManagedIdentityConfiguration, ~azure.ai.ml.AmlTokenConfiguration,
+    :paramtype identity: Optional[Union[~azure.ai.ml.ManagedIdentityConfiguration, ~azure.ai.ml.AmlTokenConfiguration,
         ~azure.ai.ml.UserIdentityConfiguration]]
     :keyword limits: The limits for the job.
-    :type limits: Optional[~azure.ai.ml.entities.CommandJobLimits]
+    :paramtype limits: Optional[~azure.ai.ml.entities.CommandJobLimits]
     :keyword kwargs: A dictionary of additional configuration parameters.
-    :type kwargs: dict
+    :paramtype kwargs: dict
 
     .. admonition:: Example:
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/data_transfer/data_transfer_job.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/data_transfer/data_transfer_job.py
@@ -66,7 +66,7 @@ class DataTransferJob(Job, JobIOMixin):
     :param data_copy_mode: data copy mode in copy task, possible value is "merge_with_overwrite", "fail_if_conflict".
     :type data_copy_mode: str
     :keyword kwargs: A dictionary of additional configuration parameters.
-    :type kwargs: dict
+    :paramtype kwargs: dict
     """
 
     def __init__(

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/data_transfer/data_transfer_job.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/data_transfer/data_transfer_job.py
@@ -179,7 +179,7 @@ class DataTransferCopyJob(DataTransferJob):
         """Translate a data transfer copy job to component.
 
         :param context: Context of data transfer job YAML file.
-        :type context: dict, optional
+        :type context: dict
         :keyword kwargs: Extra arguments.
         :return: Translated data transfer copy component.
         :rtype: DataTransferCopyComponent
@@ -206,7 +206,7 @@ class DataTransferCopyJob(DataTransferJob):
         """Translate a data transfer copy job to a pipeline node.
 
         :param context: Context of data transfer job YAML file.
-        :type context: dict, optional
+        :type context: dict
         :keyword kwargs: Extra arguments.
         :return: Translated data transfer component.
         :rtype: DataTransferCopy
@@ -253,7 +253,7 @@ class DataTransferImportJob(DataTransferJob):
         """Translate a data transfer import job to component.
 
         :param context: Context of data transfer job YAML file.
-        :type context: dict, optional
+        :type context: dict
         :keyword kwargs: Extra arguments.
         :return: Translated data transfer import component.
         :rtype: str
@@ -270,7 +270,7 @@ class DataTransferImportJob(DataTransferJob):
         """Translate a data transfer import job to a pipeline node.
 
         :param context: Context of data transfer job YAML file.
-        :type context: dict, optional
+        :type context: dict
         :keyword kwargs: Extra arguments.
         :return: Translated data transfer import node.
         :rtype: DataTransferImport
@@ -317,7 +317,7 @@ class DataTransferExportJob(DataTransferJob):
         """Translate a data transfer export job to component.
 
         :param context: Context of data transfer job YAML file.
-        :type context: dict, optional
+        :type context: dict
         :keyword kwargs: Extra arguments.
         :return: Translated data transfer export component.
         :rtype: str
@@ -338,7 +338,7 @@ class DataTransferExportJob(DataTransferJob):
         """Translate a data transfer export job to a pipeline node.
 
         :param context: Context of data transfer job YAML file.
-        :type context: dict, optional
+        :type context: dict
         :keyword kwargs: Extra arguments.
         :return: Translated data transfer export node.
         :rtype: DataTransferExport

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/distribution.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/distribution.py
@@ -78,7 +78,7 @@ class MpiDistribution(DistributionConfiguration):
     """MPI distribution configuration.
 
     :keyword process_count_per_instance: The number of processes per node.
-    :type process_count_per_instance: Optional[int]
+    :paramtype process_count_per_instance: Optional[int]
 
     .. admonition:: Example:
 
@@ -104,7 +104,7 @@ class PyTorchDistribution(DistributionConfiguration):
     """PyTorch distribution configuration.
 
     :keyword process_count_per_instance: The number of processes per node.
-    :type process_count_per_instance: Optional[int]
+    :paramtype process_count_per_instance: Optional[int]
 
     .. admonition:: Example:
 
@@ -130,9 +130,9 @@ class TensorFlowDistribution(DistributionConfiguration):
     """TensorFlow distribution configuration.
 
     :keyword parameter_server_count: The number of parameter server tasks. Defaults to 0.
-    :type parameter_server_count: Optional[int]
+    :paramtype parameter_server_count: Optional[int]
     :keyword worker_count: The number of workers. Defaults to the instance count.
-    :type worker_count: Optional[int]
+    :paramtype worker_count: Optional[int]
 
     .. admonition:: Example:
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/import_job.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/import_job.py
@@ -228,7 +228,7 @@ class ImportJob(Job, JobIOMixin):
         """Translate a import job to component.
 
         :param context: Context of import job YAML file.
-        :type context: dict, optional
+        :type context: dict
         :keyword kwargs: Extra arguments.
         :return: Translated import component.
         :rtype: ImportComponent
@@ -254,7 +254,7 @@ class ImportJob(Job, JobIOMixin):
         """Translate a import job to a pipeline node.
 
         :param context: Context of import job YAML file.
-        :type context: dict, optional
+        :type context: dict
         :keyword kwargs: Extra arguments.
         :return: Translated import node.
         :rtype: Import

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/job.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/job.py
@@ -247,12 +247,12 @@ class Job(Resource, ComponentTranslatableMixin, TelemetryMixin):
         :param cls: Indicates that this is a class method.
         :type cls: class
         :param data: Data Dictionary, defaults to None
-        :type data: Dict, optional
+        :type data: Dict
         :param yaml_path: YAML Path, defaults to None
-        :type yaml_path: Union[PathLike, str], optional
+        :type yaml_path: Union[PathLike, str]
         :param params_override: Fields to overwrite on top of the yaml file.
             Format is [{"field1": "value1"}, {"field2": "value2"}], defaults to None
-        :type params_override: List[Dict], optional
+        :type params_override: List[Dict]
         :keyword kwargs: A dictionary of additional configuration parameters.
         :type kwargs: dict
         :raises Exception: An exception

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/job.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/job.py
@@ -69,7 +69,7 @@ class Job(Resource, ComponentTranslatableMixin, TelemetryMixin):
     :param compute: Information about the compute resources associated with the job.
     :type compute: Optional[str]
     :keyword kwargs: A dictionary of additional configuration parameters.
-    :type kwargs: dict
+    :paramtype kwargs: dict
     """
 
     def __init__(
@@ -167,7 +167,7 @@ class Job(Resource, ComponentTranslatableMixin, TelemetryMixin):
             If dest is an open file, the file will be written to directly.
         :type dest: Union[PathLike, str, IO[AnyStr]]
         :keyword kwargs: Additional arguments to pass to the YAML serializer.
-        :type kwargs: dict
+        :paramtype kwargs: dict
         :raises FileExistsError: Raised if dest is a file path and the file already exists.
         :raises IOError: Raised if dest is an open file and the file is not writable.
         """
@@ -254,7 +254,7 @@ class Job(Resource, ComponentTranslatableMixin, TelemetryMixin):
             Format is [{"field1": "value1"}, {"field2": "value2"}], defaults to None
         :type params_override: List[Dict]
         :keyword kwargs: A dictionary of additional configuration parameters.
-        :type kwargs: dict
+        :paramtype kwargs: dict
         :raises Exception: An exception
         :return: Loaded job object.
         :rtype: Job

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/job_limits.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/job_limits.py
@@ -36,7 +36,7 @@ class CommandJobLimits(JobLimits):
     """Limits for Command Jobs.
 
     :keyword timeout: The maximum run duration, in seconds, after which the job will be cancelled.
-    :type timeout: Optional[Union[int, str]]
+    :paramtype timeout: Optional[Union[int, str]]
 
     .. admonition:: Example:
 
@@ -77,13 +77,13 @@ class SweepJobLimits(JobLimits):
     """Limits for Sweep Jobs.
 
     :keyword max_concurrent_trials: The maximum number of concurrent trials for the Sweep Job.
-    :type max_concurrent_trials: Optional[int]
+    :paramtype max_concurrent_trials: Optional[int]
     :keyword max_total_trials: The maximum number of total trials for the Sweep Job.
-    :type max_total_trials: Optional[int]
+    :paramtype max_total_trials: Optional[int]
     :keyword timeout: The maximum run duration, in seconds, after which the job will be cancelled.
-    :type timeout: Optional[int]
+    :paramtype timeout: Optional[int]
     :keyword trial_timeout: The timeout value, in seconds, for each Sweep Job trial.
-    :type trial_timeout: Optional[int]
+    :paramtype trial_timeout: Optional[int]
 
     .. admonition:: Example:
 
@@ -178,7 +178,7 @@ class DoWhileJobLimits(JobLimits):
     """DoWhile Job limit class.
 
     :keyword max_iteration_count: The maximum number of iterations for the DoWhile Job.
-    :type max_iteration_count: Optional[int]
+    :paramtype max_iteration_count: Optional[int]
     """
 
     def __init__(

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/job_resource_configuration.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/job_resource_configuration.py
@@ -87,25 +87,25 @@ class JobResourceConfiguration(RestTranslatableMixin, DictMixin):
     """Job resource configuration class, inherited and extended functionalities from ResourceConfiguration.
 
     :keyword locations: A list of locations where the job can run.
-    :type locations: Optional[list[str]]
+    :paramtype locations: Optional[list[str]]
     :keyword instance_count: The number of instances or nodes used by the compute target.
-    :type instance_count: Optional[int]
+    :paramtype instance_count: Optional[int]
     :keyword instance_type: The type of VM to be used, as supported by the compute target.
-    :type instance_type: Optional[str]
+    :paramtype instance_type: Optional[str]
     :keyword properties: A dictionary of properties for the job.
-    :type properties: Optional[dict[str, Any]]
+    :paramtype properties: Optional[dict[str, Any]]
     :keyword docker_args: Extra arguments to pass to the Docker run command. This would override any
         parameters that have already been set by the system, or in this section. This parameter is only
         supported for Azure ML compute types.
-    :type docker_args: Optional[str]
+    :paramtype docker_args: Optional[str]
     :keyword shm_size: The size of the docker container's shared memory block. This should be in the
         format of (number)(unit) where the number has to be greater than 0 and the unit can be one of
         b(bytes), k(kilobytes), m(megabytes), or g(gigabytes).
-    :type shm_size: Optional[str]
+    :paramtype shm_size: Optional[str]
     :keyword max_instance_count: The maximum number of instances or nodes used by the compute target.
-    :type max_instance_count: Optional[int]
+    :paramtype max_instance_count: Optional[int]
     :keyword kwargs: A dictionary of additional configuration parameters.
-    :type kwargs: dict
+    :paramtype kwargs: dict
 
     .. admonition:: Example:
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/job_service.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/job_service.py
@@ -24,19 +24,19 @@ class JobServiceBase(RestTranslatableMixin, DictMixin):
     This class should not be instantiated directly. Instead, use one of its subclasses.
 
     :keyword endpoint: The endpoint URL.
-    :type endpoint: Optional[str]
+    :paramtype endpoint: Optional[str]
     :keyword type: The endpoint type. Accepted values are "jupyter_lab", "ssh", "tensor_board", and "vs_code".
-    :type type: Optional[Literal["jupyter_lab", "ssh", "tensor_board", "vs_code"]]
+    :paramtype type: Optional[Literal["jupyter_lab", "ssh", "tensor_board", "vs_code"]]
     :keyword port: The port for the endpoint.
-    :type port: Optional[int]
+    :paramtype port: Optional[int]
     :keyword nodes: Indicates whether the service has to run in all nodes.
-    :type nodes: Optional[Literal["all"]]
+    :paramtype nodes: Optional[Literal["all"]]
     :keyword properties: Additional properties to set on the endpoint.
-    :type properties: Optional[dict[str, str]]
+    :paramtype properties: Optional[dict[str, str]]
     :keyword status: The status of the endpoint.
-    :type status: Optional[str]
+    :paramtype status: Optional[str]
     :keyword kwargs: A dictionary of additional configuration parameters.
-    :type kwargs: dict
+    :paramtype kwargs: dict
     """
 
     def __init__(  # pylint: disable=unused-argument
@@ -151,19 +151,19 @@ class JobService(JobServiceBase):
     This class is not intended to be used directly. Instead, use one of its subclasses specific to your job type.
 
     :keyword endpoint: The endpoint URL.
-    :type endpoint: Optional[str]
+    :paramtype endpoint: Optional[str]
     :keyword type: The endpoint type. Accepted values are "jupyter_lab", "ssh", "tensor_board", and "vs_code".
-    :type type: Optional[Literal["jupyter_lab", "ssh", "tensor_board", "vs_code"]]
+    :paramtype type: Optional[Literal["jupyter_lab", "ssh", "tensor_board", "vs_code"]]
     :keyword port: The port for the endpoint.
-    :type port: Optional[int]
+    :paramtype port: Optional[int]
     :keyword nodes: Indicates whether the service has to run in all nodes.
-    :type nodes: Optional[Literal["all"]]
+    :paramtype nodes: Optional[Literal["all"]]
     :keyword properties: Additional properties to set on the endpoint.
-    :type properties: Optional[dict[str, str]]
+    :paramtype properties: Optional[dict[str, str]]
     :keyword status: The status of the endpoint.
-    :type status: Optional[str]
+    :paramtype status: Optional[str]
     :keyword kwargs: A dictionary of additional configuration parameters.
-    :type kwargs: dict
+    :paramtype kwargs: dict
     """
 
     @classmethod
@@ -178,19 +178,19 @@ class SshJobService(JobServiceBase):
     """SSH job service configuration.
 
     :keyword endpoint: The endpoint URL.
-    :type endpoint: Optional[str]
+    :paramtype endpoint: Optional[str]
     :keyword port: The port for the endpoint.
-    :type port: Optional[int]
+    :paramtype port: Optional[int]
     :keyword nodes: Indicates whether the service has to run in all nodes.
-    :type nodes: Optional[Literal["all"]]
+    :paramtype nodes: Optional[Literal["all"]]
     :keyword properties: Additional properties to set on the endpoint.
-    :type properties: Optional[dict[str, str]]
+    :paramtype properties: Optional[dict[str, str]]
     :keyword status: The status of the endpoint.
-    :type status: Optional[str]
+    :paramtype status: Optional[str]
     :keyword ssh_public_keys: The SSH Public Key to access the job container.
-    :type ssh_public_keys: Optional[str]
+    :paramtype ssh_public_keys: Optional[str]
     :keyword kwargs: A dictionary of additional configuration parameters.
-    :type kwargs: dict
+    :paramtype kwargs: dict
 
     .. admonition:: Example:
 
@@ -239,19 +239,19 @@ class TensorBoardJobService(JobServiceBase):
     """TensorBoard job service configuration.
 
     :keyword endpoint: The endpoint URL.
-    :type endpoint: Optional[str]
+    :paramtype endpoint: Optional[str]
     :keyword port: The port for the endpoint.
-    :type port: Optional[int]
+    :paramtype port: Optional[int]
     :keyword nodes: Indicates whether the service has to run in all nodes.
-    :type nodes: Optional[Literal["all"]]
+    :paramtype nodes: Optional[Literal["all"]]
     :keyword properties: Additional properties to set on the endpoint.
-    :type properties: Optional[dict[str, str]]
+    :paramtype properties: Optional[dict[str, str]]
     :keyword status: The status of the endpoint.
-    :type status: Optional[str]
+    :paramtype status: Optional[str]
     :keyword log_dir: The directory path for the log file.
-    :type log_dir: Optional[str]
+    :paramtype log_dir: Optional[str]
     :keyword kwargs: A dictionary of additional configuration parameters.
-    :type kwargs: dict
+    :paramtype kwargs: dict
 
     .. admonition:: Example:
 
@@ -300,17 +300,17 @@ class JupyterLabJobService(JobServiceBase):
     """JupyterLab job service configuration.
 
     :keyword endpoint: The endpoint URL.
-    :type endpoint: Optional[str]
+    :paramtype endpoint: Optional[str]
     :keyword port: The port for the endpoint.
-    :type port: Optional[int]
+    :paramtype port: Optional[int]
     :keyword nodes: Indicates whether the service has to run in all nodes.
-    :type nodes: Optional[Literal["all"]]
+    :paramtype nodes: Optional[Literal["all"]]
     :keyword properties: Additional properties to set on the endpoint.
-    :type properties: Optional[dict[str, str]]
+    :paramtype properties: Optional[dict[str, str]]
     :keyword status: The status of the endpoint.
-    :type status: Optional[str]
+    :paramtype status: Optional[str]
     :keyword kwargs: A dictionary of additional configuration parameters.
-    :type kwargs: dict
+    :paramtype kwargs: dict
 
     .. admonition:: Example:
 
@@ -354,17 +354,17 @@ class VsCodeJobService(JobServiceBase):
     """VS Code job service configuration.
 
     :keyword endpoint: The endpoint URL.
-    :type endpoint: Optional[str]
+    :paramtype endpoint: Optional[str]
     :keyword port: The port for the endpoint.
-    :type port: Optional[int]
+    :paramtype port: Optional[int]
     :keyword nodes: Indicates whether the service has to run in all nodes.
-    :type nodes: Optional[Literal["all"]]
+    :paramtype nodes: Optional[Literal["all"]]
     :keyword properties: Additional properties to set on the endpoint.
-    :type properties: Optional[dict[str, str]]
+    :paramtype properties: Optional[dict[str, str]]
     :keyword status: The status of the endpoint.
-    :type status: Optional[str]
+    :paramtype status: Optional[str]
     :keyword kwargs: A dictionary of additional configuration parameters.
-    :type kwargs: dict
+    :paramtype kwargs: dict
 
     .. admonition:: Example:
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/parallel/parallel_job.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/parallel/parallel_job.py
@@ -97,7 +97,7 @@ class ParallelJob(Job, ParameterizedParallel, JobIOMixin):
         """Translate a parallel job to component job.
 
         :param context: Context of parallel job YAML file.
-        :type context: dict, optional
+        :type context: dict
         :keyword kwargs: Extra arguments.
         :return: Translated parallel component.
         :rtype: ParallelComponent
@@ -128,7 +128,7 @@ class ParallelJob(Job, ParameterizedParallel, JobIOMixin):
         """Translate a parallel job to a pipeline node.
 
         :param context: Context of parallel job YAML file.
-        :type context: dict, optional
+        :type context: dict
         :keyword kwargs: Extra arguments.
         :return: Translated parallel component.
         :rtype: Parallel

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/parameterized_command.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/parameterized_command.py
@@ -62,7 +62,7 @@ class ParameterizedCommand:
     :param queue_settings: The queue settings for the job.
     :type queue_settings: Optional[~azure.ai.ml.entities.QueueSettings]
     :keyword kwargs: A dictionary of additional configuration parameters.
-    :type kwargs: dict
+    :paramtype kwargs: dict
     """
 
     def __init__(

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/parameterized_command.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/parameterized_command.py
@@ -45,7 +45,7 @@ class ParameterizedCommand:
     ~azure.ai.ml.entities.CommandComponent.
 
     :param command: The command to be executed. Defaults to "".
-    :type command: str, optional
+    :type command: str
     :param resources: The compute resource configuration for the command.
     :type resources: Optional[Union[dict, ~azure.ai.ml.entities.JobResourceConfiguration]]
     :param code: The source code to run the job. Can be a local path or "http:", "https:", or "azureml:" url pointing

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/parameterized_spark.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/parameterized_spark.py
@@ -39,7 +39,7 @@ class ParameterizedSpark(SparkJobEntryMixin):
     :param args: The arguments for the job.
     :type args: Optional[str]
     :keyword kwargs: A dictionary of additional configuration parameters.
-    :type kwargs: dict
+    :paramtype kwargs: dict
     """
 
     def __init__(

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/pipeline/_component_translatable.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/pipeline/_component_translatable.py
@@ -231,7 +231,7 @@ class ComponentTranslatableMixin:
         :param input: The input
         :type input: Union[Input, str, bool, int, float]
         :param pipeline_job_dict: The pipeline job dict
-        :type pipeline_job_dict: Optional[dict], optional
+        :type pipeline_job_dict: Optional[dict]
         :return: The Component Input
         :rtype: Input
         """
@@ -306,7 +306,7 @@ class ComponentTranslatableMixin:
         :param output: The output
         :type output: Union[Output, str, bool, int, float]
         :param pipeline_job_dict: The pipeline job dict
-        :type pipeline_job_dict: Optional[dict], optional
+        :type pipeline_job_dict: Optional[dict]
         :return: The output object
         :rtype: Output
         """
@@ -381,7 +381,7 @@ class ComponentTranslatableMixin:
         """Translate to Component.
 
         :param context: The context
-        :type context: Optional[context], optional
+        :type context: Optional[context]
         :return: Translated Component.
         :rtype: Component
         """
@@ -393,7 +393,7 @@ class ComponentTranslatableMixin:
         """Translate to pipeline node.
 
         :param context: The context
-        :type context: Optional[context], optional
+        :type context: Optional[context]
         :keyword kwargs:
         :return: Translated node.
         :rtype: BaseNode

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/pipeline/_io/mixin.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/pipeline/_io/mixin.py
@@ -95,7 +95,7 @@ class NodeIOMixin:
         :param inputs: Provided kwargs when parameterizing component func.
         :type inputs: Dict[str, Union[Input, str, bool, int, float]]
         :keyword input_definition_dict: Static input definition dict. If not provided, will build inputs without meta.
-        :type input_definition_dict: dict
+        :paramtype input_definition_dict: dict
         :return: Built dynamic input attribute dict.
         :rtype: InputsAttrDict
         """
@@ -124,9 +124,9 @@ class NodeIOMixin:
         :param outputs: Provided kwargs when parameterizing component func.
         :type outputs: Dict[str, Output]
         :keyword output_definition_dict: Static output definition dict.
-        :type output_definition_dict: Dict
+        :paramtype output_definition_dict: Dict
         :keyword none_data: If True, will set output data to None.
-        :type none_data: bool
+        :paramtype none_data: bool
         :return: Built dynamic output attribute dict.
         :rtype: OutputsAttrDict
         """
@@ -345,7 +345,7 @@ def flatten_dict(
     :param _type: Either _GroupAttrDict or GroupInput (both have the method `flatten`)
     :type _type: Union[Type["_GroupAttrDict"], Type[GroupInput]]
     :keyword allow_dict_fields: A list of keys for dictionary values that will be included in flattened output
-    :type allow_dict_fields: Optional[List[str]]
+    :paramtype allow_dict_fields: Optional[List[str]]
     :return: The flattened dict
     :rtype: Dict
     """
@@ -416,7 +416,7 @@ class NodeWithGroupInputMixin(NodeIOMixin):
         :param inputs: Provided kwargs when parameterizing component func.
         :type inputs: Dict[str, Union[Input, str, bool, int, float]]
         :keyword input_definition_dict: Input definition dict from component entity.
-        :type input_definition_dict: dict
+        :paramtype input_definition_dict: dict
         :return: Built input attribute dict.
         :rtype: InputsAttrDict
         """

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/pipeline/_io/mixin.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/pipeline/_io/mixin.py
@@ -95,7 +95,7 @@ class NodeIOMixin:
         :param inputs: Provided kwargs when parameterizing component func.
         :type inputs: Dict[str, Union[Input, str, bool, int, float]]
         :keyword input_definition_dict: Static input definition dict. If not provided, will build inputs without meta.
-        :type input_definition_dict: dict, optional
+        :type input_definition_dict: dict
         :return: Built dynamic input attribute dict.
         :rtype: InputsAttrDict
         """
@@ -345,7 +345,7 @@ def flatten_dict(
     :param _type: Either _GroupAttrDict or GroupInput (both have the method `flatten`)
     :type _type: Union[Type["_GroupAttrDict"], Type[GroupInput]]
     :keyword allow_dict_fields: A list of keys for dictionary values that will be included in flattened output
-    :type allow_dict_fields: Optional[List[str]], optional
+    :type allow_dict_fields: Optional[List[str]]
     :return: The flattened dict
     :rtype: Dict
     """
@@ -416,7 +416,7 @@ class NodeWithGroupInputMixin(NodeIOMixin):
         :param inputs: Provided kwargs when parameterizing component func.
         :type inputs: Dict[str, Union[Input, str, bool, int, float]]
         :keyword input_definition_dict: Input definition dict from component entity.
-        :type input_definition_dict: dict, optional
+        :type input_definition_dict: dict
         :return: Built input attribute dict.
         :rtype: InputsAttrDict
         """

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/pipeline/_load_component.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/pipeline/_load_component.py
@@ -174,13 +174,13 @@ class _PipelineNodeFactory:
         :param _type: The type of the node.
         :type _type: str
         :keyword create_instance_func: A function to create a new instance of the node
-        :type create_instance_func: typing.Optional[typing.Callable[..., typing.Union[BaseNode, AutoMLJob]]]
+        :paramtype create_instance_func: typing.Optional[typing.Callable[..., typing.Union[BaseNode, AutoMLJob]]]
         :keyword load_from_rest_object_func: A function to load a node from a rest object
-        :type load_from_rest_object_func: typing.Optional[typing.Callable[[Any], typing.Union[BaseNode, AutoMLJob\
+        :paramtype load_from_rest_object_func: typing.Optional[typing.Callable[[Any], typing.Union[BaseNode, AutoMLJob\
             , ControlFlowNode]]]
         :keyword nested_schema: schema/schemas of corresponding nested field, will be used in \
             PipelineJobSchema.jobs.value
-        :type nested_schema: typing.Optional[typing.Union[NestedField, List[NestedField]]]
+        :paramtype nested_schema: typing.Optional[typing.Union[NestedField, List[NestedField]]]
         """
         # pylint: disable=no-member
         if create_instance_func is not None:
@@ -206,9 +206,9 @@ class _PipelineNodeFactory:
         """Load a node from a dict.
 
         :keyword data: A dict containing the node's data.
-        :type data: dict
+        :paramtype data: dict
         :keyword _type: The type of the node. If not specified, it will be inferred from the data.
-        :type _type: str
+        :paramtype _type: str
         :return: The node
         :rtype: Union[BaseNode, AutoMLJob]
         """
@@ -240,9 +240,9 @@ class _PipelineNodeFactory:
         """Load a node from a rest object.
 
         :keyword obj: A rest object containing the node's data.
-        :type obj: dict
+        :paramtype obj: dict
         :keyword _type: The type of the node. If not specified, it will be inferred from the data.
-        :type _type: str
+        :paramtype _type: str
         :return: The node
         :rtype: Union[BaseNode, AutoMLJob, ControlFlowNode]
         """

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/pipeline/pipeline_job.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/pipeline/pipeline_job.py
@@ -75,30 +75,30 @@ class PipelineJob(Job, YamlTranslatableMixin, PipelineJobIOMixin, SchemaValidata
     :param outputs: Outputs of the pipeline job.
     :type outputs: dict[str, ~azure.ai.ml.entities.Output]
     :param name: Name of the PipelineJob. Defaults to None
-    :type name: str, optional
+    :type name: str
     :param description: Description of the pipeline job. Defaults to None
-    :type description: str, optional
+    :type description: str
     :param display_name: Display name of the pipeline job. Defaults to None
-    :type display_name: str, optional
+    :type display_name: str
     :param experiment_name: Name of the experiment the job will be created under.
         If None is provided, the experiment will be set to the current directory. Defaults to None
-    :type experiment_name: str, optional
+    :type experiment_name: str
     :param jobs: Pipeline component node name to component object. Defaults to None
-    :type jobs: dict[str, ~azure.ai.ml.entities._builders.BaseNode], optional
+    :type jobs: dict[str, ~azure.ai.ml.entities._builders.BaseNode]
     :param settings: Setting of the pipeline job. Defaults to None
-    :type settings: ~azure.ai.ml.entities.PipelineJobSettings, optional
+    :type settings: ~azure.ai.ml.entities.PipelineJobSettings
     :param identity: Identity that the training job will use while running on compute. Defaults to None
     :type identity: Union[
         ~azure.ai.ml.entities._credentials.ManagedIdentityConfiguration,
         ~azure.ai.ml.entities._credentials.AmlTokenConfiguration,
         ~azure.ai.ml.entities._credentials.UserIdentityConfiguration
-    ], optional
+    ]
     :param compute: Compute target name of the built pipeline. Defaults to None
-    :type compute: str, optional
+    :type compute: str
     :param tags: Tag dictionary. Tags can be added, removed, and updated. Defaults to None
-    :type tags: dict[str, str], optional
+    :type tags: dict[str, str]
     :param kwargs: A dictionary of additional configuration parameters. Defaults to None
-    :type kwargs: dict, optional
+    :type kwargs: dict
 
     .. admonition:: Example:
 
@@ -462,7 +462,7 @@ class PipelineJob(Job, YamlTranslatableMixin, PipelineJobIOMixin, SchemaValidata
         (Write a pipeline job as node in yaml is not supported presently.)
 
         :param context: Context of command job YAML file.
-        :type context: dict, optional
+        :type context: dict
         :keyword kwargs: Extra arguments.
         :return: Translated command component.
         :rtype: Pipeline
@@ -662,7 +662,7 @@ class PipelineJob(Job, YamlTranslatableMixin, PipelineJobIOMixin, SchemaValidata
         """Translate a pipeline job to pipeline component.
 
         :param context: Context of pipeline job YAML file.
-        :type context: dict, optional
+        :type context: dict
         :keyword kwargs: Extra arguments.
         :return: Translated pipeline component.
         :rtype: PipelineComponent

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/pipeline/pipeline_job_settings.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/pipeline/pipeline_job_settings.py
@@ -11,13 +11,13 @@ class PipelineJobSettings(_AttrDict):
     """Settings of PipelineJob, include default_datastore, default_compute, continue_on_step_failure and force_rerun.
 
     :param default_datastore: The default datastore of the pipeline.
-    :type default_datastore: str, optional
+    :type default_datastore: str
     :param default_compute: The default compute target of the pipeline.
-    :type default_compute: str, optional
+    :type default_compute: str
     :param continue_on_step_failure: Flag indicating whether to continue pipeline execution if a step fails.
-    :type continue_on_step_failure: bool, optional
+    :type continue_on_step_failure: bool
     :param force_rerun: Flag indicating whether to force rerun pipeline execution.
-    :type force_rerun: bool, optional
+    :type force_rerun: bool
 
     .. admonition:: Example:
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/queue_settings.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/queue_settings.py
@@ -24,12 +24,12 @@ class QueueSettings(RestTranslatableMixin, DictMixin):
     """Queue settings for a pipeline job.
 
     :keyword job_tier: The job tier. Accepted values are "Spot", "Basic", "Standard", and "Premium".
-    :type job_tier: Optional[Literal]]
+    :paramtype job_tier: Optional[Literal]]
     :keyword priority: The priority of the job on a compute. Accepted values are "low", "medium", and "high".
         Defaults to "medium".
-    :type priority: Optional[Literal]
+    :paramtype priority: Optional[Literal]
     :keyword kwargs: Additional properties for QueueSettings.
-    :type kwargs: Optional[dict]
+    :paramtype kwargs: Optional[dict]
     """
 
     def __init__(

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/resource_configuration.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/resource_configuration.py
@@ -19,11 +19,11 @@ class ResourceConfiguration(RestTranslatableMixin, DictMixin):
     This class should not be instantiated directly. Instead, use its subclasses.
 
     :keyword instance_count: The number of instances to use for the job.
-    :type instance_count: Optional[int]
+    :paramtype instance_count: Optional[int]
     :keyword instance_type: The type of instance to use for the job.
-    :type instance_type: Optional[str]
+    :paramtype instance_type: Optional[str]
     :keyword properties: The resource's property dictionary.
-    :type properties: Optional[dict[str, Any]]
+    :paramtype properties: Optional[dict[str, Any]]
     """
 
     def __init__(

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/service_instance.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/service_instance.py
@@ -15,17 +15,17 @@ class ServiceInstance(RestTranslatableMixin, DictMixin):
     """Service Instance Result.
 
     :keyword type: The type of service.
-    :type type: Optional[str]
+    :paramtype type: Optional[str]
     :keyword port: The port used by the service.
-    :type port: Optional[int]
+    :paramtype port: Optional[int]
     :keyword status: The status of the service.
-    :type status: Optional[str]
+    :paramtype status: Optional[str]
     :keyword error: The error message.
-    :type error: Optional[str]
+    :paramtype error: Optional[str]
     :keyword endpoint: The service endpoint.
-    :type endpoint: Optional[str]
+    :paramtype endpoint: Optional[str]
     :keyword properties: The service instance's properties.
-    :type properties: Optional[dict[str, str]]
+    :paramtype properties: Optional[dict[str, str]]
     """
 
     def __init__(

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/spark_job.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/spark_job.py
@@ -49,66 +49,66 @@ class SparkJob(Job, ParameterizedSpark, JobIOMixin, SparkJobEntryMixin):
     """A standalone Spark job.
 
     :keyword driver_cores: The number of cores to use for the driver process, only in cluster mode.
-    :type driver_cores: Optional[int]
+    :paramtype driver_cores: Optional[int]
     :keyword driver_memory: The amount of memory to use for the driver process, formatted as strings with a size unit
         suffix ("k", "m", "g" or "t") (e.g. "512m", "2g").
-    :type driver_memory: Optional[str]
+    :paramtype driver_memory: Optional[str]
     :keyword executor_cores: The number of cores to use on each executor.
-    :type executor_cores: Optional[int]
+    :paramtype executor_cores: Optional[int]
     :keyword executor_memory: The amount of memory to use per executor process, formatted as strings with a size unit
         suffix ("k", "m", "g" or "t") (e.g. "512m", "2g").
-    :type executor_memory: Optional[str]
+    :paramtype executor_memory: Optional[str]
     :keyword executor_instances: The initial number of executors.
-    :type executor_instances: Optional[int]
+    :paramtype executor_instances: Optional[int]
     :keyword dynamic_allocation_enabled: Whether to use dynamic resource allocation, which scales the number of
         executors registered with this application up and down based on the workload.
-    :type dynamic_allocation_enabled: Optional[bool]
+    :paramtype dynamic_allocation_enabled: Optional[bool]
     :keyword dynamic_allocation_min_executors: The lower bound for the number of executors if dynamic allocation is
         enabled.
-    :type dynamic_allocation_min_executors: Optional[int]
+    :paramtype dynamic_allocation_min_executors: Optional[int]
     :keyword dynamic_allocation_max_executors: The upper bound for the number of executors if dynamic allocation is
         enabled.
-    :type dynamic_allocation_max_executors: Optional[int]
+    :paramtype dynamic_allocation_max_executors: Optional[int]
     :keyword inputs: The mapping of input data bindings used in the job.
-    :type inputs: Optional[dict[str, ~azure.ai.ml.Input]]
+    :paramtype inputs: Optional[dict[str, ~azure.ai.ml.Input]]
     :keyword outputs: The mapping of output data bindings used in the job.
-    :type outputs: Optional[dict[str, ~azure.ai.ml.Output]]
+    :paramtype outputs: Optional[dict[str, ~azure.ai.ml.Output]]
     :keyword compute: The compute resource the job runs on.
-    :type compute: Optional[str]
+    :paramtype compute: Optional[str]
     :keyword identity: The identity that the Spark job will use while running on compute.
-    :type identity: Optional[Union[dict[str, str], ~azure.ai.ml.ManagedIdentityConfiguration,
+    :paramtype identity: Optional[Union[dict[str, str], ~azure.ai.ml.ManagedIdentityConfiguration,
         ~azure.ai.ml.AmlTokenConfiguration, ~azure.ai.ml.UserIdentityConfiguration]]
     :keyword resources: The compute resource configuration for the job.
-    :type resources: Optional[Union[dict, ~azure.ai.ml.entities.SparkResourceConfiguration]]
+    :paramtype resources: Optional[Union[dict, ~azure.ai.ml.entities.SparkResourceConfiguration]]
     :keyword experiment_name: The name of the experiment the job will be created under.
-    :type experiment_name: str
+    :paramtype experiment_name: str
     :keyword name: The name of the job.
-    :type name: str
+    :paramtype name: str
     :keyword display_name: The job display name.
-    :type display_name: str
+    :paramtype display_name: str
     :keyword description: The job description.
-    :type description: str
+    :paramtype description: str
     :keyword tags: The tag dictionary. Tags can be added, removed, and updated.
-    :type tags: dict[str, str]
+    :paramtype tags: dict[str, str]
     :keyword code: The source code to run the job. Can be a local path or "http:", "https:", or "azureml:" url pointing
         to a remote location.
     :type code: Union[str, os.PathLike]
     :keyword entry: The file or class entry point.
-    :type entry: dict[str, str]
+    :paramtype entry: dict[str, str]
     :keyword py_files: The list of .zip, .egg or .py files to place on the PYTHONPATH for Python apps.
-    :type py_files: list[str]
+    :paramtype py_files: list[str]
     :keyword jars: The list of .JAR files to include on the driver and executor classpaths.
-    :type jars: list[str]
+    :paramtype jars: list[str]
     :keyword files: The list of files to be placed in the working directory of each executor.
-    :type files: list[str]
+    :paramtype files: list[str]
     :keyword archives: The list of archives to be extracted into the working directory of each executor.
-    :type archives: list[str]
+    :paramtype archives: list[str]
     :keyword conf: A dictionary with pre-defined Spark configurations key and values.
-    :type conf: dict[str, str]
+    :paramtype conf: dict[str, str]
     :keyword environment: The Azure ML environment to run the job in.
-    :type environment: Union[str, ~azure.ai.ml.entities.Environment]
+    :paramtype environment: Union[str, ~azure.ai.ml.entities.Environment]
     :keyword args: The arguments for the job.
-    :type args: str
+    :paramtype args: str
 
     .. admonition:: Example:
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/spark_job.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/spark_job.py
@@ -327,7 +327,7 @@ class SparkJob(Job, ParameterizedSpark, JobIOMixin, SparkJobEntryMixin):
         """Translate a spark job to component.
 
         :param context: Context of spark job YAML file.
-        :type context: dict, optional
+        :type context: dict
         :keyword kwargs: Extra arguments.
         :return: Translated spark component.
         :rtype: SparkComponent
@@ -369,7 +369,7 @@ class SparkJob(Job, ParameterizedSpark, JobIOMixin, SparkJobEntryMixin):
         """Translate a spark job to a pipeline node.
 
         :param context: Context of spark job YAML file.
-        :type context: dict, optional
+        :type context: dict
         :keyword kwargs: Extra arguments.
         :return: Translated spark component.
         :rtype: Spark

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/spark_job_entry.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/spark_job_entry.py
@@ -24,7 +24,7 @@ class SparkJobEntry(RestTranslatableMixin):
     :type entry: str
     :keyword type: The entry type. Accepted values are SparkJobEntryType.SPARK_JOB_FILE_ENTRY or
         SparkJobEntryType.SPARK_JOB_CLASS_ENTRY. Defaults to SparkJobEntryType.SPARK_JOB_FILE_ENTRY.
-    :type type: ~azure.ai.ml.entities.SparkJobEntryType, optional
+    :type type: ~azure.ai.ml.entities.SparkJobEntryType
 
     .. admonition:: Example:
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/spark_job_entry.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/spark_job_entry.py
@@ -21,10 +21,10 @@ class SparkJobEntry(RestTranslatableMixin):
     """Entry for Spark job.
 
     :keyword entry: The file or class entry point.
-    :type entry: str
+    :paramtype entry: str
     :keyword type: The entry type. Accepted values are SparkJobEntryType.SPARK_JOB_FILE_ENTRY or
         SparkJobEntryType.SPARK_JOB_CLASS_ENTRY. Defaults to SparkJobEntryType.SPARK_JOB_FILE_ENTRY.
-    :type type: ~azure.ai.ml.entities.SparkJobEntryType
+    :paramtype type: ~azure.ai.ml.entities.SparkJobEntryType
 
     .. admonition:: Example:
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/spark_resource_configuration.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/spark_resource_configuration.py
@@ -15,9 +15,9 @@ class SparkResourceConfiguration(RestTranslatableMixin, DictMixin):
     """Compute resource configuration for Spark component or job.
 
     :keyword instance_type: The type of VM to be used by the compute target.
-    :type instance_type: Optional[str]
+    :paramtype instance_type: Optional[str]
     :keyword runtime_version: The Spark runtime version.
-    :type runtime_version: Optional[str]
+    :paramtype runtime_version: Optional[str]
 
     .. admonition:: Example:
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/sweep/early_termination_policy.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/sweep/early_termination_policy.py
@@ -52,13 +52,13 @@ class BanditPolicy(EarlyTerminationPolicy):
     """Defines an early termination policy based on slack criteria and a frequency and delay interval for evaluation.
 
     :keyword delay_evaluation: Number of intervals by which to delay the first evaluation. Defaults to 0.
-    :type delay_evaluation: int
+    :paramtype delay_evaluation: int
     :keyword evaluation_interval: Interval (number of runs) between policy evaluations. Defaults to 0.
-    :type evaluation_interval: int
+    :paramtype evaluation_interval: int
     :keyword slack_amount: Absolute distance allowed from the best performing run. Defaults to 0.
-    :type slack_amount: float
+    :paramtype slack_amount: float
     :keyword slack_factor: Ratio of the allowed distance from the best performing run. Defaults to 0.
-    :type slack_factor: float
+    :paramtype slack_factor: float
 
     .. admonition:: Example:
 
@@ -106,9 +106,9 @@ class MedianStoppingPolicy(EarlyTerminationPolicy):
     """Defines an early termination policy based on a running average of the primary metric of all runs.
 
     :keyword delay_evaluation: Number of intervals by which to delay the first evaluation. Defaults to 0.
-    :type delay_evaluation: int
+    :paramtype delay_evaluation: int
     :keyword evaluation_interval: Interval (number of runs) between policy evaluations. Defaults to 1.
-    :type evaluation_interval: int
+    :paramtype evaluation_interval: int
 
     .. admonition:: Example:
 
@@ -147,11 +147,11 @@ class TruncationSelectionPolicy(EarlyTerminationPolicy):
     """Defines an early termination policy that cancels a given percentage of runs at each evaluation interval.
 
     :keyword delay_evaluation: Number of intervals by which to delay the first evaluation. Defaults to 0.
-    :type delay_evaluation: int
+    :paramtype delay_evaluation: int
     :keyword evaluation_interval: Interval (number of runs) between policy evaluations. Defaults to 0.
-    :type evaluation_interval: int
+    :paramtype evaluation_interval: int
     :keyword truncation_percentage: The percentage of runs to cancel at each evaluation interval. Defaults to 0.
-    :type truncation_percentage: int
+    :paramtype truncation_percentage: int
 
     .. admonition:: Example:
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/sweep/parameterized_sweep.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/sweep/parameterized_sweep.py
@@ -139,13 +139,13 @@ class ParameterizedSweep:
         """Set limits for Sweep node. Leave parameters as None if you don't want to update corresponding values.
 
         :keyword max_concurrent_trials: maximum concurrent trial number.
-        :type max_concurrent_trials: int
+        :paramtype max_concurrent_trials: int
         :keyword max_total_trials: maximum total trial number.
-        :type max_total_trials: int
+        :paramtype max_total_trials: int
         :keyword timeout: total timeout in seconds for sweep node
-        :type timeout: int
+        :paramtype timeout: int
         :keyword trial_timeout: timeout in seconds for each trial
-        :type trial_timeout: int
+        :paramtype trial_timeout: int
         """
         if self._limits is None:
             self._limits = SweepJobLimits(
@@ -171,7 +171,7 @@ class ParameterizedSweep:
         "minimize", "maximize".
         :type goal: str
         :keyword primary_metric: Name of the metric to optimize.
-        :type primary_metric: str
+        :paramtype primary_metric: str
         """
 
         if self.objective is not None:

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/sweep/sampling_algorithm.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/sweep/sampling_algorithm.py
@@ -47,10 +47,10 @@ class RandomSamplingAlgorithm(SamplingAlgorithm):
     :keyword rule: The specific type of random algorithm. Accepted values are: "random" and "sobol".
     :type rule: str
     :keyword seed: The seed for random number generation.
-    :type seed: int
+    :paramtype seed: int
     :keyword logbase: A positive number or the number "e" in string format to be used as the base for log
         based random sampling.
-    :type logbase: Union[float, str]
+    :paramtype logbase: Union[float, str]
 
     .. admonition:: Example:
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/sweep/search_space.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/sweep/search_space.py
@@ -19,7 +19,7 @@ class SweepDistribution(ABC, RestTranslatableMixin):
     This class should not be instantiated directly. Instead, use one of its subclasses.
 
     :keyword type: Type of distribution.
-    :type type: str
+    :paramtype type: str
     """
 
     def __init__(self, *, type: Optional[str] = None) -> None:  # pylint: disable=redefined-builtin

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/sweep/sweep_job.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/sweep/sweep_job.py
@@ -71,49 +71,49 @@ class SweepJob(Job, ParameterizedSweep, JobIOMixin):
     """Sweep job for hyperparameter tuning.
 
     :keyword name: Name of the job.
-    :type name: str
+    :paramtype name: str
     :keyword display_name: Display name of the job.
-    :type display_name: str
+    :paramtype display_name: str
     :keyword description: Description of the job.
-    :type description: str
+    :paramtype description: str
     :keyword tags: Tag dictionary. Tags can be added, removed, and updated.
-    :type tags: dict[str, str]
+    :paramtype tags: dict[str, str]
     :keyword properties: The asset property dictionary.
-    :type properties: dict[str, str]
+    :paramtype properties: dict[str, str]
     :keyword experiment_name:  Name of the experiment the job will be created under, if None is provided,
         job will be created under experiment 'Default'.
-    :type experiment_name: str
+    :paramtype experiment_name: str
     :keyword identity: Identity that the training job will use while running on compute.
-    :type identity: Union[~azure.ai.ml.ManagedIdentityConfiguration, ~azure.ai.ml.AmlTokenConfiguration,
+    :paramtype identity: Union[~azure.ai.ml.ManagedIdentityConfiguration, ~azure.ai.ml.AmlTokenConfiguration,
         ~azure.ai.ml.UserIdentityConfiguration]
     :keyword inputs: Inputs to the command.
-    :type inputs: dict
+    :paramtype inputs: dict
     :keyword outputs: Mapping of output data bindings used in the job.
-    :type outputs: dict[str, ~azure.ai.ml.Output]
+    :paramtype outputs: dict[str, ~azure.ai.ml.Output]
     :keyword sampling_algorithm: The hyperparameter sampling algorithm to use over the `search_space`.
         Defaults to "random".
-    :type sampling_algorithm: str
+    :paramtype sampling_algorithm: str
     :keyword search_space: Dictionary of the hyperparameter search space. The key is the name of the
         hyperparameter and the value is the parameter expression.
-    :type search_space: Dict
+    :paramtype search_space: Dict
     :keyword objective: Metric to optimize for.
-    :type objective: Objective
+    :paramtype objective: Objective
     :keyword compute: The compute target the job runs on.
-    :type compute: str
+    :paramtype compute: str
     :keyword trial: The job configuration for each trial. Each trial will be provided with a different combination
         of hyperparameter values that the system samples from the search_space.
-    :type trial: Union[~azure.ai.ml.entities.CommandJob, ~azure.ai.ml.entities.CommandComponent]
+    :paramtype trial: Union[~azure.ai.ml.entities.CommandJob, ~azure.ai.ml.entities.CommandComponent]
     :keyword early_termination: The early termination policy to use. A trial job is canceled
         when the criteria of the specified policy are met. If omitted, no early termination policy will be applied.
-    :type early_termination:  Union[~azure.mgmt.machinelearningservices.models.BanditPolicy,
+    :paramtype early_termination:  Union[~azure.mgmt.machinelearningservices.models.BanditPolicy,
         ~azure.mgmt.machinelearningservices.models.MedianStoppingPolicy,
         ~azure.mgmt.machinelearningservices.models.TruncationSelectionPolicy]
     :keyword limits: Limits for the sweep job.
-    :type limits: ~azure.ai.ml.entities.SweepJobLimits
+    :paramtype limits: ~azure.ai.ml.entities.SweepJobLimits
     :keyword queue_settings: Queue settings for the job.
-    :type queue_settings: ~azure.ai.ml.entities.QueueSettings
+    :paramtype queue_settings: ~azure.ai.ml.entities.QueueSettings
     :keyword kwargs: A dictionary of additional configuration parameters.
-    :type kwargs: dict
+    :paramtype kwargs: dict
 
     .. admonition:: Example:
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_load_functions.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_load_functions.py
@@ -65,7 +65,7 @@ def load_common(
         functions that call this.
     :type relative_origin: str
     :param params_override: List of values to override in loaded yaml
-    :type params_override: Optional[list], optional
+    :type params_override: Optional[list]
     :return: The loaded resource
     :rtype: Resource
     """

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_load_functions.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_load_functions.py
@@ -162,9 +162,9 @@ def load_job(
     :keyword relative_origin: The root directory for the YAML. This directory will be used as the origin for deducing
         the relative locations of files referenced in the parsed YAML. Defaults to the same directory as source if
         source is a file or file path input. Defaults to "./" if the source is a stream input with no name value.
-    :type relative_origin: Optional[str]
+    :paramtype relative_origin: Optional[str]
     :keyword params_override: Parameter fields to overwrite values in the YAML file.
-    :type params_override: Optional[list[dict]]
+    :paramtype params_override: Optional[list[dict]]
     :raises ~azure.ai.ml.exceptions.ValidationException: Raised if Job cannot be successfully validated.
         Details will be provided in the error message.
     :return: A loaded Job object.
@@ -201,10 +201,10 @@ def load_workspace(
         the relative locations of files referenced in the parsed yaml.
         Defaults to the inputted source's directory if it is a file or file path input.
         Defaults to "./" if the source is a stream input with no name value.
-    :type relative_origin: str
+    :paramtype relative_origin: str
     :keyword params_override: Fields to overwrite on top of the yaml file.
         Format is [{"field1": "value1"}, {"field2": "value2"}]
-    :type params_override: List[Dict]
+    :paramtype params_override: List[Dict]
 
     :return: Loaded workspace object.
     :rtype: Workspace
@@ -231,10 +231,10 @@ def load_registry(
         the relative locations of files referenced in the parsed yaml.
         Defaults to the inputted source's directory if it is a file or file path input.
         Defaults to "./" if the source is a stream input with no name value.
-    :type relative_origin: str
+    :paramtype relative_origin: str
     :keyword params_override: Fields to overwrite on top of the yaml file.
         Format is [{"field1": "value1"}, {"field2": "value2"}]
-    :type params_override: List[Dict]
+    :paramtype params_override: List[Dict]
 
     :return: Loaded registry object.
     :rtype: Registry
@@ -261,10 +261,10 @@ def load_datastore(
         the relative locations of files referenced in the parsed yaml.
         Defaults to the inputted source's directory if it is a file or file path input.
         Defaults to "./" if the source is a stream input with no name value.
-    :type relative_origin: str
+    :paramtype relative_origin: str
     :keyword params_override: Fields to overwrite on top of the yaml file.
         Format is [{"field1": "value1"}, {"field2": "value2"}]
-    :type params_override: List[Dict]
+    :paramtype params_override: List[Dict]
     :raises ~azure.ai.ml.exceptions.ValidationException: Raised if Datastore cannot be successfully validated.
         Details will be provided in the error message.
     :return: Loaded datastore object.
@@ -292,10 +292,10 @@ def load_code(
         the relative locations of files referenced in the parsed yaml.
         Defaults to the inputted source's directory if it is a file or file path input.
         Defaults to "./" if the source is a stream input with no name value.
-    :type relative_origin: Optional[str]
+    :paramtype relative_origin: Optional[str]
     :keyword params_override: Fields to overwrite on top of the yaml file.
         Format is [{"field1": "value1"}, {"field2": "value2"}]
-    :type params_override: Optional[list[dict]]
+    :paramtype params_override: Optional[list[dict]]
     :raises ~azure.ai.ml.exceptions.ValidationException: Raised if Code cannot be successfully validated.
         Details will be provided in the error message.
     :return: Loaded code object.
@@ -323,10 +323,10 @@ def load_compute(
         the relative locations of files referenced in the parsed yaml.
         Defaults to the inputted source's directory if it is a file or file path input.
         Defaults to "./" if the source is a stream input with no name value.
-    :type relative_origin: str
+    :paramtype relative_origin: str
     :keyword params_override: Fields to overwrite on top of the yaml file.
         Format is [{"field1": "value1"}, {"field2": "value2"}]
-    :type params_override: List[Dict]
+    :paramtype params_override: List[Dict]
 
     :return: Loaded compute object.
     :rtype: Compute
@@ -353,18 +353,18 @@ def load_component(
         the relative locations of files referenced in the parsed yaml.
         Defaults to the inputted source's directory if it is a file or file path input.
         Defaults to "./" if the source is a stream input with no name value.
-    :type relative_origin: str
+    :paramtype relative_origin: str
     :keyword params_override: Fields to overwrite on top of the yaml file.
         Format is [{"field1": "value1"}, {"field2": "value2"}]
-    :type params_override: List[Dict]
+    :paramtype params_override: List[Dict]
     :keyword client: An MLClient instance.
-    :type client: MLClient
+    :paramtype client: MLClient
     :keyword name: Name of the component.
-    :type name: str
+    :paramtype name: str
     :keyword version: Version of the component.
-    :type version: str
+    :paramtype version: str
     :keyword kwargs: A dictionary of additional configuration parameters.
-    :type kwargs: dict
+    :paramtype kwargs: dict
 
     :return: A function that can be called with parameters to get a `azure.ai.ml.entities.Component`
     :rtype: Union[CommandComponent, ParallelComponent, PipelineComponent]
@@ -414,9 +414,9 @@ def load_model(
     :keyword relative_origin: The root directory for the YAML. This directory will be used as the origin for deducing
         the relative locations of files referenced in the parsed YAML. Defaults to the same directory as source if
         source is a file or file path input. Defaults to "./" if the source is a stream input with no name value.
-    :type relative_origin: Optional[str]
+    :paramtype relative_origin: Optional[str]
     :keyword params_override: Parameter fields to overwrite values in the YAML file.
-    :type params_override: Optional[list[dict]]
+    :paramtype params_override: Optional[list[dict]]
     :raises ~azure.ai.ml.exceptions.ValidationException: Raised if Job cannot be successfully validated.
         Details will be provided in the error message.
     :return: A loaded Model object.
@@ -453,10 +453,10 @@ def load_data(
         the relative locations of files referenced in the parsed yaml.
         Defaults to the inputted source's directory if it is a file or file path input.
         Defaults to "./" if the source is a stream input with no name value.
-    :type relative_origin: str
+    :paramtype relative_origin: str
     :keyword params_override: Fields to overwrite on top of the yaml file.
         Format is [{"field1": "value1"}, {"field2": "value2"}]
-    :type params_override: List[Dict]
+    :paramtype params_override: List[Dict]
     :raises ~azure.ai.ml.exceptions.ValidationException: Raised if Data cannot be successfully validated.
         Details will be provided in the error message.
     :return: Constructed Data or DataImport object.
@@ -484,10 +484,10 @@ def load_environment(
         the relative locations of files referenced in the parsed yaml.
         Defaults to the inputted source's directory if it is a file or file path input.
         Defaults to "./" if the source is a stream input with no name value.
-    :type relative_origin: str
+    :paramtype relative_origin: str
     :keyword params_override: Fields to overwrite on top of the yaml file.
         Format is [{"field1": "value1"}, {"field2": "value2"}]
-    :type params_override: List[Dict]
+    :paramtype params_override: List[Dict]
     :raises ~azure.ai.ml.exceptions.ValidationException: Raised if Environment cannot be successfully validated.
         Details will be provided in the error message.
     :return: Constructed environment object.
@@ -515,10 +515,10 @@ def load_online_deployment(
         the relative locations of files referenced in the parsed yaml.
         Defaults to the inputted source's directory if it is a file or file path input.
         Defaults to "./" if the source is a stream input with no name value.
-    :type relative_origin: str
+    :paramtype relative_origin: str
     :keyword params_override: Fields to overwrite on top of the yaml file.
         Format is [{"field1": "value1"}, {"field2": "value2"}]
-    :type params_override: List[Dict]
+    :paramtype params_override: List[Dict]
     :raises ~azure.ai.ml.exceptions.ValidationException: Raised if Online Deployment cannot be successfully validated.
         Details will be provided in the error message.
     :return: Constructed online deployment object.
@@ -546,10 +546,10 @@ def load_batch_deployment(
         the relative locations of files referenced in the parsed yaml.
         Defaults to the inputted source's directory if it is a file or file path input.
         Defaults to "./" if the source is a stream input with no name value.
-    :type relative_origin: str
+    :paramtype relative_origin: str
     :keyword params_override: Fields to overwrite on top of the yaml file.
         Format is [{"field1": "value1"}, {"field2": "value2"}]
-    :type params_override: List[Dict]
+    :paramtype params_override: List[Dict]
 
     :return: Constructed batch deployment object.
     :rtype: BatchDeployment
@@ -576,10 +576,10 @@ def load_model_batch_deployment(
         the relative locations of files referenced in the parsed yaml.
         Defaults to the inputted source's directory if it is a file or file path input.
         Defaults to "./" if the source is a stream input with no name value.
-    :type relative_origin: str
+    :paramtype relative_origin: str
     :keyword params_override: Fields to overwrite on top of the yaml file.
         Format is [{"field1": "value1"}, {"field2": "value2"}]
-    :type params_override: List[Dict]
+    :paramtype params_override: List[Dict]
 
     :return: Constructed model batch deployment object.
     :rtype: ModelBatchDeployment
@@ -606,10 +606,10 @@ def load_pipeline_component_batch_deployment(
         the relative locations of files referenced in the parsed yaml.
         Defaults to the inputted source's directory if it is a file or file path input.
         Defaults to "./" if the source is a stream input with no name value.
-    :type relative_origin: str
+    :paramtype relative_origin: str
     :keyword params_override: Fields to overwrite on top of the yaml file.
         Format is [{"field1": "value1"}, {"field2": "value2"}]
-    :type params_override: List[Dict]
+    :paramtype params_override: List[Dict]
 
     :return: Constructed pipeline component batch deployment object.
     :rtype: PipelineComponentBatchDeployment
@@ -636,10 +636,10 @@ def load_online_endpoint(
         the relative locations of files referenced in the parsed yaml.
         Defaults to the inputted source's directory if it is a file or file path input.
         Defaults to "./" if the source is a stream input with no name value.
-    :type relative_origin: str
+    :paramtype relative_origin: str
     :keyword params_override: Fields to overwrite on top of the yaml file.
         Format is [{"field1": "value1"}, {"field2": "value2"}]
-    :type params_override: List[Dict]
+    :paramtype params_override: List[Dict]
     :raises ~azure.ai.ml.exceptions.ValidationException: Raised if Online Endpoint cannot be successfully validated.
         Details will be provided in the error message.
     :return: Constructed online endpoint object.
@@ -669,7 +669,7 @@ def load_batch_endpoint(
     :type relative_origin: str
     :keyword params_override: Fields to overwrite on top of the yaml file.
         Format is [{"field1": "value1"}, {"field2": "value2"}]
-    :type params_override: List[Dict]
+    :paramtype params_override: List[Dict]
 
     :return: Constructed batch endpoint object.
     :rtype: BatchEndpoint
@@ -696,10 +696,10 @@ def load_workspace_connection(
         the relative locations of files referenced in the parsed yaml.
         Defaults to the inputted source's directory if it is a file or file path input.
         Defaults to "./" if the source is a stream input with no name value.
-    :type relative_origin: str
+    :paramtype relative_origin: str
     :keyword params_override: Fields to overwrite on top of the yaml file.
         Format is [{"field1": "value1"}, {"field2": "value2"}]
-    :type params_override: List[Dict]
+    :paramtype params_override: List[Dict]
 
     :return: Constructed workspace connection object.
     :rtype: WorkspaceConnection
@@ -728,7 +728,7 @@ def load_schedule(
     :type relative_origin: str
     :keyword params_override: Fields to overwrite on top of the yaml file.
         Format is [{"field1": "value1"}, {"field2": "value2"}]
-    :type params_override: List[Dict]
+    :paramtype params_override: List[Dict]
 
     :return: Constructed schedule object.
     :rtype: Schedule
@@ -754,10 +754,10 @@ def load_feature_store(
         the relative locations of files referenced in the parsed yaml.
         Defaults to the inputted source's directory if it is a file or file path input.
         Defaults to "./" if the source is a stream input with no name value.
-    :type relative_origin: str
+    :paramtype relative_origin: str
     :keyword params_override: Fields to overwrite on top of the yaml file.
         Format is [{"field1": "value1"}, {"field2": "value2"}]
-    :type params_override: List[Dict]
+    :paramtype params_override: List[Dict]
     :return: Loaded feature store object.
     :rtype: FeatureStore
     """
@@ -783,10 +783,10 @@ def load_feature_set(
         the relative locations of files referenced in the parsed yaml.
         Defaults to the inputted source's directory if it is a file or file path input.
         Defaults to "./" if the source is a stream input with no name value.
-    :type relative_origin: str
+    :paramtype relative_origin: str
     :keyword params_override: Fields to overwrite on top of the yaml file.
         Format is [{"field1": "value1"}, {"field2": "value2"}]
-    :type params_override: List[Dict]
+    :paramtype params_override: List[Dict]
     :raises ~azure.ai.ml.exceptions.ValidationException: Raised if FeatureSet cannot be successfully validated.
         Details will be provided in the error message.
     :return: Constructed FeatureSet object.
@@ -814,10 +814,10 @@ def load_feature_store_entity(
         the relative locations of files referenced in the parsed yaml.
         Defaults to the inputted source's directory if it is a file or file path input.
         Defaults to "./" if the source is a stream input with no name value.
-    :type relative_origin: str
+    :paramtype relative_origin: str
     :keyword params_override: Fields to overwrite on top of the yaml file.
         Format is [{"field1": "value1"}, {"field2": "value2"}]
-    :type params_override: List[Dict]
+    :paramtype params_override: List[Dict]
     :raises ~azure.ai.ml.exceptions.ValidationException: Raised if FeatureStoreEntity cannot be successfully validated.
         Details will be provided in the error message.
     :return: Constructed FeatureStoreEntity object.
@@ -844,10 +844,10 @@ def load_workspace_hub(
         the relative locations of files referenced in the parsed yaml.
         Defaults to the inputted source's directory if it is a file or file path input.
         Defaults to "./" if the source is a stream input with no name value.
-    :type relative_origin: str
+    :paramtype relative_origin: str
     :keyword params_override: Fields to overwrite on top of the yaml file.
         Format is [{"field1": "value1"}, {"field2": "value2"}]
-    :type params_override: List[Dict]
+    :paramtype params_override: List[Dict]
     :return: Loaded WorkspaceHub object.
     :rtype: WorkspaceHub
     """
@@ -870,9 +870,9 @@ def load_model_package(
     :keyword relative_origin: The root directory for the YAML. This directory will be used as the origin for deducing
         the relative locations of files referenced in the parsed YAML. Defaults to the same directory as source if
         source is a file or file path input. Defaults to "./" if the source is a stream input with no name value.
-    :type relative_origin: Optional[str]
+    :paramtype relative_origin: Optional[str]
     :keyword params_override: Parameter fields to overwrite values in the YAML file.
-    :type params_override: Optional[list[dict]]
+    :paramtype params_override: Optional[list[dict]]
     :raises ~azure.ai.ml.exceptions.ValidationException: Raised if Job cannot be successfully validated.
         Details will be provided in the error message.
     :return: A loaded ModelPackage object.

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_monitoring/alert_notification.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_monitoring/alert_notification.py
@@ -19,7 +19,7 @@ class AlertNotification(RestTranslatableMixin):
 
     :keyword emails: A list of email addresses that will receive notifications for monitoring alerts.
         Defaults to None.
-    :type emails: Optional[list[str]]
+    :paramtype emails: Optional[list[str]]
 
     .. admonition:: Example:
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_monitoring/definition.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_monitoring/definition.py
@@ -38,18 +38,18 @@ class MonitorDefinition(RestTranslatableMixin):
     """Monitor definition
 
     :keyword compute: The Spark resource configuration to be associated with the monitor
-    :type compute: ~azure.ai.ml.entities.SparkResourceConfiguration
+    :paramtype compute: ~azure.ai.ml.entities.SparkResourceConfiguration
     :keyword monitoring_target: The ARM ID object associated with the model or deployment that is being monitored.
-    :type monitoring_target: Optional[~azure.ai.ml.entities.MonitoringTarget]
+    :paramtype monitoring_target: Optional[~azure.ai.ml.entities.MonitoringTarget]
     :keyword monitoring_signals: The dictionary of signals to monitor. The key is the name of the signal and the value
         is the DataSignal object. Accepted values for the DataSignal objects are DataDriftSignal, DataQualitySignal,
         PredictionDriftSignal, FeatureAttributionDriftSignal, and CustomMonitoringSignal.
-    :type monitoring_signals: Optional[Dict[str, Union[~azure.ai.ml.entities.DataDriftSignal
+    :paramtype monitoring_signals: Optional[Dict[str, Union[~azure.ai.ml.entities.DataDriftSignal
         , ~azure.ai.ml.entities.DataQualitySignal, ~azure.ai.ml.entities.PredictionDriftSignal
         , ~azure.ai.ml.entities.FeatureAttributionDriftSignal
         , ~azure.ai.ml.entities.CustomMonitoringSignal]]]
     :keyword alert_notification: The alert configuration for the monitor.
-    :type alert_notification: Optional[Union[Literal['azmonitoring'], ~azure.ai.ml.entities.AlertNotification]]
+    :paramtype alert_notification: Optional[Union[Literal['azmonitoring'], ~azure.ai.ml.entities.AlertNotification]]
 
     .. admonition:: Example:
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_monitoring/input_data.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_monitoring/input_data.py
@@ -15,15 +15,15 @@ class MonitorInputData(RestTranslatableMixin):
     """Monitor input data.
 
     :keyword input_dataset: Input data used by the monitor
-    :type input_dataset: Optional[~azure.ai.ml.Input]
+    :paramtype input_dataset: Optional[~azure.ai.ml.Input]
     :keyword dataset_context: The context of the input dataset. Accepted values are "model_inputs",
         "model_outputs", "training", "test", "validation", and "ground_truth".
-    :type dataset_context: Optional[Union[str, ~azure.ai.ml.constants.MonitorDatasetContext]]
+    :paramtype dataset_context: Optional[Union[str, ~azure.ai.ml.constants.MonitorDatasetContext]]
     :keyword target_column_name: The target column in the given input dataset.
-    :type target_column_name: Optional[str]
+    :paramtype target_column_name: Optional[str]
     :keyword pre_processing_component: The ARM (Azure Resource Manager) resource ID of the component resource used to
         preprocess the data.
-    :type pre_processing_component: Optional[str]
+    :paramtype pre_processing_component: Optional[str]
     """
 
     def __init__(

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_monitoring/schedule.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_monitoring/schedule.py
@@ -32,19 +32,19 @@ class MonitorSchedule(Schedule, RestTranslatableMixin):
     """Monitor schedule.
 
     :keyword name: The schedule name.
-    :type name: str
+    :paramtype name: str
     :keyword trigger: The schedule trigger.
-    :type trigger: Union[~azure.ai.ml.entities.CronTrigger, ~azure.ai.ml.entities.RecurrenceTrigger]
+    :paramtype trigger: Union[~azure.ai.ml.entities.CronTrigger, ~azure.ai.ml.entities.RecurrenceTrigger]
     :keyword create_monitor: The schedule action monitor definition.
-    :type create_monitor: ~azure.ai.ml.entities.MonitorDefinition
+    :paramtype create_monitor: ~azure.ai.ml.entities.MonitorDefinition
     :keyword display_name: The display name of the schedule.
-    :type display_name: Optional[str]
+    :paramtype display_name: Optional[str]
     :keyword description: A description of the schedule.
-    :type description: Optional[str]
+    :paramtype description: Optional[str]
     :keyword tags: Tag dictionary. Tags can be added, removed, and updated.
-    :type tags: Optional[dict[str, str]]
+    :paramtype tags: Optional[dict[str, str]]
     :keyword properties: The job property dictionary.
-    :type properties: Optional[dict[str, str]]
+    :paramtype properties: Optional[dict[str, str]]
     """
 
     def __init__(
@@ -137,7 +137,7 @@ class MonitorSchedule(Schedule, RestTranslatableMixin):
             If dest is an open file, the file will be written to directly.
         :type dest: Union[PathLike, str, IO[AnyStr]]
         :keyword kwargs: Additional arguments to pass to the YAML serializer.
-        :type kwargs: dict
+        :paramtype kwargs: dict
         :raises FileExistsError: Raised if dest is a file path and the file already exists.
         :raises IOError: Raised if dest is an open file and the file is not writable.
         """

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_monitoring/signals.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_monitoring/signals.py
@@ -55,9 +55,9 @@ class DataSegment(RestTranslatableMixin):
     """Data segment for monitoring.
 
     :keyword feature_name: The feature to segment the data on.
-    :type feature_name: str
+    :paramtype feature_name: str
     :keyword feature_values: A list of values for the given segmented feature to filter.
-    :type feature_values: list[str]
+    :paramtype feature_values: list[str]
     """
 
     def __init__(
@@ -85,7 +85,7 @@ class MonitorFeatureFilter(RestTranslatableMixin):
     """Monitor feature filter
 
     :keyword top_n_feature_importance: The number of top features to include. Defaults to 10.
-    :type top_n_feature_importance: int
+    :paramtype top_n_feature_importance: int
     """
 
     def __init__(
@@ -110,9 +110,9 @@ class TargetDataset:
     """Monitor target dataset.
 
     :keyword dataset: The target dataset definition for monitor input.
-    :type dataset: ~azure.ai.ml.entities.MonitorInputData
+    :paramtype dataset: ~azure.ai.ml.entities.MonitorInputData
     :keyword data_window_size: The time window to select for the data, in days.
-    :type data_window_size: Optional[int]
+    :paramtype data_window_size: Optional[int]
     """
 
     def __init__(
@@ -133,11 +133,11 @@ class MonitoringSignal(RestTranslatableMixin):
     This class should not be instantiated directly. Instead, use one of its subclasses.
 
     :keyword target_dataset: The target dataset definition for monitor input.
-    :type target_dataset: ~azure.ai.ml.entities.TargetDataset
+    :paramtype target_dataset: ~azure.ai.ml.entities.TargetDataset
     :keyword baseline_dataset: The baseline dataset definition for monitor input.
-    :type baseline_dataset: ~azure.ai.ml.entities.MonitorInputData
+    :paramtype baseline_dataset: ~azure.ai.ml.entities.MonitorInputData
     :keyword metric_thresholds: The metric thresholds for the signal.
-    :type metric_thresholds: Union[
+    :paramtype metric_thresholds: Union[
         ~azure.ai.ml.entities.DataDriftMetricThreshold,
         ~azure.ai.ml.entities.DataQualityMetricThreshold,
         ~azure.ai.ml.entities.PredictionDriftMetricThreshold,
@@ -151,7 +151,7 @@ class MonitoringSignal(RestTranslatableMixin):
             ~azure.ai.ml.entities.CustomMonitoringMetricThreshold
         ]]]
     :keyword alert_enabled: Whether or not to enable alerts for the signal. Defaults to True.
-    :type alert_enabled: bool
+    :paramtype alert_enabled: bool
     """
 
     def __init__(
@@ -194,13 +194,13 @@ class DataSignal(MonitoringSignal):
     This class should not be instantiated directly. Instead, use one of its subclasses.
 
     :keyword target_dataset: The target dataset definition for monitor input.
-    :type target_dataset: ~azure.ai.ml.entities.TargetDataset
+    :paramtype target_dataset: ~azure.ai.ml.entities.TargetDataset
     :keyword baseline_dataset: The baseline dataset definition for monitor input.
-    :type baseline_dataset: ~azure.ai.ml.entities.MonitorInputData
+    :paramtype baseline_dataset: ~azure.ai.ml.entities.MonitorInputData
     :keyword features: The features to include in the signal.
-    :type features: Union[list[str], ~azure.ai.ml.entities.MonitorFeatureFilter, Literal[ALL_FEATURES]]
+    :paramtype features: Union[list[str], ~azure.ai.ml.entities.MonitorFeatureFilter, Literal[ALL_FEATURES]]
     :keyword metric_thresholds: The metric thresholds for the signal.
-    :type metric_thresholds: list[Union[
+    :paramtype metric_thresholds: list[Union[
         ~azure.ai.ml.entities.DataDriftMetricThreshold,
         ~azure.ai.ml.entities.DataQualityMetricThreshold,
         ~azure.ai.ml.entities.PredictionDriftMetricThreshold,
@@ -208,7 +208,7 @@ class DataSignal(MonitoringSignal):
         ~azure.ai.ml.entities.CustomMonitoringMetricThreshold
     ]]
     :keyword alert_enabled: Whether or not to enable alerts for the signal. Defaults to True.
-    :type alert_enabled: bool
+    :paramtype alert_enabled: bool
     """
 
     def __init__(
@@ -234,19 +234,19 @@ class DataDriftSignal(DataSignal):
     """Data drift signal.
 
     :keyword target_dataset: The dataset for which drift will be calculated.
-    :type target_dataset: ~azure.ai.ml.entities.TargetDataset
+    :paramtype target_dataset: ~azure.ai.ml.entities.TargetDataset
     :keyword baseline_dataset: The dataset to calculate drift against.
-    :type baseline_dataset: ~azure.ai.ml.entities.MonitorInputData
+    :paramtype baseline_dataset: ~azure.ai.ml.entities.MonitorInputData
     :keyword metric_thresholds: A list of metrics to calculate and their
         associated thresholds.
-    :type metric_thresholds: list[~azure.ai.ml.entities.DataDriftMetricThreshold]
+    :paramtype metric_thresholds: list[~azure.ai.ml.entities.DataDriftMetricThreshold]
     :keyword alert_enabled: Whether or not to enable alerts for the signal. Defaults to True.
-    :type alert_enabled: bool
+    :paramtype alert_enabled: bool
     :keyword data_segment: The data segment used for scoping on a subset of the data population.
-    :type data_segment: ~azure.ai.ml.entities.DataSegment
+    :paramtype data_segment: ~azure.ai.ml.entities.DataSegment
     :keyword features: The feature filter identifying which feature(s) to
         calculate drift over.
-    :type features: Union[list[str], ~azure.ai.ml.entities.MonitorFeatureFilter, Literal['all_features']]
+    :paramtype features: Union[list[str], ~azure.ai.ml.entities.MonitorFeatureFilter, Literal['all_features']]
     """
 
     def __init__(
@@ -315,13 +315,13 @@ class PredictionDriftSignal(MonitoringSignal):
     """Prediction drift signal.
 
     :keyword baseline_dataset: The dataset to calculate drift against.
-    :type baseline_dataset: ~azure.ai.ml.entities.MonitorInputData
+    :paramtype baseline_dataset: ~azure.ai.ml.entities.MonitorInputData
     :keyword target_dataset: The dataset for which drift will be calculated.
-    :type target_dataset: ~azure.ai.ml.entities.TargetDataset
+    :paramtype target_dataset: ~azure.ai.ml.entities.TargetDataset
     :keyword metric_thresholds: A list of metrics to calculate and their associated thresholds
-    :type metric_thresholds: list[~azure.ai.ml.entities.PredictionDriftMetricThreshold]
+    :paramtype metric_thresholds: list[~azure.ai.ml.entities.PredictionDriftMetricThreshold]
     :keyword alert_enabled: Whether or not to enable alerts for the signal. Defaults to True.
-    :type alert_enabled: bool
+    :paramtype alert_enabled: bool
     """
 
     def __init__(
@@ -383,17 +383,17 @@ class DataQualitySignal(DataSignal):
 
 
     :keyword target_dataset: The data for which quality will be calculated.
-    :type target_dataset: ~azure.ai.ml.entities.TargetDataset
+    :paramtype target_dataset: ~azure.ai.ml.entities.TargetDataset
     :keyword baseline_dataset: The data to calculate quality against.
-    :type baseline_dataset: ~azure.ai.ml.entities.MonitorInputData
+    :paramtype baseline_dataset: ~azure.ai.ml.entities.MonitorInputData
     :keyword metric_thresholds: A list of metrics to calculate and their
         associated thresholds.
-    :type metric_thresholds: list[~azure.ai.ml.entities.DataQualityMetricThreshold]
+    :paramtype metric_thresholds: list[~azure.ai.ml.entities.DataQualityMetricThreshold]
     :keyword alert_enabled: Whether or not to enable alerts for the signal. Defaults to True.
-    :type alert_enabled: bool
+    :paramtype alert_enabled: bool
     :keyword features: The feature filter identifying which feature(s) to
         calculate quality over.
-    :type features: Union[list[str], ~azure.ai.ml.entities.MonitorFeatureFilter, Literal['all_features']]
+    :paramtype features: Union[list[str], ~azure.ai.ml.entities.MonitorFeatureFilter, Literal['all_features']]
     """
 
     def __init__(
@@ -462,16 +462,16 @@ class ModelSignal(MonitoringSignal):
     This class should not be instantiated directly. Instead, use one of its subclasses.
 
     :keyword target_dataset: The data for which quality will be calculated.
-    :type target_dataset: ~azure.ai.ml.entities.TargetDataset
+    :paramtype target_dataset: ~azure.ai.ml.entities.TargetDataset
     :keyword baseline_dataset: The data to calculate quality against.
-    :type baseline_dataset: ~azure.ai.ml.entities.MonitorInputData
+    :paramtype baseline_dataset: ~azure.ai.ml.entities.MonitorInputData
     :keyword metric_thresholds: A list of metrics to calculate and their
         associated thresholds.
-    :type metric_thresholds: list[~azure.ai.ml.entities.MetricThreshold]
+    :paramtype metric_thresholds: list[~azure.ai.ml.entities.MetricThreshold]
     :keyword model_type: The type of model to monitor.
-    :type model_type: ~azure.ai.ml.constants.MonitorModelType
+    :paramtype model_type: ~azure.ai.ml.constants.MonitorModelType
     :keyword alert_enabled: Whether or not to enable alerts for the signal. Defaults to True.
-    :type alert_enabled: bool
+    :paramtype alert_enabled: bool
     """
 
     def __init__(
@@ -497,16 +497,16 @@ class FeatureAttributionDriftSignal(ModelSignal):
     """Feature attribution drift signal
 
     :keyword target_dataset: The data for which drift will be calculated.
-    :type target_dataset: ~azure.ai.ml.entities.TargetDataset
+    :paramtype target_dataset: ~azure.ai.ml.entities.TargetDataset
     :keyword baseline_dataset: The data to calculate drift against.
-    :type baseline_dataset: ~azure.ai.ml.entities.MonitorInputData
+    :paramtype baseline_dataset: ~azure.ai.ml.entities.MonitorInputData
     :keyword metric_thresholds: A list of metrics to calculate and their
         associated thresholds.
-    :type metric_thresholds: ~azure.ai.ml.entities.FeatureAttributionDriftMetricThreshold
+    :paramtype metric_thresholds: ~azure.ai.ml.entities.FeatureAttributionDriftMetricThreshold
     :keyword model_type: The model type.
-    :type model_type: ~azure.ai.ml.constants.MonitorModelType
+    :paramtype model_type: ~azure.ai.ml.constants.MonitorModelType
     :keyword alert_enabled: Whether or not to enable alerts for the signal. Defaults to True.
-    :type alert_enabled: bool
+    :paramtype alert_enabled: bool
     """
 
     def __init__(
@@ -561,18 +561,18 @@ class ModelPerformanceSignal(ModelSignal):
     """Model performance signal.
 
     :keyword target_dataset: The data for which performance will be calculated.
-    :type target_dataset: ~azure.ai.ml.entities.TargetDataset
+    :paramtype target_dataset: ~azure.ai.ml.entities.TargetDataset
     :keyword baseline_dataset: The data to calculate performance against.
-    :type baseline_dataset: ~azure.ai.ml.entities.MonitorInputData
+    :paramtype baseline_dataset: ~azure.ai.ml.entities.MonitorInputData
     :keyword metric_thresholds: A list of metrics to calculate and their
         associated thresholds.
-    :type metric_thresholds: ~azure.ai.ml.entities.ModelPerformanceMetricThreshold
+    :paramtype metric_thresholds: ~azure.ai.ml.entities.ModelPerformanceMetricThreshold
     :keyword model_type: The model type.
-    :type model_type: ~azure.ai.ml.constants.MonitorModelType
+    :paramtype model_type: ~azure.ai.ml.constants.MonitorModelType
     :keyword data_segment: The data segment to calculate performance against.
-    :type data_segment: ~azure.ai.ml.entities.DataSegment
+    :paramtype data_segment: ~azure.ai.ml.entities.DataSegment
     :keyword alert_enabled: Whether or not to enable alerts for the signal. Defaults to True.
-    :type alert_enabled: bool
+    :paramtype alert_enabled: bool
     """
 
     def __init__(
@@ -631,18 +631,18 @@ class CustomMonitoringSignal(RestTranslatableMixin):
 
     :keyword input_datasets: A dictionary of input datasets for monitoring.
         Each key is the component input port name, and its value is the data asset.
-    :type input_datasets: Optional[dict[str, ~azure.ai.ml.entities.MonitorInputData]]
+    :paramtype input_datasets: Optional[dict[str, ~azure.ai.ml.entities.MonitorInputData]]
     :keyword metric_thresholds: A list of metrics to calculate and their
         associated thresholds.
-    :type metric_thresholds: list[~azure.ai.ml.entities.CustomMonitoringMetricThreshold]
+    :paramtype metric_thresholds: list[~azure.ai.ml.entities.CustomMonitoringMetricThreshold]
     :keyword component_id: The ARM (Azure Resource Manager) ID of the component resource used to
         calculate the custom metrics.
-    :type component_id: str
+    :paramtype component_id: str
     :keyword alert_enabled: Whether or not to enable alerts for the signal. Defaults to True.
-    :type alert_enabled: bool
+    :paramtype alert_enabled: bool
     :keyword data_window_size: The number of days a single monitor looks back
         over the target
-    :type data_window_size: Optional[int]
+    :paramtype data_window_size: Optional[int]
     """
 
     def __init__(

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_monitoring/target.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_monitoring/target.py
@@ -10,9 +10,9 @@ class MonitoringTarget:
     """Monitoring target.
 
     :keyword endpoint_deployment_id: The ARM ID of the target deployment. Mutually exclusive with model_id.
-    :type endpoint_deployment_id: Optional[str]
+    :paramtype endpoint_deployment_id: Optional[str]
     :keyword model_id: ARM ID of the target model ID. Mutually exclusive with endpoint_deployment_id.
-    :type model_id: Optional[str]
+    :paramtype model_id: Optional[str]
 
     .. admonition:: Example:
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_resource.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_resource.py
@@ -37,7 +37,7 @@ class Resource(abc.ABC):
     :keyword print_as_yaml: Specifies if the the resource should print out as a YAML-formatted object. If False,
         the resource will print out in a more-compact style. By default, the YAML output is only used in Jupyter
         notebooks. Be aware that some bookkeeping values are shown only in the non-YAML output.
-    :type print_as_yaml: bool
+    :paramtype print_as_yaml: bool
     """
 
     def __init__(
@@ -149,7 +149,7 @@ class Resource(abc.ABC):
         :param params_override: Parameters to override, defaults to None
         :type params_override: typing.Optional[list]
         :keyword kwargs: A dictionary of additional configuration parameters.
-        :type kwargs: dict
+        :paramtype kwargs: dict
         :return: Resource
         :rtype: Resource
         """
@@ -162,7 +162,7 @@ class Resource(abc.ABC):
         """Get arm resource.
 
         :keyword kwargs: A dictionary of additional configuration parameters.
-        :type kwargs: dict
+        :paramtype kwargs: dict
 
         :return: Resource
         :rtype: dict
@@ -179,7 +179,7 @@ class Resource(abc.ABC):
         """Get arm resource and parameters.
 
         :keyword kwargs: A dictionary of additional configuration parameters.
-        :type kwargs: dict
+        :paramtype kwargs: dict
 
         :return: Resource and parameters
         :rtype: dict

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_schedule/schedule.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_schedule/schedule.py
@@ -293,11 +293,11 @@ class JobSchedule(RestTranslatableMixin, Schedule, TelemetryMixin):
                     input: ..
 
         :param data: The REST object to convert
-        :type data: Optional[Dict], optional
+        :type data: Optional[Dict]
         :param yaml_path: The yaml path
-        :type yaml_path: Optional[Union[PathLike str]], optional
+        :type yaml_path: Optional[Union[PathLike str]]
         :param params_override: A list of parameter overrides
-        :type params_override: Optional[list], optional
+        :type params_override: Optional[list]
         :return: The job schedule
         :rtype: JobSchedule
         """

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_schedule/schedule.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_schedule/schedule.py
@@ -41,19 +41,19 @@ class Schedule(YamlTranslatableMixin, SchemaValidatableMixin, Resource):
     This class should not be instantiated directly. Instead, please use the subclasses.
 
     :keyword name: The name of the schedule.
-    :type name: str
+    :paramtype name: str
     :keyword trigger: The schedule trigger configuration.
-    :type trigger: Union[~azure.ai.ml.entities.CronTrigger, ~azure.ai.ml.entities.RecurrenceTrigger]
+    :paramtype trigger: Union[~azure.ai.ml.entities.CronTrigger, ~azure.ai.ml.entities.RecurrenceTrigger]
     :keyword display_name: The display name of the schedule.
-    :type display_name: Optional[str]
+    :paramtype display_name: Optional[str]
     :keyword description: The description of the schedule.
-    :type description: Optional[str]
+    :paramtype description: Optional[str]
     :keyword tags: Tag dictionary. Tags can be added, removed, and updated.
-    :type tags: Optional[dict]]
+    :paramtype tags: Optional[dict]]
     :keyword properties: A dictionary of properties to associate with the schedule.
-    :type properties: Optional[dict[str, str]]
+    :paramtype properties: Optional[dict[str, str]]
     :keyword kwargs: Additional keyword arguments passed to the Resource constructor.
-    :type kwargs: dict
+    :paramtype kwargs: dict
     """
 
     def __init__(
@@ -84,7 +84,7 @@ class Schedule(YamlTranslatableMixin, SchemaValidatableMixin, Resource):
             If dest is an open file, the file will be written to directly.
         :type dest: Union[PathLike, str, IO[AnyStr]]
         :keyword kwargs: Additional arguments to pass to the YAML serializer.
-        :type kwargs: dict
+        :paramtype kwargs: dict
         :raises FileExistsError: Raised if dest is a file path and the file already exists.
         :raises IOError: Raised if dest is an open file and the file is not writable.
         """
@@ -172,19 +172,19 @@ class JobSchedule(RestTranslatableMixin, Schedule, TelemetryMixin):
     """Class for managing job schedules.
 
     :keyword name: The name of the schedule.
-    :type name: str
+    :paramtype name: str
     :keyword trigger: The trigger configuration for the schedule.
-    :type trigger: Union[~azure.ai.ml.entities.CronTrigger, ~azure.ai.ml.entities.RecurrenceTrigger]
+    :paramtype trigger: Union[~azure.ai.ml.entities.CronTrigger, ~azure.ai.ml.entities.RecurrenceTrigger]
     :keyword create_job: The job definition or an existing job name.
-    :type create_job: Union[~azure.ai.ml.entities.Job, str]
+    :paramtype create_job: Union[~azure.ai.ml.entities.Job, str]
     :keyword display_name: The display name of the schedule.
-    :type display_name: Optional[str]
+    :paramtype display_name: Optional[str]
     :keyword description: The description of the schedule.
-    :type description: Optional[str]
+    :paramtype description: Optional[str]
     :keyword tags: Tag dictionary. Tags can be added, removed, and updated.
-    :type tags: Optional[dict[str, str]]
+    :paramtype tags: Optional[dict[str, str]]
     :keyword properties: A dictionary of properties to associate with the schedule.
-    :type properties: Optional[dict[str, str]]
+    :paramtype properties: Optional[dict[str, str]]
 
     .. admonition:: Example:
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_schedule/trigger.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_schedule/trigger.py
@@ -25,15 +25,15 @@ class TriggerBase(RestTranslatableMixin, ABC):
     This class should not be instantiated directly. Instead, use one of its subclasses.
 
     :keyword type: The type of trigger.
-    :type type: str
+    :paramtype type: str
     :keyword start_time: Specifies the start time of the schedule in ISO 8601 format.
-    :type start_time: Optional[Union[str, datetime]]
+    :paramtype start_time: Optional[Union[str, datetime]]
     :keyword end_time: Specifies the end time of the schedule in ISO 8601 format.
         Note that end_time is not supported for compute schedules.
-    :type end_time: Optional[Union[str, datetime]]
+    :paramtype end_time: Optional[Union[str, datetime]]
     :keyword time_zone: The time zone where the schedule will run. Defaults to UTC(+00:00).
         Note that this applies to the start_time and end_time.
-    :type time_zone: ~azure.ai.ml.constants.TimeZone
+    :paramtype time_zone: ~azure.ai.ml.constants.TimeZone
     """
 
     def __init__(
@@ -64,14 +64,14 @@ class RecurrencePattern(RestTranslatableMixin):
     """Recurrence pattern for a job schedule.
 
     :keyword hours: The number of hours for the recurrence schedule pattern.
-    :type hours: Union[int, list[int]]
+    :paramtype hours: Union[int, list[int]]
     :keyword minutes: The number of minutes for the recurrence schedule pattern.
-    :type minutes: Union[int, list[int]]
+    :paramtype minutes: Union[int, list[int]]
     :keyword week_days: A list of days of the week for the recurrence schedule pattern.
         Acceptable values include: "monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"
     :type week_days: Optional[Union[str, list[str]]]
     :keyword month_days: A list of days of the month for the recurrence schedule pattern.
-    :type month_days: Optional[Union[int, list[int]]]
+    :paramtype month_days: Optional[Union[int, list[int]]]
 
     .. admonition:: Example:
 
@@ -131,20 +131,20 @@ class CronTrigger(TriggerBase):
     """Cron Trigger for a job schedule.
 
     :keyword expression: The cron expression of schedule, following NCronTab format.
-    :type expression: str
+    :paramtype expression: str
     :keyword start_time: The start time for the trigger. If using a datetime object, leave the tzinfo as None and use
         the ``time_zone`` parameter to specify a time zone if needed. If using a string, use the format
         YYYY-MM-DDThh:mm:ss. Defaults to running the first workload instantly and continuing future workloads
         based on the schedule. If the start time is in the past, the first workload is run at the next calculated run
         time.
-    :type start_time: Optional[Union[str, datetime]]
+    :paramtype start_time: Optional[Union[str, datetime]]
     :keyword end_time: The start time for the trigger. If using a datetime object, leave the tzinfo as None and use
         the ``time_zone`` parameter to specify a time zone if needed. If using a string, use the format
         YYYY-MM-DDThh:mm:ss. Note that end_time is not supported for compute schedules.
-    :type end_time: Optional[Union[str, datetime]]
+    :paramtype end_time: Optional[Union[str, datetime]]
     :keyword time_zone: The time zone where the schedule will run. Defaults to UTC(+00:00).
         Note that this applies to the start_time and end_time.
-    :type time_zone: Union[str, ~azure.ai.ml.constants.TimeZone]
+    :paramtype time_zone: Union[str, ~azure.ai.ml.constants.TimeZone]
     :raises Exception: Raised if end_time is in the past.
 
     .. admonition:: Example:
@@ -207,21 +207,21 @@ class RecurrenceTrigger(TriggerBase):
     """Recurrence trigger for a job schedule.
 
     :keyword start_time: Specifies the start time of the schedule in ISO 8601 format.
-    :type start_time: Optional[Union[str, datetime]]
+    :paramtype start_time: Optional[Union[str, datetime]]
     :keyword end_time: Specifies the end time of the schedule in ISO 8601 format.
         Note that end_time is not supported for compute schedules.
-    :type end_time: Optional[Union[str, datetime]]
+    :paramtype end_time: Optional[Union[str, datetime]]
     :keyword time_zone: The time zone where the schedule will run. Defaults to UTC(+00:00).
         Note that this applies to the start_time and end_time.
-    :type time_zone: Union[str, ~azure.ai.ml.constants.TimeZone]
+    :paramtype time_zone: Union[str, ~azure.ai.ml.constants.TimeZone]
     :keyword frequency: Specifies the frequency that the schedule should be triggered with.
      Possible values include: "minute", "hour", "day", "week", "month".
     :type frequency: str
     :keyword interval: Specifies the interval in conjunction with the frequency that the schedule should be triggered
         with.
-    :type interval: int
+    :paramtype interval: int
     :keyword schedule: Specifies the recurrence pattern.
-    :type schedule: Optional[~azure.ai.ml.entities.RecurrencePattern]
+    :paramtype schedule: Optional[~azure.ai.ml.entities.RecurrencePattern]
 
     .. admonition:: Example:
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_system_data.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_system_data.py
@@ -10,19 +10,19 @@ class SystemData(RestTranslatableMixin):
     """Metadata related to the creation and most recent modification of a resource.
 
     :keyword created_by: The identity that created the resource.
-    :type created_by: str
+    :paramtype created_by: str
     :keyword created_by_type: The type of identity that created the resource. Accepted values are
         "User", "Application", "ManagedIdentity", "Key".
-    :type created_by_type: Union[str, ~azure.ai.ml.entities.CreatedByType]
+    :paramtype created_by_type: Union[str, ~azure.ai.ml.entities.CreatedByType]
     :keyword created_at: The timestamp of resource creation (UTC).
-    :type created_at: datetime
+    :paramtype created_at: datetime
     :keyword last_modified_by: The identity that last modified the resource.
-    :type last_modified_by: str
+    :paramtype last_modified_by: str
     :keyword last_modified_by_type: The type of identity that last modified the resource. Accepted values are
         "User", "Application", "ManagedIdentity", "Key".
-    :type last_modified_by_type: Union[str, ~azure.ai.ml.entities.CreatedByType]
+    :paramtype last_modified_by_type: Union[str, ~azure.ai.ml.entities.CreatedByType]
     :keyword last_modified_at: The timestamp of resource last modification in UTC.
-    :type last_modified_at: datetime
+    :paramtype last_modified_at: datetime
     """
 
     def __init__(self, **kwargs) -> None:

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_util.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_util.py
@@ -511,7 +511,7 @@ def get_type_from_spec(data: dict, *, valid_keys: Iterable[str]) -> str:
     :param data: The data
     :type data: dict
     :keyword valid_keys: An iterable of valid types
-    :type valid_keys: Iterable[str]
+    :paramtype valid_keys: Iterable[str]
     :return: The type of the node or component
     :rtype: str
     """

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_util.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_util.py
@@ -215,7 +215,7 @@ def convert_ordered_dict_to_dict(target_object: Union[Dict, List], remove_empty:
     :param target_object: The object to convert
     :type target_object: Union[Dict, List]
     :param remove_empty: Whether to omit values that are None or empty dictionaries. Defaults to True.
-    :type remove_empty: bool, optional
+    :type remove_empty: bool
     :return: Converted ordered dict with removed None values
     :rtype: Union[Dict, List]
     """
@@ -248,7 +248,7 @@ def _general_copy(src: Union[str, os.PathLike], dst: Union[str, os.PathLike], ma
     :param dst: The destination path to copy to
     :type dst: Union[str, os.PathLike]
     :param make_dirs: Whether to ensure the destination path exists. Defaults to True.
-    :type make_dirs: bool, optional
+    :type make_dirs: bool
     """
     if make_dirs:
         os.makedirs(os.path.dirname(dst), exist_ok=True)
@@ -281,7 +281,7 @@ def get_rest_dict_for_node_attrs(target_obj: T, clear_empty_value: bool = False)
     :param target_obj: The object to convert
     :type target_obj: T
     :param clear_empty_value: Whether to clear empty values. Defaults to False.
-    :type clear_empty_value: bool, optional
+    :type clear_empty_value: bool
     :return: The translated dict, or the the original object
     :rtype: Union[T, Dict]
     """
@@ -400,7 +400,7 @@ def resolve_pipeline_parameters(
     :param pipeline_parameters: The pipeline parameters
     :type pipeline_parameters: Optional[Dict[str, T]]
     :param remove_empty: Whether to remove None values. Defaults to False.
-    :type remove_empty: bool, optional
+    :type remove_empty: bool
     :return:
         * None if pipeline_parameters is None
         * The resolved dict of pipeline parameters

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_validation.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_validation.py
@@ -36,11 +36,11 @@ class Diagnostic(object):
         """Init Diagnostic.
 
         :keyword yaml_path: A dash path from root to the target element of the diagnostic. jobs.job_a.inputs.input_str
-        :type yaml_path: str
+        :paramtype yaml_path: str
         :keyword message: Error message of diagnostic.
-        :type message: str
+        :paramtype message: str
         :keyword error_code: Error code of diagnostic.
-        :type error_code: str
+        :paramtype error_code: str
         """
         self.yaml_path = yaml_path
         self.message = message
@@ -559,7 +559,7 @@ class _ValidationResultBuilder:
         :param error: ValidationError raised by marshmallow.Schema.load.
         :type error: ValidationError
         :keyword error_on_unknown_field: whether to raise error if there are unknown field diagnostics.
-        :type error_on_unknown_field: bool
+        :paramtype error_on_unknown_field: bool
         :return: The validation result
         :rtype: MutableValidationResult
         """
@@ -581,7 +581,7 @@ class _ValidationResultBuilder:
         :param data: serialized data to validate
         :type data: dict
         :keyword error_on_unknown_field: whether to raise error if there are unknown field diagnostics.
-        :type error_on_unknown_field: bool
+        :paramtype error_on_unknown_field: bool
         :return: The validation result
         :rtype: MutableValidationResult
         """

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_batch_deployment_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_batch_deployment_operations.py
@@ -235,7 +235,7 @@ class BatchDeploymentOperations(_ScopeDependentOperations):
         :param endpoint_name: Name of endpoint.
         :type endpoint_name: str
         :keyword name: (Optional) Name of deployment.
-        :type name: str
+        :paramtype name: str
         :raise: Exception if endpoint_type is not BATCH_ENDPOINT_TYPE
         :return: List of jobs
         :rtype: ~azure.core.paging.ItemPaged[~azure.ai.ml.entities.BatchJob]

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_batch_endpoint_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_batch_endpoint_operations.py
@@ -215,10 +215,10 @@ class BatchEndpointOperations(_ScopeDependentOperations):
         :type endpoint_name: str
         :keyword deployment_name: (Optional) The name of a specific deployment to invoke. This is optional.
             By default requests are routed to any of the deployments according to the traffic rules.
-        :type deployment_name: str
+        :paramtype deployment_name: str
         :keyword inputs: (Optional) A dictionary of existing data asset, public uri file or folder
             to use with the deployment
-        :type inputs: Dict[str, Input]
+        :paramtype inputs: Dict[str, Input]
         :raises ~azure.ai.ml.exceptions.ValidationException: Raised if deployment cannot be successfully validated.
             Details will be provided in the error message.
         :raises ~azure.ai.ml.exceptions.AssetException: Raised if BatchEndpoint assets

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_component_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_component_operations.py
@@ -349,7 +349,7 @@ class ComponentOperations(_ScopeDependentOperations):
         :param component: The component object or a mldesigner component function that generates component object
         :type component: Union[Component, types.FunctionType]
         :param raise_on_failure: Whether to raise exception on validation error. Defaults to False
-        :type raise_on_failure: bool, optional
+        :type raise_on_failure: bool
         :return: All validation errors
         :rtype: ~azure.ai.ml.entities.ValidationResult
         """

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_component_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_component_operations.py
@@ -286,7 +286,7 @@ class ComponentOperations(_ScopeDependentOperations):
             defaults to current working directory of the current user. Will be created if not exists.
         :type download_path: str
         :keyword version: Version of the component.
-        :type version: Optional[str]
+        :paramtype version: Optional[str]
         :raises ~OSError: Raised if download_path is pointing to an existing directory that is not empty.
             identified and retrieved. Details will be provided in the error message.
         :return: The specified component object.
@@ -423,7 +423,7 @@ class ComponentOperations(_ScopeDependentOperations):
         :param version: The component version to override.
         :type version: str
         :keyword skip_validation: whether to skip validation before creating/updating the component, defaults to False
-        :type skip_validation: bool
+        :paramtype skip_validation: bool
         :raises ~azure.ai.ml.exceptions.ValidationException: Raised if Component cannot be successfully validated.
             Details will be provided in the error message.
         :raises ~azure.ai.ml.exceptions.AssetException: Raised if Component assets
@@ -960,7 +960,7 @@ class ComponentOperations(_ScopeDependentOperations):
         :param resolver: The resolver to resolve the dependencies.
         :type resolver: _AssetResolver
         :keyword resolve_inputs: Whether to resolve inputs.
-        :type resolve_inputs: bool
+        :paramtype resolve_inputs: bool
         """
         if not isinstance(component, PipelineComponent) or not component.jobs:
             return

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_compute_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_compute_operations.py
@@ -49,7 +49,7 @@ class ComputeOperations(_ScopeDependentOperations):
         """List computes of the workspace.
 
         :keyword compute_type: the type of the compute to be listed, defaults to amlcompute
-        :type compute_type: str
+        :paramtype compute_type: str
         :return: An iterator like instance of Compute objects
         :rtype: ~azure.core.paging.ItemPaged[Compute]
         """
@@ -252,7 +252,7 @@ class ComputeOperations(_ScopeDependentOperations):
 
         :keyword location: The location for which resource usage is queried.
             If location not provided , defaults to workspace location
-        :type location: str
+        :paramtype location: str
         :return: An iterator over current usage info
         :rtype: ~azure.core.paging.ItemPaged[Usage]
         """
@@ -270,7 +270,7 @@ class ComputeOperations(_ScopeDependentOperations):
 
         :keyword location: The location upon which virtual-machine-sizes is queried.
             If location not provided, defaults to workspace location.
-        :type location: str
+        :paramtype location: str
 
         :return: An iterator over virtual machine sizes.
         :rtype: Iterable[VmSize]

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_data_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_data_operations.py
@@ -435,7 +435,7 @@ class DataOperations(_ScopeDependentOperations):
         :param name: name of asset being created by the materialization jobs.
         :type name: str
         :keyword list_view_type: View type for including/excluding (for example) archived jobs. Default: ACTIVE_ONLY.
-        :type list_view_type: Optional[ListViewType]
+        :paramtype list_view_type: Optional[ListViewType]
         :return: An iterator like instance of Job objects.
         :rtype: ~azure.core.paging.ItemPaged[PipelineJob]
         """
@@ -598,11 +598,11 @@ class DataOperations(_ScopeDependentOperations):
         :param version: Version of data asset.
         :type version: str
         :keyword share_with_name: Name of data asset to share with.
-        :type share_with_name: str
+        :paramtype share_with_name: str
         :keyword share_with_version: Version of data asset to share with.
-        :type share_with_version: str
+        :paramtype share_with_version: str
         :keyword registry_name: Name of the destination registry.
-        :type registry_name: str
+        :paramtype registry_name: str
         :return: Data asset object.
         :rtype: ~azure.ai.ml.entities.Data
         """

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_datastore_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_datastore_operations.py
@@ -51,7 +51,7 @@ class DatastoreOperations(_ScopeDependentOperations):
         """Lists all datastores and associated information within a workspace.
 
         :keyword include_secrets: Include datastore secrets in returned datastores, defaults to False
-        :type include_secrets: bool, optional
+        :type include_secrets: bool
         :return: An iterator like instance of Datastore objects
         :rtype: ~azure.core.paging.ItemPaged[Datastore]
         """
@@ -100,7 +100,7 @@ class DatastoreOperations(_ScopeDependentOperations):
         :param name: Datastore name
         :type name: str
         :keyword include_secrets: Include datastore secrets in the returned datastore, defaults to False
-        :type include_secrets: bool, optional
+        :type include_secrets: bool
         :return: Datastore with the specified name.
         :rtype: Datastore
         """
@@ -129,7 +129,7 @@ class DatastoreOperations(_ScopeDependentOperations):
         """Returns the workspace's default datastore.
 
         :keyword include_secrets: Include datastore secrets in the returned datastore, defaults to False
-        :type include_secrets: bool, optional
+        :type include_secrets: bool
         :return: The default datastore.
         :rtype: Datastore
         """

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_datastore_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_datastore_operations.py
@@ -51,7 +51,7 @@ class DatastoreOperations(_ScopeDependentOperations):
         """Lists all datastores and associated information within a workspace.
 
         :keyword include_secrets: Include datastore secrets in returned datastores, defaults to False
-        :type include_secrets: bool
+        :paramtype include_secrets: bool
         :return: An iterator like instance of Datastore objects
         :rtype: ~azure.core.paging.ItemPaged[Datastore]
         """
@@ -100,7 +100,7 @@ class DatastoreOperations(_ScopeDependentOperations):
         :param name: Datastore name
         :type name: str
         :keyword include_secrets: Include datastore secrets in the returned datastore, defaults to False
-        :type include_secrets: bool
+        :paramtype include_secrets: bool
         :return: Datastore with the specified name.
         :rtype: Datastore
         """
@@ -129,7 +129,7 @@ class DatastoreOperations(_ScopeDependentOperations):
         """Returns the workspace's default datastore.
 
         :keyword include_secrets: Include datastore secrets in the returned datastore, defaults to False
-        :type include_secrets: bool
+        :paramtype include_secrets: bool
         :return: The default datastore.
         :rtype: Datastore
         """

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_environment_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_environment_operations.py
@@ -394,11 +394,11 @@ class EnvironmentOperations(_ScopeDependentOperations):
         :param version: Version of environment asset.
         :type version: str
         :keyword share_with_name: Name of environment asset to share with.
-        :type share_with_name: str
+        :paramtype share_with_name: str
         :keyword share_with_version: Version of environment asset to share with.
-        :type share_with_version: str
+        :paramtype share_with_version: str
         :keyword registry_name: Name of the destination registry.
-        :type registry_name: str
+        :paramtype registry_name: str
         :return: Environment asset object.
         :rtype: ~azure.ai.ml.entities.Environment
         """

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_feature_set_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_feature_set_operations.py
@@ -190,23 +190,23 @@ class FeatureSetOperations(_ScopeDependentOperations):
         """Backfill.
 
         :keyword name: Feature set name. This is case-sensitive.
-        :type name: str
+        :paramtype name: str
         :keyword version: Version identifier. This is case-sensitive.
-        :type version: str
+        :paramtype version: str
         :keyword feature_window_start_time: Start time of the feature window to be materialized.
-        :type feature_window_start_time: datetime
+        :paramtype feature_window_start_time: datetime
         :keyword feature_window_end_time: End time of the feature window to be materialized.
-        :type feature_window_end_time: datetime
+        :paramtype feature_window_end_time: datetime
         :keyword display_name: Specifies description.
-        :type display_name: str
+        :paramtype display_name: str
         :keyword description: Specifies description.
-        :type description: str
+        :paramtype description: str
         :keyword tags: A set of tags. Specifies the tags.
-        :type tags: dict[str, str]
+        :paramtype tags: dict[str, str]
         :keyword compute_resource: Specifies the compute resource settings.
-        :type compute_resource: ~azure.ai.ml.entities.MaterializationComputeResource
+        :paramtype compute_resource: ~azure.ai.ml.entities.MaterializationComputeResource
         :keyword spark_configuration: Specifies the spark compute settings.
-        :type spark_configuration: dict[str, str]
+        :paramtype spark_configuration: dict[str, str]
         :return: An instance of LROPoller that returns ~azure.ai.ml.entities.FeatureSetBackfillMetadata
         :rtype: ~azure.core.polling.LROPoller[~azure.ai.ml.entities.FeatureSetBackfillMetadata]
         """
@@ -250,11 +250,11 @@ class FeatureSetOperations(_ScopeDependentOperations):
         :param version: Feature set version.
         :type version: str
         :keyword feature_window_start_time: Start time of the feature window to filter materialization jobs.
-        :type feature_window_start_time: Union[str, datetime]
+        :paramtype feature_window_start_time: Union[str, datetime]
         :keyword feature_window_end_time: End time of the feature window to filter materialization jobs.
-        :type feature_window_end_time: Union[str, datetime]
+        :paramtype feature_window_end_time: Union[str, datetime]
         :keyword filters: Comma-separated list of tag names (and optionally values). Example: tag1,tag2=value2.
-        :type filters: str
+        :paramtype filters: str
         :return: An iterator like instance of ~azure.ai.ml.entities.FeatureSetMaterializationMetadata objects
         :rtype: ~azure.core.paging.ItemPaged[FeatureSetMaterializationMetadata]
         """
@@ -292,11 +292,11 @@ class FeatureSetOperations(_ScopeDependentOperations):
         :param version: Feature set version.
         :type version: str
         :keyword feature_name: feature name.
-        :type feature_name: str
+        :paramtype feature_name: str
         :keyword description: Description of the featureset.
-        :type description: str
+        :paramtype description: str
         :keyword tags: Comma-separated list of tag names (and optionally values). Example: tag1,tag2=value2.
-        :type tags: str
+        :paramtype tags: str
         :return: An iterator like instance of Feature objects
         :rtype: ~azure.core.paging.ItemPaged[Feature]
         """
@@ -323,9 +323,9 @@ class FeatureSetOperations(_ScopeDependentOperations):
         :param version: Feature set version.
         :type version: str
         :keyword feature_name. This is case-sensitive.
-        :type feature_name: str
+        :paramtype feature_name: str
         :keyword tags: Comma-separated list of tag names (and optionally values). Example: tag1,tag2=value2.
-        :type tags: str
+        :paramtype tags: str
         :return: Feature object
         :rtype: ~azure.ai.ml.entities.Feature
         """

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_feature_store_entity_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_feature_store_entity_operations.py
@@ -66,7 +66,7 @@ class FeatureStoreEntityOperations(_ScopeDependentOperations):
         :type name: Optional[str]
         :keyword list_view_type: View type for including/excluding (for example) archived FeatureStoreEntity assets.
         Default: ACTIVE_ONLY.
-        :type list_view_type: Optional[ListViewType]
+        :paramtype list_view_type: Optional[ListViewType]
         :return: An iterator like instance of FeatureStoreEntity objects
         :rtype: ~azure.core.paging.ItemPaged[FeatureStoreEntity]
         """

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_feature_store_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_feature_store_operations.py
@@ -73,7 +73,7 @@ class FeatureStoreOperations(WorkspaceOperationsBase):
         resource group or subscription.
 
         :keyword scope: scope of the listing, "resource_group" or "subscription", defaults to "resource_group"
-        :type scope: str, optional
+        :type scope: str
         :return: An iterator like instance of FeatureStore objects
         :rtype: ~azure.core.paging.ItemPaged[FeatureStore]
         """

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_feature_store_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_feature_store_operations.py
@@ -73,7 +73,7 @@ class FeatureStoreOperations(WorkspaceOperationsBase):
         resource group or subscription.
 
         :keyword scope: scope of the listing, "resource_group" or "subscription", defaults to "resource_group"
-        :type scope: str
+        :paramtype scope: str
         :return: An iterator like instance of FeatureStore objects
         :rtype: ~azure.core.paging.ItemPaged[FeatureStore]
         """
@@ -399,7 +399,7 @@ class FeatureStoreOperations(WorkspaceOperationsBase):
         :keyword delete_dependent_resources: Whether to delete resources associated with the feature store,
             i.e., container registry, storage account, key vault, and application insights.
             The default is False. Set to True to delete these resources.
-        :type delete_dependent_resources: bool
+        :paramtype delete_dependent_resources: bool
         :return: A poller to track the operation status.
         :rtype: ~azure.core.polling.LROPoller[None]
         """

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_job_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_job_operations.py
@@ -257,10 +257,10 @@ class JobOperations(_ScopeDependentOperations):
 
         :keyword parent_job_name: When provided, only returns jobs that are children of the named job. Defaults to None,
             listing all jobs in the workspace.
-        :type parent_job_name: Optional[str]
+        :paramtype parent_job_name: Optional[str]
         :keyword list_view_type: The view type for including/excluding archived jobs. Defaults to
             ~azure.mgt.machinelearningservices.models.ListViewType.ACTIVE_ONLY, excluding archived jobs.
-        :type list_view_type: ~azure.mgmt.machinelearningservices.models.ListViewType
+        :paramtype list_view_type: ~azure.mgmt.machinelearningservices.models.ListViewType
         :return: An iterator-like instance of Job objects.
         :rtype: ~azure.core.paging.ItemPaged[~azure.ai.ml.entities.Job]
 
@@ -476,7 +476,7 @@ class JobOperations(_ScopeDependentOperations):
         :param job: The job object to be validated.
         :type job: ~azure.ai.ml.entities.Job
         :keyword raise_on_failure: Specifies if an error should be raised if validation fails. Defaults to False.
-        :type raise_on_failure: bool
+        :paramtype raise_on_failure: bool
         :return: A ValidationResult object containing all found errors.
         :rtype: ~azure.ai.ml.entities.ValidationResult
 
@@ -504,7 +504,7 @@ class JobOperations(_ScopeDependentOperations):
         :param job: The job to validate
         :type job: Job
         :keyword raise_on_failure: Whether to raise on validation failure
-        :type raise_on_failure: bool
+        :paramtype raise_on_failure: bool
         :return: The validation result
         :rtype: ValidationResult
         """
@@ -568,18 +568,18 @@ class JobOperations(_ScopeDependentOperations):
         :param job: The job object.
         :type job: ~azure.ai.ml.entities.Job
         :keyword description: The job description.
-        :type description: Optional[str]
+        :paramtype description: Optional[str]
         :keyword compute: The compute target for the job.
-        :type compute: Optional[str]
+        :paramtype compute: Optional[str]
         :keyword tags: The tags for the job.
-        :type tags: Optional[dict]
+        :paramtype tags: Optional[dict]
         :keyword experiment_name: The name of the experiment the job will be created under. If None is provided,
             job will be created under experiment 'Default'.
-        :type experiment_name: Optional[str]
+        :paramtype experiment_name: Optional[str]
         :keyword skip_validation: Specifies whether or not to skip validation before creating or updating the job. Note
             that validation for dependent resources such as an anonymous component will not be skipped. Defaults to
             False.
-        :type skip_validation: bool
+        :paramtype skip_validation: bool
         :raises Union[~azure.ai.ml.exceptions.UserErrorException, ~azure.ai.ml.exceptions.ValidationException]: Raised
             if Job cannot be successfully validated. Details will be provided in the error message.
         :raises ~azure.ai.ml.exceptions.AssetException: Raised if Job assets
@@ -795,11 +795,11 @@ class JobOperations(_ScopeDependentOperations):
         :param name: The name of a job.
         :type name: str
         :keyword download_path: The local path to be used as the download destination. Defaults to ".".
-        :type download_path: Union[PathLike, str]
+        :paramtype download_path: Union[PathLike, str]
         :keyword output_name: The name of the output to download. Defaults to None.
-        :type output_name: Optional[str]
+        :paramtype output_name: Optional[str]
         :keyword all: Specifies if all logs and named outputs should be downloaded. Defaults to False.
-        :type all: bool
+        :paramtype all: bool
         :raises ~azure.ai.ml.exceptions.JobException: Raised if Job is not yet in a terminal state.
             Details will be provided in the error message.
         :raises ~azure.ai.ml.exceptions.MlException: Raised if logs and outputs cannot be successfully downloaded.

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_job_ops_helper.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_job_ops_helper.py
@@ -443,7 +443,7 @@ def get_job_output_uris_from_dataplane(
     :param model_dataplane_operations:  The ModelDataplaneOperations used to fetch dataset uris
     :type model_dataplane_operations: ModelDataplaneOperations
     :param output_names: The output name(s) to fetch. If not specified, retrieves all.
-    :type output_names: Optional[Union[Iterable[str] str]], optional
+    :type output_names: Optional[Union[Iterable[str] str]]
     :return: Dictionary mapping user-defined output name to output uri
     :rtype: Dict[str, str]
     """

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_local_endpoint_helper.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_local_endpoint_helper.py
@@ -168,7 +168,7 @@ def _convert_container_to_endpoint(
     :param container: Container for a local deployment.
     :type container: docker.models.containers.Container
     :param endpoint_json: The endpoint json
-    :type endpoint_json: Optional[dict], optional
+    :type endpoint_json: Optional[dict]
     :return: The OnlineEndpoint entity
     :rtype: OnlineEndpoint
     """

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_model_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_model_operations.py
@@ -478,11 +478,11 @@ class ModelOperations(_ScopeDependentOperations):
         :param version: Version of model asset.
         :type version: str
         :keyword share_with_name: Name of model asset to share with.
-        :type share_with_name: str
+        :paramtype share_with_name: str
         :keyword share_with_version: Version of model asset to share with.
-        :type share_with_version: str
+        :paramtype share_with_version: str
         :keyword registry_name: Name of the destination registry.
-        :type registry_name: str
+        :paramtype registry_name: str
         :return: Model asset object.
         :rtype: ~azure.ai.ml.entities.Model
         """

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_model_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_model_operations.py
@@ -424,12 +424,12 @@ class ModelOperations(_ScopeDependentOperations):
         """List all model assets in workspace.
 
         :param name: Name of the model.
-        :type name: Optional[str], optional
+        :type name: Optional[str]
         :param stage: The Model stage
-        :type stage: Optional[str], optional
+        :type stage: Optional[str]
         :keyword list_view_type: View type for including/excluding (for example) archived models. Defaults to
              :attr:`ListViewType.ACTIVE_ONLY`.
-        :type list_view_type: ListViewType, optional
+        :type list_view_type: ListViewType
         :return: An iterator like instance of Model objects
         :rtype: ~azure.core.paging.ItemPaged[Model]
         """

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_online_deployment_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_online_deployment_operations.py
@@ -93,11 +93,11 @@ class OnlineDeploymentOperations(_ScopeDependentOperations):
         :param deployment: the deployment entity
         :type deployment: ~azure.ai.ml.entities.OnlineDeployment
         :keyword local: Whether deployment should be created locally, defaults to False
-        :type local: bool, optional
+        :type local: bool
         :keyword vscode_debug: Whether to open VSCode instance to debug local deployment, defaults to False
-        :type vscode_debug: bool, optional
+        :type vscode_debug: bool
         :keyword local_enable_gpu: enable local container to access gpu
-        :type local_enable_gpu: bool, optional
+        :type local_enable_gpu: bool
         :raises ~azure.ai.ml.exceptions.ValidationException: Raised if OnlineDeployment cannot
             be successfully validated. Details will be provided in the error message.
         :raises ~azure.ai.ml.exceptions.AssetException: Raised if OnlineDeployment assets
@@ -291,9 +291,9 @@ class OnlineDeploymentOperations(_ScopeDependentOperations):
         :type lines: int
         :keyword container_type: The type of container to retrieve logs from. Possible values include:
             "StorageInitializer", "InferenceServer", defaults to None
-        :type container_type: Optional[str], optional
+        :type container_type: Optional[str]
         :keyword local: [description], defaults to False
-        :type local: bool, optional
+        :type local: bool
         :return: the logs
         :rtype: str
         """
@@ -321,7 +321,7 @@ class OnlineDeploymentOperations(_ScopeDependentOperations):
         :param endpoint_name: The name of the endpoint
         :type endpoint_name: str
         :keyword local: Whether deployment should be retrieved from local docker environment, defaults to False
-        :type local: bool, optional
+        :type local: bool
         :return: an iterator of deployment entities
         :rtype: Iterable[~azure.ai.ml.entities.OnlineDeployment]
         """

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_online_deployment_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_online_deployment_operations.py
@@ -93,11 +93,11 @@ class OnlineDeploymentOperations(_ScopeDependentOperations):
         :param deployment: the deployment entity
         :type deployment: ~azure.ai.ml.entities.OnlineDeployment
         :keyword local: Whether deployment should be created locally, defaults to False
-        :type local: bool
+        :paramtype local: bool
         :keyword vscode_debug: Whether to open VSCode instance to debug local deployment, defaults to False
-        :type vscode_debug: bool
+        :paramtype vscode_debug: bool
         :keyword local_enable_gpu: enable local container to access gpu
-        :type local_enable_gpu: bool
+        :paramtype local_enable_gpu: bool
         :raises ~azure.ai.ml.exceptions.ValidationException: Raised if OnlineDeployment cannot
             be successfully validated. Details will be provided in the error message.
         :raises ~azure.ai.ml.exceptions.AssetException: Raised if OnlineDeployment assets
@@ -224,7 +224,7 @@ class OnlineDeploymentOperations(_ScopeDependentOperations):
         :param endpoint_name: The name of the endpoint
         :type endpoint_name: str
         :keyword local: Whether deployment should be retrieved from local docker environment, defaults to False
-        :type local: Optional[bool]
+        :paramtype local: Optional[bool]
         :raises ~azure.ai.ml.exceptions.LocalEndpointNotFoundError: Raised if local endpoint resource does not exist.
         :return: a deployment entity
         :rtype: ~azure.ai.ml.entities.OnlineDeployment
@@ -255,7 +255,7 @@ class OnlineDeploymentOperations(_ScopeDependentOperations):
         :param endpoint_name: The name of the endpoint
         :type endpoint_name: str
         :keyword local: Whether deployment should be retrieved from local docker environment, defaults to False
-        :type local: Optional[bool]
+        :paramtype local: Optional[bool]
         :raises ~azure.ai.ml.exceptions.LocalEndpointNotFoundError: Raised if local endpoint resource does not exist.
         :return: A poller to track the operation status
         :rtype: ~azure.core.polling.LROPoller[None]
@@ -293,7 +293,7 @@ class OnlineDeploymentOperations(_ScopeDependentOperations):
             "StorageInitializer", "InferenceServer", defaults to None
         :type container_type: Optional[str]
         :keyword local: [description], defaults to False
-        :type local: bool
+        :paramtype local: bool
         :return: the logs
         :rtype: str
         """
@@ -321,7 +321,7 @@ class OnlineDeploymentOperations(_ScopeDependentOperations):
         :param endpoint_name: The name of the endpoint
         :type endpoint_name: str
         :keyword local: Whether deployment should be retrieved from local docker environment, defaults to False
-        :type local: bool
+        :paramtype local: bool
         :return: an iterator of deployment entities
         :rtype: Iterable[~azure.ai.ml.entities.OnlineDeployment]
         """

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_online_endpoint_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_online_endpoint_operations.py
@@ -121,7 +121,7 @@ class OnlineEndpointOperations(_ScopeDependentOperations):
         :param name: Name of the endpoint.
         :type name: str
         :keyword local: Indicates whether to interact with endpoints in local Docker environment. Defaults to False.
-        :type local: Optional[bool]
+        :paramtype local: Optional[bool]
         :raises ~azure.ai.ml.exceptions.LocalEndpointNotFoundError: Raised if local endpoint resource does not exist.
         :return: Endpoint object retrieved from the service.
         :rtype: ~azure.ai.ml.entities.OnlineEndpoint
@@ -164,7 +164,7 @@ class OnlineEndpointOperations(_ScopeDependentOperations):
         :param name: Name of the endpoint.
         :type name: str
         :keyword local: Whether to interact with the endpoint in local Docker environment. Defaults to False.
-        :type local: bool
+        :paramtype local: bool
         :raises ~azure.ai.ml.exceptions.LocalEndpointNotFoundError: Raised if local endpoint resource does not exist.
         :return: A poller to track the operation status if remote, else returns None if local.
         :rtype: ~azure.core.polling.LROPoller[None]
@@ -200,7 +200,7 @@ class OnlineEndpointOperations(_ScopeDependentOperations):
         :param endpoint: The endpoint entity.
         :type endpoint: ~azure.ai.ml.entities.OnlineEndpoint
         :keyword local: Whether to interact with the endpoint in local Docker environment. Defaults to False.
-        :type local: bool
+        :paramtype local: bool
         :raises ~azure.ai.ml.exceptions.ValidationException: Raised if OnlineEndpoint cannot be successfully validated.
             Details will be provided in the error message.
         :raises ~azure.ai.ml.exceptions.AssetException: Raised if OnlineEndpoint assets
@@ -268,7 +268,7 @@ class OnlineEndpointOperations(_ScopeDependentOperations):
         :param name: The endpoint name.
         :type name: The endpoint type. Defaults to ONLINE_ENDPOINT_TYPE.
         :keyword key_type: One of "primary", "secondary". Defaults to "primary".
-        :type key_type: str
+        :paramtype key_type: str
         :return: A poller to track the operation status.
         :rtype: ~azure.core.polling.LROPoller[None]
         """
@@ -308,14 +308,14 @@ class OnlineEndpointOperations(_ScopeDependentOperations):
         :param endpoint_name: The endpoint name
         :type endpoint_name: str
         :keyword request_file: File containing the request payload. This is only valid for online endpoint.
-        :type request_file: Optional[str]
+        :paramtype request_file: Optional[str]
         :keyword deployment_name: Name of a specific deployment to invoke. This is optional.
             By default requests are routed to any of the deployments according to the traffic rules.
-        :type deployment_name: Optional[str]
+        :paramtype deployment_name: Optional[str]
         :keyword input_data: To use a pre-registered data asset, pass str in format
-        :type input_data: Optional[Union[str, Data]]
+        :paramtype input_data: Optional[Union[str, Data]]
         :keyword local: Indicates whether to interact with endpoints in local Docker environment. Defaults to False.
-        :type local: Optional[bool]
+        :paramtype local: Optional[bool]
         :raises ~azure.ai.ml.exceptions.LocalEndpointNotFoundError: Raised if local endpoint resource does not exist.
         :raises ~azure.ai.ml.exceptions.MultipleLocalDeploymentsFoundError: Raised if there are multiple deployments
             and no deployment_name is specified.

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_operation_orchestrator.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_operation_orchestrator.py
@@ -447,7 +447,7 @@ class OperationOrchestrator(object):
         TODO: It is debatable whether this method should be in operation_orchestrator.
 
         :param arm_id: entity's ARM id, defaults to None
-        :type arm_id: str, optional
+        :type arm_id: str
         :return: AzureML id
         :rtype: str
         """

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_registry_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_registry_operations.py
@@ -53,7 +53,7 @@ class RegistryOperations:
         """List all registries that the user has access to in the current resource group or subscription.
 
         :keyword scope: scope of the listing, "resource_group" or "subscription", defaults to "resource_group"
-        :type scope: str, optional
+        :type scope: str
         :return: An iterator like instance of Registry objects
         :rtype: ~azure.core.paging.ItemPaged[Registry]
         """

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_registry_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_registry_operations.py
@@ -53,7 +53,7 @@ class RegistryOperations:
         """List all registries that the user has access to in the current resource group or subscription.
 
         :keyword scope: scope of the listing, "resource_group" or "subscription", defaults to "resource_group"
-        :type scope: str
+        :paramtype scope: str
         :return: An iterator like instance of Registry objects
         :rtype: ~azure.core.paging.ItemPaged[Registry]
         """
@@ -149,7 +149,7 @@ class RegistryOperations:
         """Delete a registry if it exists. Returns nothing on a successful operation.
 
         :keyword name: Name of the registry
-        :type name: str
+        :paramtype name: str
         :return: A poller to track the operation status.
         :rtype: LROPoller
         """

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_virtual_cluster_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_virtual_cluster_operations.py
@@ -70,7 +70,7 @@ class VirtualClusterOperations:
 
         :keyword scope: scope of the listing, "subscription" or None, defaults to None.
             If None, list virtual clusters across all subscriptions a customer has access to.
-        :type scope: str, optional
+        :type scope: str
         :return: An iterator like instance of dictionaries.
         :rtype: ~azure.core.paging.ItemPaged[Dict]
         """

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_virtual_cluster_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_virtual_cluster_operations.py
@@ -70,7 +70,7 @@ class VirtualClusterOperations:
 
         :keyword scope: scope of the listing, "subscription" or None, defaults to None.
             If None, list virtual clusters across all subscriptions a customer has access to.
-        :type scope: str
+        :paramtype scope: str
         :return: An iterator like instance of dictionaries.
         :rtype: ~azure.core.paging.ItemPaged[Dict]
         """

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_workspace_hub_operation.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_workspace_hub_operation.py
@@ -58,7 +58,7 @@ class WorkspaceHubOperations(WorkspaceOperationsBase):
         resource group or subscription.
 
         :keyword scope: scope of the listing, "resource_group" or "subscription", defaults to "resource_group"
-        :type scope: str, optional
+        :type scope: str
         :return: An iterator like instance of WorkspaceHub objects
         :rtype: ~azure.core.paging.ItemPaged[WorkspaceHub]
         """

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_workspace_hub_operation.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_workspace_hub_operation.py
@@ -58,7 +58,7 @@ class WorkspaceHubOperations(WorkspaceOperationsBase):
         resource group or subscription.
 
         :keyword scope: scope of the listing, "resource_group" or "subscription", defaults to "resource_group"
-        :type scope: str
+        :paramtype scope: str
         :return: An iterator like instance of WorkspaceHub objects
         :rtype: ~azure.core.paging.ItemPaged[WorkspaceHub]
         """
@@ -175,10 +175,10 @@ class WorkspaceHubOperations(WorkspaceOperationsBase):
         :keyword delete_dependent_resources: Whether to delete resources associated with the WorkspaceHub,
             i.e., container registry, storage account, key vault.
             The default is False. Set to True to delete these resources.
-        :type delete_dependent_resources: bool
+        :paramtype delete_dependent_resources: bool
         :keyword permanently_delete: Workspaces are soft-deleted by default to allow recovery of workspace data.
             Set this flag to true to override the soft-delete behavior and permanently delete your workspace.
-        :type permanently_delete: bool
+        :paramtype permanently_delete: bool
         :return: A poller to track the operation status.
         :rtype: ~azure.core.polling.LROPoller[None]
         """

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_workspace_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_workspace_operations.py
@@ -63,7 +63,7 @@ class WorkspaceOperations(WorkspaceOperationsBase):
         """List all workspaces that the user has access to in the current resource group or subscription.
 
         :keyword scope: scope of the listing, "resource_group" or "subscription", defaults to "resource_group"
-        :type scope: str, optional
+        :type scope: str
         :return: An iterator like instance of Workspace objects
         :rtype: ~azure.core.paging.ItemPaged[Workspace]
         """

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_workspace_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_workspace_operations.py
@@ -63,7 +63,7 @@ class WorkspaceOperations(WorkspaceOperationsBase):
         """List all workspaces that the user has access to in the current resource group or subscription.
 
         :keyword scope: scope of the listing, "resource_group" or "subscription", defaults to "resource_group"
-        :type scope: str
+        :paramtype scope: str
         :return: An iterator like instance of Workspace objects
         :rtype: ~azure.core.paging.ItemPaged[Workspace]
         """
@@ -136,7 +136,7 @@ class WorkspaceOperations(WorkspaceOperationsBase):
         as true prepares the workspace managed network for supporting Spark.
 
         :keyword workspace_name: Name of the workspace.
-        :type workspace_name: str
+        :paramtype workspace_name: str
         :return: An instance of LROPoller.
         :rtype: ~azure.core.polling.LROPoller[~azure.ai.ml.entities.ManagedNetworkProvisionStatus]
         """
@@ -199,10 +199,10 @@ class WorkspaceOperations(WorkspaceOperationsBase):
         :keyword delete_dependent_resources: Whether to delete resources associated with the workspace,
             i.e., container registry, storage account, key vault, and application insights.
             The default is False. Set to True to delete these resources.
-        :type delete_dependent_resources: bool
+        :paramtype delete_dependent_resources: bool
         :keyword permanently_delete: Workspaces are soft-deleted by default to allow recovery of workspace data.
             Set this flag to true to override the soft-delete behavior and permanently delete your workspace.
-        :type permanently_delete: bool
+        :paramtype permanently_delete: bool
         :return: A poller to track the operation status.
         :rtype: ~azure.core.polling.LROPoller[None]
         """


### PR DESCRIPTION
# Description

This PR addresses several docstring related comments brought up in our SDK view:

* Remove `, optional` from `:type:` fields in docstrings
  
  This seems to have been breaking ApiVIEW's type parser, and prevented type hints from appearing in the review tool.

  Sphinx may annotate this automatically.

* Use `:paramtype` instead of `:type` when annotating the type of a `:keyword:` argument

  Sphinx doesn't pick up the type unless `:paramtype` is used

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
