### PR TITLE
Unpin pyopenssl in regression tooling

### DIFF
--- a/eng/regression_test_tools.txt
+++ b/eng/regression_test_tools.txt
@@ -16,7 +16,6 @@ typing-extensions<=4.6.3
 # locking packages defined as deps from azure-sdk-tools or azure-devtools
 pytoml==0.1.21
 readme-renderer[md]==25.0
-pyOpenSSL==23.2.0
 json-delta==2.0
 ConfigArgParse==1.2.3
 six==1.14.0

--- a/eng/regression_tools.txt
+++ b/eng/regression_tools.txt
@@ -1,5 +1,4 @@
 # requirements leveraged by ci tools
-cryptography==3.3.2
 setuptools==67.6.0; python_version >= '3.5'
 virtualenv==20.23.0
 wheel==0.37.0
@@ -19,7 +18,6 @@ typing-extensions<=4.6.3
 
 # locking packages defined as deps from azure-sdk-tools or azure-devtools
 pytoml==0.1.21
-pyOpenSSL==23.2.0
 json-delta==2.0
 ConfigArgParse==1.2.3
 six==1.14.0


### PR DESCRIPTION
To address [regression failures](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3055703&view=results)