### PR TITLE
Fix Snippet-Update Tests

### DIFF
--- a/tools/azure-sdk-tools/ci_tools/functions.py
+++ b/tools/azure-sdk-tools/ci_tools/functions.py
@@ -235,7 +235,7 @@ def get_config_setting(package_path: str, setting: str, default: Any = True) -> 
 def is_package_active(package_path: str):
     disabled = INACTIVE_CLASSIFIER in ParsedSetup.from_path(package_path).classifiers
 
-    override_value = os.getenv(f"ENABLE_{os.path.basename(package_path).upper()}", None)
+    override_value = os.getenv(f"ENABLE_{os.path.basename(package_path).upper().replace('-', '_')}", None)
 
     if override_value:
         return str_to_bool(override_value)

--- a/tools/azure-sdk-tools/ci_tools/snippet_update/python_snippet_updater.py
+++ b/tools/azure-sdk-tools/ci_tools/snippet_update/python_snippet_updater.py
@@ -72,8 +72,9 @@ def update_snippet(file: str) -> None:
     file_obj = Path(file)
     with open(file_obj, 'r', encoding='utf8') as f:
         content = f.read()
-    pattern = "(?P<content>(?P<header><!-- SNIPPET:(?P<name>[A-Z a-z0-9_.]+)-->)\\n\\n```python\\n[\\s\\S]*?\\n<!-- END SNIPPET -->)"
-    matches = re.findall(pattern, content)
+    pattern = r"(?P<content>(?P<header><!-- SNIPPET:(?P<name>[A-Z a-z0-9_.]+)-->)[\n]+```python\n[\s\S]*?\n<!-- END SNIPPET -->)"
+    matches = re.findall(pattern, content, flags=re.MULTILINE)
+
     for match in matches:
         s = match
         body = s[0].strip()

--- a/tools/azure-sdk-tools/ci_tools/snippet_update/test_python_snippet_updater.py
+++ b/tools/azure-sdk-tools/ci_tools/snippet_update/test_python_snippet_updater.py
@@ -1,6 +1,6 @@
 import os
 import tempfile
-from python_snippet_updater import get_snippet, update_snippet, check_snippets, check_not_up_to_date
+from .python_snippet_updater import get_snippet, update_snippet, check_snippets, check_not_up_to_date
 
 def test_update_snippet():
     temp_sample = tempfile.NamedTemporaryFile(delete=False)

--- a/tools/azure-sdk-tools/tests/integration/test_package_discovery.py
+++ b/tools/azure-sdk-tools/tests/integration/test_package_discovery.py
@@ -16,8 +16,9 @@ def test_toml_result():
     result = parsed_setup.get_build_config()
 
     expected = {
-        "type_check_samples": False,
-        "verifytypes": False,
+        "mypy": True,
+        "type_check_samples": True,
+        "verifytypes": True,
         "pyright": False,
     }
 

--- a/tools/azure-sdk-tools/tests/test_python_snippet_updater.py
+++ b/tools/azure-sdk-tools/tests/test_python_snippet_updater.py
@@ -1,5 +1,4 @@
 import os
-import sys
 import pytest
 from ci_tools.snippet_update.python_snippet_updater import get_snippet, update_snippet, check_snippets, check_not_up_to_date
 


### PR DESCRIPTION
I am working on the `optional` environment, and would like the test environment to run clean. 

- Fixed bad import in snippet_updater tests
- Fixed broken package discovery tests
- Also flipped a regex string to an `r` string so that it's a tiny bit easier to read.

