### PR TITLE
[ML][Cherry-Pick] Fix the issue causing apistub to fail generator (#32315)

### DIFF
--- a/eng/apiview_reqs.txt
+++ b/eng/apiview_reqs.txt
@@ -1,2 +1,3 @@
 apiview-stub-generator==0.3.8
 azure-pylint-guidelines-checker==0.0.7
+pylint<3.0.0


### PR DESCRIPTION
# Description

This pull request cherry-picks a fix merged into main that resolves an issue where ApiView fails to run because it depends on `pylint<3`.

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
