### PR TITLE
[ML] test: Fix unittest failing in CI because of `urllib3>2`

### DIFF
--- a/sdk/ml/azure-ai-ml/tests/dataset/unittests/test_data_utils.py
+++ b/sdk/ml/azure-ai-ml/tests/dataset/unittests/test_data_utils.py
@@ -4,6 +4,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 
+from azure.core.exceptions import ServiceRequestError
 from azure.ai.ml._scope_dependent_operations import OperationConfig, OperationScope
 from azure.ai.ml._utils._data_utils import read_local_mltable_metadata_contents, read_remote_mltable_metadata_contents
 from azure.ai.ml._utils._http_utils import HttpPipeline
@@ -68,13 +69,12 @@ class TestDataUtils:
             assert contents["paths"] == [OrderedDict([("file", "./tmp_file.csv")])]
 
         # remote https inaccessible
-        with pytest.raises(Exception) as ex:
+        with pytest.raises(ServiceRequestError) as ex:
             contents = read_remote_mltable_metadata_contents(
                 datastore_operations=mock_datastore_operations,
                 base_uri="https://fake.localhost/file.yaml",
                 requests_pipeline=mock_requests_pipeline,
             )
-        assert "Failed to establish a new connection" in str(ex)
 
         # remote azureml accessible
         with patch("azure.ai.ml._utils._data_utils.TemporaryDirectory", return_value=mltable_folder):


### PR DESCRIPTION
# Description

This pull requests fixes a unit test failure that only happens in CI due to a change in `urllib3>2` 

## Background

Until about 18 hours ago, running the ML testsuite would install `urllib3<2` ([see last merged ML PR](https://github.com/Azure/azure-sdk-for-python/pull/32237)) and all our tests would pass.

For some reason soon after that PR was merged, `urllib3==2.0.5` started getting installed in our CI runs (was a cache invalidated?) and we started seeing a single unittest failure with the message:

```
Error message:

assert "Failed to establish a new connection" in str(ex)

E       assert 'Failed to establish a new connection' in '<ExceptionInfo ServiceRequestError("<urllib3.connection.HTTPSConnection object at 0x0000000016532c98>: Failed to resolve \'fake.localhost\' ([Errno -2] Name or service not known)") tblen=14>'
```

I'm guessing we're starting to see `urllib3==2.0.5` in our CI builds since azure-sdk-tools no longer pins `urllib<2` [after the Sphinx upgrade from a few days ago](https://github.com/Azure/azure-sdk-for-python/pull/32066/files#diff-5cd3072371963f58614f1e0b362614b83b94113f52d0ea156ceebb05a4a588fcR21).


`[Errno -2] Name or service not known` suggests a DNS resolution failure, and [urllib3 was changed to raise a NameResolutionError in version 2.0.0](https://github.com/urllib3/urllib3/blob/740380c59ca2a7c2dceca19e5dba99f6b7060e62/CHANGES.rst?plain=1#L107) which has a different message than the one the test checked for. I'm guessing our CI is doing weird stuff with the DNS, since running the test locally with urllib3==2.0.5 works as we'd expect.


# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
