### PR TITLE
[ML][Pipelines] feat: support data binding expression in inline parallel job

### DIFF
--- a/sdk/ml/azure-ai-ml/assets.json
+++ b/sdk/ml/azure-ai-ml/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "python",
   "TagPrefix": "python/ml/azure-ai-ml",
-  "Tag": "python/ml/azure-ai-ml_3c8879412f"
+  "Tag": "python/ml/azure-ai-ml_748fafdb82"
 }

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/pipeline/pipeline_parallel_job.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/pipeline/pipeline_parallel_job.py
@@ -7,25 +7,34 @@
 import logging
 from typing import Any
 
-from marshmallow import fields, post_load
+from marshmallow import post_load
 
-from azure.ai.ml._schema.core.fields import ComputeField, EnvironmentField, NestedField, UnionField
-from azure.ai.ml._schema.job.input_output_entry import OutputSchema
-from azure.ai.ml._schema.job.parallel_job import ParallelJobSchema
+from azure.ai.ml._schema.core.fields import ComputeField, EnvironmentField, StringTransformedEnum
+from azure.ai.ml._schema.job import ParameterizedParallelSchema
+from azure.ai.ml._schema.pipeline.component_job import BaseNodeSchema
+
+from ...constants._component import NodeType
 
 module_logger = logging.getLogger(__name__)
 
 
-class PipelineParallelJobSchema(ParallelJobSchema):
+# parallel job inherits parallel attributes from ParameterizedParallelSchema and node functionality from BaseNodeSchema
+class PipelineParallelJobSchema(BaseNodeSchema, ParameterizedParallelSchema):
+    """Schema for ParallelJob in PipelineJob/PipelineComponent."""
+
+    type = StringTransformedEnum(allowed_values=NodeType.PARALLEL)
     compute = ComputeField()
     environment = EnvironmentField()
-    outputs = fields.Dict(
-        keys=fields.Str(),
-        values=UnionField([NestedField(OutputSchema), fields.Str()], allow_none=True),
-    )
 
     @post_load
     def make(self, data: Any, **kwargs: Any):
+        """Construct a ParallelJob from deserialized data.
+
+        :param data: The deserialized data.
+        :type data: dict[str, Any]
+        :return: A ParallelJob.
+        :rtype: azure.ai.ml.entities._job.parallel.ParallelJob
+        """
         from azure.ai.ml.entities._job.parallel.parallel_job import ParallelJob
 
         return ParallelJob(**data)

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_job_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_job_operations.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Union
 
 import jwt
+from marshmallow import ValidationError
 
 from azure.ai.ml._artifacts._artifact_utilities import (
     _upload_and_generate_remote_uri,
@@ -617,98 +618,94 @@ class JobOperations(_ScopeDependentOperations):
                 :dedent: 8
                 :caption: Creating a new job and then updating its compute.
         """
+        if isinstance(job, BaseNode) and not (
+            isinstance(job, (Command, Spark))
+        ):  # Command/Spark objects can be used directly
+            job = job._to_job()
+
+        # Set job properties before submission
+        if description is not None:
+            job.description = description
+        if compute is not None:
+            job.compute = compute
+        if tags is not None:
+            job.tags = tags
+        if experiment_name is not None:
+            job.experiment_name = experiment_name
+
+        if job.compute == LOCAL_COMPUTE_TARGET:
+            job.environment_variables[COMMON_RUNTIME_ENV_VAR] = "true"
+
+        # TODO: why we put log logic here instead of inside self._validate()?
         try:
-            if isinstance(job, BaseNode) and not (
-                isinstance(job, (Command, Spark))
-            ):  # Command/Spark objects can be used directly
-                job = job._to_job()
-
-            # Set job properties before submission
-            if description is not None:
-                job.description = description
-            if compute is not None:
-                job.compute = compute
-            if tags is not None:
-                job.tags = tags
-            if experiment_name is not None:
-                job.experiment_name = experiment_name
-
-            if job.compute == LOCAL_COMPUTE_TARGET:
-                job.environment_variables[COMMON_RUNTIME_ENV_VAR] = "true"
-
             if not skip_validation:
                 self._validate(job, raise_on_failure=True)
 
             # Create all dependent resources
             self._resolve_arm_id_or_upload_dependencies(job)
+        except (ValidationException, ValidationError) as ex:  # pylint: disable=broad-except
+            log_and_raise_error(ex)
 
-            git_props = get_git_properties()
-            # Do not add git props if they already exist in job properties.
-            # This is for update specifically-- if the user switches branches and tries to update
-            # their job, the request will fail since the git props will be repopulated.
-            # MFE does not allow existing properties to be updated, only for new props to be added
-            if not any(prop_name in job.properties for prop_name in git_props):
-                job.properties = {**job.properties, **git_props}
-            rest_job_resource = to_rest_job_object(job)
+        git_props = get_git_properties()
+        # Do not add git props if they already exist in job properties.
+        # This is for update specifically-- if the user switches branches and tries to update
+        # their job, the request will fail since the git props will be repopulated.
+        # MFE does not allow existing properties to be updated, only for new props to be added
+        if not any(prop_name in job.properties for prop_name in git_props):
+            job.properties = {**job.properties, **git_props}
+        rest_job_resource = to_rest_job_object(job)
 
-            # Make a copy of self._kwargs instead of contaminate the original one
-            kwargs = dict(**self._kwargs)
-            # set headers with user aml token if job is a pipeline or has a user identity setting
-            if (rest_job_resource.properties.job_type == RestJobType.PIPELINE) or (
-                hasattr(rest_job_resource.properties, "identity")
-                and (isinstance(rest_job_resource.properties.identity, UserIdentity))
-            ):
-                self._set_headers_with_user_aml_token(kwargs)
+        # Make a copy of self._kwargs instead of contaminate the original one
+        kwargs = dict(**self._kwargs)
+        # set headers with user aml token if job is a pipeline or has a user identity setting
+        if (rest_job_resource.properties.job_type == RestJobType.PIPELINE) or (
+            hasattr(rest_job_resource.properties, "identity")
+            and (isinstance(rest_job_resource.properties.identity, UserIdentity))
+        ):
+            self._set_headers_with_user_aml_token(kwargs)
+
+        result = self._operation_2023_02_preview.create_or_update(
+            id=rest_job_resource.name,  # type: ignore
+            resource_group_name=self._operation_scope.resource_group_name,
+            workspace_name=self._workspace_name,
+            body=rest_job_resource,
+            **kwargs,
+        )
+
+        if is_local_run(result):
+            ws_base_url = self._all_operations.all_operations[
+                AzureMLResourceType.WORKSPACE
+            ]._operation._client._base_url
+            snapshot_id = start_run_if_local(
+                result,
+                self._credential,
+                ws_base_url,
+                self._requests_pipeline,
+            )
+            # in case of local run, the first create/update call to MFE returns the
+            # request for submitting to ES. Once we request to ES and start the run, we
+            # need to put the same body to MFE to append user tags etc.
+            job_object = self._get_job(rest_job_resource.name)
+            if result.properties.tags is not None:
+                for tag_name, tag_value in rest_job_resource.properties.tags.items():
+                    job_object.properties.tags[tag_name] = tag_value
+            if result.properties.properties is not None:
+                for (
+                    prop_name,
+                    prop_value,
+                ) in rest_job_resource.properties.properties.items():
+                    job_object.properties.properties[prop_name] = prop_value
+            if snapshot_id is not None:
+                job_object.properties.properties["ContentSnapshotId"] = snapshot_id
 
             result = self._operation_2023_02_preview.create_or_update(
                 id=rest_job_resource.name,  # type: ignore
                 resource_group_name=self._operation_scope.resource_group_name,
                 workspace_name=self._workspace_name,
-                body=rest_job_resource,
+                body=job_object,
                 **kwargs,
             )
-
-            if is_local_run(result):
-                ws_base_url = self._all_operations.all_operations[
-                    AzureMLResourceType.WORKSPACE
-                ]._operation._client._base_url
-                snapshot_id = start_run_if_local(
-                    result,
-                    self._credential,
-                    ws_base_url,
-                    self._requests_pipeline,
-                )
-                # in case of local run, the first create/update call to MFE returns the
-                # request for submitting to ES. Once we request to ES and start the run, we
-                # need to put the same body to MFE to append user tags etc.
-                job_object = self._get_job(rest_job_resource.name)
-                if result.properties.tags is not None:
-                    for tag_name, tag_value in rest_job_resource.properties.tags.items():
-                        job_object.properties.tags[tag_name] = tag_value
-                if result.properties.properties is not None:
-                    for (
-                        prop_name,
-                        prop_value,
-                    ) in rest_job_resource.properties.properties.items():
-                        job_object.properties.properties[prop_name] = prop_value
-                if snapshot_id is not None:
-                    job_object.properties.properties["ContentSnapshotId"] = snapshot_id
-
-                result = self._operation_2023_02_preview.create_or_update(
-                    id=rest_job_resource.name,  # type: ignore
-                    resource_group_name=self._operation_scope.resource_group_name,
-                    workspace_name=self._workspace_name,
-                    body=job_object,
-                    **kwargs,
-                )
-            return self._resolve_azureml_id(Job._from_rest_object(result))
-        except Exception as ex:  # pylint: disable=broad-except
-            from marshmallow.exceptions import ValidationError as SchemaValidationError
-
-            if isinstance(ex, (ValidationException, SchemaValidationError)):
-                log_and_raise_error(ex)
-            else:
-                raise ex
+        return self._resolve_azureml_id(Job._from_rest_object(result))
 
     def _archive_or_restore(self, name: str, is_archived: bool):
         job_object = self._get_job(name)

--- a/sdk/ml/azure-ai-ml/tests/dsl/unittests/test_mldesigner_imports.py
+++ b/sdk/ml/azure-ai-ml/tests/dsl/unittests/test_mldesigner_imports.py
@@ -1,19 +1,26 @@
+import re
+
 import pytest
+
 from azure.ai.ml import Input, load_component
-from azure.ai.ml.entities import (
-    Component,
-    CommandComponent,
-    PipelineComponent,
-    ValidationResult,
-)
-from azure.ai.ml.dsl._mldesigner import (
-    InternalAdditionalIncludes,
-    InternalComponent,
-    ParallelFor,
-)
+from azure.ai.ml.dsl._mldesigner import ParallelFor
+from azure.ai.ml.entities import CommandComponent, Component, PipelineComponent, ValidationResult
 from azure.ai.ml.entities._builders.base_node import BaseNode
 from azure.ai.ml.entities._inputs_outputs import GroupInput
-from azure.ai.ml.entities._job.pipeline._io import PipelineInput, NodeOutput, NodeInput
+from azure.ai.ml.entities._job.pipeline._io import NodeInput, NodeOutput, PipelineInput
+
+
+# mldesigner use this function to check if a component is an internal component
+def is_internal_component(component):
+    """Check if the component is internal component.
+
+    Use class name to check to avoid import InternalComponent in mldesigner.
+    """
+    if not isinstance(component, Component):
+        return False
+    if re.match(r"Internal.*Component", component.__class__.__name__):
+        return True
+    return False
 
 
 @pytest.mark.unittest
@@ -51,6 +58,7 @@ class TestMldesignerImports:
         assert hasattr(obj, "with_includes")
         assert hasattr(obj, "code_path")
         assert hasattr(obj, "includes")
+        assert is_internal_component(internal_component)
 
     def test_necessary_attributes_for_input(self):
         input_obj = Input()

--- a/sdk/ml/azure-ai-ml/tests/pipeline_job/e2etests/test_pipeline_job.py
+++ b/sdk/ml/azure-ai-ml/tests/pipeline_job/e2etests/test_pipeline_job.py
@@ -566,6 +566,17 @@ class TestPipelineJob(AzureRecordedTestCase):
         # assert on the number of converted jobs to make sure we didn't drop the parallel job
         assert len(created_job.jobs.items()) == 1
 
+    def test_pipeline_job_with_parallel_job_with_input_bindings(self, client: MLClient, randstr: Callable[[str], str]):
+        yaml_path = "tests/test_configs/pipeline_jobs/pipeline_job_with_parallel_job_with_input_bindings.yml"
+
+        params_override = [{"name": randstr("name")}]
+        pipeline_job = load_job(
+            source=yaml_path,
+            params_override=params_override,
+        )
+        created_job = client.jobs.create_or_update(pipeline_job)
+        assert created_job.jobs["hello_world"].resources.instance_count == "${{parent.inputs.instance_count}}"
+
     @pytest.mark.skip(
         reason="The task for fixing this is tracked by "
         "https://msdata.visualstudio.com/Vienna/_workitems/edit/2298433"

--- a/sdk/ml/azure-ai-ml/tests/pipeline_job/unittests/test_controlflow_pipeline_job.py
+++ b/sdk/ml/azure-ai-ml/tests/pipeline_job/unittests/test_controlflow_pipeline_job.py
@@ -5,6 +5,7 @@ from azure.ai.ml import load_job
 from azure.ai.ml.entities import PipelineJob
 from azure.ai.ml.entities._job.to_rest_functions import to_rest_job_object
 from azure.ai.ml.exceptions import ValidationException
+
 from .._util import _PIPELINE_JOB_TIMEOUT_SECOND
 
 
@@ -110,54 +111,54 @@ class TestParallelForPipelineJobUT(TestControlFlowPipelineJobUT):
     @pytest.mark.parametrize(
         "exception_cls, yaml_path, msg, location",
         [
-            # items with invalid content type
-            (
+            pytest.param(
                 ValidationError,
                 "./tests/test_configs/pipeline_jobs/invalid/parallel_for/items_invalid_value_type.yml",
                 "Not a valid mapping type.",
                 '"path": "jobs.parallelfor.items",',
+                id="items_invalid_content_type",
             ),
-            # # items with empty dict as content
-            (
+            pytest.param(
                 ValidationException,
                 "./tests/test_configs/pipeline_jobs/invalid/parallel_for/items_empty.yml",
                 "Items is an empty list/dict.",
                 '"path": "jobs.parallelfor.items",',
+                id="items_empty_dict_content",
             ),
-            # item meta not match
-            (
+            pytest.param(
                 ValidationException,
                 "./tests/test_configs/pipeline_jobs/invalid/parallel_for/items_meta_mismatch.yml",
                 '"message": "Items should have same keys',
                 '"path": "jobs.parallelfor.items"',
+                id="items_meta_mismatch",
             ),
-            # items not exist
-            (
+            pytest.param(
                 ValidationException,
                 "./tests/test_configs/pipeline_jobs/invalid/parallel_for/items_not_exist.yml",
                 "got unmatched inputs with loop body component",
                 '"path": "jobs.parallelfor.items"',
+                id="items_not_exist",
             ),
-            # items invalid json
-            (
+            pytest.param(
                 ValidationException,
                 "./tests/test_configs/pipeline_jobs/invalid/parallel_for/items_invalid_json.yml",
                 '"message": "Items is neither a valid JSON',
                 '"path": "jobs.parallelfor.items"',
+                id="items_invalid_json",
             ),
-            # required field unprovided
-            (
+            pytest.param(
                 ValidationError,
                 "./tests/test_configs/pipeline_jobs/invalid/parallel_for/items_unprovided.yml",
                 '"message": "Missing data for required field',
                 "items_unprovided.yml#line 7",
+                id="required_field_unprovided",
             ),
-            # body unsupported
-            (
+            pytest.param(
                 ValidationException,
                 "./tests/test_configs/pipeline_jobs/invalid/parallel_for/body_not_supported.yml",
                 " got <class 'azure.ai.ml.entities._builders.parallel.Parallel'> instead.",
                 "",
+                id="body_not_supported",
             ),
         ],
     )

--- a/sdk/ml/azure-ai-ml/tests/pipeline_job/unittests/test_pipeline_job_schema.py
+++ b/sdk/ml/azure-ai-ml/tests/pipeline_job/unittests/test_pipeline_job_schema.py
@@ -776,7 +776,7 @@ class TestPipelineJobSchema:
     @pytest.mark.parametrize(
         "test_path,expected_inputs",
         [
-            (
+            pytest.param(
                 "tests/test_configs/pipeline_jobs/pipeline_job_with_sweep_job_with_input_bindings.yml",
                 {
                     "hello_world": {
@@ -793,8 +793,9 @@ class TestPipelineJobSchema:
                         "test2": {"job_input_type": "literal", "value": "${{parent.inputs.job_data_path}}"},
                     },
                 },
+                id="pipeline_job_with_sweep_job_with_input_bindings",
             ),
-            (
+            pytest.param(
                 "tests/test_configs/pipeline_jobs/pipeline_job_with_command_job_with_input_bindings.yml",
                 {
                     "hello_world": {
@@ -819,19 +820,21 @@ class TestPipelineJobSchema:
                         },
                     },
                 },
+                id="pipeline_job_with_command_job_with_input_bindings",
             ),
-            (
+            pytest.param(
                 "tests/test_configs/pipeline_jobs/pipeline_job_with_parallel_job_with_input_bindings.yml",
                 {
                     "hello_world": {
-                        "test1": {
+                        "job_data_path": {
                             "job_input_type": "literal",
                             "value": "${{parent.inputs.job_data_path}}",
                         }
                     },
                 },
+                id="pipeline_job_with_parallel_job_with_input_bindings",
             ),
-            (
+            pytest.param(
                 "tests/test_configs/pipeline_jobs/pipeline_job_with_spark_job_with_input_bindings.yml",
                 {
                     "hello_world": {
@@ -845,6 +848,7 @@ class TestPipelineJobSchema:
                         },
                     }
                 },
+                id="pipeline_job_with_spark_job_with_input_bindings",
             ),
         ],
     )
@@ -869,14 +873,12 @@ class TestPipelineJobSchema:
             assert "Failed to find top level definition for input binding" in str(e.value)
 
         # Check that all inputs are present and are of type Input or are literals
-        for index, input_name in enumerate(yaml_obj["inputs"].keys()):
+        for input_name, input_yaml in yaml_obj["inputs"].items():
             job_obj_input = job.inputs.get(input_name, None)
-            assert job_obj_input is not None
+            assert job_obj_input is not None, f"Input {input_name} not found in loaded job"
             assert isinstance(job_obj_input, PipelineInput)
             job_obj_input = job_obj_input._to_job_input()
-            if index == 0:
-                assert isinstance(job_obj_input, Input)
-            elif index == 1:
+            if isinstance(input_yaml, dict):
                 assert isinstance(job_obj_input, Input)
             else:
                 assert isinstance(job_obj_input, int)

--- a/sdk/ml/azure-ai-ml/tests/test_configs/pipeline_jobs/pipeline_job_with_parallel_job_with_input_bindings.yml
+++ b/sdk/ml/azure-ai-ml/tests/test_configs/pipeline_jobs/pipeline_job_with_parallel_job_with_input_bindings.yml
@@ -13,6 +13,7 @@ inputs:
     type: uri_file
     path: https://azuremlexamples.blob.core.windows.net/datasets/iris.csv
     mode: ro_mount
+  instance_count: 1
 
 outputs:
   job_out_path_1:
@@ -25,12 +26,12 @@ jobs:
     type: parallel
     compute: "azureml:cpu-cluster"
     inputs:
-      test1: ${{parent.inputs.job_data_path}}
+      job_data_path: ${{parent.inputs.job_data_path}}
     outputs:
       scored_result: ${{parent.outputs.job_out_path_1}}
 
     resources:
-      instance_count: 3
+      instance_count: ${{parent.inputs.instance_count}}
     mini_batch_size: "100kb"
     mini_batch_error_threshold: 5
     logging_level: "DEBUG"
@@ -42,4 +43,4 @@ jobs:
       code: "../python"
       entry_script: pass_through.py
       append_row_to: ${{outputs.scored_result}} # optional, If Null, equals to summary_only mode in v1.
-      environment: azureml:my-env:1
+      environment: azureml:AzureML-Minimal:2


### PR DESCRIPTION
# Description

Support using data binding expression in node level run settings of inline parallel job like below:
```yaml
...
jobs:
  hello_world:
    # We pass the trained model from the train step to use to parallel inference
    type: parallel
    compute: "azureml:cpu-cluster"
    inputs:
      test1: ${{parent.inputs.job_data_path}}
    outputs:
      scored_result: ${{parent.outputs.job_out_path_1}}

    resources:
      instance_count: ${{parent.inputs.instance_count}}
    input_data: ${{inputs.job_data_path}}

    task:
      type: run_function
      code: "../python"
      entry_script: pass_through.py
      environment: azureml:AzureML-Minimal:2
```

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
