### PR TITLE
[ML] docs: Update docstring for child classes of OutboundSignal to include `type`

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_workspace/networking.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_workspace/networking.py
@@ -78,6 +78,8 @@ class FqdnDestination(OutboundRule):
     :param destination: Fully qualified domain name to which outbound connections are allowed.
         For example: “*.contoso.com”.
     :type destination: str
+    :ivar type: Type of the outbound rule. Set to "FQDN" for this class.
+    :vartype type: str
     """
 
     def __init__(self, *, name: str, destination: str, **kwargs) -> None:
@@ -108,6 +110,8 @@ class PrivateEndpointDestination(OutboundRule):
     :type subresource_target: str
     :param spark_enabled: Indicates if the private endpoint can be used for Spark jobs, default is “false”.
     :type spark_enabled: bool
+    :ivar type: Type of the outbound rule. Set to "PrivateEndpoint" for this class.
+    :vartype type: str
     """
 
     def __init__(
@@ -161,6 +165,8 @@ class ServiceTagDestination(OutboundRule):
     :param port_ranges: A comma-separated list of single ports and/or range of ports, such as "80,1024-65535".
         Traffics should be allowed to these port ranges.
     :type port_ranges: str
+    :ivar type: Type of the outbound rule. Set to "ServiceTag" for this class.
+    :vartype type: str
     """
 
     def __init__(


### PR DESCRIPTION
# Description

This pull request addresses some feedback during our API review that child classes of `OutboundSignals` are a field in the class docstring documenting the type discriminator `type`.


# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
