### PR TITLE
[ML] refactor: Make ManagedNetwork.__init__ keyword only

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/workspace/networking.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/workspace/networking.py
@@ -179,6 +179,6 @@ class ManagedNetworkSchema(metaclass=PatchedSchemaMeta):
     def make(self, data, **kwargs):
         outbound_rules = data.get("outbound_rules", False)
         if outbound_rules:
-            return ManagedNetwork(_snake_to_camel(data["isolation_mode"]), outbound_rules)
+            return ManagedNetwork(isolation_mode=_snake_to_camel(data["isolation_mode"]), outbound_rules=outbound_rules)
         else:
-            return ManagedNetwork(_snake_to_camel(data["isolation_mode"]))
+            return ManagedNetwork(isolation_mode=_snake_to_camel(data["isolation_mode"]))

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_workspace/networking.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_workspace/networking.py
@@ -209,6 +209,7 @@ class ServiceTagDestination(OutboundRule):
 class ManagedNetwork:
     def __init__(
         self,
+        *,
         isolation_mode: str = IsolationMode.DISABLED,
         outbound_rules: Optional[List[OutboundRule]] = None,
         network_id: Optional[str] = None,

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_workspace_operations_base.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_workspace_operations_base.py
@@ -207,7 +207,7 @@ class WorkspaceOperationsBase:
 
         managed_network = kwargs.get("managed_network", workspace.managed_network)
         if isinstance(managed_network, str):
-            managed_network = ManagedNetwork(managed_network)._to_rest_object()
+            managed_network = ManagedNetwork(isolation_mode=managed_network)._to_rest_object()
         elif isinstance(managed_network, ManagedNetwork):
             managed_network = workspace.managed_network._to_rest_object()
 
@@ -601,7 +601,7 @@ class WorkspaceOperationsBase:
         if workspace.managed_network:
             managed_network = workspace.managed_network._to_rest_object()
         else:
-            managed_network = ManagedNetwork(IsolationMode.DISABLED)._to_rest_object()
+            managed_network = ManagedNetwork(isolation_mode=IsolationMode.DISABLED)._to_rest_object()
         _set_val(param["managedNetwork"], managed_network)
         if workspace.enable_data_isolation:
             _set_val(param["enable_data_isolation"], "true")

--- a/sdk/ml/azure-ai-ml/tests/workspace/e2etests/test_workspace_outbound_rule_operations.py
+++ b/sdk/ml/azure-ai-ml/tests/workspace/e2etests/test_workspace_outbound_rule_operations.py
@@ -10,6 +10,7 @@ from azure.ai.ml import MLClient, load_workspace
 from azure.ai.ml.entities._workspace.workspace import Workspace
 from azure.ai.ml.entities._workspace.networking import (
     FqdnDestination,
+    ManagedNetwork,
     PrivateEndpointDestination,
     ServiceTagDestination,
 )
@@ -194,7 +195,7 @@ class TestWorkspaceOutboundRules(AzureRecordedTestCase):
             {"display_name": wps_display_name},
         ]
         wps = load_workspace(None, params_override=params_override)
-        wps.managed_network = ManagedNetwork(IsolationMode.ALLOW_INTERNET_OUTBOUND)
+        wps.managed_network = ManagedNetwork(isolation_mode=IsolationMode.ALLOW_INTERNET_OUTBOUND)
 
         # test creation
         workspace_poller = client.workspaces.begin_create(workspace=wps)


### PR DESCRIPTION
# Description

This pull request addresses feedback from our Api Review that `ManagedNetwork.__init__` should be keyword only.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
