### PR TITLE
[Test Proxy] Automatically rotate local certificate

### DIFF
--- a/tools/azure-sdk-tools/devtools_testutils/proxy_startup.py
+++ b/tools/azure-sdk-tools/devtools_testutils/proxy_startup.py
@@ -191,7 +191,11 @@ def check_certificate_location(repo_root: str) -> None:
         if repo_cert != bundle_data:
             write_dev_cert_bundle()
 
-    _LOGGER.info("Setting SSL_CERT_DIR and REQUESTS_CA_BUNDLE environment variables for the current session.")
+    _LOGGER.info(
+        "Setting SSL_CERT_DIR and REQUESTS_CA_BUNDLE environment variables for the current session.\n"
+        f"SSL_CERT_DIR={combined_folder}\n"
+        f"REQUESTS_CA_BUNDLE={combined_location}"
+    )
     os.environ["SSL_CERT_DIR"] = combined_folder
     os.environ["REQUESTS_CA_BUNDLE"] = combined_location
 


### PR DESCRIPTION
# Description

Resolves https://github.com/Azure/azure-sdk-for-python/issues/31462. This PR makes three main changes:

1. We now _always_ check for test proxy certificate configuration, whether or not `SSL_CERT_DIR` or `REQUESTS_CA_BUNDLE` is set.
2. We now _always_ set `SSL_CERT_DIR` and `REQUESTS_CA_BUNDLE` for the current session. This won't affect the variables outside the session, and setting them avoids issues with the variables being unintentionally or incorrectly set prior to testing.
3. Instead of just checking for an existing cert bundle, we now verify that the bundle contains the latest test proxy certificate (i.e. whatever is in `eng/common/testproxy/dotnet-devcert.crt` (the "repo cert")).
  a. This is slightly breaking, only insofar as users could be switched _back_ to an expired certificate after having already rotated. This would only happen if they're working from a branch with an outdated repo cert, and would be fixed by updating the file to what's in `main`. Not a real concern.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
