### PR TITLE
azure-core: remove six dependency

### DIFF
--- a/sdk/core/azure-core/setup.py
+++ b/sdk/core/azure-core/setup.py
@@ -70,7 +70,6 @@ setup(
     python_requires=">=3.7",
     install_requires=[
         "requests>=2.18.4",
-        "six>=1.11.0",
         "typing-extensions>=4.6.0",
     ],
     extras_require={


### PR DESCRIPTION
# Description

This removes the `six` dependency from `azure-core`, which doesn't seem to be using it at all.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
  - Insignificant change. 
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
  - No code changes.