### PR TITLE
Move identity live test variables into subscription config

### DIFF
--- a/sdk/identity/test-resources-pre.ps1
+++ b/sdk/identity/test-resources-pre.ps1
@@ -1,0 +1,41 @@
+[CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
+param (
+    # Captures any arguments from eng/New-TestResources.ps1 not declared here (no parameter errors).
+    [Parameter(ValueFromRemainingArguments = $true)]
+    $RemainingArguments
+)
+
+if (!$CI) {
+    # TODO: Remove this once auto-cloud config downloads are supported locally
+    Write-Host "Skipping cert setup in local testing mode"
+    return
+}
+
+if ($EnvironmentVariables -eq $null -or $EnvironmentVariables.Count -eq 0) {
+    throw "EnvironmentVariables must be set in the calling script New-TestResources.ps1"
+}
+
+$tmp = $env:TEMP ? $env:TEMP : [System.IO.Path]::GetTempPath()
+$pemPath = Join-Path $tmp "test.pem"
+$pemPasswordProtectedPath = Join-Path $tmp "testPasswordProtected.pem"
+
+Write-Host "Creating identity test files: $pemPath $pemPasswordProtectedPath"
+
+$pemContent = $EnvironmentVariables['PEM_CONTENT'] -replace "\n","`n"
+$pemContentPasswordProtected = $EnvironmentVariables['PEM_CONTENT_PASSWORD_PROTECTED'] -replace "\n","`n"
+
+Set-Content -Path $pemPath -Value $pemContent
+Set-Content -Path $pemPasswordProtectedPath -Value $pemContentPasswordProtected
+
+# Set for pipeline
+Write-Host "##vso[task.setvariable variable=IDENTITY_CERT_PEM;]$pemPath"
+Write-Host "##vso[task.setvariable variable=IDENTITY_CERT_PEM_PASSWORD_PROTECTED;]$pemPasswordProtectedPath"
+Write-Host "##vso[task.setvariable variable=CERTIFICATE_PASSWORD;]$($EnvironmentVariables['CERTIFICATE_PASSWORD'])"
+Write-Host "##vso[task.setvariable variable=PFX_CONTENT;]$($EnvironmentVariables['PFX_CONTENT'])"
+Write-Host "##vso[task.setvariable variable=PFX_CONTENT_PASSWORD_PROTECTED;]$($EnvironmentVariables['PFX_CONTENT_PASSWORD_PROTECTED'])"
+# Set for local
+$env:IDENTITY_CERT_PEM = $pemPath
+$env:IDENTITY_CERT_PEM_PASSWORD_PROTECTED = $pemPasswordProtectedPath
+$env:CERTIFICATE_PASSWORD = $EnvironmentVariables['CERTIFICATE_PASSWORD']
+$env:PFX_CONTENT = $EnvironmentVariables['PFX_CONTENT']
+$env:PFX_CONTENT_PASSWORD_PROTECTED = $EnvironmentVariables['PFX_CONTENT_PASSWORD_PROTECTED']

--- a/sdk/identity/test-resources.bicep
+++ b/sdk/identity/test-resources.bicep
@@ -1,0 +1,1 @@
+param baseName string

--- a/sdk/identity/tests.yml
+++ b/sdk/identity/tests.yml
@@ -4,14 +4,17 @@ stages:
   - template: ../../eng/pipelines/templates/stages/archetype-sdk-tests.yml
     parameters:
       ServiceDirectory: identity
+      CloudConfig:
+        Public:
+          SubscriptionConfigurations:
+            - $(sub-config-azure-cloud-test-resources)
+            # Contains alternate tenant, AAD app and cert info for testing
+            - $(sub-config-identity-test-resources)
+            - $(sub-config-identity-test-resources-python)
       EnvVars:
-        AZURE_CLIENT_ID: $(python-identity-client-id)
-        AZURE_CLIENT_SECRET: $(python-identity-client-secret)
-        AZURE_TENANT_ID: $(aad-azure-sdk-test-tenant-id)
-        CERTIFICATE_PASSWORD: $(python-identity-certificate-password)
-        PEM_CONTENT: $(python-identity-certificate)
-        PEM_CONTENT_PASSWORD_PROTECTED: $(python-identity-certificate-with-password)
-        PFX_CONTENT: $(python-identity-certificate-pfx)
-        PFX_CONTENT_PASSWORD_PROTECTED: $(python-identity-certificate-with-password-pfx)
+        AZURE_CLIENT_ID: $(IDENTITY_CLIENT_ID)
+        AZURE_CLIENT_SECRET: $(IDENTITY_CLIENT_SECRET)
+        AZURE_TENANT_ID: $(IDENTITY_TENANT_ID)
+        AZURE_SUBSCRIPTION_ID: $(IDENTITY_SUBSCRIPTION_ID)
         AZURE_TEST_RUN_LIVE: true
         AZURE_SKIP_LIVE_RECORDING: 'True'


### PR DESCRIPTION
Updating the identity live tests to remove logic and env setting from yaml in favor of a dedicated keyvault config. This will make it possible to improve local and sovereign cloud testing, and make cross-language config updates more easily.

Related: https://github.com/Azure/azure-sdk-for-net/pull/38473
