### PR TITLE
[Cosmos] additional resource id validation and tests

### DIFF
--- a/sdk/cosmos/azure-cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos/CHANGELOG.md
@@ -9,7 +9,7 @@
 #### Bugs Fixed
 
 #### Other Changes
-- Added additional checks for resource creation using specific characters that cause issues. See [PR 123](https://github.com/Azure/azure-sdk-for-python/pull/123).
+- Added additional checks for resource creation using specific characters that cause issues. See [PR 31861](https://github.com/Azure/azure-sdk-for-python/pull/31861).
 
 ### 4.5.0 (2023-08-09)
 

--- a/sdk/cosmos/azure-cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos/CHANGELOG.md
@@ -9,6 +9,7 @@
 #### Bugs Fixed
 
 #### Other Changes
+- Added additional checks for resource creation using specific characters that cause issues. See [PR 123](https://github.com/Azure/azure-sdk-for-python/pull/123).
 
 ### 4.5.0 (2023-08-09)
 

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_cosmos_client_connection.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_cosmos_client_connection.py
@@ -2615,7 +2615,8 @@ class CosmosClientConnection(object):  # pylint: disable=too-many-public-methods
         id_ = resource.get("id")
         if id_:
             try:
-                if id_.find("/") != -1 or id_.find("\\") != -1 or id_.find("?") != -1 or id_.find("#") != -1:
+                if id_.find("/") != -1 or id_.find("\\") != -1 or id_.find("?") != -1 or id_.find("#") != -1\
+                        or id_.find("\t") != -1 or id_.find("\r") != -1 or id_.find("\n") != -1:
                     raise ValueError("Id contains illegal chars.")
 
                 if id_[-1] == " ":

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_cosmos_client_connection_async.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_cosmos_client_connection_async.py
@@ -2595,7 +2595,7 @@ class CosmosClientConnection(object):  # pylint: disable=too-many-public-methods
         if id_:
             try:
                 if id_.find("/") != -1 or id_.find("\\") != -1 or id_.find("?") != -1 or id_.find("#") != -1 \
-                        or id_.find("\t") != -1 or id_.find("\r") != -1 or id_.find("\n") != -1:
+                        or id_.find("\t") != -1 or id_.find("\r") != -1 or id_.find("\n") != -1 or id_.endswith(" "):
                     raise ValueError("Id contains illegal chars.")
 
                 if id_[-1] == " ":

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_cosmos_client_connection_async.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_cosmos_client_connection_async.py
@@ -2594,7 +2594,8 @@ class CosmosClientConnection(object):  # pylint: disable=too-many-public-methods
         id_ = resource.get("id")
         if id_:
             try:
-                if id_.find("/") != -1 or id_.find("\\") != -1 or id_.find("?") != -1 or id_.find("#") != -1:
+                if id_.find("/") != -1 or id_.find("\\") != -1 or id_.find("?") != -1 or id_.find("#") != -1 \
+                        or id_.find("\t") != -1 or id_.find("\r") != -1 or id_.find("\n") != -1:
                     raise ValueError("Id contains illegal chars.")
 
                 if id_[-1] == " ":

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/cosmos_client.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/cosmos_client.py
@@ -392,7 +392,7 @@ class CosmosClient(object):  # pylint: disable=client-accepts-api-version-keywor
     def query_databases(
         self,
         query=None,  # type: Optional[str]
-        parameters=None,  # type: Optional[List[str]]
+        parameters=None,  # type: Optional[List[Dict[str, any]]]
         enable_cross_partition_query=None,  # type: Optional[bool]
         max_item_count=None,  # type:  Optional[int]
         populate_query_metrics=None,  # type: Optional[bool]

--- a/sdk/cosmos/azure-cosmos/test/test_crud.py
+++ b/sdk/cosmos/azure-cosmos/test/test_crud.py
@@ -2414,37 +2414,6 @@ class CRUDTests(unittest.TestCase):
         created_db.delete_container(created_collection1)
         created_db.delete_container(created_collection2)
 
-    #TODO: fix test
-    @pytest.mark.skip
-    def test_id_unicode_validation(self):
-        # create database
-        created_db = self.databaseForTest
-
-        # unicode chars in Hindi for Id which translates to: "Hindi is the national language of India"
-        collection_id1 = u'हिन्दी भारत की राष्ट्रीय भाषा है' # cspell:disable-line
-
-        # Special chars for Id
-        collection_id2 = "!@$%^&*()-~`'_[]{}|;:,.<>"
-
-        # verify that collections are created with specified IDs
-        created_collection1 = created_db.create_container(
-            id=collection_id1,
-            partition_key=PartitionKey(path='/id', kind='Hash')
-        )
-        created_collection2 = created_db.create_container(
-            id=collection_id2,
-            partition_key=PartitionKey(path='/id', kind='Hash')
-        )
-
-        self.assertEqual(collection_id1, created_collection1.id)
-        self.assertEqual(collection_id2, created_collection2.id)
-        
-        created_collection1_properties = created_collection1.read()
-        created_collection2_properties = created_collection2.read()
-
-        created_db.client_connection.DeleteContainer(created_collection1_properties['_self'])
-        created_db.client_connection.DeleteContainer(created_collection2_properties['_self'])
-
     def test_get_resource_with_dictionary_and_object(self):
         created_db = self.databaseForTest
 

--- a/sdk/cosmos/azure-cosmos/test/test_crud_async.py
+++ b/sdk/cosmos/azure-cosmos/test/test_crud_async.py
@@ -2428,35 +2428,6 @@ class CRUDTests(unittest.TestCase):
         await created_db.delete_container(created_collection1)
         await created_db.delete_container(created_collection2)
 
-    async def test_id_unicode_validation(self):
-        # create database
-        created_db = self.databaseForTest
-
-        # unicode chars in Hindi for Id which translates to: "Hindi is the national language of India"
-        collection_id1 = u'हिन्दी भारत की राष्ट्रीय भाषा है' # cspell:disable-line
-
-        # Special chars for Id
-        collection_id2 = "!@$%^&*()-~`'_[]{}|;:,.<>"
-
-        # verify that collections are created with specified IDs
-        created_collection1 = await created_db.create_container(
-            id=collection_id1,
-            partition_key=PartitionKey(path='/id', kind='Hash')
-        )
-        created_collection2 = await created_db.create_container(
-            id=collection_id2,
-            partition_key=PartitionKey(path='/id', kind='Hash')
-        )
-
-        self.assertEqual(collection_id1, created_collection1.id)
-        self.assertEqual(collection_id2, created_collection2.id)
-
-        created_collection1_properties = await created_collection1.read()
-        created_collection2_properties = await created_collection2.read()
-
-        await created_db.delete_container(created_collection1_properties)
-        await created_db.delete_container(created_collection2_properties)
-
     async def test_get_resource_with_dictionary_and_object(self):
         created_db = self.databaseForTest
 

--- a/sdk/cosmos/azure-cosmos/test/test_resource_id.py
+++ b/sdk/cosmos/azure-cosmos/test/test_resource_id.py
@@ -95,7 +95,7 @@ class ResourceIdTests(unittest.TestCase):
             "ID_with_back/slash",
             "ID_\\with_forward_slashes",
             "ID_with_question?_mark",
-            "ID_with_poun#d",
+            "ID_with_#pound",
             "ID_with_tab\t",
             "ID\r_with_return_carriage",
             "ID_with_newline\n",

--- a/sdk/cosmos/azure-cosmos/test/test_resource_id.py
+++ b/sdk/cosmos/azure-cosmos/test/test_resource_id.py
@@ -90,6 +90,10 @@ class ResourceIdTests(unittest.TestCase):
         created_database = self.client.create_database(id=database_id)
         created_container = created_database.create_container(id=container_id, partition_key=partition_key)
 
+        # Define errors returned by checks
+        illegal_chars_string = 'Id contains illegal chars.'
+        space_chars_string = 'Id ends with a space.'
+
         # Define illegal strings
         illegal_strings = [
             "ID_with_back/slash",
@@ -103,27 +107,30 @@ class ResourceIdTests(unittest.TestCase):
         ]
 
         # test illegal resource id's for all resources
+        error_string = illegal_chars_string
         for resource_id in illegal_strings:
+            if resource_id == "ID_with_trailing_spaces   ":
+                error_string = space_chars_string
             try:
                 self.client.create_database(resource_id)
                 self.fail("Database create should have failed for id {}".format(resource_id))
             except ValueError as e:
-                self.assertEquals(str(e), 'Id contains illegal chars.')
+                self.assertEquals(str(e), error_string)
 
             try:
                 created_database.create_container(id=resource_id, partition_key=partition_key)
                 self.fail("Container create should have failed for id {}".format(resource_id))
             except ValueError as e:
-                self.assertEquals(str(e), 'Id contains illegal chars.')
+                self.assertEquals(str(e), error_string)
 
             try:
                 created_container.create_item({"id": resource_id})
                 self.fail("Item create should have failed for id {}".format(resource_id))
             except ValueError as e:
-                self.assertEquals(str(e), 'Id contains illegal chars.')
+                self.assertEquals(str(e), error_string)
             try:
                 created_container.upsert_item({"id": resource_id})
                 self.fail("Item upsert should have failed for id {}".format(resource_id))
             except ValueError as e:
-                self.assertEquals(str(e), 'Id contains illegal chars.')
+                self.assertEquals(str(e), error_string)
 

--- a/sdk/cosmos/azure-cosmos/test/test_resource_id.py
+++ b/sdk/cosmos/azure-cosmos/test/test_resource_id.py
@@ -1,0 +1,138 @@
+# The MIT License (MIT)
+# Copyright (c) 2023 Microsoft Corporation
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+import unittest
+
+import uuid
+import pytest
+import test_config
+import azure.cosmos.cosmos_client as cosmos_client
+from azure.cosmos.partition_key import PartitionKey
+
+pytestmark = pytest.mark.cosmosEmulator
+
+
+@pytest.mark.usefixtures("teardown")
+class ResourceIdTests(unittest.TestCase):
+    configs = test_config._test_config
+    host = configs.host
+    masterKey = configs.masterKey
+    connectionPolicy = configs.connectionPolicy
+    last_headers = []
+
+    @classmethod
+    def setUpClass(cls):
+        if (cls.masterKey == '[YOUR_KEY_HERE]' or
+                cls.host == '[YOUR_ENDPOINT_HERE]'):
+            raise Exception(
+                "You must specify your Azure Cosmos account values for "
+                "'masterKey' and 'host' at the top of this class to run the "
+                "tests.")
+        cls.client = cosmos_client.CosmosClient(cls.host, cls.masterKey, connection_policy=cls.connectionPolicy)
+        cls.databaseForTest = cls.configs.create_database_if_not_exist(cls.client)
+
+    def test_id_unicode_validation(self):
+        # unicode chars in Hindi for Id which translates to: "Hindi is the national language of India"
+        resource_id1 = u'हिन्दी भारत की राष्ट्रीय भाषा है'  # cspell:disable-line
+
+        # Special allowed chars for Id
+        resource_id2 = "!@$%^&*()-~`'_[]{}|;:,.<>"
+
+        # verify that databases are created with specified IDs
+        created_db1 = self.client.create_database(resource_id1)
+        created_db2 = self.client.create_database(resource_id2)
+
+        self.assertEqual(resource_id1, created_db1.id)
+        self.assertEqual(resource_id2, created_db2.id)
+
+        # verify that collections are created with specified IDs
+        created_collection1 = created_db1.create_container(
+            id=resource_id1,
+            partition_key=PartitionKey(path='/id', kind='Hash'))
+        created_collection2 = created_db2.create_container(
+            id=resource_id2,
+            partition_key=PartitionKey(path='/id', kind='Hash'))
+
+        self.assertEqual(resource_id1, created_collection1.id)
+        self.assertEqual(resource_id2, created_collection2.id)
+
+        # verify that collections are created with specified IDs
+        item1 = created_collection1.create_item({"id": resource_id1})
+        item2 = created_collection1.create_item({"id": resource_id2})
+
+        self.assertEqual(resource_id1, item1.get("id"))
+        self.assertEqual(resource_id2, item2.get("id"))
+
+    def test_create_illegal_characters(self):
+        database_id = str(uuid.uuid4())
+        container_id = str(uuid.uuid4())
+        partition_key = PartitionKey(path="/id")
+
+        created_database = self.client.create_database(id=database_id)
+        created_container = created_database.create_container(id=container_id, partition_key=partition_key)
+
+        # Define illegal strings
+        illegal_strings = [
+            "ID_with_back/slash",
+            "ID_\\with_forward_slashes",
+            "ID_with_question?_mark",
+            "ID_with_poun#d",
+            "ID_with_tab\t",
+            "ID\r_with_return_carriage",
+            "ID_with_newline\n"
+        ]
+
+        # test illegal resource id's for all resources
+        for resource_id in illegal_strings:
+            try:
+                self.client.create_database(resource_id)
+                self.fail("Database create should have failed for id {}".format(resource_id))
+            except ValueError as e:
+                self.assertEquals(str(e), 'Id contains illegal chars.')
+            try:
+                self.client.create_database_if_not_exists(resource_id)
+                self.fail("Database create should have failed for id {}".format(resource_id))
+            except ValueError as e:
+                self.assertEquals(str(e), 'Id contains illegal chars.')
+
+            try:
+                created_database.create_container(id=resource_id, partition_key=partition_key)
+                self.fail("Container create should have failed for id {}".format(resource_id))
+            except ValueError as e:
+                self.assertEquals(str(e), 'Id contains illegal chars.')
+            try:
+                created_database.create_container_if_not_exists(id=resource_id, partition_key=partition_key)
+                self.fail("Container create should have failed for id {}".format(resource_id))
+            except ValueError as e:
+                self.assertEquals(str(e), 'Id contains illegal chars.')
+
+            try:
+                created_container.create_item({"id": resource_id})
+                self.fail("Item create should have failed for id {}".format(resource_id))
+            except ValueError as e:
+                self.assertEquals(str(e), 'Id contains illegal chars.')
+            try:
+                created_container.upsert_item({"id": resource_id})
+                self.fail("Item upsert should have failed for id {}".format(resource_id))
+            except ValueError as e:
+                self.assertEquals(str(e), 'Id contains illegal chars.')
+

--- a/sdk/cosmos/azure-cosmos/test/test_resource_id.py
+++ b/sdk/cosmos/azure-cosmos/test/test_resource_id.py
@@ -98,7 +98,8 @@ class ResourceIdTests(unittest.TestCase):
             "ID_with_poun#d",
             "ID_with_tab\t",
             "ID\r_with_return_carriage",
-            "ID_with_newline\n"
+            "ID_with_newline\n",
+            "ID_with_trailing_spaces   "
         ]
 
         # test illegal resource id's for all resources

--- a/sdk/cosmos/azure-cosmos/test/test_resource_id.py
+++ b/sdk/cosmos/azure-cosmos/test/test_resource_id.py
@@ -109,19 +109,9 @@ class ResourceIdTests(unittest.TestCase):
                 self.fail("Database create should have failed for id {}".format(resource_id))
             except ValueError as e:
                 self.assertEquals(str(e), 'Id contains illegal chars.')
-            try:
-                self.client.create_database_if_not_exists(resource_id)
-                self.fail("Database create should have failed for id {}".format(resource_id))
-            except ValueError as e:
-                self.assertEquals(str(e), 'Id contains illegal chars.')
 
             try:
                 created_database.create_container(id=resource_id, partition_key=partition_key)
-                self.fail("Container create should have failed for id {}".format(resource_id))
-            except ValueError as e:
-                self.assertEquals(str(e), 'Id contains illegal chars.')
-            try:
-                created_database.create_container_if_not_exists(id=resource_id, partition_key=partition_key)
                 self.fail("Container create should have failed for id {}".format(resource_id))
             except ValueError as e:
                 self.assertEquals(str(e), 'Id contains illegal chars.')

--- a/sdk/cosmos/azure-cosmos/test/test_resource_id_async.py
+++ b/sdk/cosmos/azure-cosmos/test/test_resource_id_async.py
@@ -83,7 +83,7 @@ class ResourceIdTests(unittest.TestCase):
         self.assertEqual(resource_id1, item1.get("id"))
         self.assertEqual(resource_id2, item2.get("id"))
 
-    def test_create_illegal_characters(self):
+    async def test_create_illegal_characters(self):
         database_id = str(uuid.uuid4())
         container_id = str(uuid.uuid4())
         partition_key = PartitionKey(path="/id")
@@ -99,7 +99,8 @@ class ResourceIdTests(unittest.TestCase):
             "ID_with_poun#d",
             "ID_with_tab\t",
             "ID\r_with_return_carriage",
-            "ID_with_newline\n"
+            "ID_with_newline\n",
+            "ID_with_trailing_spaces   "
         ]
 
         # test illegal resource id's for all resources

--- a/sdk/cosmos/azure-cosmos/test/test_resource_id_async.py
+++ b/sdk/cosmos/azure-cosmos/test/test_resource_id_async.py
@@ -1,0 +1,139 @@
+# The MIT License (MIT)
+# Copyright (c) 2023 Microsoft Corporation
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+import unittest
+
+import uuid
+import pytest
+import test_config
+import azure.cosmos.cosmos_client as cosmos_client
+from azure.cosmos.partition_key import PartitionKey
+
+pytestmark = pytest.mark.cosmosEmulator
+
+
+@pytest.mark.usefixtures("teardown")
+class ResourceIdTests(unittest.TestCase):
+    configs = test_config._test_config
+    host = configs.host
+    masterKey = configs.masterKey
+    connectionPolicy = configs.connectionPolicy
+    last_headers = []
+
+    @classmethod
+    async def setUpClass(cls):
+        if (cls.masterKey == '[YOUR_KEY_HERE]' or
+                cls.host == '[YOUR_ENDPOINT_HERE]'):
+            raise Exception(
+                "You must specify your Azure Cosmos account values for "
+                "'masterKey' and 'host' at the top of this class to run the "
+                "tests.")
+        cls.client = cosmos_client.CosmosClient(cls.host, cls.masterKey, consistency_level="Session",
+                                                connection_policy=cls.connectionPolicy)
+        cls.databaseForTest = await cls.configs.create_database_if_not_exist(cls.client)
+
+    async def test_id_unicode_validation(self):
+        # unicode chars in Hindi for Id which translates to: "Hindi is the national language of India"
+        resource_id1 = u'हिन्दी भारत की राष्ट्रीय भाषा है'  # cspell:disable-line
+
+        # Special allowed chars for Id
+        resource_id2 = "!@$%^&*()-~`'_[]{}|;:,.<>"
+
+        # verify that databases are created with specified IDs
+        created_db1 = await self.client.create_database(resource_id1)
+        created_db2 = await self.client.create_database(resource_id2)
+
+        self.assertEqual(resource_id1, created_db1.id)
+        self.assertEqual(resource_id2, created_db2.id)
+
+        # verify that collections are created with specified IDs
+        created_collection1 = await created_db1.create_container(
+            id=resource_id1,
+            partition_key=PartitionKey(path='/id', kind='Hash'))
+        created_collection2 = await created_db2.create_container(
+            id=resource_id2,
+            partition_key=PartitionKey(path='/id', kind='Hash'))
+
+        self.assertEqual(resource_id1, created_collection1.id)
+        self.assertEqual(resource_id2, created_collection2.id)
+
+        # verify that collections are created with specified IDs
+        item1 = await created_collection1.create_item({"id": resource_id1})
+        item2 = await created_collection1.create_item({"id": resource_id2})
+
+        self.assertEqual(resource_id1, item1.get("id"))
+        self.assertEqual(resource_id2, item2.get("id"))
+
+    def test_create_illegal_characters(self):
+        database_id = str(uuid.uuid4())
+        container_id = str(uuid.uuid4())
+        partition_key = PartitionKey(path="/id")
+
+        created_database = await self.client.create_database(id=database_id)
+        created_container = await created_database.create_container(id=container_id, partition_key=partition_key)
+
+        # Define illegal strings
+        illegal_strings = [
+            "ID_with_back/slash",
+            "ID_\\with_forward_slashes",
+            "ID_with_question?_mark",
+            "ID_with_poun#d",
+            "ID_with_tab\t",
+            "ID\r_with_return_carriage",
+            "ID_with_newline\n"
+        ]
+
+        # test illegal resource id's for all resources
+        for resource_id in illegal_strings:
+            try:
+                await self.client.create_database(resource_id)
+                self.fail("Database create should have failed for id {}".format(resource_id))
+            except ValueError as e:
+                self.assertEquals(str(e), 'Id contains illegal chars.')
+            try:
+                await self.client.create_database_if_not_exists(resource_id)
+                self.fail("Database create should have failed for id {}".format(resource_id))
+            except ValueError as e:
+                self.assertEquals(str(e), 'Id contains illegal chars.')
+
+            try:
+                await created_database.create_container(id=resource_id, partition_key=partition_key)
+                self.fail("Container create should have failed for id {}".format(resource_id))
+            except ValueError as e:
+                self.assertEquals(str(e), 'Id contains illegal chars.')
+            try:
+                await created_database.create_container_if_not_exists(id=resource_id, partition_key=partition_key)
+                self.fail("Container create should have failed for id {}".format(resource_id))
+            except ValueError as e:
+                self.assertEquals(str(e), 'Id contains illegal chars.')
+
+            try:
+                await created_container.create_item({"id": resource_id})
+                self.fail("Item create should have failed for id {}".format(resource_id))
+            except ValueError as e:
+                self.assertEquals(str(e), 'Id contains illegal chars.')
+            try:
+                await created_container.upsert_item({"id": resource_id})
+                self.fail("Item upsert should have failed for id {}".format(resource_id))
+            except ValueError as e:
+                self.assertEquals(str(e), 'Id contains illegal chars.')
+

--- a/sdk/cosmos/azure-cosmos/test/test_resource_id_async.py
+++ b/sdk/cosmos/azure-cosmos/test/test_resource_id_async.py
@@ -96,7 +96,7 @@ class ResourceIdTests(unittest.TestCase):
             "ID_with_back/slash",
             "ID_\\with_forward_slashes",
             "ID_with_question?_mark",
-            "ID_with_poun#d",
+            "ID_with_#pound",
             "ID_with_tab\t",
             "ID\r_with_return_carriage",
             "ID_with_newline\n",

--- a/sdk/cosmos/azure-cosmos/test/test_resource_id_async.py
+++ b/sdk/cosmos/azure-cosmos/test/test_resource_id_async.py
@@ -110,19 +110,9 @@ class ResourceIdTests(unittest.TestCase):
                 self.fail("Database create should have failed for id {}".format(resource_id))
             except ValueError as e:
                 self.assertEquals(str(e), 'Id contains illegal chars.')
-            try:
-                await self.client.create_database_if_not_exists(resource_id)
-                self.fail("Database create should have failed for id {}".format(resource_id))
-            except ValueError as e:
-                self.assertEquals(str(e), 'Id contains illegal chars.')
 
             try:
                 await created_database.create_container(id=resource_id, partition_key=partition_key)
-                self.fail("Container create should have failed for id {}".format(resource_id))
-            except ValueError as e:
-                self.assertEquals(str(e), 'Id contains illegal chars.')
-            try:
-                await created_database.create_container_if_not_exists(id=resource_id, partition_key=partition_key)
                 self.fail("Container create should have failed for id {}".format(resource_id))
             except ValueError as e:
                 self.assertEquals(str(e), 'Id contains illegal chars.')

--- a/sdk/cosmos/azure-cosmos/test/test_resource_id_async.py
+++ b/sdk/cosmos/azure-cosmos/test/test_resource_id_async.py
@@ -91,6 +91,10 @@ class ResourceIdTests(unittest.TestCase):
         created_database = await self.client.create_database(id=database_id)
         created_container = await created_database.create_container(id=container_id, partition_key=partition_key)
 
+        # Define errors returned by checks
+        illegal_chars_string = 'Id contains illegal chars.'
+        space_chars_string = 'Id ends with a space.'
+
         # Define illegal strings
         illegal_strings = [
             "ID_with_back/slash",
@@ -104,27 +108,30 @@ class ResourceIdTests(unittest.TestCase):
         ]
 
         # test illegal resource id's for all resources
+        error_string = illegal_chars_string
         for resource_id in illegal_strings:
+            if resource_id == "ID_with_trailing_spaces   ":
+                error_string = space_chars_string
             try:
                 await self.client.create_database(resource_id)
                 self.fail("Database create should have failed for id {}".format(resource_id))
             except ValueError as e:
-                self.assertEquals(str(e), 'Id contains illegal chars.')
+                self.assertEquals(str(e), error_string)
 
             try:
                 await created_database.create_container(id=resource_id, partition_key=partition_key)
                 self.fail("Container create should have failed for id {}".format(resource_id))
             except ValueError as e:
-                self.assertEquals(str(e), 'Id contains illegal chars.')
+                self.assertEquals(str(e), error_string)
 
             try:
                 await created_container.create_item({"id": resource_id})
                 self.fail("Item create should have failed for id {}".format(resource_id))
             except ValueError as e:
-                self.assertEquals(str(e), 'Id contains illegal chars.')
+                self.assertEquals(str(e), error_string)
             try:
                 await created_container.upsert_item({"id": resource_id})
                 self.fail("Item upsert should have failed for id {}".format(resource_id))
             except ValueError as e:
-                self.assertEquals(str(e), 'Id contains illegal chars.')
+                self.assertEquals(str(e), error_string)
 


### PR DESCRIPTION
Our SDK was missing some of the validations for resource ids that we should have had to begin with in order to avoid customers having issues with this. Based on https://github.com/Azure/azure-sdk-for-python/issues/31639 where a user was unable to use their container due to a mistake with a tab character.

Also quickly took care of this update to the typehint that was pointed out: https://github.com/Azure/azure-sdk-for-python/issues/31811