### PR TITLE
[SB] Fix NoneType Error on Idle Connection Drop

### DIFF
--- a/sdk/servicebus/azure-servicebus/CHANGELOG.md
+++ b/sdk/servicebus/azure-servicebus/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fix the error `NoneType object has no attribute 'settle_messages'` which was raised when a connection was dropped due to a blocked process ([#30514](https://github.com/Azure/azure-sdk-for-python/issues/30514))
+
 ### Other Changes
 
 ## 7.11.1 (2023-07-12)

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_servicebus_receiver.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_servicebus_receiver.py
@@ -13,7 +13,6 @@ import warnings
 from enum import Enum
 from typing import Any, List, Optional, Dict, Iterator, Union, TYPE_CHECKING, cast
 
-
 from .exceptions import MessageLockLostError
 from ._base_handler import BaseHandler
 from ._common.message import ServiceBusReceivedMessage

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_servicebus_receiver.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_servicebus_receiver.py
@@ -13,7 +13,6 @@ import warnings
 from enum import Enum
 from typing import Any, List, Optional, Dict, Iterator, Union, TYPE_CHECKING, cast
 
-from azure.servicebus._pyamqp.error import AMQPConnectionError
 
 from .exceptions import MessageLockLostError
 from ._base_handler import BaseHandler
@@ -355,9 +354,7 @@ class ServiceBusReceiver(
 
     def _open(self):
         # pylint: disable=protected-access
-        print(f"the value of {self._running} while trying to open the handler")
         if self._running:
-            print(f"ITS TRUEEEEE")
             return
         if self._handler and not self._handler._shutdown:
             self._handler.close()
@@ -508,7 +505,7 @@ class ServiceBusReceiver(
                         dead_letter_error_description=dead_letter_error_description,
                     )
                     return
-                except (AttributeError, AMQPConnectionError, RuntimeError) as exception:
+                except RuntimeError as exception:
                     _LOGGER.info(
                         "Message settling: %r has encountered an exception (%r)."
                         "Trying to settle through management link",

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_servicebus_receiver.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_servicebus_receiver.py
@@ -13,6 +13,8 @@ import warnings
 from enum import Enum
 from typing import Any, List, Optional, Dict, Iterator, Union, TYPE_CHECKING, cast
 
+from azure.servicebus._pyamqp.error import AMQPConnectionError
+
 from .exceptions import MessageLockLostError
 from ._base_handler import BaseHandler
 from ._common.message import ServiceBusReceivedMessage
@@ -353,7 +355,9 @@ class ServiceBusReceiver(
 
     def _open(self):
         # pylint: disable=protected-access
+        print(f"the value of {self._running} while trying to open the handler")
         if self._running:
+            print(f"ITS TRUEEEEE")
             return
         if self._handler and not self._handler._shutdown:
             self._handler.close()
@@ -504,7 +508,7 @@ class ServiceBusReceiver(
                         dead_letter_error_description=dead_letter_error_description,
                     )
                     return
-                except RuntimeError as exception:
+                except (AttributeError, AMQPConnectionError, RuntimeError) as exception:
                     _LOGGER.info(
                         "Message settling: %r has encountered an exception (%r)."
                         "Trying to settle through management link",

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_transport/_pyamqp_transport.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_transport/_pyamqp_transport.py
@@ -699,9 +699,6 @@ class PyamqpTransport(AmqpTransport):   # pylint: disable=too-many-public-method
         dead_letter_error_description: Optional[str] = None,
     ) -> None:
         # pylint: disable=protected-access
-        if not handler:
-            raise RuntimeError("handler is not open")
-        
         try:
             if settle_operation == MESSAGE_COMPLETE:
                 return handler.settle_messages(message._delivery_id, 'accepted')
@@ -732,6 +729,9 @@ class PyamqpTransport(AmqpTransport):   # pylint: disable=too-many-public-method
                     delivery_failed=True,
                     undeliverable_here=True
                 )
+        except AttributeError as ae:
+            raise RuntimeError("handler is not open") from ae
+
         except AMQPConnectionError as e:
             raise RuntimeError("Connection lost during settle operation.") from e
         

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_transport/_pyamqp_transport.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_transport/_pyamqp_transport.py
@@ -700,7 +700,7 @@ class PyamqpTransport(AmqpTransport):   # pylint: disable=too-many-public-method
     ) -> None:
         # pylint: disable=protected-access
         if not handler:
-            raise RuntimeError("handler is None")
+            raise RuntimeError("handler is not open")
         
         try:
             if settle_operation == MESSAGE_COMPLETE:

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_transport/_pyamqp_transport.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_transport/_pyamqp_transport.py
@@ -699,35 +699,42 @@ class PyamqpTransport(AmqpTransport):   # pylint: disable=too-many-public-method
         dead_letter_error_description: Optional[str] = None,
     ) -> None:
         # pylint: disable=protected-access
-        if settle_operation == MESSAGE_COMPLETE:
-            return handler.settle_messages(message._delivery_id, 'accepted')
-        if settle_operation == MESSAGE_ABANDON:
-            return handler.settle_messages(
-                message._delivery_id,
-                'modified',
-                delivery_failed=True,
-                undeliverable_here=False
-            )
-        if settle_operation == MESSAGE_DEAD_LETTER:
-            return handler.settle_messages(
-                message._delivery_id,
-                'rejected',
-                error=AMQPError(
-                    condition=DEADLETTERNAME,
-                    description=dead_letter_error_description,
-                    info={
-                        RECEIVER_LINK_DEAD_LETTER_REASON: dead_letter_reason,
-                        RECEIVER_LINK_DEAD_LETTER_ERROR_DESCRIPTION: dead_letter_error_description,
-                    }
+        if not handler:
+            raise RuntimeError("handler is None")
+        
+        try:
+            if settle_operation == MESSAGE_COMPLETE:
+                return handler.settle_messages(message._delivery_id, 'accepted')
+            if settle_operation == MESSAGE_ABANDON:
+                return handler.settle_messages(
+                    message._delivery_id,
+                    'modified',
+                    delivery_failed=True,
+                    undeliverable_here=False
                 )
-            )
-        if settle_operation == MESSAGE_DEFER:
-            return handler.settle_messages(
-                message._delivery_id,
-                'modified',
-                delivery_failed=True,
-                undeliverable_here=True
-            )
+            if settle_operation == MESSAGE_DEAD_LETTER:
+                return handler.settle_messages(
+                    message._delivery_id,
+                    'rejected',
+                    error=AMQPError(
+                        condition=DEADLETTERNAME,
+                        description=dead_letter_error_description,
+                        info={
+                            RECEIVER_LINK_DEAD_LETTER_REASON: dead_letter_reason,
+                            RECEIVER_LINK_DEAD_LETTER_ERROR_DESCRIPTION: dead_letter_error_description,
+                        }
+                    )
+                )
+            if settle_operation == MESSAGE_DEFER:
+                return handler.settle_messages(
+                    message._delivery_id,
+                    'modified',
+                    delivery_failed=True,
+                    undeliverable_here=True
+                )
+        except AMQPConnectionError as e:
+            raise RuntimeError("Connection lost during settle operation.") from e
+        
         raise ValueError(
             f"Unsupported settle operation type: {settle_operation}"
         )

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_transport/_pyamqp_transport.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_transport/_pyamqp_transport.py
@@ -734,7 +734,7 @@ class PyamqpTransport(AmqpTransport):   # pylint: disable=too-many-public-method
 
         except AMQPConnectionError as e:
             raise RuntimeError("Connection lost during settle operation.") from e
-        
+
         raise ValueError(
             f"Unsupported settle operation type: {settle_operation}"
         )

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_transport/_pyamqp_transport.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_transport/_pyamqp_transport.py
@@ -730,7 +730,7 @@ class PyamqpTransport(AmqpTransport):   # pylint: disable=too-many-public-method
                     undeliverable_here=True
                 )
         except AttributeError as ae:
-            raise RuntimeError("handler is not open") from ae
+            raise RuntimeError("handler is not initialized and cannot complete the message") from ae
 
         except AMQPConnectionError as e:
             raise RuntimeError("Connection lost during settle operation.") from e

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_transport/_pyamqp_transport_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_transport/_pyamqp_transport_async.py
@@ -269,9 +269,6 @@ class PyamqpTransportAsync(PyamqpTransport, AmqpTransportAsync):
         dead_letter_error_description: Optional[str] = None,
     ) -> None:
         # pylint: disable=protected-access
-        if not handler:
-            raise RuntimeError("Handler is not open")
-
         try:
             if settle_operation == MESSAGE_COMPLETE:
                 return await handler.settle_messages_async(message._delivery_id, 'accepted')
@@ -302,6 +299,9 @@ class PyamqpTransportAsync(PyamqpTransport, AmqpTransportAsync):
                     delivery_failed=True,
                     undeliverable_here=True
                 )
+        except AttributeError as ae:
+            raise RuntimeError("handler is not open") from ae
+        
         except AMQPConnectionError as e:
             raise RuntimeError("Connection lost during settle operation.") from e
 

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_transport/_pyamqp_transport_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_transport/_pyamqp_transport_async.py
@@ -301,7 +301,7 @@ class PyamqpTransportAsync(PyamqpTransport, AmqpTransportAsync):
                 )
         except AttributeError as ae:
             raise RuntimeError("handler is not initialized and cannot complete the message") from ae
-        
+
         except AMQPConnectionError as e:
             raise RuntimeError("Connection lost during settle operation.") from e
 

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_transport/_pyamqp_transport_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_transport/_pyamqp_transport_async.py
@@ -300,7 +300,7 @@ class PyamqpTransportAsync(PyamqpTransport, AmqpTransportAsync):
                     undeliverable_here=True
                 )
         except AttributeError as ae:
-            raise RuntimeError("handler is not open") from ae
+            raise RuntimeError("handler is not initialized and cannot complete the message") from ae
         
         except AMQPConnectionError as e:
             raise RuntimeError("Connection lost during settle operation.") from e

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_transport/_pyamqp_transport_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_transport/_pyamqp_transport_async.py
@@ -15,6 +15,7 @@ from ..._pyamqp.aio import SendClientAsync, ReceiveClientAsync
 from ..._pyamqp.aio._authentication_async import JWTTokenAuthAsync
 from ..._pyamqp.aio._connection_async import Connection as ConnectionAsync
 from ..._pyamqp.error import (
+    AMQPConnectionError,
     AMQPError,
     MessageException,
 )
@@ -268,35 +269,42 @@ class PyamqpTransportAsync(PyamqpTransport, AmqpTransportAsync):
         dead_letter_error_description: Optional[str] = None,
     ) -> None:
         # pylint: disable=protected-access
-        if settle_operation == MESSAGE_COMPLETE:
-            return await handler.settle_messages_async(message._delivery_id, 'accepted')
-        if settle_operation == MESSAGE_ABANDON:
-            return await handler.settle_messages_async(
-                message._delivery_id,
-                'modified',
-                delivery_failed=True,
-                undeliverable_here=False
-            )
-        if settle_operation == MESSAGE_DEAD_LETTER:
-            return await handler.settle_messages_async(
-                message._delivery_id,
-                'rejected',
-                error=AMQPError(
-                    condition=DEADLETTERNAME,
-                    description=dead_letter_error_description,
-                    info={
-                        RECEIVER_LINK_DEAD_LETTER_REASON: dead_letter_reason,
-                        RECEIVER_LINK_DEAD_LETTER_ERROR_DESCRIPTION: dead_letter_error_description,
-                    }
+        if not handler:
+            raise RuntimeError("Handler is not open")
+
+        try:
+            if settle_operation == MESSAGE_COMPLETE:
+                return await handler.settle_messages_async(message._delivery_id, 'accepted')
+            if settle_operation == MESSAGE_ABANDON:
+                return await handler.settle_messages_async(
+                    message._delivery_id,
+                    'modified',
+                    delivery_failed=True,
+                    undeliverable_here=False
                 )
-            )
-        if settle_operation == MESSAGE_DEFER:
-            return await handler.settle_messages_async(
-                message._delivery_id,
-                'modified',
-                delivery_failed=True,
-                undeliverable_here=True
-            )
+            if settle_operation == MESSAGE_DEAD_LETTER:
+                return await handler.settle_messages_async(
+                    message._delivery_id,
+                    'rejected',
+                    error=AMQPError(
+                        condition=DEADLETTERNAME,
+                        description=dead_letter_error_description,
+                        info={
+                            RECEIVER_LINK_DEAD_LETTER_REASON: dead_letter_reason,
+                            RECEIVER_LINK_DEAD_LETTER_ERROR_DESCRIPTION: dead_letter_error_description,
+                        }
+                    )
+                )
+            if settle_operation == MESSAGE_DEFER:
+                return await handler.settle_messages_async(
+                    message._delivery_id,
+                    'modified',
+                    delivery_failed=True,
+                    undeliverable_here=True
+                )
+        except AMQPConnectionError as e:
+            raise RuntimeError("Connection lost during settle operation.") from e
+
         raise ValueError(
             f"Unsupported settle operation type: {settle_operation}"
         )


### PR DESCRIPTION
This error `AttributeError: 'NoneType' object has no attribute 'settle_messages' would show up when there was a connection drop happening and a settle operation being attempted. 

This particular scenario would happen when the entire process was being blocked which also meant no keep alives or auto lock renewers were being able to run in the background (along with the main thread ). 

Repro Steps:- 

* Run the [receive_queue.py](https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/servicebus/azure-servicebus/samples/sync_samples/receive_queue.py) sample with a break point right at the for loop stmt.
* Wait for 5 mins, this causes the service to send a detach to be sent to the client
* Once the time passes, F10 your way forward and as soon as "complete_message" executes, the above error comes up

Why It Happens
* As the socket is closed due to the detach, the function `settle_message_via_receiver_link` in `_pyamqp_tranport.py` first raises an AMQPConnectionError as it tries to complete.
* The exception ends up getting caught in `_servicebus_receiver.py` at line [528](https://github.com/Azure/azure-sdk-for-python/blob/04a1595cbdeb18ad31b983f48af759dbd72d86d7/sdk/servicebus/azure-servicebus/azure/servicebus/_servicebus_receiver.py#L528) instead of line [507](https://github.com/Azure/azure-sdk-for-python/blob/04a1595cbdeb18ad31b983f48af759dbd72d86d7/sdk/servicebus/azure-servicebus/azure/servicebus/_servicebus_receiver.py#L507) as its expecting a `RuntimeError`
* As it loops back up in the retry, handler is closed and `None`. when it attempts again, this time it raises an `AttributeError`

The fix was to raise a RuntimeError similar to uamqp in pyamqp_transport in order to fix the retry loop flow. The other option was to add in AMQPConnection at the receiver level but that would mean an import of pyamqp error in to servicebus level.

Fixes #30514