### PR TITLE
remove crypto<4 pin from `depends` tox env

### DIFF
--- a/eng/tox/tox.ini
+++ b/eng/tox/tox.ini
@@ -340,7 +340,6 @@ setenv =
   PROXY_URL=http://localhost:5008
 deps =
   {[packaging]pkgs}
-  cryptography<4
 commands =
     python -m pip install {repository_root}/tools/azure-sdk-tools --no-deps
     python {repository_root}/eng/tox/sanitize_setup.py -t {tox_root}


### PR DESCRIPTION
@kdestin @xiangyan99 

Resolves this [build failure caused by `depends` env running on pypy39](https://dev.azure.com/azure-sdk/public/_build/results?buildId=3051746&view=logs&j=8e5196d1-9c2a-56bb-41fd-e329e85c48fa&t=6119a4c1-14d2-5fe9-3d3b-b95005807b68&l=359)

