### PR TITLE
Compatibility between 12.18 and <12.18 through dynamic insertion of sdk_moniker

### DIFF
--- a/sdk/storage/azure-storage-blob/CHANGELOG.md
+++ b/sdk/storage/azure-storage-blob/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release History
 
+## 12.18.1 (2023-09-13)
+
+### Bugs Fixed
+- compatibility between 12.18 and <12.18 through dynamic insertion of sdk_moniker
+
 ## 12.18.0 (2023-09-12)
 
 ### Features Added

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/base_client.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/base_client.py
@@ -410,9 +410,11 @@ def parse_connection_str(conn_str, credential, service):
 
 def create_configuration(**kwargs):
     # type: (**Any) -> Configuration
+    if not kwargs.get("skd_moniker"):
+        kwargs["sdk_moniker"] = f"storage-{kwargs.get("storage-sdk")}/{VERSION}"
     config = Configuration(**kwargs)
     config.headers_policy = StorageHeadersPolicy(**kwargs)
-    config.user_agent_policy = UserAgentPolicy(sdk_moniker=kwargs.pop('sdk_moniker'), **kwargs)
+    config.user_agent_policy = UserAgentPolicy(**kwargs)
     config.retry_policy = kwargs.get("retry_policy") or ExponentialRetry(**kwargs)
     config.logging_policy = StorageLoggingPolicy(**kwargs)
     config.proxy_policy = ProxyPolicy(**kwargs)

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/base_client.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/base_client.py
@@ -411,7 +411,7 @@ def parse_connection_str(conn_str, credential, service):
 def create_configuration(**kwargs):
     # type: (**Any) -> Configuration
     if not kwargs.get("skd_moniker"):
-        kwargs["sdk_moniker"] = f"storage-{kwargs.get("storage-sdk")}/{VERSION}"
+        kwargs["sdk_moniker"] = f"storage-{kwargs.get("storage-sdk")}"
     config = Configuration(**kwargs)
     config.headers_policy = StorageHeadersPolicy(**kwargs)
     config.user_agent_policy = UserAgentPolicy(**kwargs)


### PR DESCRIPTION
# Description

Fixes [this reported issue](https://github.com/Azure/azure-sdk-for-python/issues/32056) whereby create_configuration with throw an error in the latest version if sdk_moniker is not given as a kwarg, buit will throw an error in previous versions if it is.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes. (I can't see any test suite for the impacted code?)
