### PR TITLE
[Key Vault] Prepare for next version of `mypy`

### DIFF
--- a/sdk/keyvault/azure-keyvault-administration/README.md
+++ b/sdk/keyvault/azure-keyvault-administration/README.md
@@ -215,6 +215,7 @@ from azure.keyvault.administration import KeyVaultRoleScope
 
 role_assignments = client.list_role_assignments(KeyVaultRoleScope.GLOBAL)
 for assignment in role_assignments:
+    assert assignment.properties
     print(f"Role assignment name: {assignment.name}")
     print(f"Principal ID associated with this assignment: {assignment.properties.principal_id}")
 ```
@@ -246,6 +247,7 @@ specified scope and unique name.
 
 ```python
 fetched_assignment = client.get_role_assignment(scope=scope, name=role_assignment.name)
+assert fetched_assignment.properties
 print(f"Role assignment for principal {fetched_assignment.properties.principal_id} fetched successfully.")
 ```
 
@@ -276,7 +278,7 @@ to the library's [credential documentation][sas_docs]. Alternatively, it is poss
 CONTAINER_URL = os.environ["CONTAINER_URL"]
 SAS_TOKEN = os.environ["SAS_TOKEN"]
 
-backup_result = client.begin_backup(CONTAINER_URL, SAS_TOKEN).result()
+backup_result: KeyVaultBackupResult = client.begin_backup(CONTAINER_URL, SAS_TOKEN).result()
 print(f"Azure Storage Blob URL of the backup: {backup_result.folder_url}")
 ```
 
@@ -301,7 +303,7 @@ to the library's [credential documentation][sas_docs]. Alternatively, it is poss
 CONTAINER_URL = os.environ["CONTAINER_URL"]
 SAS_TOKEN = os.environ["SAS_TOKEN"]
 
-backup_result = client.begin_backup(CONTAINER_URL, SAS_TOKEN).result()
+backup_result: KeyVaultBackupResult = client.begin_backup(CONTAINER_URL, SAS_TOKEN).result()
 print(f"Azure Storage Blob URL of the backup: {backup_result.folder_url}")
 ```
 

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_models.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_models.py
@@ -160,7 +160,7 @@ class KeyVaultBackupResult(object):
     # pylint:disable=unused-argument
 
     def __init__(self, **kwargs) -> None:
-        self.folder_url = kwargs.get("folder_url")
+        self.folder_url: Optional[str] = kwargs.get("folder_url")
 
     @classmethod
     def _from_generated(

--- a/sdk/keyvault/azure-keyvault-administration/samples/access_control_operations.py
+++ b/sdk/keyvault/azure-keyvault-administration/samples/access_control_operations.py
@@ -89,6 +89,7 @@ updated_definition = client.set_role_definition(
 )
 # [END update_a_role_definition]
 print(f"Role definition '{updated_definition.role_name}' updated successfully.")
+assert unique_definition_name
 
 # We can now fetch the created definition to verify that it was created as expected.
 print("\n.. Get a role definition")
@@ -104,6 +105,7 @@ from azure.keyvault.administration import KeyVaultRoleScope
 
 role_assignments = client.list_role_assignments(KeyVaultRoleScope.GLOBAL)
 for assignment in role_assignments:
+    assert assignment.properties
     print(f"Role assignment name: {assignment.name}")
     print(f"Principal ID associated with this assignment: {assignment.properties.principal_id}")
 # [END list_role_assignments]
@@ -114,6 +116,7 @@ for assignment in role_assignments:
 print("\n.. Create a role assignment")
 principal_id = os.environ["AZURE_CLIENT_ID"]
 definition_id = updated_definition.id
+assert definition_id
 # [START create_a_role_assignment]
 from azure.keyvault.administration import KeyVaultRoleScope
 
@@ -121,11 +124,13 @@ scope = KeyVaultRoleScope.GLOBAL
 role_assignment = client.create_role_assignment(scope=scope, definition_id=definition_id, principal_id=principal_id)
 print(f"Role assignment {role_assignment.name} created successfully.")
 # [END create_a_role_assignment]
+assert role_assignment.name
 
 # We can now fetch the role assignment to verify that it was created correctly.
 print("\n.. Get a role assignment")
 # [START get_a_role_assignment]
 fetched_assignment = client.get_role_assignment(scope=scope, name=role_assignment.name)
+assert fetched_assignment.properties
 print(f"Role assignment for principal {fetched_assignment.properties.principal_id} fetched successfully.")
 # [END get_a_role_assignment]
 

--- a/sdk/keyvault/azure-keyvault-administration/samples/access_control_operations_async.py
+++ b/sdk/keyvault/azure-keyvault-administration/samples/access_control_operations_async.py
@@ -73,10 +73,12 @@ async def run_sample():
     print("\n.. Create a role assignment")
     principal_id = os.environ["AZURE_CLIENT_ID"]
     definition_id = updated_definition.id
+    assert definition_id
     role_assignment = await client.create_role_assignment(
         scope=scope, definition_id=definition_id, principal_id=principal_id
     )
-    print("Role assignment created successfully.")
+    assert role_assignment.name
+    print(f"Role assignment {role_assignment.name} created successfully.")
 
     # Let's delete the role assignment.
     print("\n.. Delete a role assignment")

--- a/sdk/keyvault/azure-keyvault-administration/samples/backup_restore_operations.py
+++ b/sdk/keyvault/azure-keyvault-administration/samples/backup_restore_operations.py
@@ -4,6 +4,8 @@
 # ------------------------------------
 import os
 
+from azure.keyvault.administration import KeyVaultBackupResult
+
 # ----------------------------------------------------------------------------------------------------------
 # Prerequisites:
 # 1. A managed HSM (https://docs.microsoft.com/azure/key-vault/managed-hsm/quick-create-cli)
@@ -50,10 +52,11 @@ print("\n.. Back up the vault")
 CONTAINER_URL = os.environ["CONTAINER_URL"]
 SAS_TOKEN = os.environ["SAS_TOKEN"]
 
-backup_result = client.begin_backup(CONTAINER_URL, SAS_TOKEN).result()
+backup_result: KeyVaultBackupResult = client.begin_backup(CONTAINER_URL, SAS_TOKEN).result()
 print(f"Azure Storage Blob URL of the backup: {backup_result.folder_url}")
 # [END begin_backup]
 print("Vault backed up successfully.")
+assert backup_result.folder_url
 
 # Now let's the vault by calling begin_restore, which also returns a poller. Calling result() on the poller will
 # return None after the operation completes. Calling wait() on the poller will wait until the operation is complete.

--- a/sdk/keyvault/azure-keyvault-administration/samples/backup_restore_operations_async.py
+++ b/sdk/keyvault/azure-keyvault-administration/samples/backup_restore_operations_async.py
@@ -52,6 +52,7 @@ async def run_sample():
     backup_poller = await client.begin_backup(CONTAINER_URL, SAS_TOKEN)
     backup_result = await backup_poller.result()
     print("Vault backed up successfully.")
+    assert backup_result.folder_url
 
     # Now let's the vault by calling begin_restore, which also returns a poller. Calling result() on the poller will
     # return None after the operation completes. Calling wait() on the poller will wait until the operation is

--- a/sdk/keyvault/azure-keyvault-administration/samples/settings_operations.py
+++ b/sdk/keyvault/azure-keyvault-administration/samples/settings_operations.py
@@ -45,6 +45,7 @@ for setting in settings:
     if setting.setting_type == KeyVaultSettingType.BOOLEAN:
         boolean_setting = setting
     print(f"{setting.name}: {setting.value} (type: {setting.setting_type})")
+assert isinstance(boolean_setting, KeyVaultSetting)
 
 # Now, let's flip the value of a boolean setting
 # The `value` property is a string, but you can get the value of a boolean setting as a bool with `getboolean`

--- a/sdk/keyvault/azure-keyvault-administration/samples/settings_operations.py
+++ b/sdk/keyvault/azure-keyvault-administration/samples/settings_operations.py
@@ -45,7 +45,7 @@ for setting in settings:
     if setting.setting_type == KeyVaultSettingType.BOOLEAN:
         boolean_setting = setting
     print(f"{setting.name}: {setting.value} (type: {setting.setting_type})")
-assert isinstance(boolean_setting, KeyVaultSetting)
+assert boolean_setting
 
 # Now, let's flip the value of a boolean setting
 # The `value` property is a string, but you can get the value of a boolean setting as a bool with `getboolean`

--- a/sdk/keyvault/azure-keyvault-administration/samples/settings_operations_async.py
+++ b/sdk/keyvault/azure-keyvault-administration/samples/settings_operations_async.py
@@ -45,6 +45,7 @@ async def run_sample():
         if setting.setting_type == KeyVaultSettingType.BOOLEAN:
             boolean_setting = setting
         print(f"{setting.name}: {setting.value} (type: {setting.setting_type})")
+    assert isinstance(boolean_setting, KeyVaultSetting)
 
     # Now, let's flip the value of a boolean setting
     # The `value` property is a string, but you can get the value of a boolean setting as a bool with `getboolean`

--- a/sdk/keyvault/azure-keyvault-administration/samples/settings_operations_async.py
+++ b/sdk/keyvault/azure-keyvault-administration/samples/settings_operations_async.py
@@ -45,7 +45,7 @@ async def run_sample():
         if setting.setting_type == KeyVaultSettingType.BOOLEAN:
             boolean_setting = setting
         print(f"{setting.name}: {setting.value} (type: {setting.setting_type})")
-    assert isinstance(boolean_setting, KeyVaultSetting)
+    assert boolean_setting
 
     # Now, let's flip the value of a boolean setting
     # The `value` property is a string, but you can get the value of a boolean setting as a bool with `getboolean`

--- a/sdk/keyvault/azure-keyvault-certificates/samples/backup_restore_operations.py
+++ b/sdk/keyvault/azure-keyvault-certificates/samples/backup_restore_operations.py
@@ -4,6 +4,7 @@
 # ------------------------------------
 import os
 import time
+
 from azure.keyvault.certificates import CertificateClient, CertificatePolicy
 from azure.identity import DefaultAzureCredential
 
@@ -61,6 +62,7 @@ print(f"Backup created for certificate with name '{cert_name}'.")
 print("\n.. Delete the certificate")
 delete_operation = client.begin_delete_certificate(cert_name)
 deleted_certificate = delete_operation.result()
+assert deleted_certificate.name
 print(f"Deleted certificate with name '{deleted_certificate.name}'")
 
 # Wait for the deletion to complete before purging the certificate.

--- a/sdk/keyvault/azure-keyvault-certificates/samples/backup_restore_operations_async.py
+++ b/sdk/keyvault/azure-keyvault-certificates/samples/backup_restore_operations_async.py
@@ -4,6 +4,7 @@
 # ------------------------------------
 import asyncio
 import os
+
 from azure.keyvault.certificates.aio import CertificateClient
 from azure.keyvault.certificates import CertificatePolicy
 from azure.identity.aio import DefaultAzureCredential

--- a/sdk/keyvault/azure-keyvault-certificates/samples/hello_world.py
+++ b/sdk/keyvault/azure-keyvault-certificates/samples/hello_world.py
@@ -3,6 +3,7 @@
 # Licensed under the MIT License.
 # ------------------------------------
 import os
+
 from azure.identity import DefaultAzureCredential
 from azure.keyvault.certificates import CertificateClient, CertificatePolicy, CertificateContentType, WellKnownIssuerNames
 
@@ -75,6 +76,7 @@ print("\n.. Get a certificate by name")
 # [START get_certificate]
 certificate = client.get_certificate(cert_name)
 # [END get_certificate]
+assert certificate.name
 print(f"Certificate with name '{certificate.name}' was found'.")
 
 # After one year, the account is still active, and we have decided to update the tags.
@@ -85,6 +87,7 @@ updated_certificate = client.update_certificate_properties(
     certificate_name=certificate.name, tags=tags
 )
 # [END update_certificate]
+assert updated_certificate.properties
 print(
     f"Certificate with name '{certificate.name}' was updated on date '{updated_certificate.properties.updated_on}'"
 )

--- a/sdk/keyvault/azure-keyvault-certificates/samples/hello_world_async.py
+++ b/sdk/keyvault/azure-keyvault-certificates/samples/hello_world_async.py
@@ -4,6 +4,7 @@
 # ------------------------------------
 import asyncio
 import os
+
 from azure.identity.aio import DefaultAzureCredential
 from azure.keyvault.certificates.aio import CertificateClient
 from azure.keyvault.certificates import CertificatePolicy, CertificateContentType, WellKnownIssuerNames
@@ -69,6 +70,7 @@ async def run_sample():
     # Let's get the bank certificate using its name
     print("\n.. Get a certificate by name")
     bank_certificate = await client.get_certificate(cert_name)
+    assert bank_certificate.name
     print(f"Certificate with name '{bank_certificate.name}' was found.")
 
     # After one year, the bank account is still active, and we have decided to update the tags.
@@ -77,6 +79,7 @@ async def run_sample():
     updated_certificate = await client.update_certificate_properties(
         certificate_name=bank_certificate.name, tags=tags
     )
+    assert updated_certificate.properties
     print(
         f"Certificate with name '{bank_certificate.name}' was updated on date "
         f"'{updated_certificate.properties.updated_on}'"

--- a/sdk/keyvault/azure-keyvault-certificates/samples/issuers.py
+++ b/sdk/keyvault/azure-keyvault-certificates/samples/issuers.py
@@ -3,6 +3,7 @@
 # Licensed under the MIT License.
 # ------------------------------------
 import os
+
 from azure.identity import DefaultAzureCredential
 from azure.keyvault.certificates import AdministratorContact, CertificateClient
 
@@ -49,6 +50,7 @@ client.create_issuer(
 
 # Now we get this issuer by name
 issuer1 = client.get_issuer(issuer_name="issuer1")
+assert issuer1.admin_contacts
 
 print(issuer1.name)
 print(issuer1.provider)
@@ -65,6 +67,7 @@ admin_contacts = [
     AdministratorContact(first_name="Jane", last_name="Doe", email="admin@microsoft.com", phone="4255555555")
 ]
 issuer1 = client.update_issuer(issuer_name="issuer1", admin_contacts=admin_contacts)
+assert issuer1.admin_contacts
 
 for contact in issuer1.admin_contacts:
     print(contact.first_name)

--- a/sdk/keyvault/azure-keyvault-certificates/samples/issuers_async.py
+++ b/sdk/keyvault/azure-keyvault-certificates/samples/issuers_async.py
@@ -4,6 +4,7 @@
 # ------------------------------------
 import os
 import asyncio
+
 from azure.identity.aio import DefaultAzureCredential
 from azure.keyvault.certificates.aio import CertificateClient
 from azure.keyvault.certificates import AdministratorContact
@@ -52,6 +53,7 @@ async def run_sample():
 
     # Now we get this issuer by name
     issuer1 = await client.get_issuer("issuer1")
+    assert issuer1.admin_contacts
 
     print(issuer1.name)
     print(issuer1.provider)
@@ -68,6 +70,7 @@ async def run_sample():
         AdministratorContact(first_name="Jane", last_name="Doe", email="admin@microsoft.com", phone="4255555555")
     ]
     issuer1 = await client.update_issuer(issuer_name="issuer1", admin_contacts=admin_contacts)
+    assert issuer1.admin_contacts
 
     for contact in issuer1.admin_contacts:
         print(contact.first_name)

--- a/sdk/keyvault/azure-keyvault-certificates/samples/list_operations.py
+++ b/sdk/keyvault/azure-keyvault-certificates/samples/list_operations.py
@@ -3,7 +3,8 @@
 # Licensed under the MIT License.
 # ------------------------------------
 import os
-from azure.keyvault.certificates import CertificateClient, CertificatePolicy
+
+from azure.keyvault.certificates import CertificateClient, CertificatePolicy, KeyVaultCertificate
 from azure.identity import DefaultAzureCredential
 
 # ----------------------------------------------------------------------------------------------------------
@@ -70,6 +71,7 @@ bank_certificate_poller = client.begin_create_certificate(
     certificate_name=bank_cert_name, policy=CertificatePolicy.get_default(), tags=tags
 )
 bank_certificate = bank_certificate_poller.result()
+assert isinstance(bank_certificate, KeyVaultCertificate) and bank_certificate.properties
 print(
     f"Certificate with name '{bank_certificate.name}' was created again with tags '{bank_certificate.properties.tags}'"
 )

--- a/sdk/keyvault/azure-keyvault-certificates/samples/list_operations_async.py
+++ b/sdk/keyvault/azure-keyvault-certificates/samples/list_operations_async.py
@@ -4,7 +4,8 @@
 # ------------------------------------
 import asyncio
 import os
-from azure.keyvault.certificates import CertificatePolicy
+
+from azure.keyvault.certificates import CertificatePolicy, KeyVaultCertificate
 from azure.keyvault.certificates.aio import CertificateClient
 from azure.identity.aio import DefaultAzureCredential
 
@@ -69,6 +70,7 @@ async def run_sample():
     bank_certificate = await client.create_certificate(
         certificate_name=bank_cert_name, policy=CertificatePolicy.get_default(), tags=tags
     )
+    assert isinstance(bank_certificate, KeyVaultCertificate) and bank_certificate.properties
     print(
         f"Certificate with name '{bank_certificate.name}' was created again with tags "
         f"'{bank_certificate.properties.tags}'"

--- a/sdk/keyvault/azure-keyvault-certificates/samples/parse_certificate.py
+++ b/sdk/keyvault/azure-keyvault-certificates/samples/parse_certificate.py
@@ -4,6 +4,7 @@
 # ------------------------------------
 import base64
 import os
+
 from azure.identity import DefaultAzureCredential
 from azure.keyvault.certificates import CertificateClient, CertificatePolicy
 from azure.keyvault.secrets import SecretClient
@@ -87,6 +88,7 @@ delete_operation_poller = certificate_client.begin_delete_certificate(
     certificate_name=cert_name
 )
 deleted_certificate = delete_operation_poller.result()
+assert deleted_certificate.name
 delete_operation_poller.wait()
 print(f"Certificate with name '{deleted_certificate.name}' was deleted.")
 

--- a/sdk/keyvault/azure-keyvault-certificates/samples/parse_certificate_async.py
+++ b/sdk/keyvault/azure-keyvault-certificates/samples/parse_certificate_async.py
@@ -85,6 +85,7 @@ async def run_sample():
     # Now we can clean up the vault by deleting, then purging, the certificate.
     print("\n.. Delete certificate")
     deleted_certificate = await certificate_client.delete_certificate(certificate_name=cert_name)
+    assert deleted_certificate.name
     print(f"Certificate with name '{deleted_certificate.name}' was deleted.")
 
     await certificate_client.purge_deleted_certificate(certificate_name=deleted_certificate.name)

--- a/sdk/keyvault/azure-keyvault-certificates/samples/recover_purge_operations.py
+++ b/sdk/keyvault/azure-keyvault-certificates/samples/recover_purge_operations.py
@@ -3,7 +3,7 @@
 # Licensed under the MIT License.
 # ------------------------------------
 import os
-import time
+
 from azure.keyvault.certificates import CertificateClient, CertificatePolicy
 from azure.identity import DefaultAzureCredential
 
@@ -58,6 +58,7 @@ print(f"Certificate with name '{storage_certificate.name}' was created.")
 print("\n.. Delete a Certificate")
 deleted_bank_poller = client.begin_delete_certificate(bank_cert_name)
 deleted_bank_certificate = deleted_bank_poller.result()
+assert deleted_bank_certificate.name
 # To ensure certificate is deleted on the server side.
 deleted_bank_poller.wait()
 

--- a/sdk/keyvault/azure-keyvault-certificates/samples/recover_purge_operations_async.py
+++ b/sdk/keyvault/azure-keyvault-certificates/samples/recover_purge_operations_async.py
@@ -4,6 +4,7 @@
 # ------------------------------------
 import asyncio
 import os
+
 from azure.keyvault.certificates import CertificatePolicy
 from azure.keyvault.certificates.aio import CertificateClient
 from azure.identity.aio import DefaultAzureCredential
@@ -56,6 +57,7 @@ async def run_sample():
     # The storage account was closed, need to delete its credentials from the Key Vault.
     print("\n.. Delete a Certificate")
     deleted_bank_certificate = await client.delete_certificate(bank_cert_name)
+    assert deleted_bank_certificate.name
     # To ensure certificate is deleted on the server side.
     await asyncio.sleep(30)
 

--- a/sdk/keyvault/azure-keyvault-keys/samples/key_rotation.py
+++ b/sdk/keyvault/azure-keyvault-keys/samples/key_rotation.py
@@ -3,6 +3,7 @@
 # Licensed under the MIT License.
 # ------------------------------------
 import os
+
 from azure.identity import DefaultAzureCredential
 from azure.keyvault.keys import KeyClient
 
@@ -72,6 +73,7 @@ policy_action = None
 for i in range(len(current_policy.lifetime_actions)):
     if current_policy.lifetime_actions[i].action == KeyRotationPolicyAction.rotate:
         policy_action = current_policy.lifetime_actions[i]
+assert policy_action
 print(f"\nCurrent rotation policy: {policy_action.action} after {policy_action.time_after_create}")
 
 # Update the key's automated rotation policy to notify 10 days before the key expires

--- a/sdk/keyvault/azure-keyvault-keys/samples/key_rotation_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/samples/key_rotation_async.py
@@ -4,6 +4,7 @@
 # ------------------------------------
 import asyncio
 import os
+
 from azure.identity.aio import DefaultAzureCredential
 from azure.keyvault.keys import KeyRotationLifetimeAction, KeyRotationPolicy, KeyRotationPolicyAction
 from azure.keyvault.keys.aio import KeyClient
@@ -72,6 +73,7 @@ async def run_sample():
     for i in range(len(current_policy.lifetime_actions)):
         if current_policy.lifetime_actions[i].action == KeyRotationPolicyAction.rotate:
             policy_action = current_policy.lifetime_actions[i]
+    assert policy_action
     print(f"\nCurrent rotation policy: {policy_action.action} after {policy_action.time_after_create}")
 
     # Update the key's automated rotation policy to notify 10 days before the key expires

--- a/sdk/keyvault/azure-keyvault-secrets/samples/backup_restore_operations.py
+++ b/sdk/keyvault/azure-keyvault-secrets/samples/backup_restore_operations.py
@@ -4,6 +4,7 @@
 # ------------------------------------
 import os
 import time
+
 from azure.keyvault.secrets import SecretClient
 from azure.identity import DefaultAzureCredential
 
@@ -40,6 +41,7 @@ client = SecretClient(vault_url=VAULT_URL, credential=credential)
 # if the secret already exists in the Key Vault, then a new version of the secret is created.
 print("\n.. Create Secret")
 secret = client.set_secret("backupRestoreSecretName", "backupRestoreSecretValue")
+assert secret.name
 print(f"Secret with name '{secret.name}' created with value '{secret.value}'")
 
 # Backups are good to have, if in case secrets gets deleted accidentally.
@@ -52,6 +54,7 @@ print(f"Backup created for secret with name '{secret.name}'.")
 print("\n.. Deleting secret...")
 delete_operation = client.begin_delete_secret(secret.name)
 deleted_secret = delete_operation.result()
+assert deleted_secret.name
 print(f"Deleted secret with name '{deleted_secret.name}'")
 
 # Wait for the deletion to complete before purging the secret.
@@ -64,5 +67,5 @@ print(f"Purged secret with name '{deleted_secret.name}'")
 
 # In the future, if the secret is required again, we can use the backup value to restore it in the Key Vault.
 print("\n.. Restore the secret using the backed up secret bytes")
-secret = client.restore_secret_backup(secret_backup)
-print(f"Restored secret with name '{secret.name}'")
+secret_properties = client.restore_secret_backup(secret_backup)
+print(f"Restored secret with name '{secret_properties.name}'")

--- a/sdk/keyvault/azure-keyvault-secrets/samples/backup_restore_operations_async.py
+++ b/sdk/keyvault/azure-keyvault-secrets/samples/backup_restore_operations_async.py
@@ -4,6 +4,7 @@
 # ------------------------------------
 import asyncio
 import os
+
 from azure.keyvault.secrets.aio import SecretClient
 from azure.identity.aio import DefaultAzureCredential
 
@@ -41,6 +42,7 @@ async def run_sample():
     # if the secret already exists in the Key Vault, then a new version of the secret is created.
     print("\n.. Create Secret")
     secret = await client.set_secret("backupRestoreSecretNameAsync", "backupRestoreSecretValue")
+    assert secret.name
     print(f"Secret with name '{secret.name}' created with value '{secret.value}'")
 
     # Backups are good to have, if in case secrets gets deleted accidentally.
@@ -63,8 +65,8 @@ async def run_sample():
 
     # In the future, if the secret is required again, we can use the backup value to restore it in the Key Vault.
     print("\n.. Restore the secret using the backed up secret bytes")
-    secret = await client.restore_secret_backup(secret_backup)
-    print(f"Restored secret with name '{secret.name}'")
+    secret_properties = await client.restore_secret_backup(secret_backup)
+    print(f"Restored secret with name '{secret_properties.name}'")
 
     print("\nrun_sample done")
     await credential.close()

--- a/sdk/keyvault/azure-keyvault-secrets/samples/hello_world.py
+++ b/sdk/keyvault/azure-keyvault-secrets/samples/hello_world.py
@@ -4,6 +4,8 @@
 # ------------------------------------
 import datetime
 import os
+from typing import cast
+
 from azure.keyvault.secrets import SecretClient
 from azure.identity import DefaultAzureCredential
 
@@ -43,19 +45,21 @@ client = SecretClient(vault_url=VAULT_URL, credential=credential)
 print("\n.. Create Secret")
 expires = datetime.datetime.utcnow() + datetime.timedelta(days=365)
 secret = client.set_secret("helloWorldSecretName", "helloWorldSecretValue", expires_on=expires)
+assert secret.name
 print(f"Secret with name '{secret.name}' created with value '{secret.value}'")
 print(f"Secret with name '{secret.name}' expires on '{secret.properties.expires_on}'")
 
 # Let's get the bank secret using its name
 print("\n.. Get a Secret by name")
 bank_secret = client.get_secret(secret.name)
+assert bank_secret.properties.expires_on
 print(f"Secret with name '{bank_secret.name}' was found with value '{bank_secret.value}'.")
 
 # After one year, the bank account is still active, we need to update the expiry time of the secret.
 # The update method can be used to update the expiry attribute of the secret. It cannot be used to update
 # the value of the secret.
 print("\n.. Update a Secret by name")
-expires = bank_secret.properties.expires_on + datetime.timedelta(days=365)
+expires = cast(datetime.datetime, bank_secret.properties.expires_on + datetime.timedelta(days=365))
 updated_secret_properties = client.update_secret_properties(secret.name, expires_on=expires)
 print(f"Secret with name '{secret.name}' was updated on date '{updated_secret_properties.updated_on}'")
 print(f"Secret with name '{secret.name}' was updated to expire on '{updated_secret_properties.expires_on}'")
@@ -63,8 +67,8 @@ print(f"Secret with name '{secret.name}' was updated to expire on '{updated_secr
 # Bank forced a password update for security purposes. Let's change the value of the secret in the Key Vault.
 # To achieve this, we need to create a new version of the secret in the Key Vault. The update operation cannot
 # change the value of the secret.
-secret = client.set_secret(secret.name, "newSecretValue")
-print(f"Secret with name '{secret.name}' created with value '{secret.value}'")
+new_secret = client.set_secret(secret.name, "newSecretValue")
+print(f"Secret with name '{new_secret.name}' created with value '{new_secret.value}'")
 
 # The bank account was closed, need to delete its credentials from the Key Vault.
 print("\n.. Deleting Secret...")

--- a/sdk/keyvault/azure-keyvault-secrets/samples/hello_world.py
+++ b/sdk/keyvault/azure-keyvault-secrets/samples/hello_world.py
@@ -4,7 +4,6 @@
 # ------------------------------------
 import datetime
 import os
-from typing import cast
 
 from azure.keyvault.secrets import SecretClient
 from azure.identity import DefaultAzureCredential
@@ -59,7 +58,7 @@ print(f"Secret with name '{bank_secret.name}' was found with value '{bank_secret
 # The update method can be used to update the expiry attribute of the secret. It cannot be used to update
 # the value of the secret.
 print("\n.. Update a Secret by name")
-expires = cast(datetime.datetime, bank_secret.properties.expires_on + datetime.timedelta(days=365))
+expires = bank_secret.properties.expires_on + datetime.timedelta(days=365)
 updated_secret_properties = client.update_secret_properties(secret.name, expires_on=expires)
 print(f"Secret with name '{secret.name}' was updated on date '{updated_secret_properties.updated_on}'")
 print(f"Secret with name '{secret.name}' was updated to expire on '{updated_secret_properties.expires_on}'")

--- a/sdk/keyvault/azure-keyvault-secrets/samples/hello_world_async.py
+++ b/sdk/keyvault/azure-keyvault-secrets/samples/hello_world_async.py
@@ -2,9 +2,11 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
+import asyncio
 import datetime
 import os
-import asyncio
+from typing import cast
+
 from azure.keyvault.secrets.aio import SecretClient
 from azure.identity.aio import DefaultAzureCredential
 
@@ -41,19 +43,21 @@ async def run_sample():
     print("\n.. Create Secret")
     expires_on = datetime.datetime.utcnow() + datetime.timedelta(days=365)
     secret = await client.set_secret("helloWorldSecretNameAsync", "helloWorldSecretValue", expires_on=expires_on)
+    assert secret.name
     print(f"Secret with name '{secret.name}' created with value '{secret.value}'")
     print(f"Secret with name '{secret.name}' expires on '{secret.properties.expires_on}'")
 
     # Let's get the bank secret using its name
     print("\n.. Get a Secret by name")
     bank_secret = await client.get_secret(secret.name)
+    assert bank_secret.properties.expires_on
     print(f"Secret with name '{bank_secret.name}' was found with value '{bank_secret.value}'.")
 
     # After one year, the bank account is still active, we need to update the expiry time of the secret.
     # The update method can be used to update the expiry attribute of the secret. It cannot be used to update
     # the value of the secret.
     print("\n.. Update a Secret by name")
-    expires_on = bank_secret.properties.expires_on + datetime.timedelta(days=365)
+    expires_on = cast(datetime.datetime, bank_secret.properties.expires_on + datetime.timedelta(days=365))
     updated_secret_properties = await client.update_secret_properties(secret.name, expires_on=expires_on)
     print(
         f"Secret with name '{updated_secret_properties.name}' was updated on date "

--- a/sdk/keyvault/azure-keyvault-secrets/samples/hello_world_async.py
+++ b/sdk/keyvault/azure-keyvault-secrets/samples/hello_world_async.py
@@ -5,7 +5,6 @@
 import asyncio
 import datetime
 import os
-from typing import cast
 
 from azure.keyvault.secrets.aio import SecretClient
 from azure.identity.aio import DefaultAzureCredential
@@ -57,7 +56,7 @@ async def run_sample():
     # The update method can be used to update the expiry attribute of the secret. It cannot be used to update
     # the value of the secret.
     print("\n.. Update a Secret by name")
-    expires_on = cast(datetime.datetime, bank_secret.properties.expires_on + datetime.timedelta(days=365))
+    expires_on = bank_secret.properties.expires_on + datetime.timedelta(days=365)
     updated_secret_properties = await client.update_secret_properties(secret.name, expires_on=expires_on)
     print(
         f"Secret with name '{updated_secret_properties.name}' was updated on date "

--- a/sdk/keyvault/azure-keyvault-secrets/samples/list_operations.py
+++ b/sdk/keyvault/azure-keyvault-secrets/samples/list_operations.py
@@ -3,6 +3,7 @@
 # Licensed under the MIT License.
 # ------------------------------------
 import os
+
 from azure.keyvault.secrets import SecretClient
 from azure.identity import DefaultAzureCredential
 
@@ -43,6 +44,8 @@ client = SecretClient(vault_url=VAULT_URL, credential=credential)
 print("\n.. Create Secret")
 bank_secret = client.set_secret("listOpsBankSecretName", "listOpsSecretValue1")
 storage_secret = client.set_secret("listOpsStorageSecretName", "listOpsSecretValue2")
+assert bank_secret.name
+assert storage_secret.name
 print(f"Secret with name '{bank_secret.name}' was created.")
 print(f"Secret with name '{storage_secret.name}' was created.")
 
@@ -53,6 +56,7 @@ print(f"Secret with name '{storage_secret.name}' was created.")
 print("\n.. List secrets from the Key Vault")
 secrets = client.list_properties_of_secrets()
 for secret in secrets:
+    assert secret.name
     retrieved_secret = client.get_secret(secret.name)
     print(
         f"Secret with name '{retrieved_secret.name}' and value {retrieved_secret.name} was found."

--- a/sdk/keyvault/azure-keyvault-secrets/samples/list_operations_async.py
+++ b/sdk/keyvault/azure-keyvault-secrets/samples/list_operations_async.py
@@ -4,6 +4,7 @@
 # ------------------------------------
 import asyncio
 import os
+
 from azure.keyvault.secrets.aio import SecretClient
 from azure.identity.aio import DefaultAzureCredential
 
@@ -43,6 +44,8 @@ async def run_sample():
     print("\n.. Create Secret")
     bank_secret = await client.set_secret("listOpsBankSecretNameAsync", "listOpsSecretValue1")
     storage_secret = await client.set_secret("listOpsStorageSecretNameAsync", "listOpsSecretValue2")
+    assert bank_secret.name
+    assert storage_secret.name
     print(f"Secret with name '{bank_secret.name}' was created.")
     print(f"Secret with name '{storage_secret.name}' was created.")
 
@@ -53,6 +56,7 @@ async def run_sample():
     print("\n.. List secrets from the Key Vault")
     secrets = client.list_properties_of_secrets()
     async for secret in secrets:
+        assert secret.name
         retrieved_secret = await client.get_secret(secret.name)
         print(f"Secret with name '{retrieved_secret.name}' with value '{retrieved_secret.value}' was found.")
 

--- a/sdk/keyvault/azure-keyvault-secrets/samples/recover_purge_operations.py
+++ b/sdk/keyvault/azure-keyvault-secrets/samples/recover_purge_operations.py
@@ -3,6 +3,7 @@
 # Licensed under the MIT License.
 # ------------------------------------
 import os
+
 from azure.keyvault.secrets import SecretClient
 from azure.identity import DefaultAzureCredential
 
@@ -40,6 +41,8 @@ client = SecretClient(vault_url=VAULT_URL, credential=credential)
 print("\n.. Create Secret")
 bank_secret = client.set_secret("recoverPurgeBankSecretName", "recoverPurgeSecretValue1")
 storage_secret = client.set_secret("recoverPurgeStorageSecretName", "recoverPurgeSecretValue2")
+assert bank_secret.name
+assert storage_secret.name
 print(f"Secret with name '{bank_secret.name}' was created.")
 print(f"Secret with name '{storage_secret.name}' was created.")
 

--- a/sdk/keyvault/azure-keyvault-secrets/samples/recover_purge_operations_async.py
+++ b/sdk/keyvault/azure-keyvault-secrets/samples/recover_purge_operations_async.py
@@ -4,6 +4,7 @@
 # ------------------------------------
 import asyncio
 import os
+
 from azure.keyvault.secrets.aio import SecretClient
 from azure.identity.aio import DefaultAzureCredential
 
@@ -41,6 +42,8 @@ async def run_sample():
     print("\n.. Create Secret")
     bank_secret = await client.set_secret("recoverPurgeBankSecretNameAsync", "recoverPurgeSecretValue1")
     storage_secret = await client.set_secret("recoverPurgeStorageSecretNameAsync", "recoverPurgeSecretValue2")
+    assert bank_secret.name
+    assert storage_secret.name
     print(f"Secret with name '{bank_secret.name}' was created.")
     print(f"Secret with name '{storage_secret.name}' was created.")
 


### PR DESCRIPTION
# Description

Resolves https://github.com/Azure/azure-sdk-for-python/issues/31609, resolves https://github.com/Azure/azure-sdk-for-python/issues/31610, resolves https://github.com/Azure/azure-sdk-for-python/issues/31611, and resolves https://github.com/Azure/azure-sdk-for-python/issues/31612.

`next-mypy` errors have all come from samples; for the most part, these have been fixed by asserting optional properties are non-`None` during execution. This also adds a type hint for a single ambiguous attribute (`KeyVaultBackupResult.folder_url`).

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
