### PR TITLE
Update CODEOWNERS for monitor distro

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -115,6 +115,9 @@
 # PRLabel: %Monitor - LogAnalytics
 /sdk/loganalytics/                                                   @pvaneck
 
+# PRLabel: %Monitor - Distro
+/sdk/monitor/azure-monitor-opentelemetry/                            @lzchen @jeremydvoss
+
 # PRLabel: %Monitor - Exporter
 /sdk/monitor/azure-monitor-opentelemetry-exporter/                   @lmazuel @lzchen @hectorhdzg @jeremydvoss
 
@@ -950,6 +953,8 @@
 # ServiceLabel: %Monitor - Exporter %Service Attention
 #/<NotInRepo>/          @lzchen @jeremydvoss
 
+# ServiceLabel: %Monitor - Distro %Service Attention
+#/<NotInRepo>/          @lzchen @jeremydvoss
 
 # Management Plane
 /**/*mgmt*/                                                          @ChenxiJiang333 @msyyc


### PR DESCRIPTION
The "Azure Monitor OpenTelemetry Distro"  project was recently added to this repository. This updates the CODEOWNERS file accordingly.
