### PR TITLE
[pyright] remove warnings which tend to disagree with mypy

### DIFF
--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,6 +1,4 @@
 {
-  "reportUnnecessaryCast": "warning",
-  "reportUnnecessaryTypeIgnoreComment": "warning",
   "reportTypeCommentUsage": true,
   "reportMissingImports": false,
   "pythonVersion": "3.7"


### PR DESCRIPTION
These pyright config options are opt-in. While they seem useful, they tend to conflict with what mypy wants most of the time, turning them into just noise. By removing, they default back to "none" which means they are turned off for pyright.