### PR TITLE
Update import-lib version restriction to reflect opentelemetry-api

### DIFF
--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/setup.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/setup.py
@@ -86,7 +86,7 @@ setup(
         "msrest>=0.6.10",
         "opentelemetry-api~=1.19.0",
         "opentelemetry-sdk~=1.19.0",
-        "importlib-metadata >= 6.0, < 7.0; python_version < '3.8'"
+        "importlib-metadata~=6.0; python_version < '3.8'"
     ],
     entry_points={
         "opentelemetry_traces_exporter": [

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/setup.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/setup.py
@@ -86,7 +86,7 @@ setup(
         "msrest>=0.6.10",
         "opentelemetry-api~=1.19.0",
         "opentelemetry-sdk~=1.19.0",
-        "importlib-metadata~=6.0.0; python_version < '3.8'"
+        "importlib-metadata >= 6.0, < 7.0; python_version < '3.8'"
     ],
     entry_points={
         "opentelemetry_traces_exporter": [


### PR DESCRIPTION
https://github.com/open-telemetry/opentelemetry-python/blob/v1.19.0/opentelemetry-api/pyproject.toml#L31