### PR TITLE
[ML] fix: Add missing type documentation for `FeatureStoreOpeations.begin_update` keyword arguments

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_feature_store_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_feature_store_operations.py
@@ -478,7 +478,7 @@ class FeatureStoreOperations(WorkspaceOperationsBase):
         as true prepares the feature store managed network for supporting Spark.
 
         :keyword feature_store_name: Name of the feature store.
-        :type feature_store_name: str
+        :paramtype feature_store_name: str
         :return: An instance of LROPoller.
         :rtype: ~azure.core.polling.LROPoller[~azure.ai.ml.entities.ManagedNetworkProvisionStatus]
         """

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_feature_store_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_feature_store_operations.py
@@ -248,8 +248,10 @@ class FeatureStoreOperations(WorkspaceOperationsBase):
             deployed inference endpoints this feature store. Only set this argument if you are sure that you want
             to perform this operation. If this argument is not set, the command to update
             Azure Container Registry and Azure Application Insights will fail.
-        :keyword application_insights: Application insights resource for feature store.
-        :keyword container_registry: Container registry resource for feature store.
+        :keyword application_insights: Application insights resource for feature store. Defaults to None.
+        :paramtype application_insights: Optional[str]
+        :keyword container_registry: Container registry resource for feature store. Defaults to None.
+        :paramtype container_registry: Optional[str]
         :return: An instance of LROPoller that returns a FeatureStore.
         :rtype: ~azure.core.polling.LROPoller[~azure.ai.ml.entities.FeatureStore]
         """

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_feature_store_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_feature_store_operations.py
@@ -5,12 +5,8 @@
 # pylint: disable=protected-access
 
 from typing import Dict, Iterable, Optional
-from marshmallow import ValidationError
 
-from azure.core.credentials import TokenCredential
-from azure.core.exceptions import ResourceNotFoundError
-from azure.core.polling import LROPoller
-from azure.core.tracing.decorator import distributed_trace
+from marshmallow import ValidationError
 
 from azure.ai.ml._restclient.v2023_06_01_preview import AzureMachineLearningWorkspaces as ServiceClient062023Preview
 from azure.ai.ml._restclient.v2023_06_01_preview.models import ManagedNetworkProvisionOptions
@@ -23,8 +19,8 @@ from azure.ai.ml.constants._common import Scope
 from azure.ai.ml.entities import (
     IdentityConfiguration,
     ManagedIdentityConfiguration,
-    WorkspaceConnection,
     ManagedNetworkProvisionStatus,
+    WorkspaceConnection,
 )
 from azure.ai.ml.entities._feature_store._constants import (
     FEATURE_STORE_KIND,
@@ -38,6 +34,10 @@ from azure.ai.ml.entities._feature_store._constants import (
 from azure.ai.ml.entities._feature_store.feature_store import FeatureStore
 from azure.ai.ml.entities._feature_store.materialization_store import MaterializationStore
 from azure.ai.ml.entities._workspace.feature_store_settings import FeatureStoreSettings
+from azure.core.credentials import TokenCredential
+from azure.core.exceptions import ResourceNotFoundError
+from azure.core.polling import LROPoller
+from azure.core.tracing.decorator import distributed_trace
 
 from ._workspace_operations_base import WorkspaceOperationsBase
 


### PR DESCRIPTION
# Description

This pull request:

* Adds missing type hints for `FeatureStoreOpeations.begin_update` keyword arguments 
* Fixes a keyword argument erroneously annotated with :type instead of :paramtype

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
