### PR TITLE
Remove pkg_resources

### DIFF
--- a/sdk/monitor/azure-monitor-opentelemetry/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-opentelemetry/CHANGELOG.md
@@ -2,13 +2,14 @@
 
 ## 1.0.1 (Unreleased)
 
-- Add message ids for AppLens
-    ([#32195](https://github.com/Azure/azure-sdk-for-python/pull/32195))
-
 ### Features Added
 
 - Add ability to specify which logger to export telemetry for via `logger_name` configuration
     ([#32192](https://github.com/Azure/azure-sdk-for-python/pull/32192))
+- Add message ids for AppLens
+    ([#32195](https://github.com/Azure/azure-sdk-for-python/pull/32195))
+- Remove pkg_resources
+    ([#32299](https://github.com/Azure/azure-sdk-for-python/pull/32299))
 
 ### Breaking Changes
 

--- a/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_configure.py
+++ b/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_configure.py
@@ -8,6 +8,7 @@ import os
 from logging import getLogger
 from typing import Dict, cast
 
+from importlib_metadata import entry_points
 from opentelemetry._logs import get_logger_provider, set_logger_provider
 from opentelemetry.instrumentation.dependencies import (
     get_dist_dependency_conflicts,
@@ -24,7 +25,6 @@ from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
 from opentelemetry.trace import get_tracer_provider, set_tracer_provider
-from pkg_resources import iter_entry_points  # type: ignore
 
 from azure.core.settings import settings
 from azure.core.tracing.ext.opentelemetry_span import OpenTelemetrySpan
@@ -147,9 +147,8 @@ def _setup_metrics(configurations: Dict[str, ConfigurationValue]):
 
 
 def _setup_instrumentations(configurations: Dict[str, ConfigurationValue]):
-    # use pkg_resources for now until https://github.com/open-telemetry/opentelemetry-python/pull/3168 is merged
-    for entry_point in iter_entry_points(
-        "opentelemetry_instrumentor"
+    for entry_point in entry_points(
+        group="opentelemetry_instrumentor"
     ):
         lib_name = entry_point.name
         if lib_name not in _ALL_SUPPORTED_INSTRUMENTED_LIBRARIES:

--- a/sdk/monitor/azure-monitor-opentelemetry/tests/configuration/test_configure.py
+++ b/sdk/monitor/azure-monitor-opentelemetry/tests/configuration/test_configure.py
@@ -382,7 +382,7 @@ class TestConfigure(unittest.TestCase):
     @patch("azure.monitor.opentelemetry._configure._ALL_SUPPORTED_INSTRUMENTED_LIBRARIES", ("test_instr2"))
     @patch("azure.monitor.opentelemetry._configure._is_instrumentation_enabled")
     @patch("azure.monitor.opentelemetry._configure.get_dist_dependency_conflicts")
-    @patch("azure.monitor.opentelemetry._configure.iter_entry_points")
+    @patch("azure.monitor.opentelemetry._configure.entry_points")
     def test_setup_instrumentations_lib_not_supported(
         self,
         iter_mock,
@@ -410,7 +410,7 @@ class TestConfigure(unittest.TestCase):
     @patch("azure.monitor.opentelemetry._configure._is_instrumentation_enabled")
     @patch("azure.monitor.opentelemetry._configure._logger")
     @patch("azure.monitor.opentelemetry._configure.get_dist_dependency_conflicts")
-    @patch("azure.monitor.opentelemetry._configure.iter_entry_points")
+    @patch("azure.monitor.opentelemetry._configure.entry_points")
     def test_setup_instrumentations_conflict(
         self,
         iter_mock,
@@ -437,7 +437,7 @@ class TestConfigure(unittest.TestCase):
     @patch("azure.monitor.opentelemetry._configure._is_instrumentation_enabled")
     @patch("azure.monitor.opentelemetry._configure._logger")
     @patch("azure.monitor.opentelemetry._configure.get_dist_dependency_conflicts")
-    @patch("azure.monitor.opentelemetry._configure.iter_entry_points")
+    @patch("azure.monitor.opentelemetry._configure.entry_points")
     def test_setup_instrumentations_exception(
         self,
         iter_mock,
@@ -464,7 +464,7 @@ class TestConfigure(unittest.TestCase):
     @patch("azure.monitor.opentelemetry._configure._is_instrumentation_enabled")
     @patch("azure.monitor.opentelemetry._configure._logger")
     @patch("azure.monitor.opentelemetry._configure.get_dist_dependency_conflicts")
-    @patch("azure.monitor.opentelemetry._configure.iter_entry_points")
+    @patch("azure.monitor.opentelemetry._configure.entry_points")
     def test_setup_instrumentations_disabled(
         self,
         iter_mock,


### PR DESCRIPTION
# Description

Remove deprecated pkg_resources. Replace with importlib_metadata. Related PRs:
https://github.com/open-telemetry/opentelemetry-python/issues/3167
https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1973

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
