### PR TITLE
Updated OneLake datastore field names: artifact_name -> name, artifact_type -> type

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_datastore/one_lake.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_datastore/one_lake.py
@@ -18,9 +18,7 @@ from .credentials import NoneCredentialsSchema, ServicePrincipalSchema
 
 class OneLakeArtifactSchema(Schema):
     name = fields.Str(required=True)
-    type = StringTransformedEnum(
-        allowed_values=OneLakeArtifactType.LAKE_HOUSE, casing_transform=camel_to_snake
-    )
+    type = StringTransformedEnum(allowed_values=OneLakeArtifactType.LAKE_HOUSE, casing_transform=camel_to_snake)
 
 
 class OneLakeSchema(PathAwareSchema):

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_datastore/one_lake.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_datastore/one_lake.py
@@ -17,8 +17,8 @@ from .credentials import NoneCredentialsSchema, ServicePrincipalSchema
 
 
 class OneLakeArtifactSchema(Schema):
-    artifact_name = fields.Str(required=True)
-    artifact_type = StringTransformedEnum(
+    name = fields.Str(required=True)
+    type = StringTransformedEnum(
         allowed_values=OneLakeArtifactType.LAKE_HOUSE, casing_transform=camel_to_snake
     )
 
@@ -33,8 +33,8 @@ class OneLakeSchema(PathAwareSchema):
     )
     # required fields for OneLake
     one_lake_workspace_name = fields.Str(required=True)
+    endpoint = fields.Str(required=True)
     artifact = NestedField(OneLakeArtifactSchema)
-    endpoint = fields.Str()
     # ServicePrincipal and UserIdentity are the two supported credential types
     credentials = UnionField(
         [

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_datastore/one_lake.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_datastore/one_lake.py
@@ -100,7 +100,9 @@ class OneLakeDatastore(Datastore):
 
     def _to_rest_object(self) -> DatastoreData:
         one_lake_ds = RestOneLakeDatastore(
-            credentials= RestNoneDatastoreCredentials() if self.credentials is None else self.credentials._to_datastore_rest_object(),
+            credentials=RestNoneDatastoreCredentials()
+            if self.credentials is None
+            else self.credentials._to_datastore_rest_object(),
             artifact=RestLakeHouseArtifact(artifact_name=self.artifact["name"]),
             one_lake_workspace_name=self.one_lake_workspace_name,
             endpoint=self.endpoint,

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_datastore/one_lake.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_datastore/one_lake.py
@@ -13,6 +13,7 @@ from azure.ai.ml._restclient.v2023_04_01_preview.models import (
     Datastore as DatastoreData,
     DatastoreType,
     LakeHouseArtifact as RestLakeHouseArtifact,
+    NoneDatastoreCredentials as RestNoneDatastoreCredentials,
 )
 from azure.ai.ml._schema._datastore.one_lake import OneLakeSchema
 from azure.ai.ml.constants._common import BASE_PATH_CONTEXT_KEY, TYPE
@@ -26,16 +27,16 @@ from azure.ai.ml.entities._util import load_from_dict
 class OneLakeArtifact(RestTranslatableMixin, DictMixin, ABC):
     """OneLake artifact (data source) backing the OneLake workspace.
 
-    :param artifact_name: OneLake artifact name/GUID. ex) 01234567-abcd-1234-5678-012345678901
-    :type artifact_name: str
-    :param artifact_type: OneLake artifact type. Only LakeHouse artifacts are currently supported.
-    :type artifact_type: str
+    :param name: OneLake artifact name/GUID. ex) 01234567-abcd-1234-5678-012345678901
+    :type name: str
+    :param type: OneLake artifact type. Only LakeHouse artifacts are currently supported.
+    :type type: str
     """
 
-    def __init__(self, artifact_name: str, artifact_type: Optional[str] = None):
+    def __init__(self, name: str, type: Optional[str] = None):
         super().__init__()
-        self.artifact_name = artifact_name
-        self.artifact_type = artifact_type
+        self.name = name
+        self.type = type
 
 
 class LakeHouseArtifact(OneLakeArtifact):
@@ -45,11 +46,11 @@ class LakeHouseArtifact(OneLakeArtifact):
     :type artifact_name: str
     """
 
-    def __init__(self, artifact_name: str):
-        super(LakeHouseArtifact, self).__init__(artifact_name=artifact_name, artifact_type="lake_house")
+    def __init__(self, name: str):
+        super(LakeHouseArtifact, self).__init__(name=name, type="lake_house")
 
     def _to_datastore_rest_object(self) -> RestLakeHouseArtifact:
-        return RestLakeHouseArtifact(artifact_name=self.artifact_name)
+        return RestLakeHouseArtifact(artifact_name=self.name)
 
 
 class OneLakeDatastore(Datastore):
@@ -99,8 +100,8 @@ class OneLakeDatastore(Datastore):
 
     def _to_rest_object(self) -> DatastoreData:
         one_lake_ds = RestOneLakeDatastore(
-            credentials=self.credentials._to_datastore_rest_object(),
-            artifact=RestLakeHouseArtifact(artifact_name=self.artifact["artifact_name"]),
+            credentials= RestNoneDatastoreCredentials() if self.credentials is None else self.credentials._to_datastore_rest_object(),
+            artifact=RestLakeHouseArtifact(artifact_name=self.artifact["name"]),
             one_lake_workspace_name=self.one_lake_workspace_name,
             endpoint=self.endpoint,
             description=self.description,
@@ -118,7 +119,7 @@ class OneLakeDatastore(Datastore):
         return OneLakeDatastore(
             name=datastore_resource.name,
             id=datastore_resource.id,
-            artifact=LakeHouseArtifact(artifact_name=properties.artifact.artifact_name),
+            artifact=LakeHouseArtifact(name=properties.artifact.artifact_name),
             one_lake_workspace_name=properties.one_lake_workspace_name,
             endpoint=properties.endpoint,
             credentials=from_rest_datastore_credentials(properties.credentials),
@@ -130,8 +131,8 @@ class OneLakeDatastore(Datastore):
         return (
             super().__eq__(other)
             and self.one_lake_workspace_name == other.one_lake_workspace_name
-            and self.artifact.artifact_type == other.artifact["artifact_type"]
-            and self.artifact.artifact_name == other.artifact["artifact_name"]
+            and self.artifact.type == other.artifact["type"]
+            and self.artifact.name == other.artifact["name"]
             and self.endpoint == other.endpoint
         )
 

--- a/sdk/ml/azure-ai-ml/tests/test_configs/datastore/credential_less_one_lake.yml
+++ b/sdk/ml/azure-ai-ml/tests/test_configs/datastore/credential_less_one_lake.yml
@@ -3,6 +3,6 @@ name: credential_less_one_lake_datastore
 description: credential-less OneLake datastore
 one_lake_workspace_name: 01234567-abcd-1234-5678-012345678901
 artifact:
-  artifact_name: abcdefgh-0123-4567-8901-abcde0123456
-  artifact_type: lake_house
+  name: abcdefgh-0123-4567-8901-abcde0123456
+  type: lake_house
 endpoint: https://onelake.dfs.fabric.microsoft.com

--- a/sdk/ml/azure-ai-ml/tests/test_configs/datastore/one_lake.yml
+++ b/sdk/ml/azure-ai-ml/tests/test_configs/datastore/one_lake.yml
@@ -3,8 +3,8 @@ name: one_lake_datastore
 description: OneLake datastore
 one_lake_workspace_name: 01234567-abcd-1234-5678-012345678901
 artifact:
-  artifact_name: abcdefgh-0123-4567-8901-abcde0123456
-  artifact_type: lake_house
+  name: abcdefgh-0123-4567-8901-abcde0123456
+  type: lake_house
 endpoint: https://onelake.dfs.fabric.microsoft.com
 credentials:
   tenant_id: 72f988bf-86f1-41af-91ab-2d7cd011db47


### PR DESCRIPTION
# Description
This PR updates OneLake datastore field names: artifact_name -> name AND artifact_type -> type

This is to simplify the yaml representation and keep the correct mapping for serialization/deserialization.

# All SDK Contribution checklist:
- [X] **The pull request does not introduce [breaking changes]**
- [X] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [X] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [X] Title of the pull request is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [X] Pull request includes test coverage for the included changes.
