### PR TITLE
[CI] Update autorest CI to use Python 3.8

### DIFF
--- a/eng/pipelines/autorest_checks.yml
+++ b/eng/pipelines/autorest_checks.yml
@@ -15,7 +15,7 @@ pr:
 
 variables:
   NodeVersion: '18.x'
-  PythonVersion: '3.7'
+  PythonVersion: '3.8'
   auto_rest_clone_url: 'https://github.com/Azure/autorest.python.git'
   source_path_azure_core: 'sdk/core/azure-core'
   source_path_azure_mgmt_core: 'sdk/core/azure-mgmt-core'


### PR DESCRIPTION
This was prompted due to the[ required version of tox](https://github.com/Azure/autorest.python/blob/main/eng/requirements.txt#L4) requiring a Python version >= 3.8.

