### PR TITLE
Fixes for mypy CI check

### DIFF
--- a/eng/tox/run_mypy.py
+++ b/eng/tox/run_mypy.py
@@ -76,19 +76,25 @@ if __name__ == "__main__":
             f"Package {package_name} opts-out of mypy check on samples."
         )
     else:
-        sample_code = [
-            *commands,
-            "--check-untyped-defs",
-            "--follow-imports=silent",
-            os.path.join(args.target_package, "samples")
-        ]
-        try:
+        # check if samples dir exists, if not, skip sample code check
+        if not os.path.exists(os.path.join(args.target_package, "samples")):
             logging.info(
-                f"Running mypy commands on sample code: {sample_code}"
+                f"Package {package_name} does not have a samples directory."
             )
-            check_call(sample_code)
-        except CalledProcessError as sample_err:
-            sample_code_error = sample_err
+        else:
+            sample_code = [
+                *commands,
+                "--check-untyped-defs",
+                "--follow-imports=silent",
+                os.path.join(args.target_package, "samples")
+            ]
+            try:
+                logging.info(
+                    f"Running mypy commands on sample code: {sample_code}"
+                )
+                check_call(sample_code)
+            except CalledProcessError as sample_err:
+                sample_code_error = sample_err
 
     if args.next and in_ci() and is_check_enabled(args.target_package, "mypy") and not is_typing_ignored(package_name):
         if src_code_error or sample_code_error:

--- a/tools/azure-sdk-tools/gh_tools/vnext_issue_creator.py
+++ b/tools/azure-sdk-tools/gh_tools/vnext_issue_creator.py
@@ -114,7 +114,7 @@ def create_vnext_issue(package_name: str, check_type: Literal["mypy", "pylint", 
         f"\n**{check_type.capitalize()} errors:** [Link to build ({today.strftime('%Y-%m-%d')})]({build_link})"
         f"\n**How to fix:** Run the `next-{check_type}` tox command at the library package-level and resolve "
         f"the {error_type} errors.\n"
-        f"1) `../{package_name}>pip install tox<5`\n"
+        f"1) `../{package_name}>pip install \"tox<5\"`\n"
         f"2) `../{package_name}>tox run -e next-{check_type} -c ../../../eng/tox/tox.ini --root .`\n\n"
         f"See the {guide_link} for more information."
     )


### PR DESCRIPTION
Two small fixes:

1) Some libraries don't have a `samples` directory (e.g. stuff under `core` like azure-mgmt-core, opencensus), but we want to enable type checking of samples for the rest of the libraries under the same directory. In this case, we should just skip any library that doesn't have `samples` instead of failing.
2) In our vnext issue template, we say to `pip install tox<5`. To work with pwsh, cmd, and wsl, we should wrap tox in double quotes.