### PR TITLE
[ML] refactor: Make defaults() a @classmethod

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_monitoring/thresholds.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_monitoring/thresholds.py
@@ -98,8 +98,9 @@ class NumericalDriftMetrics(RestTranslatableMixin):
             normalized_wasserstein_distance=0.1,
         )
 
-    def defaults(self) -> "NumericalDriftMetrics":
-        return self._get_default_thresholds()
+    @classmethod
+    def defaults(cls) -> "NumericalDriftMetrics":
+        return cls._get_default_thresholds()
 
     def get_name_and_threshold(self):
         return self._find_name_and_threshold()
@@ -151,8 +152,9 @@ class CategoricalDriftMetrics(RestTranslatableMixin):
             jensen_shannon_distance=0.1,
         )
 
-    def defaults(self) -> "CategoricalDriftMetrics":
-        return self._get_default_thresholds()
+    @classmethod
+    def defaults(cls) -> "CategoricalDriftMetrics":
+        return cls._get_default_thresholds()
 
     def get_name_and_threshold(self):
         return self._find_name_and_threshold()
@@ -236,8 +238,8 @@ class DataDriftMetricThreshold(MetricThreshold):
     @classmethod
     def _get_default_thresholds(cls) -> "DataDriftMetricThreshold":
         return cls(
-            numerical=NumericalDriftMetrics().defaults(),
-            categorical=CategoricalDriftMetrics().defaults(),
+            numerical=NumericalDriftMetrics.defaults(),
+            categorical=CategoricalDriftMetrics.defaults(),
         )
 
     def __eq__(self, other: Any):
@@ -322,8 +324,8 @@ class PredictionDriftMetricThreshold(MetricThreshold):
     @classmethod
     def _get_default_thresholds(cls) -> "PredictionDriftMetricThreshold":
         return cls(
-            numerical=NumericalDriftMetrics().defaults(),
-            categorical=CategoricalDriftMetrics().defaults(),
+            numerical=NumericalDriftMetrics.defaults(),
+            categorical=CategoricalDriftMetrics.defaults(),
         )
 
     def __eq__(self, other: Any):
@@ -394,8 +396,9 @@ class DataQualityMetricsNumerical(RestTranslatableMixin):
             out_of_bounds_rate=0.0,
         )
 
-    def defaults(self) -> "DataQualityMetricsNumerical":
-        return self._get_default_thresholds()
+    @classmethod
+    def defaults(cls) -> "DataQualityMetricsNumerical":
+        return cls._get_default_thresholds()
 
 
 @experimental
@@ -456,8 +459,9 @@ class DataQualityMetricsCategorical(RestTranslatableMixin):
             out_of_bounds_rate=0.0,
         )
 
-    def defaults(self) -> "DataQualityMetricsCategorical":
-        return self._get_default_thresholds()
+    @classmethod
+    def defaults(cls) -> "DataQualityMetricsCategorical":
+        return cls._get_default_thresholds()
 
 
 @experimental


### PR DESCRIPTION
# Description

This pull request addresses some feedback during our API review that the `defaults()` methods in `azure/ai/ml/entities/_monitoring/thresholds.py` should be classmethods.

Related to #31428 

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
