### PR TITLE
Skip pypy3 tests for psycopg2

### DIFF
--- a/sdk/monitor/azure-monitor-opentelemetry/tests/instrumentation/test_psycopg2.py
+++ b/sdk/monitor/azure-monitor-opentelemetry/tests/instrumentation/test_psycopg2.py
@@ -3,15 +3,19 @@
 # Licensed under the MIT License. See License in the project root for
 # license information.
 # --------------------------------------------------------------------------
-
+import pytest
+import sys
 import unittest
 
-from opentelemetry.instrumentation.psycopg2 import (
-    Psycopg2Instrumentor,
-)
+if sys.implementation.name != "pypy":
+    from opentelemetry.instrumentation.psycopg2 import (
+        Psycopg2Instrumentor,
+    )
 
 
 class TestPsycopg2Instrumentation(unittest.TestCase):
+
+    @pytest.mark.skipif(sys.implementation.name == "pypy", reason="Psycopg2 not supported for pypy3.9")
     def test_instrument(self):
         try:
             Psycopg2Instrumentor().instrument()


### PR DESCRIPTION
OpenTelemetry contrib [skips](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/tox.ini#L130) pypy3 env for psycopg2 so we should follow suite.