### PR TITLE
Remove explicite log procerros env var

### DIFF
--- a/sdk/monitor/azure-monitor-opentelemetry/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-opentelemetry/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Unpin OTel SDK/API version
     ([#310](https://github.com/microsoft/ApplicationInsights-Python/pull/310))
+- Replace explicit log processor exporter interval env var with OT SDK env var
+    ([#31740](https://github.com/Azure/azure-sdk-for-python/pull/31740))
 
 ### Breaking Changes
 

--- a/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_configure.py
+++ b/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_configure.py
@@ -25,7 +25,6 @@ from azure.monitor.opentelemetry._constants import (
     DISABLE_METRICS_ARG,
     DISABLE_TRACING_ARG,
     DISABLED_INSTRUMENTATIONS_ARG,
-    LOGGING_EXPORT_INTERVAL_MS_ARG,
     SAMPLING_RATIO_ARG,
 )
 from azure.monitor.opentelemetry._types import ConfigurationValue
@@ -114,14 +113,11 @@ def _setup_tracing(configurations: Dict[str, ConfigurationValue]):
 
 
 def _setup_logging(configurations: Dict[str, ConfigurationValue]):
-    # TODO: Remove after upgrading to OTel SDK 1.18
-    logging_export_interval_ms = configurations[LOGGING_EXPORT_INTERVAL_MS_ARG]
     logger_provider = LoggerProvider()
     set_logger_provider(logger_provider)
     log_exporter = AzureMonitorLogExporter(**configurations)
     log_record_processor = BatchLogRecordProcessor(
         log_exporter,
-        schedule_delay_millis=cast(int, logging_export_interval_ms),
     )
     get_logger_provider().add_log_record_processor(log_record_processor)
     handler = LoggingHandler(logger_provider=get_logger_provider())

--- a/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_constants.py
+++ b/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_constants.py
@@ -21,7 +21,6 @@ DISABLE_LOGGING_ARG = "disable_logging"
 DISABLE_METRICS_ARG = "disable_metrics"
 DISABLE_TRACING_ARG = "disable_tracing"
 DISABLED_INSTRUMENTATIONS_ARG = "disabled_instrumentations"
-LOGGING_EXPORT_INTERVAL_MS_ARG = "logging_export_interval_ms"
 SAMPLING_RATIO_ARG = "sampling_ratio"
 
 

--- a/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/util/_configurations.py
+++ b/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/util/_configurations.py
@@ -21,7 +21,6 @@ from azure.monitor.opentelemetry._constants import (
     DISABLE_METRICS_ARG,
     DISABLE_TRACING_ARG,
     DISABLED_INSTRUMENTATIONS_ARG,
-    LOGGING_EXPORT_INTERVAL_MS_ARG,
     SAMPLING_RATIO_ARG,
 )
 from azure.monitor.opentelemetry._types import ConfigurationValue
@@ -34,8 +33,6 @@ _INVALID_FLOAT_MESSAGE = "Value of %s must be a float. Defaulting to %s: %s"
 _INVALID_INT_MESSAGE = "Value of %s must be a integer. Defaulting to %s: %s"
 
 
-# Speced out but unused by OTel SDK as of 1.17.0
-LOGGING_EXPORT_INTERVAL_MS_ENV_VAR = "OTEL_BLRP_SCHEDULE_DELAY"
 # TODO: remove when sampler uses env var instead
 SAMPLING_RATIO_ENV_VAR = OTEL_TRACES_SAMPLER_ARG
 
@@ -53,15 +50,8 @@ def _get_configurations(**kwargs) -> Dict[str, ConfigurationValue]:
     _default_disable_metrics(configurations)
     _default_disable_tracing(configurations)
     _default_disabled_instrumentations(configurations)
-    _default_logging_export_interval_ms(configurations)
     _default_sampling_ratio(configurations)
     _default_disable_azure_core_tracing(configurations)
-
-    # TODO: remove when validation added to BLRP
-    if configurations[LOGGING_EXPORT_INTERVAL_MS_ARG] <= 0:
-        raise ValueError(
-            "%s must be positive." % LOGGING_EXPORT_INTERVAL_MS_ARG
-        )
 
     return configurations
 
@@ -101,21 +91,6 @@ def _default_disabled_instrumentations(configurations):
             x.strip() for x in disabled_instrumentation
         ]
     configurations[DISABLED_INSTRUMENTATIONS_ARG] = disabled_instrumentation
-
-
-def _default_logging_export_interval_ms(configurations):
-    default = 5000
-    if LOGGING_EXPORT_INTERVAL_MS_ENV_VAR in environ:
-        try:
-            default = int(environ[LOGGING_EXPORT_INTERVAL_MS_ENV_VAR])
-        except ValueError as e:
-            _logger.error(
-                _INVALID_INT_MESSAGE,
-                LOGGING_EXPORT_INTERVAL_MS_ENV_VAR,
-                default,
-                e,
-            )
-    configurations[LOGGING_EXPORT_INTERVAL_MS_ARG] = default
 
 
 # TODO: remove when sampler uses env var instead

--- a/sdk/monitor/azure-monitor-opentelemetry/tests/configuration/test_configure.py
+++ b/sdk/monitor/azure-monitor-opentelemetry/tests/configuration/test_configure.py
@@ -270,7 +270,6 @@ class TestConfigure(unittest.TestCase):
 
         configurations = {
             "connection_string": "test_cs",
-            "logging_export_interval_ms": 10000,
         }
         _setup_logging(configurations)
 
@@ -279,7 +278,7 @@ class TestConfigure(unittest.TestCase):
         get_logger_provider_mock.assert_called()
         log_exporter_mock.assert_called_once_with(**configurations)
         blrp_mock.assert_called_once_with(
-            log_exp_init_mock, schedule_delay_millis=10000
+            log_exp_init_mock,
         )
         lp_init_mock.add_log_record_processor.assert_called_once_with(
             blrp_init_mock

--- a/sdk/monitor/azure-monitor-opentelemetry/tests/configuration/test_util.py
+++ b/sdk/monitor/azure-monitor-opentelemetry/tests/configuration/test_util.py
@@ -19,7 +19,6 @@ from azure.monitor.opentelemetry._vendor.v0_39b0.opentelemetry.instrumentation.e
     OTEL_PYTHON_DISABLED_INSTRUMENTATIONS,
 )
 from azure.monitor.opentelemetry.util._configurations import (
-    LOGGING_EXPORT_INTERVAL_MS_ENV_VAR,
     SAMPLING_RATIO_ENV_VAR,
     _get_configurations,
 )
@@ -44,7 +43,6 @@ class TestUtil(TestCase):
         self.assertEqual(configurations["disable_tracing"], False)
         self.assertEqual(configurations["disabled_instrumentations"], [])
         self.assertEqual(configurations["sampling_ratio"], 1.0)
-        self.assertEqual(configurations["logging_export_interval_ms"], 5000)
         self.assertEqual(configurations["credential"], ("test_credential"))
         self.assertTrue("storage_directory" not in configurations)
 
@@ -59,25 +57,13 @@ class TestUtil(TestCase):
         self.assertEqual(configurations["disable_tracing"], False)
         self.assertEqual(configurations["disabled_instrumentations"], [])
         self.assertEqual(configurations["sampling_ratio"], 1.0)
-        self.assertEqual(configurations["logging_export_interval_ms"], 5000)
         self.assertTrue("credential" not in configurations)
         self.assertTrue("storage_directory" not in configurations)
 
     @patch.dict(
         "os.environ",
         {
-            LOGGING_EXPORT_INTERVAL_MS_ENV_VAR: "-1",
-        },
-        clear=True,
-    )
-    def test_get_configurations_logging_export_validation(self):
-        self.assertRaises(ValueError, _get_configurations)
-
-    @patch.dict(
-        "os.environ",
-        {
             OTEL_PYTHON_DISABLED_INSTRUMENTATIONS: "flask , requests,fastapi",
-            LOGGING_EXPORT_INTERVAL_MS_ENV_VAR: "10000",
             SAMPLING_RATIO_ENV_VAR: "0.5",
             OTEL_TRACES_EXPORTER: "None",
             OTEL_LOGS_EXPORTER: "none",
@@ -98,12 +84,10 @@ class TestUtil(TestCase):
             ["flask", "requests", "fastapi"],
         )
         self.assertEqual(configurations["sampling_ratio"], 0.5)
-        self.assertEqual(configurations["logging_export_interval_ms"], 10000)
 
     @patch.dict(
         "os.environ",
         {
-            LOGGING_EXPORT_INTERVAL_MS_ENV_VAR: "Ten Thousand",
             SAMPLING_RATIO_ENV_VAR: "Half",
             OTEL_TRACES_EXPORTER: "False",
             OTEL_LOGS_EXPORTER: "no",
@@ -120,4 +104,3 @@ class TestUtil(TestCase):
         self.assertEqual(configurations["disable_metrics"], False)
         self.assertEqual(configurations["disable_tracing"], False)
         self.assertEqual(configurations["sampling_ratio"], 1.0)
-        self.assertEqual(configurations["logging_export_interval_ms"], 5000)


### PR DESCRIPTION
# Description

Copy of https://github.com/microsoft/ApplicationInsights-Python/pull/311

We are now leveraging OT env vars for our configuration instead of custom ones. Confirmed that OT sdk uses [OTEL_BLRP_SCHEDULE_DELAY](https://github.com/open-telemetry/opentelemetry-python/blob/main/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/export/__init__.py#L404) as specified [here](https://github.com/microsoft/ApplicationInsights-Python/tree/main/azure-monitor-opentelemetry#usage) in the usage docs.

Fixes https://github.com/microsoft/ApplicationInsights-Python/issues/265

PR that added these env vars to OT sdk: https://github.com/open-telemetry/opentelemetry-python/pull/3237

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
