### PR TITLE
[Storage] Fix failing audience tests in test pipeline

### DIFF
--- a/sdk/storage/azure-storage-file-datalake/assets.json
+++ b/sdk/storage/azure-storage-file-datalake/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "python",
   "TagPrefix": "python/storage/azure-storage-file-datalake",
-  "Tag": "python/storage/azure-storage-file-datalake_c893a9b8ce"
+  "Tag": "python/storage/azure-storage-file-datalake_6b9a03594a"
 }

--- a/sdk/storage/azure-storage-file-datalake/tests/test_datalake_service_client_async.py
+++ b/sdk/storage/azure-storage-file-datalake/tests/test_datalake_service_client_async.py
@@ -462,7 +462,8 @@ class TestDatalakeServiceAsync(AsyncStorageRecordedTestCase):
         datalake_storage_account_key = kwargs.pop("datalake_storage_account_key")
 
         self._setup(datalake_storage_account_name, datalake_storage_account_key)
-        await self.dsc.create_file_system('testfs1')
+        file_system_name = self.get_resource_name('filesystem')
+        await self.dsc.create_file_system(file_system_name)
 
         # Act
         token_credential = self.generate_oauth_token()
@@ -474,7 +475,7 @@ class TestDatalakeServiceAsync(AsyncStorageRecordedTestCase):
 
         # Assert
         response1 = dsc.list_file_systems()
-        response2 = dsc.create_file_system('testfs11')
+        response2 = dsc.create_file_system(file_system_name + '1')
         assert response1 is not None
         assert response2 is not None
 
@@ -485,7 +486,8 @@ class TestDatalakeServiceAsync(AsyncStorageRecordedTestCase):
         datalake_storage_account_key = kwargs.pop("datalake_storage_account_key")
 
         self._setup(datalake_storage_account_name, datalake_storage_account_key)
-        await self.dsc.create_file_system('testfs2')
+        file_system_name = self.get_resource_name('filesystem')
+        await self.dsc.create_file_system(file_system_name)
 
         # Act
         token_credential = self.generate_oauth_token()
@@ -498,4 +500,4 @@ class TestDatalakeServiceAsync(AsyncStorageRecordedTestCase):
         # Assert
         with pytest.raises(ClientAuthenticationError):
             dsc.list_file_systems()
-            await dsc.create_file_system('testfs22')
+            await dsc.create_file_system(file_system_name + '1')


### PR DESCRIPTION
I believe the issue is that a previous test may be causing a collision in file system names. Switched to using the unique file system name associated with the test 😄 