### PR TITLE
[eventhub] Fixed local variable's name typo in eventhub

### DIFF
--- a/sdk/eventhub/azure-eventhub/tests/unittest/asynctests/test_in_memory_checkpointstore.py
+++ b/sdk/eventhub/azure-eventhub/tests/unittest/asynctests/test_in_memory_checkpointstore.py
@@ -42,7 +42,7 @@ async def test_claim_existing_ownership():
     listed_ownership = await checkpoint_store.list_ownership(TEST_NAMESPACE, TEST_EVENTHUB, TEST_CONSUMER_GROUP)
     existing_ownership = listed_ownership[0]
     etag_existing = existing_ownership["etag"]
-    last_modified_exising = existing_ownership["last_modified_time"]
+    last_modified_existing = existing_ownership["last_modified_time"]
 
     time.sleep(0.01)  # so time is changed
     copied_existing_ownership = existing_ownership.copy()
@@ -54,7 +54,7 @@ async def test_claim_existing_ownership():
     assert listed_ownership2[0] == copied_existing_ownership
     assert listed_ownership2[0]["owner_id"] == "owner_1"
     assert listed_ownership2[0]["etag"] != etag_existing
-    assert listed_ownership2[0]["last_modified_time"] != last_modified_exising
+    assert listed_ownership2[0]["last_modified_time"] != last_modified_existing
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
fixed local variable's name typo(last_modified_exising -> last_modified_existing) at `sdk/eventhub/azure-eventhub/tests/unittest/asynctests/test_in_memory_checkpointstore.py` via Cspell

# Description

fixing local variable's name(last_modified_exising -> last_modified_existing) typo via Cspell

# All SDK Contribution checklist:
- [X] **The pull request does not introduce [breaking changes]**
- [X] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [X] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [X] Title of the pull request is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
