### PR TITLE
[ML][Pipelines] refactor for reference from other packages

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_internal/_setup.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_internal/_setup.py
@@ -1,11 +1,13 @@
 # ---------------------------------------------------------
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
+from typing import NoReturn
 
 # pylint: disable=protected-access
 from marshmallow import INCLUDE
 
 from .._schema import NestedField
+from ..entities._builders.control_flow_node import LoopNode
 from ..entities._component.component_factory import component_factory
 from ..entities._job.pipeline._load_component import pipeline_node_factory
 from ._schema.command import CommandSchema, DistributedSchema, ParallelSchema
@@ -20,6 +22,7 @@ from .entities import (
     InternalBaseNode,
     InternalComponent,
     Parallel,
+    Pipeline,
     Scope,
     Starlite,
 )
@@ -57,7 +60,14 @@ def _register_node(_type, node_cls, schema_cls):
     )
 
 
-def enable_internal_components_in_pipeline(*, force=False):
+def enable_internal_components_in_pipeline(*, force=False) -> NoReturn:
+    """Enable internal components in pipeline.
+
+    :keyword force: Whether to force re-enable internal components. Defaults to False.
+    :type force: bool
+    :return: No return value.
+    :rtype: None
+    """
     if _registered and not force:
         return  # already registered
 
@@ -83,4 +93,8 @@ def enable_internal_components_in_pipeline(*, force=False):
     _register_node(NodeType.SCOPE_V2, Scope, ScopeSchema)
     _register_node(NodeType.HDI_V2, HDInsight, HDInsightSchema)
     # Ae365exepool and AetherBridge have been registered to InternalBaseNode
+
+    # allow using internal nodes in do-while loop
+    LoopNode._extra_body_types = (Command, Pipeline)
+
     _set_registered(True)

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_internal/entities/environment.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_internal/entities/environment.py
@@ -7,8 +7,8 @@ from pathlib import Path
 from typing import Dict, Optional, Union
 
 from ..._utils.utils import load_yaml
-from ...constants._common import DefaultOpenEncoding, FILE_PREFIX
-from ...entities._validation import MutableValidationResult, _ValidationResultBuilder
+from ...constants._common import FILE_PREFIX, DefaultOpenEncoding
+from ...entities._validation import MutableValidationResult, ValidationResultBuilder
 
 
 class InternalEnvironment:
@@ -45,7 +45,7 @@ class InternalEnvironment:
     def _validate_conda_section(
         self, base_path: Union[str, PathLike], skip_path_validation: bool
     ) -> MutableValidationResult:
-        validation_result = _ValidationResultBuilder.success()
+        validation_result = ValidationResultBuilder.success()
         if not self.conda:
             return validation_result
         dependencies_field_names = {self.CONDA_DEPENDENCIES, self.CONDA_DEPENDENCIES_FILE, self.PIP_REQUIREMENTS_FILE}
@@ -74,7 +74,7 @@ class InternalEnvironment:
     def _validate_docker_section(
         self, base_path: Union[str, PathLike], skip_path_validation: bool
     ) -> MutableValidationResult:
-        validation_result = _ValidationResultBuilder.success()
+        validation_result = ValidationResultBuilder.success()
         if not self.docker:
             return validation_result
         if not self.docker.get(self.BUILD) or not self.docker[self.BUILD].get(self.DOCKERFILE):
@@ -104,7 +104,7 @@ class InternalEnvironment:
         :return: The validation result
         :rtype: MutableValidationResult
         """
-        validation_result = _ValidationResultBuilder.success()
+        validation_result = ValidationResultBuilder.success()
         if self.os is not None and self.os not in {"Linux", "Windows", "linux", "windows"}:
             validation_result.append_error(
                 yaml_path="os",

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_internal/entities/spark.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_internal/entities/spark.py
@@ -17,7 +17,7 @@ from .environment import InternalEnvironment
 
 class InternalSparkComponent(
     InternalComponent, ParameterizedSpark, SparkJobEntryMixin
-):  # pylint: disable=too-many-instance-attributes
+):  # pylint: disable=too-many-instance-attributes, too-many-ancestors
     """Internal Spark Component
     This class is used to handle internal spark component.
     It can be loaded from internal spark component yaml or from rest object of an internal spark component.
@@ -91,13 +91,25 @@ class InternalSparkComponent(
         return InternalSparkComponentSchema(context=context)
 
     @property
-    def environment(self):
+    def environment(self) -> Union[str, Environment, dict]:
+        """Get the environment of the component.
+
+        :return: The environment of the component.
+        :rtype: Union[str, Environment, dict]
+        """
         if isinstance(self._environment, Environment) and self._environment.image is None:
             return Environment(conda_file=self._environment.conda_file, image=DUMMY_IMAGE)
         return self._environment
 
     @environment.setter
     def environment(self, value):
+        """Set the environment of the component.
+
+        :param value: The environment of the component.
+        :type value: Union[str, Environment, dict]
+        :return: No return
+        :rtype: None
+        """
         if value is None or isinstance(value, (str, Environment)):
             self._environment = value
         elif isinstance(value, dict):
@@ -119,21 +131,45 @@ class InternalSparkComponent(
             raise ValueError(f"Unsupported environment type: {type(value)}")
 
     @property
-    def jars(self):
+    def jars(self) -> List[str]:
+        """Get the jars of the component.
+
+        :return: The jars of the component.
+        :rtype: List[str]
+        """
         return self._jars
 
     @jars.setter
-    def jars(self, value):
+    def jars(self, value: Union[str, List[str]]):
+        """Set the jars of the component.
+
+        :param value: The jars of the component.
+        :type value: Union[str, List[str]]
+        :return: No return
+        :rtype: None
+        """
         if isinstance(value, str):
             value = [value]
         self._jars = value
 
     @property
-    def py_files(self):
+    def py_files(self) -> List[str]:
+        """Get the py_files of the component.
+
+        :return: The py_files of the component.
+        :rtype: List[str]
+        """
         return self._py_files
 
     @py_files.setter
     def py_files(self, value):
+        """Set the py_files of the component.
+
+        :param value: The py_files of the component.
+        :type value: Union[str, List[str]]
+        :return: No return
+        :rtype: None
+        """
         if isinstance(value, str):
             value = [value]
         self._py_files = value

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_utils/utils.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_utils/utils.py
@@ -20,7 +20,7 @@ from contextlib import contextmanager, nullcontext
 from datetime import timedelta
 from functools import singledispatch, wraps
 from os import PathLike
-from pathlib import Path, PosixPath, PureWindowsPath
+from pathlib import Path, PureWindowsPath
 from typing import IO, Any, AnyStr, Callable, Dict, Iterable, List, Optional, Tuple, Union
 from urllib.parse import urlparse
 from uuid import UUID
@@ -28,7 +28,6 @@ from uuid import UUID
 import isodate
 import pydash
 import yaml
-from azure.core.pipeline.policies import RetryPolicy
 
 from azure.ai.ml._restclient.v2022_05_01.models import ListViewType, ManagedServiceIdentity
 from azure.ai.ml._scope_dependent_operations import OperationScope
@@ -38,9 +37,12 @@ from azure.ai.ml.constants._common import (
     AZUREML_DISABLE_CONCURRENT_COMPONENT_REGISTRATION,
     AZUREML_DISABLE_ON_DISK_CACHE_ENV_VAR,
     AZUREML_INTERNAL_COMPONENTS_ENV_VAR,
+    AZUREML_INTERNAL_COMPONENTS_SCHEMA_PREFIX,
     AZUREML_PRIVATE_FEATURES_ENV_VAR,
+    CommonYamlFields,
     DefaultOpenEncoding,
 )
+from azure.core.pipeline.policies import RetryPolicy
 
 module_logger = logging.getLogger(__name__)
 
@@ -74,10 +76,28 @@ def _snake_to_pascal_convert(text: str) -> str:
 
 
 def snake_to_pascal(text: Optional[str]) -> str:
+    """Convert snake name to pascal.
+
+    :param text: String to convert
+    :type text: Optional[str]
+    :return:
+        * None if text is None
+        * Converted text from snake_case to PascalCase
+    :rtype: Optional[str]
+    """
     return _csv_parser(text, _snake_to_pascal_convert)
 
 
 def snake_to_kebab(text: Optional[str]) -> Optional[str]:
+    """Convert snake name to kebab.
+
+    :param text: String to convert
+    :type text: Optional[str]
+    :return:
+        * None if text is None
+        * Converted text from snake_case to kebab-case
+    :rtype: Optional[str]
+    """
     if text:
         return re.sub("_", "-", text)
     return None
@@ -91,6 +111,15 @@ def _camel_to_snake_convert(text: str) -> str:
 
 
 def camel_to_snake(text: str) -> Optional[str]:
+    """Convert camel name to snake.
+
+     :param text: String to convert
+     :type text: str
+     :return:
+        * None if text is None
+        * Converted text from camelCase to snake_case
+    :rtype: Optional[str]
+    """
     return _csv_parser(text, _camel_to_snake_convert)
 
 
@@ -117,6 +146,13 @@ def _snake_to_camel(name):
 
 
 def float_to_str(f):
+    """Convert a float to a string without scientific notation.
+
+    :param f: Float to convert
+    :type f: float
+    :return: String representation of the float
+    :rtype: str
+    """
     with decimal.localcontext() as ctx:
         ctx.prec = 20  # Support up to 20 significant figures.
         float_as_dec = ctx.create_decimal(repr(f))
@@ -413,16 +449,41 @@ def dump_yaml_to_file(
 
 
 def dict_eq(dict1: Dict[str, Any], dict2: Dict[str, Any]) -> bool:
+    """Compare two dictionaries.
+
+    :param dict1: The first dictionary
+    :type dict1: Dict[str, Any]
+    :param dict2: The second dictionary
+    :type dict2: Dict[str, Any]
+    :return: True if the two dictionaries are equal, False otherwise
+    :rtype: bool
+    """
     if not dict1 and not dict2:
         return True
     return dict1 == dict2
 
 
 def xor(a: Any, b: Any) -> bool:
+    """XOR two values.
+
+    :param a: The first value
+    :type a: Any
+    :param b: The second value
+    :type b: Any
+    :return: False if the two values are both True or both False, True otherwise
+    :rtype: bool
+    """
     return bool(a) != bool(b)
 
 
 def is_url(value: Union[PathLike, str]) -> bool:
+    """Check if a string is a valid URL.
+
+    :param value: The string to check
+    :type value: Union[PathLike, str]
+    :return: True if the string is a valid URL, False otherwise
+    :rtype: bool
+    """
     try:
         result = urlparse(str(value))
         return all([result.scheme, result.netloc])
@@ -432,6 +493,15 @@ def is_url(value: Union[PathLike, str]) -> bool:
 
 # Resolve an URL to long form if it is an azureml short from datastore URL, otherwise return the same value
 def resolve_short_datastore_url(value: Union[PathLike, str], workspace: OperationScope) -> str:
+    """Resolve an URL to long form if it is an azureml short from datastore URL, otherwise return the same value.
+
+    :param value: The URL to resolve
+    :type value: Union[PathLike, str]
+    :param workspace: The workspace
+    :type workspace: OperationScope
+    :return: The resolved URL
+    :rtype: str
+    """
     from azure.ai.ml.exceptions import ValidationException
 
     # These imports can't be placed in at top file level because it will cause a circular import in
@@ -459,6 +529,13 @@ def resolve_short_datastore_url(value: Union[PathLike, str], workspace: Operatio
 
 
 def is_mlflow_uri(value: Union[PathLike, str]) -> bool:
+    """Check if a string is a valid mlflow uri.
+
+    :param value: The string to check
+    :type value: Union[PathLike, str]
+    :return: True if the string is a valid mlflow uri, False otherwise
+    :rtype: bool
+    """
     try:
         return urlparse(str(value)).scheme == "runs"
     except ValueError:
@@ -466,6 +543,16 @@ def is_mlflow_uri(value: Union[PathLike, str]) -> bool:
 
 
 def validate_ml_flow_folder(path: str, model_type: string) -> None:
+    """Validate that the path is a valid ml flow folder.
+
+    :param path: The path to validate
+    :type path: str
+    :param model_type: The model type
+    :type model_type: str
+    :return: No return value
+    :rtype: None
+    :raises ~azure.ai.ml.exceptions.ValidationException: Raised if the path is not a valid ml flow folder.
+    """
     from azure.ai.ml.exceptions import ErrorTarget, ValidationErrorType, ValidationException
 
     # These imports can't be placed in at top file level because it will cause a circular import in
@@ -487,6 +574,13 @@ def validate_ml_flow_folder(path: str, model_type: string) -> None:
 
 # modified from: https://stackoverflow.com/a/33245493/8093897
 def is_valid_uuid(test_uuid: str) -> bool:
+    """Check if a string is a valid UUID.
+
+    :param test_uuid: The string to check
+    :type test_uuid: str
+    :return: True if the string is a valid UUID, False otherwise
+    :rtype: bool
+    """
     try:
         uuid_obj = UUID(test_uuid, version=4)
     except ValueError:
@@ -496,6 +590,13 @@ def is_valid_uuid(test_uuid: str) -> bool:
 
 @singledispatch
 def from_iso_duration_format(duration: Optional[Any] = None) -> int:  # pylint: disable=unused-argument
+    """Convert ISO duration format to seconds.
+
+    :param duration: The duration to convert
+    :type duration: Optional[Any]
+    :return: The converted duration
+    :rtype: int
+    """
     return None
 
 
@@ -510,26 +611,68 @@ def _(duration: timedelta) -> int:
 
 
 def to_iso_duration_format_mins(time_in_mins: Optional[Union[int, float]]) -> str:
+    """Convert minutes to ISO duration format.
+
+    :param time_in_mins: The time in minutes to convert
+    :type time_in_mins: Optional[Union[int, float]]
+    :return: The converted time in ISO duration format
+    :rtype: str
+    """
     return isodate.duration_isoformat(timedelta(minutes=time_in_mins)) if time_in_mins else None
 
 
 def from_iso_duration_format_mins(duration: Optional[str]) -> int:
+    """Convert ISO duration format to minutes.
+
+    :param duration: The duration to convert
+    :type duration: Optional[str]
+    :return: The converted duration
+    :rtype: int
+    """
     return int(from_iso_duration_format(duration) / 60) if duration else None
 
 
 def to_iso_duration_format(time_in_seconds: Optional[Union[int, float]]) -> str:
+    """Convert seconds to ISO duration format.
+
+    :param time_in_seconds: The time in seconds to convert
+    :type time_in_seconds: Optional[Union[int, float]]
+    :return: The converted time in ISO duration format
+    :rtype: str
+    """
     return isodate.duration_isoformat(timedelta(seconds=time_in_seconds)) if time_in_seconds else None
 
 
 def to_iso_duration_format_ms(time_in_ms: Optional[Union[int, float]]) -> str:
+    """Convert milliseconds to ISO duration format.
+
+    :param time_in_ms: The time in milliseconds to convert
+    :type time_in_ms: Optional[Union[int, float]]
+    :return: The converted time in ISO duration format
+    :rtype: str
+    """
     return isodate.duration_isoformat(timedelta(milliseconds=time_in_ms)) if time_in_ms else None
 
 
 def from_iso_duration_format_ms(duration: Optional[str]) -> int:
+    """Convert ISO duration format to milliseconds.
+
+    :param duration: The duration to convert
+    :type duration: Optional[str]
+    :return: The converted duration
+    :rtype: int
+    """
     return from_iso_duration_format(duration) * 1000 if duration else None
 
 
 def to_iso_duration_format_days(time_in_days: Optional[int]) -> str:
+    """Convert days to ISO duration format.
+
+    :param time_in_days: The time in days to convert
+    :type time_in_days: Optional[int]
+    :return: The converted time in ISO duration format
+    :rtype: str
+    """
     return isodate.duration_isoformat(timedelta(days=time_in_days)) if time_in_days else None
 
 
@@ -583,6 +726,15 @@ def _get_mfe_base_url_from_batch_endpoint(endpoint: "BatchEndpoint") -> str:
 # Allows to use a modified client with a provided url
 @contextmanager
 def modified_operation_client(operation_to_modify, url_to_use):
+    """Modify the operation client to use a different url.
+
+    :param operation_to_modify: The operation to modify
+    :type operation_to_modify: Any
+    :param url_to_use: The url to use
+    :type url_to_use: str
+    :return: The modified operation
+    :rtype: Any
+    """
     original_api_base_url = None
     try:
         # Modify the operation
@@ -597,6 +749,13 @@ def modified_operation_client(operation_to_modify, url_to_use):
 
 
 def from_iso_duration_format_min_sec(duration: Optional[str]) -> str:
+    """Convert ISO duration format to min:sec format.
+
+    :param duration: The duration to convert
+    :type duration: Optional[str]
+    :return: The converted duration
+    :rtype: str
+    """
     return duration.split(".")[0].replace("PT", "").replace("M", "m ") + "s"
 
 
@@ -623,6 +782,13 @@ def hash_dict(items: Dict[str, Any], keys_to_omit: Optional[Iterable[str]] = Non
 def convert_identity_dict(
     identity: Optional[ManagedServiceIdentity] = None,
 ) -> ManagedServiceIdentity:
+    """Convert identity to the right format.
+
+    :param identity: The identity to convert
+    :type identity: Optional[ManagedServiceIdentity]
+    :return: The converted identity
+    :rtype: ManagedServiceIdentity
+    """
     if identity:
         if identity.type.lower() in ("system_assigned", "none"):
             identity = ManagedServiceIdentity(type="SystemAssigned")
@@ -641,14 +807,36 @@ def convert_identity_dict(
 
 
 def strip_double_curly(io_binding_val: str) -> str:
+    """Strip double curly brackets from a string.
+
+    :param io_binding_val: The string to strip
+    :type io_binding_val: str
+    :return: The string with double curly brackets stripped
+    :rtype: str
+    """
     return io_binding_val.replace("${{", "").replace("}}", "")
 
 
 def append_double_curly(io_binding_val: str) -> str:
+    """Append double curly brackets to a string.
+
+    :param io_binding_val: The string to append to
+    :type io_binding_val: str
+    :return: The string with double curly brackets appended
+    :rtype: str
+    """
     return f"${{{{{io_binding_val}}}}}"
 
 
-def map_single_brackets_and_warn(command: str):
+def map_single_brackets_and_warn(command: str) -> str:
+    """Map single brackets to double brackets and warn if found.
+
+    :param command: The command to map
+    :type command: str
+    :return: The mapped command
+    :rtype: str
+    """
+
     def _check_for_parameter(param_prefix: str, command_string: str) -> Tuple[bool, str]:
         template_prefix = r"(?<!\{)\{"
         template_suffix = r"\.([^}]*)\}(?!\})"
@@ -683,7 +871,19 @@ def transform_dict_keys(data: Dict[str, Any], casing_transform: Callable[[str], 
     }
 
 
-def merge_dict(origin, delta, dep=0):
+def merge_dict(origin, delta, dep=0) -> dict:
+    """Merge two dicts recursively.
+    Note that the function will return a copy of the origin dict if the depth of the recursion is 0.
+
+    :param origin: The original dictionary
+    :type origin: dict
+    :param delta: The delta dictionary
+    :type delta: dict
+    :param dep: The depth of the recursion
+    :type dep: int
+    :return: The merged dictionary
+    :rtype: dict
+    """
     result = copy.deepcopy(origin) if dep == 0 else origin
     for key, val in delta.items():
         origin_val = origin.get(key)
@@ -701,7 +901,23 @@ def retry(
     logger: Any,
     max_attempts: int = 1,
     delay_multiplier: int = 0.25,
-):
+) -> Callable:
+    """Retry a function if it fails.
+
+    :param exceptions: Exceptions to retry on.
+    :type exceptions: Union[Tuple[Exception], Exception]
+    :param failure_msg: Message to log on failure.
+    :type failure_msg: str
+    :param logger: Logger to use.
+    :type logger: Any
+    :param max_attempts: Maximum number of attempts.
+    :type max_attempts: int
+    :param delay_multiplier: Multiplier for delay between attempts.
+    :type delay_multiplier: int
+    :return: Decorated function.
+    :rtype: Callable
+    """
+
     def retry_decorator(f):
         @wraps(f)
         def func_with_retries(*args, **kwargs):
@@ -726,6 +942,15 @@ def retry(
 
 
 def get_list_view_type(include_archived: bool, archived_only: bool) -> ListViewType:
+    """Get the list view type based on the include_archived and archived_only flags.
+
+    :param include_archived: Whether to include archived items.
+    :type include_archived: bool
+    :param archived_only: Whether to only include archived items.
+    :type archived_only: bool
+    :return: The list view type.
+    :rtype: ListViewType
+    """
     if include_archived and archived_only:
         raise Exception("Cannot provide both archived-only and include-archived.")
     if include_archived:
@@ -782,32 +1007,95 @@ def get_all_data_binding_expressions(
 
 
 def is_private_preview_enabled():
+    """Check if private preview features are enabled.
+
+    :return: True if private preview features are enabled, False otherwise.
+    :rtype: bool
+    """
     return os.getenv(AZUREML_PRIVATE_FEATURES_ENV_VAR) in ["True", "true", True]
 
 
 def is_on_disk_cache_enabled():
+    """Check if on-disk cache for component registrations in pipeline submission is enabled.
+
+    :return: True if on-disk cache is enabled, False otherwise.
+    :rtype: bool
+    """
     return os.getenv(AZUREML_DISABLE_ON_DISK_CACHE_ENV_VAR) not in ["True", "true", True]
 
 
 def is_concurrent_component_registration_enabled():  # pylint: disable=name-too-long
+    """Check if concurrent component registrations in pipeline submission is enabled.
+
+    :return: True if concurrent component registration is enabled, False otherwise.
+    :rtype: bool
+    """
     return os.getenv(AZUREML_DISABLE_CONCURRENT_COMPONENT_REGISTRATION) not in ["True", "true", True]
 
 
-def is_internal_components_enabled():
+def _is_internal_components_enabled():
     return os.getenv(AZUREML_INTERNAL_COMPONENTS_ENV_VAR) in ["True", "true", True]
 
 
-def try_enable_internal_components(*, force=False):
+def try_enable_internal_components(*, force=False) -> bool:
     """Try to enable internal components for the current process. This is the only function outside _internal that
     references _internal.
 
     :keyword force: Force enable internal components even if enabled before.
-    :paramtype force: bool
+    :type force: bool
+    :return: True if internal components are enabled, False otherwise.
+    :rtype: bool
     """
-    if is_internal_components_enabled():
+    if _is_internal_components_enabled():
         from azure.ai.ml._internal import enable_internal_components_in_pipeline
 
         enable_internal_components_in_pipeline(force=force)
+
+        return True
+    return False
+
+
+def is_internal_component_data(data: Dict[str, Any], *, raise_if_not_enabled: bool = False) -> bool:
+    """Check if the data is an internal component data by checking schema url prefix.
+
+    :param data: The data to check.
+    :type data: Dict[str, Any]
+    :keyword raise_if_not_enabled: Raise exception if the data is an internal component data but
+        internal components is not enabled.
+    :type raise_if_not_enabled: bool
+    :return: True if the data is an internal component data, False otherwise.
+    :rtype: bool
+    :raises ~azure.ai.ml.exceptions.ValidationException: Raised if the data is an internal component data but
+        internal components is not enabled.
+    """
+    from azure.ai.ml.exceptions import ErrorCategory, ErrorTarget, ValidationErrorType, ValidationException
+
+    # These imports can't be placed in at top file level because it will cause a circular import in
+    # exceptions.py via _get_mfe_url_override
+
+    schema = data.get(CommonYamlFields.SCHEMA, None)
+
+    if schema is None or not isinstance(schema, str):
+        return False
+
+    if not schema.startswith(AZUREML_INTERNAL_COMPONENTS_SCHEMA_PREFIX):
+        return False
+
+    if not _is_internal_components_enabled() and raise_if_not_enabled:
+        no_personal_data_message = (
+            f"Internal components is a private feature in v2, please set environment variable "
+            f"{AZUREML_INTERNAL_COMPONENTS_ENV_VAR} to true to use it."
+        )
+        msg = f"Detected schema url {schema}. {no_personal_data_message}"
+        raise ValidationException(
+            message=msg,
+            target=ErrorTarget.COMPONENT,
+            error_type=ValidationErrorType.INVALID_VALUE,
+            no_personal_data_message=no_personal_data_message,
+            error_category=ErrorCategory.USER_ERROR,
+        )
+
+    return True
 
 
 def is_valid_node_name(name: str) -> bool:
@@ -882,7 +1170,14 @@ def parse_args_description_from_docstring(docstring: str) -> Dict[str, str]:
     return args
 
 
-def convert_windows_path_to_unix(path: Union[str, PathLike]) -> PosixPath:
+def convert_windows_path_to_unix(path: Union[str, PathLike]) -> str:
+    """Convert a Windows path to a Unix path.
+
+    :param path: A Windows path
+    :type path: Union[str, os.PathLike]
+    :return: A Unix path
+    :rtype: str
+    """
     return PureWindowsPath(path).as_posix()
 
 
@@ -919,6 +1214,10 @@ def _is_user_error_from_exception_type(e: Optional[Exception]) -> bool:
 
 
 class DockerProxy:
+    """A proxy class for docker module. It will raise a more user-friendly error message if docker module is not
+    installed.
+    """
+
     def __getattribute__(self, name: str) -> Any:
         try:
             import docker  # pylint: disable=import-error
@@ -1037,10 +1336,21 @@ def get_valid_dot_keys_with_wildcard(
 
 
 def get_base_directory_for_cache() -> Path:
+    """Get the base directory for cache files.
+
+    :return: The base directory for cache files.
+    :rtype: Path
+    """
     return Path(tempfile.gettempdir()).joinpath("azure-ai-ml")
 
 
 def get_versioned_base_directory_for_cache() -> Path:
+    """Get the base directory for cache files of current version of azure-ai-ml.
+    Cache files of different versions will be stored in different directories.
+
+    :return: The base directory for cache files of current version of azure-ai-ml.
+    :rtype: Path
+    """
     # import here to avoid circular import
     from azure.ai.ml._version import VERSION
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_builders/base_node.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_builders/base_node.py
@@ -27,8 +27,8 @@ from azure.ai.ml.entities._job.pipeline._pipeline_expression import PipelineExpr
 from azure.ai.ml.entities._job.sweep.search_space import SweepDistribution
 from azure.ai.ml.entities._mixins import YamlTranslatableMixin
 from azure.ai.ml.entities._util import convert_ordered_dict_to_dict, resolve_pipeline_parameters
-from azure.ai.ml.entities._validation import MutableValidationResult, SchemaValidatableMixin
-from azure.ai.ml.exceptions import ErrorTarget
+from azure.ai.ml.entities._validation import MutableValidationResult, PathAwareSchemaValidatableMixin
+from azure.ai.ml.exceptions import ErrorTarget, ValidationException
 
 module_logger = logging.getLogger(__name__)
 
@@ -76,7 +76,7 @@ def pipeline_node_decorator(func):
 
 
 # pylint: disable=too-many-instance-attributes
-class BaseNode(Job, YamlTranslatableMixin, _AttrDict, SchemaValidatableMixin, NodeWithGroupInputMixin):
+class BaseNode(Job, YamlTranslatableMixin, _AttrDict, PathAwareSchemaValidatableMixin, NodeWithGroupInputMixin):
     """Base class for node in pipeline, used for component version consumption. Can't be instantiated directly.
 
     You should not instantiate this class directly. Instead, you should
@@ -315,20 +315,17 @@ class BaseNode(Job, YamlTranslatableMixin, _AttrDict, SchemaValidatableMixin, No
         return self._component.name
 
     def _to_dict(self) -> Dict:
-        return self._dump_for_validation()
+        return convert_ordered_dict_to_dict(self._dump_for_validation())
 
     @classmethod
-    def _get_validation_error_target(cls) -> ErrorTarget:
-        """Return the error target of this resource.
+    def _create_validation_error(cls, message: str, no_personal_data_message: str):
+        return ValidationException(
+            message=message,
+            no_personal_data_message=no_personal_data_message,
+            target=ErrorTarget.PIPELINE,
+        )
 
-        Should be overridden by subclass. Value should be in ErrorTarget enum.
-
-        :return: The error target
-        :rtype: ErrorTarget
-        """
-        return ErrorTarget.PIPELINE
-
-    def _validate_inputs(self, raise_error=True):
+    def _validate_inputs(self):
         validation_result = self._create_empty_validation_result()
         if self._validate_required_input_not_provided:
             # validate required inputs not provided
@@ -353,7 +350,7 @@ class BaseNode(Job, YamlTranslatableMixin, _AttrDict, SchemaValidatableMixin, No
                     message=f"Input of command {self.name} is a SweepDistribution, "
                     f"please use command.sweep to transform the command into a sweep node.",
                 )
-        return validation_result.try_raise(self._get_validation_error_target(), raise_error=raise_error)
+        return validation_result
 
     def _customized_validate(self) -> MutableValidationResult:
         """Validate the resource with customized logic.
@@ -363,7 +360,7 @@ class BaseNode(Job, YamlTranslatableMixin, _AttrDict, SchemaValidatableMixin, No
         :return: The validation result
         :rtype: MutableValidationResult
         """
-        validate_result = self._validate_inputs(raise_error=False)
+        validate_result = self._validate_inputs()
         return validate_result
 
     @classmethod

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_builders/condition_node.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_builders/condition_node.py
@@ -79,13 +79,10 @@ class ConditionNode(ControlFlowNode):
         """
         return self._false_block
 
-    def _to_dict(self) -> Dict:
-        return self._dump_for_validation()
-
     def _customized_validate(self) -> MutableValidationResult:
-        return self._validate_params(raise_error=False)
+        return self._validate_params()
 
-    def _validate_params(self, raise_error=True) -> MutableValidationResult:
+    def _validate_params(self) -> MutableValidationResult:
         # pylint disable=protected-access
         validation_result = self._create_empty_validation_result()
         if not isinstance(self.condition, (str, bool, InputOutputBase)):
@@ -146,4 +143,4 @@ class ConditionNode(ControlFlowNode):
                         message=f"'{name}' of dsl.condition has invalid binding expression: {block}, {error_tail}",
                     )
 
-        return validation_result.try_raise(self._get_validation_error_target(), raise_error=raise_error)
+        return validation_result

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_builders/control_flow_node.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_builders/control_flow_node.py
@@ -9,7 +9,7 @@ from typing import Dict, Union  # pylint: disable=unused-import
 
 from marshmallow import ValidationError
 
-from azure.ai.ml._utils.utils import is_data_binding_expression, is_internal_components_enabled
+from azure.ai.ml._utils.utils import is_data_binding_expression
 from azure.ai.ml.constants._common import CommonYamlFields
 from azure.ai.ml.constants._component import ComponentSource, ControlFlowType
 from azure.ai.ml.entities._mixins import YamlTranslatableMixin
@@ -111,17 +111,16 @@ class LoopNode(ControlFlowNode, ABC):
         """
         return self._body
 
+    _extra_body_types = None
+
     @classmethod
     def _attr_type_map(cls) -> dict:
         from .command import Command
         from .pipeline import Pipeline
 
         enable_body_type = (Command, Pipeline)
-        if is_internal_components_enabled():
-            from azure.ai.ml._internal.entities import Command as InternalCommand
-            from azure.ai.ml._internal.entities import Pipeline as InternalPipeline
-
-            enable_body_type = enable_body_type + (InternalCommand, InternalPipeline)
+        if cls._extra_body_types is not None:
+            enable_body_type = enable_body_type + cls._extra_body_types
         return {
             "body": enable_body_type,
         }

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_builders/control_flow_node.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_builders/control_flow_node.py
@@ -13,8 +13,8 @@ from azure.ai.ml._utils.utils import is_data_binding_expression
 from azure.ai.ml.constants._common import CommonYamlFields
 from azure.ai.ml.constants._component import ComponentSource, ControlFlowType
 from azure.ai.ml.entities._mixins import YamlTranslatableMixin
-from azure.ai.ml.entities._validation import SchemaValidatableMixin
-from azure.ai.ml.exceptions import ErrorCategory, ErrorTarget, ValidationErrorType
+from azure.ai.ml.entities._validation import PathAwareSchemaValidatableMixin
+from azure.ai.ml.exceptions import ErrorCategory, ErrorTarget, ValidationErrorType, ValidationException
 
 from .._util import convert_ordered_dict_to_dict
 from .base_node import BaseNode
@@ -23,7 +23,7 @@ module_logger = logging.getLogger(__name__)
 
 
 # ControlFlowNode did not inherit from BaseNode since it doesn't have inputs/outputs like other nodes.
-class ControlFlowNode(YamlTranslatableMixin, SchemaValidatableMixin, ABC):
+class ControlFlowNode(YamlTranslatableMixin, PathAwareSchemaValidatableMixin, ABC):
     """Base class for control flow node in the pipeline.
 
     Please do not directly use this class.
@@ -74,15 +74,12 @@ class ControlFlowNode(YamlTranslatableMixin, SchemaValidatableMixin, ABC):
         _add_component_to_current_definition_builder(self)
 
     @classmethod
-    def _get_validation_error_target(cls) -> ErrorTarget:
-        """Return the error target of this resource.
-
-        Should be overridden by subclass. Value should be in ErrorTarget enum.
-
-        :return: The error target
-        :rtype: ErrorTarget
-        """
-        return ErrorTarget.PIPELINE
+    def _create_validation_error(cls, message: str, no_personal_data_message: str):
+        return ValidationException(
+            message=message,
+            no_personal_data_message=no_personal_data_message,
+            target=ErrorTarget.PIPELINE,
+        )
 
 
 class LoopNode(ControlFlowNode, ABC):
@@ -131,20 +128,20 @@ class LoopNode(ControlFlowNode, ABC):
         if body_name not in pipeline_jobs:
             raise ValidationError(
                 message=f'Cannot find the do-while loop body "{body_name}" in the pipeline.',
-                target=cls._get_validation_error_target(),
+                target=ErrorTarget.PIPELINE,
                 error_category=ErrorCategory.USER_ERROR,
                 error_type=ValidationErrorType.INVALID_VALUE,
             )
         return pipeline_jobs[body_name]
 
-    def _validate_body(self, raise_error=True):
+    def _validate_body(self):
         # pylint: disable=protected-access
         validation_result = self._create_empty_validation_result()
 
         if self._instance_id != self.body._referenced_control_flow_node_instance_id:
             # When the body is used in another loop node record the error message in validation result.
             validation_result.append_error("body", "The body of loop node cannot be promoted as another loop again.")
-        return validation_result.try_raise(self._get_validation_error_target(), raise_error=raise_error)
+        return validation_result
 
     def _get_body_binding_str(self):
         return "${{parent.jobs.%s}}" % self.body.name

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_builders/do_while.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_builders/do_while.py
@@ -4,7 +4,6 @@
 import logging
 from typing import Dict, List, Optional, Union
 
-from marshmallow import ValidationError
 from typing_extensions import Literal
 
 from azure.ai.ml._schema.pipeline.control_flow_job import DoWhileSchema
@@ -13,7 +12,6 @@ from azure.ai.ml.entities._inputs_outputs import Input, Output
 from azure.ai.ml.entities._job.job_limits import DoWhileJobLimits
 from azure.ai.ml.entities._job.pipeline._io import InputOutputBase, NodeInput, NodeOutput
 from azure.ai.ml.entities._validation import MutableValidationResult
-from azure.ai.ml.exceptions import ErrorCategory, ValidationErrorType
 
 from .._util import load_from_dict, validate_attribute_type
 from .base_node import BaseNode
@@ -110,6 +108,24 @@ class DoWhile(LoopNode):
         return cls(**loaded_data)
 
     @classmethod
+    def _get_port_obj(
+        cls, body: BaseNode, port_name: str, is_input: bool = True, validate_port: bool = True
+    ) -> Union[str, NodeInput, NodeOutput]:
+        if is_input:
+            port = body.inputs.get(port_name, None)
+        else:
+            port = body.outputs.get(port_name, None)
+        if port is None:
+            if validate_port:
+                raise cls._create_validation_error(
+                    message=f"Cannot find {port_name} in do_while loop body {'inputs' if is_input else 'outputs'}.",
+                    no_personal_data_message=f"Miss port in do_while loop body {'inputs' if is_input else 'outputs'}.",
+                )
+            return port_name
+
+        return port
+
+    @classmethod
     def _create_instance_from_schema_dict(
         cls, pipeline_jobs: Dict[str, BaseNode], loaded_data: Dict, validate_port: bool = True
     ) -> "DoWhile":
@@ -126,26 +142,6 @@ class DoWhile(LoopNode):
         """
 
         # pylint: disable=protected-access
-
-        def get_port_obj(
-            body: BaseNode, port_name: str, is_input: bool = True, validate_port: bool = True
-        ) -> Union[str, NodeInput, NodeOutput]:
-            if is_input:
-                port = body.inputs.get(port_name, None)
-            else:
-                port = body.outputs.get(port_name, None)
-            if port is None:
-                if validate_port:
-                    raise ValidationError(
-                        message=f"Cannot find {port_name} in do_while loop body {'inputs' if is_input else 'outputs'}.",
-                        target=cls._get_validation_error_target(),
-                        error_category=ErrorCategory.USER_ERROR,
-                        error_type=ValidationErrorType.INVALID_VALUE,
-                    )
-                return port_name
-
-            return port
-
         # Get body object from pipeline job list.
         body_name = cls._get_data_binding_expression_value(loaded_data.pop("body"), regex=r"\{\{.*\.jobs\.(.*)\}\}")
         body = cls._get_body_from_pipeline_jobs(pipeline_jobs, body_name)
@@ -159,7 +155,7 @@ class DoWhile(LoopNode):
                 cls._get_data_binding_expression_value(item, regex=r"\{\{.*\.%s\.inputs\.(.*)\}\}" % body_name)
                 for item in input_names
             ]
-            mapping[output_name] = [get_port_obj(body, item, validate_port=validate_port) for item in input_names]
+            mapping[output_name] = [cls._get_port_obj(body, item, validate_port=validate_port) for item in input_names]
 
         limits = loaded_data.pop("limits", None)
 
@@ -168,7 +164,7 @@ class DoWhile(LoopNode):
             condition_name = cls._get_data_binding_expression_value(
                 loaded_data.pop("condition"), regex=r"\{\{.*\.%s\.outputs\.(.*)\}\}" % body_name
             )
-            condition_value = get_port_obj(body, condition_name, is_input=False, validate_port=validate_port)
+            condition_value = cls._get_port_obj(body, condition_name, is_input=False, validate_port=validate_port)
         else:
             condition_value = None
 
@@ -213,10 +209,10 @@ class DoWhile(LoopNode):
             self._limits = DoWhileJobLimits(max_iteration_count=max_iteration_count)
 
     def _customized_validate(self):
-        validation_result = self._validate_loop_condition(raise_error=False)
-        validation_result.merge_with(self._validate_body(raise_error=False))
-        validation_result.merge_with(self._validate_do_while_limit(raise_error=False))
-        validation_result.merge_with(self._validate_body_output_mapping(raise_error=False))
+        validation_result = self._validate_loop_condition()
+        validation_result.merge_with(self._validate_body())
+        validation_result.merge_with(self._validate_do_while_limit())
+        validation_result.merge_with(self._validate_body_output_mapping())
         return validation_result
 
     def _validate_port(
@@ -270,7 +266,7 @@ class DoWhile(LoopNode):
             )
         return validation_result
 
-    def _validate_loop_condition(self, raise_error=True):
+    def _validate_loop_condition(self):
         # pylint: disable=protected-access
         validation_result = self._create_empty_validation_result()
         if self.condition is not None:
@@ -289,12 +285,12 @@ class DoWhile(LoopNode):
                             "The condition of dowhile must be the control output or primitive type of the body."
                         ),
                     )
-        return validation_result.try_raise(self._get_validation_error_target(), raise_error=raise_error)
+        return validation_result
 
-    def _validate_do_while_limit(self, raise_error=True):
+    def _validate_do_while_limit(self):
         validation_result = self._create_empty_validation_result()
         if not self.limits or self.limits.max_iteration_count is None:
-            return validation_result.try_raise(self._get_validation_error_target(), raise_error=raise_error)
+            return validation_result
         if isinstance(self.limits.max_iteration_count, InputOutputBase):
             validation_result.append_error(
                 yaml_path="limit.max_iteration_count",
@@ -305,9 +301,9 @@ class DoWhile(LoopNode):
                 yaml_path="limit.max_iteration_count",
                 message=f"The max iteration count cannot be less than 0 or larger than {DO_WHILE_MAX_ITERATION}.",
             )
-        return validation_result.try_raise(self._get_validation_error_target(), raise_error=raise_error)
+        return validation_result
 
-    def _validate_body_output_mapping(self, raise_error=True):
+    def _validate_body_output_mapping(self):
         # pylint disable=protected-access
         validation_result = self._create_empty_validation_result()
         if not isinstance(self.mapping, dict):
@@ -347,7 +343,7 @@ class DoWhile(LoopNode):
                                 message=(
                                     f"{output_name} is a non-primitive type output and {input_name} "
                                     "is a primitive input. Non-primitive type output cannot be connected "
-                                    "to an a primitive type input.",
+                                    "to an a primitive type input."
                                 ),
                             )
 
@@ -358,4 +354,4 @@ class DoWhile(LoopNode):
                     validation_result.append_error(
                         yaml_path="mapping", message=f"Input {_input} has been linked to multiple outputs {outputs}."
                     )
-        return validation_result.try_raise(self._get_validation_error_target(), raise_error=raise_error)
+        return validation_result

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_builders/fl_scatter_gather.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_builders/fl_scatter_gather.py
@@ -703,10 +703,7 @@ class FLScatterGather(ControlFlowNode, NodeIOMixin):
                 message=f"max_iterations must be a positive value, not '{max_iterations}'.",
             )
 
-        return validation_result.try_raise(
-            cls._get_validation_error_target(),
-            raise_error=raise_error,
-        )
+        return cls._try_raise(validation_result, raise_error=raise_error)
 
     @classmethod
     def _custom_fl_data_path(

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_builders/parallel_for.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_builders/parallel_for.py
@@ -255,7 +255,7 @@ class ParallelFor(LoopNode, NodeIOMixin):
         :rtype: MutableValidationResult
         """
         # pylint: disable=protected-access
-        validation_result = self._validate_body(raise_error=False)
+        validation_result = self._validate_body()
         validation_result.merge_with(
             self._validate_items(items=self.items, raise_error=False, body_component=self.body._component)
         )
@@ -289,10 +289,7 @@ class ParallelFor(LoopNode, NodeIOMixin):
                 yaml_path="items",
                 message="Items is required for parallel_for node",
             )
-        return validation_result.try_raise(
-            cls._get_validation_error_target(),
-            raise_error=raise_error,
-        )
+        return cls._try_raise(validation_result, raise_error=raise_error)
 
     @classmethod
     def _validate_items_list(cls, items: list, validation_result, body_component=None):

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_builders/spark.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_builders/spark.py
@@ -508,11 +508,11 @@ class Spark(BaseNode, SparkJobEntryMixin):
                 yaml_path="environment.image",
                 message=SPARK_ENVIRONMENT_WARNING_MESSAGE,
             )
-        result.merge_with(self._validate_entry_exist(raise_error=False))
+        result.merge_with(self._validate_entry_exist())
         result.merge_with(self._validate_fields())
         return result
 
-    def _validate_entry_exist(self, raise_error=False) -> MutableValidationResult:
+    def _validate_entry_exist(self) -> MutableValidationResult:
         is_remote_code = isinstance(self.code, str) and (
             self.code.startswith("git+")
             or self.code.startswith(REGISTRY_URI_FORMAT)
@@ -546,7 +546,7 @@ class Spark(BaseNode, SparkJobEntryMixin):
                     validation_result.append_error(
                         message=f"Entry {entry_path} doesn't exist.", yaml_path="component.entry"
                     )
-        return validation_result.try_raise(error_target=self._get_validation_error_target(), raise_error=raise_error)
+        return validation_result
 
     def _validate_fields(self) -> MutableValidationResult:
         validation_result = self._create_empty_validation_result()

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_component/_additional_includes.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_component/_additional_includes.py
@@ -14,7 +14,7 @@ from pathlib import Path
 from typing import Dict, Iterable, List, Optional, Tuple, Union
 
 from azure.ai.ml.constants._common import AzureDevopsArtifactsType
-from azure.ai.ml.entities._validation import MutableValidationResult, _ValidationResultBuilder
+from azure.ai.ml.entities._validation import MutableValidationResult, ValidationResultBuilder
 
 from ..._utils._artifact_utils import ArtifactCache
 from ..._utils._asset_utils import IgnoreFile, get_upload_files_from_folder
@@ -104,7 +104,7 @@ class AdditionalIncludes:
         )
 
     def _validate_additional_include_config(self, additional_include_config):
-        validation_result = _ValidationResultBuilder.success()
+        validation_result = ValidationResultBuilder.success()
         if (
             isinstance(additional_include_config, dict)
             and additional_include_config.get("type") == AzureDevopsArtifactsType.ARTIFACT
@@ -313,7 +313,7 @@ class AdditionalIncludes:
         :return: The validation result.
         :rtype: ~azure.ai.ml.entities._validation.MutableValidationResult
         """
-        validation_result = _ValidationResultBuilder.success()
+        validation_result = ValidationResultBuilder.success()
         include_path = self.base_path / local_path
         # if additional include has not supported characters, resolve will fail and raise OSError
         try:
@@ -356,7 +356,7 @@ class AdditionalIncludes:
         :return: The validation result.
         :rtype: ~azure.ai.ml.entities._validation.MutableValidationResult
         """
-        validation_result = _ValidationResultBuilder.success()
+        validation_result = ValidationResultBuilder.success()
         for additional_include_config in self.origin_configs:
             validation_result.merge_with(self._validate_additional_include_config(additional_include_config))
         return validation_result

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_component/pipeline_component.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_component/pipeline_component.py
@@ -17,12 +17,7 @@ from azure.ai.ml._restclient.v2022_10_01.models import ComponentVersion, Compone
 from azure.ai.ml._schema import PathAwareSchema
 from azure.ai.ml._schema.pipeline.pipeline_component import PipelineComponentSchema
 from azure.ai.ml._utils.utils import hash_dict, is_data_binding_expression
-from azure.ai.ml.constants._common import (
-    ARM_ID_PREFIX,
-    ASSET_ARM_ID_REGEX_FORMAT,
-    BASE_PATH_CONTEXT_KEY,
-    COMPONENT_TYPE,
-)
+from azure.ai.ml.constants._common import ARM_ID_PREFIX, ASSET_ARM_ID_REGEX_FORMAT, COMPONENT_TYPE
 from azure.ai.ml.constants._component import ComponentSource, NodeType
 from azure.ai.ml.constants._job.pipeline import ValidationErrorCode
 from azure.ai.ml.entities._builders import BaseNode, Command
@@ -441,10 +436,7 @@ class PipelineComponent(Component):
         return init_params_dict
 
     def _to_dict(self) -> Dict:
-        # Replace the name of $schema to schema.
-        component_schema_dict = self._dump_for_validation()
-        component_schema_dict.pop(BASE_PATH_CONTEXT_KEY, None)
-        return {**self._other_parameter, **component_schema_dict}
+        return {**self._other_parameter, **super()._to_dict()}
 
     def _build_rest_component_jobs(self) -> Dict[str, dict]:
         """Build pipeline component jobs to rest.

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/pipeline/pipeline_job.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/pipeline/pipeline_job.py
@@ -56,13 +56,13 @@ from azure.ai.ml.entities._job.pipeline._io import PipelineInput, PipelineJobIOM
 from azure.ai.ml.entities._job.pipeline.pipeline_job_settings import PipelineJobSettings
 from azure.ai.ml.entities._mixins import YamlTranslatableMixin
 from azure.ai.ml.entities._system_data import SystemData
-from azure.ai.ml.entities._validation import MutableValidationResult, SchemaValidatableMixin
-from azure.ai.ml.exceptions import ErrorTarget, UserErrorException
+from azure.ai.ml.entities._validation import MutableValidationResult, PathAwareSchemaValidatableMixin
+from azure.ai.ml.exceptions import ErrorTarget, UserErrorException, ValidationException
 
 module_logger = logging.getLogger(__name__)
 
 
-class PipelineJob(Job, YamlTranslatableMixin, PipelineJobIOMixin, SchemaValidatableMixin):
+class PipelineJob(Job, YamlTranslatableMixin, PipelineJobIOMixin, PathAwareSchemaValidatableMixin):
     """Pipeline job.
 
     You should not instantiate this class directly. Instead, you should
@@ -234,8 +234,12 @@ class PipelineJob(Job, YamlTranslatableMixin, PipelineJobIOMixin, SchemaValidata
         self._settings = value
 
     @classmethod
-    def _get_validation_error_target(cls) -> ErrorTarget:
-        return ErrorTarget.PIPELINE
+    def _create_validation_error(cls, message: str, no_personal_data_message: str):
+        return ValidationException(
+            message=message,
+            no_personal_data_message=no_personal_data_message,
+            target=ErrorTarget.PIPELINE,
+        )
 
     @classmethod
     def _create_schema_for_validation(cls, context) -> PathAwareSchema:

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_load_functions.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_load_functions.py
@@ -5,12 +5,14 @@
 import logging
 import warnings
 from os import PathLike
+from pathlib import Path
 from typing import IO, AnyStr, Dict, List, Optional, Type, Union
 
 from marshmallow import ValidationError
 
 from azure.ai.ml._utils._experimental import experimental
 from azure.ai.ml._utils.utils import load_yaml
+from azure.ai.ml.constants._common import BASE_PATH_CONTEXT_KEY
 from azure.ai.ml.entities._assets._artifacts._package.model_package import ModelPackage
 from azure.ai.ml.entities._assets._artifacts.code import Code
 from azure.ai.ml.entities._assets._artifacts.data import Data
@@ -35,7 +37,7 @@ from azure.ai.ml.entities._job.job import Job
 from azure.ai.ml.entities._registry.registry import Registry
 from azure.ai.ml.entities._resource import Resource
 from azure.ai.ml.entities._schedule.schedule import Schedule
-from azure.ai.ml.entities._validation import SchemaValidatableMixin, _ValidationResultBuilder
+from azure.ai.ml.entities._validation import PathAwareSchemaValidatableMixin, ValidationResultBuilder
 from azure.ai.ml.entities._workspace.connections.workspace_connection import WorkspaceConnection
 from azure.ai.ml.entities._workspace.workspace import Workspace
 from azure.ai.ml.entities._workspace_hub.workspace_hub import WorkspaceHub
@@ -96,20 +98,30 @@ def load_common(
     try:
         return _load_common_raising_marshmallow_error(cls, yaml_dict, relative_origin, params_override, **kwargs)
     except ValidationError as e:
-        if issubclass(cls, SchemaValidatableMixin):
-            validation_result = _ValidationResultBuilder.from_validation_error(e, source_path=relative_origin)
-            validation_result.try_raise(
-                # pylint: disable=protected-access
-                error_target=cls._get_validation_error_target(),
-                # pylint: disable=protected-access
-                schema=cls._create_schema_for_validation_with_base_path(),
-                raise_mashmallow_error=True,
-                additional_message=""
-                if type_str is None
-                else f"If you are trying to configure an entity that is not "
-                f"of type {type_str}, please specify the correct "
-                f"type in the 'type' property.",
-            )
+        if issubclass(cls, PathAwareSchemaValidatableMixin):
+            validation_result = ValidationResultBuilder.from_validation_error(e, source_path=relative_origin)
+            schema = cls._create_schema_for_validation(context={BASE_PATH_CONTEXT_KEY: Path.cwd()})
+            if type_str is None:
+                additional_message = ""
+            else:
+                additional_message = (
+                    f"If you are trying to configure an entity that is not "
+                    f"of type {type_str}, please specify the correct "
+                    f"type in the 'type' property."
+                )
+
+            def build_error(message, _):
+                from azure.ai.ml.entities._util import decorate_validation_error
+
+                return ValidationError(
+                    message=decorate_validation_error(
+                        schema=schema.__class__,
+                        pretty_error=message,
+                        additional_message=additional_message,
+                    ),
+                )
+
+            validation_result.try_raise(error_func=build_error)
         raise e
 
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_schedule/schedule.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_schedule/schedule.py
@@ -7,6 +7,7 @@ import typing
 from os import PathLike
 from pathlib import Path
 from typing import IO, AnyStr, Dict, Optional, Union
+
 from typing_extensions import Literal
 
 from azure.ai.ml._restclient.v2023_06_01_preview.models import JobBase as RestJobBase
@@ -25,7 +26,7 @@ from azure.ai.ml.entities._mixins import RestTranslatableMixin, TelemetryMixin, 
 from azure.ai.ml.entities._resource import Resource
 from azure.ai.ml.entities._system_data import SystemData
 from azure.ai.ml.entities._util import load_from_dict
-from azure.ai.ml.entities._validation import MutableValidationResult, SchemaValidatableMixin
+from azure.ai.ml.entities._validation import MutableValidationResult, PathAwareSchemaValidatableMixin
 
 from ...exceptions import ErrorCategory, ErrorTarget, ScheduleException, ValidationException
 from .. import CommandJob, SparkJob
@@ -35,7 +36,7 @@ from .trigger import CronTrigger, RecurrenceTrigger, TriggerBase
 module_logger = logging.getLogger(__name__)
 
 
-class Schedule(YamlTranslatableMixin, SchemaValidatableMixin, Resource):
+class Schedule(YamlTranslatableMixin, PathAwareSchemaValidatableMixin, Resource):
     """Schedule object used to create and manage schedules.
 
     This class should not be instantiated directly. Instead, please use the subclasses.
@@ -93,8 +94,12 @@ class Schedule(YamlTranslatableMixin, SchemaValidatableMixin, Resource):
         dump_yaml_to_file(dest, yaml_serialized, default_flow_style=False, path=path, **kwargs)
 
     @classmethod
-    def _get_validation_error_target(cls) -> ErrorTarget:
-        return ErrorTarget.SCHEDULE
+    def _create_validation_error(cls, message: str, no_personal_data_message: str):
+        return ValidationException(
+            message=message,
+            no_personal_data_message=no_personal_data_message,
+            target=ErrorTarget.SCHEDULE,
+        )
 
     @classmethod
     def _resolve_cls_and_type(cls, data, params_override):  # pylint: disable=unused-argument

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_validate_funcs.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_validate_funcs.py
@@ -8,7 +8,7 @@ from marshmallow import ValidationError
 from ..exceptions import ValidationException
 from . import Component, Job
 from ._load_functions import _load_common_raising_marshmallow_error, _try_load_yaml_dict
-from ._validation import SchemaValidatableMixin, ValidationResult, _ValidationResultBuilder
+from ._validation import PathAwareSchemaValidatableMixin, ValidationResult, ValidationResultBuilder
 
 
 def validate_common(cls, path, validate_func, params_override=None) -> ValidationResult:
@@ -24,13 +24,13 @@ def validate_common(cls, path, validate_func, params_override=None) -> Validatio
 
         if validate_func is not None:
             return validate_func(entity)
-        if isinstance(entity, SchemaValidatableMixin):
+        if isinstance(entity, PathAwareSchemaValidatableMixin):
             return entity._validate()
-        return _ValidationResultBuilder.success()
+        return ValidationResultBuilder.success()
     except ValidationException as err:
-        return _ValidationResultBuilder.from_single_message(err.message)
+        return ValidationResultBuilder.from_single_message(err.message)
     except ValidationError as err:
-        return _ValidationResultBuilder.from_validation_error(err, source_path=path)
+        return ValidationResultBuilder.from_validation_error(err, source_path=path)
 
 
 def validate_component(path, ml_client=None, params_override=None) -> ValidationResult:

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_validation/__init__.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_validation/__init__.py
@@ -1,0 +1,18 @@
+# ---------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# ---------------------------------------------------------
+
+
+from .core import MutableValidationResult, ValidationResult, ValidationResultBuilder
+from .path_aware_schema import PathAwareSchemaValidatableMixin
+from .remote import RemoteValidatableMixin
+from .schema import SchemaValidatableMixin
+
+__all__ = [
+    "SchemaValidatableMixin",
+    "PathAwareSchemaValidatableMixin",
+    "RemoteValidatableMixin",
+    "MutableValidationResult",
+    "ValidationResult",
+    "ValidationResultBuilder",
+]

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_validation/core.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_validation/core.py
@@ -9,24 +9,27 @@ import json
 import logging
 import os.path
 import typing
-from os import PathLike
 from pathlib import Path
 from typing import Dict, List, Optional
 
-import msrest
 import pydash
 import strictyaml
-from marshmallow import Schema, ValidationError
-
-from .._schema import PathAwareSchema
-from .._vendor.azure_resources.models import Deployment, DeploymentProperties, DeploymentValidateResult, ErrorResponse
-from ..constants._common import BASE_PATH_CONTEXT_KEY, OperationStatus
-from ..entities._job.pipeline._attr_dict import try_get_non_arbitrary_attr
-from ..entities._util import convert_ordered_dict_to_dict, decorate_validation_error
-from ..exceptions import ErrorCategory, ErrorTarget, ValidationException
-from ._mixins import RestTranslatableMixin
+from marshmallow import ValidationError
 
 module_logger = logging.getLogger(__name__)
+
+
+class _ValidationStatus:
+    """Validation status class.
+
+    Validation status is used to indicate the status of an validation result. It can be one of the following values:
+    Succeeded, Failed.
+    """
+
+    SUCCEEDED = "Succeeded"
+    """Succeeded."""
+    FAILED = "Failed"
+    """Failed."""
 
 
 class Diagnostic(object):
@@ -128,7 +131,7 @@ class ValidationResult(object):
 
     def _to_dict(self) -> typing.Dict[str, typing.Any]:
         result = {
-            "result": OperationStatus.SUCCEEDED if self.passed else OperationStatus.FAILED,
+            "result": _ValidationStatus.SUCCEEDED if self.passed else _ValidationStatus.FAILED,
         }
         for diagnostic_type, diagnostics in [
             ("errors", self._errors),
@@ -169,7 +172,7 @@ class MutableValidationResult(ValidationResult):
 
     def merge_with(
         self,
-        target: typing.Union[ValidationResult, DeploymentValidateResult],
+        target: ValidationResult,
         field_name: Optional[str] = None,
         condition_skip: Optional[typing.Callable] = None,
         overwrite: bool = False,
@@ -180,8 +183,8 @@ class MutableValidationResult(ValidationResult):
         If field_name is not None, then yaml_path in the other validation result will be updated accordingly.
         * => field_name, jobs.job_a => field_name.jobs.job_a e.g.. If None, then no update.
 
-        :param target: Validation result to merge. Also accept DeploymentValidateResult.
-        :type target: Union[ValidationResult, DeploymentValidateResult]
+        :param target: Validation result to merge.
+        :type target: ValidationResult
         :param field_name: The base field name for the target to merge.
         :type field_name: str
         :param condition_skip: A function to determine whether to skip the merge of a diagnostic in the target.
@@ -192,9 +195,6 @@ class MutableValidationResult(ValidationResult):
         :return: The current validation result.
         :rtype: MutableValidationResult
         """
-        if isinstance(target, DeploymentValidateResult):
-            target = _ValidationResultBuilder.from_rest_object(target)
-            return self.merge_with(target, field_name, condition_skip, overwrite)
         for source_diagnostics, target_diagnostics in [
             (target._errors, self._errors),
             (target._warnings, self._warnings),
@@ -218,30 +218,21 @@ class MutableValidationResult(ValidationResult):
 
     def try_raise(
         self,
-        error_target: ErrorTarget,
-        error_category: ErrorCategory = ErrorCategory.USER_ERROR,
         raise_error: bool = True,
-        schema: Optional[Schema] = None,
-        additional_message: str = "",
-        raise_mashmallow_error: bool = False,
+        *,
+        error_func: typing.Callable[[str, str], Exception] = None,
     ) -> "MutableValidationResult":
         """Try to raise an error from the validation result.
 
         If the validation is passed or raise_error is False, this method
         will return the validation result.
 
-        :param error_target: The target of the error.
-        :type error_target: ErrorTarget
-        :param error_category: The category of the error.
-        :type error_category: ErrorCategory
         :param raise_error: Whether to raise the error.
         :type raise_error: bool
-        :param schema: The schema to do the validation, will be used in the error message.
-        :type schema: Schema
-        :param additional_message: Additional message to add to the error message.
-        :type additional_message: str
-        :param raise_mashmallow_error: Whether to raise a marshmallow.ValidationError instead of ValidationException.
-        :type raise_mashmallow_error: bool
+        :keyword error_func: A function to create the error. If None, a marshmallow.ValidationError will be created.
+                             The first parameter of the function is the string representation of the validation result,
+                             and the second parameter is the error message without personal data.
+        :type error_func: typing.Callable[[str, str], Exception]
         :return: The current validation result.
         :rtype: MutableValidationResult
         """
@@ -253,23 +244,14 @@ class MutableValidationResult(ValidationResult):
             module_logger.warning("Warnings: %s" % str(self._warnings))
 
         if not self.passed:
-            message = (
-                decorate_validation_error(
-                    schema=schema.__class__,
-                    pretty_error=self.__repr__(),
-                    additional_message=additional_message,
-                )
-                if schema
-                else self.__repr__()
-            )
-            if raise_mashmallow_error:
-                raise ValidationError(message)
+            if error_func is None:
 
-            raise ValidationException(
-                message=message,
-                no_personal_data_message="validation failed on the following fields: " + ", ".join(self.error_messages),
-                target=error_target,
-                error_category=error_category,
+                def error_func(msg, _):
+                    return ValidationError(message=msg)
+
+            raise error_func(
+                self.__repr__(),
+                "validation failed on the following fields: " + ", ".join(self.error_messages),
             )
         return self
 
@@ -345,154 +327,9 @@ class MutableValidationResult(ValidationResult):
         return self
 
 
-class SchemaValidatableMixin:
-    @classmethod
-    def _create_empty_validation_result(cls) -> MutableValidationResult:
-        """Simply create an empty validation result
+class ValidationResultBuilder:
+    """A helper class to create a validation result."""
 
-        To reduce _ValidationResultBuilder importing, which is a private class.
-
-        :return: An empty validation result
-        :rtype: MutableValidationResult
-        """
-        return _ValidationResultBuilder.success()
-
-    @classmethod
-    def _create_schema_for_validation_with_base_path(cls, base_path=None):
-        # Note that, although context can be passed here, nested.schema will be initialized only once
-        # base_path works well because it's fixed after loaded
-        return cls._create_schema_for_validation(context={BASE_PATH_CONTEXT_KEY: base_path or Path.cwd()})
-
-    @classmethod
-    def _load_with_schema(cls, data, *, context=None, raise_original_exception=False, **kwargs):
-        if context is None:
-            schema = cls._create_schema_for_validation_with_base_path()
-        else:
-            schema = cls._create_schema_for_validation(context=context)
-
-        try:
-            return schema.load(data, **kwargs)
-        except ValidationError as e:
-            if raise_original_exception:
-                raise e
-            msg = "Trying to load data with schema failed. Data:\n%s\nError: %s" % (
-                json.dumps(data, indent=4) if isinstance(data, dict) else data,
-                json.dumps(e.messages, indent=4),
-            )
-            raise ValidationException(
-                message=msg,
-                no_personal_data_message=str(e),
-                target=cls._get_validation_error_target(),
-                error_category=ErrorCategory.USER_ERROR,
-            ) from e
-
-    @classmethod
-    # pylint: disable-next=docstring-missing-param
-    def _create_schema_for_validation(cls, context) -> PathAwareSchema:
-        """Create a schema of the resource with specific context. Should be overridden by subclass.
-
-        :return: The schema of the resource. PathAwareSchema will add marshmallow.Schema as super class on runtime.
-        :rtype: PathAwareSchema.
-        """
-        raise NotImplementedError()
-
-    @property
-    def __base_path_for_validation(self) -> typing.Union[str, PathLike]:
-        """Get the base path of the resource.
-
-        It will try to return self.base_path, then self._base_path, then Path.cwd() if above attrs are non-existent or
-        `None.
-
-        :return: The base path of the resource
-        :rtype: typing.Union[str, os.PathLike]
-        """
-        return (
-            try_get_non_arbitrary_attr(self, BASE_PATH_CONTEXT_KEY)
-            or try_get_non_arbitrary_attr(self, f"_{BASE_PATH_CONTEXT_KEY}")
-            or Path.cwd()
-        )
-
-    @classmethod
-    def _get_validation_error_target(cls) -> ErrorTarget:
-        """Return the error target of this resource.
-
-        Should be overridden by subclass. Value should be in ErrorTarget enum.
-
-        :return: The error target of the resource
-        :rtype: ErrorTarget
-        """
-        raise NotImplementedError()
-
-    @property
-    def _schema_for_validation(self) -> PathAwareSchema:
-        """Return the schema of this Resource with self._base_path as base_path of Schema. Do not override this method.
-        Override _get_schema instead.
-
-        :return: The schema of the resource. Note that PathAwareSchema will add marshmallow.Schema as super class on
-            runtime.
-        :rtype: PathAwareSchema.
-        """
-        return self._create_schema_for_validation_with_base_path(self.__base_path_for_validation)
-
-    def _dump_for_validation(self) -> typing.Dict:
-        """Convert the resource to a dictionary.
-
-        :return: Converted dictionary
-        :rtype: Dict
-        """
-        return convert_ordered_dict_to_dict(self._schema_for_validation.dump(self))
-
-    def _validate(self, raise_error=False) -> MutableValidationResult:
-        """Validate the resource. If raise_error is True, raise ValidationError if validation fails and log warnings if
-        applicable; Else, return the validation result.
-
-        :param raise_error: Whether to raise ValidationError if validation fails.
-        :type raise_error: bool
-        :return: The validation result
-        :rtype: ValidationResult
-        """
-        result = self.__schema_validate()
-        result.merge_with(self._customized_validate())
-        return result.try_raise(raise_error=raise_error, error_target=self._get_validation_error_target())
-
-    def _customized_validate(self) -> MutableValidationResult:
-        """Validate the resource with customized logic.
-
-        Override this method to add customized validation logic.
-
-        :return: The customized validation result
-        :rtype: MutableValidationResult
-        """
-        return self._create_empty_validation_result()
-
-    @classmethod
-    def _get_skip_fields_in_schema_validation(
-        cls,
-    ) -> typing.List[str]:
-        """Get the fields that should be skipped in schema validation.
-
-        Override this method to add customized validation logic.
-
-        :return: The fields to skip in schema validation
-        :rtype: typing.List[str]
-        """
-        return []
-
-    def __schema_validate(self) -> MutableValidationResult:
-        """Validate the resource with the schema.
-
-        :return: The validation result
-        :rtype: MutableValidationResult
-        """
-        data = self._dump_for_validation()
-        messages = self._schema_for_validation.validate(data)
-        for skip_field in self._get_skip_fields_in_schema_validation():
-            if skip_field in messages:
-                del messages[skip_field]
-        return _ValidationResultBuilder.from_validation_messages(messages, data=data)
-
-
-class _ValidationResultBuilder:
     UNKNOWN_MESSAGE = "Unknown field."
 
     def __init__(self):
@@ -506,28 +343,6 @@ class _ValidationResultBuilder:
         :rtype: MutableValidationResult
         """
         return MutableValidationResult()
-
-    @classmethod
-    def from_rest_object(cls, rest_obj: DeploymentValidateResult) -> MutableValidationResult:
-        """Create a validation result from a rest object. Note that the created validation result does not have
-        target_obj so should only be used for merging.
-
-        :param rest_obj: The Deployment Validate REST obj
-        :type rest_obj: DeploymentValidateResult
-        :return: The validation result created from rest_obj
-        :rtype: MutableValidationResult
-        """
-        if not rest_obj.error or not rest_obj.error.details:
-            return cls.success()
-        result = MutableValidationResult(target_obj=None)
-        details: List[ErrorResponse] = rest_obj.error.details
-        for detail in details:
-            result.append_error(
-                message=detail.message,
-                yaml_path=detail.target.replace("/", "."),
-                error_code=detail.code,  # will always be UserError for now, not sure if innerError can be passed back
-            )
-        return result
 
     @classmethod
     def from_single_message(
@@ -703,123 +518,4 @@ class _YamlLocationResolver:
         return (
             f"{source_path.resolve().absolute()}#line {loaded_yaml.start_line}",
             None if attrs else loaded_yaml.value,
-        )
-
-
-class PreflightResource(msrest.serialization.Model):
-    """Specified resource.
-
-    Variables are only populated by the server, and will be ignored when sending a request.
-
-    :ivar id: Resource ID.
-    :vartype id: str
-    :ivar name: Resource name.
-    :vartype name: str
-    :ivar type: Resource type.
-    :vartype type: str
-    :param location: Resource location.
-    :type location: str
-    :param tags: A set of tags. Resource tags.
-    :type tags: dict[str, str]
-    """
-
-    _attribute_map = {
-        "type": {"key": "type", "type": "str"},
-        "name": {"key": "name", "type": "str"},
-        "location": {"key": "location", "type": "str"},
-        "api_version": {"key": "apiversion", "type": "str"},
-        "properties": {"key": "properties", "type": "object"},
-    }
-
-    def __init__(self, **kwargs):
-        super(PreflightResource, self).__init__(**kwargs)
-        self.name = kwargs.get("name", None)
-        self.type = kwargs.get("type", None)
-        self.location = kwargs.get("location", None)
-        self.properties = kwargs.get("properties", None)
-        self.api_version = kwargs.get("api_version", None)
-
-
-class ValidationTemplateRequest(msrest.serialization.Model):
-    """Export resource group template request parameters.
-
-    :param resources: The rest objects to be validated.
-    :type resources: list[_models.Resource]
-    :param options: The export template options. A CSV-formatted list containing zero or more of
-     the following: 'IncludeParameterDefaultValue', 'IncludeComments',
-     'SkipResourceNameParameterization', 'SkipAllParameterization'.
-    :type options: str
-    """
-
-    _attribute_map = {
-        "resources": {"key": "resources", "type": "[PreflightResource]"},
-        "content_version": {"key": "contentVersion", "type": "str"},
-        "parameters": {"key": "parameters", "type": "object"},
-        "_schema": {
-            "key": "$schema",
-            "type": "str",
-            "default": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-        },
-    }
-
-    def __init__(self, **kwargs):
-        super(ValidationTemplateRequest, self).__init__(**kwargs)
-        self._schema = kwargs.get("_schema", None)
-        self.content_version = kwargs.get("content_version", None)
-        self.parameters = kwargs.get("parameters", None)
-        self.resources = kwargs.get("resources", None)
-
-
-class RemoteValidatableMixin(RestTranslatableMixin):
-    @classmethod
-    def _get_resource_type(cls) -> str:
-        """Return resource type to be used in remote validation.
-
-        Should be overridden by subclass.
-
-        :return: The resource type
-        :rtype: str
-        """
-        raise NotImplementedError()
-
-    def _get_resource_name_version(self) -> typing.Tuple[str, str]:
-        """Return resource name and version to be used in remote validation.
-
-        Should be overridden by subclass.
-
-        :return: The name and version
-        :rtype: typing.Tuple[str, str]
-        """
-        raise NotImplementedError()
-
-    def _to_preflight_resource(self, location: str, workspace_name: str) -> PreflightResource:
-        """Return the preflight resource to be used in remote validation.
-
-        :param location: The location of the resource.
-        :type location: str
-        :param workspace_name: The workspace name
-        :type workspace_name: str
-        :return: The preflight resource
-        :rtype: PreflightResource
-        """
-        name, version = self._get_resource_name_version()
-        return PreflightResource(
-            type=self._get_resource_type(),
-            name=f"{workspace_name}/{name}/{version}",
-            location=location,
-            properties=self._to_rest_object().properties,
-            api_version="2023-03-01-preview",
-        )
-
-    def _build_rest_object_for_remote_validation(self, location: str, workspace_name: str) -> Deployment:
-        return Deployment(
-            properties=DeploymentProperties(
-                mode="Incremental",
-                template=ValidationTemplateRequest(
-                    _schema="https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-                    content_version="1.0.0.0",
-                    parameters={},
-                    resources=[self._to_preflight_resource(location=location, workspace_name=workspace_name)],
-                ),
-            )
         )

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_validation/path_aware_schema.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_validation/path_aware_schema.py
@@ -1,0 +1,53 @@
+# ---------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# ---------------------------------------------------------
+import typing
+from os import PathLike
+from pathlib import Path
+
+from azure.ai.ml.constants._common import BASE_PATH_CONTEXT_KEY
+
+from ..._schema import PathAwareSchema
+from .._job.pipeline._attr_dict import try_get_non_arbitrary_attr
+from .._util import convert_ordered_dict_to_dict
+from .schema import SchemaValidatableMixin
+
+
+class PathAwareSchemaValidatableMixin(SchemaValidatableMixin):
+    """The mixin class for schema validation. Entity classes inheriting from this class should have a base path
+    and a schema of PathAwareSchema.
+    """
+
+    @property
+    def __base_path_for_validation(self) -> typing.Union[str, PathLike]:
+        """Get the base path of the resource.
+
+        It will try to return self.base_path, then self._base_path, then Path.cwd() if above attrs are non-existent or
+        `None.
+
+        :return: The base path of the resource
+        :rtype: typing.Union[str, os.PathLike]
+        """
+        return (
+            try_get_non_arbitrary_attr(self, BASE_PATH_CONTEXT_KEY)
+            or try_get_non_arbitrary_attr(self, f"_{BASE_PATH_CONTEXT_KEY}")
+            or Path.cwd()
+        )
+
+    def _default_context(self) -> dict:
+        # Note that, although context can be passed, nested.schema will be initialized only once
+        # base_path works well because it's fixed after loaded
+        return {BASE_PATH_CONTEXT_KEY: self.__base_path_for_validation}
+
+    @classmethod
+    def _create_schema_for_validation(cls, context) -> PathAwareSchema:
+        raise NotImplementedError()
+
+    @classmethod
+    def _create_validation_error(cls, message: str, no_personal_data_message: str) -> Exception:
+        raise NotImplementedError()
+
+    def _dump_for_validation(self) -> typing.Dict:
+        # this is not a necessary step but to keep the same behavior as before
+        # empty items will be removed when converting to dict
+        return convert_ordered_dict_to_dict(super()._dump_for_validation())

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_validation/remote.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_validation/remote.py
@@ -1,0 +1,163 @@
+# ---------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# ---------------------------------------------------------
+# pylint: disable=protected-access
+
+import logging
+import typing
+
+import msrest
+
+from azure.ai.ml._vendor.azure_resources.models import (
+    Deployment,
+    DeploymentProperties,
+    DeploymentValidateResult,
+    ErrorResponse,
+)
+from azure.ai.ml.entities._mixins import RestTranslatableMixin
+
+from .core import MutableValidationResult, ValidationResultBuilder
+
+module_logger = logging.getLogger(__name__)
+
+
+class PreflightResource(msrest.serialization.Model):
+    """Specified resource.
+
+    Variables are only populated by the server, and will be ignored when sending a request.
+
+    :ivar id: Resource ID.
+    :vartype id: str
+    :ivar name: Resource name.
+    :vartype name: str
+    :ivar type: Resource type.
+    :vartype type: str
+    :param location: Resource location.
+    :type location: str
+    :param tags: A set of tags. Resource tags.
+    :type tags: dict[str, str]
+    """
+
+    _attribute_map = {
+        "type": {"key": "type", "type": "str"},
+        "name": {"key": "name", "type": "str"},
+        "location": {"key": "location", "type": "str"},
+        "api_version": {"key": "apiversion", "type": "str"},
+        "properties": {"key": "properties", "type": "object"},
+    }
+
+    def __init__(self, **kwargs):
+        super(PreflightResource, self).__init__(**kwargs)
+        self.name = kwargs.get("name", None)
+        self.type = kwargs.get("type", None)
+        self.location = kwargs.get("location", None)
+        self.properties = kwargs.get("properties", None)
+        self.api_version = kwargs.get("api_version", None)
+
+
+class ValidationTemplateRequest(msrest.serialization.Model):
+    """Export resource group template request parameters.
+
+    :param resources: The rest objects to be validated.
+    :type resources: list[_models.Resource]
+    :param options: The export template options. A CSV-formatted list containing zero or more of
+     the following: 'IncludeParameterDefaultValue', 'IncludeComments',
+     'SkipResourceNameParameterization', 'SkipAllParameterization'.
+    :type options: str
+    """
+
+    _attribute_map = {
+        "resources": {"key": "resources", "type": "[PreflightResource]"},
+        "content_version": {"key": "contentVersion", "type": "str"},
+        "parameters": {"key": "parameters", "type": "object"},
+        "_schema": {
+            "key": "$schema",
+            "type": "str",
+            "default": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+        },
+    }
+
+    def __init__(self, **kwargs):
+        super(ValidationTemplateRequest, self).__init__(**kwargs)
+        self._schema = kwargs.get("_schema", None)
+        self.content_version = kwargs.get("content_version", None)
+        self.parameters = kwargs.get("parameters", None)
+        self.resources = kwargs.get("resources", None)
+
+
+class RemoteValidatableMixin(RestTranslatableMixin):
+    @classmethod
+    def _get_resource_type(cls) -> str:
+        """Return resource type to be used in remote validation.
+
+        Should be overridden by subclass.
+
+        :return: The resource type
+        :rtype: str
+        """
+        raise NotImplementedError()
+
+    def _get_resource_name_version(self) -> typing.Tuple[str, str]:
+        """Return resource name and version to be used in remote validation.
+
+        Should be overridden by subclass.
+
+        :return: The name and version
+        :rtype: typing.Tuple[str, str]
+        """
+        raise NotImplementedError()
+
+    def _to_preflight_resource(self, location: str, workspace_name: str) -> PreflightResource:
+        """Return the preflight resource to be used in remote validation.
+
+        :param location: The location of the resource.
+        :type location: str
+        :param workspace_name: The workspace name
+        :type workspace_name: str
+        :return: The preflight resource
+        :rtype: PreflightResource
+        """
+        name, version = self._get_resource_name_version()
+        return PreflightResource(
+            type=self._get_resource_type(),
+            name=f"{workspace_name}/{name}/{version}",
+            location=location,
+            properties=self._to_rest_object().properties,
+            api_version="2023-03-01-preview",
+        )
+
+    def _build_rest_object_for_remote_validation(self, location: str, workspace_name: str) -> Deployment:
+        return Deployment(
+            properties=DeploymentProperties(
+                mode="Incremental",
+                template=ValidationTemplateRequest(
+                    _schema="https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                    content_version="1.0.0.0",
+                    parameters={},
+                    resources=[self._to_preflight_resource(location=location, workspace_name=workspace_name)],
+                ),
+            )
+        )
+
+    @classmethod
+    def _build_validation_result_from_rest_object(cls, rest_obj: DeploymentValidateResult) -> MutableValidationResult:
+        """Create a validation result from a rest object. Note that the created validation result does not have
+        target_obj so should only be used for merging.
+
+        :param rest_obj: The Deployment Validate REST obj
+        :type rest_obj: DeploymentValidateResult
+        :return: The validation result created from rest_obj
+        :rtype: MutableValidationResult
+        """
+        if not rest_obj.error or not rest_obj.error.details:
+            return ValidationResultBuilder.success()
+        result = MutableValidationResult(target_obj=None)
+        details: typing.List[ErrorResponse] = rest_obj.error.details
+        for detail in details:
+            result.append_error(
+                message=detail.message,
+                yaml_path=detail.target.replace("/", "."),
+                error_code=detail.code,
+                # will always be UserError for now, not sure if innerError can be passed back
+            )
+        return result

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_validation/schema.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_validation/schema.py
@@ -1,0 +1,155 @@
+# ---------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# ---------------------------------------------------------
+
+# pylint: disable=protected-access
+
+import json
+import logging
+import typing
+
+from marshmallow import Schema, ValidationError
+
+from .core import MutableValidationResult, ValidationResultBuilder
+
+module_logger = logging.getLogger(__name__)
+
+
+class SchemaValidatableMixin:
+    """The mixin class for schema validation."""
+
+    @classmethod
+    def _create_empty_validation_result(cls) -> MutableValidationResult:
+        """Simply create an empty validation result
+
+        To reduce _ValidationResultBuilder importing, which is a private class.
+
+        :return: An empty validation result
+        :rtype: MutableValidationResult
+        """
+        return ValidationResultBuilder.success()
+
+    @classmethod
+    def _load_with_schema(cls, data, *, context, raise_original_exception=False, **kwargs):
+        schema = cls._create_schema_for_validation(context=context)
+
+        try:
+            return schema.load(data, **kwargs)
+        except ValidationError as e:
+            if raise_original_exception:
+                raise e
+            msg = "Trying to load data with schema failed. Data:\n%s\nError: %s" % (
+                json.dumps(data, indent=4) if isinstance(data, dict) else data,
+                json.dumps(e.messages, indent=4),
+            )
+            raise cls._create_validation_error(
+                message=msg,
+                no_personal_data_message=str(e),
+            ) from e
+
+    @classmethod
+    # pylint: disable-next=docstring-missing-param
+    def _create_schema_for_validation(cls, context) -> Schema:
+        """Create a schema of the resource with specific context. Should be overridden by subclass.
+
+        :return: The schema of the resource.
+        :rtype: Schema.
+        """
+        raise NotImplementedError()
+
+    def _default_context(self) -> dict:
+        """Get the default context for schema validation. Should be overridden by subclass.
+
+        :return: The default context for schema validation
+        :rtype: dict
+        """
+        raise NotImplementedError()
+
+    @property
+    def _schema_for_validation(self) -> Schema:
+        """Return the schema of this Resource with default context. Do not override this method.
+        Override _create_schema_for_validation instead.
+
+        :return: The schema of the resource.
+        :rtype: Schema.
+        """
+        return self._create_schema_for_validation(context=self._default_context())
+
+    def _dump_for_validation(self) -> typing.Dict:
+        """Convert the resource to a dictionary.
+
+        :return: Converted dictionary
+        :rtype: typing.Dict
+        """
+        return self._schema_for_validation.dump(self)
+
+    @classmethod
+    def _create_validation_error(cls, message: str, no_personal_data_message: str) -> Exception:
+        """The function to create the validation exception to raise in _try_raise and _validate when
+        raise_error is True.
+
+        Should be overridden by subclass.
+
+        :param message: The error message containing detailed information
+        :type message: str
+        :param no_personal_data_message: The error message without personal data
+        :type no_personal_data_message: str
+        :return: The validation exception to raise
+        :rtype: Exception
+        """
+        raise NotImplementedError()
+
+    @classmethod
+    def _try_raise(
+        cls, validation_result: MutableValidationResult, *, raise_error: bool = True
+    ) -> MutableValidationResult:
+        return validation_result.try_raise(raise_error=raise_error, error_func=cls._create_validation_error)
+
+    def _validate(self, raise_error=False) -> MutableValidationResult:
+        """Validate the resource. If raise_error is True, raise ValidationError if validation fails and log warnings if
+        applicable; Else, return the validation result.
+
+        :param raise_error: Whether to raise ValidationError if validation fails.
+        :type raise_error: bool
+        :return: The validation result
+        :rtype: MutableValidationResult
+        """
+        result = self.__schema_validate()
+        result.merge_with(self._customized_validate())
+        return self._try_raise(result, raise_error=raise_error)
+
+    def _customized_validate(self) -> MutableValidationResult:
+        """Validate the resource with customized logic.
+
+        Override this method to add customized validation logic.
+
+        :return: The customized validation result
+        :rtype: MutableValidationResult
+        """
+        return self._create_empty_validation_result()
+
+    @classmethod
+    def _get_skip_fields_in_schema_validation(
+        cls,
+    ) -> typing.List[str]:
+        """Get the fields that should be skipped in schema validation.
+
+        Override this method to add customized validation logic.
+
+        :return: The fields to skip in schema validation
+        :rtype: typing.List[str]
+        """
+        return []
+
+    def __schema_validate(self) -> MutableValidationResult:
+        """Validate the resource with the schema.
+
+        :return: The validation result
+        :rtype: MutableValidationResult
+        """
+        data = self._dump_for_validation()
+        messages = self._schema_for_validation.validate(data)
+        for skip_field in self._get_skip_fields_in_schema_validation():
+            if skip_field in messages:
+                del messages[skip_field]
+        return ValidationResultBuilder.from_validation_messages(messages, data=data)

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_component_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_component_operations.py
@@ -414,11 +414,15 @@ class ComponentOperations(_ScopeDependentOperations):
                 ),
                 **self._init_args,
             )
-            result.merge_with(remote_validation_result.result(), overwrite=True)
+            result.merge_with(
+                # pylint: disable=protected-access
+                component._build_validation_result_from_rest_object(remote_validation_result.result()),
+                overwrite=True,
+            )
         # resolve location for diagnostics from remote validation
         result.resolve_location_for_diagnostics(component._source_path)
-        return result.try_raise(
-            error_target=ErrorTarget.COMPONENT,
+        return component._try_raise(  # pylint: disable=protected-access
+            result,
             raise_error=raise_on_failure,
         )
 

--- a/sdk/ml/azure-ai-ml/tests/component/unittests/test_component_validate.py
+++ b/sdk/ml/azure-ai-ml/tests/component/unittests/test_component_validate.py
@@ -80,13 +80,15 @@ class TestComponentValidate:
     @pytest.mark.parametrize(
         "expected_location,asset_object",
         [
-            (
+            pytest.param(
                 "code",
                 Code(name="AzureML-Code", version="1"),
+                id="code",
             ),
-            (
+            pytest.param(
                 "environment",
                 Environment(name="AzureML-Minimal", version="1"),
+                id="environment",
             ),
         ],
     )

--- a/sdk/ml/azure-ai-ml/tests/component/unittests/test_flow_component.py
+++ b/sdk/ml/azure-ai-ml/tests/component/unittests/test_flow_component.py
@@ -131,6 +131,12 @@ class TestFlowComponent:
             # we won't update the flow.dag.yaml for now. user may use `mldesigner compile` if they want to update it
             assert "additional_includes" in flow_dag
 
+    def test_flow_component_load_from_run_with_additional_includes(self):
+        flow_base_dir = "./tests/test_configs/flows"
+        component = load_component(f"{flow_base_dir}/runs/additional_includes_run.yml")
+        with component._build_code() as code:
+            assert Path(code.path, "convert_to_dict.py").is_file()
+
     def test_flow_component_entity(self):
         component: FlowComponent = load_component("./tests/test_configs/flows/basic/flow.dag.yaml")
 
@@ -143,7 +149,9 @@ class TestFlowComponent:
         with pytest.raises(RuntimeError, match="Ports of flow component are not editable."):
             del input_port_dict["text"]
 
-        component.flow = None
+        with pytest.raises(AttributeError):
+            component.flow = None
+
         component.column_mapping = None
         component.variant = None
         component.connections = None

--- a/sdk/ml/azure-ai-ml/tests/conftest.py
+++ b/sdk/ml/azure-ai-ml/tests/conftest.py
@@ -16,9 +16,6 @@ from unittest.mock import Mock, patch
 
 import pytest
 from _pytest.fixtures import FixtureRequest
-from azure.core.exceptions import ResourceNotFoundError
-from azure.core.pipeline.transport import HttpTransport
-from azure.identity import AzureCliCredential, ClientSecretCredential, DefaultAzureCredential
 from devtools_testutils import (
     add_body_key_sanitizer,
     add_general_regex_sanitizer,
@@ -52,6 +49,9 @@ from azure.ai.ml.entities._credentials import NoneCredentialConfiguration
 from azure.ai.ml.entities._job.job_name_generator import generate_job_name
 from azure.ai.ml.operations._run_history_constants import RunHistoryConstants
 from azure.ai.ml.operations._workspace_operations_base import get_deployment_name, get_name_for_dependent_resource
+from azure.core.exceptions import ResourceNotFoundError
+from azure.core.pipeline.transport import HttpTransport
+from azure.identity import AzureCliCredential, ClientSecretCredential, DefaultAzureCredential
 
 E2E_TEST_LOGGING_ENABLED = "E2E_TEST_LOGGING_ENABLED"
 test_folder = Path(os.path.abspath(__file__)).parent.absolute()
@@ -973,6 +973,7 @@ def disable_internal_components():
     """
     from azure.ai.ml._internal._schema.component import NodeType
     from azure.ai.ml._internal._setup import _set_registered
+    from azure.ai.ml.entities._builders.control_flow_node import LoopNode
     from azure.ai.ml.entities._component.component_factory import component_factory
     from azure.ai.ml.entities._job.pipeline._load_component import pipeline_node_factory
 
@@ -982,6 +983,7 @@ def disable_internal_components():
         component_factory._create_instance_funcs.pop(_type, None)  # pylint: disable=protected-access
         component_factory._create_schema_funcs.pop(_type, None)  # pylint: disable=protected-access
 
+    LoopNode._extra_body_types = None
     _set_registered(False)
 
     with reload_schema_for_nodes_in_pipeline_job(revert_after_yield=False):

--- a/sdk/ml/azure-ai-ml/tests/dsl/e2etests/test_dsl_pipeline.py
+++ b/sdk/ml/azure-ai-ml/tests/dsl/e2etests/test_dsl_pipeline.py
@@ -1519,7 +1519,7 @@ class TestDSLPipeline(AzureRecordedTestCase):
             node1.compute = "cpu-cluster"
 
         dsl_pipeline: PipelineJob = pipeline(10, job_input)
-        with patch("azure.ai.ml.entities._validation.module_logger.warning") as mock_logging:
+        with patch("azure.ai.ml.entities._validation.core.module_logger.warning") as mock_logging:
             _ = client.jobs.create_or_update(dsl_pipeline)
             mock_logging.assert_called_with("Warnings: [jobs.node1.jeff_special_option: Unknown field.]")
 

--- a/sdk/ml/azure-ai-ml/tests/dsl/unittests/test_controlflow_pipeline.py
+++ b/sdk/ml/azure-ai-ml/tests/dsl/unittests/test_controlflow_pipeline.py
@@ -395,6 +395,8 @@ class TestDoWhilePipelineUT(TestControlFlowPipelineUT):
 
 
 class TestParallelForPipelineUT(TestControlFlowPipelineUT):
+    # Need to disable internal components or internal nodes will be in allowed node types
+    @pytest.mark.usefixtures("disable_internal_components")
     def test_dsl_parallel_for_pipeline_illegal_cases(self):
         # body unsupported
         parallel_component = load_component(

--- a/sdk/ml/azure-ai-ml/tests/internal/unittests/test_component.py
+++ b/sdk/ml/azure-ai-ml/tests/internal/unittests/test_component.py
@@ -881,7 +881,7 @@ class TestComponent:
         loop_node = LoopNode(body=component_func())
         loop_node.body._referenced_control_flow_node_instance_id = loop_node._instance_id
         with environment_variable_overwrite(AZUREML_INTERNAL_COMPONENTS_ENV_VAR, "True"):
-            validate_result = loop_node._validate_body(raise_error=False)
+            validate_result = loop_node._validate_body()
             assert validate_result.passed
 
     @pytest.mark.parametrize(

--- a/sdk/ml/azure-ai-ml/tests/internal_utils/unittests/test_validation.py
+++ b/sdk/ml/azure-ai-ml/tests/internal_utils/unittests/test_validation.py
@@ -2,7 +2,7 @@ import pytest
 from marshmallow import ValidationError
 
 from azure.ai.ml.entities import PipelineJobSettings
-from azure.ai.ml.entities._validation import _ValidationResultBuilder
+from azure.ai.ml.entities._validation import ValidationResultBuilder
 
 
 @pytest.mark.unittest
@@ -19,7 +19,7 @@ class TestValidation:
                 }
             },
         )
-        result = _ValidationResultBuilder.from_validation_error(validation_error)
+        result = ValidationResultBuilder.from_validation_error(validation_error)
         assert result._to_dict() == {
             "errors": [
                 {
@@ -44,7 +44,7 @@ class TestValidation:
                 }
             },
         )
-        result = _ValidationResultBuilder.from_validation_error(validation_error, error_on_unknown_field=True)
+        result = ValidationResultBuilder.from_validation_error(validation_error, error_on_unknown_field=True)
         assert result._to_dict() == {
             "errors": [
                 {
@@ -56,7 +56,7 @@ class TestValidation:
             "result": "Failed",
         }
 
-        result = _ValidationResultBuilder.from_validation_error(validation_error)
+        result = ValidationResultBuilder.from_validation_error(validation_error)
         assert result._to_dict() == {
             "warnings": [
                 {
@@ -79,7 +79,7 @@ class TestValidation:
                 ]
             },
         )
-        result = _ValidationResultBuilder.from_validation_error(validation_error)
+        result = ValidationResultBuilder.from_validation_error(validation_error)
         assert result._to_dict() == {
             "errors": [
                 {"message": "Not a valid string.; Not a valid URL.; Not a valid string.", "path": "code", "value": None}
@@ -92,7 +92,7 @@ class TestValidation:
             field="_schema",
             message={"jeff_special_option": ["Unknown field."]},
         )
-        result = _ValidationResultBuilder.from_validation_error(validation_error)
+        result = ValidationResultBuilder.from_validation_error(validation_error)
         assert result._to_dict() == {
             "warnings": [{"message": "Unknown field.", "path": "jeff_special_option", "value": None}],
             "result": "Succeeded",

--- a/sdk/ml/azure-ai-ml/tests/pipeline_job/_util.py
+++ b/sdk/ml/azure-ai-ml/tests/pipeline_job/_util.py
@@ -60,25 +60,3 @@ DATABINDING_EXPRESSION_TEST_CASE_ENUMERATE = list(
         )
     )
 )
-
-
-SERVERLESS_COMPUTE_TEST_PARAMETERS = [
-    # test matrix: <pipeline-default-compute> + <step-compute>
-    (
-        "none_pipeline_default_compute_invalid",
-        {
-            "jobs.vanilla_node.compute": "Compute not set",
-            "jobs.node_with_resources.compute": "Compute not set",
-            "jobs.pipeline_node.jobs.vanilla_node.compute": "Compute not set",
-            "jobs.pipeline_node.jobs.node_with_resources.compute": "Compute not set",
-        },
-    ),  # invalid: none + none / none + resources
-    (
-        "none_pipeline_default_compute_valid",
-        None,
-    ),  # valid: none + resources / none + serverless / none + compute target
-    (
-        "serverless_pipeline_default_compute_valid",
-        None,
-    ),  # valid serverless + <step-compute> (any combination should be valid)
-]

--- a/sdk/ml/azure-ai-ml/tests/test_configs/flows/runs/additional_includes_run.yml
+++ b/sdk/ml/azure-ai-ml/tests/test_configs/flows/runs/additional_includes_run.yml
@@ -1,0 +1,3 @@
+$schema: https://azuremlschemas.azureedge.net/promptflow/latest/Run.schema.json
+flow: ../web_classification_with_additional_includes
+description: A run of a flow with additional includes


### PR DESCRIPTION
# Description

+ Divide _validation.py into a package, making core implementation independent from other code in azure-ai-ml.
  + After this, we can easily vendor the core implementation of schema validation in another package.
+ An optimization for the error message when customer use internal spark component without enabling internal components.
+ fix a bug that can't load from `run.yaml` of a flow with additional includes.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
