### PR TITLE
[Storage] STG90 API View Feedback

### DIFF
--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_client.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_client.py
@@ -239,6 +239,8 @@ class BlobClient(StorageAccountHostsMixin, StorageEncryptionMixin):  # pylint: d
             The optional blob snapshot on which to operate. This can be the snapshot ID string
             or the response returned from :func:`create_snapshot`. If specified, this will override
             the snapshot in the url.
+        :keyword str version_id: The version id parameter is an opaque DateTime value that, when present,
+            specifies the version of the blob to operate on.
         :returns: A Blob client.
         :rtype: ~azure.storage.blob.BlobClient
         """
@@ -283,10 +285,11 @@ class BlobClient(StorageAccountHostsMixin, StorageEncryptionMixin):  # pylint: d
                     path_snapshot = snapshot['snapshot'] # type: ignore
                 except TypeError:
                     path_snapshot = snapshot
+        version_id = kwargs.pop('version_id', None)
 
         return cls(
             account_url, container_name=container_name, blob_name=blob_name,
-            snapshot=path_snapshot, credential=credential, **kwargs
+            snapshot=path_snapshot, credential=credential, version_id=version_id, **kwargs
         )
 
     @classmethod
@@ -319,6 +322,8 @@ class BlobClient(StorageAccountHostsMixin, StorageEncryptionMixin):  # pylint: d
             If using an instance of AzureNamedKeyCredential, "name" should be the storage account name, and "key"
             should be the storage account key.
         :type credential: Optional[Union[str, Dict[str, str], "AzureNamedKeyCredential", "AzureSasCredential", "TokenCredential"]]  # pylint: disable=line-too-long
+        :keyword str version_id: The version id parameter is an opaque DateTime value that, when present,
+            specifies the version of the blob to operate on.
         :returns: A Blob client.
         :rtype: ~azure.storage.blob.BlobClient
 
@@ -334,9 +339,10 @@ class BlobClient(StorageAccountHostsMixin, StorageEncryptionMixin):  # pylint: d
         account_url, secondary, credential = parse_connection_str(conn_str, credential, 'blob')
         if 'secondary_hostname' not in kwargs:
             kwargs['secondary_hostname'] = secondary
+        version_id = kwargs.pop('version_id', None)
         return cls(
             account_url, container_name=container_name, blob_name=blob_name,
-            snapshot=snapshot, credential=credential, **kwargs
+            snapshot=snapshot, credential=credential, version_id=version_id, **kwargs
         )
 
     @distributed_trace

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_client.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_client.py
@@ -285,11 +285,10 @@ class BlobClient(StorageAccountHostsMixin, StorageEncryptionMixin):  # pylint: d
                     path_snapshot = snapshot['snapshot'] # type: ignore
                 except TypeError:
                     path_snapshot = snapshot
-        version_id = kwargs.pop('version_id', None)
 
         return cls(
             account_url, container_name=container_name, blob_name=blob_name,
-            snapshot=path_snapshot, credential=credential, version_id=version_id, **kwargs
+            snapshot=path_snapshot, credential=credential, **kwargs
         )
 
     @classmethod
@@ -339,10 +338,9 @@ class BlobClient(StorageAccountHostsMixin, StorageEncryptionMixin):  # pylint: d
         account_url, secondary, credential = parse_connection_str(conn_str, credential, 'blob')
         if 'secondary_hostname' not in kwargs:
             kwargs['secondary_hostname'] = secondary
-        version_id = kwargs.pop('version_id', None)
         return cls(
             account_url, container_name=container_name, blob_name=blob_name,
-            snapshot=snapshot, credential=credential, version_id=version_id, **kwargs
+            snapshot=snapshot, credential=credential, **kwargs
         )
 
     @distributed_trace

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_queue_client.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_queue_client.py
@@ -316,25 +316,22 @@ class QueueClient(StorageAccountHostsMixin, StorageEncryptionMixin):
 
     @distributed_trace
     def set_queue_metadata(
-        self, metadata=None,  # type: Optional[Dict[str, Any]]
-        **kwargs  # type: Any
-     ):
-        # type: (...) -> Dict[str, Any]
+        self, metadata: Optional[Dict[str, Any]] = None,
+        **kwargs: Any
+    ) -> Dict[str, Any]:
         """Sets user-defined metadata on the specified queue.
 
         Metadata is associated with the queue as name-value pairs.
 
-        :param metadata:
+        :param Optional[Dict[str, Any]] metadata:
             A dict containing name-value pairs to associate with the
             queue as metadata.
-        :type metadata: dict(str, str)
         :keyword int timeout:
             Sets the server-side timeout for the operation in seconds. For more details see
             https://learn.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-queue-service-operations.
             This value is not tracked or validated on the client. To configure client-side network timesouts
             see `here <https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/storage/azure-storage-queue
             #other-client--per-operation-configuration>`_.
-
         :return: A dictionary of response headers.
         :rtype: Dict[str, Any]
 

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_queue_client.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_queue_client.py
@@ -318,7 +318,7 @@ class QueueClient(StorageAccountHostsMixin, StorageEncryptionMixin):
     def set_queue_metadata(
         self, metadata: Optional[Dict[str, Any]] = None,
         **kwargs: Any
-    ) -> Dict[str, Any]:
+        ) -> Dict[str, Any]:
         """Sets user-defined metadata on the specified queue.
 
         Metadata is associated with the queue as name-value pairs.

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_queue_client.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_queue_client.py
@@ -316,8 +316,8 @@ class QueueClient(StorageAccountHostsMixin, StorageEncryptionMixin):
 
     @distributed_trace
     def set_queue_metadata(
-        self, metadata: Optional[Dict[str, Any]] = None,
-        **kwargs: Any
+            self, metadata: Optional[Dict[str, Any]] = None,
+            **kwargs: Any
         ) -> Dict[str, Any]:
         """Sets user-defined metadata on the specified queue.
 

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/aio/_queue_client_async.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/aio/_queue_client_async.py
@@ -210,22 +210,25 @@ class QueueClient(AsyncStorageAccountHostsMixin, QueueClientBase, StorageEncrypt
         return response  # type: ignore
 
     @distributed_trace_async
-    async def set_queue_metadata(self, metadata=None, **kwargs):
-        # type: (Optional[Dict[str, Any]], Optional[Any]) -> None
+    async def set_queue_metadata(
+        self, metadata: Optional[Dict[str, Any]] = None,
+        **kwargs: Any
+    ) -> Dict[str, Any]:
         """Sets user-defined metadata on the specified queue.
 
         Metadata is associated with the queue as name-value pairs.
 
-        :param metadata:
+        :param Optional[Dict[str, Any]] metadata:
             A dict containing name-value pairs to associate with the
             queue as metadata.
-        :type metadata: dict(str, str)
         :keyword int timeout:
             Sets the server-side timeout for the operation in seconds. For more details see
             https://learn.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-queue-service-operations.
             This value is not tracked or validated on the client. To configure client-side network timesouts
             see `here <https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/storage/azure-storage-queue
             #other-client--per-operation-configuration>`_.
+        :return: A dictionary of response headers.
+        :rtype: Dict[str, Any]
 
         .. admonition:: Example:
 

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/aio/_queue_client_async.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/aio/_queue_client_async.py
@@ -213,7 +213,7 @@ class QueueClient(AsyncStorageAccountHostsMixin, QueueClientBase, StorageEncrypt
     async def set_queue_metadata(
         self, metadata: Optional[Dict[str, Any]] = None,
         **kwargs: Any
-    ) -> Dict[str, Any]:
+        ) -> Dict[str, Any]:
         """Sets user-defined metadata on the specified queue.
 
         Metadata is associated with the queue as name-value pairs.

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/aio/_queue_client_async.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/aio/_queue_client_async.py
@@ -211,8 +211,8 @@ class QueueClient(AsyncStorageAccountHostsMixin, QueueClientBase, StorageEncrypt
 
     @distributed_trace_async
     async def set_queue_metadata(
-        self, metadata: Optional[Dict[str, Any]] = None,
-        **kwargs: Any
+            self, metadata: Optional[Dict[str, Any]] = None,
+            **kwargs: Any
         ) -> Dict[str, Any]:
         """Sets user-defined metadata on the specified queue.
 


### PR DESCRIPTION
This PR addresses the following items of feedback:

- Adding `version_id` as a kwarg to `from_blob_url` and `from_connection_string` in Blobs
- Fixing typehints for `set_queue_metadata` in Queue