### PR TITLE
Fix identity-broker sdist

### DIFF
--- a/sdk/identity/azure-identity-broker/MANIFEST.in
+++ b/sdk/identity/azure-identity-broker/MANIFEST.in
@@ -3,4 +3,5 @@ recursive-include tests *.py
 include *.md
 include LICENSE
 include azure/__init__.py
+include azure/identity/__init__.py
 include azure/identity/broker/py.typed


### PR DESCRIPTION
Today, with the current MANIFEST.in content, we build an incorrect sdist. Which means we build empty documentation for this package. As we've made recently building the doc more strict on DevOps, those kind of error shows more visibly.