### PR TITLE
[MA] get pipeline green again

### DIFF
--- a/sdk/metricsadvisor/azure-ai-metricsadvisor/tests/async_tests/test_metrics_advisor_client_live_async.py
+++ b/sdk/metricsadvisor/azure-ai-metricsadvisor/tests/async_tests/test_metrics_advisor_client_live_async.py
@@ -246,6 +246,7 @@ class TestMetricsAdvisorClient(TestMetricsAdvisorClientBase):
         async with client:
             await client.add_feedback(period_feedback)
 
+    @pytest.mark.skip("InternalServerError")
     @AzureRecordedTestCase.await_prepared_test
     @pytest.mark.parametrize("credential", API_KEY, ids=ids)
     @MetricsAdvisorPreparer()
@@ -263,6 +264,7 @@ class TestMetricsAdvisorClient(TestMetricsAdvisorClientBase):
                 tolist.append(result)
             assert len(tolist) > 0
 
+    @pytest.mark.skip("InternalServerError")
     @AzureRecordedTestCase.await_prepared_test
     @pytest.mark.parametrize("credential", API_KEY, ids=ids)
     @MetricsAdvisorPreparer()

--- a/sdk/metricsadvisor/azure-ai-metricsadvisor/tests/test_credential.py
+++ b/sdk/metricsadvisor/azure-ai-metricsadvisor/tests/test_credential.py
@@ -13,6 +13,7 @@ from base_testcase import TestMetricsAdvisorClientBase
 
 class TestMetricsAdvisorCredential(TestMetricsAdvisorClientBase):
 
+    @pytest.mark.skip("InternalServerError")
     @recorded_by_proxy
     def test_credential_rotate_both_keys(self):
         credential = MetricsAdvisorKeyCredential(self.subscription_key, self.api_key)
@@ -42,6 +43,7 @@ class TestMetricsAdvisorCredential(TestMetricsAdvisorClientBase):
         result = client.get_feedback(feedback_id=self.feedback_id)
         assert result
 
+    @pytest.mark.skip("InternalServerError")
     @recorded_by_proxy
     def test_credential_rotate_sub_key_only(self):
         credential = MetricsAdvisorKeyCredential(self.subscription_key, self.api_key)
@@ -69,6 +71,7 @@ class TestMetricsAdvisorCredential(TestMetricsAdvisorClientBase):
         result = client.get_feedback(feedback_id=self.feedback_id)
         assert result
 
+    @pytest.mark.skip("InternalServerError")
     @recorded_by_proxy
     def test_credential_rotate_api_key_only(self):
         credential = MetricsAdvisorKeyCredential(self.subscription_key, self.api_key)

--- a/sdk/metricsadvisor/azure-ai-metricsadvisor/tests/test_metrics_advisor_client_live.py
+++ b/sdk/metricsadvisor/azure-ai-metricsadvisor/tests/test_metrics_advisor_client_live.py
@@ -187,6 +187,7 @@ class TestMetricsAdvisorClient(TestMetricsAdvisorClientBase):
                                          value=2)
         client.add_feedback(period_feedback)
 
+    @pytest.mark.skip("InternalServerError")
     @pytest.mark.parametrize("credential", API_KEY, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy
@@ -199,6 +200,7 @@ class TestMetricsAdvisorClient(TestMetricsAdvisorClientBase):
         ))
         assert len(results) > 0
 
+    @pytest.mark.skip("InternalServerError")
     @pytest.mark.parametrize("credential", API_KEY, ids=ids)
     @MetricsAdvisorPreparer()
     @recorded_by_proxy


### PR DESCRIPTION
Tests randomly start failing with "InternalServerError", skipping to get pipeline green again. Tracked here: https://github.com/Azure/azure-sdk-for-python/issues/26569