### PR TITLE
Murmurhash3 128 bit implementation in python

### DIFF
--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_cosmos_integers.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_cosmos_integers.py
@@ -1,0 +1,169 @@
+# The MIT License (MIT)
+# Copyright (c) 2014 Microsoft Corporation
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import struct
+
+
+class UInt64:
+    def __init__(self, value):
+        self.value = value & 0xFFFFFFFFFFFFFFFF
+
+    @property
+    def value(self):
+        return self._value
+
+    @value.setter
+    def value(self, new_value):
+        self._value = new_value & 0xFFFFFFFFFFFFFFFF
+
+    def __add__(self, other):
+        result = self.value + (other.value if isinstance(other, UInt64) else other)
+        return UInt64(result & 0xFFFFFFFFFFFFFFFF)
+
+    def __sub__(self, other):
+        result = self.value - (other.value if isinstance(other, UInt64) else other)
+        return UInt64(result & 0xFFFFFFFFFFFFFFFF)
+
+    def __mul__(self, other):
+        result = self.value * (other.value if isinstance(other, UInt64) else other)
+        return UInt64(result & 0xFFFFFFFFFFFFFFFF)
+
+    def __xor__(self, other):
+        result = self.value ^ (other.value if isinstance(other, UInt64) else other)
+        return UInt64(result & 0xFFFFFFFFFFFFFFFF)
+
+    def __lshift__(self, other):
+        result = self.value << (other.value if isinstance(other, UInt64) else other)
+        return UInt64(result & 0xFFFFFFFFFFFFFFFF)
+
+    def __rshift__(self, other):
+        result = self.value >> (other.value if isinstance(other, UInt64) else other)
+        return UInt64(result & 0xFFFFFFFFFFFFFFFF)
+
+    def __and__(self, other):
+        result = self.value & (other.value if isinstance(other, UInt64) else other)
+        return UInt64(result & 0xFFFFFFFFFFFFFFFF)
+
+    def __or__(self, other):
+        if isinstance(other, UInt64):
+            return UInt64(self.value | other.value)
+        elif isinstance(other, int):
+            return UInt64(self.value | other)
+        else:
+            raise TypeError("Unsupported type for OR operation")
+
+    def __invert__(self):
+        return UInt64(~self.value & 0xFFFFFFFFFFFFFFFF)
+
+    @staticmethod
+    def encode_double_as_uint64(value):
+        value_in_uint64 = struct.unpack('<Q', struct.pack('<d', value))[0]
+        mask = 0x8000000000000000
+        return (value_in_uint64 ^ mask) if value_in_uint64 < mask else (~value_in_uint64) + 1
+
+    @staticmethod
+    def decode_double_from_uint64(value):
+        mask = 0x8000000000000000
+        value = ~(value - 1) if value < mask else value ^ mask
+        return struct.unpack('<d', struct.pack('<Q', value))[0]
+
+    def __int__(self):
+        return self.value
+
+
+class UInt128:
+    def __init__(self, low, high):
+        if isinstance(low, UInt64):
+            self.low = low
+        else:
+            self.low = UInt64(low)
+
+        if isinstance(high, UInt64):
+            self.high = high
+        else:
+            self.high = UInt64(high)
+
+    def __add__(self, other):
+        low = self.low + other.low
+        high = self.high + other.high + UInt64(int(low.value > 0xFFFFFFFFFFFFFFFF))
+        return UInt128(low & 0xFFFFFFFFFFFFFFFF, high & 0xFFFFFFFFFFFFFFFF)
+
+    def __sub__(self, other):
+        borrow = UInt64(0)
+        if self.low < other.low:
+            borrow = UInt64(1)
+
+        low = (self.low - other.low) & 0xFFFFFFFFFFFFFFFF
+        high = (self.high - other.high - borrow) & 0xFFFFFFFFFFFFFFFF
+        return UInt128(low, high)
+
+    def __mul__(self, other):
+        # Multiplication logic here for 128 bits
+        pass
+
+    def __xor__(self, other):
+        low = self.low ^ other.low
+        high = self.high ^ other.high
+        return UInt128(low, high)
+
+    def __and__(self, other):
+        low = self.low & other.low
+        high = self.high & other.high
+        return UInt128(low, high)
+
+    def __or__(self, other):
+        low = self.low | other.low
+        high = self.high | other.high
+        return UInt128(low, high)
+
+    def __lshift__(self, shift):
+        # Left shift logic for 128 bits
+        pass
+
+    def __rshift__(self, shift):
+        # Right shift logic for 128 bits
+        pass
+
+    def get_low(self):
+        return self.low
+
+    def get_high(self):
+        return self.high
+
+    def as_tuple(self):
+        return self.low.value, self.high.value
+
+    def as_hex(self):
+        return hex(self.high.value)[2:].zfill(16) + hex(self.low.value)[2:].zfill(16)
+
+    def as_int(self):
+        return (self.high.value << 64) | self.low.value
+
+    def __str__(self):
+        return str(self.as_int())
+
+    def to_byte_array(self):
+        high_bytes = self.high.value.to_bytes(8, byteorder='little')
+        low_bytes = self.low.value.to_bytes(8, byteorder='little')
+        return low_bytes + high_bytes
+
+    @staticmethod
+    def create(low, high):
+        return UInt128(low, high)

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_cosmos_integers.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_cosmos_integers.py
@@ -1,5 +1,5 @@
 # The MIT License (MIT)
-# Copyright (c) 2014 Microsoft Corporation
+# Copyright (c) 2023 Microsoft Corporation
 
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_cosmos_murmurhash3.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_cosmos_murmurhash3.py
@@ -1,5 +1,5 @@
 # The MIT License (MIT)
-# Copyright (c) 2014 Microsoft Corporation
+# Copyright (c) 2023 Microsoft Corporation
 
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_cosmos_murmurhash3.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_cosmos_murmurhash3.py
@@ -1,0 +1,136 @@
+# The MIT License (MIT)
+# Copyright (c) 2014 Microsoft Corporation
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+from ._cosmos_integers import UInt128, UInt64
+
+
+def rotate_left_64(val, shift):
+    return (val << shift) | (val >> (64 - shift))
+
+
+def mix(value):
+    value ^= value >> 33
+    value *= 0xff51afd7ed558ccd
+    value = value & 0xFFFFFFFFFFFFFFFF
+    value ^= value >> 33
+    value *= 0xc4ceb9fe1a85ec53
+    value = value & 0xFFFFFFFFFFFFFFFF
+    value ^= value >> 33
+    return value
+
+
+def murmurhash3_128(span: bytearray, seed: UInt128) -> UInt128:
+    """
+    Python implementation of 128 bit murmurhash3 from Dot Net SDK. To match with other SDKs, It is recommended to
+    do the following with number values, especially floats as other SDKs use Doubles
+    -> bytearray(struct.pack("d", #)) where # represents any number. The d will treat it as a double.
+
+    :param bytearray span:
+        bytearray of value to hash
+    :param UInt128 seed:
+        seed value for murmurhash3, takes in a UInt128 value from Cosmos Integers
+    :return:
+        The hash value as a UInt128
+    :rtype:
+        UInt128"""
+    c1 = UInt64(0x87c37b91114253d5)
+    c2 = UInt64(0x4cf5ad432745937f)
+    h1 = UInt64(seed.get_low())
+    h2 = UInt64(seed.get_high())
+
+    position = 0
+    while position < len(span) - 15:
+        k1 = UInt64(int.from_bytes(span[position: position + 8], 'little'))
+        k2 = UInt64(int.from_bytes(span[position + 8: position + 16], 'little'))
+
+        k1 *= c1
+        k1.value = rotate_left_64(k1.value, 31)
+        k1 *= c2
+        h1 ^= k1
+        h1.value = rotate_left_64(h1.value, 27)
+        h1 += h2
+        h1 = h1 * 5 + UInt64(0x52dce729)
+
+        k2 *= c2
+        k2.value = rotate_left_64(k2.value, 33)
+        k2 *= c1
+        h2 ^= k2
+        h2.value = rotate_left_64(h2.value, 31)
+        h2 += h1
+        h2 = h2 * 5 + UInt64(0x38495ab5)
+
+        position += 16
+
+    k1 = UInt64(0)
+    k2 = UInt64(0)
+    n = len(span) & 15
+    if n >= 15:
+        k2 ^= UInt64(span[position + 14] << 48)
+    if n >= 14:
+        k2 ^= UInt64(span[position + 13] << 40)
+    if n >= 13:
+        k2 ^= UInt64(span[position + 12] << 32)
+    if n >= 12:
+        k2 ^= UInt64(span[position + 11] << 24)
+    if n >= 11:
+        k2 ^= UInt64(span[position + 10] << 16)
+    if n >= 10:
+        k2 ^= UInt64(span[position + 9] << 8)
+    if n >= 9:
+        k2 ^= UInt64(span[position + 8] << 0)
+
+    k2 *= c2
+    k2.value = rotate_left_64(k2.value, 33)
+    k2 *= c1
+    h2 ^= k2
+
+    if n >= 8:
+        k1 ^= UInt64(span[position + 7] << 56)
+    if n >= 7:
+        k1 ^= UInt64(span[position + 6] << 48)
+    if n >= 6:
+        k1 ^= UInt64(span[position + 5] << 40)
+    if n >= 5:
+        k1 ^= UInt64(span[position + 4] << 32)
+    if n >= 4:
+        k1 ^= UInt64(span[position + 3] << 24)
+    if n >= 3:
+        k1 ^= UInt64(span[position + 2] << 16)
+    if n >= 2:
+        k1 ^= UInt64(span[position + 1] << 8)
+    if n >= 1:
+        k1 ^= UInt64(span[position + 0] << 0)
+
+    k1 *= c1
+    k1.value = rotate_left_64(k1.value, 31)
+    k1 *= c2
+    h1 ^= k1
+
+    # Finalization
+    h1 ^= UInt64(len(span))
+    h2 ^= UInt64(len(span))
+    h1 += h2
+    h2 += h1
+    h1 = mix(h1)
+    h2 = mix(h2)
+    h1 += h2
+    h2 += h1
+
+    return UInt128.create(int(h1.value), int(h2.value))

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_cosmos_murmurhash3.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_cosmos_murmurhash3.py
@@ -18,6 +18,18 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+
+# Implementation of the MurmurHash3 128-bit hash function.
+
+# MurmurHash is a non-cryptographic hash function suitable for general hash-based lookup. The name comes from two basic
+# operations, multiply (MU) and rotate (R), used in its inner loop. Unlike cryptographic hash functions, it is not
+# specifically designed to be difficult to reverse by an adversary, making it unsuitable for cryptographic purposes.
+
+ # This contains a Python port of the 128-bit hash function from Austin Appleby's original C++ code in SMHasher.
+
+ # This is public domain code with no copyrights. From home page of
+ # <a href="https://github.com/aappleby/smhasher">SMHasher</a>:
+ #  "All MurmurHash versions are public domain software, and the author disclaims all copyright to their code."
 from ._cosmos_integers import UInt128, UInt64
 
 

--- a/sdk/cosmos/azure-cosmos/test/test_murmurhash3.py
+++ b/sdk/cosmos/azure-cosmos/test/test_murmurhash3.py
@@ -43,7 +43,7 @@ class MurmurHash3Test(unittest.TestCase):
         self.assertEqual(self.float_high_value, ret.get_high().value)
 
     def test_string_hash(self):
-        s = "afdgdd"
+        s = "afdgdd"  # cspell:disable-line
         ba = bytearray()
         ba.extend(s.encode('utf-8'))
         ret = murmurhash3_128(ba, self.test_seed)

--- a/sdk/cosmos/azure-cosmos/test/test_murmurhash3.py
+++ b/sdk/cosmos/azure-cosmos/test/test_murmurhash3.py
@@ -1,0 +1,59 @@
+# The MIT License (MIT)
+# Copyright (c) 2014 Microsoft Corporation
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import unittest
+import pytest
+import struct
+
+pytestmark = pytest.mark.cosmosEmulator
+from azure.cosmos._cosmos_murmurhash3 import murmurhash3_128
+from azure.cosmos._cosmos_integers import UInt128
+
+@pytest.mark.usefixtures("teardown")
+class MurmurHash3Test(unittest.TestCase):
+    """Python Murmurhash3 Tests and its compatibility with backend implementation..
+        """
+    string_low_value = 2792699143512860960
+    string_high_value = 15069672278200047189
+    test_seed = UInt128.create(0, 0)
+    float_low_value = 16628891264555680919
+    float_high_value = 12953474369317462
+
+    def test_float_hash(self):
+        ba = bytearray(struct.pack("d", 374.0))
+        ret = murmurhash3_128(ba, self.test_seed)
+        self.assertEqual(self.float_low_value, ret.get_low().value)
+        self.assertEqual(self.float_high_value, ret.get_high().value)
+
+    def test_string_hash(self):
+        s = "afdgdd"
+        ba = bytearray()
+        ba.extend(s.encode('utf-8'))
+        ret = murmurhash3_128(ba, self.test_seed)
+        self.assertEqual(self.string_low_value, ret.get_low().value)
+        self.assertEqual(self.string_high_value, ret.get_high().value)
+
+
+if __name__ == '__main__':
+    try:
+        unittest.main()
+    except SystemExit as inst:
+        if inst.args[0] is True:  # raised by sys.exit(True) when tests failed
+            raise


### PR DESCRIPTION
Adds the murmurhash3 implementation from the backend for use in the cosmos python sdk.

# Description

This PR adds cosmos integers that implement Unsigned 64 bit and Unsigned 128 bit integers to python. This also adds an implementation of a 128 bit murmurhash 3 algorithm for use in cosmos python sdk. 

Murmurhash takes in a byte array and a Unsigned 128 bit seed and returns a hash in the form of an Unsigned 128 bit integer.

Sample use of murmurhash:

```python
 s = "afdgdd"
 b = bytearray()
 b.extend(s.encode('utf-8'))

 murmurhash3_128(b, UInt128.create(0, 0))
 
 ba = bytearray(struct.pack("d", 374.0))
 murmurhash3_128(ba, UInt128.create(0, 0))
```


# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
