### PR TITLE
[ML][Cherry-Pick] tests: Fix unittest that breaks in CI with urllib3>2 installed (#32250)

### DIFF
--- a/sdk/ml/azure-ai-ml/tests/dataset/unittests/test_data_utils.py
+++ b/sdk/ml/azure-ai-ml/tests/dataset/unittests/test_data_utils.py
@@ -4,6 +4,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 
+from azure.core.exceptions import ServiceRequestError
 from azure.ai.ml._scope_dependent_operations import OperationConfig, OperationScope
 from azure.ai.ml._utils._data_utils import read_local_mltable_metadata_contents, read_remote_mltable_metadata_contents
 from azure.ai.ml._utils._http_utils import HttpPipeline
@@ -68,13 +69,12 @@ class TestDataUtils:
             assert contents["paths"] == [OrderedDict([("file", "./tmp_file.csv")])]
 
         # remote https inaccessible
-        with pytest.raises(Exception) as ex:
+        with pytest.raises(ServiceRequestError) as ex:
             contents = read_remote_mltable_metadata_contents(
                 datastore_operations=mock_datastore_operations,
                 base_uri="https://fake.localhost/file.yaml",
                 requests_pipeline=mock_requests_pipeline,
             )
-        assert "Failed to establish a new connection" in str(ex)
 
         # remote azureml accessible
         with patch("azure.ai.ml._utils._data_utils.TemporaryDirectory", return_value=mltable_folder):


### PR DESCRIPTION
The test in question would break in CI because the test would fail
    because of DNS resolution in CI, which urllib3 started showing
    a different error message for. This didn't happen locally.

    Regardless, catching azure.core.exceptions.ServiceRequestError
    seems to be in the spirit of what the test was trying to do

# Description

Please add an informative description that covers that changes made by the pull request and link all relevant issues.

If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
