### PR TITLE
Update Monitor labels

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -58,12 +58,6 @@
 # PRLabel: %App Configuration Provider
 /sdk/appconfiguration/azure-appconfiguration-provider/               @mametcal @albertofori @avanigupta @mrm9084
 
-# PRLabel: %Monitor - ApplicationInsights
-/sdk/applicationinsights/azure-applicationinsights/                  @azmonapplicationinsights @pvaneck
-
-# PRLabel: %Monitor - LogAnalytics
-/sdk/loganalytics/azure-loganalytics/                                @azmonapplicationinsights @pvaneck
-
 # PRLabel: %Attestation
 /sdk/attestation/azure-security-attestation/                         @anilba06 @Azure/azure-sdk-write-attestation @gkostal
 
@@ -112,20 +106,20 @@
 # PRLabel: %Load Testing
 /sdk/loadtestservice/azure-developer-loadtesting/                    @msyyc @iscai-msft
 
-# PRLabel: %Monitor - LogAnalytics
+# PRLabel: %Monitor
+/sdk/loganalytics/azure-loganalytics/                                @azmonapplicationinsights @pvaneck
 /sdk/loganalytics/                                                   @pvaneck
+/sdk/monitor/azure-monitor-ingestion/                                @pvaneck @Azure/azure-sdk-write-monitor-data-plane
+/sdk/monitor/azure-monitor-query/                                    @pvaneck @Azure/azure-sdk-write-monitor-data-plane
+
+# PRLabel: %Monitor - ApplicationInsights
+/sdk/applicationinsights/azure-applicationinsights/                  @azmonapplicationinsights @pvaneck
 
 # PRLabel: %Monitor - Distro
 /sdk/monitor/azure-monitor-opentelemetry/                            @lzchen @jeremydvoss
 
 # PRLabel: %Monitor - Exporter
 /sdk/monitor/azure-monitor-opentelemetry-exporter/                   @lmazuel @lzchen @hectorhdzg @jeremydvoss
-
-# PRLabel: %Monitor - Query
-/sdk/monitor/azure-monitor-query/                                    @pvaneck @Azure/azure-sdk-write-monitor-data-plane
-
-# PRLabel: %Monitor - Ingestion
-/sdk/monitor/azure-monitor-ingestion/                                @pvaneck @Azure/azure-sdk-write-monitor-data-plane
 
 # PRLabel: %Consumption
 /sdk/consumption/                                                    @sandeepnl
@@ -660,31 +654,16 @@
 #/<NotInRepo>/          @kpiteira
 
 # ServiceLabel: %Monitor %Service Attention
-#/<NotInRepo>/          @SameergMS @dadunl
-
-# ServiceLabel: %Monitor - Autoscale %Service Attention
-#/<NotInRepo>/          @AzMonEssential
-
-# ServiceLabel: %Monitor - ActivityLogs %Service Attention
-#/<NotInRepo>/          @AzMonEssential
-
-# ServiceLabel: %Monitor - Metrics %Service Attention
-#/<NotInRepo>/          @AzMonEssential
-
-# ServiceLabel: %Monitor - Diagnostic Settings %Service Attention
-#/<NotInRepo>/          @AzMonEssential
-
-# ServiceLabel: %Monitor - Alerts %Service Attention
-#/<NotInRepo>/          @AzmonAlerts
-
-# ServiceLabel: %Monitor - ActionGroups %Service Attention
-#/<NotInRepo>/          @AzmonActionG
-
-# ServiceLabel: %Monitor - LogAnalytics %Service Attention
-#/<NotInRepo>/          @AzmonLogA
+#/<NotInRepo>/          @SameergMS @dadunl @AzMonEssential @AzmonAlerts @AzmonActionG @AzmonLogA
 
 # ServiceLabel: %Monitor - ApplicationInsights %Service Attention
 #/<NotInRepo>/          @azmonapplicationinsights
+
+# ServiceLabel: %Monitor - Distro %Service Attention
+#/<NotInRepo>/          @lzchen @jeremydvoss
+
+# ServiceLabel: %Monitor - Exporter %Service Attention
+#/<NotInRepo>/          @lzchen @jeremydvoss
 
 # ServiceLabel: %MySQL %Service Attention
 #/<NotInRepo>/          @ambhatna @savjani
@@ -946,12 +925,6 @@
 
 # ServiceLabel: %Consumption - RIandShowBack %Service Attention
 #/<NotInRepo>/          @ccmshowbackdevs
-
-# ServiceLabel: %Monitor - Exporter %Service Attention
-#/<NotInRepo>/          @lzchen @jeremydvoss
-
-# ServiceLabel: %Monitor - Distro %Service Attention
-#/<NotInRepo>/          @lzchen @jeremydvoss
 
 # Management Plane
 /**/*mgmt*/                                                          @ChenxiJiang333 @msyyc


### PR DESCRIPTION
Following suit with the Azure Monitor label consolidation effort that was completed for Java at https://github.com/Azure/azure-sdk-for-java/pull/36538. These labels have been removed from issues and PRs and have been deleted from the Labels admin page on GitHub.