### PR TITLE
[Monitor][Otel][Exporter] Fix for disabled storage shoutdown

### DIFF
--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/logs/_exporter.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/logs/_exporter.py
@@ -62,7 +62,8 @@ class AzureMonitorLogExporter(BaseExporter, LogExporter):
 
         Called when the SDK is shut down.
         """
-        self.storage.close()
+        if self.storage:
+            self.storage.close()
 
     def _log_to_envelope(self, log_data: LogData) -> TelemetryItem:
         if not log_data:

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/logs/test_logs.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/logs/test_logs.py
@@ -154,6 +154,7 @@ class TestAzureLogExporter(unittest.TestCase):
             exporter._instrumentation_key,
             "4321abcd-5678-4efa-8abc-1234567890ab",
         )
+        self.assertIsNotNone(exporter.storage)
 
     def test_from_connection_string(self):
         exporter = AzureMonitorLogExporter.from_connection_string(
@@ -317,6 +318,10 @@ class TestAzureLogExporter(unittest.TestCase):
 
 class TestAzureLogExporterWithDisabledStorage(TestAzureLogExporter):
     _exporter_class = partial(AzureMonitorLogExporter, disable_offline_storage=True)
+    
+    @classmethod
+    def tearDownClass(cls):
+        pass
     
     def test_constructor(self):
         """Test the constructor."""


### PR DESCRIPTION
# Description

I noticed that, if I'm shutting down my application that has AzureMonitorLogExporter running with disabled offline storage, then on shutdown I get `NoneType object has no attribute close`.

I think that exporter for trace and metrics would require similar changes or shutdown implementation shut be moved to `BaseExporter`.

Tests are passing locally.

Trace log:
```
Error in atexit._run_exitfuncs:
Traceback (most recent call last):
  File "/home/vsts/.local/share/virtualenvs/s-8OsOGiLq/lib/python3.9/site-packages/opentelemetry/sdk/_logs/_internal/__init__.py", line 630, in shutdown
    self._multi_log_record_processor.shutdown()
  File "/home/vsts/.local/share/virtualenvs/s-8OsOGiLq/lib/python3.9/site-packages/opentelemetry/sdk/_logs/_internal/__init__.py", line 301, in shutdown
    lp.shutdown()
  File "/home/vsts/.local/share/virtualenvs/s-8OsOGiLq/lib/python3.9/site-packages/opentelemetry/sdk/_logs/_internal/export/__init__.py", line 368, in shutdown
    self._exporter.shutdown()
  File "/home/vsts/.local/share/virtualenvs/s-8OsOGiLq/lib/python3.9/site-packages/azure/monitor/opentelemetry/exporter/export/logs/_exporter.py", line 59, in shutdown
    self.storage.close()
AttributeError: 'NoneType' object has no attribute 'close'
Error in atexit._run_exitfuncs:
Traceback (most recent call last):
  File "/home/vsts/.local/share/virtualenvs/s-8OsOGiLq/lib/python3.9/site-packages/opentelemetry/sdk/_logs/_internal/__init__.py", line 630, in shutdown
    self._multi_log_record_processor.shutdown()
  File "/home/vsts/.local/share/virtualenvs/s-8OsOGiLq/lib/python3.9/site-packages/opentelemetry/sdk/_logs/_internal/__init__.py", line 301, in shutdown
    lp.shutdown()
  File "/home/vsts/.local/share/virtualenvs/s-8OsOGiLq/lib/python3.9/site-packages/opentelemetry/sdk/_logs/_internal/export/__init__.py", line 368, in shutdown
    self._exporter.shutdown()
  File "/home/vsts/.local/share/virtualenvs/s-8OsOGiLq/lib/python3.9/site-packages/azure/monitor/opentelemetry/exporter/export/logs/_exporter.py", line 59, in shutdown
    self.storage.close()
AttributeError: 'NoneType' object has no attribute 'close'
```

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
