### PR TITLE
Fix azure-core tests

### DIFF
--- a/sdk/core/azure-core/dev_requirements.txt
+++ b/sdk/core/azure-core/dev_requirements.txt
@@ -1,6 +1,8 @@
 trio
 requests
-aiohttp>=3.0; python_version <= '3.11'
+# Aiohttp 3.8.6 triggers https://github.com/aio-libs/aiohttp/issues/4581 on pypy for some reasons
+aiohttp<3.8.6 ; platform_python_implementation == "PyPy"
+aiohttp ; platform_python_implementation != "PyPy"
 opencensus>=0.6.0
 opencensus-ext-azure
 opencensus-ext-threading

--- a/sdk/core/azure-core/dev_requirements.txt
+++ b/sdk/core/azure-core/dev_requirements.txt
@@ -7,3 +7,4 @@ opencensus-ext-threading
 -e ../../../tools/azure-sdk-tools
 -e ../../../tools/azure-devtools
 -e tests/testserver_tests/coretestserver
+pytest-trio

--- a/sdk/core/azure-core/tests/async_tests/conftest.py
+++ b/sdk/core/azure-core/tests/async_tests/conftest.py
@@ -31,7 +31,7 @@ import subprocess
 import sys
 import random
 import urllib
-from rest_client_async import AsyncTestRestClient
+from rest_client_async import AsyncMockRestClient
 
 
 def is_port_available(port_num):
@@ -91,4 +91,4 @@ def testserver():
 
 @pytest.fixture
 def client(port):
-    return AsyncTestRestClient(port)
+    return AsyncMockRestClient(port)

--- a/sdk/core/azure-core/tests/async_tests/rest_client_async.py
+++ b/sdk/core/azure-core/tests/async_tests/rest_client_async.py
@@ -31,7 +31,7 @@ class TestRestClientConfiguration(Configuration):
         self.authentication_policy = kwargs.get("authentication_policy")
 
 
-class AsyncTestRestClient(object):
+class AsyncMockRestClient(object):
     def __init__(self, port, **kwargs):
         self._config = TestRestClientConfiguration(**kwargs)
 

--- a/sdk/core/azure-core/tests/async_tests/test_base_polling_async.py
+++ b/sdk/core/azure-core/tests/async_tests/test_base_polling_async.py
@@ -47,7 +47,7 @@ from azure.core.polling.async_base_polling import (
     AsyncLROBasePolling,
 )
 from utils import ASYNCIO_REQUESTS_TRANSPORT_RESPONSES, request_and_responses_product, create_transport_response
-from rest_client_async import AsyncTestRestClient
+from rest_client_async import AsyncMockRestClient
 
 
 class SimpleResource:
@@ -787,7 +787,7 @@ async def test_post_final_state_via(async_pipeline_client_builder, deserializati
 @pytest.mark.asyncio
 @pytest.mark.parametrize("http_request", HTTP_REQUESTS)
 async def test_final_get_via_location(port, http_request, deserialization_cb):
-    client = AsyncTestRestClient(port)
+    client = AsyncMockRestClient(port)
     request = http_request(
         "PUT",
         "http://localhost:{}/polling/polling-with-options".format(port),

--- a/sdk/core/azure-core/tests/async_tests/test_basic_transport_async.py
+++ b/sdk/core/azure-core/tests/async_tests/test_basic_transport_async.py
@@ -983,6 +983,7 @@ class MockAiohttpContent:
         raise aiohttp.client_exceptions.ClientResponseError(request_info, None)
 
 
+@pytest.mark.asyncio
 async def test_aiohttp_errors():
     request = HttpRequest("GET", "http://example.org")
     response = AioHttpTransportResponse(request, MockAiohttpResponse())

--- a/sdk/core/azure-core/tests/async_tests/test_basic_transport_async.py
+++ b/sdk/core/azure-core/tests/async_tests/test_basic_transport_async.py
@@ -973,13 +973,13 @@ class MockAiohttpResponse:
         self.content = MockAiohttpContent()
 
     def read(self):
-        request_info = aiohttp.RequestInfo("http://example.org", "GET", {})
+        request_info = aiohttp.RequestInfo("http://example.org", "GET", {}, "http://example.org")
         raise aiohttp.client_exceptions.ClientResponseError(request_info, None)
 
 
 class MockAiohttpContent:
     async def read(self, block_size):
-        request_info = aiohttp.RequestInfo("http://example.org", "GET", {})
+        request_info = aiohttp.RequestInfo("http://example.org", "GET", {}, "http://example.org")
         raise aiohttp.client_exceptions.ClientResponseError(request_info, None)
 
 

--- a/sdk/core/azure-core/tests/async_tests/test_rest_asyncio_transport.py
+++ b/sdk/core/azure-core/tests/async_tests/test_rest_asyncio_transport.py
@@ -6,7 +6,7 @@
 from azure.core.pipeline.transport import AsyncioRequestsTransport
 from azure.core.rest import HttpRequest
 from azure.core.rest._requests_asyncio import RestAsyncioRequestsTransportResponse
-from rest_client_async import AsyncTestRestClient
+from rest_client_async import AsyncMockRestClient
 
 import pytest
 import pytest_asyncio
@@ -16,7 +16,7 @@ from utils import readonly_checks
 @pytest_asyncio.fixture
 async def client(port):
     async with AsyncioRequestsTransport() as transport:
-        async with AsyncTestRestClient(port, transport=transport) as client:
+        async with AsyncMockRestClient(port, transport=transport) as client:
             yield client
 
 

--- a/sdk/core/azure-core/tests/async_tests/test_rest_context_manager_async.py
+++ b/sdk/core/azure-core/tests/async_tests/test_rest_context_manager_async.py
@@ -7,7 +7,7 @@
 from azure.core.exceptions import ResponseNotReadError
 import pytest
 from azure.core.rest import HttpRequest
-from rest_client_async import AsyncTestRestClient
+from rest_client_async import AsyncMockRestClient
 
 
 @pytest.mark.asyncio

--- a/sdk/core/azure-core/tests/async_tests/test_rest_context_manager_async.py
+++ b/sdk/core/azure-core/tests/async_tests/test_rest_context_manager_async.py
@@ -4,7 +4,6 @@
 # Licensed under the MIT License. See LICENSE.txt in the project root for
 # license information.
 # -------------------------------------------------------------------------
-import sys
 from azure.core.exceptions import ResponseNotReadError
 import pytest
 from azure.core.rest import HttpRequest
@@ -31,10 +30,6 @@ async def test_normal_call(client):
         await _raise_and_get_text(response)
 
 
-@pytest.mark.skipif(
-    hasattr(sys, "pypy_version_info"),
-    reason="Aiohttp 3.8.6 triggers https://github.com/aio-libs/aiohttp/issues/4581 on pypy for some reason",
-)
 @pytest.mark.asyncio
 async def test_stream_call(client):
     async def _raise_and_get_text(response):

--- a/sdk/core/azure-core/tests/async_tests/test_rest_context_manager_async.py
+++ b/sdk/core/azure-core/tests/async_tests/test_rest_context_manager_async.py
@@ -4,6 +4,7 @@
 # Licensed under the MIT License. See LICENSE.txt in the project root for
 # license information.
 # -------------------------------------------------------------------------
+import sys
 from azure.core.exceptions import ResponseNotReadError
 import pytest
 from azure.core.rest import HttpRequest
@@ -30,6 +31,10 @@ async def test_normal_call(client):
         await _raise_and_get_text(response)
 
 
+@pytest.mark.skipif(
+    hasattr(sys, "pypy_version_info"),
+    reason="Aiohttp 3.8.6 triggers https://github.com/aio-libs/aiohttp/issues/4581 on pypy for some reason",
+)
 @pytest.mark.asyncio
 async def test_stream_call(client):
     async def _raise_and_get_text(response):

--- a/sdk/core/azure-core/tests/async_tests/test_rest_headers_async.py
+++ b/sdk/core/azure-core/tests/async_tests/test_rest_headers_async.py
@@ -71,9 +71,6 @@ async def test_headers_response_keys(get_response_headers):
     assert set(h.keys()) == set(ref_dict.keys())
 
 
-@pytest.mark.skipif(
-    platform.python_implementation() == "PyPy", reason="https://github.com/aio-libs/aiohttp/issues/5967"
-)
 @pytest.mark.asyncio
 async def test_headers_response_keys_mutability(get_response_headers):
     h = await get_response_headers(HttpRequest("GET", "/headers/duplicate/numbers"))
@@ -95,9 +92,6 @@ async def test_headers_response_values(get_response_headers):
     assert set(h.values()) == set(ref_dict.values())
 
 
-@pytest.mark.skipif(
-    platform.python_implementation() == "PyPy", reason="https://github.com/aio-libs/aiohttp/issues/5967"
-)
 @pytest.mark.asyncio
 async def test_headers_response_values_mutability(get_response_headers):
     h = await get_response_headers(HttpRequest("GET", "/headers/duplicate/numbers"))
@@ -123,9 +117,6 @@ async def test_headers_response_items(get_response_headers):
     assert set(h.items()) == set(ref_dict.items())
 
 
-@pytest.mark.skipif(
-    platform.python_implementation() == "PyPy", reason="https://github.com/aio-libs/aiohttp/issues/5967"
-)
 @pytest.mark.asyncio
 async def test_headers_response_items_mutability(get_response_headers):
     h = await get_response_headers(HttpRequest("GET", "/headers/duplicate/numbers"))

--- a/sdk/core/azure-core/tests/async_tests/test_rest_response_backcompat_async.py
+++ b/sdk/core/azure-core/tests/async_tests/test_rest_response_backcompat_async.py
@@ -71,6 +71,10 @@ def _test_response_attr_parity(old_response, new_response):
             assert hasattr(new_response, attr)
 
 
+@pytest.mark.skipif(
+    hasattr(sys, "pypy_version_info"),
+    reason="Aiohttp 3.8.6 triggers https://github.com/aio-libs/aiohttp/issues/4581 on pypy for some reason",
+)
 @pytest.mark.asyncio
 @pytest.mark.parametrize("transport", TRANSPORTS)
 async def test_response_attr_parity(get_old_response, get_new_response, transport):
@@ -101,6 +105,10 @@ def _test_response_set_attrs(old_response, new_response):
             assert getattr(old_response, attr) == getattr(new_response, attr) == "foo"
 
 
+@pytest.mark.skipif(
+    hasattr(sys, "pypy_version_info"),
+    reason="Aiohttp 3.8.6 triggers https://github.com/aio-libs/aiohttp/issues/4581 on pypy for some reason",
+)
 @pytest.mark.asyncio
 @pytest.mark.parametrize("transport", TRANSPORTS)
 async def test_response_set_attrs(get_old_response, get_new_response, transport):
@@ -123,6 +131,10 @@ def _test_response_block_size(old_response, new_response):
     assert old_response.block_size == new_response.block_size == 500
 
 
+@pytest.mark.skipif(
+    hasattr(sys, "pypy_version_info"),
+    reason="Aiohttp 3.8.6 triggers https://github.com/aio-libs/aiohttp/issues/4581 on pypy for some reason",
+)
 @pytest.mark.asyncio
 @pytest.mark.parametrize("transport", TRANSPORTS)
 async def test_response_block_size(get_old_response, get_new_response, transport):
@@ -136,6 +148,7 @@ async def test_response_block_size_trio(get_old_response_trio, get_new_response_
     old_response = await get_old_response_trio()
     new_response = await get_new_response_trio()
     _test_response_block_size(old_response, new_response)
+
 
 @pytest.mark.skipif(
     hasattr(sys, "pypy_version_info"),
@@ -215,6 +228,10 @@ def _test_response_request(old_response, new_response, port):
     assert old_response.request == new_response.request == "foo"
 
 
+@pytest.mark.skipif(
+    hasattr(sys, "pypy_version_info"),
+    reason="Aiohttp 3.8.6 triggers https://github.com/aio-libs/aiohttp/issues/4581 on pypy for some reason",
+)
 @pytest.mark.asyncio
 @pytest.mark.parametrize("transport", TRANSPORTS)
 async def test_response_request(get_old_response, get_new_response, port, transport):
@@ -237,6 +254,10 @@ def _test_response_status_code(old_response, new_response):
     assert old_response.status_code == new_response.status_code == 202
 
 
+@pytest.mark.skipif(
+    hasattr(sys, "pypy_version_info"),
+    reason="Aiohttp 3.8.6 triggers https://github.com/aio-libs/aiohttp/issues/4581 on pypy for some reason",
+)
 @pytest.mark.asyncio
 @pytest.mark.parametrize("transport", TRANSPORTS)
 async def test_response_status_code(get_old_response, get_new_response, transport):
@@ -289,6 +310,10 @@ def _test_response_reason(old_response, new_response):
     assert old_response.reason == new_response.reason == "Not OK"
 
 
+@pytest.mark.skipif(
+    hasattr(sys, "pypy_version_info"),
+    reason="Aiohttp 3.8.6 triggers https://github.com/aio-libs/aiohttp/issues/4581 on pypy for some reason",
+)
 @pytest.mark.asyncio
 @pytest.mark.parametrize("transport", TRANSPORTS)
 async def test_response_reason(get_old_response, get_new_response, transport):

--- a/sdk/core/azure-core/tests/async_tests/test_rest_response_backcompat_async.py
+++ b/sdk/core/azure-core/tests/async_tests/test_rest_response_backcompat_async.py
@@ -4,6 +4,7 @@
 # Licensed under the MIT License. See LICENSE.txt in the project root for
 # license information.
 # -------------------------------------------------------------------------
+import sys
 import pytest
 import pytest_asyncio
 from azure.core.pipeline.transport import HttpRequest as PipelineTransportHttpRequest
@@ -136,7 +137,10 @@ async def test_response_block_size_trio(get_old_response_trio, get_new_response_
     new_response = await get_new_response_trio()
     _test_response_block_size(old_response, new_response)
 
-
+@pytest.mark.skipif(
+    hasattr(sys, "pypy_version_info"),
+    reason="Aiohttp 3.8.6 triggers https://github.com/aio-libs/aiohttp/issues/4581 on pypy for some reason",
+)
 @pytest.mark.asyncio
 @pytest.mark.parametrize("transport", TRANSPORTS)
 async def test_response_body(get_old_response, get_new_response, transport):
@@ -259,6 +263,10 @@ def _test_response_headers(old_response, new_response):
     assert old_response.headers == new_response.headers == {"Hello": "world!"}
 
 
+@pytest.mark.skipif(
+    hasattr(sys, "pypy_version_info"),
+    reason="Aiohttp 3.8.6 triggers https://github.com/aio-libs/aiohttp/issues/4581 on pypy for some reason",
+)
 @pytest.mark.asyncio
 @pytest.mark.parametrize("transport", TRANSPORTS)
 async def test_response_headers(get_old_response, get_new_response, transport):

--- a/sdk/core/azure-core/tests/async_tests/test_rest_response_backcompat_async.py
+++ b/sdk/core/azure-core/tests/async_tests/test_rest_response_backcompat_async.py
@@ -10,7 +10,7 @@ from azure.core.pipeline.transport import HttpRequest as PipelineTransportHttpRe
 from azure.core.rest import HttpRequest as RestHttpRequest
 from azure.core.pipeline import Pipeline
 from azure.core.pipeline.transport import AioHttpTransport, AsyncioRequestsTransport, TrioRequestsTransport
-from rest_client_async import AsyncTestRestClient
+from rest_client_async import AsyncMockRestClient
 
 TRANSPORTS = [AioHttpTransport, AsyncioRequestsTransport]
 
@@ -362,8 +362,8 @@ async def test_response_parts(port, transport):
     # there's no support for trio + multipart rn
     old_request = _create_multiapart_request(PipelineTransportHttpRequest)
     new_request = _create_multiapart_request(RestHttpRequest)
-    old_response = await AsyncTestRestClient(port, transport=transport()).send_request(old_request, stream=True)
-    new_response = await AsyncTestRestClient(port, transport=transport()).send_request(new_request, stream=True)
+    old_response = await AsyncMockRestClient(port, transport=transport()).send_request(old_request, stream=True)
+    new_response = await AsyncMockRestClient(port, transport=transport()).send_request(new_request, stream=True)
     if hasattr(old_response, "load_body"):
         # only aiohttp has this attr
         await old_response.load_body()

--- a/sdk/core/azure-core/tests/async_tests/test_rest_response_backcompat_async.py
+++ b/sdk/core/azure-core/tests/async_tests/test_rest_response_backcompat_async.py
@@ -71,10 +71,6 @@ def _test_response_attr_parity(old_response, new_response):
             assert hasattr(new_response, attr)
 
 
-@pytest.mark.skipif(
-    hasattr(sys, "pypy_version_info"),
-    reason="Aiohttp 3.8.6 triggers https://github.com/aio-libs/aiohttp/issues/4581 on pypy for some reason",
-)
 @pytest.mark.asyncio
 @pytest.mark.parametrize("transport", TRANSPORTS)
 async def test_response_attr_parity(get_old_response, get_new_response, transport):
@@ -105,10 +101,6 @@ def _test_response_set_attrs(old_response, new_response):
             assert getattr(old_response, attr) == getattr(new_response, attr) == "foo"
 
 
-@pytest.mark.skipif(
-    hasattr(sys, "pypy_version_info"),
-    reason="Aiohttp 3.8.6 triggers https://github.com/aio-libs/aiohttp/issues/4581 on pypy for some reason",
-)
 @pytest.mark.asyncio
 @pytest.mark.parametrize("transport", TRANSPORTS)
 async def test_response_set_attrs(get_old_response, get_new_response, transport):
@@ -131,10 +123,6 @@ def _test_response_block_size(old_response, new_response):
     assert old_response.block_size == new_response.block_size == 500
 
 
-@pytest.mark.skipif(
-    hasattr(sys, "pypy_version_info"),
-    reason="Aiohttp 3.8.6 triggers https://github.com/aio-libs/aiohttp/issues/4581 on pypy for some reason",
-)
 @pytest.mark.asyncio
 @pytest.mark.parametrize("transport", TRANSPORTS)
 async def test_response_block_size(get_old_response, get_new_response, transport):
@@ -150,10 +138,6 @@ async def test_response_block_size_trio(get_old_response_trio, get_new_response_
     _test_response_block_size(old_response, new_response)
 
 
-@pytest.mark.skipif(
-    hasattr(sys, "pypy_version_info"),
-    reason="Aiohttp 3.8.6 triggers https://github.com/aio-libs/aiohttp/issues/4581 on pypy for some reason",
-)
 @pytest.mark.asyncio
 @pytest.mark.parametrize("transport", TRANSPORTS)
 async def test_response_body(get_old_response, get_new_response, transport):
@@ -228,10 +212,6 @@ def _test_response_request(old_response, new_response, port):
     assert old_response.request == new_response.request == "foo"
 
 
-@pytest.mark.skipif(
-    hasattr(sys, "pypy_version_info"),
-    reason="Aiohttp 3.8.6 triggers https://github.com/aio-libs/aiohttp/issues/4581 on pypy for some reason",
-)
 @pytest.mark.asyncio
 @pytest.mark.parametrize("transport", TRANSPORTS)
 async def test_response_request(get_old_response, get_new_response, port, transport):
@@ -254,10 +234,6 @@ def _test_response_status_code(old_response, new_response):
     assert old_response.status_code == new_response.status_code == 202
 
 
-@pytest.mark.skipif(
-    hasattr(sys, "pypy_version_info"),
-    reason="Aiohttp 3.8.6 triggers https://github.com/aio-libs/aiohttp/issues/4581 on pypy for some reason",
-)
 @pytest.mark.asyncio
 @pytest.mark.parametrize("transport", TRANSPORTS)
 async def test_response_status_code(get_old_response, get_new_response, transport):
@@ -284,10 +260,6 @@ def _test_response_headers(old_response, new_response):
     assert old_response.headers == new_response.headers == {"Hello": "world!"}
 
 
-@pytest.mark.skipif(
-    hasattr(sys, "pypy_version_info"),
-    reason="Aiohttp 3.8.6 triggers https://github.com/aio-libs/aiohttp/issues/4581 on pypy for some reason",
-)
 @pytest.mark.asyncio
 @pytest.mark.parametrize("transport", TRANSPORTS)
 async def test_response_headers(get_old_response, get_new_response, transport):
@@ -310,10 +282,6 @@ def _test_response_reason(old_response, new_response):
     assert old_response.reason == new_response.reason == "Not OK"
 
 
-@pytest.mark.skipif(
-    hasattr(sys, "pypy_version_info"),
-    reason="Aiohttp 3.8.6 triggers https://github.com/aio-libs/aiohttp/issues/4581 on pypy for some reason",
-)
 @pytest.mark.asyncio
 @pytest.mark.parametrize("transport", TRANSPORTS)
 async def test_response_reason(get_old_response, get_new_response, transport):

--- a/sdk/core/azure-core/tests/async_tests/test_rest_stream_responses_async.py
+++ b/sdk/core/azure-core/tests/async_tests/test_rest_stream_responses_async.py
@@ -3,18 +3,10 @@
 # Licensed under the MIT License. See LICENSE.txt in the project root for
 # license information.
 # -------------------------------------------------------------------------
-import sys
 from azure.core.exceptions import HttpResponseError, ServiceRequestError
 import pytest
 from azure.core.rest import HttpRequest
 from azure.core.exceptions import StreamClosedError, StreamConsumedError, ResponseNotReadError
-
-
-if hasattr(sys, "pypy_version_info"):
-    pytest.skip(
-        "Aiohttp 3.8.6 triggers https://github.com/aio-libs/aiohttp/issues/4581 on pypy for some reason",
-        allow_module_level=True,
-    )
 
 
 @pytest.mark.asyncio

--- a/sdk/core/azure-core/tests/async_tests/test_rest_stream_responses_async.py
+++ b/sdk/core/azure-core/tests/async_tests/test_rest_stream_responses_async.py
@@ -3,10 +3,18 @@
 # Licensed under the MIT License. See LICENSE.txt in the project root for
 # license information.
 # -------------------------------------------------------------------------
+import sys
 from azure.core.exceptions import HttpResponseError, ServiceRequestError
 import pytest
 from azure.core.rest import HttpRequest
 from azure.core.exceptions import StreamClosedError, StreamConsumedError, ResponseNotReadError
+
+
+if hasattr(sys, "pypy_version_info"):
+    pytest.skip(
+        "Aiohttp 3.8.6 triggers https://github.com/aio-libs/aiohttp/issues/4581 on pypy for some reason",
+        allow_module_level=True,
+    )
 
 
 @pytest.mark.asyncio

--- a/sdk/core/azure-core/tests/async_tests/test_rest_trio_transport.py
+++ b/sdk/core/azure-core/tests/async_tests/test_rest_trio_transport.py
@@ -6,7 +6,7 @@
 from azure.core.pipeline.transport import TrioRequestsTransport
 from azure.core.rest import HttpRequest
 from azure.core.rest._requests_trio import RestTrioRequestsTransportResponse
-from rest_client_async import AsyncTestRestClient
+from rest_client_async import AsyncMockRestClient
 from utils import readonly_checks
 import pytest
 
@@ -14,7 +14,7 @@ import pytest
 @pytest.fixture
 async def client(port):
     async with TrioRequestsTransport() as transport:
-        async with AsyncTestRestClient(port, transport=transport) as client:
+        async with AsyncMockRestClient(port, transport=transport) as client:
             yield client
 
 

--- a/sdk/core/azure-core/tests/conftest.py
+++ b/sdk/core/azure-core/tests/conftest.py
@@ -31,7 +31,7 @@ import subprocess
 import random
 import platform
 import urllib
-from rest_client import TestRestClient
+from rest_client import MockRestClient
 import sys
 
 # If opencensus is loadable while doing these tests, register an empty tracer to avoid this:
@@ -107,4 +107,4 @@ def testserver():
 
 @pytest.fixture
 def client(port):
-    return TestRestClient(port)
+    return MockRestClient(port)

--- a/sdk/core/azure-core/tests/rest_client.py
+++ b/sdk/core/azure-core/tests/rest_client.py
@@ -50,7 +50,7 @@ class TestRestClientConfiguration(Configuration):
         self.authentication_policy = kwargs.get("authentication_policy")
 
 
-class TestRestClient(object):
+class MockRestClient(object):
     def __init__(self, port, **kwargs):
         self._config = TestRestClientConfiguration(**kwargs)
         self._client = PipelineClient(base_url="http://localhost:{}/".format(port), config=self._config, **kwargs)

--- a/sdk/core/azure-core/tests/test_base_polling.py
+++ b/sdk/core/azure-core/tests/test_base_polling.py
@@ -50,7 +50,7 @@ from azure.core.polling.base_polling import LROBasePolling, OperationResourcePol
 from azure.core.pipeline.policies._utils import _FixedOffset
 from utils import request_and_responses_product, REQUESTS_TRANSPORT_RESPONSES, create_transport_response, HTTP_REQUESTS
 from azure.core.pipeline._tools import is_rest
-from rest_client import TestRestClient
+from rest_client import MockRestClient
 
 
 class SimpleResource:
@@ -800,7 +800,7 @@ class TestBasePolling(object):
 
 @pytest.mark.parametrize("http_request", HTTP_REQUESTS)
 def test_final_get_via_location(port, http_request, deserialization_cb):
-    client = TestRestClient(port)
+    client = MockRestClient(port)
     request = http_request(
         "PUT",
         "http://localhost:{}/polling/polling-with-options".format(port),

--- a/sdk/core/azure-core/tests/test_rest_http_request.py
+++ b/sdk/core/azure-core/tests/test_rest_http_request.py
@@ -21,7 +21,7 @@ from azure.core.configuration import Configuration
 from azure.core.rest import HttpRequest
 from azure.core.pipeline.policies import CustomHookPolicy, UserAgentPolicy, SansIOHTTPPolicy, RetryPolicy
 from azure.core.pipeline._tools import is_rest
-from rest_client import TestRestClient
+from rest_client import MockRestClient
 from azure.core import PipelineClient
 
 
@@ -350,7 +350,7 @@ def test_request_policies_raw_request_hook(port):
 
     custom_hook_policy = CustomHookPolicy(raw_request_hook=callback)
     policies = [UserAgentPolicy("myuseragent"), custom_hook_policy]
-    client = TestRestClient(port=port, policies=policies)
+    client = MockRestClient(port=port, policies=policies)
 
     with pytest.raises(ValueError) as ex:
         client.send_request(request)
@@ -397,7 +397,7 @@ def test_request_policies_chain(port):
         OldPolicySerializeRequest(),
     ]
     request = HttpRequest("DELETE", "/container0/blob0")
-    client = TestRestClient(port="5000", policies=policies)
+    client = MockRestClient(port="5000", policies=policies)
     with pytest.raises(ValueError) as ex:
         client.send_request(
             request,
@@ -431,7 +431,7 @@ def test_per_call_policies_old_then_new(port):
     pipeline_client = PipelineClient(
         base_url="http://localhost:{}".format(port), config=config, per_call_policies=[OldPolicy(), NewPolicy()]
     )
-    client = TestRestClient(port=port)
+    client = MockRestClient(port=port)
     client._client = pipeline_client
 
     with pytest.raises(ValueError) as ex:

--- a/sdk/core/azure-core/tests/test_rest_response_backcompat.py
+++ b/sdk/core/azure-core/tests/test_rest_response_backcompat.py
@@ -5,7 +5,7 @@
 # license information.
 # -------------------------------------------------------------------------
 import sys
-from rest_client import TestRestClient
+from rest_client import MockRestClient
 import pytest
 from azure.core.pipeline.transport import HttpRequest as PipelineTransportHttpRequest
 from azure.core.rest import HttpRequest as RestHttpRequest
@@ -161,7 +161,7 @@ def test_response_parts(port):
     old_request = _create_multiapart_request(PipelineTransportHttpRequest)
     new_request = _create_multiapart_request(RestHttpRequest)
 
-    old_response = TestRestClient(port).send_request(old_request, stream=True)
-    new_response = TestRestClient(port).send_request(new_request, stream=True)
+    old_response = MockRestClient(port).send_request(old_request, stream=True)
+    new_response = MockRestClient(port).send_request(new_request, stream=True)
     _test_parts(old_response)
     _test_parts(new_response)


### PR DESCRIPTION
While testing the pypy39 issue, discovered that some warnings from pytest were correct, and some tests were never executed. Also some naming was causing confusion with the test colletion from pytest.