### PR TITLE
fix CODEOWNERs for Service Attention tag

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -425,7 +425,7 @@
 # ServiceLabel: %Bot Service %Service Attention
 #/<NotInRepo>/          @sgellock
 
-# ServiceLabel: %Client
+# ServiceLabel: %Cosmos %Service Attention
 #/<NotInRepo>/          @simorenoh @gahl-levy @bambriz
 
 # ServiceLabel: %Cloud Shell %Service Attention


### PR DESCRIPTION
I think this might have been a copy/paste mistake, any client + service attention tags are erroneously going to the cosmos folks