### PR TITLE
[Monitor][OTel] Fix latestdependency check

### DIFF
--- a/sdk/monitor/azure-monitor-opentelemetry/setup.py
+++ b/sdk/monitor/azure-monitor-opentelemetry/setup.py
@@ -97,8 +97,6 @@ setup(
         "opentelemetry-instrumentation-urllib3~=0.40b0",
         "opentelemetry-sdk~=1.19.0",
         "wrapt >= 1.14.0, < 2.0.0",
-        "importlib-metadata>=6.0,<6.8; python_version < '3.8'",
-        "importlib-metadata~=6.0; python_version >= '3.8'",
     ],
     entry_points={
         "opentelemetry_distro": [


### PR DESCRIPTION
In the internal `python - monitor` job, the `latestdependency` check is failing due to dependency conflicts for `importlib-metadata`.

```
The conflict is caused by:
    The user requested importlib-metadata==6.7.0
    The user requested importlib-metadata==6.7.0
    azure-monitor-opentelemetry-exporter 1.0.0b15 depends on importlib-metadata~=6.0.0; python_version < "3.8"
```

This removes the `importlib-metadata` requirement since it isn't explicitly used in this package.

[Sample failing pipeline](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3029136&view=logs&j=4fa73ede-de59-50b0-851d-db96582ea108&t=271dca1a-6c62-5d1b-458d-2dd10be9b8db&l=2517)