### PR TITLE
Add language-settings functions for generic regeneration pipeline support

### DIFF
--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -642,10 +642,11 @@ function Get-python-EmitterAdditionalOptions([string]$projectDirectory) {
 }
 
 function Get-python-DirectoriesForGeneration () {
-  Get-ChildItem "$RepoRoot/sdk" -Directory
+    # TODO: Reenable swagger generation when tox generate supports arbitrary generator versions
+    Get-ChildItem "$RepoRoot/sdk" -Directory
     | Get-ChildItem -Directory
     | Where-Object { $_ -notmatch "-mgmt-" }
-    | Where-Object { (Test-Path "$_/tsp-location.yaml") -or (Test-Path "$_/swagger/README.md") }
+    | Where-Object { (Test-Path "$_/tsp-location.yaml") } # -or (Test-Path "$_/swagger/README.md")
 }
 
 function Update-python-GeneratedSdks([string]$PackageDirectoriesFile) {

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -664,7 +664,7 @@ function Update-python-GeneratedSdks([string]$PackageDirectoriesFile) {
       Write-Host "======================================================================`n"
 
       $toxConfigPath = Resolve-Path "$RepoRoot/eng/tox/tox.ini"
-      Invoke-LoggedCommand "tox run -e generate -c `"$toxConfigPath`" --root ." -GroupOutput
+      Invoke-LoggedCommand "tox run -e generate -c `"$toxConfigPath`" --root ."
     }
     catch {
       Write-Host "##[error]Error generating project under directory $directory"

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -663,7 +663,8 @@ function Update-python-GeneratedSdks([string]$PackageDirectoriesFile) {
       Write-Host "Generating project under directory 'sdk/$directory'" -ForegroundColor Yellow
       Write-Host "======================================================================`n"
 
-      Invoke-LoggedCommand "tox run -e generate -c `"$RepoRoot\eng\tox\tox.ini`" --root ." -GroupOutput
+      $toxConfigPath = Resolve-Path "$RepoRoot/eng/tox/tox.ini"
+      Invoke-LoggedCommand "tox run -e generate -c `"$toxConfigPath`" --root ." -GroupOutput
     }
     catch {
       Write-Host "##[error]Error generating project under directory $directory"

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -642,11 +642,13 @@ function Get-python-EmitterAdditionalOptions([string]$projectDirectory) {
 }
 
 function Get-python-DirectoriesForGeneration () {
-    # TODO: Reenable swagger generation when tox generate supports arbitrary generator versions
     Get-ChildItem "$RepoRoot/sdk" -Directory
     | Get-ChildItem -Directory
     | Where-Object { $_ -notmatch "-mgmt-" }
-    | Where-Object { (Test-Path "$_/tsp-location.yaml") } # -or (Test-Path "$_/swagger/README.md")
+    | Where-Object { (Test-Path "$_/tsp-location.yaml") }
+
+    # TODO: Reenable swagger generation when tox generate supports arbitrary generator versions
+    # -or (Test-Path "$_/swagger/README.md")
 }
 
 function Update-python-GeneratedSdks([string]$PackageDirectoriesFile) {

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -660,7 +660,7 @@ function Update-python-GeneratedSdks([string]$PackageDirectoriesFile) {
       Write-Host "Generating project under directory 'sdk/$directory'" -ForegroundColor Yellow
       Write-Host "======================================================================`n"
 
-      Invoke-LoggedCommand "tox run -e generate" -GroupOutput
+      Invoke-LoggedCommand "tox run -e generate -c `"$RepoRoot\eng\tox\tox.ini`" --root ." -GroupOutput
     }
     catch {
       Write-Host "##[error]Error generating project under directory $directory"

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -642,11 +642,10 @@ function Get-python-EmitterAdditionalOptions([string]$projectDirectory) {
 }
 
 function Get-python-DirectoriesForGeneration () {
-  Get-ChildItem "$RepoRoot/sdk" -Directory
+  return Get-ChildItem "$RepoRoot/sdk" -Directory
   | Get-ChildItem -Directory
   | Where-Object { $_ -notmatch "-mgmt-" }
   | Where-Object { (Test-Path "$_/tsp-location.yaml") }
-
   # TODO: Reenable swagger generation when tox generate supports arbitrary generator versions
   # -or (Test-Path "$_/swagger/README.md")
 }

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -642,13 +642,13 @@ function Get-python-EmitterAdditionalOptions([string]$projectDirectory) {
 }
 
 function Get-python-DirectoriesForGeneration () {
-    Get-ChildItem "$RepoRoot/sdk" -Directory
-    | Get-ChildItem -Directory
-    | Where-Object { $_ -notmatch "-mgmt-" }
-    | Where-Object { (Test-Path "$_/tsp-location.yaml") }
+  Get-ChildItem "$RepoRoot/sdk" -Directory
+  | Get-ChildItem -Directory
+  | Where-Object { $_ -notmatch "-mgmt-" }
+  | Where-Object { (Test-Path "$_/tsp-location.yaml") }
 
-    # TODO: Reenable swagger generation when tox generate supports arbitrary generator versions
-    # -or (Test-Path "$_/swagger/README.md")
+  # TODO: Reenable swagger generation when tox generate supports arbitrary generator versions
+  # -or (Test-Path "$_/swagger/README.md")
 }
 
 function Update-python-GeneratedSdks([string]$PackageDirectoriesFile) {

--- a/tools/azure-sdk-tools/packaging_tools/generate_client.py
+++ b/tools/azure-sdk-tools/packaging_tools/generate_client.py
@@ -23,7 +23,7 @@ def check_post_process(folder: Path) -> bool:
     return False
 
 def run_post_process(folder: Path) -> None:
-    completed_process = run(["autorest", "--postprocess", f"--output-folder={folder}", "--perform-load=false", "--python"], cwd=folder, shell=True)
+    completed_process = run(f"autorest --postprocess --output-folder={folder} --perform-load=false --python", cwd=folder, shell=True)
 
     if completed_process.returncode != 0:
         raise ValueError("Something happened during autorest post processing: " + str(completed_process))
@@ -32,7 +32,7 @@ def run_post_process(folder: Path) -> None:
 def generate_autorest(folder: Path) -> None:
 
     readme_path = folder / "swagger" / "README.md"
-    completed_process = run(["autorest", readme_path, "--python-sdks-folder=../../"], cwd=folder, shell=True)
+    completed_process = run(f"autorest {readme_path} --python-sdks-folder=../../", cwd=folder, shell=True)
 
     if completed_process.returncode != 0:
         raise ValueError("Something happened with autorest: " + str(completed_process))
@@ -50,7 +50,7 @@ def generate_typespec(folder: Path) -> None:
             "https://github.com/Azure/azure-sdk-tools/tree/main/tools/tsp-client/README.md"
         )
 
-    completed_process = run(["tsp-client", "update"], cwd=folder, shell=True, stderr=PIPE)
+    completed_process = run("tsp-client update", cwd=folder, shell=True, stderr=PIPE)
     if completed_process.returncode != 0:
         if "'tsp-client' is not recognized" in completed_process.stderr.decode("utf-8"):
             raise ValueError(


### PR DESCRIPTION
The common autorest preview pipeline requires standard methods in each language's sdk repository.