### PR TITLE
[Identity] Disable loading profiles in powershell

### DIFF
--- a/sdk/identity/azure-identity/CHANGELOG.md
+++ b/sdk/identity/azure-identity/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bugs Fixed
 
-- Ensure `AzurePowershellCredential` calls PowerShell with the `-NoProfile` flag to avoid loading user profiles for more consistent behavior.
+- Ensure `AzurePowershellCredential` calls PowerShell with the `-NoProfile` flag to avoid loading user profiles for more consistent behavior.  ([#31682](https://github.com/Azure/azure-sdk-for-python/pull/31682))
 
 ### Other Changes
 

--- a/sdk/identity/azure-identity/CHANGELOG.md
+++ b/sdk/identity/azure-identity/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Ensure `AzurePowershellCredential` calls PowerShell with the `-NoProfile` flag to avoid loading user profiles for more consistent behavior.
+
 ### Other Changes
 
 ## 1.14.0 (2023-08-08)

--- a/sdk/identity/azure-identity/azure/identity/_credentials/azure_powershell.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/azure_powershell.py
@@ -183,7 +183,7 @@ def get_command_line(scopes: Tuple[str, ...], tenant_id: str) -> List[str]:
     script = SCRIPT.format(NO_AZ_ACCOUNT_MODULE, resource, tenant_argument)
     encoded_script = base64.b64encode(script.encode("utf-16-le")).decode()
 
-    command = "pwsh -NonInteractive -EncodedCommand " + encoded_script
+    command = "pwsh -NoProfile -NonInteractive -EncodedCommand " + encoded_script
     if sys.platform.startswith("win"):
         return ["cmd", "/c", command]
     return ["/bin/sh", "-c", command]

--- a/sdk/identity/azure-identity/tests/test_powershell_credential.py
+++ b/sdk/identity/azure-identity/tests/test_powershell_credential.py
@@ -88,7 +88,7 @@ def test_get_token(stderr):
     assert Popen.call_count == 1
     args, kwargs = Popen.call_args
     command = args[0][-1]
-    assert command.startswith("pwsh -NonInteractive -EncodedCommand ")
+    assert command.startswith("pwsh -NoProfile -NonInteractive -EncodedCommand ")
 
     encoded_script = command.split()[-1]
     decoded_script = base64.b64decode(encoded_script).decode("utf-16-le")
@@ -267,7 +267,7 @@ def test_multitenant_authentication():
     second_token = first_token * 2
 
     def fake_Popen(command, **_):
-        assert command[-1].startswith("pwsh -NonInteractive -EncodedCommand ")
+        assert command[-1].startswith("pwsh -NoProfile -NonInteractive -EncodedCommand ")
         encoded_script = command[-1].split()[-1]
         decoded_script = base64.b64decode(encoded_script).decode("utf-16-le")
         match = re.search(r"Get-AzAccessToken -ResourceUrl '(\S+)'(?: -TenantId (\S+))?", decoded_script)
@@ -297,7 +297,7 @@ def test_multitenant_authentication_not_allowed():
     expected_token = "***"
 
     def fake_Popen(command, **_):
-        assert command[-1].startswith("pwsh -NonInteractive -EncodedCommand ")
+        assert command[-1].startswith("pwsh -NoProfile -NonInteractive -EncodedCommand ")
         encoded_script = command[-1].split()[-1]
         decoded_script = base64.b64decode(encoded_script).decode("utf-16-le")
         match = re.search(r"Get-AzAccessToken -ResourceUrl '(\S+)'(?: -TenantId (\S+))?", decoded_script)

--- a/sdk/identity/azure-identity/tests/test_powershell_credential_async.py
+++ b/sdk/identity/azure-identity/tests/test_powershell_credential_async.py
@@ -78,7 +78,7 @@ async def test_get_token(stderr):
     assert mock_exec.call_count == 1
     args, kwargs = mock_exec.call_args
     command = args[-1]
-    assert command.startswith("pwsh -NonInteractive -EncodedCommand ")
+    assert command.startswith("pwsh -NoProfile -NonInteractive -EncodedCommand ")
 
     encoded_script = command.split()[-1]
     decoded_script = base64.b64decode(encoded_script).decode("utf-16-le")
@@ -265,7 +265,7 @@ async def test_multitenant_authentication():
 
     async def fake_exec(*args, **_):
         command = args[2]
-        assert command.startswith("pwsh -NonInteractive -EncodedCommand ")
+        assert command.startswith("pwsh -NoProfile -NonInteractive -EncodedCommand ")
         encoded_script = command.split()[-1]
         decoded_script = base64.b64decode(encoded_script).decode("utf-16-le")
         match = re.search(r"Get-AzAccessToken -ResourceUrl '(\S+)'(?: -TenantId (\S+))?", decoded_script)
@@ -296,7 +296,7 @@ async def test_multitenant_authentication_not_allowed():
 
     async def fake_exec(*args, **_):
         command = args[2]
-        assert command.startswith("pwsh -NonInteractive -EncodedCommand ")
+        assert command.startswith("pwsh -NoProfile -NonInteractive -EncodedCommand ")
         encoded_script = command.split()[-1]
         decoded_script = base64.b64decode(encoded_script).decode("utf-16-le")
         match = re.search(r"Get-AzAccessToken -ResourceUrl '(\S+)'(?: -TenantId (\S+))?", decoded_script)


### PR DESCRIPTION
Passing `-NoProfile` is generally recommended to ensure the powershell script is run in the default environment without user profile side effects interfering.
