### PR TITLE
fix sample live tests by pinning pyproject-api dependency of tox

### DIFF
--- a/eng/ci_tools.txt
+++ b/eng/ci_tools.txt
@@ -5,6 +5,7 @@ wheel==0.37.0
 packaging==23.1
 wheel==0.37.0
 tox==4.5.0
+pyproject-api<1.6
 pathlib2==2.3.5
 doc-warden==0.7.2
 beautifulsoup4==4.9.1

--- a/eng/test_tools.txt
+++ b/eng/test_tools.txt
@@ -7,6 +7,7 @@ pytest-xdist==3.2.1
 coverage==7.2.5
 bandit==1.6.2
 protobuf==3.17.3; python_version == '2.7'
+pyproject-api<1.6
 
 # locking packages defined as deps from azure-sdk-tools or azure-devtools
 Jinja2==3.1.2


### PR DESCRIPTION
Live sample tests are failing with "AttributeError: 'NoneType' object has no attribute 'metadata'".
Example: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3107728&view=logs&j=9a70031a-ff5a-5fd1-19bb-62ae7cc4efb0&t=27f01896-a7f7-54e7-d105-b88365882c7a&l=128

This is due to an incompatibility between tox and pyproject-api discussed in the issue here: https://github.com/tox-dev/tox/issues/3110

A newer, patched version of tox pinned this dependency to fix the incompatibility: https://github.com/tox-dev/tox/commit/2886397b3d98d914f04ca0229c657a1fa0d9952e

Figured we'd pin the pyproject-api dependency before bumping our tox version as I'm not sure what other incompatibilities will lie there