### PR TITLE
Resolve missing version dropdown on sphinx pages

### DIFF
--- a/doc/sphinx/conf.py
+++ b/doc/sphinx/conf.py
@@ -56,7 +56,7 @@ for example_file in all_files:
 # ones.
 extensions = ['sphinx.ext.autodoc', 'sphinx.ext.autosummary', 'sphinx.ext.doctest',
               'sphinx.ext.viewcode', 'sphinx.ext.intersphinx', 'sphinx.ext.napoleon',
-              'myst_parser', 'sphinxcontrib-jquery']
+              'myst_parser', 'sphinxcontrib.jquery']
 
 intersphinx_mapping = {
     # Dependencies

--- a/doc/sphinx/conf.py
+++ b/doc/sphinx/conf.py
@@ -56,7 +56,7 @@ for example_file in all_files:
 # ones.
 extensions = ['sphinx.ext.autodoc', 'sphinx.ext.autosummary', 'sphinx.ext.doctest',
               'sphinx.ext.viewcode', 'sphinx.ext.intersphinx', 'sphinx.ext.napoleon',
-              'myst_parser']
+              'myst_parser', 'sphinxcontrib-jquery']
 
 intersphinx_mapping = {
     # Dependencies

--- a/doc/sphinx/individual_build_conf.py
+++ b/doc/sphinx/individual_build_conf.py
@@ -54,7 +54,7 @@ import sphinx_rtd_theme
 # ones.
 extensions = ['sphinx.ext.autodoc', 'sphinx.ext.autosummary', 'sphinx.ext.doctest',
               'sphinx.ext.viewcode', 'sphinx.ext.intersphinx', 'sphinx.ext.napoleon',
-              'myst_parser', 'sphinxcontrib-jquery']
+              'myst_parser', 'sphinxcontrib.jquery']
 
 intersphinx_mapping = {
     # Dependencies

--- a/doc/sphinx/individual_build_conf.py
+++ b/doc/sphinx/individual_build_conf.py
@@ -54,7 +54,7 @@ import sphinx_rtd_theme
 # ones.
 extensions = ['sphinx.ext.autodoc', 'sphinx.ext.autosummary', 'sphinx.ext.doctest',
               'sphinx.ext.viewcode', 'sphinx.ext.intersphinx', 'sphinx.ext.napoleon',
-              'myst_parser']
+              'myst_parser', 'sphinxcontrib-jquery']
 
 intersphinx_mapping = {
     # Dependencies

--- a/eng/tox/tox.ini
+++ b/eng/tox/tox.ini
@@ -324,6 +324,7 @@ deps =
   sphinx==6.2.1
   sphinx_rtd_theme==1.3.0
   myst_parser==2.0.0
+  sphinxcontrib-jquery==4.1
 commands =
   python {repository_root}/eng/tox/create_package_and_install.py \
     -d {envtmpdir}/dist \


### PR DESCRIPTION
Resolves #32257

Expected:
![image](https://github.com/Azure/azure-sdk-for-python/assets/45376673/1efe2e7b-46a4-4e66-a195-aaec094d6b8a)

What we see:

![image](https://github.com/Azure/azure-sdk-for-python/assets/45376673/3b058f9b-3638-465a-b4a9-231c3d9a1e02)

Same github.io using docs built from this PR:

![image](https://github.com/Azure/azure-sdk-for-python/assets/45376673/2b06457a-25c7-4d34-a068-8504da236452)