### PR TITLE
[Identity] Adjust log level for EnvCred warning

### DIFF
--- a/sdk/identity/azure-identity/CHANGELOG.md
+++ b/sdk/identity/azure-identity/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Other Changes
 
 - Update typing of async credentials to match the `AsyncTokenCredential` protocol.
+- If within `DefaultAzureCredential`, `EnvironmentCredential` will now use log level INFO instead of WARNING to inform users of an incomplete environment configuration.  ([#31814](https://github.com/Azure/azure-sdk-for-python/pull/31814))
 
 ## 1.14.0 (2023-08-08)
 

--- a/sdk/identity/azure-identity/azure/identity/_credentials/default.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/default.py
@@ -146,7 +146,7 @@ class DefaultAzureCredential(ChainedTokenCredential):
 
         credentials: List["TokenCredential"] = []
         if not exclude_environment_credential:
-            credentials.append(EnvironmentCredential(authority=authority, **kwargs))
+            credentials.append(EnvironmentCredential(authority=authority, _within_dac=True, **kwargs))
         if not exclude_workload_identity_credential:
             if all(os.environ.get(var) for var in EnvironmentVariables.WORKLOAD_IDENTITY_VARS):
                 client_id = workload_identity_client_id

--- a/sdk/identity/azure-identity/azure/identity/_credentials/environment.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/environment.py
@@ -101,8 +101,8 @@ class EnvironmentCredential:
             set_variables = [v for v in expected_variables if v in os.environ]
             if set_variables:
                 _LOGGER.log(
-                    logging.INFO if set_variables == [EnvironmentVariables.AZURE_CLIENT_ID] else logging.WARNING,
-                    "Incomplete environment configuration. These variables are set: %s",
+                    logging.INFO if kwargs.get("_within_dac") else logging.WARNING,
+                    "Incomplete environment configuration for EnvironmentCredential. These variables are set: %s",
                     ", ".join(set_variables),
                 )
             else:

--- a/sdk/identity/azure-identity/azure/identity/_credentials/environment.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/environment.py
@@ -100,8 +100,10 @@ class EnvironmentCredential:
             )
             set_variables = [v for v in expected_variables if v in os.environ]
             if set_variables:
-                _LOGGER.warning(
-                    "Incomplete environment configuration. These variables are set: %s", ", ".join(set_variables)
+                _LOGGER.log(
+                    logging.INFO if set_variables == [EnvironmentVariables.AZURE_CLIENT_ID] else logging.WARNING,
+                    "Incomplete environment configuration. These variables are set: %s",
+                    ", ".join(set_variables),
                 )
             else:
                 _LOGGER.info("No environment configuration found.")

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/default.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/default.py
@@ -136,7 +136,7 @@ class DefaultAzureCredential(ChainedTokenCredential):
 
         credentials = []  # type: List[AsyncTokenCredential]
         if not exclude_environment_credential:
-            credentials.append(EnvironmentCredential(authority=authority, **kwargs))
+            credentials.append(EnvironmentCredential(authority=authority, _within_dac=True, **kwargs))
         if not exclude_workload_identity_credential:
             if all(os.environ.get(var) for var in EnvironmentVariables.WORKLOAD_IDENTITY_VARS):
                 client_id = workload_identity_client_id

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/environment.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/environment.py
@@ -75,8 +75,10 @@ class EnvironmentCredential(AsyncContextManager):
             expected_variables = set(EnvironmentVariables.CERT_VARS + EnvironmentVariables.CLIENT_SECRET_VARS)
             set_variables = [v for v in expected_variables if v in os.environ]
             if set_variables:
-                _LOGGER.warning(
-                    "Incomplete environment configuration. These variables are set: %s", ", ".join(set_variables)
+                _LOGGER.log(
+                    logging.INFO if set_variables == [EnvironmentVariables.AZURE_CLIENT_ID] else logging.WARNING,
+                    "Incomplete environment configuration. These variables are set: %s",
+                    ", ".join(set_variables),
                 )
             else:
                 _LOGGER.info("No environment configuration found.")

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/environment.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/environment.py
@@ -76,8 +76,8 @@ class EnvironmentCredential(AsyncContextManager):
             set_variables = [v for v in expected_variables if v in os.environ]
             if set_variables:
                 _LOGGER.log(
-                    logging.INFO if set_variables == [EnvironmentVariables.AZURE_CLIENT_ID] else logging.WARNING,
-                    "Incomplete environment configuration. These variables are set: %s",
+                    logging.INFO if kwargs.get("_within_dac") else logging.WARNING,
+                    "Incomplete environment configuration for EnvironmentCredential. These variables are set: %s",
                     ", ".join(set_variables),
                 )
             else:


### PR DESCRIPTION
If a possible environment credential is passed in, but no complete environment configuration is found, we output a warning log statement.

However, since the default log level is WARNING, this warning is always printed when a user is trying to use DefaultAzureCredential with the AZURE_CLIENT_ID envvar set (typically for using a user-assigned managed identity).

This warning is not printed with the `WARNING` prefix and can cause confusion for the user.

To address the most common case of this confusing users using DAC, the log level has been changed to INFO if the credential is detected to be within DAC.

Closes: https://github.com/Azure/azure-sdk-for-python/issues/30214

