### PR TITLE
[Identity] Adjust IMDS probe logic

### DIFF
--- a/sdk/identity/azure-identity/CHANGELOG.md
+++ b/sdk/identity/azure-identity/CHANGELOG.md
@@ -20,6 +20,8 @@
 - Update typing of async credentials to match the `AsyncTokenCredential` protocol.
 - If within `DefaultAzureCredential`, `EnvironmentCredential` will now use log level INFO instead of WARNING to inform users of an incomplete environment configuration.  ([#31814](https://github.com/Azure/azure-sdk-for-python/pull/31814))
 - Strengthened `AzureCliCredential` and `AzureDeveloperCliCredential` error checking when determining if a user is logged in or not. Now, if an AADSTS error exists in the error, the full error message is propagated instead of a canned error message. ([#30047](https://github.com/Azure/azure-sdk-for-python/pull/30047))
+- `ManagedIdentityCredential` instances using IMDS will now be allowed to continue sending requests to the IMDS endpoint even after previous attempts failed. This is to prevent credential instances from potentially being permanently disabled after a temporary network failure.
+- IMDS endpoint probes in `ManagedIdentityCredential` will now only occur when inside a credential chain such as `DefaultAzureCredential`. This probe request timeout has been increased to 1 second from 0.3 seconds to reduce the likelihood of false negatives.
 
 ## 1.14.0 (2023-08-08)
 

--- a/sdk/identity/azure-identity/azure/identity/_credentials/chained.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/chained.py
@@ -94,6 +94,7 @@ class ChainedTokenCredential:
                 token = credential.get_token(*scopes, claims=claims, tenant_id=tenant_id, **kwargs)
                 _LOGGER.info("%s acquired a token from %s", self.__class__.__name__, credential.__class__.__name__)
                 self._successful_credential = credential
+                within_credential_chain.set(False)
                 return token
             except CredentialUnavailableError as ex:
                 # credential didn't attempt authentication because it lacks required data or state -> continue

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/chained.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/chained.py
@@ -78,6 +78,7 @@ class ChainedTokenCredential(AsyncContextManager):
                 token = await credential.get_token(*scopes, claims=claims, tenant_id=tenant_id, **kwargs)
                 _LOGGER.info("%s acquired a token from %s", self.__class__.__name__, credential.__class__.__name__)
                 self._successful_credential = credential
+                within_credential_chain.set(False)
                 return token
             except CredentialUnavailableError as ex:
                 # credential didn't attempt authentication because it lacks required data or state -> continue

--- a/sdk/identity/azure-identity/tests/test_chained_credential.py
+++ b/sdk/identity/azure-identity/tests/test_chained_credential.py
@@ -2,19 +2,22 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
-try:
-    from unittest.mock import MagicMock, Mock
-except ImportError:  # python < 3.3
-    from mock import MagicMock, Mock  # type: ignore
+import time
+from unittest.mock import Mock, MagicMock, patch
 
 from azure.core.credentials import AccessToken
 from azure.core.exceptions import ClientAuthenticationError
+from azure.identity._credentials.imds import IMDS_TOKEN_PATH, IMDS_AUTHORITY
+from azure.identity._internal.user_agent import USER_AGENT
 from azure.identity import (
     ChainedTokenCredential,
     ClientSecretCredential,
+    ManagedIdentityCredential,
     CredentialUnavailableError,
 )
 import pytest
+
+from helpers import validating_transport, Request, mock_response
 
 
 def test_close():
@@ -110,3 +113,64 @@ def test_returns_first_token():
 
     assert credential is expected_token
     assert second_credential.get_token.call_count == 0
+
+
+def test_managed_identity_imds_probe():
+    access_token = "****"
+    expires_on = 42
+    expected_token = AccessToken(access_token, expires_on)
+    scope = "scope"
+    transport = validating_transport(
+        requests=[
+            Request(base_url=IMDS_AUTHORITY + IMDS_TOKEN_PATH),
+            Request(
+                base_url=IMDS_AUTHORITY + IMDS_TOKEN_PATH,
+                method="GET",
+                required_headers={"Metadata": "true", "User-Agent": USER_AGENT},
+                required_params={"api-version": "2018-02-01", "resource": scope},
+            ),
+        ],
+        responses=[
+            # probe receives error response
+            mock_response(status_code=400, json_payload={"error": "this is an error message"}),
+            mock_response(
+                json_payload={
+                    "access_token": access_token,
+                    "expires_in": 42,
+                    "expires_on": expires_on,
+                    "ext_expires_in": 42,
+                    "not_before": int(time.time()),
+                    "resource": scope,
+                    "token_type": "Bearer",
+                }
+            ),
+        ],
+    )
+
+    with patch.dict("os.environ", clear=True):
+        credentials = [
+            Mock(get_token=Mock(side_effect=CredentialUnavailableError(message=""))),
+            ManagedIdentityCredential(transport=transport)
+        ]
+        token = ChainedTokenCredential(*credentials).get_token(scope)
+    assert token == expected_token
+
+
+def test_managed_identity_failed_probe():
+    mock_send = Mock(side_effect=Exception("timeout"))
+    transport = Mock(send=mock_send)
+    expected_token = Mock()
+
+    credentials = [
+        Mock(get_token=Mock(side_effect=CredentialUnavailableError(message=""))),
+        ManagedIdentityCredential(transport=transport),
+        Mock(get_token=Mock(return_value=expected_token))
+    ]
+
+    with patch.dict("os.environ", clear=True):
+        token = ChainedTokenCredential(*credentials).get_token("scope")
+
+    assert token is expected_token
+    # ManagedIdentityCredential should be tried and skipped with the last credential in the chain
+    # being used.
+    assert credentials[-1].get_token.call_count == 1

--- a/sdk/identity/azure-identity/tests/test_chained_credential.py
+++ b/sdk/identity/azure-identity/tests/test_chained_credential.py
@@ -150,7 +150,7 @@ def test_managed_identity_imds_probe():
     with patch.dict("os.environ", clear=True):
         credentials = [
             Mock(get_token=Mock(side_effect=CredentialUnavailableError(message=""))),
-            ManagedIdentityCredential(transport=transport)
+            ManagedIdentityCredential(transport=transport),
         ]
         token = ChainedTokenCredential(*credentials).get_token(scope)
     assert token == expected_token
@@ -164,7 +164,7 @@ def test_managed_identity_failed_probe():
     credentials = [
         Mock(get_token=Mock(side_effect=CredentialUnavailableError(message=""))),
         ManagedIdentityCredential(transport=transport),
-        Mock(get_token=Mock(return_value=expected_token))
+        Mock(get_token=Mock(return_value=expected_token)),
     ]
 
     with patch.dict("os.environ", clear=True):

--- a/sdk/identity/azure-identity/tests/test_chained_token_credential_async.py
+++ b/sdk/identity/azure-identity/tests/test_chained_token_credential_async.py
@@ -2,14 +2,19 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
+import time
+from unittest.mock import Mock, patch
+
 from azure.core.credentials import AccessToken
 from azure.core.exceptions import ClientAuthenticationError
 from azure.identity import CredentialUnavailableError, ClientSecretCredential
-from azure.identity.aio import ChainedTokenCredential
+from azure.identity.aio import ChainedTokenCredential, ManagedIdentityCredential
+from azure.identity._credentials.imds import IMDS_TOKEN_PATH, IMDS_AUTHORITY
+from azure.identity._internal.user_agent import USER_AGENT
 import pytest
-from unittest.mock import Mock
 
-from helpers_async import get_completed_future, wrap_in_future
+from helpers import mock_response, Request
+from helpers_async import get_completed_future, wrap_in_future, async_validating_transport
 
 
 @pytest.mark.asyncio
@@ -106,3 +111,69 @@ async def test_returns_first_token():
 
     assert credential is expected_token
     assert second_credential.get_token.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_managed_identity_imds_probe():
+    access_token = "****"
+    expires_on = 42
+    expected_token = AccessToken(access_token, expires_on)
+    scope = "scope"
+    transport = async_validating_transport(
+        requests=[
+            Request(base_url=IMDS_AUTHORITY + IMDS_TOKEN_PATH),
+            Request(
+                base_url=IMDS_AUTHORITY + IMDS_TOKEN_PATH,
+                method="GET",
+                required_headers={"Metadata": "true", "User-Agent": USER_AGENT},
+                required_params={"api-version": "2018-02-01", "resource": scope},
+            ),
+        ],
+        responses=[
+            mock_response(status_code=400, json_payload={"error": "this is an error message"}),
+            mock_response(
+                json_payload={
+                    "access_token": access_token,
+                    "expires_in": 42,
+                    "expires_on": expires_on,
+                    "ext_expires_in": 42,
+                    "not_before": int(time.time()),
+                    "resource": scope,
+                    "token_type": "Bearer",
+                }
+            ),
+        ],
+    )
+
+    # ensure e.g. $MSI_ENDPOINT isn't set, so we get ImdsCredential
+    with patch.dict("os.environ", clear=True):
+        credentials = [
+            Mock(get_token=Mock(side_effect=CredentialUnavailableError(message=""))),
+            ManagedIdentityCredential(transport=transport)
+        ]
+        token = await ChainedTokenCredential(*credentials).get_token(scope)
+    assert token == expected_token
+
+
+@pytest.mark.asyncio
+async def test_managed_identity_failed_probe():
+    async def credential_unavailable(message="it didn't work", **_):
+        raise CredentialUnavailableError(message)
+
+    mock_send = Mock(side_effect=Exception("timeout"))
+    transport = Mock(send=wrap_in_future(mock_send))
+
+    expected_token = AccessToken("**", 42)
+    credentials = [
+        Mock(get_token=Mock(wraps=credential_unavailable)),
+        ManagedIdentityCredential(transport=transport),
+        Mock(get_token=Mock(wraps=wrap_in_future(lambda _, **__: expected_token)))
+    ]
+
+    with patch.dict("os.environ", clear=True):
+        token = await ChainedTokenCredential(*credentials).get_token("scope")
+
+    assert token is expected_token
+    # ManagedIdentityCredential should be tried and skipped with the last credential in the chain
+    # being used.
+    assert credentials[-1].get_token.call_count == 1

--- a/sdk/identity/azure-identity/tests/test_chained_token_credential_async.py
+++ b/sdk/identity/azure-identity/tests/test_chained_token_credential_async.py
@@ -149,7 +149,7 @@ async def test_managed_identity_imds_probe():
     with patch.dict("os.environ", clear=True):
         credentials = [
             Mock(get_token=Mock(side_effect=CredentialUnavailableError(message=""))),
-            ManagedIdentityCredential(transport=transport)
+            ManagedIdentityCredential(transport=transport),
         ]
         token = await ChainedTokenCredential(*credentials).get_token(scope)
     assert token == expected_token
@@ -167,7 +167,7 @@ async def test_managed_identity_failed_probe():
     credentials = [
         Mock(get_token=Mock(wraps=credential_unavailable)),
         ManagedIdentityCredential(transport=transport),
-        Mock(get_token=Mock(wraps=wrap_in_future(lambda _, **__: expected_token)))
+        Mock(get_token=Mock(wraps=wrap_in_future(lambda _, **__: expected_token))),
     ]
 
     with patch.dict("os.environ", clear=True):

--- a/sdk/identity/azure-identity/tests/test_imds_credential.py
+++ b/sdk/identity/azure-identity/tests/test_imds_credential.py
@@ -36,9 +36,7 @@ def test_multiple_scopes():
 
 def test_identity_not_available():
     """The credential should raise CredentialUnavailableError when the endpoint responds 400 to a token request"""
-    transport = validating_transport(
-        requests=[Request()], responses=[mock_response(status_code=400, json_payload={})]
-    )
+    transport = validating_transport(requests=[Request()], responses=[mock_response(status_code=400, json_payload={})])
 
     credential = ImdsCredential(transport=transport)
 

--- a/sdk/identity/azure-identity/tests/test_imds_credential_async.py
+++ b/sdk/identity/azure-identity/tests/test_imds_credential_async.py
@@ -31,22 +31,14 @@ pytestmark = pytest.mark.asyncio
 
 async def test_no_scopes():
     """The credential should raise ValueError when get_token is called with no scopes"""
-
-    successful_probe = mock_response(status_code=400, json_payload={})
-    transport = mock.Mock(send=mock.Mock(return_value=get_completed_future(successful_probe)))
-    credential = ImdsCredential(transport=transport)
-
+    credential = ImdsCredential()
     with pytest.raises(ValueError):
         await credential.get_token()
 
 
 async def test_multiple_scopes():
     """The credential should raise ValueError when get_token is called with more than one scope"""
-
-    successful_probe = mock_response(status_code=400, json_payload={})
-    transport = mock.Mock(send=mock.Mock(return_value=get_completed_future(successful_probe)))
-    credential = ImdsCredential(transport=transport)
-
+    credential = ImdsCredential()
     with pytest.raises(ValueError):
         await credential.get_token("one scope", "and another")
 
@@ -74,9 +66,8 @@ async def test_imds_context_manager():
 async def test_identity_not_available():
     """The credential should raise CredentialUnavailableError when the endpoint responds 400 to a token request"""
 
-    # first request is a probe, second a token request
     transport = async_validating_transport(
-        requests=[Request()] * 2, responses=[mock_response(status_code=400, json_payload={})] * 2
+        requests=[Request()], responses=[mock_response(status_code=400, json_payload={})]
     )
 
     credential = ImdsCredential(transport=transport)
@@ -96,9 +87,6 @@ async def test_unexpected_error():
             # ensure the `claims` and `tenant_id` kwargs from credential's `get_token` method don't make it to transport
             assert "claims" not in kwargs
             assert "tenant_id" not in kwargs
-            if "resource" not in request.query:
-                # availability probe
-                return mock_response(status_code=400, json_payload={})
             return mock_response(status_code=code, json_payload={"error": error_message})
 
         transport = mock.Mock(send=send, sleep=lambda _: get_completed_future())
@@ -135,7 +123,7 @@ async def test_cache():
     credential = ImdsCredential(transport=mock.Mock(send=wrap_in_future(mock_send)))
     token = await credential.get_token(scope)
     assert token.token == expired
-    assert mock_send.call_count == 2  # first request was probing for endpoint availability
+    assert mock_send.call_count == 1
 
     # calling get_token again should provoke another HTTP request
     good_for_an_hour = "this token's good for an hour"
@@ -144,12 +132,12 @@ async def test_cache():
     token_payload["access_token"] = good_for_an_hour
     token = await credential.get_token(scope)
     assert token.token == good_for_an_hour
-    assert mock_send.call_count == 3
+    assert mock_send.call_count == 2
 
     # get_token should return the cached token now
     token = await credential.get_token(scope)
     assert token.token == good_for_an_hour
-    assert mock_send.call_count == 3
+    assert mock_send.call_count == 2
 
 
 async def test_retries():
@@ -171,9 +159,8 @@ async def test_retries():
             ).get_token("scope")
         except ClientAuthenticationError:
             pass
-        # first call was availability probe, second the original request;
         # credential should have then exhausted retries for each of these status codes
-        assert mock_send.call_count == 2 + total_retries
+        assert mock_send.call_count == 1 + total_retries
 
 
 async def test_identity_config():
@@ -186,7 +173,6 @@ async def test_identity_config():
 
     transport = async_validating_transport(
         requests=[
-            Request(base_url=IMDS_AUTHORITY + IMDS_TOKEN_PATH),
             Request(
                 base_url=IMDS_AUTHORITY + IMDS_TOKEN_PATH,
                 method="GET",
@@ -195,7 +181,6 @@ async def test_identity_config():
             ),
         ],
         responses=[
-            mock_response(status_code=400, json_payload={"error": "this is an error message"}),
             mock_response(
                 json_payload={
                     "access_token": access_token,

--- a/sdk/identity/azure-identity/tests/test_managed_identity.py
+++ b/sdk/identity/azure-identity/tests/test_managed_identity.py
@@ -103,19 +103,11 @@ def test_custom_hooks(environ):
         )
     credential.get_token(scope)
 
-    if environ:
-        # some environment variables are set, so we're not mocking IMDS and should expect 1 request
-        assert request_hook.call_count == 1
-        assert response_hook.call_count == 1
-        args, kwargs = response_hook.call_args
-        pipeline_response = args[0]
-        assert pipeline_response.http_response == expected_response
-    else:
-        # we're mocking IMDS and should expect 2 requests
-        assert request_hook.call_count == 2
-        assert response_hook.call_count == 2
-        responses = [args[0].http_response for args, _ in response_hook.call_args_list]
-        assert responses == [expected_response] * 2
+    assert request_hook.call_count == 1
+    assert response_hook.call_count == 1
+    args, kwargs = response_hook.call_args
+    pipeline_response = args[0]
+    assert pipeline_response.http_response == expected_response
 
 
 @pytest.mark.parametrize("environ", ALL_ENVIRONMENTS)
@@ -144,19 +136,12 @@ def test_tenant_id(environ):
         )
     credential.get_token(scope)
 
-    if environ:
-        # some environment variables are set, so we're not mocking IMDS and should expect 1 request
-        assert request_hook.call_count == 1
-        assert response_hook.call_count == 1
-        args, kwargs = response_hook.call_args
-        pipeline_response = args[0]
-        assert pipeline_response.http_response == expected_response
-    else:
-        # we're mocking IMDS and should expect 2 requests
-        assert request_hook.call_count == 2
-        assert response_hook.call_count == 2
-        responses = [args[0].http_response for args, _ in response_hook.call_args_list]
-        assert responses == [expected_response] * 2
+    assert request_hook.call_count == 1
+    assert response_hook.call_count == 1
+    args, kwargs = response_hook.call_args
+    pipeline_response = args[0]
+    assert pipeline_response.http_response == expected_response
+
 
 
 def test_cloud_shell():
@@ -638,7 +623,6 @@ def test_imds():
     scope = "scope"
     transport = validating_transport(
         requests=[
-            Request(base_url=IMDS_AUTHORITY + IMDS_TOKEN_PATH),
             Request(
                 base_url=IMDS_AUTHORITY + IMDS_TOKEN_PATH,
                 method="GET",
@@ -647,8 +631,6 @@ def test_imds():
             ),
         ],
         responses=[
-            # probe receives error response
-            mock_response(status_code=400, json_payload={"error": "this is an error message"}),
             mock_response(
                 json_payload={
                     "access_token": access_token,
@@ -676,7 +658,6 @@ def test_imds_tenant_id():
     scope = "scope"
     transport = validating_transport(
         requests=[
-            Request(base_url=IMDS_AUTHORITY + IMDS_TOKEN_PATH),
             Request(
                 base_url=IMDS_AUTHORITY + IMDS_TOKEN_PATH,
                 method="GET",
@@ -685,8 +666,6 @@ def test_imds_tenant_id():
             ),
         ],
         responses=[
-            # probe receives error response
-            mock_response(status_code=400, json_payload={"error": "this is an error message"}),
             mock_response(
                 json_payload={
                     "access_token": access_token,
@@ -747,7 +726,6 @@ def test_imds_user_assigned_identity():
     client_id = "some-guid"
     transport = validating_transport(
         requests=[
-            Request(base_url=endpoint),  # first request should be availability probe => match only the URL
             Request(
                 base_url=endpoint,
                 method="GET",
@@ -756,8 +734,6 @@ def test_imds_user_assigned_identity():
             ),
         ],
         responses=[
-            # probe receives error response
-            mock_response(status_code=400, json_payload={"error": "this is an error message"}),
             mock_response(
                 json_payload={
                     "access_token": access_token,

--- a/sdk/identity/azure-identity/tests/test_managed_identity.py
+++ b/sdk/identity/azure-identity/tests/test_managed_identity.py
@@ -143,7 +143,6 @@ def test_tenant_id(environ):
     assert pipeline_response.http_response == expected_response
 
 
-
 def test_cloud_shell():
     """Cloud Shell environment: only MSI_ENDPOINT set"""
 

--- a/sdk/identity/azure-identity/tests/test_managed_identity_async.py
+++ b/sdk/identity/azure-identity/tests/test_managed_identity_async.py
@@ -52,19 +52,11 @@ async def test_custom_hooks(environ):
         )
     await credential.get_token(scope)
 
-    if environ:
-        # some environment variables are set, so we're not mocking IMDS and should expect 1 request
-        assert request_hook.call_count == 1
-        assert response_hook.call_count == 1
-        args, kwargs = response_hook.call_args
-        pipeline_response = args[0]
-        assert pipeline_response.http_response == expected_response
-    else:
-        # we're mocking IMDS and should expect 2 requests
-        assert request_hook.call_count == 2
-        assert response_hook.call_count == 2
-        responses = [args[0].http_response for args, _ in response_hook.call_args_list]
-        assert responses == [expected_response] * 2
+    assert request_hook.call_count == 1
+    assert response_hook.call_count == 1
+    args, kwargs = response_hook.call_args
+    pipeline_response = args[0]
+    assert pipeline_response.http_response == expected_response
 
 
 @pytest.mark.asyncio
@@ -94,19 +86,11 @@ async def test_tenant_id(environ):
         )
     await credential.get_token(scope)
 
-    if environ:
-        # some environment variables are set, so we're not mocking IMDS and should expect 1 request
-        assert request_hook.call_count == 1
-        assert response_hook.call_count == 1
-        args, kwargs = response_hook.call_args
-        pipeline_response = args[0]
-        assert pipeline_response.http_response == expected_response
-    else:
-        # we're mocking IMDS and should expect 2 requests
-        assert request_hook.call_count == 2
-        assert response_hook.call_count == 2
-        responses = [args[0].http_response for args, _ in response_hook.call_args_list]
-        assert responses == [expected_response] * 2
+    assert request_hook.call_count == 1
+    assert response_hook.call_count == 1
+    args, kwargs = response_hook.call_args
+    pipeline_response = args[0]
+    assert pipeline_response.http_response == expected_response
 
 
 @pytest.mark.asyncio
@@ -630,7 +614,6 @@ async def test_imds():
     scope = "scope"
     transport = async_validating_transport(
         requests=[
-            Request(base_url=IMDS_AUTHORITY + IMDS_TOKEN_PATH),
             Request(
                 base_url=IMDS_AUTHORITY + IMDS_TOKEN_PATH,
                 method="GET",
@@ -639,8 +622,6 @@ async def test_imds():
             ),
         ],
         responses=[
-            # probe receives error response
-            mock_response(status_code=400, json_payload={"error": "this is an error message"}),
             mock_response(
                 json_payload={
                     "access_token": access_token,
@@ -669,7 +650,6 @@ async def test_imds_tenant_id():
     scope = "scope"
     transport = async_validating_transport(
         requests=[
-            Request(base_url=IMDS_AUTHORITY + IMDS_TOKEN_PATH),
             Request(
                 base_url=IMDS_AUTHORITY + IMDS_TOKEN_PATH,
                 method="GET",
@@ -678,8 +658,6 @@ async def test_imds_tenant_id():
             ),
         ],
         responses=[
-            # probe receives error response
-            mock_response(status_code=400, json_payload={"error": "this is an error message"}),
             mock_response(
                 json_payload={
                     "access_token": access_token,
@@ -709,7 +687,6 @@ async def test_imds_user_assigned_identity():
     client_id = "some-guid"
     transport = async_validating_transport(
         requests=[
-            Request(base_url=IMDS_AUTHORITY + IMDS_TOKEN_PATH),
             Request(
                 base_url=IMDS_AUTHORITY + IMDS_TOKEN_PATH,
                 method="GET",
@@ -718,8 +695,6 @@ async def test_imds_user_assigned_identity():
             ),
         ],
         responses=[
-            # probe receives error response
-            mock_response(status_code=400, json_payload={"error": "this is an error message"}),
             mock_response(
                 json_payload={
                     "access_token": access_token,


### PR DESCRIPTION
## Motivation

Currently, `ManagedIdentityCredential` instances relying on IMDS will first probe the IMDS endpoint using a [singular request](https://github.com/Azure/azure-sdk-for-python/blob/306cf013a6481c4c71627b8d4c1aa055b3749bc4/sdk/identity/azure-identity/azure/identity/aio/_credentials/imds.py#L48) with a 0.3 second connection timeout. If an HTTP error response is returned, it is presumed that the IMDS endpoint is available. If not, or the connection timeouts, then an internal variable `_endpoint_available` is set to False, and `CredentialUnavailableError` is raised. Further attempts to call `get_token` using this credential will now automatically fail with `CredentialUnavailableError` because the credential was, in essence, disabled with `_endpoint_available` being set to false. 

There have been cases where transient network errors, lag spikes, or high system CPU utilization might cause the intial request to fail/timeout (example issue: https://github.com/Azure/azure-sdk-for-python/issues/31637).

This PR aims to make this `ManagedIdentityCredential` a bit more robust when IMDS is involved.

## Modification

1. Logic was adjusted so that the IMDS endpoint is only probed when inside a credential chain so as to allow fast failure and not cause too long of a delay before the next credential in the chain is checked. If a user uses the `ManagedIdentityCredential` directly, then no initial probing is done, and the original pipeline connection_timeout and retry settings are used.
2. The probe connection timeout was increased from 0.3 seconds to 1 second to reduce the likelihood of false negatives.
    -  .NET uses a [one second timeout](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/identity/Azure.Identity/src/DefaultAzureCredentialFactory.cs#L130) for the initial IMDS discovery request for ManagedIdentityCredentials created in DefaultAzureCredential. This change aligns with that.
4. IMDS request failures no longer disable the credential. A user can retry using the same credential instance.

## Results

- Users using `ManagedIdentityCredential` directly will now be less prone to transient IMDS endpoint failures.
- Users no longer have to create a new instance of `ManagedIdentityCredential` due to disablement. 
- Those using `DefaultAzureCredential` and not using a managed identity will have a slightly longer wait for the next credential in the flow to be tried as the IMDS endpoint probe request will need to timeout after 1 second instead of 0.3 seconds.



