### PR TITLE
[SchemaRegistry] reroute CI to not run windows311

### DIFF
--- a/sdk/schemaregistry/azure-schemaregistry/dev_requirements.txt
+++ b/sdk/schemaregistry/azure-schemaregistry/dev_requirements.txt
@@ -3,6 +3,6 @@
 -e ../../core/azure-core
 -e ../../identity/azure-identity
 jsonschema>=4.10.3    # lowest version that supports validator_for(default=False)
-aiohttp>=3.0,<4.0
+aiohttp>=3.0
 genson
 azure-eventhub

--- a/sdk/schemaregistry/ci.yml
+++ b/sdk/schemaregistry/ci.yml
@@ -27,6 +27,11 @@ extends:
   template: ../../eng/pipelines/templates/stages/archetype-sdk-client.yml
   parameters:
     ServiceDirectory: schemaregistry
+    MatrixConfigs:
+      - Name: schemaregistry_ci_matrix
+        Path: eng/pipelines/templates/stages/platform-matrix-metricsadvisor_tables.json
+        Selection: sparse
+        GenerateVMJobs: true
     Artifacts:
     - name: azure-schemaregistry
       safeName: azureschemaregistry

--- a/sdk/schemaregistry/tests.yml
+++ b/sdk/schemaregistry/tests.yml
@@ -4,6 +4,11 @@ stages:
   - template: ../../eng/pipelines/templates/stages/archetype-sdk-tests.yml
     parameters:
       ServiceDirectory: schemaregistry
+      MatrixConfigs:
+        - Name: schemaregistry_ci_matrix
+          Path: eng/pipelines/templates/stages/platform-matrix-metricsadvisor_tables.json
+          Selection: sparse
+          GenerateVMJobs: true
       TestTimeoutInMinutes: 300
       BuildTargetingString: azure-schemaregistry*
       EnvVars:


### PR DESCRIPTION
Fixing the following:
- Windows311 is failing with the following. Seems to be related to #32409 
```
whl: exit 3221225477 (32.80 seconds) D:\a\_work\1\s\sdk\schemaregistry\azure-schemaregistry-avroencoder> pytest -rsfE --junitxml=D:\a\_work\1\s\sdk\schemaregistry\azure-schemaregistry-avroencoder/test-junit-whl.xml --verbose --durations=10 --ignore=azure --ignore=.tox --ignore=build --ignore=.eggs --no-cov --ignore azure_schemaregistry_avroencoder.egg-info D:\a\_work\1\s\sdk\schemaregistry\azure-schemaregistry-avroencoder pid=6368
  whl: FAIL code 3221225477 (76.20=setup[31.47]+cmd[0.39,11.00,0.55,32.80] seconds)
  evaluation failed :( (76.38 seconds)
```
- Ubuntu312 is failing b/c of max version in dev reqs for aiohttp