### PR TITLE
[Key Vault] Update key rotation tests for service changes and MHSM support

### DIFF
--- a/sdk/keyvault/azure-keyvault-keys/assets.json
+++ b/sdk/keyvault/azure-keyvault-keys/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "python",
   "TagPrefix": "python/keyvault/azure-keyvault-keys",
-  "Tag": "python/keyvault/azure-keyvault-keys_a5a3c2671c"
+  "Tag": "python/keyvault/azure-keyvault-keys_6410889878"
 }

--- a/sdk/keyvault/azure-keyvault-keys/assets.json
+++ b/sdk/keyvault/azure-keyvault-keys/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "python",
   "TagPrefix": "python/keyvault/azure-keyvault-keys",
-  "Tag": "python/keyvault/azure-keyvault-keys_5e22177a49"
+  "Tag": "python/keyvault/azure-keyvault-keys_28b4323b48"
 }

--- a/sdk/keyvault/azure-keyvault-keys/assets.json
+++ b/sdk/keyvault/azure-keyvault-keys/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "python",
   "TagPrefix": "python/keyvault/azure-keyvault-keys",
-  "Tag": "python/keyvault/azure-keyvault-keys_6410889878"
+  "Tag": "python/keyvault/azure-keyvault-keys_5e22177a49"
 }

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_enums.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_enums.py
@@ -46,6 +46,13 @@ class KeyRotationPolicyAction(str, Enum, metaclass=CaseInsensitiveEnumMeta):
     rotate = "Rotate"  #: Rotate the key based on the key policy.
     notify = "Notify"  #: Trigger Event Grid events.
 
+    @classmethod
+    def _missing_(cls, value):
+        for member in cls:
+            if member.value.lower() == value.lower():
+                return member
+        raise ValueError(f"{value} is not a valid KeyRotationPolicyAction")
+
 
 class KeyType(str, Enum, metaclass=CaseInsensitiveEnumMeta):
     """Supported key types"""

--- a/sdk/keyvault/azure-keyvault-keys/tests/conftest.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/conftest.py
@@ -28,13 +28,13 @@ def pytest_configure(config):
 
 @pytest.fixture(scope="session", autouse=True)
 def add_sanitizers(test_proxy):
-    azure_keyvault_url = os.getenv("azure_keyvault_url", "https://vaultname.vault.azure.net")
+    azure_keyvault_url = os.getenv("AZURE_KEYVAULT_URL", "https://vaultname.vault.azure.net")
     azure_keyvault_url = azure_keyvault_url.rstrip("/")
-    keyvault_tenant_id = os.getenv("keyvault_tenant_id", "keyvault_tenant_id")
-    keyvault_subscription_id = os.getenv("keyvault_subscription_id", "keyvault_subscription_id")
-    azure_managedhsm_url = os.environ.get("azure_managedhsm_url","https://managedhsmvaultname.managedhsm.azure.net")
+    keyvault_tenant_id = os.getenv("KEYVAULT_TENANT_ID", "keyvault_tenant_id")
+    keyvault_subscription_id = os.getenv("KEYVAULT_SUBSCRIPTION_ID", "keyvault_subscription_id")
+    azure_managedhsm_url = os.environ.get("AZURE_MANAGEDHSM_URL","https://managedhsmvaultname.managedhsm.azure.net")
     azure_managedhsm_url = azure_managedhsm_url.rstrip("/")
-    azure_attestation_uri = os.environ.get("azure_keyvault_attestation_url","https://fakeattestation.azurewebsites.net")
+    azure_attestation_uri = os.environ.get("AZURE_KEYVAULT_ATTESTATION_URL","https://fakeattestation.azurewebsites.net")
     azure_attestation_uri = azure_attestation_uri.rstrip('/')
 
     add_general_regex_sanitizer(regex=azure_keyvault_url, value="https://vaultname.vault.azure.net")

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_key_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_key_client.py
@@ -636,16 +636,21 @@ class TestKeyClient(KeyVaultTestCase, KeysTestCase):
         with pytest.raises(HttpResponseError):
             self._update_key_properties(client, key, new_release_policy)
 
-    @pytest.mark.parametrize("api_version,is_hsm",only_vault_latest)
+    @pytest.mark.parametrize("api_version,is_hsm",only_latest)
     @KeysClientPreparer()
     @recorded_by_proxy
-    def test_key_rotation(self, client, **kwargs):
+    def test_key_rotation(self, client, is_hsm, **kwargs):
         if (not is_public_cloud() and self.is_live):
             pytest.skip("This test is not supported in usgov/china region. Follow up with service team.")
 
         set_bodiless_matcher()
         key_name = self.get_resource_name("rotation-key")
-        key = self._create_rsa_key(client, key_name)
+        key = self._create_rsa_key(client, key_name, hardware_protected=is_hsm)
+
+        # MHSM doesn't automatically give keys a default rotation policy, unlike KV
+        if is_hsm:
+            actions = [KeyRotationLifetimeAction(KeyRotationPolicyAction.rotate, time_after_create="P6M")]
+            client.update_key_rotation_policy(key_name, KeyRotationPolicy(lifetime_actions=actions, expires_in="P1Y"))
         rotated_key = client.rotate_key(key_name)
 
         # the rotated key should have a new ID, version, and key material (for RSA, n and e fields)
@@ -653,40 +658,46 @@ class TestKeyClient(KeyVaultTestCase, KeysTestCase):
         assert key.properties.version != rotated_key.properties.version
         assert key.key.n != rotated_key.key.n
 
-    @pytest.mark.playback_test_only("Currently fails in live mode because of service regression; will be fixed soon.")
-    @pytest.mark.parametrize("api_version,is_hsm",only_vault_latest)
+    @pytest.mark.parametrize("api_version,is_hsm",only_latest)
     @KeysClientPreparer()
     @recorded_by_proxy
-    def test_key_rotation_policy(self, client, **kwargs):
+    def test_key_rotation_policy(self, client, is_hsm, **kwargs):
         if (not is_public_cloud() and self.is_live):
             pytest.skip("This test is not supported in usgov/china region. Follow up with service team.")
 
         set_bodiless_matcher()
         key_name = self.get_resource_name("rotation-key")
-        self._create_rsa_key(client, key_name)
+        self._create_rsa_key(client, key_name, hardware_protected=is_hsm)
 
-        # ensure passing an empty policy with no kwargs doesn't raise an error
-        client.update_key_rotation_policy(key_name, KeyRotationPolicy())
+        # ensure passing an empty policy with no kwargs doesn't raise an error on KV (MHSM requires an expiry time)
+        if not is_hsm:
+            client.update_key_rotation_policy(key_name, KeyRotationPolicy())
 
-        # updating a rotation policy with an empty policy and override
+        # updating a rotation policy with an empty policy and override(s)
         actions = [KeyRotationLifetimeAction(KeyRotationPolicyAction.rotate, time_after_create="P2M")]
-        updated_policy = client.update_key_rotation_policy(key_name, KeyRotationPolicy(), lifetime_actions=actions)
+        if is_hsm:
+            updated_policy = client.update_key_rotation_policy(
+                key_name, KeyRotationPolicy(), lifetime_actions=actions, expires_in="P6M"
+            )
+            assert updated_policy.expires_in == "P6M"
+        else:  # try a policy without an expiry time (only allowed on KV)
+            updated_policy = client.update_key_rotation_policy(key_name, KeyRotationPolicy(), lifetime_actions=actions)
+            assert updated_policy.expires_in is None
+
         fetched_policy = client.get_key_rotation_policy(key_name)
-        assert updated_policy.expires_in is None
         _assert_rotation_policies_equal(updated_policy, fetched_policy)
 
         updated_policy_actions = None
         for i in range(len(updated_policy.lifetime_actions)):
-            if updated_policy.lifetime_actions[i].action == KeyRotationPolicyAction.rotate:
+            if updated_policy.lifetime_actions[i].action.lower() == KeyRotationPolicyAction.rotate.lower():
                 updated_policy_actions = updated_policy.lifetime_actions[i]
         assert updated_policy_actions, "Specified rotation policy action not found in updated policy"
-        assert updated_policy_actions.action == KeyRotationPolicyAction.rotate
         assert updated_policy_actions.time_after_create == "P2M"
         assert updated_policy_actions.time_before_expiry is None
 
         fetched_policy_actions = None
         for i in range(len(fetched_policy.lifetime_actions)):
-            if fetched_policy.lifetime_actions[i].action == KeyRotationPolicyAction.rotate:
+            if fetched_policy.lifetime_actions[i].action.lower() == KeyRotationPolicyAction.rotate.lower():
                 fetched_policy_actions = fetched_policy.lifetime_actions[i]
         assert fetched_policy_actions, "Specified rotation policy action not found in fetched policy"
         _assert_lifetime_actions_equal(updated_policy_actions, fetched_policy_actions)
@@ -697,30 +708,31 @@ class TestKeyClient(KeyVaultTestCase, KeysTestCase):
 
         new_policy_actions = None
         for i in range(len(new_policy.lifetime_actions)):
-            if new_policy.lifetime_actions[i].action == KeyRotationPolicyAction.rotate:
+            if new_policy.lifetime_actions[i].action.lower() == KeyRotationPolicyAction.rotate.lower():
                 new_policy_actions = new_policy.lifetime_actions[i]
         _assert_lifetime_actions_equal(updated_policy_actions, new_policy_actions)
 
-        # updating with a round-tripped policy and overriding lifetime_actions
-        newest_actions = [KeyRotationLifetimeAction(KeyRotationPolicyAction.notify, time_before_expiry="P60D")]
-        newest_policy = client.update_key_rotation_policy(key_name, policy=new_policy, lifetime_actions=newest_actions)
-        newest_fetched_policy = client.get_key_rotation_policy(key_name)
-        assert newest_policy.expires_in == "P90D"
-        _assert_rotation_policies_equal(newest_policy, newest_fetched_policy)
+        # at this time, MHSM doesn't support notify actions
+        if not is_hsm:
+            # updating with a round-tripped policy and overriding lifetime_actions
+            newest_actions = [KeyRotationLifetimeAction(KeyRotationPolicyAction.notify, time_before_expiry="P60D")]
+            newest_policy = client.update_key_rotation_policy(key_name, policy=new_policy, lifetime_actions=newest_actions)
+            newest_fetched_policy = client.get_key_rotation_policy(key_name)
+            assert newest_policy.expires_in == "P90D"
+            _assert_rotation_policies_equal(newest_policy, newest_fetched_policy)
 
-        newest_policy_actions = None
-        for i in range(len(newest_policy.lifetime_actions)):
-            if newest_policy.lifetime_actions[i].action == KeyRotationPolicyAction.notify:
-                newest_policy_actions = newest_policy.lifetime_actions[i]
-        assert newest_policy_actions.action == KeyRotationPolicyAction.notify
-        assert newest_policy_actions.time_after_create is None
-        assert newest_policy_actions.time_before_expiry == "P60D"
+            newest_policy_actions = None
+            for i in range(len(newest_policy.lifetime_actions)):
+                if newest_policy.lifetime_actions[i].action.lower() == KeyRotationPolicyAction.notify.lower():
+                    newest_policy_actions = newest_policy.lifetime_actions[i]
+            assert newest_policy_actions.time_after_create is None
+            assert newest_policy_actions.time_before_expiry == "P60D"
 
-        newest_fetched_policy_actions = None
-        for i in range(len(newest_fetched_policy.lifetime_actions)):
-            if newest_fetched_policy.lifetime_actions[i].action == KeyRotationPolicyAction.notify:
-                newest_fetched_policy_actions = newest_fetched_policy.lifetime_actions[i]
-        _assert_lifetime_actions_equal(newest_policy_actions, newest_fetched_policy_actions)
+            newest_fetched_policy_actions = None
+            for i in range(len(newest_fetched_policy.lifetime_actions)):
+                if newest_fetched_policy.lifetime_actions[i].action.lower() == KeyRotationPolicyAction.notify.lower():
+                    newest_fetched_policy_actions = newest_fetched_policy.lifetime_actions[i]
+            _assert_lifetime_actions_equal(newest_policy_actions, newest_fetched_policy_actions)
 
     @pytest.mark.parametrize("api_version,is_hsm",all_api_versions)
     @KeysClientPreparer()

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_keys_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_keys_async.py
@@ -652,6 +652,13 @@ class TestKeyVaultKey(KeyVaultTestCase, KeysTestCase):
         set_bodiless_matcher()
         key_name = self.get_resource_name("rotation-key")
         key = await self._create_rsa_key(client, key_name, hardware_protected=is_hsm)
+
+        # MHSM doesn't automatically give keys a default rotation policy, unlike KV
+        if is_hsm:
+            actions = [KeyRotationLifetimeAction(KeyRotationPolicyAction.rotate, time_after_create="P6M")]
+            await client.update_key_rotation_policy(
+                key_name, KeyRotationPolicy(lifetime_actions=actions, expires_in="P1Y")
+            )
         rotated_key = await client.rotate_key(key_name)
 
         # the rotated key should have a new ID, version, and key material (for RSA, n and e fields)
@@ -671,30 +678,36 @@ class TestKeyVaultKey(KeyVaultTestCase, KeysTestCase):
         key_name = self.get_resource_name("rotation-key")
         await self._create_rsa_key(client, key_name, hardware_protected=is_hsm)
 
-        # ensure passing an empty policy with no kwargs doesn't raise an error
-        await client.update_key_rotation_policy(key_name, KeyRotationPolicy())
+        # ensure passing an empty policy with no kwargs doesn't raise an error on KV (MHSM requires an expiry time)
+        if not is_hsm:
+            await client.update_key_rotation_policy(key_name, KeyRotationPolicy())
 
-        # updating a rotation policy with an empty policy and override
+        # updating a rotation policy with an empty policy and override(s)
         actions = [KeyRotationLifetimeAction(KeyRotationPolicyAction.rotate, time_after_create="P2M")]
-        updated_policy = await client.update_key_rotation_policy(
-            key_name, KeyRotationPolicy(), lifetime_actions=actions
-        )
+        if is_hsm:
+            updated_policy = await client.update_key_rotation_policy(
+                key_name, KeyRotationPolicy(), lifetime_actions=actions, expires_in="P6M"
+            )
+            assert updated_policy.expires_in == "P6M"
+        else:  # try a policy without an expiry time (only allowed on KV)
+            updated_policy = await client.update_key_rotation_policy(
+                key_name, KeyRotationPolicy(), lifetime_actions=actions
+            )
+            assert updated_policy.expires_in is None
         fetched_policy = await client.get_key_rotation_policy(key_name)
-        assert updated_policy.expires_in is None
         _assert_rotation_policies_equal(updated_policy, fetched_policy)
 
         updated_policy_actions = None
         for i in range(len(updated_policy.lifetime_actions)):
-            if updated_policy.lifetime_actions[i].action == KeyRotationPolicyAction.rotate:
+            if updated_policy.lifetime_actions[i].action.lower() == KeyRotationPolicyAction.rotate.lower():
                 updated_policy_actions = updated_policy.lifetime_actions[i]
         assert updated_policy_actions, "Specified rotation policy action not found in updated policy"
-        assert updated_policy_actions.action == KeyRotationPolicyAction.rotate
         assert updated_policy_actions.time_after_create == "P2M"
         assert updated_policy_actions.time_before_expiry is None
 
         fetched_policy_actions = None
         for i in range(len(fetched_policy.lifetime_actions)):
-            if fetched_policy.lifetime_actions[i].action == KeyRotationPolicyAction.rotate:
+            if fetched_policy.lifetime_actions[i].action.lower() == KeyRotationPolicyAction.rotate.lower():
                 fetched_policy_actions = fetched_policy.lifetime_actions[i]
         assert fetched_policy_actions, "Specified rotation policy action not found in fetched policy"
         _assert_lifetime_actions_equal(updated_policy_actions, fetched_policy_actions)
@@ -705,32 +718,33 @@ class TestKeyVaultKey(KeyVaultTestCase, KeysTestCase):
 
         new_policy_actions = None
         for i in range(len(new_policy.lifetime_actions)):
-            if new_policy.lifetime_actions[i].action == KeyRotationPolicyAction.rotate:
+            if new_policy.lifetime_actions[i].action.lower() == KeyRotationPolicyAction.rotate.lower():
                 new_policy_actions = new_policy.lifetime_actions[i]
         _assert_lifetime_actions_equal(updated_policy_actions, new_policy_actions)
 
-        # updating with a round-tripped policy and overriding lifetime_actions
-        newest_actions = [KeyRotationLifetimeAction(KeyRotationPolicyAction.notify, time_before_expiry="P60D")]
-        newest_policy = await client.update_key_rotation_policy(
-            key_name, policy=new_policy, lifetime_actions=newest_actions
-        )
-        newest_fetched_policy = await client.get_key_rotation_policy(key_name)
-        assert newest_policy.expires_in == "P90D"
-        _assert_rotation_policies_equal(newest_policy, newest_fetched_policy)
+        # at this time, MHSM doesn't support notify actions
+        if not is_hsm:
+            # updating with a round-tripped policy and overriding lifetime_actions
+            newest_actions = [KeyRotationLifetimeAction(KeyRotationPolicyAction.notify, time_before_expiry="P60D")]
+            newest_policy = await client.update_key_rotation_policy(
+                key_name, policy=new_policy, lifetime_actions=newest_actions
+            )
+            newest_fetched_policy = await client.get_key_rotation_policy(key_name)
+            assert newest_policy.expires_in == "P90D"
+            _assert_rotation_policies_equal(newest_policy, newest_fetched_policy)
 
-        newest_policy_actions = None
-        for i in range(len(newest_policy.lifetime_actions)):
-            if newest_policy.lifetime_actions[i].action == KeyRotationPolicyAction.notify:
-                newest_policy_actions = newest_policy.lifetime_actions[i]
-        assert newest_policy_actions.action == KeyRotationPolicyAction.notify
-        assert newest_policy_actions.time_after_create is None
-        assert newest_policy_actions.time_before_expiry == "P60D"
+            newest_policy_actions = None
+            for i in range(len(newest_policy.lifetime_actions)):
+                if newest_policy.lifetime_actions[i].action.lower() == KeyRotationPolicyAction.notify.lower():
+                    newest_policy_actions = newest_policy.lifetime_actions[i]
+            assert newest_policy_actions.time_after_create is None
+            assert newest_policy_actions.time_before_expiry == "P60D"
 
-        newest_fetched_policy_actions = None
-        for i in range(len(newest_fetched_policy.lifetime_actions)):
-            if newest_fetched_policy.lifetime_actions[i].action == KeyRotationPolicyAction.notify:
-                newest_fetched_policy_actions = newest_fetched_policy.lifetime_actions[i]
-        _assert_lifetime_actions_equal(newest_policy_actions, newest_fetched_policy_actions)
+            newest_fetched_policy_actions = None
+            for i in range(len(newest_fetched_policy.lifetime_actions)):
+                if newest_fetched_policy.lifetime_actions[i].action.lower() == KeyRotationPolicyAction.notify.lower():
+                    newest_fetched_policy_actions = newest_fetched_policy.lifetime_actions[i]
+            _assert_lifetime_actions_equal(newest_policy_actions, newest_fetched_policy_actions)
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("api_version,is_hsm",all_api_versions)


### PR DESCRIPTION
# Description

Resolves https://github.com/Azure/azure-sdk-for-python/issues/30889. This makes the `KeyRotationPolicyAction` enum case-insensitive (which is necessary since KV and MHSM use different casing in API version 7.4, as of today) and re-enables live key rotation policy tests. In addition, key rotation tests now also run against MHSM.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
