### PR TITLE
We want to test against latest cryptography

### DIFF
--- a/eng/tox/install_depend_packages.py
+++ b/eng/tox/install_depend_packages.py
@@ -53,7 +53,6 @@ MINIMUM_VERSION_SPECIFIC_OVERRIDES = {
 }
 
 MAXIMUM_VERSION_GENERIC_OVERRIDES = {
-    "cryptography": "4.0.0",
     "typing-extensions": "4.6.3"
 }
 


### PR DESCRIPTION
cryptography < 4 locks us into cryptography that shipped two years ago.

Let's run against latest cryptography.