### PR TITLE
{Logging} Do not leak credentials in exception handling/stack traces

### DIFF
--- a/sdk/eventhub/azure-eventhub-checkpointstoreblob-aio/azure/eventhub/extensions/checkpointstoreblobaio/_vendor/storage/blob/_shared/base_client.py
+++ b/sdk/eventhub/azure-eventhub-checkpointstoreblob-aio/azure/eventhub/extensions/checkpointstoreblobaio/_vendor/storage/blob/_shared/base_client.py
@@ -230,7 +230,7 @@ class StorageAccountHostsMixin(object):  # pylint: disable=too-many-instance-att
         elif isinstance(credential, AzureSasCredential):
             self._credential_policy = AzureSasCredentialPolicy(credential)
         elif credential is not None:
-            raise TypeError("Unsupported credential: {}".format(credential))
+            raise TypeError("Unsupported credential: {}".format(type(credential)))
 
         config = kwargs.get("_configuration") or create_configuration(**kwargs)
         if kwargs.get("_pipeline"):

--- a/sdk/eventhub/azure-eventhub-checkpointstoreblob-aio/azure/eventhub/extensions/checkpointstoreblobaio/_vendor/storage/blob/_shared/base_client_async.py
+++ b/sdk/eventhub/azure-eventhub-checkpointstoreblob-aio/azure/eventhub/extensions/checkpointstoreblobaio/_vendor/storage/blob/_shared/base_client_async.py
@@ -76,7 +76,7 @@ class AsyncStorageAccountHostsMixin(object):
         elif isinstance(credential, AzureSasCredential):
             self._credential_policy = AzureSasCredentialPolicy(credential)
         elif credential is not None:
-            raise TypeError("Unsupported credential: {}".format(credential))
+            raise TypeError("Unsupported credential: {}".format(type(credential)))
         config = kwargs.get('_configuration') or create_configuration(**kwargs)
         if kwargs.get('_pipeline'):
             return config, kwargs['_pipeline']

--- a/sdk/eventhub/azure-eventhub-checkpointstoreblob/azure/eventhub/extensions/checkpointstoreblob/_vendor/storage/blob/_shared/base_client.py
+++ b/sdk/eventhub/azure-eventhub-checkpointstoreblob/azure/eventhub/extensions/checkpointstoreblob/_vendor/storage/blob/_shared/base_client.py
@@ -230,7 +230,7 @@ class StorageAccountHostsMixin(object):  # pylint: disable=too-many-instance-att
         elif isinstance(credential, AzureSasCredential):
             self._credential_policy = AzureSasCredentialPolicy(credential)
         elif credential is not None:
-            raise TypeError("Unsupported credential: {}".format(credential))
+            raise TypeError("Unsupported credential: {}".format(type(credential)))
 
         config = kwargs.get("_configuration") or create_configuration(**kwargs)
         if kwargs.get("_pipeline"):

--- a/sdk/eventhub/azure-eventhub-checkpointstoreblob/azure/eventhub/extensions/checkpointstoreblob/_vendor/storage/blob/_shared/base_client_async.py
+++ b/sdk/eventhub/azure-eventhub-checkpointstoreblob/azure/eventhub/extensions/checkpointstoreblob/_vendor/storage/blob/_shared/base_client_async.py
@@ -76,7 +76,7 @@ class AsyncStorageAccountHostsMixin(object):
         elif isinstance(credential, AzureSasCredential):
             self._credential_policy = AzureSasCredentialPolicy(credential)
         elif credential is not None:
-            raise TypeError("Unsupported credential: {}".format(credential))
+            raise TypeError("Unsupported credential: {}".format(type(credential)))
         config = kwargs.get('_configuration') or create_configuration(**kwargs)
         if kwargs.get('_pipeline'):
             return config, kwargs['_pipeline']

--- a/sdk/eventhub/azure-eventhub-checkpointstoretable/azure/eventhub/extensions/checkpointstoretable/_vendor/data/tables/_base_client.py
+++ b/sdk/eventhub/azure-eventhub-checkpointstoretable/azure/eventhub/extensions/checkpointstoretable/_vendor/data/tables/_base_client.py
@@ -254,7 +254,7 @@ class TablesBaseClient(AccountHostsMixin):
         elif isinstance(credential, AzureNamedKeyCredential):
             self._credential_policy = SharedKeyCredentialPolicy(credential)  # type: ignore
         elif credential is not None:
-            raise TypeError("Unsupported credential: {}".format(credential))
+            raise TypeError("Unsupported credential: {}".format(type(credential)))
 
     def _batch_send(self, *reqs, **kwargs):
         # type: (List[HttpRequest], Any) -> List[Mapping[str, Any]]

--- a/sdk/eventhub/azure-eventhub-checkpointstoretable/azure/eventhub/extensions/checkpointstoretable/_vendor/data/tables/aio/_base_client_async.py
+++ b/sdk/eventhub/azure-eventhub-checkpointstoretable/azure/eventhub/extensions/checkpointstoretable/_vendor/data/tables/aio/_base_client_async.py
@@ -83,7 +83,7 @@ class AsyncTablesBaseClient(AccountHostsMixin):
         elif isinstance(credential, AzureNamedKeyCredential):
             self._credential_policy = SharedKeyCredentialPolicy(credential)  # type: ignore
         elif credential is not None:
-            raise TypeError("Unsupported credential: {}".format(credential))
+            raise TypeError("Unsupported credential: {}".format(type(credential)))
 
     def _configure_policies(self, **kwargs):
         return [

--- a/sdk/iothub/azure-iot-deviceprovisioning/azure/iot/deviceprovisioning/_patch.py
+++ b/sdk/iothub/azure-iot-deviceprovisioning/azure/iot/deviceprovisioning/_patch.py
@@ -165,7 +165,7 @@ class DeviceProvisioningClient(
                 endpoint=base_url, key=key, policy_name=name
             )
         elif credential is not None:
-            raise TypeError(f"Unsupported credential: {credential}")
+            raise TypeError(f"Unsupported credential: {type(credential)}")
 
         policies = [
             user_agent_policy,

--- a/sdk/iothub/azure-iot-deviceprovisioning/azure/iot/deviceprovisioning/aio/_patch.py
+++ b/sdk/iothub/azure-iot-deviceprovisioning/azure/iot/deviceprovisioning/aio/_patch.py
@@ -169,7 +169,7 @@ class DeviceProvisioningClient(
                 endpoint=base_url, key=key, policy_name=name
             )
         elif credential is not None:
-            raise TypeError(f"Unsupported credential: {credential}")
+            raise TypeError(f"Unsupported credential: {type(credential)}")
 
         transport = kwargs.get("transport", None)
         if not transport:

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/base_client.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/base_client.py
@@ -227,7 +227,7 @@ class StorageAccountHostsMixin(object):  # pylint: disable=too-many-instance-att
         elif isinstance(credential, AzureSasCredential):
             self._credential_policy = AzureSasCredentialPolicy(credential)
         elif credential is not None:
-            raise TypeError(f"Unsupported credential: {credential}")
+            raise TypeError(f"Unsupported credential: {type(credential)}")
 
         config = kwargs.get("_configuration") or create_configuration(**kwargs)
         if kwargs.get("_pipeline"):

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/base_client_async.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/base_client_async.py
@@ -75,7 +75,7 @@ class AsyncStorageAccountHostsMixin(object):
         elif isinstance(credential, AzureSasCredential):
             self._credential_policy = AzureSasCredentialPolicy(credential)
         elif credential is not None:
-            raise TypeError(f"Unsupported credential: {credential}")
+            raise TypeError(f"Unsupported credential: {type(credential)}")
         config = kwargs.get('_configuration') or create_configuration(**kwargs)
         if kwargs.get('_pipeline'):
             return config, kwargs['_pipeline']

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/base_client.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/base_client.py
@@ -227,7 +227,7 @@ class StorageAccountHostsMixin(object):  # pylint: disable=too-many-instance-att
         elif isinstance(credential, AzureSasCredential):
             self._credential_policy = AzureSasCredentialPolicy(credential)
         elif credential is not None:
-            raise TypeError(f"Unsupported credential: {credential}")
+            raise TypeError(f"Unsupported credential: {type(credential)}")
 
         config = kwargs.get("_configuration") or create_configuration(**kwargs)
         if kwargs.get("_pipeline"):

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/base_client_async.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/base_client_async.py
@@ -76,7 +76,7 @@ class AsyncStorageAccountHostsMixin(object):
         elif isinstance(credential, AzureSasCredential):
             self._credential_policy = AzureSasCredentialPolicy(credential)
         elif credential is not None:
-            raise TypeError(f"Unsupported credential: {credential}")
+            raise TypeError(f"Unsupported credential: {type(credential)}")
         config = kwargs.get('_configuration') or create_configuration(**kwargs)
         if kwargs.get('_pipeline'):
             return config, kwargs['_pipeline']

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/base_client.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/base_client.py
@@ -227,7 +227,7 @@ class StorageAccountHostsMixin(object):  # pylint: disable=too-many-instance-att
         elif isinstance(credential, AzureSasCredential):
             self._credential_policy = AzureSasCredentialPolicy(credential)
         elif credential is not None:
-            raise TypeError(f"Unsupported credential: {credential}")
+            raise TypeError(f"Unsupported credential: {type(credential)}")
 
         config = kwargs.get("_configuration") or create_configuration(**kwargs)
         if kwargs.get("_pipeline"):

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/base_client_async.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/base_client_async.py
@@ -76,7 +76,7 @@ class AsyncStorageAccountHostsMixin(object):
         elif isinstance(credential, AzureSasCredential):
             self._credential_policy = AzureSasCredentialPolicy(credential)
         elif credential is not None:
-            raise TypeError(f"Unsupported credential: {credential}")
+            raise TypeError(f"Unsupported credential: {type(credential)}")
         config = kwargs.get('_configuration') or create_configuration(**kwargs)
         if kwargs.get('_pipeline'):
             return config, kwargs['_pipeline']

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/base_client.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/base_client.py
@@ -227,7 +227,7 @@ class StorageAccountHostsMixin(object):  # pylint: disable=too-many-instance-att
         elif isinstance(credential, AzureSasCredential):
             self._credential_policy = AzureSasCredentialPolicy(credential)
         elif credential is not None:
-            raise TypeError(f"Unsupported credential: {credential}")
+            raise TypeError(f"Unsupported credential: {type(credential)}")
 
         config = kwargs.get("_configuration") or create_configuration(**kwargs)
         if kwargs.get("_pipeline"):

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/base_client_async.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/base_client_async.py
@@ -76,7 +76,7 @@ class AsyncStorageAccountHostsMixin(object):
         elif isinstance(credential, AzureSasCredential):
             self._credential_policy = AzureSasCredentialPolicy(credential)
         elif credential is not None:
-            raise TypeError(f"Unsupported credential: {credential}")
+            raise TypeError(f"Unsupported credential: {type(credential)}")
         config = kwargs.get('_configuration') or create_configuration(**kwargs)
         if kwargs.get('_pipeline'):
             return config, kwargs['_pipeline']

--- a/sdk/tables/azure-data-tables/azure/data/tables/_authentication.py
+++ b/sdk/tables/azure-data-tables/azure/data/tables/_authentication.py
@@ -260,5 +260,5 @@ def _configure_credential(
     if isinstance(credential, AzureNamedKeyCredential):
         return SharedKeyCredentialPolicy(credential)
     if credential is not None:
-        raise TypeError(f"Unsupported credential: {credential}")
+        raise TypeError(f"Unsupported credential: {type(credential)}")
     return None

--- a/sdk/tables/azure-data-tables/azure/data/tables/aio/_authentication_async.py
+++ b/sdk/tables/azure-data-tables/azure/data/tables/aio/_authentication_async.py
@@ -111,5 +111,5 @@ def _configure_credential(
     if isinstance(credential, AzureNamedKeyCredential):
         return SharedKeyCredentialPolicy(credential)
     if credential is not None:
-        raise TypeError(f"Unsupported credential: {credential}")
+        raise TypeError(f"Unsupported credential: {type(credential)}")
     return None


### PR DESCRIPTION
# Description

The output of `rg -A1 'Unsupported credential'` when having this commit's parent checked out is:

```text
sdk/maps/azure-maps-render/azure/maps/render/_base_client.py:            "Unsupported credential: {}. Use an instance of AzureKeyCredential "
sdk/maps/azure-maps-render/azure/maps/render/_base_client.py-            "or a token credential from azure.identity".format(type(credential))
--
sdk/maps/azure-maps-render/azure/maps/render/aio/_base_client_async.py:            "Unsupported credential: {}. Use an instance of AzureKeyCredential "
sdk/maps/azure-maps-render/azure/maps/render/aio/_base_client_async.py-            "or a token credential from azure.identity".format(type(credential))
--
sdk/maps/azure-maps-search/azure/maps/search/aio/_base_client_async.py:            "Unsupported credential: {}. Use an instance of AzureKeyCredential "
sdk/maps/azure-maps-search/azure/maps/search/aio/_base_client_async.py-            "or a token credential from azure.identity".format(type(credential))
--
sdk/maps/azure-maps-search/azure/maps/search/_base_client.py:            "Unsupported credential: {}. Use an instance of AzureKeyCredential "
sdk/maps/azure-maps-search/azure/maps/search/_base_client.py-            "or a token credential from azure.identity".format(type(credential))
--
sdk/translation/azure-ai-translation-document/azure/ai/translation/document/_helpers.py:            "Unsupported credential: {}. Use an instance of AzureKeyCredential "
sdk/translation/azure-ai-translation-document/azure/ai/translation/document/_helpers.py-            "or a token credential from azure.identity".format(type(credential))
--
sdk/maps/azure-maps-route/azure/maps/route/_base_client.py:            "Unsupported credential: {}. Use an instance of AzureKeyCredential "
sdk/maps/azure-maps-route/azure/maps/route/_base_client.py-            "or a token credential from azure.identity".format(type(credential))
--
sdk/maps/azure-maps-route/azure/maps/route/aio/_base_client_async.py:            "Unsupported credential: {}. Use an instance of AzureKeyCredential "
sdk/maps/azure-maps-route/azure/maps/route/aio/_base_client_async.py-            "or a token credential from azure.identity".format(type(credential))
--
sdk/maps/azure-maps-geolocation/azure/maps/geolocation/_base_client.py:            "Unsupported credential: {}. Use an instance of AzureKeyCredential "
sdk/maps/azure-maps-geolocation/azure/maps/geolocation/_base_client.py-            "or a token credential from azure.identity".format(type(credential))
--
sdk/maps/azure-maps-geolocation/azure/maps/geolocation/aio/_base_client_async.py:            "Unsupported credential: {}. Use an instance of AzureKeyCredential "
sdk/maps/azure-maps-geolocation/azure/maps/geolocation/aio/_base_client_async.py-            "or a token credential from azure.identity".format(type(credential))
--
sdk/communication/azure-communication-sms/azure/communication/sms/_shared/auth_policy_utils.py:        f"Unsupported credential: {format(type(credential))}. Use an access token string to use HMACCredentialsPolicy"
sdk/communication/azure-communication-sms/azure/communication/sms/_shared/auth_policy_utils.py-        "or a token credential from azure.identity"
--
sdk/communication/azure-communication-jobrouter/azure/communication/jobrouter/aio/_router_client_async.py:            raise TypeError("Unsupported credential: {}. Use an AzureKeyCredential to use HMACCredentialsPolicy"
sdk/communication/azure-communication-jobrouter/azure/communication/jobrouter/aio/_router_client_async.py-                            " for authentication".format(type(credential)))
--
sdk/communication/azure-communication-jobrouter/azure/communication/jobrouter/aio/_router_administration_client_async.py:            raise TypeError("Unsupported credential: {}. Use an AzureKeyCredential to use HMACCredentialsPolicy"
sdk/communication/azure-communication-jobrouter/azure/communication/jobrouter/aio/_router_administration_client_async.py-                            " for authentication".format(type(credential)))
--
sdk/communication/azure-communication-jobrouter/azure/communication/jobrouter/_router_client.py:            raise TypeError("Unsupported credential: {}. Use an AzureKeyCredential to use HMACCredentialsPolicy"
sdk/communication/azure-communication-jobrouter/azure/communication/jobrouter/_router_client.py-                            " for authentication".format(type(credential)))
--
sdk/communication/azure-communication-jobrouter/azure/communication/jobrouter/_router_administration_client.py:            raise TypeError("Unsupported credential: {}. Use an AzureKeyCredential to use HMACCredentialsPolicy"
sdk/communication/azure-communication-jobrouter/azure/communication/jobrouter/_router_administration_client.py-                            " for authentication".format(type(credential)))
--
sdk/communication/azure-communication-jobrouter/azure/communication/jobrouter/_shared/auth_policy_utils.py:        f"Unsupported credential: {format(type(credential))}. Use an access token string to use HMACCredentialsPolicy"
sdk/communication/azure-communication-jobrouter/azure/communication/jobrouter/_shared/auth_policy_utils.py-        "or a token credential from azure.identity"
--
sdk/communication/azure-communication-rooms/azure/communication/rooms/_shared/auth_policy_utils.py:        f"Unsupported credential: {format(type(credential))}. Use an access token string to use HMACCredentialsPolicy"
sdk/communication/azure-communication-rooms/azure/communication/rooms/_shared/auth_policy_utils.py-        "or a token credential from azure.identity"
--
sdk/communication/azure-communication-networktraversal/azure/communication/networktraversal/_shared/auth_policy_utils.py:        f"Unsupported credential: {format(type(credential))}. Use an access token string to use HMACCredentialsPolicy"
sdk/communication/azure-communication-networktraversal/azure/communication/networktraversal/_shared/auth_policy_utils.py-        "or a token credential from azure.identity"
--
sdk/communication/azure-communication-callautomation/azure/communication/callautomation/_credential/call_automation_auth_policy_utils.py:        f"Unsupported credential: {format(type(credential))}. Use an access token string to use HMACCredentialsPolicy"
sdk/communication/azure-communication-callautomation/azure/communication/callautomation/_credential/call_automation_auth_policy_utils.py-        "or a token credential from azure.identity"
--
sdk/communication/azure-communication-identity/azure/communication/identity/_shared/auth_policy_utils.py:        f"Unsupported credential: {format(type(credential))}. Use an access token string to use HMACCredentialsPolicy"
sdk/communication/azure-communication-identity/azure/communication/identity/_shared/auth_policy_utils.py-        "or a token credential from azure.identity"
--
sdk/communication/azure-communication-callautomation/azure/communication/callautomation/_shared/auth_policy_utils.py:        f"Unsupported credential: {format(type(credential))}. Use an access token string to use HMACCredentialsPolicy"
sdk/communication/azure-communication-callautomation/azure/communication/callautomation/_shared/auth_policy_utils.py-        "or a token credential from azure.identity"
--
sdk/communication/azure-communication-phonenumbers/azure/communication/phonenumbers/_shared/auth_policy_utils.py:        f"Unsupported credential: {format(type(credential))}. Use an access token string to use HMACCredentialsPolicy"
sdk/communication/azure-communication-phonenumbers/azure/communication/phonenumbers/_shared/auth_policy_utils.py-        "or a token credential from azure.identity"
--
sdk/communication/azure-communication-chat/azure/communication/chat/_shared/auth_policy_utils.py:        f"Unsupported credential: {format(type(credential))}. Use an access token string to use HMACCredentialsPolicy"
sdk/communication/azure-communication-chat/azure/communication/chat/_shared/auth_policy_utils.py-        "or a token credential from azure.identity"
--
sdk/communication/azure-communication-email/azure/communication/email/_shared/auth_policy_utils.py:        f"Unsupported credential: {format(type(credential))}. Use an access token string to use HMACCredentialsPolicy"
sdk/communication/azure-communication-email/azure/communication/email/_shared/auth_policy_utils.py-        "or a token credential from azure.identity"
--
sdk/metricsadvisor/azure-ai-metricsadvisor/azure/ai/metricsadvisor/_patch.py:            "Unsupported credential: {}. Use an instance of MetricsAdvisorKeyCredential "
sdk/metricsadvisor/azure-ai-metricsadvisor/azure/ai/metricsadvisor/_patch.py-            "or a token credential from azure.identity".format(type(credential))
--
sdk/iothub/azure-iot-deviceprovisioning/azure/iot/deviceprovisioning/_patch.py:            raise TypeError(f"Unsupported credential: {credential}")
sdk/iothub/azure-iot-deviceprovisioning/azure/iot/deviceprovisioning/_patch.py-
--
sdk/iothub/azure-iot-deviceprovisioning/azure/iot/deviceprovisioning/aio/_patch.py:            raise TypeError(f"Unsupported credential: {credential}")
sdk/iothub/azure-iot-deviceprovisioning/azure/iot/deviceprovisioning/aio/_patch.py-
--
sdk/personalizer/azure-ai-personalizer/azure/ai/personalizer/_patch.py:            "Unsupported credential: {}. Use an instance of AzureKeyCredential "
sdk/personalizer/azure-ai-personalizer/azure/ai/personalizer/_patch.py-            "or a token credential from azure.identity".format(type(credential))
--
sdk/personalizer/azure-ai-personalizer/azure/ai/personalizer/aio/_patch.py:            "Unsupported credential: {}. Use an instance of AzureKeyCredential "
sdk/personalizer/azure-ai-personalizer/azure/ai/personalizer/aio/_patch.py-            "or a token credential from azure.identity".format(type(credential))
--
sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/base_client.py:            raise TypeError(f"Unsupported credential: {credential}")
sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/base_client.py-
--
sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/base_client_async.py:            raise TypeError(f"Unsupported credential: {credential}")
sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/base_client_async.py-        config = kwargs.get('_configuration') or create_configuration(**kwargs)
--
sdk/storage/azure-storage-blob/azure/storage/blob/_shared/base_client.py:            raise TypeError(f"Unsupported credential: {credential}")
sdk/storage/azure-storage-blob/azure/storage/blob/_shared/base_client.py-
--
sdk/storage/azure-storage-blob/azure/storage/blob/_shared/base_client_async.py:            raise TypeError(f"Unsupported credential: {credential}")
sdk/storage/azure-storage-blob/azure/storage/blob/_shared/base_client_async.py-        config = kwargs.get('_configuration') or create_configuration(**kwargs)
--
sdk/eventhub/azure-eventhub-checkpointstoreblob/azure/eventhub/extensions/checkpointstoreblob/_vendor/storage/blob/_shared/base_client_async.py:            raise TypeError("Unsupported credential: {}".format(credential))
sdk/eventhub/azure-eventhub-checkpointstoreblob/azure/eventhub/extensions/checkpointstoreblob/_vendor/storage/blob/_shared/base_client_async.py-        config = kwargs.get('_configuration') or create_configuration(**kwargs)
--
sdk/eventhub/azure-eventhub-checkpointstoreblob/azure/eventhub/extensions/checkpointstoreblob/_vendor/storage/blob/_shared/base_client.py:            raise TypeError("Unsupported credential: {}".format(credential))
sdk/eventhub/azure-eventhub-checkpointstoreblob/azure/eventhub/extensions/checkpointstoreblob/_vendor/storage/blob/_shared/base_client.py-
--
sdk/eventhub/azure-eventhub-checkpointstoreblob-aio/azure/eventhub/extensions/checkpointstoreblobaio/_vendor/storage/blob/_shared/base_client.py:            raise TypeError("Unsupported credential: {}".format(credential))
sdk/eventhub/azure-eventhub-checkpointstoreblob-aio/azure/eventhub/extensions/checkpointstoreblobaio/_vendor/storage/blob/_shared/base_client.py-
--
sdk/eventhub/azure-eventhub-checkpointstoreblob-aio/azure/eventhub/extensions/checkpointstoreblobaio/_vendor/storage/blob/_shared/base_client_async.py:            raise TypeError("Unsupported credential: {}".format(credential))
sdk/eventhub/azure-eventhub-checkpointstoreblob-aio/azure/eventhub/extensions/checkpointstoreblobaio/_vendor/storage/blob/_shared/base_client_async.py-        config = kwargs.get('_configuration') or create_configuration(**kwargs)
--
sdk/eventhub/azure-eventhub-checkpointstoretable/azure/eventhub/extensions/checkpointstoretable/_vendor/data/tables/_base_client.py:            raise TypeError("Unsupported credential: {}".format(credential))
sdk/eventhub/azure-eventhub-checkpointstoretable/azure/eventhub/extensions/checkpointstoretable/_vendor/data/tables/_base_client.py-
--
sdk/eventhub/azure-eventhub-checkpointstoretable/azure/eventhub/extensions/checkpointstoretable/_vendor/data/tables/aio/_base_client_async.py:            raise TypeError("Unsupported credential: {}".format(credential))
sdk/eventhub/azure-eventhub-checkpointstoretable/azure/eventhub/extensions/checkpointstoretable/_vendor/data/tables/aio/_base_client_async.py-
--
sdk/storage/azure-storage-queue/azure/storage/queue/_shared/base_client.py:            raise TypeError(f"Unsupported credential: {credential}")
sdk/storage/azure-storage-queue/azure/storage/queue/_shared/base_client.py-
--
sdk/storage/azure-storage-queue/azure/storage/queue/_shared/base_client_async.py:            raise TypeError(f"Unsupported credential: {credential}")
sdk/storage/azure-storage-queue/azure/storage/queue/_shared/base_client_async.py-        config = kwargs.get('_configuration') or create_configuration(**kwargs)
--
sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/base_client_async.py:            raise TypeError(f"Unsupported credential: {credential}")
sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/base_client_async.py-        config = kwargs.get('_configuration') or create_configuration(**kwargs)
--
sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/base_client.py:            raise TypeError(f"Unsupported credential: {credential}")
sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/base_client.py-
--
sdk/formrecognizer/azure-ai-formrecognizer/azure/ai/formrecognizer/_helpers.py:            "Unsupported credential: {}. Use an instance of AzureKeyCredential "
sdk/formrecognizer/azure-ai-formrecognizer/azure/ai/formrecognizer/_helpers.py-            "or a token credential from azure.identity".format(type(credential))
--
sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/aio/_base_client_async.py:            "Unsupported credential: {}. Use an instance of AzureKeyCredential "
sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/aio/_base_client_async.py-            "or a token credential from azure.identity".format(type(credential))
--
sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/_base_client.py:            "Unsupported credential: {}. Use an instance of AzureKeyCredential "
sdk/textanalytics/azure-ai-textanalytics/azure/ai/textanalytics/_base_client.py-            "or a token credential from azure.identity".format(type(credential))
--
sdk/tables/azure-data-tables/azure/data/tables/_authentication.py:        raise TypeError(f"Unsupported credential: {credential}")
sdk/tables/azure-data-tables/azure/data/tables/_authentication.py-    return None
--
sdk/tables/azure-data-tables/azure/data/tables/aio/_authentication_async.py:        raise TypeError(f"Unsupported credential: {credential}")
sdk/tables/azure-data-tables/azure/data/tables/aio/_authentication_async.py-    return None
--
sdk/cognitivelanguage/azure-ai-language-questionanswering/azure/ai/language/questionanswering/_patch.py:            "Unsupported credential: {}. Use an instance of AzureKeyCredential "
sdk/cognitivelanguage/azure-ai-language-questionanswering/azure/ai/language/questionanswering/_patch.py-            "or a token credential from azure.identity".format(type(credential))
--
sdk/cognitivelanguage/azure-ai-language-questionanswering/azure/ai/language/questionanswering/aio/_patch.py:            "Unsupported credential: {}. Use an instance of AzureKeyCredential "
sdk/cognitivelanguage/azure-ai-language-questionanswering/azure/ai/language/questionanswering/aio/_patch.py-            "or a token credential from azure.identity".format(type(credential))
--
sdk/cognitivelanguage/azure-ai-language-questionanswering/azure/ai/language/questionanswering/authoring/_patch.py:            "Unsupported credential: {}. Use an instance of AzureKeyCredential "
sdk/cognitivelanguage/azure-ai-language-questionanswering/azure/ai/language/questionanswering/authoring/_patch.py-            "or a token credential from azure.identity".format(type(credential))
--
sdk/cognitivelanguage/azure-ai-language-questionanswering/azure/ai/language/questionanswering/authoring/aio/_patch.py:            "Unsupported credential: {}. Use an instance of AzureKeyCredential "
sdk/cognitivelanguage/azure-ai-language-questionanswering/azure/ai/language/questionanswering/authoring/aio/_patch.py-            "or a token credential from azure.identity".format(type(credential))
--
sdk/cognitivelanguage/azure-ai-language-conversations/azure/ai/language/conversations/_patch.py:            f"Unsupported credential: {type(credential)}. Use an instance of AzureKeyCredential "
sdk/cognitivelanguage/azure-ai-language-conversations/azure/ai/language/conversations/_patch.py-            "or a token credential from azure.identity"
--
sdk/cognitivelanguage/azure-ai-language-conversations/azure/ai/language/conversations/aio/_patch.py:            f"Unsupported credential: {type(credential)}. Use an instance of AzureKeyCredential "
sdk/cognitivelanguage/azure-ai-language-conversations/azure/ai/language/conversations/aio/_patch.py-            "or a token credential from azure.identity"
--
sdk/cognitivelanguage/azure-ai-language-conversations/azure/ai/language/conversations/authoring/aio/_patch.py:            f"Unsupported credential: {type(credential)}. Use an instance of AzureKeyCredential "
sdk/cognitivelanguage/azure-ai-language-conversations/azure/ai/language/conversations/authoring/aio/_patch.py-            "or a token credential from azure.identity"
--
sdk/cognitivelanguage/azure-ai-language-conversations/azure/ai/language/conversations/authoring/_patch.py:            f"Unsupported credential: {type(credential)}. Use an instance of AzureKeyCredential "
sdk/cognitivelanguage/azure-ai-language-conversations/azure/ai/language/conversations/authoring/_patch.py-            "or a token credential from azure.identity"
```

So there's roughly three categories:

1. `str.format(type(credential))` (printing the `type`)
2. `raise TypeError("Unsupported credential")` (not printing any detailed feedback)
3. `raise TypeError(f"Unsupported credential: {credential}")` (printing the value)

The third version leaks the credential to logs or the screen in case of an exception. The first version is, in quantity, the most common in the code base, so I adjusted all "vulnerable" cases to conform to it.

Noticed this issue while trying to fix
https://github.com/Azure/azure-cli/issues/20404 , and seeing my JWT leaked on screen while experimenting.

An example of a (partially!) leaked credential is: https://github.com/Azure/azure-sdk-for-python/issues/9498#issue-551033755

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
