### PR TITLE
use old cryptography for pypy

### DIFF
--- a/sdk/identity/azure-identity/setup.py
+++ b/sdk/identity/azure-identity/setup.py
@@ -59,7 +59,8 @@ setup(
     python_requires=">=3.7",
     install_requires=[
         "azure-core<2.0.0,>=1.11.0",
-        "cryptography>=2.5",
+        "cryptography>=2.5; platform_python_implementation != 'PyPy'",
+        "cryptography>=2.5,<4; platform_python_implementation == 'PyPy'",
         "msal<2.0.0,>=1.20.0",
         "msal-extensions<2.0.0,>=0.3.0",
     ],


### PR DESCRIPTION
latest cryptography is not compatible with PyPy3 < 7.3.10