### PR TITLE
add wrapt explicitly into dev_dep

### DIFF
--- a/sdk/search/azure-search-documents/dev_requirements.txt
+++ b/sdk/search/azure-search-documents/dev_requirements.txt
@@ -3,3 +3,4 @@
 ../../nspkg/azure-search-nspkg
 aiohttp>=3.0
 azure-mgmt-resource<=21.1.0
+wrapt


### PR DESCRIPTION
With removing vcrpy, add wrapt explicitly into dev_dep. We want to remove the dependency on wrapt eventually tracked in https://github.com/Azure/azure-sdk-for-python/issues/32027.