### PR TITLE
[ML] fix: Revert typing change on base_node.inputs base_node.outputs

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_builders/base_node.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_builders/base_node.py
@@ -21,7 +21,7 @@ from azure.ai.ml.entities._inputs_outputs import Input, Output
 from azure.ai.ml.entities._job._input_output_helpers import build_input_output
 from azure.ai.ml.entities._job.job import Job
 from azure.ai.ml.entities._job.pipeline._attr_dict import _AttrDict
-from azure.ai.ml.entities._job.pipeline._io import NodeInput, NodeOutput, PipelineInput
+from azure.ai.ml.entities._job.pipeline._io import NodeOutput, PipelineInput
 from azure.ai.ml.entities._job.pipeline._io.mixin import NodeWithGroupInputMixin
 from azure.ai.ml.entities._job.pipeline._pipeline_expression import PipelineExpression
 from azure.ai.ml.entities._job.sweep.search_space import SweepDistribution
@@ -489,20 +489,20 @@ class BaseNode(Job, YamlTranslatableMixin, _AttrDict, SchemaValidatableMixin, No
         return convert_ordered_dict_to_dict(rest_obj)
 
     @property
-    def inputs(self) -> Dict[str, NodeInput]:
+    def inputs(self) -> Dict[str, Union[Input, str, bool, int, float]]:
         """Get the inputs for the object.
 
         :return: A dictionary containing the inputs for the object.
-        :rtype: Dict[str, NodeInput]
+        :rtype: Dict[str, Union[Input, str, bool, int, float]]
         """
         return self._inputs
 
     @property
-    def outputs(self) -> Dict[str, NodeOutput]:
+    def outputs(self) -> Dict[str, Union[str, Output]]:
         """Get the outputs of the object.
 
         :return: A dictionary containing the outputs for the object.
-        :rtype: Dict[str, Union[str, NodeOutput]
+        :rtype: Dict[str, Union[str, Output]]
         """
         return self._outputs
 


### PR DESCRIPTION
# Description

This pull request reverts a type hint change to BaseNode.inputs and BaseNode.outputs from #31553 that is being flagged as a breaking change in ApiView. Both the old type hint and the new type hint are partially correct, but this is to be revisited once the SDK's is made to type check with mypy.

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
