### PR TITLE
Fix tox.ini for next-pylint

### DIFF
--- a/eng/tox/tox.ini
+++ b/eng/tox/tox.ini
@@ -111,7 +111,7 @@ setenv =
   {[testenv]setenv}
   PROXY_URL=http://localhost:5002
 deps =
-  -rdev_requirements
+  -rdev_requirements.txt
   pylint==1.8.4; python_version < '3.4'
   pylint==2.9.3; python_version >= '3.6' and python_version <= '3.10'
   pylint==2.14.5; python_version >= '3.11'


### PR DESCRIPTION
Running `next-pylint` locally gave me:

```sh
next-pylint: failed with Could not open requirements file /home/pvaneck/dev/pvaneck/azure-sdk-for-python/sdk/monitor/azure-monitor-query/dev_requirements: [Errno 2] No such file or directory: '/home/pvaneck/dev/pvaneck/azure-sdk-for-python/sdk/monitor/azure-monitor-query/dev_requirements' for tox env py within deps
```

This PR corrects the filename.