### PR TITLE
Add message ids for applens

### DIFF
--- a/sdk/monitor/azure-monitor-opentelemetry/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-opentelemetry/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 1.0.1 (Unreleased)
 
+- Add message ids for AppLens
+    ([#32195](https://github.com/Azure/azure-sdk-for-python/pull/32195))
+
 ### Features Added
 
 ### Breaking Changes

--- a/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_autoinstrumentation/configurator.py
+++ b/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_autoinstrumentation/configurator.py
@@ -16,8 +16,8 @@ from azure.monitor.opentelemetry._constants import (
 )
 from azure.monitor.opentelemetry._diagnostics.diagnostic_logging import (
     AzureDiagnosticLogging,
-    _ATTACH_SUCCESS_CONFIGURATOR,
     _ATTACH_FAILURE_CONFIGURATOR,
+    _ATTACH_SUCCESS_CONFIGURATOR,
 )
 from azure.monitor.opentelemetry._diagnostics.status_logger import (
     AzureStatusLogger,
@@ -32,18 +32,18 @@ class AzureMonitorConfigurator(_OTelSDKConfigurator):
             AzureStatusLogger.log_status(False, "Configurator being configured.")
             super()._configure(**kwargs)
             AzureStatusLogger.log_status(True)
-            AzureDiagnosticLogging.log(
+            AzureDiagnosticLogging.info(
                 "Azure Monitor Configurator configured successfully.",
                 _ATTACH_SUCCESS_CONFIGURATOR
             )
         except ValueError as e:
-            AzureDiagnosticLogging.log(
+            AzureDiagnosticLogging.info(
                 "Azure Monitor Configurator failed during configuration due to a ValueError: %s" % e,
                 _ATTACH_FAILURE_CONFIGURATOR,
             )
             raise e
         except Exception as e:
-            AzureDiagnosticLogging.log(
+            AzureDiagnosticLogging.info(
                 "Azure Monitor Configurator failed during configuration: %s" % e,
                 _ATTACH_FAILURE_CONFIGURATOR,
             )

--- a/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_autoinstrumentation/configurator.py
+++ b/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_autoinstrumentation/configurator.py
@@ -38,13 +38,13 @@ class AzureMonitorConfigurator(_OTelSDKConfigurator):
             )
         except ValueError as e:
             AzureDiagnosticLogging.error(
-                "Azure Monitor Configurator failed during configuration due to a ValueError: %s" % e,
+                "Azure Monitor Configurator failed during configuration due to a ValueError: %s" % str(e),
                 _ATTACH_FAILURE_CONFIGURATOR,
             )
             raise e
         except Exception as e:
             AzureDiagnosticLogging.error(
-                "Azure Monitor Configurator failed during configuration: %s" % e,
+                "Azure Monitor Configurator failed during configuration: %s" % str(e),
                 _ATTACH_FAILURE_CONFIGURATOR,
             )
             raise e

--- a/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_autoinstrumentation/configurator.py
+++ b/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_autoinstrumentation/configurator.py
@@ -5,7 +5,6 @@
 # --------------------------------------------------------------------------
 
 
-import logging
 from warnings import warn
 
 from opentelemetry.sdk._configuration import _OTelSDKConfigurator

--- a/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_autoinstrumentation/configurator.py
+++ b/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_autoinstrumentation/configurator.py
@@ -26,7 +26,6 @@ from azure.monitor.opentelemetry._diagnostics.status_logger import (
 
 class AzureMonitorConfigurator(_OTelSDKConfigurator):
     def _configure(self, **kwargs):
-        print("JEREVOSS: _configure")
         if not _is_attach_enabled():
             warn(_PREVIEW_ENTRY_POINT_WARNING)
         try:

--- a/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_autoinstrumentation/configurator.py
+++ b/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_autoinstrumentation/configurator.py
@@ -37,13 +37,13 @@ class AzureMonitorConfigurator(_OTelSDKConfigurator):
                 _ATTACH_SUCCESS_CONFIGURATOR
             )
         except ValueError as e:
-            AzureDiagnosticLogging.info(
+            AzureDiagnosticLogging.error(
                 "Azure Monitor Configurator failed during configuration due to a ValueError: %s" % e,
                 _ATTACH_FAILURE_CONFIGURATOR,
             )
             raise e
         except Exception as e:
-            AzureDiagnosticLogging.info(
+            AzureDiagnosticLogging.error(
                 "Azure Monitor Configurator failed during configuration: %s" % e,
                 _ATTACH_FAILURE_CONFIGURATOR,
             )

--- a/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_autoinstrumentation/configurator.py
+++ b/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_autoinstrumentation/configurator.py
@@ -16,25 +16,36 @@ from azure.monitor.opentelemetry._constants import (
 )
 from azure.monitor.opentelemetry._diagnostics.diagnostic_logging import (
     AzureDiagnosticLogging,
+    _ATTACH_SUCCESS_CONFIGURATOR,
+    _ATTACH_FAILURE_CONFIGURATOR,
 )
-
-_logger = logging.getLogger(__name__)
+from azure.monitor.opentelemetry._diagnostics.status_logger import (
+    AzureStatusLogger,
+)
 
 
 class AzureMonitorConfigurator(_OTelSDKConfigurator):
     def _configure(self, **kwargs):
+        print("JEREVOSS: _configure")
         if not _is_attach_enabled():
             warn(_PREVIEW_ENTRY_POINT_WARNING)
         try:
-            AzureDiagnosticLogging.enable(_logger)
+            AzureStatusLogger.log_status(False, "Configurator being configured.")
             super()._configure(**kwargs)
+            AzureStatusLogger.log_status(True)
+            AzureDiagnosticLogging.log(
+                "Azure Monitor Configurator configured successfully.",
+                _ATTACH_SUCCESS_CONFIGURATOR
+            )
         except ValueError as e:
-            _logger.error(
-                "Azure Monitor Configurator failed during configuration due to a ValueError: %s", e
+            AzureDiagnosticLogging.log(
+                "Azure Monitor Configurator failed during configuration due to a ValueError: %s" % e,
+                _ATTACH_FAILURE_CONFIGURATOR,
             )
             raise e
         except Exception as e:
-            _logger.error(
-                "Azure Monitor Configurator failed during configuration: %s", e
+            AzureDiagnosticLogging.log(
+                "Azure Monitor Configurator failed during configuration: %s" % e,
+                _ATTACH_FAILURE_CONFIGURATOR,
             )
             raise e

--- a/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_autoinstrumentation/configurator.py
+++ b/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_autoinstrumentation/configurator.py
@@ -28,19 +28,12 @@ class AzureMonitorConfigurator(_OTelSDKConfigurator):
         if not _is_attach_enabled():
             warn(_PREVIEW_ENTRY_POINT_WARNING)
         try:
-            AzureStatusLogger.log_status(False, "Configurator being configured.")
             super()._configure(**kwargs)
             AzureStatusLogger.log_status(True)
             AzureDiagnosticLogging.info(
                 "Azure Monitor Configurator configured successfully.",
                 _ATTACH_SUCCESS_CONFIGURATOR
             )
-        except ValueError as e:
-            AzureDiagnosticLogging.error(
-                "Azure Monitor Configurator failed during configuration due to a ValueError: %s" % str(e),
-                _ATTACH_FAILURE_CONFIGURATOR,
-            )
-            raise e
         except Exception as e:
             AzureDiagnosticLogging.error(
                 "Azure Monitor Configurator failed during configuration: %s" % str(e),

--- a/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_autoinstrumentation/distro.py
+++ b/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_autoinstrumentation/distro.py
@@ -27,8 +27,8 @@ from azure.monitor.opentelemetry._constants import (
 )
 from azure.monitor.opentelemetry._diagnostics.diagnostic_logging import (
     AzureDiagnosticLogging,
-    _ATTACH_SUCCESS_DISTRO,
     _ATTACH_FAILURE_DISTRO,
+    _ATTACH_SUCCESS_DISTRO,
 )
 from azure.monitor.opentelemetry._diagnostics.status_logger import (
     AzureStatusLogger,
@@ -69,13 +69,13 @@ def _configure_auto_instrumentation() -> None:
         )
         settings.tracing_implementation = OpenTelemetrySpan
         AzureStatusLogger.log_status(True)
-        AzureDiagnosticLogging.log(
+        AzureDiagnosticLogging.info(
             "Azure Monitor OpenTelemetry Distro configured successfully.",
             _ATTACH_SUCCESS_DISTRO
         )
     except Exception as exc:
         AzureStatusLogger.log_status(False, reason=str(exc))
-        AzureDiagnosticLogging.log(
+        AzureDiagnosticLogging.info(
             _CONFIG_FAILED_MSG % exc,
             _ATTACH_FAILURE_DISTRO,
         )

--- a/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_autoinstrumentation/distro.py
+++ b/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_autoinstrumentation/distro.py
@@ -45,39 +45,32 @@ class AzureMonitorDistro(BaseDistro):
             warn(_PREVIEW_ENTRY_POINT_WARNING)
         try:
             _configure_auto_instrumentation()
-        except Exception as exc:
+        except Exception as e:
+            AzureStatusLogger.log_status(False, reason=str(e))
             AzureDiagnosticLogging.error(
-                "Error occurred auto-instrumenting AzureMonitorDistro" % exc,
+                _CONFIG_FAILED_MSG % str(e),
                 _ATTACH_FAILURE_DISTRO,
             )
-            raise exc
+            raise e
 
 
 def _configure_auto_instrumentation() -> None:
-    try:
-        AzureStatusLogger.log_status(False, "Distro being configured.")
-        environ.setdefault(
-            OTEL_METRICS_EXPORTER, "azure_monitor_opentelemetry_exporter"
-        )
-        environ.setdefault(
-            OTEL_TRACES_EXPORTER, "azure_monitor_opentelemetry_exporter"
-        )
-        environ.setdefault(
-            OTEL_LOGS_EXPORTER, "azure_monitor_opentelemetry_exporter"
-        )
-        environ.setdefault(
-            _OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED, "true"
-        )
-        settings.tracing_implementation = OpenTelemetrySpan
-        AzureStatusLogger.log_status(True)
-        AzureDiagnosticLogging.info(
-            "Azure Monitor OpenTelemetry Distro configured successfully.",
-            _ATTACH_SUCCESS_DISTRO
-        )
-    except Exception as exc:
-        AzureStatusLogger.log_status(False, reason=str(exc))
-        AzureDiagnosticLogging.error(
-            _CONFIG_FAILED_MSG % exc,
-            _ATTACH_FAILURE_DISTRO,
-        )
-        raise exc
+    AzureStatusLogger.log_status(False, "Distro being configured.")
+    environ.setdefault(
+        OTEL_METRICS_EXPORTER, "azure_monitor_opentelemetry_exporter"
+    )
+    environ.setdefault(
+        OTEL_TRACES_EXPORTER, "azure_monitor_opentelemetry_exporter"
+    )
+    environ.setdefault(
+        OTEL_LOGS_EXPORTER, "azure_monitor_opentelemetry_exporter"
+    )
+    environ.setdefault(
+        _OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED, "true"
+    )
+    settings.tracing_implementation = OpenTelemetrySpan
+    AzureStatusLogger.log_status(True)
+    AzureDiagnosticLogging.info(
+        "Azure Monitor OpenTelemetry Distro configured successfully.",
+        _ATTACH_SUCCESS_DISTRO
+    )

--- a/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_autoinstrumentation/distro.py
+++ b/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_autoinstrumentation/distro.py
@@ -45,11 +45,12 @@ class AzureMonitorDistro(BaseDistro):
             warn(_PREVIEW_ENTRY_POINT_WARNING)
         try:
             _configure_auto_instrumentation()
-        except Exception as ex:
-            _logger.exception(
-                ("Error occurred auto-instrumenting AzureMonitorDistro")
+        except Exception as exc:
+            AzureDiagnosticLogging.error(
+                "Error occurred auto-instrumenting AzureMonitorDistro" % exc,
+                _ATTACH_FAILURE_DISTRO,
             )
-            raise ex
+            raise exc
 
 
 def _configure_auto_instrumentation() -> None:
@@ -75,7 +76,7 @@ def _configure_auto_instrumentation() -> None:
         )
     except Exception as exc:
         AzureStatusLogger.log_status(False, reason=str(exc))
-        AzureDiagnosticLogging.info(
+        AzureDiagnosticLogging.error(
             _CONFIG_FAILED_MSG % exc,
             _ATTACH_FAILURE_DISTRO,
         )

--- a/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_autoinstrumentation/distro.py
+++ b/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_autoinstrumentation/distro.py
@@ -41,13 +41,11 @@ _logger = logging.getLogger(__name__)
 
 class AzureMonitorDistro(BaseDistro):
     def _configure(self, **kwargs) -> None:
-        print("JEREVOSS: _configure")
         if not _is_attach_enabled():
             warn(_PREVIEW_ENTRY_POINT_WARNING)
         try:
             _configure_auto_instrumentation()
         except Exception as ex:
-            print("JEREVOSS: distro _configure Exception %s" % exc)
             _logger.exception(
                 ("Error occurred auto-instrumenting AzureMonitorDistro")
             )
@@ -55,7 +53,6 @@ class AzureMonitorDistro(BaseDistro):
 
 
 def _configure_auto_instrumentation() -> None:
-    print("JEREVOSS: _configure_auto_instrumentation")
     try:
         AzureStatusLogger.log_status(False, "Distro being configured.")
         environ.setdefault(
@@ -77,7 +74,6 @@ def _configure_auto_instrumentation() -> None:
             _ATTACH_SUCCESS_DISTRO
         )
     except Exception as exc:
-        print("JEREVOSS: distro _configure_auto_instrumentation Exception %s" % exc)
         AzureStatusLogger.log_status(False, reason=str(exc))
         AzureDiagnosticLogging.log(
             _CONFIG_FAILED_MSG % exc,

--- a/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_autoinstrumentation/distro.py
+++ b/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_autoinstrumentation/distro.py
@@ -3,7 +3,6 @@
 # Licensed under the MIT License. See License in the project root for
 # license information.
 # --------------------------------------------------------------------------
-import logging
 from os import environ
 from warnings import warn
 
@@ -35,8 +34,6 @@ from azure.monitor.opentelemetry._diagnostics.status_logger import (
 )
 
 _CONFIG_FAILED_MSG = "Azure Monitor OpenTelemetry Distro failed during configuration: %s"
-
-_logger = logging.getLogger(__name__)
 
 
 class AzureMonitorDistro(BaseDistro):

--- a/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_autoinstrumentation/distro.py
+++ b/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_autoinstrumentation/distro.py
@@ -33,8 +33,6 @@ from azure.monitor.opentelemetry._diagnostics.status_logger import (
     AzureStatusLogger,
 )
 
-_CONFIG_FAILED_MSG = "Azure Monitor OpenTelemetry Distro failed during configuration: %s"
-
 
 class AzureMonitorDistro(BaseDistro):
     def _configure(self, **kwargs) -> None:
@@ -42,17 +40,21 @@ class AzureMonitorDistro(BaseDistro):
             warn(_PREVIEW_ENTRY_POINT_WARNING)
         try:
             _configure_auto_instrumentation()
+            AzureStatusLogger.log_status(True)
+            AzureDiagnosticLogging.info(
+                "Azure Monitor OpenTelemetry Distro configured successfully.",
+                _ATTACH_SUCCESS_DISTRO
+            )
         except Exception as e:
             AzureStatusLogger.log_status(False, reason=str(e))
             AzureDiagnosticLogging.error(
-                _CONFIG_FAILED_MSG % str(e),
+                "Azure Monitor OpenTelemetry Distro failed during configuration: %s" % str(e),
                 _ATTACH_FAILURE_DISTRO,
             )
             raise e
 
 
 def _configure_auto_instrumentation() -> None:
-    AzureStatusLogger.log_status(False, "Distro being configured.")
     environ.setdefault(
         OTEL_METRICS_EXPORTER, "azure_monitor_opentelemetry_exporter"
     )
@@ -66,8 +68,3 @@ def _configure_auto_instrumentation() -> None:
         _OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED, "true"
     )
     settings.tracing_implementation = OpenTelemetrySpan
-    AzureStatusLogger.log_status(True)
-    AzureDiagnosticLogging.info(
-        "Azure Monitor OpenTelemetry Distro configured successfully.",
-        _ATTACH_SUCCESS_DISTRO
-    )

--- a/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_constants.py
+++ b/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_constants.py
@@ -32,10 +32,6 @@ _LOG_PATH_WINDOWS = "\\LogFiles\\ApplicationInsights"
 _IS_ON_APP_SERVICE = "WEBSITE_SITE_NAME" in environ
 # TODO: Add environment variable to enabled diagnostics off of App Service
 _IS_DIAGNOSTICS_ENABLED = _IS_ON_APP_SERVICE
-# TODO: Enabled when duplicate logging issue is solved
-# _EXPORTER_DIAGNOSTICS_ENABLED_ENV_VAR = (
-#     "AZURE_MONITOR_OPENTELEMETRY_DISTRO_ENABLE_EXPORTER_DIAGNOSTICS"
-# )
 _CUSTOMER_IKEY_ENV_VAR = None
 _PREVIEW_ENTRY_POINT_WARNING = "Autoinstrumentation for the Azure Monitor OpenTelemetry Distro is in preview."
 logger = logging.getLogger(__name__)
@@ -74,19 +70,9 @@ def _env_var_or_default(var_name, default_val=""):
         return default_val
 
 
-# TODO: Enabled when duplicate logging issue is solved
-# def _is_exporter_diagnostics_enabled():
-#     return (
-#         _EXPORTER_DIAGNOSTICS_ENABLED_ENV_VAR in environ
-#         and environ[_EXPORTER_DIAGNOSTICS_ENABLED_ENV_VAR] == "True"
-#     )
-
-
 _EXTENSION_VERSION = _env_var_or_default(
     "ApplicationInsightsAgent_EXTENSION_VERSION", "disabled"
 )
-# TODO: Enabled when duplicate logging issue is solved
-# _EXPORTER_DIAGNOSTICS_ENABLED = _is_exporter_diagnostics_enabled()
 
 
 def _is_attach_enabled():

--- a/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_diagnostics/diagnostic_logging.py
+++ b/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_diagnostics/diagnostic_logging.py
@@ -37,7 +37,6 @@ _ATTACH_FAILURE_CONFIGURATOR = "4401"
 class AzureDiagnosticLogging:
     _initialized = False
     _lock = threading.Lock()
-    _f_handler = None
 
     @classmethod
     def _initialize(cls):
@@ -64,7 +63,7 @@ class AzureDiagnosticLogging:
                     )
                     if not exists(_DIAGNOSTIC_LOG_PATH):
                         makedirs(_DIAGNOSTIC_LOG_PATH)
-                    AzureDiagnosticLogging._f_handler = logging.FileHandler(
+                    f_handler = logging.FileHandler(
                         join(
                             _DIAGNOSTIC_LOG_PATH, _DIAGNOSTIC_LOGGER_FILE_NAME
                         )
@@ -72,8 +71,8 @@ class AzureDiagnosticLogging:
                     formatter = logging.Formatter(
                         fmt=log_format, datefmt="%Y-%m-%dT%H:%M:%S"
                     )
-                    AzureDiagnosticLogging._f_handler.setFormatter(formatter)
-                    _logger.addHandler(AzureDiagnosticLogging._f_handler)
+                    f_handler.setFormatter(formatter)
+                    _logger.addHandler(f_handler)
                     AzureDiagnosticLogging._initialized = True
 
     @classmethod

--- a/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_diagnostics/diagnostic_logging.py
+++ b/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_diagnostics/diagnostic_logging.py
@@ -43,7 +43,6 @@ class AzureDiagnosticLogging:
 
     @classmethod
     def _initialize(cls):
-        print("JEREVOSS: _initialize")
         with AzureDiagnosticLogging._lock:
             if not AzureDiagnosticLogging._initialized:
                 if _IS_DIAGNOSTICS_ENABLED and _DIAGNOSTIC_LOG_PATH:
@@ -82,6 +81,5 @@ class AzureDiagnosticLogging:
 
     @classmethod
     def log(cls, message: str, message_id: int):
-        print("JEREVOSS: log: %s" % message)
         AzureDiagnosticLogging._initialize()
         _logger.info(message, extra={'msgId': message_id})

--- a/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_diagnostics/diagnostic_logging.py
+++ b/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_diagnostics/diagnostic_logging.py
@@ -81,3 +81,13 @@ class AzureDiagnosticLogging:
     def info(cls, message: str, message_id: int):
         AzureDiagnosticLogging._initialize()
         _logger.info(message, extra={'msgId': message_id})
+
+    @classmethod
+    def warning(cls, message: str, message_id: int):
+        AzureDiagnosticLogging._initialize()
+        _logger.warning(message, extra={'msgId': message_id})
+
+    @classmethod
+    def error(cls, message: str, message_id: int):
+        AzureDiagnosticLogging._initialize()
+        _logger.error(message, extra={'msgId': message_id})

--- a/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_diagnostics/diagnostic_logging.py
+++ b/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_diagnostics/diagnostic_logging.py
@@ -4,7 +4,6 @@
 # license information.
 # --------------------------------------------------------------------------
 
-from enum import Enum
 import logging
 import threading
 from os import makedirs

--- a/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_diagnostics/diagnostic_logging.py
+++ b/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_diagnostics/diagnostic_logging.py
@@ -29,11 +29,10 @@ _logger = logging.getLogger(__name__)
 _logger.propagate = False
 _logger.setLevel(logging.INFO)
 _DIAGNOSTIC_LOG_PATH = _get_log_path()
-_DIAGNOSTIC_LOGGING_INITIALIZED = 4100
-_ATTACH_SUCCESS_DISTRO = 4200
-_ATTACH_SUCCESS_CONFIGURATOR = 4201
-_ATTACH_FAILURE_DISTRO = 4400
-_ATTACH_FAILURE_CONFIGURATOR = 4401
+_ATTACH_SUCCESS_DISTRO = "4200"
+_ATTACH_SUCCESS_CONFIGURATOR = "4201"
+_ATTACH_FAILURE_DISTRO = "4400"
+_ATTACH_FAILURE_CONFIGURATOR = "4401"
 
 
 class AzureDiagnosticLogging:
@@ -77,9 +76,8 @@ class AzureDiagnosticLogging:
                     AzureDiagnosticLogging._f_handler.setFormatter(formatter)
                     _logger.addHandler(AzureDiagnosticLogging._f_handler)
                     AzureDiagnosticLogging._initialized = True
-                    # AzureDiagnosticLogging.log("Initialized Azure Diagnostic Logger.", _DIAGNOSTIC_LOGGING_INITIALIZED)
 
     @classmethod
-    def log(cls, message: str, message_id: int):
+    def info(cls, message: str, message_id: int):
         AzureDiagnosticLogging._initialize()
         _logger.info(message, extra={'msgId': message_id})

--- a/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_diagnostics/status_logger.py
+++ b/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_diagnostics/status_logger.py
@@ -44,7 +44,6 @@ class AzureStatusLogger:
 
     @classmethod
     def log_status(cls, agent_initialized_successfully, reason=None):
-        print("JEREVOSS: log_status: %s" % agent_initialized_successfully)
         if _IS_DIAGNOSTICS_ENABLED and _STATUS_LOG_PATH:
             pid = getpid()
             status_json = AzureStatusLogger._get_status_json(

--- a/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_diagnostics/status_logger.py
+++ b/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_diagnostics/status_logger.py
@@ -44,6 +44,7 @@ class AzureStatusLogger:
 
     @classmethod
     def log_status(cls, agent_initialized_successfully, reason=None):
+        print("JEREVOSS: log_status: %s" % agent_initialized_successfully)
         if _IS_DIAGNOSTICS_ENABLED and _STATUS_LOG_PATH:
             pid = getpid()
             status_json = AzureStatusLogger._get_status_json(

--- a/sdk/monitor/azure-monitor-opentelemetry/tests/autoinstrumentation/test_configurator.py
+++ b/sdk/monitor/azure-monitor-opentelemetry/tests/autoinstrumentation/test_configurator.py
@@ -6,26 +6,51 @@ from azure.core.tracing.ext.opentelemetry_span import OpenTelemetrySpan
 from azure.monitor.opentelemetry._autoinstrumentation.configurator import (
     AzureMonitorConfigurator,
 )
+from azure.monitor.opentelemetry._diagnostics.diagnostic_logging import (
+    _ATTACH_FAILURE_CONFIGURATOR,
+    _ATTACH_SUCCESS_CONFIGURATOR
+)
 
 
 class TestConfigurator(TestCase):
     @patch("azure.monitor.opentelemetry._autoinstrumentation.configurator._is_attach_enabled", return_value=True)
     @patch(
-        "azure.monitor.opentelemetry._autoinstrumentation.configurator.AzureDiagnosticLogging.enable"
+        "azure.monitor.opentelemetry._autoinstrumentation.configurator.AzureDiagnosticLogging"
     )
     def test_configure(self, mock_diagnostics, attach_mock):
         configurator = AzureMonitorConfigurator()
         with warnings.catch_warnings():
             warnings.simplefilter("error")
             configurator._configure()
-        mock_diagnostics.assert_called_once()
+        mock_diagnostics.info.assert_called_once_with(
+            "Azure Monitor Configurator configured successfully.",
+            _ATTACH_SUCCESS_CONFIGURATOR
+        )
 
     @patch("azure.monitor.opentelemetry._autoinstrumentation.configurator._is_attach_enabled", return_value=False)
     @patch(
-        "azure.monitor.opentelemetry._autoinstrumentation.configurator.AzureDiagnosticLogging.enable"
+        "azure.monitor.opentelemetry._autoinstrumentation.configurator.AzureDiagnosticLogging"
     )
     def test_configure_preview(self, mock_diagnostics, attach_mock):
         configurator = AzureMonitorConfigurator()
         with self.assertWarns(Warning):
             configurator._configure()
-        mock_diagnostics.assert_called_once()
+        mock_diagnostics.info.assert_called_once_with(
+            "Azure Monitor Configurator configured successfully.",
+            _ATTACH_SUCCESS_CONFIGURATOR
+        )
+
+    @patch("azure.monitor.opentelemetry._autoinstrumentation.configurator.super")
+    @patch("azure.monitor.opentelemetry._autoinstrumentation.configurator._is_attach_enabled", return_value=True)
+    @patch(
+        "azure.monitor.opentelemetry._autoinstrumentation.configurator.AzureDiagnosticLogging"
+    )
+    def test_configure_exc(self, mock_diagnostics, attach_mock, super_mock):
+        configurator = AzureMonitorConfigurator()
+        super_mock()._configure.side_effect = Exception("Test Exception")
+        with self.assertRaises(Exception):
+            configurator._configure()
+        mock_diagnostics.error.assert_called_once_with(
+            "Azure Monitor Configurator failed during configuration: Test Exception",
+            _ATTACH_FAILURE_CONFIGURATOR
+        )

--- a/sdk/monitor/azure-monitor-opentelemetry/tests/autoinstrumentation/test_distro.py
+++ b/sdk/monitor/azure-monitor-opentelemetry/tests/autoinstrumentation/test_distro.py
@@ -6,20 +6,27 @@ from azure.core.tracing.ext.opentelemetry_span import OpenTelemetrySpan
 from azure.monitor.opentelemetry._autoinstrumentation.distro import (
     AzureMonitorDistro,
 )
+from azure.monitor.opentelemetry._diagnostics.diagnostic_logging import (
+    _ATTACH_FAILURE_DISTRO,
+    _ATTACH_SUCCESS_DISTRO
+)
 
 
 class TestDistro(TestCase):
     @patch("azure.monitor.opentelemetry._autoinstrumentation.distro._is_attach_enabled", return_value=True)
     @patch("azure.monitor.opentelemetry._autoinstrumentation.distro.settings")
     @patch(
-        "azure.monitor.opentelemetry._autoinstrumentation.distro.AzureDiagnosticLogging.enable"
+        "azure.monitor.opentelemetry._autoinstrumentation.distro.AzureDiagnosticLogging"
     )
     def test_configure(self, mock_diagnostics, azure_core_mock, attach_mock):
         distro = AzureMonitorDistro()
         with warnings.catch_warnings():
             warnings.simplefilter("error")
             distro.configure()
-        self.assertEqual(mock_diagnostics.call_count, 2)
+        mock_diagnostics.info.assert_called_once_with(
+            "Azure Monitor OpenTelemetry Distro configured successfully.",
+            _ATTACH_SUCCESS_DISTRO
+        )
         self.assertEqual(
             azure_core_mock.tracing_implementation, OpenTelemetrySpan
         )
@@ -27,13 +34,32 @@ class TestDistro(TestCase):
     @patch("azure.monitor.opentelemetry._autoinstrumentation.distro._is_attach_enabled", return_value=False)
     @patch("azure.monitor.opentelemetry._autoinstrumentation.distro.settings")
     @patch(
-        "azure.monitor.opentelemetry._autoinstrumentation.distro.AzureDiagnosticLogging.enable"
+        "azure.monitor.opentelemetry._autoinstrumentation.distro.AzureDiagnosticLogging"
     )
     def test_configure_preview(self, mock_diagnostics, azure_core_mock, attach_mock):
         distro = AzureMonitorDistro()
         with self.assertWarns(Warning):
             distro.configure()
-        self.assertEqual(mock_diagnostics.call_count, 2)
+        mock_diagnostics.info.assert_called_once_with(
+            "Azure Monitor OpenTelemetry Distro configured successfully.",
+            _ATTACH_SUCCESS_DISTRO
+        )
         self.assertEqual(
             azure_core_mock.tracing_implementation, OpenTelemetrySpan
+        )
+
+    @patch("azure.monitor.opentelemetry._autoinstrumentation.distro._configure_auto_instrumentation")
+    @patch("azure.monitor.opentelemetry._autoinstrumentation.distro._is_attach_enabled", return_value=True)
+    @patch("azure.monitor.opentelemetry._autoinstrumentation.distro.settings")
+    @patch(
+        "azure.monitor.opentelemetry._autoinstrumentation.distro.AzureDiagnosticLogging"
+    )
+    def test_configure_exc(self, mock_diagnostics, azure_core_mock, attach_mock, configure_mock):
+        distro = AzureMonitorDistro()
+        configure_mock.side_effect = Exception("Test Exception")
+        with self.assertRaises(Exception):
+            distro.configure()
+        mock_diagnostics.error.assert_called_once_with(
+            "Azure Monitor OpenTelemetry Distro failed during configuration: Test Exception",
+            _ATTACH_FAILURE_DISTRO
         )

--- a/sdk/monitor/azure-monitor-opentelemetry/tests/diagnostics/test_diagnostic_logging.py
+++ b/sdk/monitor/azure-monitor-opentelemetry/tests/diagnostics/test_diagnostic_logging.py
@@ -22,10 +22,10 @@ TEST_SUBSCRIPTION_ID = "TEST_SUBSCRIPTION_ID"
 MESSAGE1 = "MESSAGE1"
 MESSAGE2 = "MESSAGE2"
 MESSAGE3 = "MESSAGE3"
-TEST_LOGGER_NAME = "test.logger.name"
-TEST_LOGGER = logging.getLogger(TEST_LOGGER_NAME)
-TEST_LOGGER_NAME_SUB_MODULE = TEST_LOGGER_NAME + ".sub.module"
-TEST_LOGGER_SUB_MODULE = logging.getLogger(TEST_LOGGER_NAME_SUB_MODULE)
+# TEST_LOGGER_NAME = "test.logger.name"
+# TEST_LOGGER = logging.getLogger(TEST_LOGGER_NAME)
+# TEST_LOGGER_NAME_SUB_MODULE = TEST_LOGGER_NAME + ".sub.module"
+# diagnostic_logger.AzureDiagnosticLogging = logging.getLogger(TEST_LOGGER_NAME_SUB_MODULE)
 
 
 def clear_file(file_path):
@@ -34,14 +34,14 @@ def clear_file(file_path):
         f.truncate()
 
 
-def check_file_for_messages(file_path, level, messages, logger_name=TEST_LOGGER_NAME_SUB_MODULE):
+def check_file_for_messages(file_path, level, messages):
     with open(file_path, "r") as f:
         f.seek(0)
-        for message in messages:
+        for (message, message_id) in messages:
             json = loads(f.readline())
             assert json["time"]
             assert json["level"] == level
-            assert json["logger"] == logger_name
+            assert json["logger"] == "azure.monitor.opentelemetry._diagnostics.diagnostic_logging"
             assert json["message"] == message
             properties = json["properties"]
             assert properties["operation"] == "Startup"
@@ -50,6 +50,7 @@ def check_file_for_messages(file_path, level, messages, logger_name=TEST_LOGGER_
             assert properties["extensionVersion"] == TEST_EXTENSION_VERSION
             assert properties["sdkVersion"] == TEST_VERSION
             assert properties["subscriptionId"] == TEST_SUBSCRIPTION_ID
+            assert properties["msgId"] == message_id
         assert not f.read()
 
 
@@ -62,14 +63,14 @@ def check_file_is_empty(file_path):
 def set_up(
     file_path,
     is_diagnostics_enabled,
-    logger=TEST_LOGGER,
+    # logger=TEST_LOGGER,
     subscription_id_env_var=TEST_SUBSCRIPTION_ID_ENV_VAR,
 ) -> None:
     diagnostic_logger._logger.handlers.clear()
-    logger.handlers.clear()
-    TEST_LOGGER.handlers.clear()
-    TEST_LOGGER_SUB_MODULE.handlers.clear()
-    TEST_LOGGER_SUB_MODULE.setLevel(logging.WARN)
+    # logger.handlers.clear()
+    # TEST_LOGGER.handlers.clear()
+    # diagnostic_logger.AzureDiagnosticLogging.handlers.clear()
+    # diagnostic_logger.AzureDiagnosticLogging.setLevel(logging.WARN)
     patch.dict(
         "os.environ",
         {
@@ -103,13 +104,14 @@ def set_up(
         "azure.monitor.opentelemetry._diagnostics.diagnostic_logging._IS_DIAGNOSTICS_ENABLED",
         is_diagnostics_enabled,
     ).start()
-    diagnostic_logger.AzureDiagnosticLogging.enable(logger)
+    # diagnostic_logger.AzureDiagnosticLogging.enable(logger)
 
 
 class TestDiagnosticLogger:
 
     def test_initialized(self, temp_file_path):
         set_up(temp_file_path, is_diagnostics_enabled=True)
+        diagnostic_logger.AzureDiagnosticLogging.info(MESSAGE1, "4200")
         assert diagnostic_logger.AzureDiagnosticLogging._initialized is True
 
     def test_uninitialized(self, temp_file_path):
@@ -118,69 +120,69 @@ class TestDiagnosticLogger:
 
     def test_info(self, temp_file_path):
         set_up(temp_file_path, is_diagnostics_enabled=True)
-        TEST_LOGGER_SUB_MODULE.info(MESSAGE1)
-        TEST_LOGGER_SUB_MODULE.info(MESSAGE2)
-        check_file_is_empty(temp_file_path)
+        diagnostic_logger.AzureDiagnosticLogging.info(MESSAGE1, "4200")
+        diagnostic_logger.AzureDiagnosticLogging.info(MESSAGE2, "4301")
+        check_file_for_messages(temp_file_path, "INFO", ((MESSAGE1, "4200"), (MESSAGE2, "4301")))
 
-    def test_info_with_info_log_level(self, temp_file_path):
-        set_up(temp_file_path, is_diagnostics_enabled=True)
-        TEST_LOGGER_SUB_MODULE.setLevel(logging.INFO)
-        TEST_LOGGER_SUB_MODULE.info(MESSAGE1)
-        TEST_LOGGER_SUB_MODULE.info(MESSAGE2)
-        TEST_LOGGER_SUB_MODULE.setLevel(logging.NOTSET)
-        check_file_for_messages(temp_file_path, "INFO", (MESSAGE1, MESSAGE2))
+    # def test_info_with_info_log_level(self, temp_file_path):
+    #     set_up(temp_file_path, is_diagnostics_enabled=True)
+    #     # diagnostic_logger.AzureDiagnosticLogging.setLevel(logging.INFO)
+    #     diagnostic_logger.AzureDiagnosticLogging.info(MESSAGE1, "4200")
+    #     diagnostic_logger.AzureDiagnosticLogging.info(MESSAGE2, "4301")
+    #     # diagnostic_logger.AzureDiagnosticLogging.setLevel(logging.NOTSET)
+    #     check_file_for_messages(temp_file_path, "INFO", ((MESSAGE1, "4200"), (MESSAGE2, "4301")))
 
     def test_info_with_sub_module_info_log_level(self, temp_file_path):
         set_up(temp_file_path, is_diagnostics_enabled=True)
-        TEST_LOGGER_SUB_MODULE.setLevel(logging.INFO)
-        TEST_LOGGER_SUB_MODULE.info(MESSAGE1)
-        TEST_LOGGER_SUB_MODULE.info(MESSAGE2)
-        TEST_LOGGER_SUB_MODULE.setLevel(logging.NOTSET)
-        check_file_for_messages(temp_file_path, "INFO", (MESSAGE1, MESSAGE2))
+        # diagnostic_logger.AzureDiagnosticLogging.setLevel(logging.INFO)
+        diagnostic_logger.AzureDiagnosticLogging.info(MESSAGE1, "4200")
+        diagnostic_logger.AzureDiagnosticLogging.info(MESSAGE2, "4301")
+        # diagnostic_logger.AzureDiagnosticLogging.setLevel(logging.NOTSET)
+        check_file_for_messages(temp_file_path, "INFO", ((MESSAGE1, "4200"), (MESSAGE2, "4301")))
 
-    def test_warning(self, temp_file_path):
-        set_up(temp_file_path, is_diagnostics_enabled=True)
-        TEST_LOGGER_SUB_MODULE.warning(MESSAGE1)
-        TEST_LOGGER_SUB_MODULE.warning(MESSAGE2)
-        check_file_for_messages(temp_file_path, "WARNING", (MESSAGE1, MESSAGE2))
+    # def test_warning(self, temp_file_path):
+    #     set_up(temp_file_path, is_diagnostics_enabled=True)
+    #     diagnostic_logger.AzureDiagnosticLogging.warning(MESSAGE1)
+    #     diagnostic_logger.AzureDiagnosticLogging.warning(MESSAGE2)
+    #     check_file_for_messages(temp_file_path, "WARNING", (MESSAGE1, MESSAGE2))
 
-    def test_warning_multiple_enable(self, temp_file_path):
-        set_up(temp_file_path, is_diagnostics_enabled=True)
-        diagnostic_logger.AzureDiagnosticLogging.enable(TEST_LOGGER)
-        diagnostic_logger.AzureDiagnosticLogging.enable(TEST_LOGGER)
-        TEST_LOGGER_SUB_MODULE.warning(MESSAGE1)
-        TEST_LOGGER_SUB_MODULE.warning(MESSAGE2)
-        check_file_for_messages(temp_file_path, "WARNING", (MESSAGE1, MESSAGE2))
+    # def test_warning_multiple_enable(self, temp_file_path):
+    #     set_up(temp_file_path, is_diagnostics_enabled=True)
+    #     diagnostic_logger.AzureDiagnosticLogging.enable(TEST_LOGGER)
+    #     diagnostic_logger.AzureDiagnosticLogging.enable(TEST_LOGGER)
+    #     diagnostic_logger.AzureDiagnosticLogging.warning(MESSAGE1)
+    #     diagnostic_logger.AzureDiagnosticLogging.warning(MESSAGE2)
+    #     check_file_for_messages(temp_file_path, "WARNING", (MESSAGE1, MESSAGE2))
 
-    def test_error(self, temp_file_path):
-        set_up(temp_file_path, is_diagnostics_enabled=True)
-        TEST_LOGGER_SUB_MODULE.error(MESSAGE1)
-        TEST_LOGGER_SUB_MODULE.error(MESSAGE2)
-        check_file_for_messages(temp_file_path, "ERROR", (MESSAGE1, MESSAGE2))
+    # def test_error(self, temp_file_path):
+    #     set_up(temp_file_path, is_diagnostics_enabled=True)
+    #     diagnostic_logger.AzureDiagnosticLogging.error(MESSAGE1)
+    #     diagnostic_logger.AzureDiagnosticLogging.error(MESSAGE2)
+    #     check_file_for_messages(temp_file_path, "ERROR", ((MESSAGE1, 4200), (MESSAGE2, 4301)))
 
     def test_off_app_service_info(self, temp_file_path):
         set_up(temp_file_path, is_diagnostics_enabled=False)
-        TEST_LOGGER.info(MESSAGE1)
-        TEST_LOGGER.info(MESSAGE2)
-        TEST_LOGGER_SUB_MODULE.info(MESSAGE1)
-        TEST_LOGGER_SUB_MODULE.info(MESSAGE2)
+        # TEST_LOGGER.info(MESSAGE1, 4200)
+        # TEST_LOGGER.info(MESSAGE2, 4301)
+        diagnostic_logger.AzureDiagnosticLogging.info(MESSAGE1, "4200")
+        diagnostic_logger.AzureDiagnosticLogging.info(MESSAGE2, "4301")
         check_file_is_empty(temp_file_path)
 
-    def test_off_app_service_warning(self, temp_file_path):
-        set_up(temp_file_path, is_diagnostics_enabled=False)
-        TEST_LOGGER.warning(MESSAGE1)
-        TEST_LOGGER.warning(MESSAGE2)
-        TEST_LOGGER_SUB_MODULE.warning(MESSAGE1)
-        TEST_LOGGER_SUB_MODULE.warning(MESSAGE2)
-        check_file_is_empty(temp_file_path)
+    # def test_off_app_service_warning(self, temp_file_path):
+    #     set_up(temp_file_path, is_diagnostics_enabled=False)
+    #     # TEST_LOGGER.warning(MESSAGE1)
+    #     # TEST_LOGGER.warning(MESSAGE2)
+    #     diagnostic_logger.AzureDiagnosticLogging.warning(MESSAGE1)
+    #     diagnostic_logger.AzureDiagnosticLogging.warning(MESSAGE2)
+    #     check_file_is_empty(temp_file_path)
 
-    def test_off_app_service_error(self, temp_file_path):
-        set_up(temp_file_path, is_diagnostics_enabled=False)
-        TEST_LOGGER.error(MESSAGE1)
-        TEST_LOGGER.error(MESSAGE2)
-        TEST_LOGGER_SUB_MODULE.error(MESSAGE1)
-        TEST_LOGGER_SUB_MODULE.error(MESSAGE2)
-        check_file_is_empty(temp_file_path)
+    # def test_off_app_service_error(self, temp_file_path):
+    #     set_up(temp_file_path, is_diagnostics_enabled=False)
+    #     # TEST_LOGGER.error(MESSAGE1)
+    #     # TEST_LOGGER.error(MESSAGE2)
+    #     diagnostic_logger.AzureDiagnosticLogging.error(MESSAGE1)
+    #     diagnostic_logger.AzureDiagnosticLogging.error(MESSAGE2)
+    #     check_file_is_empty(temp_file_path)
 
     def test_subscription_id_plus(self, temp_file_path):
         set_up(
@@ -189,9 +191,9 @@ class TestDiagnosticLogger:
             subscription_id_env_var=TEST_SUBSCRIPTION_ID_ENV_VAR,
         )
         assert diagnostic_logger._SUBSCRIPTION_ID == TEST_SUBSCRIPTION_ID
-        TEST_LOGGER_SUB_MODULE.warning(MESSAGE1)
-        TEST_LOGGER_SUB_MODULE.warning(MESSAGE2)
-        check_file_for_messages(temp_file_path, "WARNING", (MESSAGE1, MESSAGE2))
+        diagnostic_logger.AzureDiagnosticLogging.info(MESSAGE1, "4200")
+        diagnostic_logger.AzureDiagnosticLogging.info(MESSAGE2, "4301")
+        check_file_for_messages(temp_file_path, "INFO", ((MESSAGE1, "4200"), (MESSAGE2, "4301")))
 
     def test_subscription_id_no_plus(self, temp_file_path):
         set_up(
@@ -200,6 +202,6 @@ class TestDiagnosticLogger:
             subscription_id_env_var=TEST_SUBSCRIPTION_ID,
         )
         assert diagnostic_logger._SUBSCRIPTION_ID == TEST_SUBSCRIPTION_ID
-        TEST_LOGGER_SUB_MODULE.warning(MESSAGE1)
-        TEST_LOGGER_SUB_MODULE.warning(MESSAGE2)
-        check_file_for_messages(temp_file_path, "WARNING", (MESSAGE1, MESSAGE2))
+        diagnostic_logger.AzureDiagnosticLogging.info(MESSAGE1, "4200")
+        diagnostic_logger.AzureDiagnosticLogging.info(MESSAGE2, "4301")
+        check_file_for_messages(temp_file_path, "INFO", ((MESSAGE1, "4200"), (MESSAGE2, "4301")))

--- a/sdk/monitor/azure-monitor-opentelemetry/tests/diagnostics/test_diagnostic_logging.py
+++ b/sdk/monitor/azure-monitor-opentelemetry/tests/diagnostics/test_diagnostic_logging.py
@@ -17,15 +17,11 @@ TEST_SITE_NAME = "TEST_SITE_NAME"
 TEST_CUSTOMER_IKEY = "TEST_CUSTOMER_IKEY"
 TEST_EXTENSION_VERSION = "TEST_EXTENSION_VERSION"
 TEST_VERSION = "TEST_VERSION"
-TEST_SUBSCRIPTION_ID_ENV_VAR = "TEST_SUBSCRIPTION_ID+TEST_SUBSCRIPTION_ID"
+TEST_SUBSCRIPTION_ID_PLUS = "TEST_SUBSCRIPTION_ID+TEST_SUBSCRIPTION_ID"
 TEST_SUBSCRIPTION_ID = "TEST_SUBSCRIPTION_ID"
 MESSAGE1 = "MESSAGE1"
 MESSAGE2 = "MESSAGE2"
 MESSAGE3 = "MESSAGE3"
-# TEST_LOGGER_NAME = "test.logger.name"
-# TEST_LOGGER = logging.getLogger(TEST_LOGGER_NAME)
-# TEST_LOGGER_NAME_SUB_MODULE = TEST_LOGGER_NAME + ".sub.module"
-# diagnostic_logger.AzureDiagnosticLogging = logging.getLogger(TEST_LOGGER_NAME_SUB_MODULE)
 
 
 def clear_file(file_path):
@@ -63,14 +59,9 @@ def check_file_is_empty(file_path):
 def set_up(
     file_path,
     is_diagnostics_enabled,
-    # logger=TEST_LOGGER,
-    subscription_id_env_var=TEST_SUBSCRIPTION_ID_ENV_VAR,
+    subscription_id_env_var=TEST_SUBSCRIPTION_ID_PLUS,
 ) -> None:
     diagnostic_logger._logger.handlers.clear()
-    # logger.handlers.clear()
-    # TEST_LOGGER.handlers.clear()
-    # diagnostic_logger.AzureDiagnosticLogging.handlers.clear()
-    # diagnostic_logger.AzureDiagnosticLogging.setLevel(logging.WARN)
     patch.dict(
         "os.environ",
         {
@@ -104,7 +95,6 @@ def set_up(
         "azure.monitor.opentelemetry._diagnostics.diagnostic_logging._IS_DIAGNOSTICS_ENABLED",
         is_diagnostics_enabled,
     ).start()
-    # diagnostic_logger.AzureDiagnosticLogging.enable(logger)
 
 
 class TestDiagnosticLogger:
@@ -124,71 +114,41 @@ class TestDiagnosticLogger:
         diagnostic_logger.AzureDiagnosticLogging.info(MESSAGE2, "4301")
         check_file_for_messages(temp_file_path, "INFO", ((MESSAGE1, "4200"), (MESSAGE2, "4301")))
 
-    # def test_info_with_info_log_level(self, temp_file_path):
-    #     set_up(temp_file_path, is_diagnostics_enabled=True)
-    #     # diagnostic_logger.AzureDiagnosticLogging.setLevel(logging.INFO)
-    #     diagnostic_logger.AzureDiagnosticLogging.info(MESSAGE1, "4200")
-    #     diagnostic_logger.AzureDiagnosticLogging.info(MESSAGE2, "4301")
-    #     # diagnostic_logger.AzureDiagnosticLogging.setLevel(logging.NOTSET)
-    #     check_file_for_messages(temp_file_path, "INFO", ((MESSAGE1, "4200"), (MESSAGE2, "4301")))
-
-    def test_info_with_sub_module_info_log_level(self, temp_file_path):
+    def test_warning(self, temp_file_path):
         set_up(temp_file_path, is_diagnostics_enabled=True)
-        # diagnostic_logger.AzureDiagnosticLogging.setLevel(logging.INFO)
-        diagnostic_logger.AzureDiagnosticLogging.info(MESSAGE1, "4200")
-        diagnostic_logger.AzureDiagnosticLogging.info(MESSAGE2, "4301")
-        # diagnostic_logger.AzureDiagnosticLogging.setLevel(logging.NOTSET)
-        check_file_for_messages(temp_file_path, "INFO", ((MESSAGE1, "4200"), (MESSAGE2, "4301")))
+        diagnostic_logger.AzureDiagnosticLogging.warning(MESSAGE1, "4200")
+        diagnostic_logger.AzureDiagnosticLogging.warning(MESSAGE2, "4301")
+        check_file_for_messages(temp_file_path, "WARNING", ((MESSAGE1, "4200"), (MESSAGE2, "4301")))
 
-    # def test_warning(self, temp_file_path):
-    #     set_up(temp_file_path, is_diagnostics_enabled=True)
-    #     diagnostic_logger.AzureDiagnosticLogging.warning(MESSAGE1)
-    #     diagnostic_logger.AzureDiagnosticLogging.warning(MESSAGE2)
-    #     check_file_for_messages(temp_file_path, "WARNING", (MESSAGE1, MESSAGE2))
-
-    # def test_warning_multiple_enable(self, temp_file_path):
-    #     set_up(temp_file_path, is_diagnostics_enabled=True)
-    #     diagnostic_logger.AzureDiagnosticLogging.enable(TEST_LOGGER)
-    #     diagnostic_logger.AzureDiagnosticLogging.enable(TEST_LOGGER)
-    #     diagnostic_logger.AzureDiagnosticLogging.warning(MESSAGE1)
-    #     diagnostic_logger.AzureDiagnosticLogging.warning(MESSAGE2)
-    #     check_file_for_messages(temp_file_path, "WARNING", (MESSAGE1, MESSAGE2))
-
-    # def test_error(self, temp_file_path):
-    #     set_up(temp_file_path, is_diagnostics_enabled=True)
-    #     diagnostic_logger.AzureDiagnosticLogging.error(MESSAGE1)
-    #     diagnostic_logger.AzureDiagnosticLogging.error(MESSAGE2)
-    #     check_file_for_messages(temp_file_path, "ERROR", ((MESSAGE1, 4200), (MESSAGE2, 4301)))
+    def test_error(self, temp_file_path):
+        set_up(temp_file_path, is_diagnostics_enabled=True)
+        diagnostic_logger.AzureDiagnosticLogging.error(MESSAGE1, "4200")
+        diagnostic_logger.AzureDiagnosticLogging.error(MESSAGE2, "4301")
+        check_file_for_messages(temp_file_path, "ERROR", ((MESSAGE1, "4200"), (MESSAGE2, "4301")))
 
     def test_off_app_service_info(self, temp_file_path):
         set_up(temp_file_path, is_diagnostics_enabled=False)
-        # TEST_LOGGER.info(MESSAGE1, 4200)
-        # TEST_LOGGER.info(MESSAGE2, 4301)
         diagnostic_logger.AzureDiagnosticLogging.info(MESSAGE1, "4200")
         diagnostic_logger.AzureDiagnosticLogging.info(MESSAGE2, "4301")
         check_file_is_empty(temp_file_path)
 
-    # def test_off_app_service_warning(self, temp_file_path):
-    #     set_up(temp_file_path, is_diagnostics_enabled=False)
-    #     # TEST_LOGGER.warning(MESSAGE1)
-    #     # TEST_LOGGER.warning(MESSAGE2)
-    #     diagnostic_logger.AzureDiagnosticLogging.warning(MESSAGE1)
-    #     diagnostic_logger.AzureDiagnosticLogging.warning(MESSAGE2)
-    #     check_file_is_empty(temp_file_path)
+    def test_off_app_service_warning(self, temp_file_path):
+        set_up(temp_file_path, is_diagnostics_enabled=False)
+        diagnostic_logger.AzureDiagnosticLogging.warning(MESSAGE1, "4200")
+        diagnostic_logger.AzureDiagnosticLogging.warning(MESSAGE2, "4301")
+        check_file_is_empty(temp_file_path)
 
-    # def test_off_app_service_error(self, temp_file_path):
-    #     set_up(temp_file_path, is_diagnostics_enabled=False)
-    #     # TEST_LOGGER.error(MESSAGE1)
-    #     # TEST_LOGGER.error(MESSAGE2)
-    #     diagnostic_logger.AzureDiagnosticLogging.error(MESSAGE1)
-    #     diagnostic_logger.AzureDiagnosticLogging.error(MESSAGE2)
-    #     check_file_is_empty(temp_file_path)
+    def test_off_app_service_error(self, temp_file_path):
+        set_up(temp_file_path, is_diagnostics_enabled=False)
+        diagnostic_logger.AzureDiagnosticLogging.error(MESSAGE1, "4200")
+        diagnostic_logger.AzureDiagnosticLogging.error(MESSAGE2, "4301")
+        check_file_is_empty(temp_file_path)
 
     def test_subscription_id_plus(self, temp_file_path):
         set_up(
             temp_file_path,
             is_diagnostics_enabled=True,
-            subscription_id_env_var=TEST_SUBSCRIPTION_ID_ENV_VAR,
+            subscription_id_env_var=TEST_SUBSCRIPTION_ID_PLUS,
         )
         assert diagnostic_logger._SUBSCRIPTION_ID == TEST_SUBSCRIPTION_ID
         diagnostic_logger.AzureDiagnosticLogging.info(MESSAGE1, "4200")

--- a/sdk/monitor/azure-monitor-opentelemetry/tests/test_constants.py
+++ b/sdk/monitor/azure-monitor-opentelemetry/tests/test_constants.py
@@ -51,28 +51,6 @@ class TestConstants(TestCase):
             _constants._get_customer_ikey_from_env_var(), "unknown"
         )
 
-    # TODO: Enabled when duplicate logging issue is solved
-    # @patch.dict(
-    #     "os.environ",
-    #     {"AZURE_MONITOR_OPENTELEMETRY_DISTRO_ENABLE_EXPORTER_DIAGNOSTICS": "True"},
-    # )
-    # def test_exporter_diagnostics_enabled(self):
-    #     reload(_constants)
-    #     self.assertTrue(_constants._EXPORTER_DIAGNOSTICS_ENABLED)
-
-    # def test_exporter_diagnostics_disabled(self):
-    #     clear_env_var("AZURE_MONITOR_OPENTELEMETRY_DISTRO_ENABLE_EXPORTER_DIAGNOSTICS")
-    #     reload(_constants)
-    #     self.assertFalse(_constants._EXPORTER_DIAGNOSTICS_ENABLED)
-
-    # @patch.dict(
-    #     "os.environ",
-    #     {"AZURE_MONITOR_OPENTELEMETRY_DISTRO_ENABLE_EXPORTER_DIAGNOSTICS": "foobar"},
-    # )
-    # def test_exporter_diagnostics_other(self):
-    #     reload(_constants)
-    #     self.assertFalse(_constants._EXPORTER_DIAGNOSTICS_ENABLED)
-
     @patch.dict("os.environ", {"WEBSITE_SITE_NAME": TEST_VALUE})
     def test_diagnostics_enabled(self):
         reload(_constants)


### PR DESCRIPTION
# Description

Diagnostic logs should only come with clear message ids for applens to interpret.
[Spec](https://github.com/aep-health-and-standards/Telemetry-Collection-Spec/blob/main/ApplicationInsights/applens-detector-app-service-attach.md)

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
