### PR TITLE
Stop using removed platform-matrix for `ml` `livetests`

### DIFF
--- a/sdk/ml/tests.yml
+++ b/sdk/ml/tests.yml
@@ -14,11 +14,6 @@ stages:
   - template: ../../eng/pipelines/templates/stages/archetype-sdk-tests.yml
     parameters:
       ServiceDirectory: ml
-      MatrixConfigs:
-        - Name: ml_ci_matrix
-          Path: eng/pipelines/templates/stages/platform-matrix-ml.json
-          Selection: sparse
-          GenerateVMJobs: true
       MatrixReplace:
         - TestSamples=.*/true
       TestTimeoutInMinutes: 270


### PR DESCRIPTION
Went and double checked the PR. g2g now.

![image](https://github.com/Azure/azure-sdk-for-python/assets/45376673/093b54c4-2aa4-4270-a19e-a44fb863275d)
