### PR TITLE
[Storage] Improve `query_blob` docs

### DIFF
--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_client.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_client.py
@@ -1005,7 +1005,8 @@ class BlobClient(StorageAccountHostsMixin, StorageEncryptionMixin):  # pylint: d
         This operations returns a BlobQueryReader, users need to use readall() or readinto() to get query data.
 
         :param str query_expression:
-            Required. a query statement.
+            Required. a query statement. For more details see
+            https://learn.microsoft.com/azure/storage/blobs/query-acceleration-sql-reference.
         :keyword Callable[~azure.storage.blob.BlobQueryError] on_error:
             A function to be called on any processing errors returned by the service.
         :keyword blob_format:

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_client.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_client.py
@@ -1006,7 +1006,7 @@ class BlobClient(StorageAccountHostsMixin, StorageEncryptionMixin):  # pylint: d
 
         :param str query_expression:
             Required. a query statement. For more details see
-            https://learn.microsoft.com/azure/storage/blobs/query-acceleration-sql-reference.
+            https://learn.microsoft.com/azure/storage/blobs/query-acceleration-sql-reference
         :keyword Callable[~azure.storage.blob.BlobQueryError] on_error:
             A function to be called on any processing errors returned by the service.
         :keyword blob_format:

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_client.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_client.py
@@ -1006,7 +1006,7 @@ class BlobClient(StorageAccountHostsMixin, StorageEncryptionMixin):  # pylint: d
 
         :param str query_expression:
             Required. a query statement. For more details see
-            https://learn.microsoft.com/azure/storage/blobs/query-acceleration-sql-reference
+            https://learn.microsoft.com/azure/storage/blobs/query-acceleration-sql-reference.
         :keyword Callable[~azure.storage.blob.BlobQueryError] on_error:
             A function to be called on any processing errors returned by the service.
         :keyword blob_format:


### PR DESCRIPTION
As brought up in #31997, it can be difficult to understand how to use the `query_blob` API. To improve this experience, we will add a link to the documentation right in the docstring.