### PR TITLE
Fix Failing APIStubGen Step

### DIFF
--- a/eng/apiview_reqs.txt
+++ b/eng/apiview_reqs.txt
@@ -1,2 +1,3 @@
 apiview-stub-generator==0.3.8
 azure-pylint-guidelines-checker==0.0.7
+pylint<3.0.0


### PR DESCRIPTION
This PR addresses [this error](https://dev.azure.com/azure-sdk/public/_build/results?buildId=3130666&view=logs&j=4259cd7e-6a4b-5ca5-581a-0ae020cd9d20&t=cf39a10b-67fe-585b-fdab-79fae179fbd2&l=146)

It is caused by `api-stub-generator` having a dependency on `pylint`, but `pylint` isn't pinned to the current major version. `pylint` just released `3.0.0`. Connect the dots there were exposions :)

