### PR TITLE
revert format_url

### DIFF
--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 ### Bugs Fixed
 
-- Encoded URL before formatting it. #31346
 - Typing fix: `message` cannot be `None` in `AzureError`. #31564
 
 ## 1.29.2 (2023-08-14)

--- a/sdk/core/azure-core/azure/core/pipeline/transport/_base.py
+++ b/sdk/core/azure-core/azure/core/pipeline/transport/_base.py
@@ -30,7 +30,7 @@ import json
 import logging
 import time
 import copy
-from urllib.parse import urlparse, quote
+from urllib.parse import urlparse
 import xml.etree.ElementTree as ET
 
 from typing import (
@@ -591,8 +591,7 @@ class PipelineClientBase:
         :return: An HttpRequest object
         :rtype: ~azure.core.pipeline.transport.HttpRequest
         """
-        encoded_url = url.replace("{", quote("{")).replace("}", quote("}"))
-        request = HttpRequest(method, self.format_url(encoded_url))
+        request = HttpRequest(method, self.format_url(url))
 
         if params:
             request.format_parameters(params)
@@ -623,7 +622,7 @@ class PipelineClientBase:
 
         return request
 
-    def format_url(self, url_template: str, **kwargs: Any) -> str:
+    def format_url(self, url_template: str, **kwargs) -> str:
         """Format request URL with the client base URL, unless the
         supplied URL is already absolute.
 
@@ -817,7 +816,7 @@ class PipelineClientBase:
         return request
 
     def options(
-        self, url: str, params: Optional[Dict[str, str]] = None, headers: Optional[Dict[str, str]] = None, **kwargs: Any
+        self, url: str, params: Optional[Dict[str, str]] = None, headers: Optional[Dict[str, str]] = None, **kwargs
     ) -> HttpRequest:
         """Create a OPTIONS request object.
 

--- a/sdk/core/azure-core/tests/test_pipeline.py
+++ b/sdk/core/azure-core/tests/test_pipeline.py
@@ -204,20 +204,6 @@ def test_format_url_double_query():
     assert formatted == "https://bing.com/path/subpath?query=testvalue&x=2ndvalue&a=X&c=Y"
 
 
-def test_format_url_braces_with_dot():
-    base_url = "https://bing.com/{aaa.bbb}"
-    client = PipelineClientBase(base_url)
-    request = client._request("GET", base_url, None, None, None, None, None)
-    assert request
-
-
-def test_format_url_single_brace():
-    base_url = "https://bing.com/{aaa.bbb"
-    client = PipelineClientBase(base_url)
-    request = client._request("GET", base_url, None, None, None, None, None)
-    assert request
-
-
 def test_format_incorrect_endpoint():
     # https://github.com/Azure/azure-sdk-for-python/pull/12106
     client = PipelineClientBase("{Endpoint}/text/analytics/v3.0")
@@ -366,12 +352,7 @@ def test_add_custom_policy():
     pos_retry = policies.index(retry_policy)
     assert pos_boo > pos_retry
 
-    client = PipelineClient(
-        base_url="test",
-        config=config,
-        per_call_policies=boo_policy,
-        per_retry_policies=foo_policy,
-    )
+    client = PipelineClient(base_url="test", config=config, per_call_policies=boo_policy, per_retry_policies=foo_policy)
     policies = client._pipeline._impl_policies
     assert boo_policy in policies
     assert foo_policy in policies
@@ -382,10 +363,7 @@ def test_add_custom_policy():
     assert pos_foo > pos_retry
 
     client = PipelineClient(
-        base_url="test",
-        config=config,
-        per_call_policies=[boo_policy],
-        per_retry_policies=[foo_policy],
+        base_url="test", config=config, per_call_policies=[boo_policy], per_retry_policies=[foo_policy]
     )
     policies = client._pipeline._impl_policies
     assert boo_policy in policies
@@ -412,19 +390,13 @@ def test_add_custom_policy():
     assert foo_policy == actual_policies[2]
 
     client = PipelineClient(
-        base_url="test",
-        policies=policies,
-        per_call_policies=boo_policy,
-        per_retry_policies=foo_policy,
+        base_url="test", policies=policies, per_call_policies=boo_policy, per_retry_policies=foo_policy
     )
     actual_policies = client._pipeline._impl_policies
     assert boo_policy == actual_policies[0]
     assert foo_policy == actual_policies[3]
     client = PipelineClient(
-        base_url="test",
-        policies=policies,
-        per_call_policies=[boo_policy],
-        per_retry_policies=[foo_policy],
+        base_url="test", policies=policies, per_call_policies=[boo_policy], per_retry_policies=[foo_policy]
     )
     actual_policies = client._pipeline._impl_policies
     assert boo_policy == actual_policies[0]


### PR DESCRIPTION
After some discussions, we decided to put the url-encoding job into autorest/SDK developer rather than handling it in azure-core.