### PR TITLE
[Test Proxy] Reduce excessive logging during tests

### DIFF
--- a/sdk/conftest.py
+++ b/sdk/conftest.py
@@ -74,3 +74,12 @@ def pytest_runtest_makereport(item, call) -> None:
         error = call.excinfo.value
         # set a test_error attribute on the item (available to other fixtures from request.node)
         setattr(item, "test_error", error)
+
+
+@pytest.fixture(autouse=True)
+def reduce_logging_volume(caplog, pytestconfig):
+    # Unless specific log level is requested, raise minimum log level in captured call logs to WARNING
+    # By default, all INFO-level logs from test execution are printed if tests fail, making output hard to read
+    if not (pytestconfig.getoption("log_level") or pytestconfig.getoption("log_cli_level")):
+        caplog.set_level(30)
+    yield

--- a/tools/azure-sdk-tools/devtools_testutils/proxy_startup.py
+++ b/tools/azure-sdk-tools/devtools_testutils/proxy_startup.py
@@ -30,6 +30,9 @@ from .sanitizers import add_remove_header_sanitizer, set_custom_default_matcher
 
 load_dotenv(find_dotenv())
 
+# Raise urllib3's exposed logging level so that we don't see tons of warnings while polling the proxy's availability
+logging.getLogger("urllib3.connectionpool").setLevel(logging.ERROR)
+
 _LOGGER = logging.getLogger()
 
 CONTAINER_STARTUP_TIMEOUT = 60


### PR DESCRIPTION
# Description

At the moment, running tests against the test proxy frequently produces excessive logs. The two main sources are `WARNING`-level logs from `urllib3` (emitted during test proxy startup, when we're polling for availability) and `INFO`-level logs from `azure-core`'s logging policy (emitted in `pytest`'s "Captured log call" after test failure).

- To fix the former, `proxy_startup.py` now raises the logger level of `urllib3.connectionpool` to `ERROR`. Warnings are expected since we start up the test proxy during tests and poll for availability; in some cases, the amount of warnings emitted makes reading test output impossible.
- To fix the latter, the SDK's root `conftest.py` now raises the log capture level to `WARNING` by default. This way, `INFO`-level logs emitted during test execution won't be captured and printed at the end of the test session.
  - If a custom log level is configured for the session with `--log-level` or `--log-cli-level` command line options, we don't modify the log capture level. In this scenario it's assumed that the user wants full control of log output.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
