### PR TITLE
Replace azure-identity AAD references

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -208,6 +208,7 @@
     "ekus",
     "encryptor",
     "engsys",
+    "entra",
     "envname",
     "evals",
     "fileno",

--- a/sdk/identity/azure-identity-broker/azure/identity/broker/_browser.py
+++ b/sdk/identity/azure-identity-broker/azure/identity/broker/_browser.py
@@ -30,8 +30,8 @@ class InteractiveBrowserBrokerCredential(_InteractiveBrowserCredential):
         unspecified, users will authenticate to an Azure development application.
     :keyword str login_hint: a username suggestion to pre-fill the login page's username/email address field. A user
         may still log in with a different username.
-    :keyword str redirect_uri: a redirect URI for the application identified by `client_id` as configured in Azure
-        Active Directory, for example "http://localhost:8400". This is only required when passing a value for
+    :keyword str redirect_uri: a redirect URI for the application identified by `client_id` as configured in Microsoft 
+        Entra ID, for example "http://localhost:8400". This is only required when passing a value for
         **client_id**, and must match a redirect URI in the application's registration. The credential must be able to
         bind a socket to this URI.
     :keyword AuthenticationRecord authentication_record: :class:`AuthenticationRecord` returned by :func:`authenticate`

--- a/sdk/identity/azure-identity-broker/azure/identity/broker/_browser.py
+++ b/sdk/identity/azure-identity-broker/azure/identity/broker/_browser.py
@@ -18,15 +18,15 @@ from ._utils import wrap_exceptions, resolve_tenant
 class InteractiveBrowserBrokerCredential(_InteractiveBrowserCredential):
     """Opens a browser to interactively authenticate a user.
 
-    :func:`~get_token` opens a browser to a login URL provided by Azure Active Directory and authenticates a user
+    :func:`~get_token` opens a browser to a login URL provided by Microsoft Entra ID and authenticates a user
     there with the authorization code flow, using PKCE (Proof Key for Code Exchange) internally to protect the code.
 
-    :keyword str authority: Authority of an Azure Active Directory endpoint, for example "login.microsoftonline.com",
+    :keyword str authority: Authority of a Microsoft Entra endpoint, for example "login.microsoftonline.com",
         the authority for Azure Public Cloud (which is the default). :class:`~azure.identity.AzureAuthorityHosts`
         defines authorities for other clouds.
-    :keyword str tenant_id: an Azure Active Directory tenant ID. Defaults to the "organizations" tenant, which can
+    :keyword str tenant_id: a Microsoft Entra tenant ID. Defaults to the "organizations" tenant, which can
         authenticate work or school accounts.
-    :keyword str client_id: Client ID of the Azure Active Directory application users will sign in to. If
+    :keyword str client_id: Client ID of the Microsoft Entra application users will sign in to. If
         unspecified, users will authenticate to an Azure development application.
     :keyword str login_hint: a username suggestion to pre-fill the login page's username/email address field. A user
         may still log in with a different username.

--- a/sdk/identity/azure-identity-broker/azure/identity/broker/_browser.py
+++ b/sdk/identity/azure-identity-broker/azure/identity/broker/_browser.py
@@ -30,7 +30,7 @@ class InteractiveBrowserBrokerCredential(_InteractiveBrowserCredential):
         unspecified, users will authenticate to an Azure development application.
     :keyword str login_hint: a username suggestion to pre-fill the login page's username/email address field. A user
         may still log in with a different username.
-    :keyword str redirect_uri: a redirect URI for the application identified by `client_id` as configured in Microsoft 
+    :keyword str redirect_uri: a redirect URI for the application identified by `client_id` as configured in Microsoft
         Entra ID, for example "http://localhost:8400". This is only required when passing a value for
         **client_id**, and must match a redirect URI in the application's registration. The credential must be able to
         bind a socket to this URI.

--- a/sdk/identity/azure-identity-broker/azure/identity/broker/_user_password.py
+++ b/sdk/identity/azure-identity-broker/azure/identity/broker/_user_password.py
@@ -21,19 +21,19 @@ class UsernamePasswordBrokerCredential(_UsernamePasswordCredential):
     a directory admin.
 
     This credential can only authenticate work and school accounts; Microsoft accounts are not supported.
-    See `Azure Active Directory documentation
-    <https://docs.microsoft.com/azure/active-directory/fundamentals/sign-up-organization>`_ for more information about
+    See `Microsoft Entra ID documentation
+    <https://learn.microsoft.com/azure/active-directory/fundamentals/sign-up-organization>`_ for more information about
     account types.
 
     :param str client_id: The application's client ID
     :param str username: The user's username (usually an email address)
     :param str password: The user's password
 
-    :keyword str authority: Authority of an Azure Active Directory endpoint, for example "login.microsoftonline.com",
+    :keyword str authority: Authority of a Microsoft Entra endpoint, for example "login.microsoftonline.com",
         the authority for Azure Public Cloud (which is the default). :class:`~azure.identity.AzureAuthorityHosts`
         defines authorities for other clouds.
     :keyword str tenant_id: Tenant ID or a domain associated with a tenant. If not provided, defaults to the
-        "organizations" tenant, which supports only Azure Active Directory work or school accounts.
+        "organizations" tenant, which supports only Microsoft Entra work or school accounts.
     :keyword cache_persistence_options: Configuration for persistent token caching. If unspecified, the credential
         will cache tokens in memory.
     :paramtype cache_persistence_options: ~azure.identity.TokenCachePersistenceOptions

--- a/sdk/identity/azure-identity/CHANGELOG.md
+++ b/sdk/identity/azure-identity/CHANGELOG.md
@@ -27,7 +27,7 @@
 ### Features Added
 
 - Added Windows Web Account Manager (WAM) Brokered Authentication support.
-- Added `enable_msa_passthrough` suppport for `InteractiveBrowserCredential`. By default `InteractiveBrowserCredential` only lists AAD accounts. If you set `enable_msa_passthrough` to `True`, it lists both AAD accounts and MSA outlook.com accounts that are logged in to Windows.
+- Added `enable_msa_passthrough` suppport for `InteractiveBrowserCredential`. By default `InteractiveBrowserCredential` only lists Microsoft Entra accounts. If you set `enable_msa_passthrough` to `True`, it lists both Microsoft Entra accounts and MSA outlook.com accounts that are logged in to Windows.
 
 ### Bugs Fixed
 
@@ -40,7 +40,7 @@
 
 - Update typing of async credentials to match the `AsyncTokenCredential` protocol.
 - If within `DefaultAzureCredential`, `EnvironmentCredential` will now use log level INFO instead of WARNING to inform users of an incomplete environment configuration.  ([#31814](https://github.com/Azure/azure-sdk-for-python/pull/31814))
-- Strengthened `AzureCliCredential` and `AzureDeveloperCliCredential` error checking when determining if a user is logged in or not. Now, if an AADSTS error exists in the error, the full error message is propagated instead of a canned error message. ([#30047](https://github.com/Azure/azure-sdk-for-python/pull/30047))
+- Strengthened `AzureCliCredential` and `AzureDeveloperCliCredential` error checking when determining if a user is logged in or not. Now, if an `AADSTS` error exists in the error, the full error message is propagated instead of a canned error message. ([#30047](https://github.com/Azure/azure-sdk-for-python/pull/30047))
 - `ManagedIdentityCredential` instances using IMDS will now be allowed to continue sending requests to the IMDS endpoint even after previous attempts failed. This is to prevent credential instances from potentially being permanently disabled after a temporary network failure.
 - IMDS endpoint probes in `ManagedIdentityCredential` will now only occur when inside a credential chain such as `DefaultAzureCredential`. This probe request timeout has been increased to 1 second from 0.3 seconds to reduce the likelihood of false negatives.
 
@@ -98,7 +98,7 @@
 ### Features Added
 
 - Changed parameter from `instance_discovery` to `disable_instance_discovery` to make it more explicit.
-- Service principal credentials now enable support for [Continuous Access Evaluation (CAE)](https://learn.microsoft.com/azure/active-directory/conditional-access/concept-continuous-access-evaluation-workload). This indicates to Azure Active Directory that your application can handle CAE claims challenges.
+- Service principal credentials now enable support for [Continuous Access Evaluation (CAE)](https://learn.microsoft.com/azure/active-directory/conditional-access/concept-continuous-access-evaluation-workload). This indicates to Microsoft Entra ID that your application can handle CAE claims challenges.
 
 ## 1.13.0b2 (2023-02-07)
 
@@ -826,8 +826,8 @@ its use in national clouds
 ## 1.0.0b4 (2019-10-07)
 ### New features:
 - `AuthorizationCodeCredential` authenticates with a previously obtained
-authorization code. See Azure Active Directory's
-[authorization code documentation](https://docs.microsoft.com/azure/active-directory/develop/v2-oauth2-auth-code-flow)
+authorization code. See Microsoft Entra's
+[authorization code documentation](https://learn.microsoft.com/azure/active-directory/develop/v2-oauth2-auth-code-flow)
 for more information about this authentication flow.
 - Multi-cloud support: client credentials accept the authority of an Azure Active
 Directory authentication endpoint as an `authority` keyword argument. Known
@@ -899,5 +899,5 @@ See the
 for more details. User authentication will be added in an upcoming preview
 release.
 
-This release supports only global Azure Active Directory tenants, i.e. those
+This release supports only global Microsoft Entra tenants, i.e. those
 using the https://login.microsoftonline.com authentication endpoint.

--- a/sdk/identity/azure-identity/README.md
+++ b/sdk/identity/azure-identity/README.md
@@ -1,12 +1,12 @@
 # Azure Identity client library for Python
 
-The Azure Identity library provides [Azure Active Directory (Azure AD)](https://learn.microsoft.com/azure/active-directory/fundamentals/active-directory-whatis) token authentication support across the Azure SDK. It provides a set of [`TokenCredential`](https://learn.microsoft.com/python/api/azure-core/azure.core.credentials.tokencredential?view=azure-python) implementations, which can be used to construct Azure SDK clients that support Azure AD token authentication.
+The Azure Identity library provides [Microsoft Entra ID](https://learn.microsoft.com/azure/active-directory/fundamentals/active-directory-whatis) ([formerly Azure Active Directory](https://learn.microsoft.com/azure/active-directory/fundamentals/new-name)) token authentication support across the Azure SDK. It provides a set of [`TokenCredential`](https://learn.microsoft.com/python/api/azure-core/azure.core.credentials.tokencredential?view=azure-python) implementations, which can be used to construct Azure SDK clients that support Microsoft Entra token authentication.
 
 [Source code](https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/identity/azure-identity)
 | [Package (PyPI)](https://pypi.org/project/azure-identity/)
 | [Package (Conda)](https://anaconda.org/microsoft/azure-identity/)
 | [API reference documentation][ref_docs]
-| [Azure AD documentation](https://learn.microsoft.com/azure/active-directory/)
+| [Microsoft Entra ID documentation](https://learn.microsoft.com/azure/active-directory/)
 
 ## Getting started
 
@@ -55,7 +55,7 @@ For systems without a default web browser, the `azd auth login --use-device-code
 
 A credential is a class that contains or can obtain the data needed for a service client to authenticate requests. Service clients across the Azure SDK accept a credential instance when they're constructed, and use that credential to authenticate requests.
 
-The Azure Identity library focuses on OAuth authentication with Azure AD. It offers various credential classes capable of acquiring an Azure AD access token. See the [Credential classes](#credential-classes "Credential classes") section below for a list of this library's credential classes.
+The Azure Identity library focuses on OAuth authentication with Microsoft Entra ID. It offers various credential classes capable of acquiring a Microsoft Entra access token. See the [Credential classes](#credential-classes "Credential classes") section below for a list of this library's credential classes.
 
 ### DefaultAzureCredential
 
@@ -212,7 +212,7 @@ client = SecretClient("https://my-vault.vault.azure.net", credential)
 
 ## Cloud configuration
 
-Credentials default to authenticating to the Azure AD endpoint for Azure Public Cloud. To access resources in other clouds, such as Azure Government or a private cloud, configure credentials with the `authority` argument. [AzureAuthorityHosts](https://aka.ms/azsdk/python/identity/docs#azure.identity.AzureAuthorityHosts) defines authorities for well-known clouds:
+Credentials default to authenticating to the Microsoft Entra endpoint for Azure Public Cloud. To access resources in other clouds, such as Azure Government or a private cloud, configure credentials with the `authority` argument. [AzureAuthorityHosts](https://aka.ms/azsdk/python/identity/docs#azure.identity.AzureAuthorityHosts) defines authorities for well-known clouds:
 
 ```python
 from azure.identity import AzureAuthorityHosts
@@ -244,7 +244,7 @@ Not all credentials require this configuration. Credentials that authenticate th
 |[`ChainedTokenCredential`][chain_cred_ref]| Allows users to define custom authentication flows composing multiple credentials.
 |[`EnvironmentCredential`][environment_cred_ref]| Authenticates a service principal or user via credential information specified in environment variables.
 |[`ManagedIdentityCredential`][managed_id_cred_ref]| Authenticates the managed identity of an Azure resource.
-|[`WorkloadIdentityCredential`][workload_id_cred_ref]| Supports [Azure AD workload identity](https://learn.microsoft.com/azure/aks/workload-identity-overview) on Kubernetes.
+|[`WorkloadIdentityCredential`][workload_id_cred_ref]| Supports [Microsoft Entra Workload ID](https://learn.microsoft.com/azure/aks/workload-identity-overview) on Kubernetes.
 
 ### Authenticate service principals
 
@@ -282,16 +282,16 @@ variables:
 
 |Variable name|Value
 |-|-
-|`AZURE_CLIENT_ID`|ID of an Azure AD application
-|`AZURE_TENANT_ID`|ID of the application's Azure AD tenant
+|`AZURE_CLIENT_ID`|ID of a Microsoft Entra application
+|`AZURE_TENANT_ID`|ID of the application's Microsoft Entra tenant
 |`AZURE_CLIENT_SECRET`|one of the application's client secrets
 
 ### Service principal with certificate
 
 |Variable name|Value
 |-|-
-|`AZURE_CLIENT_ID`|ID of an Azure AD application
-|`AZURE_TENANT_ID`|ID of the application's Azure AD tenant
+|`AZURE_CLIENT_ID`|ID of a Microsoft Entra application
+|`AZURE_TENANT_ID`|ID of the application's Microsoft Entra tenant
 |`AZURE_CLIENT_CERTIFICATE_PATH`|path to a PEM or PKCS12 certificate file including private key
 |`AZURE_CLIENT_CERTIFICATE_PASSWORD`|password of the certificate file, if any
 
@@ -299,7 +299,7 @@ variables:
 
 |Variable name|Value
 |-|-
-|`AZURE_CLIENT_ID`|ID of an Azure AD application
+|`AZURE_CLIENT_ID`|ID of a Microsoft Entra application
 |`AZURE_USERNAME`|a username (usually an email address)
 |`AZURE_PASSWORD`|that user's password
 
@@ -314,7 +314,7 @@ As of version 1.14.0, accessing resources protected by [Continuous Access Evalua
 Token caching is a feature provided by the Azure Identity library that allows apps to:
 - Cache tokens in memory (default) or on disk (opt-in).
 - Improve resilience and performance.
-- Reduce the number of requests made to Azure AD to obtain access tokens.
+- Reduce the number of requests made to Microsoft Entra ID to obtain access tokens.
 
 The Azure Identity library offers both in-memory and persistent disk caching. For more details, see the [token caching documentation](https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/identity/azure-identity/TOKEN_CACHING.md).
 
@@ -329,7 +329,7 @@ Credentials raise `CredentialUnavailableError` when they're unable to attempt au
 
 Credentials raise `azure.core.exceptions.ClientAuthenticationError` when they fail to authenticate. `ClientAuthenticationError` has a `message` attribute, which describes why authentication failed. When raised by `DefaultAzureCredential` or `ChainedTokenCredential`, the message collects error messages from each credential in the chain.
 
-For more information on handling specific Azure AD errors, see the Azure AD [error code documentation](https://learn.microsoft.com/azure/active-directory/develop/reference-aadsts-error-codes).
+For more information on handling specific Microsoft Entra ID errors, see the Microsoft Entra ID [error code documentation](https://learn.microsoft.com/azure/active-directory/develop/reference-error-codes).
 
 ### Logging
 
@@ -348,7 +348,7 @@ credential = DefaultAzureCredential(logging_enable=True)
 
 ### Client library support
 
-Client and management libraries listed on the [Azure SDK release page](https://azure.github.io/azure-sdk/releases/latest/python.html) that support Azure AD authentication accept credentials from this library. You can learn more about using these libraries in their documentation, which is linked from the release page.
+Client and management libraries listed on the [Azure SDK release page](https://azure.github.io/azure-sdk/releases/latest/python.html) that support Microsoft Entra authentication accept credentials from this library. You can learn more about using these libraries in their documentation, which is linked from the release page.
 
 ### Known issues
 

--- a/sdk/identity/azure-identity/TOKEN_CACHING.md
+++ b/sdk/identity/azure-identity/TOKEN_CACHING.md
@@ -3,16 +3,16 @@
 *Token caching* is a feature provided by the Azure Identity library that allows apps to:
 
 - Improve their resilience and performance.
-- Reduce the number of requests made to Azure Active Directory (Azure AD) to obtain access tokens.
+- Reduce the number of requests made to Microsoft Entra ID to obtain access tokens.
 - Reduce the number of times the user is prompted to authenticate.
 
-When an app needs to access a protected Azure resource, it typically needs to obtain an access token from Azure AD. Obtaining that token involves sending a request to Azure AD and may also involve prompting the user. Azure AD then validates the credentials provided in the request and issues an access token.
+When an app needs to access a protected Azure resource, it typically needs to obtain an access token from Microsoft Entra ID. Obtaining that token involves sending a request to Microsoft Entra ID and may also involve prompting the user. Microsoft Entra ID then validates the credentials provided in the request and issues an access token.
 
-Token caching, via the Azure Identity library, allows the app to store this access token [in memory](#in-memory-token-caching), where it's accessible to the current process, or [on disk](#persistent-token-caching) where it can be accessed across application or process invocations. The token can then be retrieved quickly and easily the next time the app needs to access the same resource. The app can avoid making another request to Azure AD, which reduces network traffic and improves resilience. Additionally, in scenarios where the app is authenticating users, token caching also avoids prompting the user each time new tokens are requested.
+Token caching, via the Azure Identity library, allows the app to store this access token [in memory](#in-memory-token-caching), where it's accessible to the current process, or [on disk](#persistent-token-caching) where it can be accessed across application or process invocations. The token can then be retrieved quickly and easily the next time the app needs to access the same resource. The app can avoid making another request to Microsoft Entra ID, which reduces network traffic and improves resilience. Additionally, in scenarios where the app is authenticating users, token caching also avoids prompting the user each time new tokens are requested.
 
 ### In-memory token caching
 
-*In-memory token caching* is the default option provided by the Azure Identity library. This caching approach allows apps to store access tokens in memory. With in-memory token caching, the library first determines if a valid access token for the requested resource is already stored in memory. If a valid token is found, it's returned to the app without the need to make another request to Azure AD. If a valid token isn't found, the library will automatically acquire a token by sending a request to Azure AD.
+*In-memory token caching* is the default option provided by the Azure Identity library. This caching approach allows apps to store access tokens in memory. With in-memory token caching, the library first determines if a valid access token for the requested resource is already stored in memory. If a valid token is found, it's returned to the app without the need to make another request to Microsoft Entra ID. If a valid token isn't found, the library will automatically acquire a token by sending a request to Microsoft Entra ID.
 
 The in-memory token cache provided by the Azure Identity library can be used by multiple threads concurrently.
 
@@ -34,10 +34,10 @@ As there are many levels of cache, it's not possible to disable in-memory cachin
 
 Users can enable the cache to fall back to storing data in plaintext by setting the `allow_unencrypted_storage` argument to `True` in `TokenCachePersistenceOptions`. Enabling this does not disable encryption, but does allow plaintext storage as a fallback if encryption attempts fail. This is substantially less secure since tokens aren't encrypted to the current user, and anyone with access to the system could potentially access tokens from the cache. As such, enabling this setting is not recommended.
 
-With persistent disk token caching enabled, the library first determines if a valid access token for the requested resource is already stored in the persistent cache. If a valid token is found, it's returned to the app without the need to make another request to Azure AD. Additionally, the tokens are preserved across app runs, which:
+With persistent disk token caching enabled, the library first determines if a valid access token for the requested resource is already stored in the persistent cache. If a valid token is found, it's returned to the app without the need to make another request to Microsoft Entra ID. Additionally, the tokens are preserved across app runs, which:
 
 - Makes the app more resilient to failures.
-- Ensures the app can continue to function during an Azure AD outage or disruption.
+- Ensures the app can continue to function during a Microsoft Entra ID outage or disruption.
 - Avoids having to prompt users to authenticate each time the process is restarted.
 
 #### Code sample

--- a/sdk/identity/azure-identity/TROUBLESHOOTING.md
+++ b/sdk/identity/azure-identity/TROUBLESHOOTING.md
@@ -60,14 +60,14 @@ Calls to service clients resulting in `HttpResponseError` with a `StatusCode` of
 
 ## Find relevant information in error messages
 
-`ClientAuthenticationError` is raised when unexpected errors occurred while a credential is authenticating. This can include errors received from requests to the AAD STS and often contains information helpful to diagnosis. Consider the following `ClientAuthenticationError` message.
+`ClientAuthenticationError` is raised when unexpected errors occurred while a credential is authenticating. This can include errors received from requests to the Microsoft Entra STS and often contains information helpful to diagnosis. Consider the following `ClientAuthenticationError` message.
 
 ![ClientAuthenticationError Message Example](./images/AuthFailedErrorMessageExample.png)
 
 This error contains several pieces of information:
 
 - __Failing Credential Type__: The type of credential that failed to authenticate. This can be helpful when diagnosing issues with chained credential types such as `DefaultAzureCredential` or `ChainedTokenCredential`.
-- __STS Error Code and Message__: The error code and message returned from the Azure AD STS. This can give insight into the specific reason the request failed. For instance in this specific case because the provided client secret is incorrect. More information on STS error codes can be found [here](https://learn.microsoft.com//azure/active-directory/develop/reference-aadsts-error-codes#aadsts-error-codes).
+- __STS Error Code and Message__: The error code and message returned from the Microsoft Entra STS. This can give insight into the specific reason the request failed. For instance in this specific case because the provided client secret is incorrect. More information on STS error codes can be found [here](https://learn.microsoft.com//azure/active-directory/develop/reference-aadsts-error-codes#aadsts-error-codes).
 
 ## Logging
 
@@ -111,7 +111,7 @@ See full SDK logging documentation with examples [here][sdk_logging_docs].
 `ClientAuthenticationError`
 | Error Code | Description | Mitigation |
 |---|---|---|
-|AADSTS700027|Client assertion contains an invalid signature.|Ensure the specified certificate has been uploaded to the AAD application registration. Instructions for uploading certificates to the application registration can be found [here](https://learn.microsoft.com/azure/active-directory/develop/howto-create-service-principal-portal#option-1-upload-a-certificate).|
+|AADSTS700027|Client assertion contains an invalid signature.|Ensure the specified certificate has been uploaded to the Microsoft Entra application registration. Instructions for uploading certificates to the application registration can be found [here](https://learn.microsoft.com/azure/active-directory/develop/howto-create-service-principal-portal#option-1-upload-a-certificate).|
 |AADSTS700016|The specified application wasn't found in the specified tenant.| Ensure the specified `client_id` and `tenant_id` are correct for your application registration. For multi-tenant apps, ensure the application has been added to the desired tenant by a tenant admin. To add a new application in the desired tenant, follow the instructions [here](https://learn.microsoft.com/azure/active-directory/develop/howto-create-service-principal-portal).
 
 ## Troubleshoot `ClientAssertionCredential` authentication issues
@@ -284,7 +284,7 @@ Get-AzAccessToken -ResourceUrl "https://management.core.windows.net"
 
 | Error Message |Description| Mitigation |
 |---|---|---|
-|WorkloadIdentityCredential authentication unavailable. The workload options are not fully configured|The `WorkloadIdentityCredential` requires `client_id`, `tenant_id` and `token_file_path` to authenticate with Azure Active Directory.| <ul><li>If using `DefaultAzureCredential` then:</li><ul><li>Ensure client ID is specified via the `workload_identity_client_id` keyword argument or the `AZURE_CLIENT_ID` env variable.</li><li>Ensure tenant ID is specified via the `AZURE_TENANT_ID` env variable.</li><li>Ensure token file path is specified via `AZURE_FEDERATED_TOKEN_FILE` env variable.</li><li>Ensure authority host is specified via `AZURE_AUTHORITY_HOST` env variable.</ul><li>If using `WorkloadIdentityCredential` then:</li><ul><li>Ensure tenant ID is specified via the `tenant_id` keyword argument or the `AZURE_TENANT_ID` env variable.</li><li>Ensure client ID is specified via the `client_id` keyword argument or the `AZURE_CLIENT_ID` env variable.</li><li>Ensure token file path is specified via the `token_file_path` keyword argument or the `AZURE_FEDERATED_TOKEN_FILE` environment variable. </li></ul></li><li>Consult the [product troubleshooting guide](https://azure.github.io/azure-workload-identity/docs/troubleshooting.html) for other issues.</li></ul>
+|WorkloadIdentityCredential authentication unavailable. The workload options are not fully configured|The `WorkloadIdentityCredential` requires `client_id`, `tenant_id` and `token_file_path` to authenticate with Microsoft Entra ID.| <ul><li>If using `DefaultAzureCredential` then:</li><ul><li>Ensure client ID is specified via the `workload_identity_client_id` keyword argument or the `AZURE_CLIENT_ID` env variable.</li><li>Ensure tenant ID is specified via the `AZURE_TENANT_ID` env variable.</li><li>Ensure token file path is specified via `AZURE_FEDERATED_TOKEN_FILE` env variable.</li><li>Ensure authority host is specified via `AZURE_AUTHORITY_HOST` env variable.</ul><li>If using `WorkloadIdentityCredential` then:</li><ul><li>Ensure tenant ID is specified via the `tenant_id` keyword argument or the `AZURE_TENANT_ID` env variable.</li><li>Ensure client ID is specified via the `client_id` keyword argument or the `AZURE_CLIENT_ID` env variable.</li><li>Ensure token file path is specified via the `token_file_path` keyword argument or the `AZURE_FEDERATED_TOKEN_FILE` environment variable. </li></ul></li><li>Consult the [product troubleshooting guide](https://azure.github.io/azure-workload-identity/docs/troubleshooting.html) for other issues.</li></ul>
 
 ## Troubleshoot multi-tenant authentication issues
 
@@ -296,9 +296,9 @@ Get-AzAccessToken -ResourceUrl "https://management.core.windows.net"
 
 ## Troubleshoot WAM+MSA login issues
 
-When using `InteractiveBrowserCredential`, by default, only AAD account is listed:
+When using `InteractiveBrowserCredential`, by default, only the Microsoft Entra account is listed:
 
-![MSA AAD only](./images/MSA1.png)
+![MSA Microsoft Entra only](./images/MSA1.png)
 
 If you choose "Use another account" and type in an MSA outlook.com account, it fails:
 

--- a/sdk/identity/azure-identity/azure/identity/_credentials/application.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/application.py
@@ -17,7 +17,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class AzureApplicationCredential(ChainedTokenCredential):
-    """A credential for Azure Active Directory applications.
+    """A credential for Microsoft Entra applications.
 
     This credential is designed for applications deployed to Azure (:class:`~azure.identity.DefaultAzureCredential` is
     better suited to local development). It authenticates service principals and managed identities.
@@ -40,11 +40,11 @@ class AzureApplicationCredential(ChainedTokenCredential):
     for more information about creating and managing service principals.
 
     When this environment configuration is incomplete, the credential will attempt to authenticate a managed identity.
-    See `Azure Active Directory documentation
-    <https://docs.microsoft.com/azure/active-directory/managed-identities-azure-resources/overview>`_ for an overview of
+    See `Microsoft Entra ID documentation
+    <https://learn.microsoft.com/azure/active-directory/managed-identities-azure-resources/overview>`_ for an overview of
     managed identities.
 
-    :keyword str authority: Authority of an Azure Active Directory endpoint, for example "login.microsoftonline.com",
+    :keyword str authority: Authority of a Microsoft Entra endpoint, for example "login.microsoftonline.com",
         the authority for Azure Public Cloud, which is the default when no value is given for this keyword argument or
         environment variable AZURE_AUTHORITY_HOST. :class:`~azure.identity.AzureAuthorityHosts` defines authorities for
         other clouds. Authority configuration applies only to service principal authentication.

--- a/sdk/identity/azure-identity/azure/identity/_credentials/application.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/application.py
@@ -41,8 +41,8 @@ class AzureApplicationCredential(ChainedTokenCredential):
 
     When this environment configuration is incomplete, the credential will attempt to authenticate a managed identity.
     See `Microsoft Entra ID documentation
-    <https://learn.microsoft.com/azure/active-directory/managed-identities-azure-resources/overview>`_ for an overview of
-    managed identities.
+    <https://learn.microsoft.com/azure/active-directory/managed-identities-azure-resources/overview>`_ for an overview
+    of managed identities.
 
     :keyword str authority: Authority of a Microsoft Entra endpoint, for example "login.microsoftonline.com",
         the authority for Azure Public Cloud, which is the default when no value is given for this keyword argument or

--- a/sdk/identity/azure-identity/azure/identity/_credentials/authorization_code.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/authorization_code.py
@@ -11,18 +11,18 @@ from .._internal.get_token_mixin import GetTokenMixin
 
 
 class AuthorizationCodeCredential(GetTokenMixin):
-    """Authenticates by redeeming an authorization code previously obtained from Azure Active Directory.
+    """Authenticates by redeeming an authorization code previously obtained from Microsoft Entra ID.
 
-    See `Azure Active Directory documentation
+    See `Microsoft Entra ID documentation
     <https://docs.microsoft.com/azure/active-directory/develop/v2-oauth2-auth-code-flow>`_ for more information
     about the authentication flow.
 
-    :param str tenant_id: ID of the application's Azure Active Directory tenant. Also called its "directory" ID.
+    :param str tenant_id: ID of the application's Microsoft Entra tenant. Also called its "directory" ID.
     :param str client_id: The application's client ID
     :param str authorization_code: The authorization code from the user's log-in
     :param str redirect_uri: The application's redirect URI. Must match the URI used to request the authorization code.
 
-    :keyword str authority: Authority of an Azure Active Directory endpoint, for example "login.microsoftonline.com",
+    :keyword str authority: Authority of a Microsoft Entra endpoint, for example "login.microsoftonline.com",
         the authority for Azure Public Cloud (which is the default). :class:`~azure.identity.AzureAuthorityHosts`
         defines authorities for other clouds.
     :keyword str client_secret: One of the application's client secrets. Required only for web apps and web APIs.
@@ -82,7 +82,7 @@ class AuthorizationCodeCredential(GetTokenMixin):
         :return: An access token with the desired scopes.
         :rtype: ~azure.core.credentials.AccessToken
         :raises ~azure.core.exceptions.ClientAuthenticationError: authentication failed. The error's ``message``
-          attribute gives a reason. Any error response from Azure Active Directory is available as the error's
+          attribute gives a reason. Any error response from Microsoft Entra ID is available as the error's
           ``response`` attribute.
         """
         # pylint:disable=useless-super-delegation

--- a/sdk/identity/azure-identity/azure/identity/_credentials/azd_cli.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/azd_cli.py
@@ -35,11 +35,11 @@ class AzureDeveloperCliCredential:
     Azure Developer CLI is a command-line interface tool that allows developers to create, manage, and deploy
     resources in Azure. It's built on top of the Azure CLI and provides additional functionality specific
     to Azure developers. It allows users to authenticate as a user and/or a service principal against
-    `Azure Active Directory (Azure AD) <"https://learn.microsoft.com/azure/active-directory/fundamentals/">`__.
+    `Microsoft Entra ID <"https://learn.microsoft.com/azure/active-directory/fundamentals/">`__.
     The AzureDeveloperCliCredential authenticates in a development environment and acquires a token on behalf of
     the logged-in user or service principal in Azure Developer CLI. It acts as the Azure Developer CLI logged-in user
     or service principal and executes an Azure CLI command underneath to authenticate the application against
-    Azure Active Directory.
+    Microsoft Entra ID.
 
     To use this credential, the developer needs to authenticate locally in Azure Developer CLI using one of the
     commands below:

--- a/sdk/identity/azure-identity/azure/identity/_credentials/browser.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/browser.py
@@ -20,15 +20,15 @@ from .._internal import AuthCodeRedirectServer, InteractiveCredential, wrap_exce
 class InteractiveBrowserCredential(InteractiveCredential):
     """Opens a browser to interactively authenticate a user.
 
-    :func:`~get_token` opens a browser to a login URL provided by Azure Active Directory and authenticates a user
+    :func:`~get_token` opens a browser to a login URL provided by Microsoft Entra ID and authenticates a user
     there with the authorization code flow, using PKCE (Proof Key for Code Exchange) internally to protect the code.
 
-    :keyword str authority: Authority of an Azure Active Directory endpoint, for example "login.microsoftonline.com",
+    :keyword str authority: Authority of a Microsoft Entra endpoint, for example "login.microsoftonline.com",
         the authority for Azure Public Cloud (which is the default). :class:`~azure.identity.AzureAuthorityHosts`
         defines authorities for other clouds.
-    :keyword str tenant_id: an Azure Active Directory tenant ID. Defaults to the "organizations" tenant, which can
+    :keyword str tenant_id: a Microsoft Entra tenant ID. Defaults to the "organizations" tenant, which can
         authenticate work or school accounts.
-    :keyword str client_id: Client ID of the Azure Active Directory application users will sign in to. If
+    :keyword str client_id: Client ID of the Microsoft Entra application users will sign in to. If
         unspecified, users will authenticate to an Azure development application.
     :keyword str login_hint: a username suggestion to pre-fill the login page's username/email address field. A user
         may still log in with a different username.

--- a/sdk/identity/azure-identity/azure/identity/_credentials/certificate.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/certificate.py
@@ -18,8 +18,8 @@ class CertificateCredential(ClientCredentialBase):
     """Authenticates as a service principal using a certificate.
 
     The certificate must have an RSA private key, because this credential signs assertions using RS256. See
-    `Azure Active Directory documentation
-    <https://docs.microsoft.com/azure/active-directory/develop/active-directory-certificate-credentials#register-your-certificate-with-microsoft-identity-platform>`_
+    `Microsoft Entra ID documentation
+    <https://learn.microsoft.com/azure/active-directory/develop/active-directory-certificate-credentials#register-your-certificate-with-microsoft-identity-platform>`_
     for more information on configuring certificate authentication.
 
     :param str tenant_id: ID of the service principal's tenant. Also called its "directory" ID.
@@ -27,7 +27,7 @@ class CertificateCredential(ClientCredentialBase):
     :param str certificate_path: Optional path to a certificate file in PEM or PKCS12 format, including the private
         key. If not provided, **certificate_data** is required.
 
-    :keyword str authority: Authority of an Azure Active Directory endpoint, for example "login.microsoftonline.com",
+    :keyword str authority: Authority of a Microsoft Entra endpoint, for example "login.microsoftonline.com",
         the authority for Azure Public Cloud (which is the default). :class:`~azure.identity.AzureAuthorityHosts`
         defines authorities for other clouds.
     :keyword bytes certificate_data: The bytes of a certificate in PEM or PKCS12 format, including the private key

--- a/sdk/identity/azure-identity/azure/identity/_credentials/client_assertion.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/client_assertion.py
@@ -21,7 +21,7 @@ class ClientAssertionCredential(GetTokenMixin):
         acquires a new token.
     :paramtype func: Callable[[], str]
 
-    :keyword str authority: Authority of an Azure Active Directory endpoint, for example
+    :keyword str authority: Authority of a Microsoft Entra endpoint, for example
         "login.microsoftonline.com", the authority for Azure Public Cloud (which is the default).
         :class:`~azure.identity.AzureAuthorityHosts` defines authorities for other clouds.
     :keyword List[str] additionally_allowed_tenants: Specifies tenants in addition to the specified "tenant_id"

--- a/sdk/identity/azure-identity/azure/identity/_credentials/client_secret.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/client_secret.py
@@ -13,7 +13,7 @@ class ClientSecretCredential(ClientCredentialBase):
     :param str client_id: The service principal's client ID
     :param str client_secret: One of the service principal's client secrets
 
-    :keyword str authority: Authority of an Azure Active Directory endpoint, for example "login.microsoftonline.com",
+    :keyword str authority: Authority of a Microsoft Entra endpoint, for example "login.microsoftonline.com",
         the authority for Azure Public Cloud (which is the default). :class:`~azure.identity.AzureAuthorityHosts`
         defines authorities for other clouds.
     :keyword cache_persistence_options: Configuration for persistent token caching. If unspecified, the credential
@@ -42,12 +42,12 @@ class ClientSecretCredential(ClientCredentialBase):
 
     def __init__(self, tenant_id: str, client_id: str, client_secret: str, **kwargs: Any) -> None:
         if not client_id:
-            raise ValueError("client_id should be the id of an Azure Active Directory application")
+            raise ValueError("client_id should be the id of a Microsoft Entra application")
         if not client_secret:
-            raise ValueError("secret should be an Azure Active Directory application's client secret")
+            raise ValueError("secret should be a Microsoft Entra application's client secret")
         if not tenant_id:
             raise ValueError(
-                "tenant_id should be an Azure Active Directory tenant's id (also called its 'directory id')"
+                "tenant_id should be a Microsoft Entra tenant's id (also called its 'directory id')"
             )
 
         super(ClientSecretCredential, self).__init__(

--- a/sdk/identity/azure-identity/azure/identity/_credentials/client_secret.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/client_secret.py
@@ -46,9 +46,7 @@ class ClientSecretCredential(ClientCredentialBase):
         if not client_secret:
             raise ValueError("secret should be a Microsoft Entra application's client secret")
         if not tenant_id:
-            raise ValueError(
-                "tenant_id should be a Microsoft Entra tenant's id (also called its 'directory id')"
-            )
+            raise ValueError("tenant_id should be a Microsoft Entra tenant's id (also called its 'directory id')")
 
         super(ClientSecretCredential, self).__init__(
             client_id=client_id, client_credential=client_secret, tenant_id=tenant_id, **kwargs

--- a/sdk/identity/azure-identity/azure/identity/_credentials/default.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/default.py
@@ -46,7 +46,7 @@ class DefaultAzureCredential(ChainedTokenCredential):
 
     This default behavior is configurable with keyword arguments.
 
-    :keyword str authority: Authority of an Azure Active Directory endpoint, for example 'login.microsoftonline.com',
+    :keyword str authority: Authority of a Microsoft Entra endpoint, for example 'login.microsoftonline.com',
         the authority for Azure Public Cloud (which is the default). :class:`~azure.identity.AzureAuthorityHosts`
         defines authorities for other clouds. Managed identities ignore this because they reside in a single cloud.
     :keyword bool exclude_workload_identity_credential: Whether to exclude the workload identity from the credential.

--- a/sdk/identity/azure-identity/azure/identity/_credentials/device_code.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/device_code.py
@@ -15,8 +15,8 @@ from .._internal import InteractiveCredential, wrap_exceptions
 class DeviceCodeCredential(InteractiveCredential):
     """Authenticates users through the device code flow.
 
-    When :func:`get_token` is called, this credential acquires a verification URL and code from Azure Active Directory.
-    A user must browse to the URL, enter the code, and authenticate with Azure Active Directory. If the user
+    When :func:`get_token` is called, this credential acquires a verification URL and code from Microsoft Entra ID.
+    A user must browse to the URL, enter the code, and authenticate with Microsoft Entra ID. If the user
     authenticates successfully, the credential receives an access token.
 
     This credential is primarily useful for authenticating a user in an environment without a web browser, such as an
@@ -26,13 +26,13 @@ class DeviceCodeCredential(InteractiveCredential):
     :param str client_id: client ID of the application users will authenticate to. When not specified users will
         authenticate to an Azure development application.
 
-    :keyword str authority: Authority of an Azure Active Directory endpoint, for example "login.microsoftonline.com",
+    :keyword str authority: Authority of a Microsoft Entra endpoint, for example "login.microsoftonline.com",
         the authority for Azure Public Cloud (which is the default). :class:`~azure.identity.AzureAuthorityHosts`
         defines authorities for other clouds.
-    :keyword str tenant_id: an Azure Active Directory tenant ID. Defaults to the "organizations" tenant, which can
+    :keyword str tenant_id: a Microsoft Entra tenant ID. Defaults to the "organizations" tenant, which can
         authenticate work or school accounts. **Required for single-tenant applications.**
     :keyword int timeout: seconds to wait for the user to authenticate. Defaults to the validity period of the
-        device code as set by Azure Active Directory, which also prevails when **timeout** is longer.
+        device code as set by Microsoft Entra ID, which also prevails when **timeout** is longer.
     :keyword prompt_callback: A callback enabling control of how authentication
         instructions are presented. Must accept arguments (``verification_uri``, ``user_code``, ``expires_on``):
 

--- a/sdk/identity/azure-identity/azure/identity/_credentials/environment.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/environment.py
@@ -29,7 +29,7 @@ class EnvironmentCredential:
       - **AZURE_TENANT_ID**: ID of the service principal's tenant. Also called its 'directory' ID.
       - **AZURE_CLIENT_ID**: the service principal's client ID
       - **AZURE_CLIENT_SECRET**: one of the service principal's client secrets
-      - **AZURE_AUTHORITY_HOST**: authority of an Azure Active Directory endpoint, for example
+      - **AZURE_AUTHORITY_HOST**: authority of a Microsoft Entra endpoint, for example
         "login.microsoftonline.com", the authority for Azure Public Cloud, which is the default
         when no value is given.
 
@@ -38,7 +38,7 @@ class EnvironmentCredential:
       - **AZURE_CLIENT_ID**: the service principal's client ID
       - **AZURE_CLIENT_CERTIFICATE_PATH**: path to a PEM or PKCS12 certificate file including the private key.
       - **AZURE_CLIENT_CERTIFICATE_PASSWORD**: (optional) password of the certificate file, if any.
-      - **AZURE_AUTHORITY_HOST**: authority of an Azure Active Directory endpoint, for example
+      - **AZURE_AUTHORITY_HOST**: authority of a Microsoft Entra endpoint, for example
         "login.microsoftonline.com", the authority for Azure Public Cloud, which is the default
         when no value is given.
 
@@ -47,9 +47,9 @@ class EnvironmentCredential:
       - **AZURE_USERNAME**: a username (usually an email address)
       - **AZURE_PASSWORD**: that user's password
       - **AZURE_TENANT_ID**: (optional) ID of the service principal's tenant. Also called its 'directory' ID.
-        If not provided, defaults to the 'organizations' tenant, which supports only Azure Active Directory work or
+        If not provided, defaults to the 'organizations' tenant, which supports only Microsoft Entra work or
         school accounts.
-      - **AZURE_AUTHORITY_HOST**: authority of an Azure Active Directory endpoint, for example
+      - **AZURE_AUTHORITY_HOST**: authority of a Microsoft Entra endpoint, for example
         "login.microsoftonline.com", the authority for Azure Public Cloud, which is the default
         when no value is given.
 

--- a/sdk/identity/azure-identity/azure/identity/_credentials/managed_identity.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/managed_identity.py
@@ -21,8 +21,8 @@ class ManagedIdentityCredential:
     """Authenticates with an Azure managed identity in any hosting environment which supports managed identities.
 
     This credential defaults to using a system-assigned identity. To configure a user-assigned identity, use one of
-    the keyword arguments. See `Azure Active Directory documentation
-    <https://docs.microsoft.com/azure/active-directory/managed-identities-azure-resources/overview>`_ for more
+    the keyword arguments. See `Microsoft Entra ID documentation
+    <https://learn.microsoft.com/azure/active-directory/managed-identities-azure-resources/overview>`_ for more
     information about configuring managed identity for applications.
 
     :keyword str client_id: a user-assigned identity's client ID or, when using Pod Identity, the client ID of an Azure

--- a/sdk/identity/azure-identity/azure/identity/_credentials/on_behalf_of.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/on_behalf_of.py
@@ -23,8 +23,8 @@ class OnBehalfOfCredential(MsalCredential, GetTokenMixin):
 
     This flow is typically used by middle-tier services that authorize requests to other services with a delegated
     user identity. Because this is not an interactive authentication flow, an application using it must have admin
-    consent for any delegated permissions before requesting tokens for them. See `Azure Active Directory documentation
-    <https://docs.microsoft.com/azure/active-directory/develop/v2-oauth2-on-behalf-of-flow>`_ for a more detailed
+    consent for any delegated permissions before requesting tokens for them. See `Microsoft Entra ID documentation
+    <https://learn.microsoft.com/azure/active-directory/develop/v2-oauth2-on-behalf-of-flow>`_ for a more detailed
     description of the on-behalf-of flow.
 
     :param str tenant_id: ID of the service principal's tenant. Also called its "directory" ID.
@@ -37,7 +37,7 @@ class OnBehalfOfCredential(MsalCredential, GetTokenMixin):
     :keyword str user_assertion: Required. The access token the credential will use as the user assertion when
         requesting on-behalf-of tokens
 
-    :keyword str authority: Authority of an Azure Active Directory endpoint, for example "login.microsoftonline.com",
+    :keyword str authority: Authority of a Microsoft Entra endpoint, for example "login.microsoftonline.com",
         the authority for Azure Public Cloud (which is the default). :class:`~azure.identity.AzureAuthorityHosts`
         defines authorities for other clouds.
     :keyword password: A certificate password. Used only when **client_certificate** is provided. If this value

--- a/sdk/identity/azure-identity/azure/identity/_credentials/shared_cache.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/shared_cache.py
@@ -22,10 +22,10 @@ class SharedTokenCacheCredential:
     :param str username: Username (typically an email address) of the user to authenticate as. This is used when the
         local cache contains tokens for multiple identities.
 
-    :keyword str authority: Authority of an Azure Active Directory endpoint, for example 'login.microsoftonline.com',
+    :keyword str authority: Authority of a Microsoft Entra endpoint, for example 'login.microsoftonline.com',
         the authority for Azure Public Cloud (which is the default). :class:`~azure.identity.AzureAuthorityHosts`
         defines authorities for other clouds.
-    :keyword str tenant_id: an Azure Active Directory tenant ID. Used to select an account when the cache contains
+    :keyword str tenant_id: a Microsoft Entra tenant ID. Used to select an account when the cache contains
         tokens for multiple identities.
     :keyword AuthenticationRecord authentication_record: an authentication record returned by a user credential such as
         :class:`DeviceCodeCredential` or :class:`InteractiveBrowserCredential`

--- a/sdk/identity/azure-identity/azure/identity/_credentials/user_password.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/user_password.py
@@ -18,19 +18,19 @@ class UsernamePasswordCredential(InteractiveCredential):
     a directory admin.
 
     This credential can only authenticate work and school accounts; Microsoft accounts are not supported.
-    See `Azure Active Directory documentation
-    <https://docs.microsoft.com/azure/active-directory/fundamentals/sign-up-organization>`_ for more information about
+    See `Microsoft Entra ID documentation
+    <https://learn.microsoft.com/azure/active-directory/fundamentals/sign-up-organization>`_ for more information about
     account types.
 
     :param str client_id: The application's client ID
     :param str username: The user's username (usually an email address)
     :param str password: The user's password
 
-    :keyword str authority: Authority of an Azure Active Directory endpoint, for example "login.microsoftonline.com",
+    :keyword str authority: Authority of a Microsoft Entra endpoint, for example "login.microsoftonline.com",
         the authority for Azure Public Cloud (which is the default). :class:`~azure.identity.AzureAuthorityHosts`
         defines authorities for other clouds.
     :keyword str tenant_id: Tenant ID or a domain associated with a tenant. If not provided, defaults to the
-        "organizations" tenant, which supports only Azure Active Directory work or school accounts.
+        "organizations" tenant, which supports only Microsoft Entra work or school accounts.
     :keyword cache_persistence_options: Configuration for persistent token caching. If unspecified, the credential
         will cache tokens in memory.
     :paramtype cache_persistence_options: ~azure.identity.TokenCachePersistenceOptions

--- a/sdk/identity/azure-identity/azure/identity/_credentials/vscode.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/vscode.py
@@ -87,7 +87,7 @@ class _VSCodeCredentialBase(abc.ABC):
                 # we can't guess confidently.
                 self._unavailable_reason = (
                     'VS Code is configured to use a custom cloud. Set keyword argument "authority"'
-                    + ' with the Azure Active Directory endpoint for cloud "{}"'.format(self._cloud)
+                    + ' with the Microsoft Entra endpoint for cloud "{}"'.format(self._cloud)
                 )
                 return
 
@@ -114,13 +114,13 @@ class VisualStudioCodeCredential(_VSCodeCredentialBase, GetTokenMixin):
     versions newer than **0.9.11**. A long-term fix to this problem is in progress. In the meantime, consider
     authenticating with :class:`AzureCliCredential`.
 
-    :keyword str authority: Authority of an Azure Active Directory endpoint, for example "login.microsoftonline.com".
+    :keyword str authority: Authority of a Microsoft Entra endpoint, for example "login.microsoftonline.com".
         This argument is required for a custom cloud and usually unnecessary otherwise. Defaults to the authority
         matching the "Azure: Cloud" setting in VS Code's user settings or, when that setting has no value, the
         authority for Azure Public Cloud.
     :keyword str tenant_id: ID of the tenant the credential should authenticate in. Defaults to the "Azure: Tenant"
         setting in VS Code's user settings or, when that setting has no value, the "organizations" tenant, which
-        supports only Azure Active Directory work or school accounts.
+        supports only Microsoft Entra work or school accounts.
     :keyword List[str] additionally_allowed_tenants: Specifies tenants in addition to the specified "tenant_id"
         for which the credential may acquire tokens. Add the wildcard value "*" to allow the credential to
         acquire tokens for any tenant the application can access.

--- a/sdk/identity/azure-identity/azure/identity/_credentials/workload_identity.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/workload_identity.py
@@ -28,7 +28,7 @@ class TokenFileMixin:
 
 
 class WorkloadIdentityCredential(ClientAssertionCredential, TokenFileMixin):
-    """Authenticates using an Azure Active Directory workload identity.
+    """Authenticates using Microsoft Entra Workload ID.
 
     Workload identity authentication is a feature in Azure that allows applications running on virtual machines (VMs)
     to access other Azure resources without the need for a service principal or managed identity. With workload
@@ -44,8 +44,8 @@ class WorkloadIdentityCredential(ClientAssertionCredential, TokenFileMixin):
     to `this workload identity overview <https://learn.microsoft.com/azure/aks/workload-identity-overview>`__
     for more information.
 
-    :keyword str tenant_id: ID of the application's Azure Active Directory tenant. Also called its "directory" ID.
-    :keyword str client_id: The client ID of an Azure AD app registration.
+    :keyword str tenant_id: ID of the application's Microsoft Entra tenant. Also called its "directory" ID.
+    :keyword str client_id: The client ID of a Microsoft Entra app registration.
     :keyword str token_file_path: The path to a file containing a Kubernetes service account token that authenticates
         the identity.
 

--- a/sdk/identity/azure-identity/azure/identity/_internal/aad_client_base.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/aad_client_base.py
@@ -162,9 +162,7 @@ class AadClientBase(abc.ABC):
             expires_on = request_time + int(content["expires_in"])
         else:
             _scrub_secrets(content)
-            raise ClientAuthenticationError(
-                message="Unexpected response from Microsoft Entra ID: {}".format(content)
-            )
+            raise ClientAuthenticationError(message="Unexpected response from Microsoft Entra ID: {}".format(content))
 
         token = AccessToken(content["access_token"], expires_on)
 

--- a/sdk/identity/azure-identity/azure/identity/_internal/aad_client_base.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/aad_client_base.py
@@ -143,7 +143,7 @@ class AadClientBase(abc.ABC):
                 for invalid_token in cache_entries:
                     cache.remove_rt(invalid_token)
             if "refresh_token" in content:
-                # AAD returned a new refresh token -> update the cache entry
+                # Microsoft Entra ID returned a new refresh token -> update the cache entry
                 cache_entries = cache.find(
                     TokenCache.CredentialType.REFRESH_TOKEN,
                     query={"secret": response.http_request.body["refresh_token"]},
@@ -163,7 +163,7 @@ class AadClientBase(abc.ABC):
         else:
             _scrub_secrets(content)
             raise ClientAuthenticationError(
-                message="Unexpected response from Azure Active Directory: {}".format(content)
+                message="Unexpected response from Microsoft Entra ID: {}".format(content)
             )
 
         token = AccessToken(content["access_token"], expires_on)
@@ -298,7 +298,7 @@ class AadClientBase(abc.ABC):
             "refresh_token": refresh_token,
             "scope": " ".join(scopes),
             "client_id": self._client_id,
-            "client_info": 1,  # request AAD include home_account_id in its response
+            "client_info": 1,  # request Microsoft Entra ID include home_account_id in its response
         }
 
         claims = _merge_claims_challenge_and_capabilities(
@@ -322,7 +322,7 @@ class AadClientBase(abc.ABC):
             "refresh_token": refresh_token,
             "scope": " ".join(scopes),
             "client_id": self._client_id,
-            "client_info": 1,  # request AAD include home_account_id in its response
+            "client_info": 1,  # request Microsoft Entra ID include home_account_id in its response
         }
         claims = _merge_claims_challenge_and_capabilities(
             ["CP1"] if kwargs.get("enable_cae") else [], kwargs.get("claims")
@@ -372,7 +372,7 @@ def _raise_for_error(response: PipelineResponse, content: Dict) -> None:
 
     _scrub_secrets(content)
     if "error_description" in content:
-        message = "Azure Active Directory error '({}) {}'".format(content["error"], content["error_description"])
+        message = "Microsoft Entra ID error '({}) {}'".format(content["error"], content["error_description"])
     else:
-        message = "Azure Active Directory error '{}'".format(content)
+        message = "Microsoft Entra ID error '{}'".format(content)
     raise ClientAuthenticationError(message=message, response=response.http_response)

--- a/sdk/identity/azure-identity/azure/identity/_internal/interactive.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/interactive.py
@@ -72,7 +72,7 @@ def _build_auth_record(response):
         # tenant which issued the token, not necessarily user's home tenant
         tenant_id = id_token.get("tid") or issuer.path.strip("/")
 
-        # AAD returns "preferred_username", ADFS returns "upn"
+        # Microsoft Entra ID returns "preferred_username", ADFS returns "upn"
         username = id_token.get("preferred_username") or id_token["upn"]
 
         return AuthenticationRecord(
@@ -220,7 +220,7 @@ class InteractiveCredential(MsalCredential, ABC):
                 if result and "access_token" in result and "expires_in" in result:
                     return AccessToken(result["access_token"], now + int(result["expires_in"]))
 
-        # if we get this far, result is either None or the content of an AAD error response
+        # if we get this far, result is either None or the content of a Microsoft Entra ID error response
         if result:
             response = self._client.get_error_response(result)
             raise AuthenticationRequiredError(scopes, claims=claims, response=response)

--- a/sdk/identity/azure-identity/azure/identity/_internal/msal_client.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/msal_client.py
@@ -43,16 +43,16 @@ class MsalResponse:
         if ContentDecodePolicy.CONTEXT_NAME in self._response.context:
             content = self._response.context[ContentDecodePolicy.CONTEXT_NAME]
             if not content:
-                message = "Unexpected response from Azure Active Directory"
+                message = "Unexpected response from Microsoft Entra ID"
             elif "error" in content or "error_description" in content:
                 message = "Authentication failed: {}".format(content.get("error_description") or content.get("error"))
             else:
                 for secret in ("access_token", "refresh_token"):
                     if secret in content:
                         content[secret] = "***"
-                message = 'Unexpected response from Azure Active Directory: "{}"'.format(content)
+                message = 'Unexpected response from Microsoft Entra ID: "{}"'.format(content)
         else:
-            message = "Unexpected response from Azure Active Directory"
+            message = "Unexpected response from Microsoft Entra ID"
 
         raise ClientAuthenticationError(message=message, response=self._response.http_response)
 

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/application.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/application.py
@@ -17,7 +17,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class AzureApplicationCredential(ChainedTokenCredential):
-    """A credential for Azure Active Directory applications.
+    """A credential for Microsoft Entra applications.
 
     This credential is designed for applications deployed to Azure (:class:`~azure.identity.aio.DefaultAzureCredential`
     is better suited to local development). It authenticates service principals and managed identities.
@@ -40,11 +40,11 @@ class AzureApplicationCredential(ChainedTokenCredential):
     for more information about creating and managing service principals.
 
     When this environment configuration is incomplete, the credential will attempt to authenticate a managed identity.
-    See `Azure Active Directory documentation
-    <https://docs.microsoft.com/azure/active-directory/managed-identities-azure-resources/overview>`_ for an overview of
+    See `Microsoft Entra ID documentation
+    <https://learn.microsoft.com/azure/active-directory/managed-identities-azure-resources/overview>`_ for an overview of
     managed identities.
 
-    :keyword str authority: Authority of an Azure Active Directory endpoint, for example "login.microsoftonline.com",
+    :keyword str authority: Authority of a Microsoft Entra endpoint, for example "login.microsoftonline.com",
         the authority for Azure Public Cloud, which is the default when no value is given for this keyword argument or
         environment variable AZURE_AUTHORITY_HOST. :class:`~azure.identity.AzureAuthorityHosts` defines authorities for
         other clouds. Authority configuration applies only to service principal authentication.

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/application.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/application.py
@@ -41,8 +41,8 @@ class AzureApplicationCredential(ChainedTokenCredential):
 
     When this environment configuration is incomplete, the credential will attempt to authenticate a managed identity.
     See `Microsoft Entra ID documentation
-    <https://learn.microsoft.com/azure/active-directory/managed-identities-azure-resources/overview>`_ for an overview of
-    managed identities.
+    <https://learn.microsoft.com/azure/active-directory/managed-identities-azure-resources/overview>`_ for an overview
+    of managed identities.
 
     :keyword str authority: Authority of a Microsoft Entra endpoint, for example "login.microsoftonline.com",
         the authority for Azure Public Cloud, which is the default when no value is given for this keyword argument or

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/authorization_code.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/authorization_code.py
@@ -11,18 +11,18 @@ from .._internal.get_token_mixin import GetTokenMixin
 
 
 class AuthorizationCodeCredential(AsyncContextManager, GetTokenMixin):
-    """Authenticates by redeeming an authorization code previously obtained from Azure Active Directory.
+    """Authenticates by redeeming an authorization code previously obtained from Microsoft Entra ID.
 
-    See `Azure Active Directory documentation
-    <https://docs.microsoft.com/azure/active-directory/develop/v2-oauth2-auth-code-flow>`_ for more information
+    See `Microsoft Entra ID documentation
+    <https://learn.microsoft.com/azure/active-directory/develop/v2-oauth2-auth-code-flow>`_ for more information
     about the authentication flow.
 
-    :param str tenant_id: ID of the application's Azure Active Directory tenant. Also called its "directory" ID.
+    :param str tenant_id: ID of the application's Microsoft Entra tenant. Also called its "directory" ID.
     :param str client_id: The application's client ID
     :param str authorization_code: The authorization code from the user's log-in
     :param str redirect_uri: The application's redirect URI. Must match the URI used to request the authorization code.
 
-    :keyword str authority: Authority of an Azure Active Directory endpoint, for example "login.microsoftonline.com",
+    :keyword str authority: Authority of a Microsoft Entra endpoint, for example "login.microsoftonline.com",
         the authority for Azure Public Cloud (which is the default). :class:`~azure.identity.AzureAuthorityHosts`
         defines authorities for other clouds.
     :keyword str client_secret: One of the application's client secrets. Required only for web apps and web APIs.
@@ -89,7 +89,7 @@ class AuthorizationCodeCredential(AsyncContextManager, GetTokenMixin):
         :return: An access token with the desired scopes.
         :rtype: ~azure.core.credentials.AccessToken
         :raises ~azure.core.exceptions.ClientAuthenticationError: authentication failed. The error's ``message``
-          attribute gives a reason. Any error response from Azure Active Directory is available as the error's
+          attribute gives a reason. Any error response from Microsoft Entra ID is available as the error's
           ``response`` attribute.
         """
         return await super().get_token(*scopes, claims=claims, tenant_id=tenant_id, **kwargs)

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/azd_cli.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/azd_cli.py
@@ -32,11 +32,11 @@ class AzureDeveloperCliCredential(AsyncContextManager):
     Azure Developer CLI is a command-line interface tool that allows developers to create, manage, and deploy
     resources in Azure. It's built on top of the Azure CLI and provides additional functionality specific
     to Azure developers. It allows users to authenticate as a user and/or a service principal against
-    `Azure Active Directory (Azure AD) <"https://learn.microsoft.com/azure/active-directory/fundamentals/">`__.
+    `Microsoft Entra ID <"https://learn.microsoft.com/azure/active-directory/fundamentals/">`__.
     The AzureDeveloperCliCredential authenticates in a development environment and acquires a token on behalf of
     the logged-in user or service principal in Azure Developer CLI. It acts as the Azure Developer CLI logged-in user
     or service principal and executes an Azure CLI command underneath to authenticate the application against
-    Azure Active Directory.
+    Microsoft Entra ID.
 
     To use this credential, the developer needs to authenticate locally in Azure Developer CLI using one of the
     commands below:

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/certificate.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/certificate.py
@@ -17,7 +17,7 @@ class CertificateCredential(AsyncContextManager, GetTokenMixin):
     """Authenticates as a service principal using a certificate.
 
     The certificate must have an RSA private key, because this credential signs assertions using RS256. See
-    `Azure Active Directory documentation
+    `Microsoft Entra ID documentation
     <https://docs.microsoft.com/azure/active-directory/develop/active-directory-certificate-credentials#register-your-certificate-with-microsoft-identity-platform>`_
     for more information on configuring certificate authentication.
 
@@ -26,7 +26,7 @@ class CertificateCredential(AsyncContextManager, GetTokenMixin):
     :param str certificate_path: Path to a PEM-encoded certificate file including the private key. If not provided,
           `certificate_data` is required.
 
-    :keyword str authority: Authority of an Azure Active Directory endpoint, for example 'login.microsoftonline.com',
+    :keyword str authority: Authority of a Microsoft Entra endpoint, for example 'login.microsoftonline.com',
           the authority for Azure Public Cloud (which is the default). :class:`~azure.identity.AzureAuthorityHosts`
           defines authorities for other clouds.
     :keyword bytes certificate_data: The bytes of a certificate in PEM format, including the private key

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/client_assertion.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/client_assertion.py
@@ -21,7 +21,7 @@ class ClientAssertionCredential(AsyncContextManager, GetTokenMixin):
         acquires a new token.
     :paramtype func: Callable[[], str]
 
-    :keyword str authority: Authority of an Azure Active Directory endpoint, for example
+    :keyword str authority: Authority of a Microsoft Entra endpoint, for example
         "login.microsoftonline.com", the authority for Azure Public Cloud (which is the default).
         :class:`~azure.identity.AzureAuthorityHosts` defines authorities for other clouds.
     :keyword List[str] additionally_allowed_tenants: Specifies tenants in addition to the specified "tenant_id"

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/client_secret.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/client_secret.py
@@ -45,9 +45,7 @@ class ClientSecretCredential(AsyncContextManager, GetTokenMixin):
         if not client_secret:
             raise ValueError("secret should be a Microsoft Entra application's client secret")
         if not tenant_id:
-            raise ValueError(
-                "tenant_id should be a Microsoft Entra tenant's id (also called its 'directory id')"
-            )
+            raise ValueError("tenant_id should be a Microsoft Entra tenant's id (also called its 'directory id')")
         validate_tenant_id(tenant_id)
 
         self._client = AadClient(tenant_id, client_id, **kwargs)

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/client_secret.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/client_secret.py
@@ -19,7 +19,7 @@ class ClientSecretCredential(AsyncContextManager, GetTokenMixin):
     :param str client_id: The service principal's client ID
     :param str client_secret: One of the service principal's client secrets
 
-    :keyword str authority: Authority of an Azure Active Directory endpoint, for example 'login.microsoftonline.com',
+    :keyword str authority: Authority of a Microsoft Entra endpoint, for example 'login.microsoftonline.com',
           the authority for Azure Public Cloud (which is the default). :class:`~azure.identity.AzureAuthorityHosts`
           defines authorities for other clouds.
     :keyword cache_persistence_options: Configuration for persistent token caching. If unspecified, the credential
@@ -41,12 +41,12 @@ class ClientSecretCredential(AsyncContextManager, GetTokenMixin):
 
     def __init__(self, tenant_id: str, client_id: str, client_secret: str, **kwargs: Any) -> None:
         if not client_id:
-            raise ValueError("client_id should be the id of an Azure Active Directory application")
+            raise ValueError("client_id should be the id of a Microsoft Entra application")
         if not client_secret:
-            raise ValueError("secret should be an Azure Active Directory application's client secret")
+            raise ValueError("secret should be a Microsoft Entra application's client secret")
         if not tenant_id:
             raise ValueError(
-                "tenant_id should be an Azure Active Directory tenant's id (also called its 'directory id')"
+                "tenant_id should be a Microsoft Entra tenant's id (also called its 'directory id')"
             )
         validate_tenant_id(tenant_id)
 

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/default.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/default.py
@@ -45,7 +45,7 @@ class DefaultAzureCredential(ChainedTokenCredential):
 
     This default behavior is configurable with keyword arguments.
 
-    :keyword str authority: Authority of an Azure Active Directory endpoint, for example 'login.microsoftonline.com',
+    :keyword str authority: Authority of a Microsoft Entra endpoint, for example 'login.microsoftonline.com',
         the authority for Azure Public Cloud (which is the default). :class:`~azure.identity.AzureAuthorityHosts`
         defines authorities for other clouds. Managed identities ignore this because they reside in a single cloud.
     :keyword bool exclude_workload_identity_credential: Whether to exclude the workload identity from the credential.

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/environment.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/environment.py
@@ -27,7 +27,7 @@ class EnvironmentCredential(AsyncContextManager):
       - **AZURE_TENANT_ID**: ID of the service principal's tenant. Also called its 'directory' ID.
       - **AZURE_CLIENT_ID**: the service principal's client ID
       - **AZURE_CLIENT_SECRET**: one of the service principal's client secrets
-      - **AZURE_AUTHORITY_HOST**: authority of an Azure Active Directory endpoint, for example
+      - **AZURE_AUTHORITY_HOST**: authority of a Microsoft Entra endpoint, for example
         "login.microsoftonline.com", the authority for Azure Public Cloud, which is the default
         when no value is given.
 
@@ -36,7 +36,7 @@ class EnvironmentCredential(AsyncContextManager):
       - **AZURE_CLIENT_ID**: the service principal's client ID
       - **AZURE_CLIENT_CERTIFICATE_PATH**: path to a PEM or PKCS12 certificate file including the private key.
       - **AZURE_CLIENT_CERTIFICATE_PASSWORD**: (optional) password of the certificate file, if any.
-      - **AZURE_AUTHORITY_HOST**: authority of an Azure Active Directory endpoint, for example
+      - **AZURE_AUTHORITY_HOST**: authority of a Microsoft Entra endpoint, for example
         "login.microsoftonline.com", the authority for Azure Public Cloud, which is the default
         when no value is given.
 

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/managed_identity.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/managed_identity.py
@@ -22,8 +22,8 @@ class ManagedIdentityCredential(AsyncContextManager):
     """Authenticates with an Azure managed identity in any hosting environment which supports managed identities.
 
     This credential defaults to using a system-assigned identity. To configure a user-assigned identity, use one of
-    the keyword arguments. See `Azure Active Directory documentation
-    <https://docs.microsoft.com/azure/active-directory/managed-identities-azure-resources/overview>`_ for more
+    the keyword arguments. See `Microsoft Entra ID documentation
+    <https://learn.microsoft.com/azure/active-directory/managed-identities-azure-resources/overview>`_ for more
     information about configuring managed identity for applications.
 
     :keyword str client_id: a user-assigned identity's client ID or, when using Pod Identity, the client ID of an Azure

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/on_behalf_of.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/on_behalf_of.py
@@ -20,8 +20,8 @@ class OnBehalfOfCredential(AsyncContextManager, GetTokenMixin):
 
     This flow is typically used by middle-tier services that authorize requests to other services with a delegated
     user identity. Because this is not an interactive authentication flow, an application using it must have admin
-    consent for any delegated permissions before requesting tokens for them. See `Azure Active Directory documentation
-    <https://docs.microsoft.com/azure/active-directory/develop/v2-oauth2-on-behalf-of-flow>`_ for a more detailed
+    consent for any delegated permissions before requesting tokens for them. See `Microsoft Entra ID documentation
+    <https://learn.microsoft.com/azure/active-directory/develop/v2-oauth2-on-behalf-of-flow>`_ for a more detailed
     description of the on-behalf-of flow.
 
     :param str tenant_id: ID of the service principal's tenant. Also called its "directory" ID.
@@ -34,7 +34,7 @@ class OnBehalfOfCredential(AsyncContextManager, GetTokenMixin):
     :keyword str user_assertion: Required. The access token the credential will use as the user assertion when
         requesting on-behalf-of tokens
 
-    :keyword str authority: Authority of an Azure Active Directory endpoint, for example "login.microsoftonline.com",
+    :keyword str authority: Authority of a Microsoft Entra endpoint, for example "login.microsoftonline.com",
         the authority for Azure Public Cloud (which is the default). :class:`~azure.identity.AzureAuthorityHosts`
         defines authorities for other clouds.
     :keyword password: A certificate password. Used only when **client_certificate** is provided. If this value

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/shared_cache.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/shared_cache.py
@@ -20,10 +20,10 @@ class SharedTokenCacheCredential(SharedTokenCacheBase, AsyncContextManager):
         Username (typically an email address) of the user to authenticate as. This is required because the local cache
         may contain tokens for multiple identities.
 
-    :keyword str authority: Authority of an Azure Active Directory endpoint, for example 'login.microsoftonline.com',
+    :keyword str authority: Authority of a Microsoft Entra endpoint, for example 'login.microsoftonline.com',
         the authority for Azure Public Cloud (which is the default). :class:`~azure.identity.AzureAuthorityHosts`
         defines authorities for other clouds.
-    :keyword str tenant_id: an Azure Active Directory tenant ID. Used to select an account when the cache contains
+    :keyword str tenant_id: a Microsoft Entra tenant ID. Used to select an account when the cache contains
         tokens for multiple identities.
     :keyword cache_persistence_options: configuration for persistent token caching. If not provided, the credential
         will use the persistent cache shared by Microsoft development applications
@@ -65,7 +65,7 @@ class SharedTokenCacheCredential(SharedTokenCacheBase, AsyncContextManager):
         :raises ~azure.identity.CredentialUnavailableError: the cache is unavailable or contains insufficient user
             information
         :raises ~azure.core.exceptions.ClientAuthenticationError: authentication failed. The error's ``message``
-          attribute gives a reason. Any error response from Azure Active Directory is available as the error's
+          attribute gives a reason. Any error response from Microsoft Entra ID is available as the error's
           ``response`` attribute.
         """
         if not scopes:

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/vscode.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/vscode.py
@@ -23,13 +23,13 @@ class VisualStudioCodeCredential(_VSCodeCredentialBase, AsyncContextManager, Get
     versions newer than **0.9.11**. A long-term fix to this problem is in progress. In the meantime, consider
     authenticating with :class:`AzureCliCredential`.
 
-    :keyword str authority: Authority of an Azure Active Directory endpoint, for example "login.microsoftonline.com".
+    :keyword str authority: Authority of a Microsoft Entra endpoint, for example "login.microsoftonline.com".
         This argument is required for a custom cloud and usually unnecessary otherwise. Defaults to the authority
         matching the "Azure: Cloud" setting in VS Code's user settings or, when that setting has no value, the
         authority for Azure Public Cloud.
     :keyword str tenant_id: ID of the tenant the credential should authenticate in. Defaults to the "Azure: Tenant"
         setting in VS Code's user settings or, when that setting has no value, the "organizations" tenant, which
-        supports only Azure Active Directory work or school accounts.
+        supports only Microsoft Entra work or school accounts.
     :keyword List[str] additionally_allowed_tenants: Specifies tenants in addition to the specified "tenant_id"
         for which the credential may acquire tokens. Add the wildcard value "*" to allow the credential to
         acquire tokens for any tenant the application can access.

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/workload_identity.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/workload_identity.py
@@ -10,7 +10,7 @@ from ..._constants import EnvironmentVariables
 
 
 class WorkloadIdentityCredential(ClientAssertionCredential, TokenFileMixin):
-    """Authenticates using an Azure Active Directory workload identity.
+    """Authenticates using Microsoft Entra Workload ID.
 
     Workload identity authentication is a feature in Azure that allows applications running on virtual machines (VMs)
     to access other Azure resources without the need for a service principal or managed identity. With workload
@@ -26,8 +26,8 @@ class WorkloadIdentityCredential(ClientAssertionCredential, TokenFileMixin):
     to `this workload identity overview <https://learn.microsoft.com/azure/aks/workload-identity-overview>`__
     for more information.
 
-    :keyword str tenant_id: ID of the application's Azure Active Directory tenant. Also called its "directory" ID.
-    :keyword str client_id: The client ID of an Azure AD app registration.
+    :keyword str tenant_id: ID of the application's Microsoft Entra tenant. Also called its "directory" ID.
+    :keyword str client_id: The client ID of a Microsoft Entra app registration.
     :keyword str token_file_path: The path to a file containing a Kubernetes service account token that authenticates
         the identity.
 

--- a/sdk/identity/azure-identity/samples/azure-aad-auth-with-redis-py.md
+++ b/sdk/identity/azure-identity/samples/azure-aad-auth-with-redis-py.md
@@ -1,11 +1,11 @@
-## Azure Cache for Redis: Azure AD with redis client library
+## Azure Cache for Redis: Microsoft Entra ID with redis client library
 
 ### Table of contents
 
 - [Prerequisites](#prerequisites)
 - [Samples guidance](#samples-guidance)
-- [Authenticate with Azure AD - Hello World](#authenticate-with-azure-ad-hello-world)
-- [Authenticate with Azure AD - Handle Re-authentication](#authenticate-with-azure-ad-handle-re-authentication)
+- [Authenticate with Microsoft Entra ID - Hello World](#authenticate-with-azure-ad-hello-world)
+- [Authenticate with Microsoft Entra ID - Handle Re-authentication](#authenticate-with-azure-ad-handle-re-authentication)
 - [Troubleshooting](#troubleshooting)
 
 #### Prerequisites
@@ -17,20 +17,20 @@
 
 #### Samples guidance
 
-[Authenticate with Azure AD - Hello World](#authenticate-with-azure-ad-hello-world)
-This sample is recommended for users getting started to use Azure AD authentication with Azure Cache for Redis.
+[Authenticate with Microsoft Entra ID - Hello World](#authenticate-with-azure-ad-hello-world)
+This sample is recommended for users getting started to use Microsoft Entra authentication with Azure Cache for Redis.
 
-[Authenticate with Azure AD - Handle Re-Authentication](#authenticate-with-azure-ad-handle-re-authentication)
-This sample is recommended to users looking to build long-running applications that would like to handle re-authenticating with Azure AD upon token expiry.
+[Authenticate with Microsoft Entra ID - Handle Re-Authentication](#authenticate-with-azure-ad-handle-re-authentication)
+This sample is recommended to users looking to build long-running applications that would like to handle re-authenticating with Microsoft Entra ID upon token expiry.
 
-#### Authenticate with Azure AD: hello world
+#### Authenticate with Microsoft Entra ID: Hello world
 
-This sample is intended to assist in authenticating with Azure AD via the redis client library. It focuses on displaying the logic required to fetch an Azure AD access token and to use it as password when setting up the redis instance.
+This sample is intended to assist in authenticating with Microsoft Entra ID via the redis client library. It focuses on displaying the logic required to fetch a Microsoft Entra access token and to use it as password when setting up the redis instance.
 
 ##### Migration guidance
 
-When migrating your existing application code, you need to replace the password input with the Azure AD token.
-Integrate the logic in your application code to fetch an Azure AD access token via the azure-identity library as shown below and replace it with the password configuring/retrieving logic in your application code.
+When migrating your existing application code, you need to replace the password input with the Microsoft Entra token.
+Integrate the logic in your application code to fetch a Microsoft Entra access token via the azure-identity library as shown below and replace it with the password configuring/retrieving logic in your application code.
 
 ```python
 import redis
@@ -59,9 +59,9 @@ if __name__ == '__main__':
     hello_world()
 ```
 
-##### Supported Token Credentials for Azure AD Authentication
+##### Supported Token Credentials for Microsoft Entra Authentication
 
-**Note:** The samples in this doc use the azure-identity library's `DefaultAzureCredential` to fetch an Azure AD access token. The other supported `TokenCredential` implementations that can be used from azure-identity are as follows:
+**Note:** The samples in this doc use the azure-identity library's `DefaultAzureCredential` to fetch a Microsoft Entra access token. The other supported `TokenCredential` implementations that can be used from azure-identity are as follows:
 
 - [Client Certificate Credential](https://aka.ms/azsdk/python/identity/certificatecredential)
 - [Client Secret Credential](https://aka.ms/azsdk/python/identity/clientsecretcredential)
@@ -71,14 +71,14 @@ if __name__ == '__main__':
 - [Interactive Browser Credential](https://aka.ms/azsdk/python/identity/interactivebrowsercredential)
 - [Device Code Credential](https://aka.ms/azsdk/python/identity/devicecodecredential)
 
-#### Authenticate with Azure AD: handle re-authentication
+#### Authenticate with Microsoft Entra ID: Handle re-authentication
 
-This sample is intended to assist in authenticating with Azure AD via the redis client library. It focuses on displaying the logic required to fetch an Azure AD access token and to use it as password when setting up the redis instance. It also shows how to recreate and authenticate the redis instance when its connection is broken in error/exception scenarios.
+This sample is intended to assist in authenticating with Microsoft Entra ID via the redis client library. It focuses on displaying the logic required to fetch a Microsoft Entra access token and to use it as password when setting up the redis instance. It also shows how to recreate and authenticate the redis instance when its connection is broken in error/exception scenarios.
 
 ##### Migration guidance
 
-When migrating your existing application code, you need to replace the password input with the Azure AD token.
-Integrate the logic in your application code to fetch an Azure AD access token via the azure-identity library as shown below and replace it with the password configuring/retrieving logic in your application code.
+When migrating your existing application code, you need to replace the password input with the Microsoft Entra token.
+Integrate the logic in your application code to fetch a Microsoft Entra access token via the `azure-identity` library as shown below and replace it with the password configuring/retrieving logic in your application code.
 
 ```python
 import time
@@ -143,7 +143,7 @@ In this error scenario, the username provided and the access token used as passw
 To mitigate this error, navigate to your Azure Cache for Redis resource in the Azure portal. Confirm that:
 
 - In **Data Access Configuration**, you've assigned the required role to your user/service principal identity.
-- In **Advanced settings**, the **AAD access authorization** box is selected. If not, select it and select the **Save** button.
+- In **Advanced settings**, the **Microsoft Entra Authentication** box is selected. If not, select it and select the **Save** button.
 
 ##### Permissions not granted / NOPERM Error
 

--- a/sdk/identity/azure-identity/samples/azure-aad-auth-with-redis.py
+++ b/sdk/identity/azure-identity/samples/azure-aad-auth-with-redis.py
@@ -4,8 +4,8 @@
 # ------------------------------------
 """
 
-This sample is intended to assist in authenticating with AAD via redis-py library. 
-It focuses on displaying the logic required to fetch an AAD access token and to use it as password when setting up the redis client.
+This sample is intended to assist in authenticating with Microsoft Entra ID via redis-py library. 
+It focuses on displaying the logic required to fetch a Microsoft Entra access token and to use it as password when setting up the redis client.
 
 """
 

--- a/sdk/identity/azure-identity/samples/client_certificate_credential.md
+++ b/sdk/identity/azure-identity/samples/client_certificate_credential.md
@@ -1,6 +1,6 @@
 # Using the CertificateCredential
 
-Applications which execute in a protected environment can authenticate using a client assertion signed by a private key whose public key or root certificate is registered with AAD. The Azure.Identity library provides the `CertificateCredential` for applications choosing to authenticate this way. Below are some examples of how applications can utilize the `CertificateCredential` to authenticate clients.
+Applications which execute in a protected environment can authenticate using a client assertion signed by a private key whose public key or root certificate is registered with Microsoft Entra ID. The `azure-identity` library provides the `CertificateCredential` for applications choosing to authenticate this way. Below are some examples of how applications can utilize the `CertificateCredential` to authenticate clients.
 
 
 ## Loading certificates from disk

--- a/sdk/identity/azure-identity/tests/helpers.py
+++ b/sdk/identity/azure-identity/tests/helpers.py
@@ -46,7 +46,7 @@ def id_token_claims(iss, sub, aud, exp=None, iat=None, **claims):
     )
 
 
-def build_aad_response(  # simulate a response from AAD
+def build_aad_response(  # simulate a response from Microsoft Entra ID
     uid=None,
     utid=None,  # If present, they will form client_info
     access_token=None,
@@ -59,7 +59,7 @@ def build_aad_response(  # simulate a response from AAD
     **kwargs
 ):
     response = {}
-    if uid and utid:  # Mimic the AAD behavior for "client_info=1" request
+    if uid and utid:  # Mimic the Microsoft Entra ID behavior for "client_info=1" request
         response["client_info"] = base64.b64encode(json.dumps({"uid": uid, "utid": utid}).encode()).decode("utf-8")
     if error:
         response["error"] = error

--- a/sdk/identity/azure-identity/tests/pod-identity/readme.md
+++ b/sdk/identity/azure-identity/tests/pod-identity/readme.md
@@ -97,7 +97,7 @@ Assign needed roles to the cluster managed identity:
 az role assignment create --role "Managed Identity Operator" --assignee $KUBELET_IDENTITY_CLIENT_ID --scope $MANAGED_IDENTITY_ID
 ```
 
-Add role assignments required by AAD Pod Identity:
+Add role assignments required by Microsoft Entra Pod Identity:
 ```sh
 az role assignment create --role "Managed Identity Operator" --assignee $KUBELET_IDENTITY_CLIENT_ID --scope $NODE_RESOURCE_GROUP_SCOPE
 az role assignment create --role "Virtual Machine Contributor" --assignee $KUBELET_IDENTITY_CLIENT_ID --scope $NODE_RESOURCE_GROUP_SCOPE

--- a/sdk/identity/azure-identity/tests/test_aad_client.py
+++ b/sdk/identity/azure-identity/tests/test_aad_client.py
@@ -45,7 +45,7 @@ def test_error_reporting():
         functools.partial(client.obtain_token_by_refresh_token, ("scope",), "refresh token"),
     ]
 
-    # exceptions raised for AAD errors should contain AAD's error description
+    # exceptions raised for Microsoft Entra errors should contain Microsoft Entra's error description
     for fn in fns:
         with pytest.raises(ClientAuthenticationError) as ex:
             fn()
@@ -81,10 +81,10 @@ def test_exceptions_do_not_expose_secrets():
             assert transport.send.call_count == 1
             transport.send.reset_mock()
 
-    # AAD errors shouldn't provoke exceptions exposing secrets
+    # Microsoft Entra errors shouldn't provoke exceptions exposing secrets
     assert_secrets_not_exposed()
 
-    # neither should unexpected AAD responses
+    # neither should unexpected Microsoft Entra responses
     del body["error"]
     assert_secrets_not_exposed()
 
@@ -193,7 +193,7 @@ def test_refresh_token():
 
 
 def test_evicts_invalid_refresh_token():
-    """when AAD rejects a refresh token, the client should evict that token from its cache"""
+    """when Microsoft Entra ID rejects a refresh token, the client should evict that token from its cache"""
 
     tenant_id = "tenant-id"
     client_id = "client-id"

--- a/sdk/identity/azure-identity/tests/test_aad_client_async.py
+++ b/sdk/identity/azure-identity/tests/test_aad_client_async.py
@@ -38,7 +38,7 @@ async def test_error_reporting():
         functools.partial(client.obtain_token_by_refresh_token, ("scope",), "refresh token"),
     ]
 
-    # exceptions raised for AAD errors should contain AAD's error description
+    # exceptions raised for Microsoft Entra errors should contain Microsoft Entra's error description
     for fn in fns:
         with pytest.raises(ClientAuthenticationError) as ex:
             await fn()
@@ -75,10 +75,10 @@ async def test_exceptions_do_not_expose_secrets():
             assert transport.send.call_count == 1
             transport.send.reset_mock()
 
-    # AAD errors shouldn't provoke exceptions exposing secrets
+    # Microsoft Entra errors shouldn't provoke exceptions exposing secrets
     await assert_secrets_not_exposed()
 
-    # neither should unexpected AAD responses
+    # neither should unexpected Microsoft Entra responses
     del body["error"]
     await assert_secrets_not_exposed()
 
@@ -187,7 +187,7 @@ async def test_request_url(authority):
 
 
 async def test_evicts_invalid_refresh_token():
-    """when AAD rejects a refresh token, the client should evict that token from its cache"""
+    """when Microsoft Entra ID rejects a refresh token, the client should evict that token from its cache"""
 
     tenant_id = "tenant-id"
     client_id = "client-id"

--- a/sdk/identity/azure-identity/tests/test_certificate_credential.py
+++ b/sdk/identity/azure-identity/tests/test_certificate_credential.py
@@ -249,8 +249,8 @@ def test_request_body(cert_path, cert_password, send_certificate_chain):
 
 
 def validate_jwt(request, client_id, cert_bytes, cert_password, expect_x5c=False):
-    """Validate the request meets AAD's expectations for a client credential grant using a certificate, as documented
-    at https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-certificate-credentials
+    """Validate the request meets Microsoft Entra ID's expectations for a client credential grant using a certificate, as documented
+    at https://learn.microsoft.com/azure/active-directory/develop/active-directory-certificate-credentials
     """
 
     try:

--- a/sdk/identity/azure-identity/tests/test_device_code_credential.py
+++ b/sdk/identity/azure-identity/tests/test_device_code_credential.py
@@ -53,7 +53,7 @@ def test_authenticate():
     access_token = "***"
     scope = "scope"
 
-    # mock AAD response with id token
+    # mock Microsoft Entra ID response with id token
     object_id = "object-id"
     home_tenant = "home-tenant-id"
     username = "me@work.com"

--- a/sdk/identity/azure-identity/tests/test_interactive_credential.py
+++ b/sdk/identity/azure-identity/tests/test_interactive_credential.py
@@ -146,7 +146,7 @@ def test_disable_automatic_authentication():
         with patch("msal.PublicClientApplication", lambda *_, **__: msal_app):
             credential.get_token(scope, claims=expected_claims)
 
-    # the exception should carry the requested scopes and claims, and any error message from AAD
+    # the exception should carry the requested scopes and claims, and any error message from Microsoft Entra ID
     assert ex.value.scopes == (scope,)
     assert ex.value.claims == expected_claims
 

--- a/sdk/identity/azure-identity/tests/test_shared_cache_credential.py
+++ b/sdk/identity/azure-identity/tests/test_shared_cache_credential.py
@@ -718,7 +718,7 @@ def test_writes_to_cache():
         requests=[Request(required_data={"refresh_token": first_refresh_token})],  # credential redeems refresh token
         responses=[
             mock_response(
-                json_payload=build_aad_response(  # AAD responds with an access token and new refresh token
+                json_payload=build_aad_response(  # Microsoft Entra ID responds with an access token and new refresh token
                     uid=uid,
                     utid=utid,
                     access_token=expected_access_token,

--- a/sdk/identity/azure-identity/tests/test_username_password_credential.py
+++ b/sdk/identity/azure-identity/tests/test_username_password_credential.py
@@ -107,7 +107,7 @@ def test_username_password_credential():
         username="user@azure",
         password="secret_password",
         transport=transport,
-        disable_instance_discovery=True,  # kwargs are passed to MSAL; this one prevents an AAD verification request
+        disable_instance_discovery=True,  # kwargs are passed to MSAL; this one prevents a Microsoft Entra verification request
     )
 
     token = credential.get_token("scope")
@@ -124,7 +124,7 @@ def test_authenticate():
     access_token = "***"
     scope = "scope"
 
-    # mock AAD response with id token
+    # mock Microsoft Entra response with id token
     object_id = "object-id"
     home_tenant = "home-tenant-id"
     username = "me@work.com"


### PR DESCRIPTION
Replace Azure AD references in Markdown files and code comments with Microsoft Entra ID, per the guidance at https://learn.microsoft.com/azure/active-directory/fundamentals/how-to-rename-azure-ad.