### PR TITLE
Allow Azure Core Tracing disablement in auto-instrumentation

### DIFF
--- a/sdk/monitor/azure-monitor-opentelemetry/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-opentelemetry/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 - Add ability to specify which logger to export telemetry for via `logger_name` configuration
     ([#32192](https://github.com/Azure/azure-sdk-for-python/pull/32192))
+- Allow OTEL_PYTHON_DISABLED_INSTRUMENTATIONS functionality for Azure Core Tracing in Auto-instrumentation
+    ([#XXXXX](https://github.com/Azure/azure-sdk-for-python/pull/XXXXX))
 
 ### Breaking Changes
 

--- a/sdk/monitor/azure-monitor-opentelemetry/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-opentelemetry/CHANGELOG.md
@@ -2,13 +2,12 @@
 
 ## 1.0.1 (Unreleased)
 
-- Add message ids for AppLens
-    ([#32195](https://github.com/Azure/azure-sdk-for-python/pull/32195))
-
 ### Features Added
 
 - Add ability to specify which logger to export telemetry for via `logger_name` configuration
     ([#32192](https://github.com/Azure/azure-sdk-for-python/pull/32192))
+- Add message ids for AppLens
+    ([#32195](https://github.com/Azure/azure-sdk-for-python/pull/32195))
 - Allow OTEL_PYTHON_DISABLED_INSTRUMENTATIONS functionality for Azure Core Tracing in Auto-instrumentation
     ([#32331](https://github.com/Azure/azure-sdk-for-python/pull/32331))
 

--- a/sdk/monitor/azure-monitor-opentelemetry/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-opentelemetry/CHANGELOG.md
@@ -10,7 +10,7 @@
 - Add ability to specify which logger to export telemetry for via `logger_name` configuration
     ([#32192](https://github.com/Azure/azure-sdk-for-python/pull/32192))
 - Allow OTEL_PYTHON_DISABLED_INSTRUMENTATIONS functionality for Azure Core Tracing in Auto-instrumentation
-    ([#XXXXX](https://github.com/Azure/azure-sdk-for-python/pull/XXXXX))
+    ([#32331](https://github.com/Azure/azure-sdk-for-python/pull/32331))
 
 ### Breaking Changes
 

--- a/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_autoinstrumentation/distro.py
+++ b/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_autoinstrumentation/distro.py
@@ -14,6 +14,9 @@ from opentelemetry.environment_variables import (
 from opentelemetry.instrumentation.distro import (
     BaseDistro,
 )
+from opentelemetry.instrumentation.environment_variables import (
+    OTEL_PYTHON_DISABLED_INSTRUMENTATIONS,
+)
 from opentelemetry.sdk.environment_variables import (
     _OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED,
 )
@@ -22,6 +25,7 @@ from azure.core.settings import settings
 from azure.core.tracing.ext.opentelemetry_span import OpenTelemetrySpan
 from azure.monitor.opentelemetry._constants import (
     _is_attach_enabled,
+    _AZURE_SDK_INSTRUMENTATION_NAME,
     _PREVIEW_ENTRY_POINT_WARNING,
 )
 from azure.monitor.opentelemetry._diagnostics.diagnostic_logging import (
@@ -31,6 +35,9 @@ from azure.monitor.opentelemetry._diagnostics.diagnostic_logging import (
 )
 from azure.monitor.opentelemetry._diagnostics.status_logger import (
     AzureStatusLogger,
+)
+from azure.monitor.opentelemetry._util.configurations import (
+    _get_otel_disabled_instrumentations,
 )
 
 
@@ -67,4 +74,6 @@ def _configure_auto_instrumentation() -> None:
     environ.setdefault(
         _OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED, "true"
     )
-    settings.tracing_implementation = OpenTelemetrySpan
+    otel_disabled_instrumentations = _get_otel_disabled_instrumentations()
+    if _AZURE_SDK_INSTRUMENTATION_NAME not in otel_disabled_instrumentations:
+        settings.tracing_implementation = OpenTelemetrySpan

--- a/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_autoinstrumentation/distro.py
+++ b/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_autoinstrumentation/distro.py
@@ -14,9 +14,6 @@ from opentelemetry.environment_variables import (
 from opentelemetry.instrumentation.distro import (
     BaseDistro,
 )
-from opentelemetry.instrumentation.environment_variables import (
-    OTEL_PYTHON_DISABLED_INSTRUMENTATIONS,
-)
 from opentelemetry.sdk.environment_variables import (
     _OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED,
 )

--- a/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_util/configurations.py
+++ b/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_util/configurations.py
@@ -103,19 +103,12 @@ def _default_sampling_ratio(configurations):
 
 
 def _default_instrumentation_options(configurations):
-    disabled_instrumentation = environ.get(
-        OTEL_PYTHON_DISABLED_INSTRUMENTATIONS, ""
-    )
-    disabled_instrumentation = disabled_instrumentation.split(",")
-    # to handle users entering "requests , flask" or "requests, flask" with spaces
-    disabled_instrumentation = [
-        x.strip() for x in disabled_instrumentation
-    ]
+    otel_disabled_instrumentations = _get_otel_disabled_instrumentations()
 
     merged_instrumentation_options = {}
     instrumentation_options = configurations.get(INSTRUMENTATION_OPTIONS_ARG, {})
     for lib_name in _FULLY_SUPPORTED_INSTRUMENTED_LIBRARIES:
-        disabled_by_env_var = lib_name in disabled_instrumentation
+        disabled_by_env_var = lib_name in otel_disabled_instrumentations
         options = {"enabled": not disabled_by_env_var}
         options.update(instrumentation_options.get(lib_name, {}))
         merged_instrumentation_options[lib_name] = options
@@ -126,6 +119,17 @@ def _default_instrumentation_options(configurations):
 
     configurations[INSTRUMENTATION_OPTIONS_ARG] = merged_instrumentation_options
 
+
+def _get_otel_disabled_instrumentations():
+    disabled_instrumentation = environ.get(
+        OTEL_PYTHON_DISABLED_INSTRUMENTATIONS, ""
+    )
+    disabled_instrumentation = disabled_instrumentation.split(",")
+    # to handle users entering "requests , flask" or "requests, flask" with spaces
+    disabled_instrumentation = [
+        x.strip() for x in disabled_instrumentation
+    ]
+    return disabled_instrumentation
 
 def _is_instrumentation_enabled(configurations, lib_name):
     if INSTRUMENTATION_OPTIONS_ARG not in configurations:

--- a/sdk/monitor/azure-monitor-opentelemetry/tests/autoinstrumentation/test_distro.py
+++ b/sdk/monitor/azure-monitor-opentelemetry/tests/autoinstrumentation/test_distro.py
@@ -31,6 +31,24 @@ class TestDistro(TestCase):
             azure_core_mock.tracing_implementation, OpenTelemetrySpan
         )
 
+    @patch.dict("os.environ", {"OTEL_PYTHON_DISABLED_INSTRUMENTATIONS": " flask,azure_sdk , urllib3"})
+    @patch("azure.monitor.opentelemetry._autoinstrumentation.distro._is_attach_enabled", return_value=True)
+    @patch("azure.monitor.opentelemetry._autoinstrumentation.distro.settings")
+    @patch(
+        "azure.monitor.opentelemetry._autoinstrumentation.distro.AzureDiagnosticLogging"
+    )
+    def test_configure_disable_azure_core(self, mock_diagnostics, azure_core_mock, attach_mock):
+        distro = AzureMonitorDistro()
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            distro.configure()
+        mock_diagnostics.info.assert_called_once_with(
+            "Azure Monitor OpenTelemetry Distro configured successfully.",
+            _ATTACH_SUCCESS_DISTRO
+        )
+        self.assertNotEqual(
+            azure_core_mock.tracing_implementation, OpenTelemetrySpan
+        )
     @patch("azure.monitor.opentelemetry._autoinstrumentation.distro._is_attach_enabled", return_value=False)
     @patch("azure.monitor.opentelemetry._autoinstrumentation.distro.settings")
     @patch(


### PR DESCRIPTION
# Description

Allow attach users to disable azure core tracing with env var.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
