### PR TITLE
[Storage] Add warning for passing `prefix` to `list_blobs` API

### DIFF
--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_container_client.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_container_client.py
@@ -817,10 +817,10 @@ class ContainerClient(StorageAccountHostsMixin, StorageEncryptionMixin):    # py
         if include and not isinstance(include, list):
             include = [include]
 
-        results_per_page = kwargs.pop('results_per_page', None)
         if kwargs.pop('prefix', None):
             warnings.warn("Passing 'prefix' has no effect on filtering, " +
                           "please use the 'name_starts_with' parameter instead.")
+        results_per_page = kwargs.pop('results_per_page', None)
         timeout = kwargs.pop('timeout', None)
         command = functools.partial(
             self._client.container.list_blob_flat_segment,

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_container_client.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_container_client.py
@@ -11,6 +11,7 @@ from typing import (
     TYPE_CHECKING
 )
 from urllib.parse import urlparse, quote, unquote
+import warnings
 
 from typing_extensions import Self
 
@@ -817,6 +818,9 @@ class ContainerClient(StorageAccountHostsMixin, StorageEncryptionMixin):    # py
             include = [include]
 
         results_per_page = kwargs.pop('results_per_page', None)
+        if kwargs.pop('prefix', None):
+            warnings.warn("Passing 'prefix' has no effect on filtering, " +
+                          "please use the 'name_starts_with' parameter instead.")
         timeout = kwargs.pop('timeout', None)
         command = functools.partial(
             self._client.container.list_blob_flat_segment,

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_container_client_async.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_container_client_async.py
@@ -10,6 +10,7 @@ from typing import (  # pylint: disable=unused-import
     Any, AnyStr, AsyncIterable, AsyncIterator, Dict, List, IO, Iterable, Optional, overload, Union,
     TYPE_CHECKING
 )
+import warnings
 
 from azure.core.async_paging import AsyncItemPaged
 from azure.core.exceptions import HttpResponseError, ResourceNotFoundError
@@ -678,6 +679,9 @@ class ContainerClient(AsyncStorageAccountHostsMixin, ContainerClientBase, Storag
         if include and not isinstance(include, list):
             include = [include]
 
+        if kwargs.pop('prefix', None):
+            warnings.warn("Passing 'prefix' has no effect on filtering, " +
+                          "please use the 'name_starts_with' parameter instead.")
         results_per_page = kwargs.pop('results_per_page', None)
         timeout = kwargs.pop('timeout', None)
         command = functools.partial(


### PR DESCRIPTION
There have been a couple customer incidents where passing `prefix` seems to fall off and do nothing. Internally it is `prefix=`, but somewhere along the way of Track1 -> Track2 migration, the parameter for the customer-facing API changed to `name_starts_with`.

To alleviate this, we will raise a warning regarding this behavior.