### PR TITLE
Fix typo in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,7 +71,7 @@ breaking         -> Runs the breaking changes checker against a package
 
 Basic usage of `tox` within this monorepo is:
 
-1. `pip install tox<5`
+1. `pip install 'tox<5'`
 2. Run `tox run -e ENV_NAME -c path/to/tox.ini --root path/to/python_package`
   * **Note**: You can use environment variables to provide defaults for tox config values
     * With `TOX_CONFIG_FILE` set to the absolute path of `tox.ini`, you can avoid needing `-c path/to/tox.ini` in your tox invocations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,7 +71,7 @@ breaking         -> Runs the breaking changes checker against a package
 
 Basic usage of `tox` within this monorepo is:
 
-1. `pip install 'tox<5'`
+1. `pip install "tox<5"`
 2. Run `tox run -e ENV_NAME -c path/to/tox.ini --root path/to/python_package`
   * **Note**: You can use environment variables to provide defaults for tox config values
     * With `TOX_CONFIG_FILE` set to the absolute path of `tox.ini`, you can avoid needing `-c path/to/tox.ini` in your tox invocations


### PR DESCRIPTION
# Description

Fix small typo in CONTRIBUTING.md
`pip install tox<5` -> `pip install 'tox<5'`
Without quotes, the shell recognizes the `<` as **stdout stream operator**.
So, I added quotation marks and made the correction.

# All SDK Contribution checklist:
- [X] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [X] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [X] Title of the pull request is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
