### PR TITLE
[ML][Pipelines] fix: support implicit internal components enabling

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_internal/_setup.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_internal/_setup.py
@@ -7,6 +7,7 @@ from typing import NoReturn
 from marshmallow import INCLUDE
 
 from .._schema import NestedField
+from .._utils import utils
 from ..entities._builders.control_flow_node import LoopNode
 from ..entities._component.component_factory import component_factory
 from ..entities._job.pipeline._load_component import pipeline_node_factory
@@ -28,12 +29,9 @@ from .entities import (
 )
 from .entities.spark import InternalSparkComponent
 
-_registered = False
-
 
 def _set_registered(value: bool):
-    global _registered  # pylint: disable=global-statement
-    _registered = value
+    utils.__is_internal_components_enabled = value
 
 
 def _enable_internal_components():
@@ -68,7 +66,7 @@ def enable_internal_components_in_pipeline(*, force=False) -> NoReturn:
     :return: No return value.
     :rtype: None
     """
-    if _registered and not force:
+    if utils.__is_internal_components_enabled and not force:
         return  # already registered
 
     _enable_internal_components()

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_utils/utils.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_utils/utils.py
@@ -1033,8 +1033,14 @@ def is_concurrent_component_registration_enabled():  # pylint: disable=name-too-
     return os.getenv(AZUREML_DISABLE_CONCURRENT_COMPONENT_REGISTRATION) not in ["True", "true", True]
 
 
+__is_internal_components_enabled = False
+
+
 def _is_internal_components_enabled():
-    return os.getenv(AZUREML_INTERNAL_COMPONENTS_ENV_VAR) in ["True", "true", True]
+    global __is_internal_components_enabled  # pylint: disable=global-statement
+    if os.getenv(AZUREML_INTERNAL_COMPONENTS_ENV_VAR) in ["True", "true", True]:
+        __is_internal_components_enabled = True
+    return __is_internal_components_enabled
 
 
 def try_enable_internal_components(*, force=False) -> bool:

--- a/sdk/ml/azure-ai-ml/tests/conftest.py
+++ b/sdk/ml/azure-ai-ml/tests/conftest.py
@@ -857,7 +857,7 @@ def enable_pipeline_private_preview_features(mocker: MockFixture):
 @pytest.fixture()
 def enable_private_preview_schema_features():
     """Schemas will be imported at the very beginning, so need to reload related classes."""
-    from azure.ai.ml._internal._setup import _registered, enable_internal_components_in_pipeline
+    from azure.ai.ml._internal._setup import __is_internal_components_enabled, enable_internal_components_in_pipeline
     from azure.ai.ml._schema.component import command_component as command_component_schema
     from azure.ai.ml._schema.component import component as component_schema
     from azure.ai.ml._schema.component import input_output
@@ -879,7 +879,7 @@ def enable_private_preview_schema_features():
         pipeline_job_entity.PipelineJobSchema = pipeline_job_schema.PipelineJobSchema
 
         # check internal flag after reload, force register if it is set as True
-        if _registered:
+        if __is_internal_components_enabled:
             enable_internal_components_in_pipeline(force=True)
 
     with patch.dict(os.environ, {AZUREML_PRIVATE_FEATURES_ENV_VAR: "True"}):


### PR DESCRIPTION
# Description

Fix a bug that, exception will be raised when detecting internal component schema while corresponding environment variable is not set to True after implicitly enabling internal components by import `azure.ai.ml._internal`.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
