### PR TITLE
[Identity] Update async __aexit__ typing

### DIFF
--- a/sdk/identity/azure-identity/CHANGELOG.md
+++ b/sdk/identity/azure-identity/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Other Changes
 
+- Update typing of async credentials to match the `AsyncTokenCredential` protocol.
+
 ## 1.14.0 (2023-08-08)
 
 ### Features Added

--- a/sdk/identity/azure-identity/azure/identity/aio/_internal/__init__.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_internal/__init__.py
@@ -3,6 +3,8 @@
 # Licensed under the MIT License.
 # ------------------------------------
 import abc
+from types import TracebackType
+from typing import Optional, Type
 
 from .aad_client import AadClient
 from .decorators import wrap_exceptions
@@ -16,7 +18,12 @@ class AsyncContextManager(abc.ABC):
     async def __aenter__(self):
         return self
 
-    async def __aexit__(self, *args):
+    async def __aexit__(
+        self,
+        exc_type: Optional[Type[BaseException]] = None,
+        exc_value: Optional[BaseException] = None,
+        traceback: Optional[TracebackType] = None,
+    ) -> None:
         await self.close()
 
 


### PR DESCRIPTION
This ensures the signature of __aexit__ matches that the signature of the __aexit__ in the AsyncTokenCredential protocol.

Closes: https://github.com/Azure/azure-sdk-for-python/issues/27704
