### PR TITLE
[Monitor] Fix typing for next mypy/pyright

### DIFF
--- a/sdk/monitor/azure-monitor-ingestion/azure/monitor/ingestion/_serialization.py
+++ b/sdk/monitor/azure-monitor-ingestion/azure/monitor/ingestion/_serialization.py
@@ -1912,7 +1912,7 @@ class Deserializer(object):
         if re.search(r"[^\W\d_]", attr, re.I + re.U):  # type: ignore
             raise DeserializationError("Date must have only digits and -. Received: %s" % attr)
         # This must NOT use defaultmonth/defaultday. Using None ensure this raises an exception.
-        return isodate.parse_date(attr, defaultmonth=None, defaultday=None)
+        return isodate.parse_date(attr, defaultmonth=0, defaultday=0)
 
     @staticmethod
     def deserialize_time(attr):

--- a/sdk/monitor/azure-monitor-query/azure/monitor/query/_generated/_configuration.py
+++ b/sdk/monitor/azure-monitor-query/azure/monitor/query/_generated/_configuration.py
@@ -14,7 +14,7 @@ from azure.core.pipeline import policies
 VERSION = "unknown"
 
 
-class MonitorQueryClientConfiguration(Configuration):  # pylint: disable=too-many-instance-attributes
+class MonitorQueryClientConfiguration(Configuration):  # pylint: disable=too-many-instance-attributes,name-too-long
     """Configuration for MonitorQueryClient.
 
     Note that all parameters used to create this instance are saved as instance

--- a/sdk/monitor/azure-monitor-query/azure/monitor/query/_generated/_serialization.py
+++ b/sdk/monitor/azure-monitor-query/azure/monitor/query/_generated/_serialization.py
@@ -730,6 +730,8 @@ class Serializer(object):
 
             if kwargs.get("skip_quote") is True:
                 output = str(output)
+                # https://github.com/Azure/autorest.python/issues/2063
+                output = output.replace("{", quote("{")).replace("}", quote("}"))
             else:
                 output = quote(str(output), safe="")
         except SerializationError:
@@ -1910,7 +1912,7 @@ class Deserializer(object):
         if re.search(r"[^\W\d_]", attr, re.I + re.U):  # type: ignore
             raise DeserializationError("Date must have only digits and -. Received: %s" % attr)
         # This must NOT use defaultmonth/defaultday. Using None ensure this raises an exception.
-        return isodate.parse_date(attr, defaultmonth=None, defaultday=None)
+        return isodate.parse_date(attr, defaultmonth=0, defaultday=0)
 
     @staticmethod
     def deserialize_time(attr):

--- a/sdk/monitor/azure-monitor-query/azure/monitor/query/_generated/aio/_configuration.py
+++ b/sdk/monitor/azure-monitor-query/azure/monitor/query/_generated/aio/_configuration.py
@@ -14,7 +14,7 @@ from azure.core.pipeline import policies
 VERSION = "unknown"
 
 
-class MonitorQueryClientConfiguration(Configuration):  # pylint: disable=too-many-instance-attributes
+class MonitorQueryClientConfiguration(Configuration):  # pylint: disable=too-many-instance-attributes,name-too-long
     """Configuration for MonitorQueryClient.
 
     Note that all parameters used to create this instance are saved as instance

--- a/sdk/monitor/azure-monitor-query/azure/monitor/query/_generated/metrics/_configuration.py
+++ b/sdk/monitor/azure-monitor-query/azure/monitor/query/_generated/metrics/_configuration.py
@@ -14,7 +14,7 @@ from azure.core.pipeline import policies
 VERSION = "unknown"
 
 
-class MonitorMetricsClientConfiguration(Configuration):  # pylint: disable=too-many-instance-attributes
+class MonitorMetricsClientConfiguration(Configuration):  # pylint: disable=too-many-instance-attributes,name-too-long
     """Configuration for MonitorMetricsClient.
 
     Note that all parameters used to create this instance are saved as instance

--- a/sdk/monitor/azure-monitor-query/azure/monitor/query/_generated/metrics/_serialization.py
+++ b/sdk/monitor/azure-monitor-query/azure/monitor/query/_generated/metrics/_serialization.py
@@ -730,6 +730,8 @@ class Serializer(object):
 
             if kwargs.get("skip_quote") is True:
                 output = str(output)
+                # https://github.com/Azure/autorest.python/issues/2063
+                output = output.replace("{", quote("{")).replace("}", quote("}"))
             else:
                 output = quote(str(output), safe="")
         except SerializationError:
@@ -1910,7 +1912,7 @@ class Deserializer(object):
         if re.search(r"[^\W\d_]", attr, re.I + re.U):  # type: ignore
             raise DeserializationError("Date must have only digits and -. Received: %s" % attr)
         # This must NOT use defaultmonth/defaultday. Using None ensure this raises an exception.
-        return isodate.parse_date(attr, defaultmonth=None, defaultday=None)
+        return isodate.parse_date(attr, defaultmonth=0, defaultday=0)
 
     @staticmethod
     def deserialize_time(attr):

--- a/sdk/monitor/azure-monitor-query/azure/monitor/query/_generated/metrics/aio/_configuration.py
+++ b/sdk/monitor/azure-monitor-query/azure/monitor/query/_generated/metrics/aio/_configuration.py
@@ -14,7 +14,7 @@ from azure.core.pipeline import policies
 VERSION = "unknown"
 
 
-class MonitorMetricsClientConfiguration(Configuration):  # pylint: disable=too-many-instance-attributes
+class MonitorMetricsClientConfiguration(Configuration):  # pylint: disable=too-many-instance-attributes,name-too-long
     """Configuration for MonitorMetricsClient.
 
     Note that all parameters used to create this instance are saved as instance

--- a/sdk/monitor/azure-monitor-query/azure/monitor/query/_generated/metrics/batch/_configuration.py
+++ b/sdk/monitor/azure-monitor-query/azure/monitor/query/_generated/metrics/batch/_configuration.py
@@ -14,7 +14,9 @@ from azure.core.pipeline import policies
 VERSION = "unknown"
 
 
-class MonitorBatchMetricsClientConfiguration(Configuration):  # pylint: disable=too-many-instance-attributes
+class MonitorBatchMetricsClientConfiguration(  # pylint: disable=too-many-instance-attributes,name-too-long
+    Configuration
+):
     """Configuration for MonitorBatchMetricsClient.
 
     Note that all parameters used to create this instance are saved as instance

--- a/sdk/monitor/azure-monitor-query/azure/monitor/query/_generated/metrics/batch/_serialization.py
+++ b/sdk/monitor/azure-monitor-query/azure/monitor/query/_generated/metrics/batch/_serialization.py
@@ -730,6 +730,8 @@ class Serializer(object):
 
             if kwargs.get("skip_quote") is True:
                 output = str(output)
+                # https://github.com/Azure/autorest.python/issues/2063
+                output = output.replace("{", quote("{")).replace("}", quote("}"))
             else:
                 output = quote(str(output), safe="")
         except SerializationError:
@@ -1910,7 +1912,7 @@ class Deserializer(object):
         if re.search(r"[^\W\d_]", attr, re.I + re.U):  # type: ignore
             raise DeserializationError("Date must have only digits and -. Received: %s" % attr)
         # This must NOT use defaultmonth/defaultday. Using None ensure this raises an exception.
-        return isodate.parse_date(attr, defaultmonth=None, defaultday=None)
+        return isodate.parse_date(attr, defaultmonth=0, defaultday=0)
 
     @staticmethod
     def deserialize_time(attr):

--- a/sdk/monitor/azure-monitor-query/azure/monitor/query/_generated/metrics/batch/aio/_configuration.py
+++ b/sdk/monitor/azure-monitor-query/azure/monitor/query/_generated/metrics/batch/aio/_configuration.py
@@ -14,7 +14,9 @@ from azure.core.pipeline import policies
 VERSION = "unknown"
 
 
-class MonitorBatchMetricsClientConfiguration(Configuration):  # pylint: disable=too-many-instance-attributes
+class MonitorBatchMetricsClientConfiguration(  # pylint: disable=too-many-instance-attributes,name-too-long
+    Configuration
+):
     """Configuration for MonitorBatchMetricsClient.
 
     Note that all parameters used to create this instance are saved as instance

--- a/sdk/monitor/azure-monitor-query/azure/monitor/query/_logs_query_client.py
+++ b/sdk/monitor/azure-monitor-query/azure/monitor/query/_logs_query_client.py
@@ -5,7 +5,7 @@
 # license information.
 # --------------------------------------------------------------------------
 from datetime import timedelta, datetime
-from typing import Any, Union, Sequence, Dict, List, cast, Tuple, Optional
+from typing import Any, Union, Sequence, Dict, List, cast, Tuple, Optional, MutableMapping
 from urllib.parse import urlparse
 
 from azure.core.credentials import TokenCredential
@@ -22,6 +22,8 @@ from ._helpers import (
 )
 from ._models import LogsBatchQuery, LogsQueryResult, LogsQueryPartialResult
 from ._exceptions import LogsQueryError
+
+JSON = MutableMapping[str, Any]
 
 
 class LogsQueryClient(object):  # pylint: disable=client-accepts-api-version-keyword
@@ -119,6 +121,7 @@ class LogsQueryClient(object):  # pylint: disable=client-accepts-api-version-key
 
         body = {"query": query, "timespan": timespan_iso, "workspaces": additional_workspaces}
 
+        generated_response: JSON = {}
         try:
             generated_response = self._query_op.execute(  # pylint: disable=protected-access
                 workspace_id=workspace_id, body=body, prefer=prefer, **kwargs
@@ -236,6 +239,7 @@ class LogsQueryClient(object):  # pylint: disable=client-accepts-api-version-key
 
         body = {"query": query, "timespan": timespan_iso, "workspaces": additional_workspaces}
 
+        generated_response: JSON = {}
         try:
             generated_response = self._query_op.resource_execute(  # pylint: disable=protected-access
                 resource_id=resource_id, body=body, prefer=prefer, **kwargs

--- a/sdk/monitor/azure-monitor-query/azure/monitor/query/aio/_logs_query_client_async.py
+++ b/sdk/monitor/azure-monitor-query/azure/monitor/query/aio/_logs_query_client_async.py
@@ -5,7 +5,7 @@
 # license information.
 # --------------------------------------------------------------------------
 from datetime import datetime, timedelta
-from typing import Any, cast, Tuple, Union, Sequence, Dict, List, Optional
+from typing import Any, cast, Tuple, Union, Sequence, Dict, List, Optional, MutableMapping
 from urllib.parse import urlparse
 
 from azure.core.credentials_async import AsyncTokenCredential
@@ -17,6 +17,8 @@ from .._helpers import construct_iso8601, order_results, process_error, process_
 from .._models import LogsQueryResult, LogsBatchQuery, LogsQueryPartialResult
 from ._helpers_async import get_authentication_policy
 from .._exceptions import LogsQueryError
+
+JSON = MutableMapping[str, Any]
 
 
 class LogsQueryClient(object):  # pylint: disable=client-accepts-api-version-keyword
@@ -115,6 +117,7 @@ class LogsQueryClient(object):  # pylint: disable=client-accepts-api-version-key
 
         body = {"query": query, "timespan": timespan_iso, "workspaces": additional_workspaces}
 
+        generated_response: JSON = {}
         try:
             generated_response = await self._query_op.execute(  # pylint: disable=protected-access
                 workspace_id=workspace_id, body=body, prefer=prefer, **kwargs
@@ -235,6 +238,7 @@ class LogsQueryClient(object):  # pylint: disable=client-accepts-api-version-key
             "additional_workspaces": additional_workspaces,
         }
 
+        generated_response: JSON = {}
         try:
             generated_response = await self._query_op.resource_execute(  # pylint: disable=protected-access
                 resource_id=resource_id, body=body, prefer=prefer, **kwargs


### PR DESCRIPTION
With the latest autorest, all the pyright errors in the generated code are now fixed. With this, `azure-monitor-ingestion` and `azure-monitor-query` are now next-mypy and next-pyright compliant.

Closes: #31603
Closes: #31604
Closes: #31605
Closes: #31606