### PR TITLE
Add core version in UserAgent at all time

### DIFF
--- a/sdk/core/azure-core/azure/core/pipeline/policies/_universal.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/_universal.py
@@ -211,13 +211,14 @@ class UserAgentPolicy(SansIOHTTPPolicy[HTTPRequestType, HTTPResponseType]):
         self.overwrite: bool = kwargs.pop("user_agent_overwrite", False)
         self.use_env: bool = kwargs.pop("user_agent_use_env", True)
         application_id: Optional[str] = kwargs.pop("user_agent", None)
-        sdk_moniker: str = kwargs.pop("sdk_moniker", "core/{}".format(azcore_version))
+        core_version = "core/{}".format(azcore_version)
+        sdk_moniker: str = kwargs.pop("sdk_moniker", core_version)
 
         if base_user_agent:
             self._user_agent = base_user_agent
         else:
-            self._user_agent = "azsdk-python-{} Python/{} ({})".format(
-                sdk_moniker, platform.python_version(), platform.platform()
+            self._user_agent = "azsdk-python-{} {} Python/{} ({})".format(
+                sdk_moniker, core_version, platform.python_version(), platform.platform()
             )
 
         if application_id:

--- a/sdk/core/azure-core/tests/test_user_agent_policy.py
+++ b/sdk/core/azure-core/tests/test_user_agent_policy.py
@@ -20,7 +20,7 @@ def test_user_agent_policy(http_request):
     assert user_agent._user_agent == "foo"
 
     user_agent = UserAgentPolicy(sdk_moniker="foosdk/1.0.0")
-    assert user_agent._user_agent.startswith("azsdk-python-foosdk/1.0.0 Python")
+    assert user_agent._user_agent.startswith("azsdk-python-foosdk/1.0.0 core/")
 
     user_agent = UserAgentPolicy(base_user_agent="foo", user_agent="bar", user_agent_use_env=False)
     assert user_agent._user_agent == "bar foo"


### PR DESCRIPTION
We want to always have the core version in the user-agent, for telemetry purposes.

This is a simple and stupid approach, meaning if calling SDK do not pass "sdk_monikers" you get the core version twice, but I think it's not important since:
- We made sure all track2 were doing that, and not doing it is actually a bug in the SDK implementation
- Codegen does it automatically