### PR TITLE
[ML][Pipelines] fix: resolve jobs.xxx.inputs for subgraph

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_component_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_component_operations.py
@@ -760,7 +760,7 @@ class ComponentOperations(_ScopeDependentOperations):
     def _resolve_azureml_id(self, component: Component, jobs_only: bool = False) -> None:
         # TODO: remove the parameter `jobs_only`. Some tests are expecting an arm id after resolving for now.
         resolver = self._orchestrators.resolve_azureml_id
-        self._resolve_dependencies_for_component(component, resolver, resolve_jobs_inputs=True, jobs_only=jobs_only)
+        self._resolve_dependencies_for_component(component, resolver, jobs_only=jobs_only)
 
     def _resolve_arm_id_or_upload_dependencies(self, component: Component) -> None:
         resolver = OperationOrchestrator(
@@ -774,7 +774,6 @@ class ComponentOperations(_ScopeDependentOperations):
         component: Component,
         resolver: Callable,
         *,
-        resolve_jobs_inputs: bool = False,
         jobs_only: bool = False,
     ) -> None:
         # for now, many tests are expecting long arm id instead of short id for environment and code
@@ -805,7 +804,6 @@ class ComponentOperations(_ScopeDependentOperations):
         self._resolve_dependencies_for_pipeline_component_jobs(
             component,
             resolver=resolver,
-            resolve_inputs=resolve_jobs_inputs,
         )
 
     def _resolve_inputs_for_pipeline_component_jobs(self, jobs: Dict[str, Any], base_path: str):
@@ -1049,7 +1047,9 @@ class ComponentOperations(_ScopeDependentOperations):
         return self._client_key
 
     def _resolve_dependencies_for_pipeline_component_jobs(
-        self, component: Union[Component, str], resolver: _AssetResolver, *, resolve_inputs: bool = True
+        self,
+        component: Union[Component, str],
+        resolver: _AssetResolver,
     ):
         """Resolve dependencies for pipeline component jobs.
         Will directly return if component is not a pipeline component.
@@ -1066,8 +1066,7 @@ class ComponentOperations(_ScopeDependentOperations):
 
         from azure.ai.ml.entities._job.automl.automl_job import AutoMLJob
 
-        if resolve_inputs:
-            self._resolve_inputs_for_pipeline_component_jobs(component.jobs, component._base_path)
+        self._resolve_inputs_for_pipeline_component_jobs(component.jobs, component._base_path)
 
         # This is a preparation for concurrent resolution. Nodes will be resolved later layer by layer
         # from bottom to top, as hash calculation of a parent node will be impacted by resolution

--- a/sdk/ml/azure-ai-ml/tests/component/e2etests/test_component.py
+++ b/sdk/ml/azure-ai-ml/tests/component/e2etests/test_component.py
@@ -832,7 +832,7 @@ class TestComponent(AzureRecordedTestCase):
         )
         # Assert binding on compute not changed after resolve dependencies
         client.components._resolve_dependencies_for_pipeline_component_jobs(
-            component, resolver=client.components._orchestrators.get_asset_arm_id, resolve_inputs=False
+            component, resolver=client.components._orchestrators.get_asset_arm_id
         )
         assert component.jobs["component_a_job"].compute == "${{parent.inputs.node_compute}}"
         # Assert E2E

--- a/sdk/ml/azure-ai-ml/tests/dsl/e2etests/test_dsl_pipeline.py
+++ b/sdk/ml/azure-ai-ml/tests/dsl/e2etests/test_dsl_pipeline.py
@@ -1132,7 +1132,7 @@ class TestDSLPipeline(AzureRecordedTestCase):
 
         # Assert binding on compute not changed after resolve dependencies
         client.components._resolve_dependencies_for_pipeline_component_jobs(
-            component, resolver=client.components._orchestrators.get_asset_arm_id, resolve_inputs=False
+            component, resolver=client.components._orchestrators.get_asset_arm_id
         )
         assert component.jobs["node2"].compute == "${{parent.inputs.node_compute}}"
 


### PR DESCRIPTION
# Description

Fix a bug that jobs.xxx.inputs won't be resolved for subgraph.

for example, below code will lead to service error as local path input hasn't been uploaded:
```python
@dsl.pipeline
def subgraph()
  component_func(component_in_path=Input(path="<local-path>"))

@dsl.pipeline
def graph()
  subgraph()
```

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
