### PR TITLE
Update Sphinx to v6.x

### DIFF
--- a/doc/sphinx/conf.py
+++ b/doc/sphinx/conf.py
@@ -55,13 +55,12 @@ for example_file in all_files:
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = ['sphinx.ext.autodoc', 'sphinx.ext.autosummary', 'sphinx.ext.doctest',
-              'sphinx.ext.viewcode', 'sphinx.ext.intersphinx', 'sphinx.ext.napoleon']
+              'sphinx.ext.viewcode', 'sphinx.ext.intersphinx', 'sphinx.ext.napoleon',
+              'myst_parser']
 
 intersphinx_mapping = {
     # Dependencies
-    'python': ('https://docs.python.org/3.8', ('/usr/share/doc/python3-doc/html/objects.inv', None)),
-    'msrestazure': ('http://msrestazure.readthedocs.io/en/latest/', None),
-    'msrest': ('http://msrest.readthedocs.io/en/latest/', None),
+    'python': ('https://docs.python.org/3.11', ('/usr/share/doc/python3-doc/html/objects.inv', None)),
     'requests': ('https://requests.kennethreitz.org/en/master/', None),
     'aiohttp': ('https://aiohttp.readthedocs.io/en/stable/', None),
     'trio': ('https://trio.readthedocs.io/en/stable/', None),
@@ -76,9 +75,6 @@ autodoc_member_order = 'groupwise'
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 
-source_parsers = {
-   '.md': 'recommonmark.parser.CommonMarkParser',
-}
 
 # The suffix of source filenames.
 source_suffix = ['.rst', '.md']

--- a/doc/sphinx/individual_build_conf.py
+++ b/doc/sphinx/individual_build_conf.py
@@ -53,13 +53,12 @@ import sphinx_rtd_theme
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = ['sphinx.ext.autodoc', 'sphinx.ext.autosummary', 'sphinx.ext.doctest',
-              'sphinx.ext.viewcode', 'sphinx.ext.intersphinx', 'sphinx.ext.napoleon']
+              'sphinx.ext.viewcode', 'sphinx.ext.intersphinx', 'sphinx.ext.napoleon',
+              'myst_parser']
 
 intersphinx_mapping = {
     # Dependencies
-    'python': ('https://docs.python.org/3.8', None),
-    'msrestazure': ('http://msrestazure.readthedocs.io/en/latest/', None),
-    'msrest': ('http://msrest.readthedocs.io/en/latest/', None),
+    'python': ('https://docs.python.org/3.11', None),
     'requests': ('https://requests.kennethreitz.org/en/master/', None),
     'aiohttp': ('https://aiohttp.readthedocs.io/en/stable/', None),
     'trio': ('https://trio.readthedocs.io/en/stable/', None),
@@ -73,10 +72,6 @@ autodoc_member_order = 'groupwise'
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
-
-source_parsers = {
-   '.md': 'recommonmark.parser.CommonMarkParser',
-}
 
 # The suffix of source filenames.
 source_suffix = ['.rst', '.md']

--- a/doc/sphinx/requirements.txt
+++ b/doc/sphinx/requirements.txt
@@ -1,3 +1,3 @@
 sphinx
 sphinx_rtd_theme
-recommonmark
+myst-parser

--- a/eng/ci_tools.txt
+++ b/eng/ci_tools.txt
@@ -2,7 +2,7 @@
 setuptools==67.6.0; python_version >= '3.5'
 virtualenv==20.23.0
 wheel==0.37.0
-Jinja2==2.11.2
+Jinja2==3.1.2
 packaging==23.1
 tox==4.5.0
 twine==3.1.1; python_version >= '3.6'
@@ -13,7 +13,7 @@ pkginfo==1.5.0.1
 pip==20.3.3
 wrapt==1.12.1; python_version <= '3.10'
 wrapt==1.14.1; python_version >= '3.11'
-markupsafe==2.0.1
+MarkupSafe==2.1.3
 typing-extensions<=4.6.3
 
 # locking packages defined as deps from azure-sdk-tools or azure-devtools

--- a/eng/regression_test_tools.txt
+++ b/eng/regression_test_tools.txt
@@ -21,9 +21,8 @@ ConfigArgParse==1.2.3
 six==1.14.0
 pyyaml==5.3.1
 packaging==23.1
-Jinja2==2.11.2
-markupsafe==2.0.1; python_version > '2.7'
-markupsafe==1.1.1; python_version == '2.7'
+Jinja2==3.1.2
+MarkupSafe==2.1.3
 wrapt==1.12.1; python_version <= '3.10'
 wrapt==1.14.1; python_version >= '3.11'
 

--- a/eng/regression_tools.txt
+++ b/eng/regression_tools.txt
@@ -2,7 +2,7 @@
 setuptools==67.6.0; python_version >= '3.5'
 virtualenv==20.23.0
 wheel==0.37.0
-Jinja2==2.11.2
+Jinja2==3.1.2
 packaging==23.1
 tox==4.5.0
 twine==3.1.1; python_version >= '3.6'
@@ -13,7 +13,7 @@ pkginfo==1.5.0.1
 pip==20.3.3
 wrapt==1.12.1; python_version <= '3.10'
 wrapt==1.14.1; python_version >= '3.11'
-markupsafe==2.0.1
+MarkupSafe==2.1.3
 typing-extensions<=4.6.3
 
 # locking packages defined as deps from azure-sdk-tools or azure-devtools

--- a/eng/test_tools.txt
+++ b/eng/test_tools.txt
@@ -20,9 +20,8 @@ ConfigArgParse==1.2.3
 six==1.14.0
 pyyaml==5.3.1
 packaging==23.1
-Jinja2==2.11.2
-markupsafe==2.0.1; python_version > '2.7'
-markupsafe==1.1.1; python_version == '2.7'
+Jinja2==3.1.2
+MarkupSafe==2.1.3
 wrapt==1.12.1; python_version <= '3.10'
 wrapt==1.14.1; python_version >= '3.11'
 pyproject-api<1.6.0

--- a/eng/tox/prep_sphinx_env.py
+++ b/eng/tox/prep_sphinx_env.py
@@ -8,8 +8,6 @@
 # This script is intended to be executed from within a tox script. It takes care of of unzipping
 # an package sdist and prepping for a sphinx execution.
 
-from m2r import parse_from_file
-
 import glob
 import logging
 import shutil
@@ -30,19 +28,21 @@ logging.getLogger().setLevel(logging.INFO)
 
 RST_EXTENSION_FOR_INDEX = """
 
-Indices and tables
-------------------
+## Indices and tables
 
-* :ref:`genindex`
-* :ref:`modindex`
-* :ref:`search`
+- {{ref}}`genindex`
+- {{ref}}`modindex`
+- {{ref}}`search`
 
-.. toctree::
-  :maxdepth: 5
-  :glob:
-  :caption: Developer Documentation
+```{{toctree}}
+:caption: Developer Documentation
+:glob: true
+:maxdepth: 5
 
-  {}
+{}
+
+```
+
 """
 
 root_dir = os.path.abspath(os.path.join(os.path.abspath(__file__), "..", "..", ".."))
@@ -56,8 +56,6 @@ def create_index_file(readme_location, package_rst):
     readme_ext = os.path.splitext(readme_location)[1]
 
     if readme_ext == ".md":
-        output = parse_from_file(readme_location)
-    elif readme_ext == ".rst":
         with open(readme_location, "r") as file:
             output = file.read()
     else:
@@ -83,20 +81,17 @@ def create_index(doc_folder, source_location, namespace):
     index_content = ""
 
     package_rst = "{}.rst".format(namespace)
-    content_destination = os.path.join(doc_folder, "index.rst")
+    content_destination = os.path.join(doc_folder, "index.md")
 
     if not os.path.exists(doc_folder):
         os.mkdir(doc_folder)
 
     # grep all content
     markdown_readmes = glob.glob(os.path.join(source_location, "README.md"))
-    rst_readmes = glob.glob(os.path.join(source_location, "README.rst"))
 
     # if markdown, take that, otherwise rst
     if markdown_readmes:
         index_content = create_index_file(markdown_readmes[0], package_rst)
-    elif rst_readmes:
-        index_content = create_index_file(rst_readmes[0], package_rst)
     else:
         logging.warning("No readmes detected for this namespace {}".format(namespace))
         index_content = RST_EXTENSION_FOR_INDEX.format(package_rst)

--- a/eng/tox/tox.ini
+++ b/eng/tox/tox.ini
@@ -314,11 +314,9 @@ setenv =
   PROXY_URL=http://localhost:5007
 deps =
   {[base]deps}
-  sphinx==3.5.4
-  sphinx_rtd_theme==1.0.0
-  recommonmark==0.6.0
-  mistune<2.0.0
-  m2r==0.2.1
+  sphinx==6.2.1
+  sphinx_rtd_theme==1.3.0
+  myst_parser==2.0.0
 commands =
   python {repository_root}/eng/tox/create_package_and_install.py \
     -d {envtmpdir}/dist \

--- a/sdk/core/azure-core/tests/testserver_tests/coretestserver/setup.py
+++ b/sdk/core/azure-core/tests/testserver_tests/coretestserver/setup.py
@@ -32,6 +32,6 @@ setup(
     ],
     packages=find_packages(),
     install_requires=[
-        "flask==1.1.4",
+        "flask==2.3.3",
     ],
 )

--- a/tools/azure-sdk-tools/setup.py
+++ b/tools/azure-sdk-tools/setup.py
@@ -8,8 +8,8 @@ DEPENDENCIES = [
     # Packaging
     "packaging",
     "wheel",
-    "Jinja2",
-    "MarkupSafe==2.0.1",
+    "Jinja2>=3.1.2",
+    "MarkupSafe",
     # black,
     "pytoml",
     "json-delta>=2.0",


### PR DESCRIPTION
Move Sphinx to v6.x (matches the doc website version).

Few notes:
- Supports only MD now as Readme input format (we don't have RST anymore anyway)
- Don't convert those MD to RST, let Sphinx deal with it himself
- Update Jinja in a few places to latest version
- Remove deprecated sphinx plugin for MD, and use current recommendation myst-parser

cc @scbedd 