### PR TITLE
[Cosmos] Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -425,9 +425,6 @@
 # ServiceLabel: %Bot Service %Service Attention
 #/<NotInRepo>/          @sgellock
 
-# ServiceLabel: %Cosmos %Client
-#/<NotInRepo>/          @simorenoh @AbhinavTrips @bambriz
-
 # ServiceLabel: %Cloud Shell %Service Attention
 #/<NotInRepo>/          @maertendMSFT
 


### PR DESCRIPTION
Seems like the Cosmos Client tag mix is still making it so we get emails on anything tagged with Client:
![image](https://github.com/Azure/azure-sdk-for-python/assets/30335873/666d0854-4a88-48f8-b36d-627bdb5fa42c)


Since we are already tagged in the Cosmos Service Attention label, I'd like to remove this one altogether to stop the notifications that don't have to do directly with Cosmos. Thanks.

EDIT: have been getting tagged on a bunch of other stuff even though none of them are related to my service:
<img width="771" alt="image" src="https://github.com/Azure/azure-sdk-for-python/assets/30335873/715e1b04-ddcf-4820-96bd-3f68f087c732">
