### PR TITLE
Add ability to configure which logger to collect telemetry for Azure monitor distro

### DIFF
--- a/sdk/monitor/azure-monitor-opentelemetry/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-opentelemetry/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Features Added
 
+- Add ability to specify which logger to export telemetry for via `logger_name` configuration
+    ([#32087](https://github.com/Azure/azure-sdk-for-python/pull/32087))
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/monitor/azure-monitor-opentelemetry/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-opentelemetry/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Features Added
 
 - Add ability to specify which logger to export telemetry for via `logger_name` configuration
-    ([#32087](https://github.com/Azure/azure-sdk-for-python/pull/32087))
+    ([#32192](https://github.com/Azure/azure-sdk-for-python/pull/32192))
 
 ### Breaking Changes
 

--- a/sdk/monitor/azure-monitor-opentelemetry/README.md
+++ b/sdk/monitor/azure-monitor-opentelemetry/README.md
@@ -59,7 +59,7 @@ You can use `configure_azure_monitor` to set up instrumentation for your app to 
 | Parameter | Description | Environment Variable |
 |-------------------|----------------------------------------------------|----------------------|
 | `connection_string` | The [connection string][connection_string_doc] for your Application Insights resource. The connection string will be automatically populated from the `APPLICATIONINSIGHTS_CONNECTION_STRING` environment variable if not explicitly passed in. | `APPLICATIONINSIGHTS_CONNECTION_STRING` |
-
+| `logger_name` | The name of the [Python logger][python_logger] and all of it's children loggers that you want to collect telemetry for. | `N/A` |
 
 You can configure further with [OpenTelemetry environment variables][ot_env_vars] such as:
 | Environment Variable | Description |
@@ -130,8 +130,6 @@ contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additio
 [connection_string_doc]: https://learn.microsoft.com/azure/azure-monitor/app/sdk-connection-string
 [distro_feature_request]: https://github.com/Azure/azure-sdk-for-python/issues/new
 [exporter_configuration_docs]: https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/monitor/azure-monitor-opentelemetry-exporter#configuration
-[logging_level]: https://docs.python.org/3/library/logging.html#levels
-[logger_name_hierarchy_doc]: https://docs.python.org/3/library/logging.html#logger-objects
 [ot_env_vars]: https://opentelemetry.io/docs/reference/specification/sdk-environment-variables/
 [ot_instrumentations]: https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation
 [ot_metric_reader]: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#metricreader
@@ -165,5 +163,7 @@ contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additio
 [pypi_urllib]: https://docs.python.org/3/library/urllib.html
 [pypi_urllib3]: https://pypi.org/project/urllib3/
 [python]: https://www.python.org/downloads/
+[python_logger]: https://docs.python.org/3/library/logging.html#logger-objects
+[python_logging_level]: https://docs.python.org/3/library/logging.html#levels
 [samples]: https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/monitor/azure-monitor-opentelemetry/samples
 [samples_manual]: https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/monitor/azure-monitor-opentelemetry/samples/tracing/manual.py

--- a/sdk/monitor/azure-monitor-opentelemetry/README.md
+++ b/sdk/monitor/azure-monitor-opentelemetry/README.md
@@ -59,7 +59,7 @@ You can use `configure_azure_monitor` to set up instrumentation for your app to 
 | Parameter | Description | Environment Variable |
 |-------------------|----------------------------------------------------|----------------------|
 | `connection_string` | The [connection string][connection_string_doc] for your Application Insights resource. The connection string will be automatically populated from the `APPLICATIONINSIGHTS_CONNECTION_STRING` environment variable if not explicitly passed in. | `APPLICATIONINSIGHTS_CONNECTION_STRING` |
-| `logger_name` | The name of the [Python logger][python_logger] and all of it's children loggers that you want to collect telemetry for. | `N/A` |
+| `logger_name` | The name of the [Python logger][python_logger] to collect telemetry for. | `N/A` |
 
 You can configure further with [OpenTelemetry environment variables][ot_env_vars] such as:
 | Environment Variable | Description |

--- a/sdk/monitor/azure-monitor-opentelemetry/README.md
+++ b/sdk/monitor/azure-monitor-opentelemetry/README.md
@@ -59,7 +59,7 @@ You can use `configure_azure_monitor` to set up instrumentation for your app to 
 | Parameter | Description | Environment Variable |
 |-------------------|----------------------------------------------------|----------------------|
 | `connection_string` | The [connection string][connection_string_doc] for your Application Insights resource. The connection string will be automatically populated from the `APPLICATIONINSIGHTS_CONNECTION_STRING` environment variable if not explicitly passed in. | `APPLICATIONINSIGHTS_CONNECTION_STRING` |
-| `logger_name` | The name of the [Python logger][python_logger] to collect telemetry for. | `N/A` |
+| `logger_name` | The name of the [Python logger][python_logger] under which telemetry is collected. | `N/A` |
 
 You can configure further with [OpenTelemetry environment variables][ot_env_vars] such as:
 | Environment Variable | Description |

--- a/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_configure.py
+++ b/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_configure.py
@@ -34,6 +34,7 @@ from azure.monitor.opentelemetry._constants import (
     DISABLE_METRICS_ARG,
     DISABLE_TRACING_ARG,
     DISABLED_INSTRUMENTATIONS_ARG,
+    LOGGER_NAME_ARG,
     SAMPLING_RATIO_ARG,
 )
 from azure.monitor.opentelemetry._types import ConfigurationValue
@@ -138,7 +139,8 @@ def _setup_logging(configurations: Dict[str, ConfigurationValue]):
     )
     get_logger_provider().add_log_record_processor(log_record_processor)
     handler = LoggingHandler(logger_provider=get_logger_provider())
-    getLogger().addHandler(handler)
+    logger_name = configurations[LOGGER_NAME_ARG]
+    getLogger(logger_name).addHandler(handler)
 
 
 def _setup_metrics(configurations: Dict[str, ConfigurationValue]):

--- a/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_configure.py
+++ b/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_configure.py
@@ -140,7 +140,7 @@ def _setup_logging(configurations: Dict[str, ConfigurationValue]):
     )
     get_logger_provider().add_log_record_processor(log_record_processor)
     handler = LoggingHandler(logger_provider=get_logger_provider())
-    logger_name = configurations[LOGGER_NAME_ARG]
+    logger_name = configurations.get(LOGGER_NAME_ARG, "")
     getLogger(logger_name).addHandler(handler)
 
 

--- a/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_configure.py
+++ b/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_configure.py
@@ -77,7 +77,7 @@ def configure_azure_monitor(**kwargs) -> None:
      telemetry records for retry. Defaults to `False`.
     :keyword str storage_directory: Storage directory in which to store retry files. Defaults to
      `<tempfile.gettempdir()>/Microsoft/AzureMonitor/opentelemetry-python-<your-instrumentation-key>`.
-    :keyword str logger_name: The name of the Python logger that telemetry will be collected for.
+    :keyword str logger_name: The name of the Python logger that telemetry will be collected.
     :rtype: None
     """
 
@@ -140,7 +140,7 @@ def _setup_logging(configurations: Dict[str, ConfigurationValue]):
     )
     get_logger_provider().add_log_record_processor(log_record_processor)
     handler = LoggingHandler(logger_provider=get_logger_provider())
-    logger_name = configurations.get(LOGGER_NAME_ARG, "")
+    logger_name = configurations[LOGGER_NAME_ARG]
     getLogger(logger_name).addHandler(handler)
 
 

--- a/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_configure.py
+++ b/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_configure.py
@@ -77,6 +77,7 @@ def configure_azure_monitor(**kwargs) -> None:
      telemetry records for retry. Defaults to `False`.
     :keyword str storage_directory: Storage directory in which to store retry files. Defaults to
      `<tempfile.gettempdir()>/Microsoft/AzureMonitor/opentelemetry-python-<your-instrumentation-key>`.
+    :keyword str logger_name: The name of the Python logger that telemetry will be collected for.
     :rtype: None
     """
 

--- a/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_constants.py
+++ b/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_constants.py
@@ -22,6 +22,7 @@ DISABLE_LOGGING_ARG = "disable_logging"
 DISABLE_METRICS_ARG = "disable_metrics"
 DISABLE_TRACING_ARG = "disable_tracing"
 DISABLED_INSTRUMENTATIONS_ARG = "disabled_instrumentations"
+LOGGER_NAME_ARG = "logger_name"
 SAMPLING_RATIO_ARG = "sampling_ratio"
 
 

--- a/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_util/configurations.py
+++ b/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_util/configurations.py
@@ -24,6 +24,7 @@ from azure.monitor.opentelemetry._constants import (
     DISABLE_METRICS_ARG,
     DISABLE_TRACING_ARG,
     DISABLED_INSTRUMENTATIONS_ARG,
+    LOGGER_NAME_ARG,
     SAMPLING_RATIO_ARG,
 )
 from azure.monitor.opentelemetry._types import ConfigurationValue
@@ -50,6 +51,7 @@ def _get_configurations(**kwargs) -> Dict[str, ConfigurationValue]:
     _default_disable_metrics(configurations)
     _default_disable_tracing(configurations)
     _default_disabled_instrumentations(configurations)
+    _default_logger_name(configurations)
     _default_sampling_ratio(configurations)
     _default_disable_azure_core_tracing(configurations)
 
@@ -91,6 +93,11 @@ def _default_disabled_instrumentations(configurations):
             x.strip() for x in disabled_instrumentation
         ]
     configurations[DISABLED_INSTRUMENTATIONS_ARG] = disabled_instrumentation
+
+
+def _default_logger_name(configurations):
+    logger_name = environ.get(LOGGER_NAME_ARG, "")
+    configurations[LOGGER_NAME_ARG] = logger_name
 
 
 # TODO: remove when sampler uses env var instead

--- a/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_util/configurations.py
+++ b/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_util/configurations.py
@@ -96,8 +96,8 @@ def _default_disabled_instrumentations(configurations):
 
 
 def _default_logger_name(configurations):
-    logger_name = environ.get(LOGGER_NAME_ARG, "")
-    configurations[LOGGER_NAME_ARG] = logger_name
+    if LOGGER_NAME_ARG not in configurations:
+        configurations[LOGGER_NAME_ARG] = ""
 
 
 # TODO: remove when sampler uses env var instead

--- a/sdk/monitor/azure-monitor-opentelemetry/samples/logging/correlated_logs.py
+++ b/sdk/monitor/azure-monitor-opentelemetry/samples/logging/correlated_logs.py
@@ -4,7 +4,7 @@
 # license information.
 # --------------------------------------------------------------------------
 
-from logging import WARNING, getLogger
+from logging import getLogger
 
 from azure.monitor.opentelemetry import configure_azure_monitor
 from opentelemetry import trace

--- a/sdk/monitor/azure-monitor-opentelemetry/samples/logging/exception_logs.py
+++ b/sdk/monitor/azure-monitor-opentelemetry/samples/logging/exception_logs.py
@@ -4,7 +4,7 @@
 # license information.
 # --------------------------------------------------------------------------
 
-from logging import WARNING, getLogger
+from logging import getLogger
 
 from azure.monitor.opentelemetry import configure_azure_monitor
 

--- a/sdk/monitor/azure-monitor-opentelemetry/samples/logging/simple.py
+++ b/sdk/monitor/azure-monitor-opentelemetry/samples/logging/simple.py
@@ -4,15 +4,37 @@
 # license information.
 # --------------------------------------------------------------------------
 
-from logging import WARNING, getLogger
+from logging import INFO, getLogger
 
 from azure.monitor.opentelemetry import configure_azure_monitor
-from opentelemetry.sdk.resources import Resource, ResourceAttributes
 
-configure_azure_monitor()
+configure_azure_monitor(
+    # Set logger_name to the name of the logger you want to capture logging telemetry with
+    logger_name="my_application_logger",
+)
 
-logger = getLogger(__name__)
+# Logging calls with this logger will be tracked
+logger = getLogger("my_application_logger")
+logger.setLevel(INFO)
+
+# Logging calls with any logger that is a child logger will also be tracked
+logger_child = getLogger("my-application_logger.module")
+logger_child.setLevel(INFO)
+
+# Logging calls with this logger will not be tracked
+logger_not_tracked = getLogger("not_my_application_logger")
+logger_not_tracked.setLevel(INFO)
 
 logger.info("info log")
 logger.warning("warning log")
 logger.error("error log")
+
+logger.info("info log")
+logger.warning("warning log")
+logger.error("error log")
+
+logger_not_tracked.info("info log2")
+logger_not_tracked.warning("warning log2")
+logger_not_tracked.error("error log2")
+
+input()

--- a/sdk/monitor/azure-monitor-opentelemetry/tests/configuration/test_configure.py
+++ b/sdk/monitor/azure-monitor-opentelemetry/tests/configuration/test_configure.py
@@ -307,6 +307,7 @@ class TestConfigure(unittest.TestCase):
 
         configurations = {
             "connection_string": "test_cs",
+            "logger_name": "test",
         }
         _setup_logging(configurations)
 
@@ -323,7 +324,7 @@ class TestConfigure(unittest.TestCase):
         logging_handler_mock.assert_called_once_with(
             logger_provider=lp_init_mock
         )
-        get_logger_mock.assert_called_once_with()
+        get_logger_mock.assert_called_once_with("test")
         logger_mock.addHandler.assert_called_once_with(
             logging_handler_init_mock
         )


### PR DESCRIPTION
Introduce a `logger_name` configuration for specifying which logger to collect telemetry for.