### PR TITLE
Default exception type in exception log records

### DIFF
--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 ### Bugs Fixed
 
+- Default exception type for blank exceptions
+    ([#32327](https://github.com/Azure/azure-sdk-for-python/pull/32327))
+
 ### Other Changes
 
 ## 1.0.0b17 (2023-09-12)

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/logs/_exporter.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/logs/_exporter.py
@@ -133,6 +133,8 @@ def _convert_log_to_envelope(log_data: LogData) -> TelemetryItem:
     elif exc_type is not None or exc_message is not None:
         envelope.name = _EXCEPTION_ENVELOPE_NAME
         has_full_stack = stack_trace is not None
+        if not exc_type:
+            exc_type = "Exception"
         if not exc_message:
             exc_message = "Exception"
         exc_details = TelemetryExceptionDetails(


### PR DESCRIPTION
# Description

There's a small bug in the log exporter. A OTel can technically come through with a exception type or exception message of a blank string. To determine whether this logrecord is an exception, we check if these fields are non-null, then pass them on to the backend. However, if the exception type field is just "", then this causes breeze to drop the telemetry. So far, I have found this can happen if the logger.exception method is used without a _caught_ exception. For instance, the following used to work fine:
```
try:
    raise Exception(message)
except Exception as e:
    logger.exception(e)
```
However, the following would result in a blank exception type and a data drop 400 from Breeze:
```
logger.exception(Exception(message))
```



# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
