### PR TITLE
Fix resource_url and authority_url mapping and handling for datastore service principals

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_datastore/credentials.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_datastore/credentials.py
@@ -6,7 +6,7 @@
 
 from typing import Any, Dict
 
-from marshmallow import ValidationError, fields, post_load, pre_dump
+from marshmallow import ValidationError, fields, post_load, pre_dump, pre_load
 
 from azure.ai.ml._schema.core.schema import PatchedSchemaMeta
 from azure.ai.ml.entities._credentials import (
@@ -57,6 +57,17 @@ class BaseTenantCredentialSchema(metaclass=PatchedSchemaMeta):
     resource_url = fields.Str()
     tenant_id = fields.Str(required=True)
     client_id = fields.Str(required=True)
+
+    @pre_load
+    def accept_backward_compatible_keys(self, data, **kwargs):
+        acceptable_keys = [key for key in data.keys() if key in ("authority_url", "authority_uri")]
+        if len(acceptable_keys) > 1:
+            raise ValidationError(
+                "Cannot specify both 'authority_url' and 'authority_uri'. Please use 'authority_url'."
+            )
+        if acceptable_keys:
+            data["authority_url"] = data.pop(acceptable_keys[0])
+        return data
 
 
 class ServicePrincipalSchema(BaseTenantCredentialSchema):

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_datastore/credentials.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_datastore/credentials.py
@@ -53,7 +53,7 @@ class SasTokenSchema(metaclass=PatchedSchemaMeta):
 
 
 class BaseTenantCredentialSchema(metaclass=PatchedSchemaMeta):
-    authority_url = fields.Str(data_key="authority_uri")
+    authority_url = fields.Str()
     resource_url = fields.Str()
     tenant_id = fields.Str(required=True)
     client_id = fields.Str(required=True)

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_credentials.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_credentials.py
@@ -258,7 +258,7 @@ class ServicePrincipalConfiguration(BaseTenantCredentials):
         secrets = RestServicePrincipalDatastoreSecrets(client_secret=self.client_secret)
         return RestServicePrincipalDatastoreCredentials(
             authority_url=self.authority_url,
-            resource_uri=self.resource_url,
+            resource_url=self.resource_url,
             tenant_id=self.tenant_id,
             client_id=self.client_id,
             secrets=secrets,

--- a/sdk/ml/azure-ai-ml/tests/datastore/unittests/test_datastore_operations.py
+++ b/sdk/ml/azure-ai-ml/tests/datastore/unittests/test_datastore_operations.py
@@ -53,6 +53,7 @@ class TestDatastoreOperations:
             "adls_gen1.yml",
             "adls_gen2.yml",
             "one_lake.yml",
+            "one_lake_auth_url_back_compat.yml",
             "credential_less_one_lake.yml",
             # disable until preview release
             # "hdfs_kerberos_pw.yml",

--- a/sdk/ml/azure-ai-ml/tests/datastore/unittests/test_datastore_operations.py
+++ b/sdk/ml/azure-ai-ml/tests/datastore/unittests/test_datastore_operations.py
@@ -53,6 +53,7 @@ class TestDatastoreOperations:
             "adls_gen1.yml",
             "adls_gen2.yml",
             "one_lake.yml",
+            "credential_less_one_lake.yml",
             # disable until preview release
             # "hdfs_kerberos_pw.yml",
             # "hdfs_kerberos_keytab.yml",

--- a/sdk/ml/azure-ai-ml/tests/datastore/unittests/test_datastore_schema.py
+++ b/sdk/ml/azure-ai-ml/tests/datastore/unittests/test_datastore_schema.py
@@ -293,6 +293,8 @@ class TestDatastore:
         assert cfg_credentials["tenant_id"] == internal_credentials.tenant_id
         assert cfg_credentials["client_id"] == internal_credentials.client_id
         assert cfg_credentials["client_secret"] == internal_credentials.client_secret
+        assert cfg_credentials["resource_url"] == internal_credentials.resource_url
+        assert cfg_credentials["authority_url"] == internal_credentials.authority_url
 
         assert cfg["one_lake_workspace_name"] == internal_ds.one_lake_workspace_name
         assert cfg["endpoint"] == internal_ds.endpoint
@@ -324,6 +326,11 @@ class TestDatastore:
         assert rest_service_principal.client_id == internal_credential.client_id
         assert rest_service_principal.secrets
         assert rest_service_principal.secrets.client_secret == internal_credential.client_secret
+        # authority_url gets set to https://login.microsoftonline.com by default
+        assert rest_service_principal.authority_url
+        assert rest_service_principal.authority_url == internal_credential.authority_url
+        # resource_url doesn't get set to a default value so can be None
+        assert rest_service_principal.resource_url == internal_credential.resource_url
 
     def test_all_datastore_schemas_included(self):
         """Test that all DatastoreSchemas are included in the DATASTORE_SCHEMA_TYPES constant"""

--- a/sdk/ml/azure-ai-ml/tests/datastore/unittests/test_datastore_schema.py
+++ b/sdk/ml/azure-ai-ml/tests/datastore/unittests/test_datastore_schema.py
@@ -280,10 +280,21 @@ class TestDatastore:
         internal_ds_from_rest = Datastore._from_rest_object(datastore_resource)
         assert internal_ds_from_rest == internal_ds
 
-    def test_one_lake_schema(self):
+    def test_one_lake_schema_with_service_principal(self):
         test_path = "./tests/test_configs/datastore/one_lake.yml"
-        cfg = load_yaml(test_path)
-        internal_ds = load_datastore(test_path)
+        self.validate_one_lake_schema_with_service_principal(
+            test_yaml_file_path=test_path, auth_url_key="authority_url"
+        )
+
+    def test_one_lake_authority_url_backward_compatible_schema(self):
+        test_path = "./tests/test_configs/datastore/one_lake_auth_url_back_compat.yml"
+        self.validate_one_lake_schema_with_service_principal(
+            test_yaml_file_path=test_path, auth_url_key="authority_uri"
+        )
+
+    def validate_one_lake_schema_with_service_principal(self, test_yaml_file_path, auth_url_key):
+        cfg = load_yaml(test_yaml_file_path)
+        internal_ds = load_datastore(test_yaml_file_path)
         assert isinstance(internal_ds, OneLakeDatastore)
         assert cfg["artifact"] == internal_ds.artifact
 
@@ -294,7 +305,7 @@ class TestDatastore:
         assert cfg_credentials["client_id"] == internal_credentials.client_id
         assert cfg_credentials["client_secret"] == internal_credentials.client_secret
         assert cfg_credentials["resource_url"] == internal_credentials.resource_url
-        assert cfg_credentials["authority_url"] == internal_credentials.authority_url
+        assert cfg_credentials[auth_url_key] == internal_credentials.authority_url
 
         assert cfg["one_lake_workspace_name"] == internal_ds.one_lake_workspace_name
         assert cfg["endpoint"] == internal_ds.endpoint

--- a/sdk/ml/azure-ai-ml/tests/test_configs/datastore/one_lake.yml
+++ b/sdk/ml/azure-ai-ml/tests/test_configs/datastore/one_lake.yml
@@ -10,3 +10,5 @@ credentials:
   tenant_id: 72f988bf-86f1-41af-91ab-2d7cd011db47
   client_id: f7152bb4-cfa5-4cc9-9516-c34b65a10d04
   client_secret: -8BJ_7K1~J2BtbK8-z1oZ-28B2.1mH5ZGg
+  resource_url: https://storage.azure.com
+  authority_url: https://login.microsoftonline.com

--- a/sdk/ml/azure-ai-ml/tests/test_configs/datastore/one_lake_auth_url_back_compat.yml
+++ b/sdk/ml/azure-ai-ml/tests/test_configs/datastore/one_lake_auth_url_back_compat.yml
@@ -1,0 +1,14 @@
+type: one_lake
+name: one_lake_datastore_with_authority_uri
+description: OneLake datastore to test backward compatibility
+one_lake_workspace_name: 01234567-abcd-1234-5678-012345678901
+artifact:
+  name: abcdefgh-0123-4567-8901-abcde0123456
+  type: lake_house
+endpoint: https://onelake.dfs.fabric.microsoft.com
+credentials:
+  tenant_id: 72f988bf-86f1-41af-91ab-2d7cd011db47
+  client_id: f7152bb4-cfa5-4cc9-9516-c34b65a10d04
+  client_secret: -8BJ_7K1~J2BtbK8-z1oZ-28B2.1mH5ZGg
+  resource_url: https://storage.azure.com
+  authority_uri: https://login.microsoftonline.com


### PR DESCRIPTION
# Description

This PR fixes `resource_url` and `authority_url` mapping and handling for datastore service principals.

# All SDK Contribution checklist:
- [X] **The pull request does not introduce [breaking changes]**
- [X] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [X] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [X] Title of the pull request is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [X] Pull request includes test coverage for the included changes.
