### PR TITLE
[Test Proxy] Support `config` commands in `manage_recordings.py`

### DIFF
--- a/doc/dev/tests.md
+++ b/doc/dev/tests.md
@@ -396,23 +396,31 @@ recordings. If you `cd` into the folder containing your package's recordings, yo
 recording updates you've made. You can also use other `git` commands; for example, `git diff {file name}` to see
 specific file changes, or `git restore {file name}` to undo changes you don't want to keep.
 
-To find the directory containing your package's recordings, open the `.breadcrumb` file in the `.assets` folder. This
-file lists a package name on each line, followed by the recording directory name; for example:
-```
-sdk/{service}/{package}/assets.json;2Km2Z8755;python/{service}/{package}_<10-character-commit-SHA>
-```
-The recording directory in this case is `2Km2Z8755`, the string between the two semicolons.
+To find the directory containing your package's recordings, you can use the [`manage_recordings.py`][manage_recordings]
+script from `azure-sdk-for-python/scripts`. This script accepts a verb and a **relative** path to your package's
+`assets.json` file (this path is optional, and is simply `assets.json` by default).
 
-After verifying that your recording updates look correct, you can use the [`manage_recordings.py`][manage_recordings]
-script from `azure-sdk-for-python/scripts` to push these recordings to the `azure-sdk-assets` repo. This script accepts
-a verb and a **relative** path to your package's `assets.json` file (this path is optional, and is simply `assets.json`
-by default). For example, from the root of the `azure-sdk-for-python` repo:
+For example, to view the location of `azure-keyvault-keys`'s recordings, from a current working directory at the root
+of the repo, run the following command:
+```
+python scripts/manage_recordings.py locate -p sdk/keyvault/azure-keyvault-keys
+```
+
+The output will include an absolute path to the recordings directory; in this case:
+```
+C:/azure-sdk-for-python/.assets/Y0iKQSfTwa/python
+```
+
+After verifying that your recording updates look correct, you can use [`manage_recordings.py`][manage_recordings] to
+push your recordings to the `azure-sdk-assets` repo:
 ```
 python scripts/manage_recordings.py push -p sdk/{service}/{package}/assets.json
 ```
 
-The verbs that can be provided to this script are "push", "restore", and "reset":
+The verbs that can be provided to this script are "locate", "push", "show", "restore", and "reset":
+- **locate**: prints the location of the library's locally cached recordings.
 - **push**: pushes recording updates to a new assets repo tag and updates the tag pointer in `assets.json`.
+- **show**: prints the contents of the provided `assets.json` file.
 - **restore**: fetches recordings from the assets repo, based on the tag pointer in `assets.json`.
 - **reset**: discards any pending changes to recordings, based on the tag pointer in `assets.json`.
 


### PR DESCRIPTION
# Description

Resolves https://github.com/Azure/azure-sdk-for-python/issues/31011. This adds Python support for `test-proxy config locate` and `test-proxy config show`, and updates documentation accordingly.

This also simplifies the `manage_recordings.py` script, which was previously starting up the test proxy before running commands. This startup is no longer necessary since Docker is out of use.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
