### PR TITLE
[ML] fix: Fix `include_spark` parameter that was erroneonously marked as Optional

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_workspace_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_workspace_operations.py
@@ -127,7 +127,7 @@ class WorkspaceOperations(WorkspaceOperationsBase):
         self,
         *,
         workspace_name: Optional[str] = None,
-        include_spark: Optional[bool] = False,
+        include_spark: bool = False,
         **kwargs,
     ) -> LROPoller[ManagedNetworkProvisionStatus]:
         """Triggers the workspace to provision the managed network. Specifying spark enabled
@@ -135,6 +135,8 @@ class WorkspaceOperations(WorkspaceOperationsBase):
 
         :keyword workspace_name: Name of the workspace.
         :paramtype workspace_name: str
+        :keyword include spark: Whether the workspae managed network should prepare to support SPark
+        :paramtype include_space: bool
         :return: An instance of LROPoller.
         :rtype: ~azure.core.polling.LROPoller[~azure.ai.ml.entities.ManagedNetworkProvisionStatus]
         """


### PR DESCRIPTION
# Description

This pull request addresses feedback from our Api Review that  the `include_spark` parameter of  `azure.ai.ml.operations.WorkspaceOperations.begin_provision_network` probably doesn't need to be marked as Optional.


# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
