### PR TITLE
3 Minor changes/fixes.

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/workspace/connections/credentials.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/workspace/connections/credentials.py
@@ -8,7 +8,7 @@ from typing import Dict
 
 from marshmallow import fields, post_load
 
-from azure.ai.ml._restclient.v2023_04_01_preview.models import ConnectionAuthType
+from azure.ai.ml._restclient.v2023_06_01_preview.models import ConnectionAuthType
 from azure.ai.ml._schema.core.fields import StringTransformedEnum
 from azure.ai.ml._schema.core.schema import PatchedSchemaMeta
 from azure.ai.ml._utils.utils import camel_to_snake
@@ -19,6 +19,7 @@ from azure.ai.ml.entities._credentials import (
     ServicePrincipalConfiguration,
     UsernamePasswordConfiguration,
     AccessKeyConfiguration,
+    ApiKeyConfiguration,
 )
 
 
@@ -114,3 +115,16 @@ class AccessKeyConfigurationSchema(metaclass=PatchedSchemaMeta):
     def make(self, data: Dict[str, str], **kwargs) -> AccessKeyConfiguration:
         data.pop("type")
         return AccessKeyConfiguration(**data)
+
+class ApiKeyConfigurationSchema(metaclass=PatchedSchemaMeta):
+    type = StringTransformedEnum(
+        allowed_values=ConnectionAuthType.API_KEY,
+        casing_transform=camel_to_snake,
+        required=True,
+    )
+    key = fields.Str()
+
+    @post_load
+    def make(self, data: Dict[str, str], **kwargs) -> ApiKeyConfiguration:
+        data.pop("type")
+        return ApiKeyConfiguration(**data)

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/workspace/connections/credentials.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/workspace/connections/credentials.py
@@ -116,6 +116,7 @@ class AccessKeyConfigurationSchema(metaclass=PatchedSchemaMeta):
         data.pop("type")
         return AccessKeyConfiguration(**data)
 
+
 class ApiKeyConfigurationSchema(metaclass=PatchedSchemaMeta):
     type = StringTransformedEnum(
         allowed_values=ConnectionAuthType.API_KEY,

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_workspace_hub_operation.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_workspace_hub_operation.py
@@ -191,8 +191,11 @@ class WorkspaceHubOperations(WorkspaceOperationsBase):
             rest_workspace_obj and rest_workspace_obj.kind and rest_workspace_obj.kind.lower() == WORKSPACE_HUB_KIND
         ):
             raise ValidationError("{0} is not a WorkspaceHub".format(name))
-        if hasattr(rest_workspace_obj, "workspace_hub_config") and hasattr(
-            rest_workspace_obj.workspace_hub_config, "additional_workspace_storage_accounts") and rest_workspace_obj.workspace_hub_config.additional_workspace_storage_accounts:
+        if (
+            hasattr(rest_workspace_obj, "workspace_hub_config")
+            and hasattr(rest_workspace_obj.workspace_hub_config, "additional_workspace_storage_accounts")
+            and rest_workspace_obj.workspace_hub_config.additional_workspace_storage_accounts
+        ):
             for storageaccount in rest_workspace_obj.workspace_hub_config.additional_workspace_storage_accounts:
                 delete_resource_by_arm_id(
                     self._credentials,

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_workspace_hub_operation.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_workspace_hub_operation.py
@@ -192,8 +192,7 @@ class WorkspaceHubOperations(WorkspaceOperationsBase):
         ):
             raise ValidationError("{0} is not a WorkspaceHub".format(name))
         if hasattr(rest_workspace_obj, "workspace_hub_config") and hasattr(
-            rest_workspace_obj.workspace_hub_config, "additional_workspace_storage_accounts"
-        ):
+            rest_workspace_obj.workspace_hub_config, "additional_workspace_storage_accounts") and rest_workspace_obj.workspace_hub_config.additional_workspace_storage_accounts:
             for storageaccount in rest_workspace_obj.workspace_hub_config.additional_workspace_storage_accounts:
                 delete_resource_by_arm_id(
                     self._credentials,

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_workspace_operations_base.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_workspace_operations_base.py
@@ -330,8 +330,8 @@ class WorkspaceOperationsBase:
         real_callback = callback
         injected_callback = kwargs.get("cls", None)
         if injected_callback:
-            # pylint: unnecessary-lambda-assignment
-            real_callback = lambda _, deserialized, args: injected_callback(callback(_, deserialized, args))
+            def real_callback(_, deserialized, args):
+                return injected_callback(callback(_, deserialized, args))
 
         poller = self._operation.begin_update(
             resource_group, workspace_name, update_param, polling=True, cls=real_callback

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_workspace_operations_base.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_workspace_operations_base.py
@@ -164,8 +164,8 @@ class WorkspaceOperationsBase:
         real_callback = callback
         injected_callback = kwargs.get("cls", None)
         if injected_callback:
-            # pylint: unnecessary-lambda-assignment
-            real_callback = lambda: injected_callback(callback())
+            def real_callback():
+                return injected_callback(callback())
 
         return LROPoller(
             self._operation._client,

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_workspace_operations_base.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_workspace_operations_base.py
@@ -160,12 +160,12 @@ class WorkspaceOperationsBase:
 
         def callback():
             return get_callback() if get_callback else self.get(workspace.name, resource_group=resource_group)
-        
+
         real_callback = callback
         injected_callback = kwargs.get("cls", None)
         if injected_callback:
+            # pylint: unnecessary-lambda-assignment
             real_callback = lambda: injected_callback(callback())
-        
 
         return LROPoller(
             self._operation._client,
@@ -174,6 +174,7 @@ class WorkspaceOperationsBase:
             CustomArmTemplateDeploymentPollingMethod(poller, arm_submit, real_callback),
         )
 
+    # pylint: too-many-statements
     def begin_update(
         self,
         workspace: Workspace,
@@ -325,13 +326,16 @@ class WorkspaceOperationsBase:
                 if deserialize_callback
                 else Workspace._from_rest_object(deserialized)
             )
+
         real_callback = callback
         injected_callback = kwargs.get("cls", None)
         if injected_callback:
+            # pylint: unnecessary-lambda-assignment
             real_callback = lambda _, deserialized, args: injected_callback(callback(_, deserialized, args))
-        
 
-        poller = self._operation.begin_update(resource_group, workspace_name, update_param, polling=True, cls=real_callback)
+        poller = self._operation.begin_update(
+            resource_group, workspace_name, update_param, polling=True, cls=real_callback
+        )
         return poller
 
     def begin_delete(

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_workspace_operations_base.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_workspace_operations_base.py
@@ -164,6 +164,7 @@ class WorkspaceOperationsBase:
         real_callback = callback
         injected_callback = kwargs.get("cls", None)
         if injected_callback:
+            # pylint: disable=function-redefined
             def real_callback():
                 return injected_callback(callback())
 
@@ -174,7 +175,7 @@ class WorkspaceOperationsBase:
             CustomArmTemplateDeploymentPollingMethod(poller, arm_submit, real_callback),
         )
 
-    # pylint: too-many-statements
+    # pylint: disable=too-many-statements
     def begin_update(
         self,
         workspace: Workspace,
@@ -330,6 +331,7 @@ class WorkspaceOperationsBase:
         real_callback = callback
         injected_callback = kwargs.get("cls", None)
         if injected_callback:
+            # pylint: disable=function-redefined
             def real_callback(_, deserialized, args):
                 return injected_callback(callback(_, deserialized, args))
 


### PR DESCRIPTION
# Description

3 Minor changes/fixes to the SDK

- Adds a schema class for the new ApiKeyConfiguration credential type.
- Adds a small replacement clause in the create/update logic of workspaces to allow for custom poller callbacks to be inputted and not get bashed by internal logic. This is needed for the generative SDK.
- Fixes an NoneType iteration bug in the workspace hub delete operation.

# All SDK Contribution checklist:
Changelog will be updated once the 1.11 changelog PR goes in.

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.

Testing: TODO
