### PR TITLE
[ServiceBus] fix receive_messages receive and delete bug

### DIFF
--- a/sdk/servicebus/azure-servicebus/CHANGELOG.md
+++ b/sdk/servicebus/azure-servicebus/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fixed a bug where receiving messages in `RECEIVE_AND_DELETE` mode while messages were being sent simultaneously resulted in messages not being returned ([#31711](https://github.com/Azure/azure-sdk-for-python/issues/31711)).
+
 ### Other Changes
 
 ## 7.11.1 (2023-07-12)

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_transport/_pyamqp_transport.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_transport/_pyamqp_transport.py
@@ -647,6 +647,8 @@ class PyamqpTransport(AmqpTransport):   # pylint: disable=too-many-public-method
         if receiver._receive_context.is_set():
             receiver._handler._received_messages.put((frame, message))
         else:
+            if receiver._receive_mode == ServiceBusReceiveMode.RECEIVE_AND_DELETE:
+                receiver._handler._received_messages.put((frame, message))
             receiver._handler.settle_messages(frame[1], 'released')
 
     @staticmethod

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_transport/_uamqp_transport.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_transport/_uamqp_transport.py
@@ -767,6 +767,8 @@ try:
             if receiver._receive_context.is_set():
                 receiver._handler._received_messages.put(message)
             else:
+                if receiver._receive_mode == ServiceBusReceiveMode.RECEIVE_AND_DELETE:
+                    receiver._handler._received_messages.put(message)
                 message.release()
 
         @staticmethod

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_transport/_pyamqp_transport_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_transport/_pyamqp_transport_async.py
@@ -236,6 +236,8 @@ class PyamqpTransportAsync(PyamqpTransport, AmqpTransportAsync):
         if receiver._receive_context.is_set():
             receiver._handler._received_messages.put((frame, message))
         else:
+            if receiver._receive_mode == ServiceBusReceiveMode.RECEIVE_AND_DELETE:
+                receiver._handler._received_messages.put((frame, message))
             await receiver._handler.settle_messages_async(frame[1], 'released')
 
     @staticmethod

--- a/sdk/servicebus/azure-servicebus/tests/async_tests/test_subscriptions_async.py
+++ b/sdk/servicebus/azure-servicebus/tests/async_tests/test_subscriptions_async.py
@@ -7,6 +7,7 @@
 import logging
 import sys
 import os
+import asyncio
 import pytest
 import time
 from datetime import datetime, timedelta
@@ -231,3 +232,44 @@ class TestServiceBusSubscriptionAsync(AzureMgmtRecordedTestCase):
                 assert len(messages) == 1
                 assert messages[0].delivery_count > 0
                 await receiver.complete_message(messages[0])
+
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusTopicPreparer(name_prefix='servicebustest')
+    @ServiceBusSubscriptionPreparer(name_prefix='servicebustest', lock_duration='PT5S')
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_subscription_receive_and_delete_with_send_and_wait(self, uamqp_transport, *, servicebus_namespace=None, servicebus_namespace_key_name=None, servicebus_namespace_primary_key=None, servicebus_topic=None, servicebus_subscription=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        async with ServiceBusClient(
+            fully_qualified_namespace=fully_qualified_namespace,
+            credential=ServiceBusSharedKeyCredential(
+                policy=servicebus_namespace_key_name,
+                key=servicebus_namespace_primary_key
+            ),
+            logging_enable=False,
+            uamqp_transport=uamqp_transport
+        ) as sb_client:
+
+            sender = sb_client.get_topic_sender(topic_name=servicebus_topic.name)
+            receiver = sb_client.get_subscription_receiver(
+                    topic_name=servicebus_topic.name,
+                    subscription_name=servicebus_subscription.name,
+                    receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE,
+            )
+            async with sender, receiver:
+                # queue should be empty
+                received_msgs = await receiver.receive_messages(max_message_count=10, max_wait_time=10)
+                assert len(received_msgs) == 0
+
+                messages = [ServiceBusMessage("Message") for _ in range(10)]
+                await sender.send_messages(messages)
+                # wait for all messages to be received and added to the receiver internal buffer
+                await asyncio.sleep(10)
+
+                # internal buffer should have messages now
+                received_msgs = await receiver.receive_messages(max_message_count=10, max_wait_time=10)
+                assert len(received_msgs) == 10

--- a/sdk/servicebus/azure-servicebus/tests/test_subscriptions.py
+++ b/sdk/servicebus/azure-servicebus/tests/test_subscriptions.py
@@ -253,3 +253,43 @@ class TestServiceBusSubscription(AzureMgmtRecordedTestCase):
                 assert len(messages) == 1
                 assert messages[0].delivery_count > 0
                 receiver.complete_message(messages[0])
+
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusTopicPreparer(name_prefix='servicebustest')
+    @ServiceBusSubscriptionPreparer(name_prefix='servicebustest', lock_duration='PT5S')
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_subscription_receive_and_delete_with_send_and_wait(self, uamqp_transport, *, servicebus_namespace=None, servicebus_namespace_key_name=None, servicebus_namespace_primary_key=None, servicebus_topic=None, servicebus_subscription=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        with ServiceBusClient(
+            fully_qualified_namespace=fully_qualified_namespace,
+            credential=ServiceBusSharedKeyCredential(
+                policy=servicebus_namespace_key_name,
+                key=servicebus_namespace_primary_key
+            ),
+            logging_enable=False,
+            uamqp_transport=uamqp_transport
+        ) as sb_client:
+
+            sender = sb_client.get_topic_sender(topic_name=servicebus_topic.name)
+            receiver = sb_client.get_subscription_receiver(
+                    topic_name=servicebus_topic.name,
+                    subscription_name=servicebus_subscription.name,
+                    receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE,
+            )
+            with sender, receiver:
+                # queue should be empty
+                received_msgs = receiver.receive_messages(max_message_count=10, max_wait_time=10)
+                assert len(received_msgs) == 0
+
+                messages = [ServiceBusMessage("Message") for _ in range(10)]
+                sender.send_messages(messages)
+                # wait for all messages to be received and added to the receiver internal buffer in the background
+                time.sleep(10)
+
+                # internal buffer should have messages now
+                received_msgs = receiver.receive_messages(max_message_count=10, max_wait_time=10)
+                assert len(received_msgs) == 10


### PR DESCRIPTION
fixes: #31711 

When prefetch is set to 1, (which it is [by default](https://github.com/Azure/azure-sdk-for-python/blob/e7d72f52877a3b6d553d398964f817fc82567b1b/sdk/servicebus/azure-servicebus/azure/servicebus/_common/receiver_mixins.py#L58) + will need to be addressed in the related #31712 issue fix), the message_received callback on the AMQP Receive Client is set to the `_enhanced_message_received`. When a message is received in receive and delete mode, [this callback doesn't append received messages to the internal q before settling right away](https://github.com/Azure/azure-sdk-for-python/blob/7fb4d698ce3a099a47032dfdbabf38abe3b96711/sdk/servicebus/azure-servicebus/azure/servicebus/_transport/_pyamqp_transport.py#L650). When the user calls receive_messages again a little later, those messages are not in the internal q, so they are not returned to the user.

This [bug also existed in previously released uamqp-based versions,](https://github.com/Azure/azure-sdk-for-python/blob/7fb4d698ce3a099a47032dfdbabf38abe3b96711/sdk/servicebus/azure-servicebus/azure/servicebus/_transport/_uamqp_transport.py#L770) so adding the fix to the UamqpTransport as well.