### PR TITLE
show more jobs when specify parent_job_name

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_job_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_job_operations.py
@@ -278,10 +278,11 @@ class JobOperations(_ScopeDependentOperations):
 
         schedule_defined = kwargs.pop("schedule_defined", None)
         scheduled_job_name = kwargs.pop("scheduled_job_name", None)
-
+        top = kwargs.pop("top", None)
+        
         if parent_job_name:
             parent_job = self.get(parent_job_name)
-            return self._runs_operations.get_run_children(parent_job.name)
+            return self._runs_operations.get_run_children(parent_job.name, top=top)
 
         return self._operation_2023_02_preview.list(
             self._operation_scope.resource_group_name,

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_run_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_run_operations.py
@@ -44,13 +44,14 @@ class RunOperations(_ScopeDependentOperations):
             run_id,
         )
 
-    def get_run_children(self, run_id: str) -> Iterable[_BaseJob]:
+    def get_run_children(self, run_id: str, top: int) -> Iterable[_BaseJob]:
         return self._operation.get_child(
             self._subscription_id,
             self._resource_group_name,
             self._workspace_name,
             run_id,
             cls=lambda objs: [self._translate_from_rest_object(obj) for obj in objs],
+            top=top,
         )
 
     def _translate_from_rest_object(self, job_object: Run) -> Optional[_BaseJob]:


### PR DESCRIPTION
# Description
when using ml_client.jobs.list with parent_job_name to show children jobs, can use top to control the max number of jobs to retrieve, like ml_client.jobs.list(parent_job_name="job_name", top=100)
