### PR TITLE
[Azure AMQP] Handle Websocket Disconnect in Async

### DIFF
--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_transport_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_transport_async.py
@@ -540,7 +540,11 @@ class WebSocketTransportAsync(
                     self._read_buffer = BytesIO(data[toread:])
                     toread = 0
             return view
-        except:
+        except TypeError as te:
+            # aiohttp websocket raises TypeError when a websocket disconnects, as it ends up
+            # reading None over the wire and cant convert to bytes.
+            raise ConnectionError("Websocket disconnected: %r" % te) from None
+        except Exception:
             self._read_buffer = BytesIO(view[:length])
             raise
 

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_transport_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_transport_async.py
@@ -528,23 +528,24 @@ class WebSocketTransportAsync(
         length += nbytes
         toread -= nbytes
         try:
-            while toread:
-                data = await self.sock.receive_bytes()
-                read_length = len(data)
-                if read_length <= toread:
-                    view[length : length + read_length] = data
-                    toread -= read_length
-                    length += read_length
-                else:
-                    view[length : length + toread] = data[0:toread]
-                    self._read_buffer = BytesIO(data[toread:])
-                    toread = 0
-            return view
-        except TypeError as te:
-            # aiohttp websocket raises TypeError when a websocket disconnects, as it ends up
-            # reading None over the wire and cant convert to bytes.
-            raise ConnectionError("Websocket disconnected: %r" % te) from None
-        except Exception:
+            try:
+                while toread:
+                    data = await self.sock.receive_bytes()
+                    read_length = len(data)
+                    if read_length <= toread:
+                        view[length : length + read_length] = data
+                        toread -= read_length
+                        length += read_length
+                    else:
+                        view[length : length + toread] = data[0:toread]
+                        self._read_buffer = BytesIO(data[toread:])
+                        toread = 0
+                return view
+            except TypeError as te:
+                # aiohttp websocket raises TypeError when a websocket disconnects, as it ends up
+                # reading None over the wire and cant convert to bytes.
+                raise ConnectionError("Websocket disconnected: %r" % te) from None
+        except:
             self._read_buffer = BytesIO(view[:length])
             raise
 

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_transport_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_transport_async.py
@@ -540,7 +540,11 @@ class WebSocketTransportAsync(
                     self._read_buffer = BytesIO(data[toread:])
                     toread = 0
             return view
-        except:
+        except TypeError as te:
+            # aiohttp websocket raises TypeError when a websocket disconnects, as it ends up
+            # reading None over the wire and cant convert to bytes.
+            raise ConnectionError("Websocket disconnected: %r" % te) from None
+        except Exception:
             self._read_buffer = BytesIO(view[:length])
             raise
 

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_transport_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_transport_async.py
@@ -528,23 +528,24 @@ class WebSocketTransportAsync(
         length += nbytes
         toread -= nbytes
         try:
-            while toread:
-                data = await self.sock.receive_bytes()
-                read_length = len(data)
-                if read_length <= toread:
-                    view[length : length + read_length] = data
-                    toread -= read_length
-                    length += read_length
-                else:
-                    view[length : length + toread] = data[0:toread]
-                    self._read_buffer = BytesIO(data[toread:])
-                    toread = 0
-            return view
-        except TypeError as te:
-            # aiohttp websocket raises TypeError when a websocket disconnects, as it ends up
-            # reading None over the wire and cant convert to bytes.
-            raise ConnectionError("Websocket disconnected: %r" % te) from None
-        except Exception:
+            try:
+                while toread:
+                    data = await self.sock.receive_bytes()
+                    read_length = len(data)
+                    if read_length <= toread:
+                        view[length : length + read_length] = data
+                        toread -= read_length
+                        length += read_length
+                    else:
+                        view[length : length + toread] = data[0:toread]
+                        self._read_buffer = BytesIO(data[toread:])
+                        toread = 0
+                return view
+            except TypeError as te:
+                # aiohttp websocket raises TypeError when a websocket disconnects, as it ends up
+                # reading None over the wire and cant convert to bytes.
+                raise ConnectionError("Websocket disconnected: %r" % te) from None
+        except:
             self._read_buffer = BytesIO(view[:length])
             raise
 


### PR DESCRIPTION
Simple fix to handle a websocket disconnect or close as aiohttp raises a `TypeError` while asserting bytes. This fix will also cause the retry loop to execute properly.

Unit tests have not been added since we cannot trigger an OSError. When comparing to stress tests results without the fix, we see that stress tests with this fix no longer raise the 257: None is not bytes/WSMsgType.Binary error.