### PR TITLE
disable broker tests

### DIFF
--- a/sdk/identity/azure-identity-broker/tests/test_broker.py
+++ b/sdk/identity/azure-identity-broker/tests/test_broker.py
@@ -2,12 +2,18 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
-from azure.identity.broker import InteractiveBrowserBrokerCredential, UsernamePasswordBrokerCredential
+import pytest
+from azure.identity.broker import (
+    InteractiveBrowserBrokerCredential,
+    UsernamePasswordBrokerCredential,
+)
 
 
+@pytest.mark.skip("Not compatible with identity 1.15.0b1")
 def test_interactive_browser_cred_with_broker():
     cred = InteractiveBrowserBrokerCredential(allow_broker=True)
     assert cred._allow_broker
+    assert cred._get_app()._enable_broker
 
 
 def test_interactive_browser_cred_without_broker():
@@ -18,14 +24,20 @@ def test_interactive_browser_cred_without_broker():
     assert not cred._allow_broker
 
 
+@pytest.mark.skip("Not compatible with identity 1.15.0b1")
 def test_username_password_cred_with_broker():
-    cred = UsernamePasswordBrokerCredential("client-id", "username", "password", allow_broker=True)
+    cred = UsernamePasswordBrokerCredential(
+        "client-id", "username", "password", allow_broker=True
+    )
     assert cred._allow_broker
+    assert cred._get_app()._enable_broker
 
 
 def test_username_password_cred_without_broker():
     cred = UsernamePasswordBrokerCredential("client-id", "username", "password")
     assert not cred._allow_broker
 
-    cred = UsernamePasswordBrokerCredential("client-id", "username", "password", allow_broker=False)
+    cred = UsernamePasswordBrokerCredential(
+        "client-id", "username", "password", allow_broker=False
+    )
     assert not cred._allow_broker

--- a/sdk/identity/azure-identity-broker/tests/test_broker.py
+++ b/sdk/identity/azure-identity-broker/tests/test_broker.py
@@ -26,9 +26,7 @@ def test_interactive_browser_cred_without_broker():
 
 @pytest.mark.skip("Not compatible with identity 1.15.0b1")
 def test_username_password_cred_with_broker():
-    cred = UsernamePasswordBrokerCredential(
-        "client-id", "username", "password", allow_broker=True
-    )
+    cred = UsernamePasswordBrokerCredential("client-id", "username", "password", allow_broker=True)
     assert cred._allow_broker
     assert cred._get_app()._enable_broker
 
@@ -37,7 +35,5 @@ def test_username_password_cred_without_broker():
     cred = UsernamePasswordBrokerCredential("client-id", "username", "password")
     assert not cred._allow_broker
 
-    cred = UsernamePasswordBrokerCredential(
-        "client-id", "username", "password", allow_broker=False
-    )
+    cred = UsernamePasswordBrokerCredential("client-id", "username", "password", allow_broker=False)
     assert not cred._allow_broker

--- a/sdk/identity/ci.yml
+++ b/sdk/identity/ci.yml
@@ -40,3 +40,5 @@ extends:
     Artifacts:
      - name: azure-identity
        safeName: azureidentity
+     - name: azure-identity-broker
+       safeName: azureidentitybroker


### PR DESCRIPTION
disable broker tests because they are incompatible with identity 1.15.0b1.

Will add them back when new identity library is released.