### PR TITLE
Repair Integration Release

### DIFF
--- a/eng/pipelines/templates/stages/archetype-python-release.yml
+++ b/eng/pipelines/templates/stages/archetype-python-release.yml
@@ -86,7 +86,6 @@ stages:
                       - script: |
                           set -e
                           python -m pip install -r eng/release_requirements.txt
-                          python -m pip install tools/azure-sdk-tools
                         displayName: Install Release Dependencies
 
                       - task: PythonScript@0

--- a/eng/regression_tools.txt
+++ b/eng/regression_tools.txt
@@ -5,7 +5,6 @@ wheel==0.37.0
 Jinja2==3.1.2
 packaging==23.1
 tox==4.5.0
-twine==3.1.1; python_version >= '3.6'
 pathlib2==2.3.5
 doc-warden==0.7.2
 beautifulsoup4==4.9.1

--- a/eng/release_requirements.txt
+++ b/eng/release_requirements.txt
@@ -1,3 +1,4 @@
 twine==3.1.1; python_version >= '3.6'
-readme-renderer[md]==25.0
 pkginfo==1.5.0.1
+urllib3==2.0.4
+tools/azure-sdk-tools

--- a/eng/release_requirements.txt
+++ b/eng/release_requirements.txt
@@ -1,4 +1,2 @@
-twine==3.1.1; python_version >= '3.6'
-pkginfo==1.5.0.1
-urllib3==2.0.4
+twine==4.0.2; python_version >= '3.6'
 tools/azure-sdk-tools


### PR DESCRIPTION
`twine<4` is not compatible with `urllib>2`. We removed the `urllib3` pin recently in `azure-sdk-tools`, which is why this stage started failing.

[Successful Release Using Fix](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3109627&view=results)

The failure used to look like this:
![image](https://github.com/Azure/azure-sdk-for-python/assets/45376673/c170031b-cc9f-4ee6-9db6-6f1dbb11ead9)