### PR TITLE
[Storage] Fix `user_agent` on method calls with encryption

### DIFF
--- a/sdk/storage/azure-storage-blob/assets.json
+++ b/sdk/storage/azure-storage-blob/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "python",
   "TagPrefix": "python/storage/azure-storage-blob",
-  "Tag": "python/storage/azure-storage-blob_2fc7da368a"
+  "Tag": "python/storage/azure-storage-blob_d1c5556817"
 }

--- a/sdk/storage/azure-storage-blob/tests/test_blob_encryption_v2_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_blob_encryption_v2_async.py
@@ -1067,9 +1067,24 @@ class TestStorageBlobEncryptionV2Async(AsyncStorageRecordedTestCase):
         storage_account_key = kwargs.pop("storage_account_key")
 
         await self._setup(storage_account_name, storage_account_key)
+        kek = KeyWrapper('key1')
+        self.enable_encryption_v2(kek)
 
         app_id = 'TestAppId'
-        kek = KeyWrapper('key1')
+        content = b'Hello World Encrypted!'
+
+        def assert_user_agent(request):
+            start = f'{app_id} azstorage-clientsideencryption/2.0 '
+            assert request.http_request.headers['User-Agent'].startswith(start)
+
+        # Test method level keyword
+        blob = self.bsc.get_blob_client(self.container_name, self._get_blob_reference())
+
+        with mock.patch('os.urandom', mock_urandom):
+            await blob.upload_blob(content, overwrite=True, raw_request_hook=assert_user_agent, user_agent=app_id)
+        await (await blob.download_blob(raw_request_hook=assert_user_agent, user_agent=app_id)).readall()
+
+        # Test client constructor level keyword
         bsc = BlobServiceClient(
             self.bsc.url,
             credential=storage_account_key,
@@ -1078,14 +1093,8 @@ class TestStorageBlobEncryptionV2Async(AsyncStorageRecordedTestCase):
             key_encryption_key=kek,
             user_agent=app_id)
 
-        def assert_user_agent(request):
-            start = f'{app_id} azstorage-clientsideencryption/2.0 '
-            assert request.http_request.headers['User-Agent'].startswith(start)
-
         blob = bsc.get_blob_client(self.container_name, self._get_blob_reference())
-        content = b'Hello World Encrypted!'
 
-        # Act
         with mock.patch('os.urandom', mock_urandom):
             await blob.upload_blob(content, overwrite=True, raw_request_hook=assert_user_agent)
         await (await blob.download_blob(raw_request_hook=assert_user_agent)).readall()

--- a/sdk/storage/azure-storage-queue/assets.json
+++ b/sdk/storage/azure-storage-queue/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "python",
   "TagPrefix": "python/storage/azure-storage-queue",
-  "Tag": "python/storage/azure-storage-queue_600330aa3b"
+  "Tag": "python/storage/azure-storage-queue_4096c52c38"
 }

--- a/sdk/storage/azure-storage-queue/tests/test_queue_encryption_async.py
+++ b/sdk/storage/azure-storage-queue/tests/test_queue_encryption_async.py
@@ -781,6 +781,42 @@ class TestAsyncStorageQueueEncryption(AsyncStorageRecordedTestCase):
         # Assert
         assert content == decrypted_data
 
+    @QueuePreparer()
+    @recorded_by_proxy_async
+    async def test_encryption_user_agent(self, **kwargs):
+        storage_account_name = kwargs.pop("storage_account_name")
+        storage_account_key = kwargs.pop("storage_account_key")
+
+        app_id = 'TestAppId'
+        content = 'Hello World Encrypted!'
+        kek = KeyWrapper('key1')
+
+        def assert_user_agent(request):
+            start = f'{app_id} azstorage-clientsideencryption/2.0 '
+            assert request.http_request.headers['User-Agent'].startswith(start)
+
+        # Test method level keyword
+        qsc = QueueServiceClient(
+            self.account_url(storage_account_name, "queue"),
+            storage_account_key,
+            require_encryption=True,
+            encryption_version='2.0',
+            key_encryption_key=kek)
+        queue = await self._create_queue(qsc)
+        await queue.send_message(content, raw_request_hook=assert_user_agent, user_agent=app_id)
+
+        # Test client constructor level keyword
+        qsc = QueueServiceClient(
+            self.account_url(storage_account_name, "queue"),
+            storage_account_key,
+            require_encryption=True,
+            encryption_version='2.0',
+            key_encryption_key=kek,
+            user_agent=app_id)
+
+        queue = self._get_queue_reference(qsc)
+        await queue.send_message(content, raw_request_hook=assert_user_agent)
+
 
 # ------------------------------------------------------------------------------
 if __name__ == '__main__':


### PR DESCRIPTION
A previous change for modifying the user agent header for calls using client-side encryption made it so we would ignore a user-specified `user_agent` keyword on method calls that used client-side encryption. We would no longer prepend that value to the beginning of the `User-Agent` header. This change addresses that by ensuring we account for the `user_agent` keyword when modifying the user agent string.

This was a breaking change to these APIs and will be released in a patch.