### PR TITLE
Instrumentation options

### DIFF
--- a/sdk/monitor/azure-monitor-opentelemetry/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-opentelemetry/CHANGELOG.md
@@ -19,6 +19,8 @@
 
 - Add Azure resource detectors
     ([#32087](https://github.com/Azure/azure-sdk-for-python/pull/32087))
+- Add instrumentation_options
+    ([#31793](https://github.com/Azure/azure-sdk-for-python/pull/31793))
 
 ### Other Changes
 

--- a/sdk/monitor/azure-monitor-opentelemetry/README.md
+++ b/sdk/monitor/azure-monitor-opentelemetry/README.md
@@ -24,10 +24,6 @@ OpenTelemetry instrumentations allow automatic collection of requests sent from 
 
 If you would like to add support for another OpenTelemetry instrumentation, please submit a feature [request][distro_feature_request]. In the meantime, you can use the OpenTelemetry instrumentation manually via it's own APIs (i.e. `instrument()`) in your code. See [this][samples_manual] for an example.
 
-## Azure Core Distributed Tracing
-
-Using the [Azure Core Tracing OpenTelemetry][azure_core_tracing_opentelemetry_plugin] library, you can automatically capture the distributed tracing from Azure Core libraries. See the associated [sample][azure_core_tracing_opentelemetry_plugin_sample] for more information.
-
 ## Key concepts
 
 This package bundles a series of OpenTelemetry and Azure Monitor components to enable the collection and sending of telemetry to Azure Monitor. For MANUAL instrumentation, use the `configure_azure_monitor` function. AUTOMATIC instrumentation is not yet supported.

--- a/sdk/monitor/azure-monitor-opentelemetry/README.md
+++ b/sdk/monitor/azure-monitor-opentelemetry/README.md
@@ -9,10 +9,11 @@ This distro automatically installs the following libraries:
 
 ## Officially supported instrumentations
 
-OpenTelemetry instrumentations allow automatic collection of requests sent from underlying instrumented libraries. The following is a list of OpenTelemetry instrumentations that come bundled in with the Azure monitor distro. If you would like to add support for another OpenTelemetry instrumentation, please submit a feature [request][distro_feature_request]. In the meantime, you can use the OpenTelemetry instrumentation manually via it's own APIs (i.e. `instrument()`) in your code. See [this][samples_manual] for an example.
+OpenTelemetry instrumentations allow automatic collection of requests sent from underlying instrumented libraries. The following is a list of OpenTelemetry instrumentations that come bundled in with the Azure monitor distro. These instrumentations are enabled by default. See the [Usage](#usage) section below for how to opt-out of these instrumentations.
 
-| Instrumentation | Supported library | Supported versions |
-| ------------------------------------- | ----------------- | ------------------ |
+| Instrumentation | Supported library Name | Supported versions |
+| --------------- | ---------------------- | ------------------ |
+| [Azure Core Tracing OpenTelemetry][azure_core_tracing_opentelemetry_plugin] | `azure_sdk` | |
 | [OpenTelemetry Django Instrumentation][ot_instrumentation_django] | [django][pypi_django] | [link][ot_instrumentation_django_version]
 | [OpenTelemetry FastApi Instrumentation][ot_instrumentation_fastapi] | [fastapi][pypi_fastapi] | [link][ot_instrumentation_fastapi_version]
 | [OpenTelemetry Flask Instrumentation][ot_instrumentation_flask] | [flask][pypi_flask] | [link][ot_instrumentation_flask_version]
@@ -21,9 +22,11 @@ OpenTelemetry instrumentations allow automatic collection of requests sent from 
 | [OpenTelemetry UrlLib Instrumentation][ot_instrumentation_urllib] | [urllib][pypi_urllib] | All
 | [OpenTelemetry UrlLib3 Instrumentation][ot_instrumentation_urllib3] | [urllib3][pypi_urllib3] | [link][ot_instrumentation_urllib3_version]
 
+If you would like to add support for another OpenTelemetry instrumentation, please submit a feature [request][distro_feature_request]. In the meantime, you can use the OpenTelemetry instrumentation manually via it's own APIs (i.e. `instrument()`) in your code. See [this][samples_manual] for an example.
+
 ## Azure Core Distributed Tracing
 
-Using the [Azure Core Tracing OpenTelemetry][azure_core_tracing_opentelemetry_plugin] library, you can automatically capture the distributed tracing from Azure Core libraries. See the associated [sample][azure_core_tracing_opentelemetry_plugin_sample] for more information. This feature is enabled automatically.
+Using the [Azure Core Tracing OpenTelemetry][azure_core_tracing_opentelemetry_plugin] library, you can automatically capture the distributed tracing from Azure Core libraries. See the associated [sample][azure_core_tracing_opentelemetry_plugin_sample] for more information.
 
 ## Key concepts
 
@@ -54,12 +57,14 @@ pip install azure-monitor-opentelemetry
 
 ### Usage
 
-You can use `configure_azure_monitor` to set up instrumentation for your app to Azure Monitor. `configure_azure_monitor` supports the following optional arguments:
+You can use `configure_azure_monitor` to set up instrumentation for your app to Azure Monitor. `configure_azure_monitor` supports the following optional arguments. All pass-in parameters take priority over any related environment variables.
 
 | Parameter | Description | Environment Variable |
 |-------------------|----------------------------------------------------|----------------------|
 | `connection_string` | The [connection string][connection_string_doc] for your Application Insights resource. The connection string will be automatically populated from the `APPLICATIONINSIGHTS_CONNECTION_STRING` environment variable if not explicitly passed in. | `APPLICATIONINSIGHTS_CONNECTION_STRING` |
 | `logger_name` | The name of the [Python logger][python_logger] under which telemetry is collected. | `N/A` |
+| `instrumentation_options` | A nested dictionary that determines which instrumentations to enable or disable. Instrumentations are referred to by their [Library Names](#officially-supported-instrumentations). For example, `{"azure_sdk": {"enabled": False}, "flask": {"enabled": False}, "django": {"enabled": True}}` will disable Azure Core Tracing and the Flask instrumentation but leave Django and the other default instrumentations enabled. The `OTEL_PYTHON_DISABLED_INSTRUMENTATIONS` environment variable explained below can also be used to disable instrumentations. | `N/A` |
+
 
 You can configure further with [OpenTelemetry environment variables][ot_env_vars] such as:
 | Environment Variable | Description |
@@ -71,7 +76,7 @@ You can configure further with [OpenTelemetry environment variables][ot_env_vars
 | `OTEL_BLRP_SCHEDULE_DELAY` | Specifies the logging export interval in milliseconds. Defaults to 5000. |
 | `OTEL_BSP_SCHEDULE_DELAY` | Specifies the distributed tracing export interval in milliseconds. Defaults to 5000. |
 | `OTEL_TRACES_SAMPLER_ARG` | Specifies the ratio of distributed tracing telemetry to be [sampled][application_insights_sampling]. Accepted values are in the range [0,1]. Defaults to 1.0, meaning no telemetry is sampled out. |
-| `OTEL_PYTHON_DISABLED_INSTRUMENTATIONS` | Specifies which of the supported instrumentations to disable. Disabled instrumentations will not be instrumented as part of `configure_azure_monitor`. However, they can still be manually instrumented by users after the fact. Accepts a comma-separated list of lowercase entry point names for instrumentations. For example, set to `"psycopg2,fastapi"` to disable the Psycopg2 and FastAPI instrumentations. Defaults to an empty list, enabling all supported instrumentations. |
+| `OTEL_PYTHON_DISABLED_INSTRUMENTATIONS` | Specifies which of the supported instrumentations to disable. Disabled instrumentations will not be instrumented as part of `configure_azure_monitor`. However, they can still be manually instrumented with `instrument()` directly. Accepts a comma-separated list of lowercase [Library Names](#officially-supported-instrumentations). For example, set to `"psycopg2,fastapi"` to disable the Psycopg2 and FastAPI instrumentations. Defaults to an empty list, enabling all supported instrumentations. |
 
 #### Azure monitor OpenTelemetry Exporter configurations
 

--- a/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_configure.py
+++ b/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_configure.py
@@ -50,16 +50,6 @@ from azure.monitor.opentelemetry._util.configurations import (
 )
 
 
-_SUPPORTED_INSTRUMENTED_LIBRARIES = (
-    "django",
-    "fastapi",
-    "flask",
-    "psycopg2",
-    "requests",
-    "urllib",
-    "urllib3",
-)
-
 _SUPPORTED_RESOURCE_DETECTORS = (
     "azure_app_service",
     "azure_vm",

--- a/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_configure.py
+++ b/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_configure.py
@@ -44,7 +44,7 @@ from azure.monitor.opentelemetry.exporter import (  # pylint: disable=import-err
     AzureMonitorMetricExporter,
     AzureMonitorTraceExporter,
 )
-from azure.monitor.opentelemetry.util._configurations import (
+from azure.monitor.opentelemetry._util.configurations import (
     _get_configurations,
     _is_instrumentation_enabled,
 )

--- a/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_configure.py
+++ b/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_configure.py
@@ -29,11 +29,11 @@ from pkg_resources import iter_entry_points  # type: ignore
 from azure.core.settings import settings
 from azure.core.tracing.ext.opentelemetry_span import OpenTelemetrySpan
 from azure.monitor.opentelemetry._constants import (
-    DISABLE_AZURE_CORE_TRACING_ARG,
+    _ALL_SUPPORTED_INSTRUMENTED_LIBRARIES,
+    _AZURE_SDK_INSTRUMENTATION_NAME,
     DISABLE_LOGGING_ARG,
     DISABLE_METRICS_ARG,
     DISABLE_TRACING_ARG,
-    DISABLED_INSTRUMENTATIONS_ARG,
     LOGGER_NAME_ARG,
     SAMPLING_RATIO_ARG,
 )
@@ -44,9 +44,11 @@ from azure.monitor.opentelemetry.exporter import (  # pylint: disable=import-err
     AzureMonitorMetricExporter,
     AzureMonitorTraceExporter,
 )
-from azure.monitor.opentelemetry._util.configurations import _get_configurations
+from azure.monitor.opentelemetry.util._configurations import (
+    _get_configurations,
+    _is_instrumentation_enabled,
+)
 
-_logger = getLogger(__name__)
 
 _SUPPORTED_INSTRUMENTED_LIBRARIES = (
     "django",
@@ -62,6 +64,8 @@ _SUPPORTED_RESOURCE_DETECTORS = (
     "azure_app_service",
     "azure_vm",
 )
+
+_logger = getLogger(__name__)
 
 
 def configure_azure_monitor(**kwargs) -> None:
@@ -126,8 +130,7 @@ def _setup_tracing(configurations: Dict[str, ConfigurationValue]):
         trace_exporter,
     )
     get_tracer_provider().add_span_processor(span_processor)
-    disable_azure_core_tracing = configurations[DISABLE_AZURE_CORE_TRACING_ARG]
-    if not disable_azure_core_tracing:
+    if _is_instrumentation_enabled(configurations, _AZURE_SDK_INSTRUMENTATION_NAME):
         settings.tracing_implementation = OpenTelemetrySpan
 
 
@@ -154,16 +157,14 @@ def _setup_metrics(configurations: Dict[str, ConfigurationValue]):
 
 
 def _setup_instrumentations(configurations: Dict[str, ConfigurationValue]):
-    disabled_instrumentations = configurations[DISABLED_INSTRUMENTATIONS_ARG]
-
     # use pkg_resources for now until https://github.com/open-telemetry/opentelemetry-python/pull/3168 is merged
     for entry_point in iter_entry_points(
         "opentelemetry_instrumentor"
     ):
         lib_name = entry_point.name
-        if lib_name not in _SUPPORTED_INSTRUMENTED_LIBRARIES:
+        if lib_name not in _ALL_SUPPORTED_INSTRUMENTED_LIBRARIES:
             continue
-        if entry_point.name in disabled_instrumentations:
+        if not _is_instrumentation_enabled(configurations, lib_name):
             _logger.debug(
                 "Instrumentation skipped for library %s", entry_point.name
             )

--- a/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_constants.py
+++ b/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_constants.py
@@ -94,6 +94,7 @@ _EXTENSION_VERSION = _env_var_or_default(
 # Opt-out
 _AZURE_SDK_INSTRUMENTATION_NAME = "azure_sdk"
 _FULLY_SUPPORTED_INSTRUMENTED_LIBRARIES = (
+    _AZURE_SDK_INSTRUMENTATION_NAME,
     "django",
     "fastapi",
     "flask",
@@ -101,7 +102,6 @@ _FULLY_SUPPORTED_INSTRUMENTED_LIBRARIES = (
     "requests",
     "urllib",
     "urllib3",
-    _AZURE_SDK_INSTRUMENTATION_NAME,
 )
 # Opt-in
 _PREVIEW_INSTRUMENTED_LIBRARIES = ()

--- a/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_constants.py
+++ b/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_constants.py
@@ -21,8 +21,8 @@ DISABLE_AZURE_CORE_TRACING_ARG = "disable_azure_core_tracing"
 DISABLE_LOGGING_ARG = "disable_logging"
 DISABLE_METRICS_ARG = "disable_metrics"
 DISABLE_TRACING_ARG = "disable_tracing"
-DISABLED_INSTRUMENTATIONS_ARG = "disabled_instrumentations"
 LOGGER_NAME_ARG = "logger_name"
+INSTRUMENTATION_OPTIONS_ARG = "instrumentation_options"
 SAMPLING_RATIO_ARG = "sampling_ratio"
 
 
@@ -89,6 +89,25 @@ _EXTENSION_VERSION = _env_var_or_default(
 # TODO: Enabled when duplicate logging issue is solved
 # _EXPORTER_DIAGNOSTICS_ENABLED = _is_exporter_diagnostics_enabled()
 
+# Instrumentations
+
+# Opt-out
+_AZURE_SDK_INSTRUMENTATION_NAME = "azure_sdk"
+_FULLY_SUPPORTED_INSTRUMENTED_LIBRARIES = (
+    "django",
+    "fastapi",
+    "flask",
+    "psycopg2",
+    "requests",
+    "urllib",
+    "urllib3",
+    _AZURE_SDK_INSTRUMENTATION_NAME,
+)
+# Opt-in
+_PREVIEW_INSTRUMENTED_LIBRARIES = ()
+_ALL_SUPPORTED_INSTRUMENTED_LIBRARIES = _FULLY_SUPPORTED_INSTRUMENTED_LIBRARIES + _PREVIEW_INSTRUMENTED_LIBRARIES
+
+# Autoinstrumentation
 
 def _is_attach_enabled():
     return isdir("/agents/python/")

--- a/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_util/configurations.py
+++ b/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_util/configurations.py
@@ -19,11 +19,12 @@ from opentelemetry.instrumentation.environment_variables import (
 from opentelemetry.sdk.environment_variables import OTEL_TRACES_SAMPLER_ARG
 
 from azure.monitor.opentelemetry._constants import (
-    DISABLE_AZURE_CORE_TRACING_ARG,
+    _FULLY_SUPPORTED_INSTRUMENTED_LIBRARIES,
+    _PREVIEW_INSTRUMENTED_LIBRARIES,
     DISABLE_LOGGING_ARG,
     DISABLE_METRICS_ARG,
     DISABLE_TRACING_ARG,
-    DISABLED_INSTRUMENTATIONS_ARG,
+    INSTRUMENTATION_OPTIONS_ARG,
     LOGGER_NAME_ARG,
     SAMPLING_RATIO_ARG,
 )
@@ -31,7 +32,6 @@ from azure.monitor.opentelemetry._types import ConfigurationValue
 
 
 _INVALID_FLOAT_MESSAGE = "Value of %s must be a float. Defaulting to %s: %s"
-_INVALID_INT_MESSAGE = "Value of %s must be a integer. Defaulting to %s: %s"
 
 
 # TODO: remove when sampler uses env var instead
@@ -50,10 +50,9 @@ def _get_configurations(**kwargs) -> Dict[str, ConfigurationValue]:
     _default_disable_logging(configurations)
     _default_disable_metrics(configurations)
     _default_disable_tracing(configurations)
-    _default_disabled_instrumentations(configurations)
     _default_logger_name(configurations)
     _default_sampling_ratio(configurations)
-    _default_disable_azure_core_tracing(configurations)
+    _default_instrumentation_options(configurations)
 
     return configurations
 
@@ -82,19 +81,6 @@ def _default_disable_tracing(configurations):
     configurations[DISABLE_TRACING_ARG] = default
 
 
-def _default_disabled_instrumentations(configurations):
-    disabled_instrumentation = environ.get(
-        OTEL_PYTHON_DISABLED_INSTRUMENTATIONS, []
-    )
-    if isinstance(disabled_instrumentation, str):
-        disabled_instrumentation = disabled_instrumentation.split(",")
-        # to handle users entering "requests , flask" or "requests, flask" with spaces
-        disabled_instrumentation = [
-            x.strip() for x in disabled_instrumentation
-        ]
-    configurations[DISABLED_INSTRUMENTATIONS_ARG] = disabled_instrumentation
-
-
 def _default_logger_name(configurations):
     if LOGGER_NAME_ARG not in configurations:
         configurations[LOGGER_NAME_ARG] = ""
@@ -116,6 +102,52 @@ def _default_sampling_ratio(configurations):
     configurations[SAMPLING_RATIO_ARG] = default
 
 
-# TODO: Placeholder for future configuration
-def _default_disable_azure_core_tracing(configurations):
-    configurations[DISABLE_AZURE_CORE_TRACING_ARG] = False
+def _merge_nested_dicts_in_place(d1, d2):
+    for key, value in d2.items():
+        if key in d1 and isinstance(d1[key], dict) and isinstance(value, dict):
+            _merge_nested_dicts_in_place(d1[key], value)
+        else:
+            d1[key] = value
+
+
+def _merge_nested_dicts(d1, d2):
+    merged = d1.copy()
+    for key, value in d2.items():
+        if key in merged and isinstance(merged[key], dict) and isinstance(value, dict):
+            _merge_nested_dicts_in_place(merged[key], value)
+        else:
+            merged[key] = value
+    return merged
+
+
+def _default_instrumentation_options(configurations):
+    disabled_instrumentation = environ.get(
+        OTEL_PYTHON_DISABLED_INSTRUMENTATIONS, ""
+    )
+    disabled_instrumentation = disabled_instrumentation.split(",")
+    # to handle users entering "requests , flask" or "requests, flask" with spaces
+    disabled_instrumentation = [
+        x.strip() for x in disabled_instrumentation
+    ]
+
+    default_instrumentation_options = {}
+    for lib_name in _FULLY_SUPPORTED_INSTRUMENTED_LIBRARIES:
+        disabled_by_env_var = lib_name in disabled_instrumentation
+        default_instrumentation_options[lib_name] = {"enabled": not disabled_by_env_var}
+    for lib_name in _PREVIEW_INSTRUMENTED_LIBRARIES:
+        default_instrumentation_options[lib_name] = {"enabled": False}
+
+    # Explicit configuration takes priority over environment variables
+    instrumentation_options = configurations.get(INSTRUMENTATION_OPTIONS_ARG, {})
+    merged_instrumentation_options = _merge_nested_dicts(default_instrumentation_options, instrumentation_options)
+    configurations[INSTRUMENTATION_OPTIONS_ARG] = merged_instrumentation_options
+
+
+def _is_instrumentation_enabled(configurations, lib_name):
+    instrumentation_options = configurations[INSTRUMENTATION_OPTIONS_ARG]
+    if not lib_name in instrumentation_options:
+        return False
+    library_options = instrumentation_options[lib_name]
+    if "enabled" not in library_options:
+        return False
+    return library_options["enabled"] is True

--- a/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_util/configurations.py
+++ b/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_util/configurations.py
@@ -117,10 +117,10 @@ def _default_instrumentation_options(configurations):
     for lib_name in _FULLY_SUPPORTED_INSTRUMENTED_LIBRARIES:
         disabled_by_env_var = lib_name in disabled_instrumentation
         default = {"enabled": not disabled_by_env_var}
-        merged_instrumentation_options[lib_name] = instrumentation_options.get(lib_name, {}) | default
+        merged_instrumentation_options[lib_name] = default | instrumentation_options.get(lib_name, {})
     for lib_name in _PREVIEW_INSTRUMENTED_LIBRARIES:
         default = {"enabled": False}
-        merged_instrumentation_options[lib_name] = instrumentation_options.get(lib_name, {}) | default
+        merged_instrumentation_options[lib_name] = default | instrumentation_options.get(lib_name, {})
 
     configurations[INSTRUMENTATION_OPTIONS_ARG] = merged_instrumentation_options
 

--- a/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_util/configurations.py
+++ b/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_util/configurations.py
@@ -116,11 +116,13 @@ def _default_instrumentation_options(configurations):
     instrumentation_options = configurations.get(INSTRUMENTATION_OPTIONS_ARG, {})
     for lib_name in _FULLY_SUPPORTED_INSTRUMENTED_LIBRARIES:
         disabled_by_env_var = lib_name in disabled_instrumentation
-        default = {"enabled": not disabled_by_env_var}
-        merged_instrumentation_options[lib_name] = default | instrumentation_options.get(lib_name, {})
+        options = {"enabled": not disabled_by_env_var}
+        options.update(instrumentation_options.get(lib_name, {}))
+        merged_instrumentation_options[lib_name] = options
     for lib_name in _PREVIEW_INSTRUMENTED_LIBRARIES:
-        default = {"enabled": False}
-        merged_instrumentation_options[lib_name] = default | instrumentation_options.get(lib_name, {})
+        options = {"enabled": False}
+        options.update(instrumentation_options.get(lib_name, {}))
+        merged_instrumentation_options[lib_name] = options
 
     configurations[INSTRUMENTATION_OPTIONS_ARG] = merged_instrumentation_options
 

--- a/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_util/configurations.py
+++ b/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_util/configurations.py
@@ -128,6 +128,8 @@ def _default_instrumentation_options(configurations):
 
 
 def _is_instrumentation_enabled(configurations, lib_name):
+    if INSTRUMENTATION_OPTIONS_ARG not in configurations:
+        return False
     instrumentation_options = configurations[INSTRUMENTATION_OPTIONS_ARG]
     if not lib_name in instrumentation_options:
         return False

--- a/sdk/monitor/azure-monitor-opentelemetry/samples/README.md
+++ b/sdk/monitor/azure-monitor-opentelemetry/samples/README.md
@@ -22,10 +22,8 @@ For guidance on the samples README, visit the [sample guide](https://github.com/
 |[logging/exception_logs.py][exception_logs] | Produce exception logs |
 |[logging/logs_with_traces.py][logs_with_traces] | Produce correlated logs inside an instrumented http library's distributed tracing |
 |[logging/simple.py][logging_simple] | Produce logs |
-
 |[metrics/attributes.py][attributes] | Add attributes to custom metrics counters |
 |[metrics/instruments.py][instruments] | Create observable instruments |
-
 |[tracing/django/sample/manage.py][django] | Instrument a django app |
 |[tracing/db_psycopg2.py][db_psycopg2] | Instrument the PsycoPG2 library |
 |[tracing/http_fastapi.py][http_fastapi] | Instrument a FastAPI app |
@@ -33,6 +31,7 @@ For guidance on the samples README, visit the [sample guide](https://github.com/
 |[tracing/http_requests.py][http_requests] | Instrument the Requests library |
 |[tracing/http_urllib.py][http_urllib] | Instrument the URLLib library |
 |[tracing/http_urllib3.py][http_urllib3] | Instrument the URLLib library |
+|[tracing/instrumentation_options.py][instrumentation_options] | Enable and disable instrumentations |
 |[tracing/manual.py][manual] | Manually add instrumentation |
 |[tracing/sampling.py][sampling] | Sample distributed tracing telemetry |
 |[tracing/tracing_simple.py][tracing_simple] | Produce manual spans |
@@ -76,6 +75,7 @@ To learn more, see the [Azure Monitor OpenTelemetry Distro documentation][distro
 [http_requests]: https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/monitor/azure-monitor-opentelemetry/samples/tracing/http_requests.py
 [http_urllib]: https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/monitor/azure-monitor-opentelemetry/samples/tracing/http_urllib.py
 [http_urllib3]: https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/monitor/azure-monitor-opentelemetry/samples/tracing/http_urllib3.py
+[instrumentation_options]: https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/monitor/azure-monitor-opentelemetry/samples/tracing/instrumentation_options.py
 [manual]: https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/monitor/azure-monitor-opentelemetry/samples/tracing/manual.py
 [sampling]: https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/monitor/azure-monitor-opentelemetry/samples/tracing/sampling.py
 [tracing_simple]: https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/monitor/azure-monitor-opentelemetry/samples/tracing/simple.py

--- a/sdk/monitor/azure-monitor-opentelemetry/samples/tracing/instrumentation_options.py
+++ b/sdk/monitor/azure-monitor-opentelemetry/samples/tracing/instrumentation_options.py
@@ -1,0 +1,20 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License in the project root for
+# license information.
+# --------------------------------------------------------------------------
+from azure.monitor.opentelemetry import configure_azure_monitor
+
+# Enable or disable supported instrumentations with the instrumentation_options parameter
+configure_azure_monitor(
+    instrumentation_options = {
+        "azure_sdk": {"enabled": False},
+        "django": {"enabled": True},
+        "fastapi": {"enabled": False},
+        "flask": {"enabled": True},
+        "psycopg2": {"enabled": False},
+        "requests": {"enabled": True},
+        "urllib": {"enabled": False},
+        "urllib3": {"enabled": True},
+    }
+)

--- a/sdk/monitor/azure-monitor-opentelemetry/tests/configuration/test_configure.py
+++ b/sdk/monitor/azure-monitor-opentelemetry/tests/configuration/test_configure.py
@@ -17,7 +17,6 @@ from unittest.mock import Mock, patch
 
 from azure.core.tracing.ext.opentelemetry_span import OpenTelemetrySpan
 from azure.monitor.opentelemetry._configure import (
-    _SUPPORTED_INSTRUMENTED_LIBRARIES,
     _setup_instrumentations,
     _setup_logging,
     _setup_metrics,
@@ -93,6 +92,17 @@ class TestConfigure(unittest.TestCase):
             "disable_tracing": True,
             "disable_logging": False,
             "disable_metrics": False,
+            "instrumentation_options": {
+                "flask": {
+                    "enabled": False
+                },
+                "django": {
+                    "enabled": False
+                },
+                "requests": {
+                    "enabled": False
+                },
+            }
         }
         config_mock.return_value = configurations
         configure_azure_monitor()
@@ -244,7 +254,9 @@ class TestConfigure(unittest.TestCase):
 
         configurations = {
             "connection_string": "test_cs",
-            "disable_azure_core_tracing": False,
+            "instrumentation_options": {
+                "azure_sdk": {"enabled": True}
+            },
             "sampling_ratio": 0.5,
         }
         _setup_tracing(configurations)
@@ -367,12 +379,15 @@ class TestConfigure(unittest.TestCase):
         metric_exporter_mock.assert_called_once_with(**configurations)
         reader_mock.assert_called_once_with(metric_exp_init_mock)
 
+    @patch("azure.monitor.opentelemetry._configure._ALL_SUPPORTED_INSTRUMENTED_LIBRARIES", ("test_instr2"))
+    @patch("azure.monitor.opentelemetry._configure._is_instrumentation_enabled")
     @patch("azure.monitor.opentelemetry._configure.get_dist_dependency_conflicts")
     @patch("azure.monitor.opentelemetry._configure.iter_entry_points")
     def test_setup_instrumentations_lib_not_supported(
         self,
         iter_mock,
         dep_mock,
+        enabled_mock,
     ):
         ep_mock = Mock()
         ep2_mock = Mock()
@@ -380,16 +395,19 @@ class TestConfigure(unittest.TestCase):
         instrumentor_mock = Mock()
         instr_class_mock = Mock()
         instr_class_mock.return_value = instrumentor_mock
-        ep_mock.name = "test_instr"
-        ep2_mock.name = _SUPPORTED_INSTRUMENTED_LIBRARIES[0]
+        ep_mock.name = "test_instr1"
+        ep2_mock.name = "test_instr2"
         ep2_mock.load.return_value = instr_class_mock
         dep_mock.return_value = None
-        _setup_instrumentations({"disabled_instrumentations": []})
+        enabled_mock.return_value = True
+        _setup_instrumentations({})
         dep_mock.assert_called_with(ep2_mock.dist)
         ep_mock.load.assert_not_called()
         ep2_mock.load.assert_called_once()
         instrumentor_mock.instrument.assert_called_once()
 
+    @patch("azure.monitor.opentelemetry._configure._ALL_SUPPORTED_INSTRUMENTED_LIBRARIES", ("test_instr"))
+    @patch("azure.monitor.opentelemetry._configure._is_instrumentation_enabled")
     @patch("azure.monitor.opentelemetry._configure._logger")
     @patch("azure.monitor.opentelemetry._configure.get_dist_dependency_conflicts")
     @patch("azure.monitor.opentelemetry._configure.iter_entry_points")
@@ -398,21 +416,25 @@ class TestConfigure(unittest.TestCase):
         iter_mock,
         dep_mock,
         logger_mock,
+        enabled_mock,
     ):
         ep_mock = Mock()
         iter_mock.return_value = (ep_mock,)
         instrumentor_mock = Mock()
         instr_class_mock = Mock()
         instr_class_mock.return_value = instrumentor_mock
-        ep_mock.name = _SUPPORTED_INSTRUMENTED_LIBRARIES[0]
+        ep_mock.name = "test_instr"
         ep_mock.load.return_value = instr_class_mock
         dep_mock.return_value = True
-        _setup_instrumentations({"disabled_instrumentations": []})
+        enabled_mock.return_value = True
+        _setup_instrumentations({})
         dep_mock.assert_called_with(ep_mock.dist)
         ep_mock.load.assert_not_called()
         instrumentor_mock.instrument.assert_not_called()
         logger_mock.debug.assert_called_once()
 
+    @patch("azure.monitor.opentelemetry._configure._ALL_SUPPORTED_INSTRUMENTED_LIBRARIES", ("test_instr"))
+    @patch("azure.monitor.opentelemetry._configure._is_instrumentation_enabled")
     @patch("azure.monitor.opentelemetry._configure._logger")
     @patch("azure.monitor.opentelemetry._configure.get_dist_dependency_conflicts")
     @patch("azure.monitor.opentelemetry._configure.iter_entry_points")
@@ -421,21 +443,25 @@ class TestConfigure(unittest.TestCase):
         iter_mock,
         dep_mock,
         logger_mock,
+        enabled_mock,
     ):
         ep_mock = Mock()
         iter_mock.return_value = (ep_mock,)
         instrumentor_mock = Mock()
         instr_class_mock = Mock()
         instr_class_mock.return_value = instrumentor_mock
-        ep_mock.name = _SUPPORTED_INSTRUMENTED_LIBRARIES[0]
+        ep_mock.name = "test_instr"
         ep_mock.load.side_effect = Exception()
         dep_mock.return_value = None
-        _setup_instrumentations({"disabled_instrumentations": []})
+        enabled_mock.return_value = True
+        _setup_instrumentations({})
         dep_mock.assert_called_with(ep_mock.dist)
         ep_mock.load.assert_called_once()
         instrumentor_mock.instrument.assert_not_called()
         logger_mock.warning.assert_called_once()
 
+    @patch("azure.monitor.opentelemetry._configure._ALL_SUPPORTED_INSTRUMENTED_LIBRARIES", ("test_instr1", "test_instr2"))
+    @patch("azure.monitor.opentelemetry._configure._is_instrumentation_enabled")
     @patch("azure.monitor.opentelemetry._configure._logger")
     @patch("azure.monitor.opentelemetry._configure.get_dist_dependency_conflicts")
     @patch("azure.monitor.opentelemetry._configure.iter_entry_points")
@@ -444,6 +470,7 @@ class TestConfigure(unittest.TestCase):
         iter_mock,
         dep_mock,
         logger_mock,
+        enabled_mock,
     ):
         ep_mock = Mock()
         ep2_mock = Mock()
@@ -451,11 +478,12 @@ class TestConfigure(unittest.TestCase):
         instrumentor_mock = Mock()
         instr_class_mock = Mock()
         instr_class_mock.return_value = instrumentor_mock
-        ep_mock.name = _SUPPORTED_INSTRUMENTED_LIBRARIES[0]
-        ep2_mock.name = _SUPPORTED_INSTRUMENTED_LIBRARIES[1]
+        ep_mock.name = "test_instr1"
+        ep2_mock.name = "test_instr2"
         ep2_mock.load.return_value = instr_class_mock
         dep_mock.return_value = None
-        _setup_instrumentations({"disabled_instrumentations": [ep_mock.name]})
+        enabled_mock.side_effect = [False, True]
+        _setup_instrumentations({})
         dep_mock.assert_called_with(ep2_mock.dist)
         ep_mock.load.assert_not_called()
         ep2_mock.load.assert_called_once()

--- a/sdk/monitor/azure-monitor-opentelemetry/tests/configuration/test_util.py
+++ b/sdk/monitor/azure-monitor-opentelemetry/tests/configuration/test_util.py
@@ -30,6 +30,8 @@ from opentelemetry.environment_variables import (
 
 
 class TestUtil(TestCase):
+    @patch.dict("os.environ", {}, clear=True)
+    @patch("azure.monitor.opentelemetry.util._configurations._PREVIEW_INSTRUMENTED_LIBRARIES", ("previewlib1", "previewlib2"))
     def test_get_configurations(self):
         configurations = _get_configurations(
             connection_string="test_cs",
@@ -37,13 +39,23 @@ class TestUtil(TestCase):
         )
 
         self.assertEqual(configurations["connection_string"], "test_cs")
-        self.assertEqual(configurations["disable_azure_core_tracing"], False)
         self.assertEqual(configurations["disable_logging"], False)
         self.assertEqual(configurations["disable_metrics"], False)
         self.assertEqual(configurations["disable_tracing"], False)
-        self.assertEqual(configurations["disabled_instrumentations"], [])
         self.assertEqual(configurations["sampling_ratio"], 1.0)
         self.assertEqual(configurations["credential"], ("test_credential"))
+        self.assertEqual(configurations["instrumentation_options"], {
+            "azure_sdk" : {"enabled": True},
+            "django": {"enabled": True},
+            "fastapi": {"enabled": True},
+            "flask": {"enabled": True},
+            "psycopg2": {"enabled": True},
+            "requests": {"enabled": True},
+            "urllib": {"enabled": True},
+            "urllib3": {"enabled": True},
+            "previewlib1": {"enabled": False},
+            "previewlib2": {"enabled": False},
+        })
         self.assertTrue("storage_directory" not in configurations)
 
     @patch.dict("os.environ", {}, clear=True)
@@ -51,11 +63,9 @@ class TestUtil(TestCase):
         configurations = _get_configurations()
 
         self.assertTrue("connection_string" not in configurations)
-        self.assertEqual(configurations["disable_azure_core_tracing"], False)
         self.assertEqual(configurations["disable_logging"], False)
         self.assertEqual(configurations["disable_metrics"], False)
         self.assertEqual(configurations["disable_tracing"], False)
-        self.assertEqual(configurations["disabled_instrumentations"], [])
         self.assertEqual(configurations["sampling_ratio"], 1.0)
         self.assertTrue("credential" not in configurations)
         self.assertTrue("storage_directory" not in configurations)
@@ -63,7 +73,7 @@ class TestUtil(TestCase):
     @patch.dict(
         "os.environ",
         {
-            OTEL_PYTHON_DISABLED_INSTRUMENTATIONS: "flask , requests,fastapi",
+            OTEL_PYTHON_DISABLED_INSTRUMENTATIONS: "flask , requests,fastapi,azure_sdk",
             SAMPLING_RATIO_ENV_VAR: "0.5",
             OTEL_TRACES_EXPORTER: "None",
             OTEL_LOGS_EXPORTER: "none",
@@ -75,14 +85,19 @@ class TestUtil(TestCase):
         configurations = _get_configurations()
 
         self.assertTrue("connection_string" not in configurations)
-        self.assertEqual(configurations["disable_azure_core_tracing"], False)
         self.assertEqual(configurations["disable_logging"], True)
         self.assertEqual(configurations["disable_metrics"], True)
         self.assertEqual(configurations["disable_tracing"], True)
-        self.assertEqual(
-            configurations["disabled_instrumentations"],
-            ["flask", "requests", "fastapi"],
-        )
+        self.assertEqual(configurations["instrumentation_options"], {
+            "azure_sdk" : {"enabled": False},
+            "django" : {"enabled": True},
+            "fastapi" : {"enabled": False},
+            "flask" : {"enabled": False},
+            "psycopg2" : {"enabled": True},
+            "requests": {"enabled": False},
+            "urllib": {"enabled": True},
+            "urllib3": {"enabled": True},
+        })
         self.assertEqual(configurations["sampling_ratio"], 0.5)
 
     @patch.dict(
@@ -99,8 +114,66 @@ class TestUtil(TestCase):
         configurations = _get_configurations()
 
         self.assertTrue("connection_string" not in configurations)
-        self.assertEqual(configurations["disable_azure_core_tracing"], False)
         self.assertEqual(configurations["disable_logging"], False)
         self.assertEqual(configurations["disable_metrics"], False)
         self.assertEqual(configurations["disable_tracing"], False)
         self.assertEqual(configurations["sampling_ratio"], 1.0)
+
+    @patch.dict(
+        "os.environ",
+        {
+            OTEL_PYTHON_DISABLED_INSTRUMENTATIONS: "django , urllib3,previewlib1,azure_sdk",
+        },
+        clear=True,
+    )
+    @patch("azure.monitor.opentelemetry.util._configurations._PREVIEW_INSTRUMENTED_LIBRARIES", ("previewlib1", "previewlib2"))
+    def test_merge_instrumentation_options_conflict(self):
+        configurations = _get_configurations(
+            instrumentation_options = {
+                "azure_sdk" : {"enabled": True},
+                "django" : {"enabled": True},
+                "fastapi" : {"enabled": True},
+                "flask" : {"enabled": False},
+                "previewlib1": {"enabled": True},
+            }
+        )
+
+        self.assertEqual(configurations["instrumentation_options"], {
+            "azure_sdk" : {"enabled": True}, # Explicit configuration takes priority
+            "django" : {"enabled": True}, # Explicit configuration takes priority
+            "fastapi" : {"enabled": True},
+            "flask" : {"enabled": False},
+            "psycopg2" : {"enabled": True},
+            "previewlib1": {"enabled": True}, # Explicit configuration takes priority
+            "previewlib2": {"enabled": False},
+            "requests": {"enabled": True},
+            "urllib": {"enabled": True},
+            "urllib3": {"enabled": False},
+        })
+
+    @patch.dict("os.environ", {}, clear=True)
+    @patch("azure.monitor.opentelemetry.util._configurations._PREVIEW_INSTRUMENTED_LIBRARIES", ("previewlib1", "previewlib2"))
+    def test_merge_instrumentation_options_extra_args(self):
+        configurations = _get_configurations(
+            instrumentation_options = {
+                "django" : {"enabled": True},
+                "fastapi" : {"enabled": True, "foo": "bar"},
+                "flask" : {"enabled": False, "foo": "bar"},
+                "psycopg2" : {"foo": "bar"},
+                "previewlib1": {"enabled": True, "foo": "bar"},
+                "previewlib2": {"foo": "bar"},
+            }
+        )
+
+        self.assertEqual(configurations["instrumentation_options"], {
+            "azure_sdk" : {"enabled": True},
+            "django" : {"enabled": True},
+            "fastapi" : {"enabled": True, "foo": "bar"},
+            "flask" : {"enabled": False, "foo": "bar"},
+            "psycopg2" : {"enabled": True, "foo": "bar"},
+            "previewlib1": {"enabled": True, "foo": "bar"},
+            "previewlib2": {"enabled": False, "foo": "bar"},
+            "requests": {"enabled": True},
+            "urllib": {"enabled": True},
+            "urllib3": {"enabled": True},
+        })

--- a/sdk/monitor/azure-monitor-opentelemetry/tests/configuration/test_util.py
+++ b/sdk/monitor/azure-monitor-opentelemetry/tests/configuration/test_util.py
@@ -31,7 +31,7 @@ from opentelemetry.environment_variables import (
 
 class TestUtil(TestCase):
     @patch.dict("os.environ", {}, clear=True)
-    @patch("azure.monitor.opentelemetry.util._configurations._PREVIEW_INSTRUMENTED_LIBRARIES", ("previewlib1", "previewlib2"))
+    @patch("azure.monitor.opentelemetry._util.configurations._PREVIEW_INSTRUMENTED_LIBRARIES", ("previewlib1", "previewlib2"))
     def test_get_configurations(self):
         configurations = _get_configurations(
             connection_string="test_cs",
@@ -126,7 +126,7 @@ class TestUtil(TestCase):
         },
         clear=True,
     )
-    @patch("azure.monitor.opentelemetry.util._configurations._PREVIEW_INSTRUMENTED_LIBRARIES", ("previewlib1", "previewlib2"))
+    @patch("azure.monitor.opentelemetry._util.configurations._PREVIEW_INSTRUMENTED_LIBRARIES", ("previewlib1", "previewlib2"))
     def test_merge_instrumentation_options_conflict(self):
         configurations = _get_configurations(
             instrumentation_options = {
@@ -152,7 +152,7 @@ class TestUtil(TestCase):
         })
 
     @patch.dict("os.environ", {}, clear=True)
-    @patch("azure.monitor.opentelemetry.util._configurations._PREVIEW_INSTRUMENTED_LIBRARIES", ("previewlib1", "previewlib2"))
+    @patch("azure.monitor.opentelemetry._util.configurations._PREVIEW_INSTRUMENTED_LIBRARIES", ("previewlib1", "previewlib2"))
     def test_merge_instrumentation_options_extra_args(self):
         configurations = _get_configurations(
             instrumentation_options = {


### PR DESCRIPTION
# Description

Add new instrumentation_options field akin to [Node's implementation](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/monitor/monitor-opentelemetry/src/shared/config.ts#L48). This will allow users to disable opt out supported instrumentations and enabled opt in preview instrumentations. Explicit configuration will take priority over env vars. In order to leave the door open for instrumentation configuration in the future, I have implemented a way to merge nested dictionaries. This way, a user can pass additional options and they will be merged with the defaults instead of entirely replacing them. See tests for more details.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
