### PR TITLE
[Monitor] Enable cspell for monitor packages

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -71,7 +71,6 @@
     "sdk/keyvault/azure-keyvault-certificates/tests/certs.py",
     "sdk/keyvault/azure-keyvault-keys/tests/keys.py",
     "sdk/modelsrepository/azure-iot-modelsrepository/**",
-    "sdk/monitor/azure-monitor-query/**",
     "sdk/servicefabric/azure-servicefabric/**",
     "sdk/search/azure-search-documents/**",
     "sdk/storage/azure-storage-blob-changefeed/**",
@@ -90,7 +89,6 @@
     "sdk/ml/azure-ai-ml/swagger/**",
     "sdk/ml/azure-ai-ml/NOTICE.txt",
     "sdk/loadtestservice/azure-developer-loadtesting/**",
-    "sdk/monitor/azure-monitor-ingestion/**",
     "sdk/translation/azure-ai-translation-text/azure/ai/translation/text/_serialization.py",
     "sdk/translation/azure-ai-translation-text/tests/test_break_sentence.py",
     "sdk/translation/azure-ai-translation-text/tests/test_translation.py",
@@ -819,6 +817,13 @@
       ]
     },
     {
+      "filename": "sdk/monitor/azure-monitor-*/**/*",
+      "words": [
+        "ctxt",
+        "wday"
+      ]
+    },
+    {
       "filename": "sdk/monitor/azure-monitor-opentelemetry*/**/*",
       "words": [
         "blrp",
@@ -846,32 +851,6 @@
         "mycontainer",
         "semconv",
         "updown"
-      ]
-    },
-    {
-      "filename": "sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_vendor/**/*.py",
-      "words": [
-        "aiopg",
-        "asgiref",
-        "asyncpg",
-        "boto",
-        "botocore",
-        "Cbar",
-        "funcs",
-        "grpcio",
-        "islast",
-        "libpq",
-        "owais",
-        "psutil",
-        "pydantic",
-        "pymongo",
-        "pymysql",
-        "remoulade",
-        "setifnotnone",
-        "sklearn",
-        "starlette",
-        "tortoiseorm",
-        "trysetip"
       ]
     },
     {

--- a/sdk/monitor/azure-monitor-ingestion/azure/monitor/ingestion/_helpers.py
+++ b/sdk/monitor/azure-monitor-ingestion/azure/monitor/ingestion/_helpers.py
@@ -42,6 +42,7 @@ def _split_chunks(logs: List[JSON], max_size_bytes: int = MAX_CHUNK_SIZE_BYTES) 
 
 def _create_gzip_requests(logs: List[JSON]) -> Generator[Tuple[bytes, List[JSON]], None, None]:
     for chunk in _split_chunks(logs):
+        # cspell:ignore wbits
         zlib_mode = 16 + zlib.MAX_WBITS  # for gzip encoding
         _compress = zlib.compressobj(wbits=zlib_mode)
         data = _compress.compress(bytes(json.dumps(chunk), encoding="utf-8"))

--- a/sdk/monitor/azure-monitor-ingestion/azure/monitor/ingestion/_models.py
+++ b/sdk/monitor/azure-monitor-ingestion/azure/monitor/ingestion/_models.py
@@ -16,7 +16,7 @@ JSON = Mapping[str, Any]  # pylint: disable=unsubscriptable-object
 class LogsUploadError:
     """Error information for a failed upload to Azure Monitor.
 
-    :param error: The error that occured during the upload.
+    :param error: The error that occurred during the upload.
     :type error: Exception
     :param failed_logs: The list of logs that failed to upload.
     :type failed_logs: list[JSON]

--- a/sdk/monitor/azure-monitor-query/azure/monitor/query/_enums.py
+++ b/sdk/monitor/azure-monitor-query/azure/monitor/query/_enums.py
@@ -4,6 +4,7 @@
 # Licensed under the MIT License. See License.txt in the project root for
 # license information.
 # --------------------------------------------------------------------------
+# cspell:ignore milli
 from enum import Enum
 
 from azure.core import CaseInsensitiveEnumMeta

--- a/sdk/monitor/azure-monitor-query/azure/monitor/query/_models.py
+++ b/sdk/monitor/azure-monitor-query/azure/monitor/query/_models.py
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See License.txt in the project root for
 # license information.
 # --------------------------------------------------------------------------
-
+# cspell:ignore milli
 import uuid
 from datetime import datetime, timedelta
 import sys


### PR DESCRIPTION
Allow cspell to check ingestion and query monitor packages.

Removed a cspell ignore block for a code path that no longer exists.
