### PR TITLE
Remove importlib-metadata

### DIFF
--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_utils.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_utils.py
@@ -21,9 +21,19 @@ from azure.monitor.opentelemetry.exporter._generated.models import TelemetryItem
 from azure.monitor.opentelemetry.exporter._version import VERSION as ext_version
 from azure.monitor.opentelemetry.exporter._constants import _INSTRUMENTATIONS_BIT_MAP
 
+opentelemetry_version = ""
 
 # Workaround for missing version file
-opentelemetry_version = version("opentelemetry-sdk")
+try:
+    from importlib.metadata import version
+    opentelemetry_version = version("opentelemetry-sdk")
+except ImportError:
+    # Temporary workaround for <Py3.8
+    # importlib-metadata causing issues in CI
+    import pkg_resources
+    opentelemetry_version = pkg_resources.get_distribution(
+        "opentelemetry-sdk"
+    ).version
 
 
 def _is_on_app_service():

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/setup.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/setup.py
@@ -86,7 +86,6 @@ setup(
         "msrest>=0.6.10",
         "opentelemetry-api~=1.19.0",
         "opentelemetry-sdk~=1.19.0",
-        "importlib-metadata~=6.0; python_version < '3.8'"
     ],
     entry_points={
         "opentelemetry_traces_exporter": [

--- a/shared_requirements.txt
+++ b/shared_requirements.txt
@@ -56,7 +56,6 @@ websocket-client
 avro
 uamqp
 yarl
-importlib-metadata
 azure-identity
 openai
 wrapt


### PR DESCRIPTION
Importlib-metadata was introduced awhile ago as a way to get package version information without using pkg_resource for python3.7. We are removing this temporarily as importlib-metadata is causing some [build](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3048936&view=logs&s=ff05ad62-bb9a-53b6-ce9f-72f329a63e7c&j=90227089-9f51-5ecc-566c-84e1f2918394) issues when version is ~= to the minor version. It also causes conflicts due to dependency on opentelemetry-api which also has [dependency](https://github.com/open-telemetry/opentelemetry-python/blob/main/opentelemetry-api/pyproject.toml#L31) on it.

This is a workaround until support for python 3.7 is dropped.