### PR TITLE
Bump python stress images and addons

### DIFF
--- a/sdk/eventhub/azure-eventhub/stress/Chart.lock
+++ b/sdk/eventhub/azure-eventhub/stress/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: stress-test-addons
   repository: https://stresstestcharts.blob.core.windows.net/helm/
-  version: 0.2.0
-digest: sha256:53cbe4c0fed047f6c611523bd34181b21a310e7a3a21cb14f649bb09e4a77648
-generated: "2022-11-16T10:34:09.3008939-08:00"
+  version: 0.3.0
+digest: sha256:3e21a7fdf5d6b37e871a6dd9f755888166fbb24802aa517f51d1d9223b47656e
+generated: "2023-10-17T20:03:45.892743989-04:00"

--- a/sdk/eventhub/azure-eventhub/stress/Chart.yaml
+++ b/sdk/eventhub/azure-eventhub/stress/Chart.yaml
@@ -9,5 +9,5 @@ annotations:
 
 dependencies:
 - name: stress-test-addons
-  version: ~0.2.0
+  version: ~0.3.0
   repository: "@stress-test-charts"

--- a/sdk/eventhub/azure-eventhub/stress/Dockerfile
+++ b/sdk/eventhub/azure-eventhub/stress/Dockerfile
@@ -1,7 +1,6 @@
-# internal users should provide MCR registry to build via 'docker build . --build-arg REGISTRY="mcr.microsoft.com/mirror/docker/library/"'
-# public OSS users should simply leave this argument blank or ignore its presence entirely
-FROM mcr.microsoft.com/mirror/docker/library/python:3.8-slim
-# RUN apt-get -y update && apt-get -y install git
+FROM mcr.microsoft.com/cbl-mariner/base/python:3
+
+RUN yum update -y
 
 WORKDIR /app
 

--- a/sdk/servicebus/azure-servicebus/stress/Chart.lock
+++ b/sdk/servicebus/azure-servicebus/stress/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: stress-test-addons
   repository: https://stresstestcharts.blob.core.windows.net/helm/
-  version: 0.2.0
-digest: sha256:53cbe4c0fed047f6c611523bd34181b21a310e7a3a21cb14f649bb09e4a77648
-generated: "2023-03-14T09:57:20.6731895-07:00"
+  version: 0.3.0
+digest: sha256:3e21a7fdf5d6b37e871a6dd9f755888166fbb24802aa517f51d1d9223b47656e
+generated: "2023-10-17T20:04:32.848343767-04:00"

--- a/sdk/servicebus/azure-servicebus/stress/Chart.yaml
+++ b/sdk/servicebus/azure-servicebus/stress/Chart.yaml
@@ -9,5 +9,5 @@ annotations:
 
 dependencies:
 - name: stress-test-addons
-  version: ~0.2.0
+  version: ~0.3.0
   repository: "@stress-test-charts"

--- a/sdk/servicebus/azure-servicebus/stress/Dockerfile
+++ b/sdk/servicebus/azure-servicebus/stress/Dockerfile
@@ -1,8 +1,6 @@
-# internal users should provide MCR registry to build via 'docker build . --build-arg REGISTRY="mcr.microsoft.com/mirror/docker/library/"'
-# public OSS users should simply leave this argument blank or ignore its presence entirely
-FROM mcr.microsoft.com/mirror/docker/library/python:3.8-slim
-# Install if running off git branch
-# RUN apt-get -y update && apt-get -y install git
+FROM mcr.microsoft.com/cbl-mariner/base/python:3
+
+RUN yum update -y
 
 WORKDIR /app
 


### PR DESCRIPTION
Updating the python images to pull from latest python 3 lineage. Also updating the addons minor version to 0.3.x
