### PR TITLE
[ML] fix: Add `type` instance var to `MonitorInputData`

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/constants/_monitoring.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/constants/_monitoring.py
@@ -94,6 +94,15 @@ class MonitorTargetTasks(str, Enum, metaclass=CaseInsensitiveEnumMeta):
     QUESTION_ANSWERING = "QuestionAnswering"
 
 
+class MonitorInputDataType(str, Enum, metaclass=CaseInsensitiveEnumMeta):
+    #: An input data with a fixed window size.
+    STATIC = "Static"
+    #: An input data which trailing relatively to the monitor's current run.
+    TRAILING = "Trailing"
+    #: An input data with tabular format which doesn't require preprocessing.
+    FIXED = "Fixed"
+
+
 class FADColumnNames(str, Enum, metaclass=CaseInsensitiveEnumMeta):
     PREDICTION = "prediction"
     PREDICTION_PROBABILITY = "prediction_probability"

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_monitoring/input_data.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_monitoring/input_data.py
@@ -25,6 +25,8 @@ from azure.ai.ml.constants._monitoring import MonitorDatasetContext, MonitorInpu
 class MonitorInputData(RestTranslatableMixin):
     """Monitor input data.
 
+    :keyword type: Specifies the type of monitoring input data.
+    :paramtype type: MonitorInputDataType
     :keyword input_dataset: Input data used by the monitor
     :paramtype input_dataset: Optional[~azure.ai.ml.Input]
     :keyword dataset_context: The context of the input dataset. Accepted values are "model_inputs",
@@ -66,6 +68,11 @@ class MonitorInputData(RestTranslatableMixin):
 
 @experimental
 class FixedInputData(MonitorInputData):
+    """
+    :ivar type: Specifies the type of monitoring input data. Set automatically to "Fixed" for this class.
+    :var type: MonitorInputDataType
+    """
+
     def __init__(
         self,
         *,
@@ -102,6 +109,11 @@ class FixedInputData(MonitorInputData):
 
 @experimental
 class TrailingInputData(MonitorInputData):
+    """
+    :ivar type: Specifies the type of monitoring input data. Set automatically to "Trailing" for this class.
+    :var type: MonitorInputDataType
+    """
+
     def __init__(
         self,
         *,
@@ -150,6 +162,11 @@ class TrailingInputData(MonitorInputData):
 
 @experimental
 class StaticInputData(MonitorInputData):
+    """
+    :ivar type: Specifies the type of monitoring input data. Set automatically to "Static" for this class.
+    :var type: MonitorInputDataType
+    """
+
     def __init__(
         self,
         *,

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_monitoring/input_data.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_monitoring/input_data.py
@@ -18,7 +18,7 @@ from azure.ai.ml._restclient.v2023_06_01_preview.models import (
 
 from azure.ai.ml._utils._experimental import experimental
 from azure.ai.ml._utils.utils import camel_to_snake, snake_to_camel
-from azure.ai.ml.constants._monitoring import MonitorDatasetContext
+from azure.ai.ml.constants._monitoring import MonitorDatasetContext, MonitorInputDataType
 
 
 @experimental
@@ -54,11 +54,11 @@ class MonitorInputData(RestTranslatableMixin):
 
     @classmethod
     def _from_rest_object(cls, obj: RestMonitorInputBase) -> Optional["MonitorInputData"]:
-        if obj.input_data_type == "Fixed":
+        if obj.input_data_type == MonitorInputDataType.FIXED:
             return FixedInputData._from_rest_object(obj)
-        if obj.input_data_type == "Trailing":
+        if obj.input_data_type == MonitorInputDataType.TRAILING:
             return TrailingInputData._from_rest_object(obj)
-        if obj.input_data_type == "Static":
+        if obj.input_data_type == MonitorInputDataType.STATIC:
             return StaticInputData._from_rest_object(obj)
 
         return None
@@ -75,7 +75,7 @@ class FixedInputData(MonitorInputData):
         uri: str = None,
     ):
         super().__init__(
-            input_type="Fixed",
+            input_type=MonitorInputDataType.FIXED,
             data_context=data_context,
             target_columns=target_columns,
             job_type=job_type,
@@ -114,7 +114,7 @@ class TrailingInputData(MonitorInputData):
         pre_processing_component_id: str = None,
     ):
         super().__init__(
-            input_type="Trailing",
+            input_type=MonitorInputDataType.TRAILING,
             data_context=data_context,
             target_columns=target_columns,
             job_type=job_type,
@@ -162,7 +162,7 @@ class StaticInputData(MonitorInputData):
         window_end: str = None,
     ):
         super().__init__(
-            input_type="Static",
+            input_type=MonitorInputDataType.STATIC,
             data_context=data_context,
             target_columns=target_columns,
             job_type=job_type,

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_monitoring/input_data.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_monitoring/input_data.py
@@ -40,13 +40,13 @@ class MonitorInputData(RestTranslatableMixin):
     def __init__(
         self,
         *,
-        input_type: str = None,
+        type: MonitorInputDataType = None,
         data_context: MonitorDatasetContext = None,
         target_columns: Dict = None,
         job_type: str = None,
         uri: str = None,
     ):
-        self.input_type = input_type
+        self.type = type
         self.data_context = data_context
         self.target_columns = target_columns
         self.job_type = job_type
@@ -75,7 +75,7 @@ class FixedInputData(MonitorInputData):
         uri: str = None,
     ):
         super().__init__(
-            input_type=MonitorInputDataType.FIXED,
+            type=MonitorInputDataType.FIXED,
             data_context=data_context,
             target_columns=target_columns,
             job_type=job_type,
@@ -114,7 +114,7 @@ class TrailingInputData(MonitorInputData):
         pre_processing_component_id: str = None,
     ):
         super().__init__(
-            input_type=MonitorInputDataType.TRAILING,
+            type=MonitorInputDataType.TRAILING,
             data_context=data_context,
             target_columns=target_columns,
             job_type=job_type,
@@ -162,7 +162,7 @@ class StaticInputData(MonitorInputData):
         window_end: str = None,
     ):
         super().__init__(
-            input_type=MonitorInputDataType.STATIC,
+            type=MonitorInputDataType.STATIC,
             data_context=data_context,
             target_columns=target_columns,
             job_type=job_type,


### PR DESCRIPTION
# Description

This pull request addresses some feedback from our Api Review, and ensures the presence of type discriminator `type` on the `MonitorInputData` class and subclasses. There was an `input_type` parameter that was renamed to `type`, and documented in docstrings.

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
