### PR TITLE
Improving tracing typing

### DIFF
--- a/sdk/core/azure-core/azure/core/tracing/decorator.py
+++ b/sdk/core/azure-core/azure/core/tracing/decorator.py
@@ -27,7 +27,7 @@
 
 import functools
 
-from typing import Callable, Any, TypeVar, overload, Optional, Generic
+from typing import Callable, Any, TypeVar, overload, Optional, Generic, Union
 from typing_extensions import ParamSpec, Protocol
 from .common import change_context, get_function_and_class_name
 from . import SpanKind as _SpanKind, AbstractSpan
@@ -46,20 +46,20 @@ class TracedMethod(Protocol, Generic[P, T]):
 
 
 @overload
-def distributed_trace(__func: Callable[P, T]) -> Callable[P, T]:
+def distributed_trace(__func: Callable[P, T]) -> TracedMethod[P, T]:
     pass
 
 
 @overload
-def distributed_trace(  # pylint:disable=function-redefined
+def distributed_trace(
     **kwargs: Any,  # pylint:disable=unused-argument
-) -> Callable[[Callable[P, T]], Callable[P, T]]:
+) -> Callable[[Callable[P, T]], TracedMethod[P, T]]:
     pass
 
 
 def distributed_trace(
     __func: Optional[Callable[P, T]] = None, **kwargs: Any
-) -> Any:  # pylint:disable=function-redefined
+) -> Union[TracedMethod[P, T], Callable[[Callable[P, T]], TracedMethod[P, T]]]:
     """Decorator to apply to function to get traced automatically.
 
     Span will use the func name or "name_of_span".

--- a/sdk/core/azure-core/azure/core/tracing/decorator_async.py
+++ b/sdk/core/azure-core/azure/core/tracing/decorator_async.py
@@ -27,7 +27,7 @@
 
 import functools
 
-from typing import Awaitable, Callable, Any, TypeVar, overload, Optional, Protocol, Generic
+from typing import Awaitable, Callable, Any, TypeVar, overload, Optional, Protocol, Generic, Union
 from typing_extensions import ParamSpec
 from .common import change_context, get_function_and_class_name
 from . import SpanKind as _SpanKind, AbstractSpan
@@ -45,20 +45,20 @@ class AsyncTracedMethod(Protocol, Generic[P, T]):
 
 
 @overload
-def distributed_trace_async(__func: Callable[P, Awaitable[T]]) -> Callable[P, Awaitable[T]]:
+def distributed_trace_async(__func: Callable[P, Awaitable[T]]) -> AsyncTracedMethod[P, Awaitable[T]]:
     pass
 
 
 @overload
 def distributed_trace_async(  # pylint:disable=function-redefined
     **kwargs: Any,  # pylint:disable=unused-argument
-) -> Callable[[Callable[P, Awaitable[T]]], Callable[P, Awaitable[T]]]:
+) -> Callable[[Callable[P, Awaitable[T]]], AsyncTracedMethod[P, Awaitable[T]]]:
     pass
 
 
 def distributed_trace_async(  # pylint:disable=function-redefined
     __func: Optional[Callable[P, Awaitable[T]]] = None, **kwargs: Any
-) -> Any:
+) -> Union[AsyncTracedMethod[P, Awaitable[T]], Callable[[Callable[P, Awaitable[T]]], AsyncTracedMethod[P, Awaitable[T]]]]:
     """Decorator to apply to function to get traced automatically.
 
     Span will use the func name or "name_of_span".
@@ -73,7 +73,7 @@ def distributed_trace_async(  # pylint:disable=function-redefined
     tracing_attributes = kwargs.pop("tracing_attributes", {})
     kind = kwargs.pop("kind", _SpanKind.INTERNAL)
 
-    def decorator(func: Callable[P, Awaitable[T]]) -> AsyncTracedMethod[P, T]:
+    def decorator(func: Callable[P, Awaitable[T]]) -> AsyncTracedMethod[P, Awaitable[T]]:
         @functools.wraps(func)
         async def wrapper_use_tracer(
             *args: P.args, merge_span: bool = False, parent_span: Optional[AbstractSpan] = None, **kwargs: P.kwargs

--- a/sdk/core/azure-core/azure/core/tracing/decorator_async.py
+++ b/sdk/core/azure-core/azure/core/tracing/decorator_async.py
@@ -38,27 +38,27 @@ T = TypeVar("T", covariant=True)
 
 
 class AsyncTracedMethod(Protocol, Generic[P, T]):
-    async def __call__(
+    def __call__(
         self, *args: P.args, merge_span: bool = False, parent_span: Optional[AbstractSpan] = None, **kwds: P.kwargs
-    ) -> T:
+    ) -> Awaitable[T]:
         ...
 
 
 @overload
-def distributed_trace_async(__func: Callable[P, Awaitable[T]]) -> AsyncTracedMethod[P, Awaitable[T]]:
+def distributed_trace_async(__func: Callable[P, Awaitable[T]]) -> AsyncTracedMethod[P, T]:
     pass
 
 
 @overload
 def distributed_trace_async(  # pylint:disable=function-redefined
     **kwargs: Any,  # pylint:disable=unused-argument
-) -> Callable[[Callable[P, Awaitable[T]]], AsyncTracedMethod[P, Awaitable[T]]]:
+) -> Callable[[Callable[P, Awaitable[T]]], AsyncTracedMethod[P, T]]:
     pass
 
 
 def distributed_trace_async(  # pylint:disable=function-redefined
     __func: Optional[Callable[P, Awaitable[T]]] = None, **kwargs: Any
-) -> Union[AsyncTracedMethod[P, Awaitable[T]], Callable[[Callable[P, Awaitable[T]]], AsyncTracedMethod[P, Awaitable[T]]]]:
+) -> Union[AsyncTracedMethod[P, T], Callable[[Callable[P, Awaitable[T]]], AsyncTracedMethod[P, T]]]:
     """Decorator to apply to function to get traced automatically.
 
     Span will use the func name or "name_of_span".
@@ -73,7 +73,7 @@ def distributed_trace_async(  # pylint:disable=function-redefined
     tracing_attributes = kwargs.pop("tracing_attributes", {})
     kind = kwargs.pop("kind", _SpanKind.INTERNAL)
 
-    def decorator(func: Callable[P, Awaitable[T]]) -> AsyncTracedMethod[P, Awaitable[T]]:
+    def decorator(func: Callable[P, Awaitable[T]]) -> AsyncTracedMethod[P, T]:
         @functools.wraps(func)
         async def wrapper_use_tracer(
             *args: P.args, merge_span: bool = False, parent_span: Optional[AbstractSpan] = None, **kwargs: P.kwargs

--- a/sdk/core/azure-core/azure/core/tracing/decorator_async.py
+++ b/sdk/core/azure-core/azure/core/tracing/decorator_async.py
@@ -27,8 +27,8 @@
 
 import functools
 
-from typing import Awaitable, Callable, Any, TypeVar, overload, Optional, Protocol, Generic, Union
-from typing_extensions import ParamSpec
+from typing import Awaitable, Callable, Any, TypeVar, overload, Optional, Generic, Union
+from typing_extensions import ParamSpec, Protocol
 from .common import change_context, get_function_and_class_name
 from . import SpanKind as _SpanKind, AbstractSpan
 from ..settings import settings

--- a/sdk/core/azure-core/azure/core/tracing/decorator_async.py
+++ b/sdk/core/azure-core/azure/core/tracing/decorator_async.py
@@ -27,14 +27,21 @@
 
 import functools
 
-from typing import Awaitable, Callable, Any, TypeVar, overload, Optional
+from typing import Awaitable, Callable, Any, TypeVar, overload, Optional, Protocol, Generic
 from typing_extensions import ParamSpec
 from .common import change_context, get_function_and_class_name
-from . import SpanKind as _SpanKind
+from . import SpanKind as _SpanKind, AbstractSpan
 from ..settings import settings
 
 P = ParamSpec("P")
-T = TypeVar("T")
+T = TypeVar("T", covariant=True)
+
+
+class AsyncTracedMethod(Protocol, Generic[P, T]):
+    async def __call__(
+        self, *args: P.args, merge_span: bool = False, parent_span: Optional[AbstractSpan] = None, **kwds: P.kwargs
+    ) -> T:
+        ...
 
 
 @overload
@@ -66,21 +73,21 @@ def distributed_trace_async(  # pylint:disable=function-redefined
     tracing_attributes = kwargs.pop("tracing_attributes", {})
     kind = kwargs.pop("kind", _SpanKind.INTERNAL)
 
-    def decorator(func: Callable[P, Awaitable[T]]) -> Callable[P, Awaitable[T]]:
+    def decorator(func: Callable[P, Awaitable[T]]) -> AsyncTracedMethod[P, T]:
         @functools.wraps(func)
-        async def wrapper_use_tracer(*args: Any, **kwargs: Any) -> T:
-            merge_span = kwargs.pop("merge_span", False)
-            passed_in_parent = kwargs.pop("parent_span", None)
+        async def wrapper_use_tracer(
+            *args: P.args, merge_span: bool = False, parent_span: Optional[AbstractSpan] = None, **kwargs: P.kwargs
+        ) -> T:
 
             span_impl_type = settings.tracing_implementation()
             if span_impl_type is None:
                 return await func(*args, **kwargs)
 
             # Merge span is parameter is set, but only if no explicit parent are passed
-            if merge_span and not passed_in_parent:
+            if merge_span and not parent_span:
                 return await func(*args, **kwargs)
 
-            with change_context(passed_in_parent):
+            with change_context(parent_span):
                 name = name_of_span or get_function_and_class_name(func, *args)
                 with span_impl_type(name=name, kind=kind) as span:
                     for key, value in tracing_attributes.items():


### PR DESCRIPTION
Trying to see if I can push it to remove all `Any`.

So far I get mypy happy, and pyright:
```
          Parameter 1: type "*tuple[P.args, ...]" cannot be assigned to type "*tuple[P.args, ...]"
            "builtins.tuple" is incompatible with "builtins.tuple"
          Parameter 4: type "P.kwargs" cannot be assigned to type "P.kwargs"
            Type "P.kwargs" cannot be assigned to type "P.kwargs" (reportGeneralTypeIssues)
```

which feels pyright bug (needs to reproduce in a smaller example).

Need to write some script with invalid typing on purpose to see if actually mypy is working, or just not complaining.