### PR TITLE
Use correct argument for ClientSecretCredential

### DIFF
--- a/doc/sphinx/python_mgmt_migration_guide.rst
+++ b/doc/sphinx/python_mgmt_migration_guide.rst
@@ -102,7 +102,7 @@ To the show the code snippets for the change:
     from azure.identity import ClientSecretCredential
 
     credential = ClientSecretCredential(
-        client_secret=client_secret,
+        tenant_id=tenant_id,
         client_id=client_id,
         client_secret=client_secret
     )


### PR DESCRIPTION
# Description

Hello, 
If I refer to the ClientSecretCredential [constructor](https://github.com/Azure/azure-sdk-for-python/blob/964c6036fd41cc2b2893840832f666a36ced0596/sdk/identity/azure-identity/azure/identity/_credentials/client_secret.py#L43) it seems the arguments described in this README are incorrect.
This should not need a changelog reference, no tests as it's a readme
Thanks in advance for your review

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
