### PR TITLE
[ML][Pipelines] fix: avoid depending on bytecode for Python 3.12

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_utils/utils.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_utils/utils.py
@@ -12,6 +12,7 @@ import os
 import random
 import re
 import string
+import sys
 import tempfile
 import time
 import warnings
@@ -1013,6 +1014,23 @@ def is_private_preview_enabled():
     :rtype: bool
     """
     return os.getenv(AZUREML_PRIVATE_FEATURES_ENV_VAR) in ["True", "true", True]
+
+
+def is_bytecode_optimization_enabled():
+    """Check if bytecode optimization is enabled:
+    1) bytecode package is installed
+    2) private preview is enabled
+    3) python version is between 3.6 and 3.11
+
+    :return: True if bytecode optimization is enabled, False otherwise.
+    :rtype: bool
+    """
+    try:
+        import bytecode  # pylint: disable=unused-import
+
+        return is_private_preview_enabled() and (3, 6) < sys.version_info < (3, 12)
+    except ImportError:
+        return False
 
 
 def is_on_disk_cache_enabled():


### PR DESCRIPTION
# Description

Disable bytecode optimization on Python 3.12 and uninstall bytecode after related tests finished.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
