### PR TITLE
Remove and adjust `six` dependencies

### DIFF
--- a/sdk/core/azure-core/setup.py
+++ b/sdk/core/azure-core/setup.py
@@ -70,7 +70,6 @@ setup(
     python_requires=">=3.7",
     install_requires=[
         "requests>=2.18.4",
-        "six>=1.11.0",
         "typing-extensions>=4.6.0",
     ],
     extras_require={

--- a/sdk/eventhub/azure-eventhub-checkpointstoreblob-aio/setup.py
+++ b/sdk/eventhub/azure-eventhub-checkpointstoreblob-aio/setup.py
@@ -76,6 +76,7 @@ setup(
         "azure-core<2.0.0,>=1.20.1",
         "msrest>=0.6.18",
         "cryptography>=2.1.4",
+        "six>=1.12.0",
         # end of dependencies for the vendored storage blob
         'azure-eventhub<6.0.0,>=5.0.0',
         'aiohttp<4.0,>=3.8.3',

--- a/sdk/maps/azure-maps-render/setup.py
+++ b/sdk/maps/azure-maps-render/setup.py
@@ -84,5 +84,6 @@ setup(
         'msrest>=0.6.21',
         'azure-common~=1.1',
         'azure-mgmt-core>=1.3.0,<2.0.0',
+        'six>=1.12.0',
     ]
 )

--- a/sdk/maps/azure-maps-search/setup.py
+++ b/sdk/maps/azure-maps-search/setup.py
@@ -82,5 +82,6 @@ setup(
         'msrest>=0.6.21',
         'azure-common~=1.1',
         'azure-mgmt-core>=1.3.0,<2.0.0',
+        "six>=1.12.0",
     ]
 )

--- a/sdk/ml/azure-ai-ml/setup.py
+++ b/sdk/ml/azure-ai-ml/setup.py
@@ -86,6 +86,7 @@ setup(
         "azure-common<2.0.0,>=1.1",
         "typing-extensions<5.0.0",
         "opencensus-ext-azure<2.0.0",
+        "six>=1.12.0",
     ],
     extras_require={
         # user can run `pip install azure-ai-ml[designer]` to install mldesigner alone with this package

--- a/sdk/remoterendering/azure-mixedreality-remoterendering/setup.py
+++ b/sdk/remoterendering/azure-mixedreality-remoterendering/setup.py
@@ -65,7 +65,8 @@ setup(
     install_requires=[
         'azure-core<2.0.0,>=1.6.0',
         'azure-mixedreality-authentication>=1.0.0b1',
-        'msrest>=0.6.21'
+        'msrest>=0.6.21',
+        'six>=1.12.0',
     ],
     project_urls={
         'Bug Reports': 'https://github.com/Azure/azure-sdk-for-python/issues',

--- a/tools/azure-devtools/setup.py
+++ b/tools/azure-devtools/setup.py
@@ -23,7 +23,7 @@ CLASSIFIERS = [
     "License :: OSI Approved :: MIT License",
 ]
 
-DEPENDENCIES = ["ConfigArgParse>=0.12.0", "six>=1.10.0"]
+DEPENDENCIES = ["ConfigArgParse>=0.12.0"]
 
 with io.open("README.rst", "r", encoding="utf-8") as f:
     README = f.read()

--- a/tools/azure-devtools/src/azure_devtools/scenario_tests/base.py
+++ b/tools/azure-devtools/src/azure_devtools/scenario_tests/base.py
@@ -11,9 +11,6 @@ import tempfile
 import shutil
 import logging
 import threading
-import six
-# We don't vcrpy anymore, if this code is loaded, fail
-# import vcr
 
 from .config import TestConfig
 from .const import ENV_TEST_DIAGNOSE
@@ -197,7 +194,7 @@ class ReplayableTest(IntegrationTestBase):  # pylint: disable=too-many-instance-
 
             body = response["body"]["string"]
             response = _decompress_response_body(response)
-            if is_text_payload(response) and body and not isinstance(body, six.string_types):
+            if is_text_payload(response) and body and not isinstance(body, str):
                 try:
                     response["body"]["string"] = body.decode("utf-8")
                 except UnicodeDecodeError:
@@ -218,7 +215,7 @@ class ReplayableTest(IntegrationTestBase):  # pylint: disable=too-many-instance-
     @classmethod
     def _custom_request_query_matcher(cls, r1, r2):
         """ Ensure method, path, and query parameters match. """
-        from six.moves.urllib_parse import urlparse, parse_qs  # pylint: disable=import-error,relative-import
+        from urllib.parse import urlparse, parse_qs
 
         url1 = urlparse(r1.uri)
         url2 = urlparse(r2.uri)

--- a/tools/azure-devtools/src/azure_devtools/scenario_tests/preparers.py
+++ b/tools/azure-devtools/src/azure_devtools/scenario_tests/preparers.py
@@ -237,7 +237,7 @@ You must specify use_cache=True in the preparer decorator""".format(
 class SingleValueReplacer(RecordingProcessor):
     # pylint: disable=no-member
     def process_request(self, request):
-        from six.moves.urllib_parse import quote_plus  # pylint: disable=import-error,import-outside-toplevel
+        from urllib.parse import quote_plus  # pylint: disable=import-error,import-outside-toplevel
 
         if self.random_name in request.uri:
             request.uri = request.uri.replace(self.random_name, self.moniker)

--- a/tools/azure-devtools/src/azure_devtools/scenario_tests/recording_processors.py
+++ b/tools/azure-devtools/src/azure_devtools/scenario_tests/recording_processors.py
@@ -4,7 +4,6 @@
 # --------------------------------------------------------------------------------------------
 from copy import deepcopy
 from zlib import decompress
-import six
 
 from .utilities import is_text_payload, is_json_payload, is_batch_payload, replace_subscription_id
 
@@ -106,13 +105,12 @@ class LargeResponseBodyProcessor(RecordingProcessor):
 class LargeResponseBodyReplacer(RecordingProcessor):
     def process_response(self, response):
         if is_text_payload(response) and not is_json_payload(response):
-            import six
 
             body = response["body"]["string"]
 
             # backward compatibility. under 2.7 response body is unicode, under 3.5 response body is
             # bytes. when set the value back, the same type must be used.
-            body_is_string = isinstance(body, six.string_types)
+            body_is_string = isinstance(body, str)
 
             content_in_string = (response["body"]["string"] or b"").decode("utf-8")
             index = content_in_string.find(LargeResponseBodyProcessor.control_flag)
@@ -197,14 +195,14 @@ class GeneralNameReplacer(RecordingProcessor):
                 if isinstance(request.body, dict):
                     request.body = self._process_body_as_dict(request.body)
                 else:
-                    body = six.ensure_str(request.body)
+                    body = request.body.decode("utf-8")
                     if old in body:
                         request.body = body.replace(old, new)
 
             if request.body and request.uri and is_batch_payload(request):
                 import re
 
-                body = six.ensure_str(request.body)
+                body = request.body.decode("utf-8")
                 matched_objects = set(re.findall(old, body))
                 for matched_object in matched_objects:
                     request.body = body.replace(matched_object, new)

--- a/tools/azure-devtools/src/azure_devtools/scenario_tests/utilities.py
+++ b/tools/azure-devtools/src/azure_devtools/scenario_tests/utilities.py
@@ -9,7 +9,6 @@ import inspect
 import math
 import os
 import re
-import six
 import zlib
 
 
@@ -98,7 +97,7 @@ def is_preparer_func(fn):
 def _decompress_response_body(response):
     if "content-encoding" in response["headers"]:
         enc = response["headers"]["content-encoding"].lower()
-        if enc in ["gzip", "deflate"] and isinstance(response["body"]["string"], six.binary_type):
+        if enc in ["gzip", "deflate"] and isinstance(response["body"]["string"], bytes):
             zlib_mode = 16 + zlib.MAX_WBITS if enc == "gzip" else zlib.MAX_WBITS
             decompressor = zlib.decompressobj(wbits=zlib_mode)
             decompressed = decompressor.decompress(response["body"]["string"])

--- a/tools/azure-sdk-tools/devtools_testutils/azure_recorded_testcase.py
+++ b/tools/azure-sdk-tools/devtools_testutils/azure_recorded_testcase.py
@@ -6,7 +6,6 @@
 import functools
 import os
 import os.path
-import six
 import sys
 import time
 from typing import Dict
@@ -82,7 +81,7 @@ class AzureRecordedTestCase(object):
             try:
                 key_value = getattr(self.settings, key)
             except Exception as ex:
-                six.raise_from(ValueError("Could not get {}".format(key)), ex)
+                raise ValueError(f"Could not get {key}") from ex
         return key_value
 
     def get_credential(self, client_class, **kwargs):

--- a/tools/azure-sdk-tools/devtools_testutils/mgmt_testcase.py
+++ b/tools/azure-sdk-tools/devtools_testutils/mgmt_testcase.py
@@ -6,7 +6,6 @@
 from collections import namedtuple
 import inspect
 import re
-import six
 import os.path
 import zlib
 
@@ -185,7 +184,7 @@ class RENameReplacer(GeneralNameReplacer):
                 if isinstance(request.body, dict):
                     continue
 
-                body = six.ensure_str(request.body)
+                body = request.body.decode("utf-8")
                 for old in re.findall(expr, body):
                     request.body = body.replace(old, new)
         return request


### PR DESCRIPTION
# Description

This is a follow-up to my closed #32248.

* This removes the `six` dependency from `azure-core`, which doesn't seem to be using it at all.
* It adds an explicit dependency to `six` to the packages that _do_ depend on it.
* Further, it removes `six` dependencies from testing utility code.

Following this, PyCharm reports that `six` is only being used as a name like so:

![Screenshot 2023-09-28 at 12 51 33](https://github.com/Azure/azure-sdk-for-python/assets/58669/8859137b-2cda-42b7-99ff-65c417545c38)

All of these packages now have an explicit `six` dependency.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
  - It certainly should not, if all dependencies are correctly declared otherwise.
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
  - Should not be an user-visible change other than not requiring an extra `six` dependency. 
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
  - All code changes are in test utility code.