### PR TITLE
[Identity] Add additional dev credential tests

### DIFF
--- a/sdk/identity/azure-identity/azure/identity/_internal/msal_client.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/msal_client.py
@@ -7,7 +7,10 @@ from typing import Any, Dict, Optional, Union
 
 from azure.core.exceptions import ClientAuthenticationError
 from azure.core.pipeline.policies import ContentDecodePolicy
-from azure.core.pipeline.transport import HttpRequest, HttpResponse
+from azure.core.pipeline.transport import (  # pylint:disable=unknown-option-value,no-legacy-azure-core-http-response-import
+    HttpRequest,
+    HttpResponse,
+)
 from azure.core.pipeline import PipelineResponse
 from .pipeline import build_pipeline
 

--- a/sdk/identity/azure-identity/tests/helpers.py
+++ b/sdk/identity/azure-identity/tests/helpers.py
@@ -14,6 +14,7 @@ except ImportError:  # python < 3.3
 
 
 FAKE_CLIENT_ID = "fake-client-id"
+INVALID_CHARACTERS = "|\\`;{&' "
 
 
 def build_id_token(

--- a/sdk/identity/azure-identity/tests/test_azd_cli_credential.py
+++ b/sdk/identity/azure-identity/tests/test_azd_cli_credential.py
@@ -14,7 +14,7 @@ from azure.core.exceptions import ClientAuthenticationError
 import subprocess
 import pytest
 
-from helpers import mock
+from helpers import mock, INVALID_CHARACTERS
 
 CHECK_OUTPUT = AzureDeveloperCliCredential.__module__ + ".subprocess.check_output"
 
@@ -40,6 +40,28 @@ def test_no_scopes():
 
     with pytest.raises(ValueError):
         AzureDeveloperCliCredential().get_token()
+
+
+def test_invalid_tenant_id():
+    """Invalid tenant IDs should raise ValueErrors."""
+
+    for c in INVALID_CHARACTERS:
+        with pytest.raises(ValueError):
+            AzureDeveloperCliCredential(tenant_id="tenant" + c)
+
+        with pytest.raises(ValueError):
+            AzureDeveloperCliCredential().get_token("scope", tenant_id="tenant" + c)
+
+
+def test_invalid_scopes():
+    """Scopes with invalid characters should raise ValueErrors."""
+
+    for c in INVALID_CHARACTERS:
+        with pytest.raises(ValueError):
+            AzureDeveloperCliCredential().get_token("scope" + c)
+
+        with pytest.raises(ValueError):
+            AzureDeveloperCliCredential().get_token("scope", "scope2", "scope" + c)
 
 
 def test_get_token():

--- a/sdk/identity/azure-identity/tests/test_azd_cli_credential_async.py
+++ b/sdk/identity/azure-identity/tests/test_azd_cli_credential_async.py
@@ -16,6 +16,7 @@ from azure.identity._credentials.azd_cli import CLI_NOT_FOUND, NOT_LOGGED_IN
 from azure.core.exceptions import ClientAuthenticationError
 import pytest
 
+from helpers import INVALID_CHARACTERS
 from helpers_async import get_completed_future
 from test_azd_cli_credential import TEST_ERROR_OUTPUTS
 
@@ -37,6 +38,28 @@ async def test_no_scopes():
 
     with pytest.raises(ValueError):
         await AzureDeveloperCliCredential().get_token()
+
+
+async def test_invalid_tenant_id():
+    """Invalid tenant IDs should raise ValueErrors."""
+
+    for c in INVALID_CHARACTERS:
+        with pytest.raises(ValueError):
+            AzureDeveloperCliCredential(tenant_id="tenant" + c)
+
+        with pytest.raises(ValueError):
+            await AzureDeveloperCliCredential().get_token("scope", tenant_id="tenant" + c)
+
+
+async def test_invalid_scopes():
+    """Scopes with invalid characters should raise ValueErrors."""
+
+    for c in INVALID_CHARACTERS:
+        with pytest.raises(ValueError):
+            await AzureDeveloperCliCredential().get_token("scope" + c)
+
+        with pytest.raises(ValueError):
+            await AzureDeveloperCliCredential().get_token("scope", "scope2", "scope" + c)
 
 
 async def test_close():

--- a/sdk/identity/azure-identity/tests/test_cli_credential.py
+++ b/sdk/identity/azure-identity/tests/test_cli_credential.py
@@ -14,7 +14,7 @@ from azure.core.exceptions import ClientAuthenticationError
 import subprocess
 import pytest
 
-from helpers import mock
+from helpers import mock, INVALID_CHARACTERS
 
 CHECK_OUTPUT = AzureCliCredential.__module__ + ".subprocess.check_output"
 
@@ -47,6 +47,25 @@ def test_multiple_scopes():
 
     with pytest.raises(ValueError):
         AzureCliCredential().get_token("one scope", "and another")
+
+
+def test_invalid_tenant_id():
+    """Invalid tenant IDs should raise ValueErrors."""
+
+    for c in INVALID_CHARACTERS:
+        with pytest.raises(ValueError):
+            AzureCliCredential(tenant_id="tenant" + c)
+
+        with pytest.raises(ValueError):
+            AzureCliCredential().get_token("scope", tenant_id="tenant" + c)
+
+
+def test_invalid_scopes():
+    """Scopes with invalid characters should raise ValueErrors."""
+
+    for c in INVALID_CHARACTERS:
+        with pytest.raises(ValueError):
+            AzureCliCredential().get_token("scope" + c)
 
 
 def test_get_token():

--- a/sdk/identity/azure-identity/tests/test_cli_credential_async.py
+++ b/sdk/identity/azure-identity/tests/test_cli_credential_async.py
@@ -16,6 +16,7 @@ from azure.identity._credentials.azure_cli import CLI_NOT_FOUND, NOT_LOGGED_IN
 from azure.core.exceptions import ClientAuthenticationError
 import pytest
 
+from helpers import INVALID_CHARACTERS
 from helpers_async import get_completed_future
 from test_cli_credential import TEST_ERROR_OUTPUTS
 
@@ -44,6 +45,25 @@ async def test_multiple_scopes():
 
     with pytest.raises(ValueError):
         await AzureCliCredential().get_token("one scope", "and another")
+
+
+async def test_invalid_tenant_id():
+    """Invalid tenant IDs should raise ValueErrors."""
+
+    for c in INVALID_CHARACTERS:
+        with pytest.raises(ValueError):
+            AzureCliCredential(tenant_id="tenant" + c)
+
+        with pytest.raises(ValueError):
+            await AzureCliCredential().get_token("scope", tenant_id="tenant" + c)
+
+
+async def test_invalid_scopes():
+    """Scopes with invalid characters should raise ValueErrors."""
+
+    for c in INVALID_CHARACTERS:
+        with pytest.raises(ValueError):
+            await AzureCliCredential().get_token("https://scope" + c)
 
 
 async def test_close():

--- a/sdk/identity/azure-identity/tests/test_live.py
+++ b/sdk/identity/azure-identity/tests/test_live.py
@@ -10,6 +10,9 @@ from azure.identity import (
     ClientSecretCredential,
     DeviceCodeCredential,
     UsernamePasswordCredential,
+    AzureCliCredential,
+    AzurePowerShellCredential,
+    AzureDeveloperCliCredential,
 )
 from azure.identity._constants import DEVELOPER_SIGN_ON_CLIENT_ID
 
@@ -73,6 +76,24 @@ def test_username_password_auth(live_user_details):
         password=live_user_details["password"],
         tenant_id=live_user_details["tenant"],
     )
+    get_token(credential)
+
+
+@pytest.mark.manual
+def test_cli_credential():
+    credential = AzureCliCredential()
+    get_token(credential)
+
+
+@pytest.mark.manual
+def test_dev_cli_credential():
+    credential = AzureDeveloperCliCredential()
+    get_token(credential)
+
+
+@pytest.mark.manual
+def test_powershell_credential():
+    credential = AzurePowerShellCredential()
     get_token(credential)
 
 

--- a/sdk/identity/azure-identity/tests/test_live_async.py
+++ b/sdk/identity/azure-identity/tests/test_live_async.py
@@ -4,7 +4,14 @@
 # ------------------------------------
 import pytest
 
-from azure.identity.aio import DefaultAzureCredential, CertificateCredential, ClientSecretCredential
+from azure.identity.aio import (
+    DefaultAzureCredential,
+    CertificateCredential,
+    ClientSecretCredential,
+    AzureCliCredential,
+    AzurePowerShellCredential,
+    AzureDeveloperCliCredential,
+)
 
 from helpers import get_token_payload_contents
 
@@ -59,4 +66,22 @@ async def test_client_secret_credential(live_service_principal):
 @pytest.mark.asyncio
 async def test_default_credential(live_service_principal):
     credential = DefaultAzureCredential()
+    await get_token(credential)
+
+
+@pytest.mark.manual
+async def test_cli_credential():
+    credential = AzureCliCredential()
+    await get_token(credential)
+
+
+@pytest.mark.manual
+async def test_dev_cli_credential():
+    credential = AzureDeveloperCliCredential()
+    await get_token(credential)
+
+
+@pytest.mark.manual
+async def test_powershell_credential():
+    credential = AzurePowerShellCredential()
     await get_token(credential)

--- a/sdk/identity/azure-identity/tests/test_powershell_credential.py
+++ b/sdk/identity/azure-identity/tests/test_powershell_credential.py
@@ -28,6 +28,7 @@ from azure.identity._credentials.azure_powershell import (
 import pytest
 
 from credscan_ignore import POWERSHELL_INVALID_OPERATION_EXCEPTION, POWERSHELL_NOT_LOGGED_IN_ERROR
+from helpers import INVALID_CHARACTERS
 
 
 POPEN = AzurePowerShellCredential.__module__ + ".subprocess.Popen"
@@ -67,6 +68,25 @@ def test_cannot_execute_shell():
     with patch(POPEN, Mock(side_effect=OSError)):
         with pytest.raises(CredentialUnavailableError):
             AzurePowerShellCredential().get_token("scope")
+
+
+def test_invalid_tenant_id():
+    """Invalid tenant IDs should raise ValueErrors."""
+
+    for c in INVALID_CHARACTERS:
+        with pytest.raises(ValueError):
+            AzurePowerShellCredential(tenant_id="tenant" + c)
+
+        with pytest.raises(ValueError):
+            AzurePowerShellCredential().get_token("scope", tenant_id="tenant" + c)
+
+
+def test_invalid_scopes():
+    """Scopes with invalid characters should raise ValueErrors."""
+
+    for c in INVALID_CHARACTERS:
+        with pytest.raises(ValueError):
+            AzurePowerShellCredential().get_token("scope" + c)
 
 
 @pytest.mark.parametrize("stderr", ("", PREPARING_MODULES))

--- a/sdk/identity/azure-identity/tests/test_powershell_credential_async.py
+++ b/sdk/identity/azure-identity/tests/test_powershell_credential_async.py
@@ -24,6 +24,7 @@ from azure.identity._credentials.azure_powershell import (
 import pytest
 
 from credscan_ignore import POWERSHELL_INVALID_OPERATION_EXCEPTION, POWERSHELL_NOT_LOGGED_IN_ERROR
+from helpers import INVALID_CHARACTERS
 from helpers_async import get_completed_future
 from test_powershell_credential import PREPARING_MODULES
 
@@ -57,6 +58,25 @@ async def test_cannot_execute_shell():
     with patch(CREATE_SUBPROCESS_EXEC, Mock(side_effect=OSError)):
         with pytest.raises(CredentialUnavailableError):
             await AzurePowerShellCredential().get_token("scope")
+
+
+async def test_invalid_tenant_id():
+    """Invalid tenant IDs should raise ValueErrors."""
+
+    for c in INVALID_CHARACTERS:
+        with pytest.raises(ValueError):
+            AzurePowerShellCredential(tenant_id="tenant" + c)
+
+        with pytest.raises(ValueError):
+            await AzurePowerShellCredential().get_token("scope", tenant_id="tenant" + c)
+
+
+async def test_invalid_scopes():
+    """Scopes with invalid characters should raise ValueErrors."""
+
+    for c in INVALID_CHARACTERS:
+        with pytest.raises(ValueError):
+            await AzurePowerShellCredential().get_token("scope" + c)
 
 
 @pytest.mark.parametrize("stderr", ("", PREPARING_MODULES))


### PR DESCRIPTION
Also, ensured that we pass `next-pylint`.