### PR TITLE
[ML] test: Fix unittests/test_compute_operations failing for python>=3.11

### DIFF
--- a/sdk/ml/azure-ai-ml/tests/compute/unittests/test_compute_operations.py
+++ b/sdk/ml/azure-ai-ml/tests/compute/unittests/test_compute_operations.py
@@ -32,11 +32,6 @@ def mock_compute_operation(
     )
 
 
-class funny:
-    def __init__(self):
-        self.location = "somelocation"
-
-
 @pytest.mark.unittest
 @pytest.mark.core_sdk_test
 class TestComputeOperation:
@@ -44,15 +39,7 @@ class TestComputeOperation:
         mock_compute_operation.list()
         mock_compute_operation._operation.list.assert_called_once()
 
-    @pytest.mark.skipif(
-        sys.version_info[1] == 11,
-        reason=f"This test is not compatible with Python 3.11, skip in CI.",
-    )
     def test_create_compute_instance(self, mock_compute_operation: ComputeOperations, mocker: MockFixture) -> None:
-        mocker.patch(
-            "azure.ai.ml._restclient.v2022_10_01_preview.workspaces.get",
-            return_value=funny(),
-        )
         mocker.patch(
             "azure.ai.ml.entities.Compute._from_rest_object",
             return_value=ComputeInstance(name="name", resource_id="test_resource_id"),
@@ -62,12 +49,7 @@ class TestComputeOperation:
         mock_compute_operation.begin_create_or_update(compute=compute)
         mock_compute_operation._operation.begin_create_or_update.assert_called_once()
 
-    @pytest.mark.skipif(
-        sys.version_info[1] == 11,
-        reason=f"This test is not compatible with Python 3.11, skip in CI.",
-    )
     def test_create_aml_compute(self, mock_compute_operation: ComputeOperations, mocker: MockFixture) -> None:
-        mocker.patch("azure.ai.ml._restclient.v2022_10_01_preview.workspaces.get", return_value=funny())
         compute = load_compute("./tests/test_configs/compute/compute-aml.yaml")
         mock_compute_operation.begin_create_or_update(compute=compute)
         mock_compute_operation._operation.begin_create_or_update.assert_called_once()


### PR DESCRIPTION
# Description

This pull request fixes unit tests in `sdk/ml/azure-ai-ml/tests/compute/unittests/test_compute_operations.py` that fail when run on Python 3.12. Related to #31758

# Background

On `python>=3.11`, mocking `azure.ai.ml._restclient.v2022_10_01_preview.workspaces.get` fails with an `AttributeError` claiming that 'workspaces' is not found. The affected tests were already set to skip when run on 3.11.

Root-causing why this doesn't work was not done, since the mock itself seems unnecessary. The return value is never used, and ComputeOperations._workspace_operations is a MagicMock object already.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
