### PR TITLE
[Monitor][Ingestion] Add check for logs input type

### DIFF
--- a/sdk/monitor/azure-monitor-ingestion/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-ingestion/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+- Add type validation for the `logs` parameter in the `upload` method. ([#32591](https://github.com/Azure/azure-sdk-for-python/pull/32591/))
+
 ## 1.0.2 (2023-06-15)
 
 ### Bugs Fixed

--- a/sdk/monitor/azure-monitor-ingestion/TROUBLESHOOTING.md
+++ b/sdk/monitor/azure-monitor-ingestion/TROUBLESHOOTING.md
@@ -90,7 +90,7 @@ When you send logs to Azure Monitor for ingestion, the request may succeed, but 
 
 * Verify that the custom table specified in the DCR exists in the Log Analytics workspace. Ensure that you provide the accurate name of the custom table to the upload method. Mismatched table names can lead to logs not being stored correctly.
 
-* Confirm that the logs you're sending adhere to the format expected by the DCR. The data should be in the form of a JSON object or array, structured according to the requirements specified in the DCR. Additionally, it's essential to encode the request body in UTF-8 to avoid any data transmission issues.
+* Confirm that the logs you're sending adhere to the format expected by the DCR. The data should be an array of JSON objects, structured according to the requirements specified in the DCR. Additionally, it's essential to encode the request body in UTF-8 to avoid any data transmission issues.
 
 * Keep in mind that data ingestion may take some time, especially if you're sending data to a specific table for the first time. In such cases, allow up to 15 minutes for the data to be fully ingested and available for querying and analysis.
 

--- a/sdk/monitor/azure-monitor-ingestion/azure/monitor/ingestion/_operations/_patch.py
+++ b/sdk/monitor/azure-monitor-ingestion/azure/monitor/ingestion/_operations/_patch.py
@@ -6,6 +6,7 @@
 
 Follow our quickstart for examples: https://aka.ms/azsdk/python/dpcodegen/python/customize
 """
+from collections.abc import Sequence
 from io import IOBase
 import logging
 import sys
@@ -66,6 +67,9 @@ class LogsIngestionClientOperationsMixin(GeneratedOps):
 
             super()._upload(rule_id, stream=stream_name, body=logs, content_encoding=content_encoding, **kwargs)
             return
+
+        if not isinstance(logs, Sequence):
+            raise ValueError("The 'logs' parameter must be a list of JSON objects or an I/O stream that is readable.")
 
         for gzip_data, log_chunk in _create_gzip_requests(cast(List[JSON], logs)):
             try:

--- a/sdk/monitor/azure-monitor-ingestion/azure/monitor/ingestion/aio/_operations/_patch.py
+++ b/sdk/monitor/azure-monitor-ingestion/azure/monitor/ingestion/aio/_operations/_patch.py
@@ -6,6 +6,7 @@
 
 Follow our quickstart for examples: https://aka.ms/azsdk/python/dpcodegen/python/customize
 """
+from collections.abc import Sequence
 from io import IOBase
 import logging
 import sys
@@ -66,6 +67,9 @@ class LogsIngestionClientOperationsMixin(GeneratedOps):
 
             await super()._upload(rule_id, stream=stream_name, body=logs, content_encoding=content_encoding, **kwargs)
             return
+
+        if not isinstance(logs, Sequence):
+            raise ValueError("The 'logs' parameter must be a list of JSON objects or an I/O stream that is readable.")
 
         for gzip_data, log_chunk in _create_gzip_requests(cast(List[JSON], logs)):
             try:

--- a/sdk/monitor/azure-monitor-ingestion/tests/test_logs_ingestion.py
+++ b/sdk/monitor/azure-monitor-ingestion/tests/test_logs_ingestion.py
@@ -100,7 +100,6 @@ class TestLogsIngestionClient(AzureRecordedTestCase):
             client.upload(rule_id=monitor_info['dcr_id'], stream_name=monitor_info['stream_name'], logs=f)
         os.remove(temp_file)
 
-
     def test_abort_error_handler(self, monitor_info):
         client = self.create_client_from_credential(
             LogsIngestionClient, self.get_credential(LogsIngestionClient), endpoint=monitor_info['dce'])
@@ -140,3 +139,11 @@ class TestLogsIngestionClient(AzureRecordedTestCase):
                         on_error=on_error)
 
         assert on_error.called
+
+    def test_invalid_logs_format(self, monitor_info):
+        client = self.create_client_from_credential(
+            LogsIngestionClient, self.get_credential(LogsIngestionClient), endpoint=monitor_info['dce'])
+
+        body = {"foo": "bar"}
+        with pytest.raises(ValueError):
+            client.upload(rule_id="rule", stream_name="stream", logs=body)

--- a/sdk/monitor/azure-monitor-ingestion/tests/test_logs_ingestion_async.py
+++ b/sdk/monitor/azure-monitor-ingestion/tests/test_logs_ingestion_async.py
@@ -122,13 +122,11 @@ class TestLogsIngestionClientAsync(AzureRecordedTestCase):
         os.remove(temp_file)
         await credential.close()
 
-
     @pytest.mark.asyncio
     async def test_abort_error_handler(self, monitor_info):
         credential = self.get_credential(LogsIngestionClient, is_async=True)
         client = self.create_client_from_credential(
             LogsIngestionClient, credential, endpoint=monitor_info['dce'])
-        body = [{"foo": "bar"}]
 
         class TestException(Exception):
             pass
@@ -165,4 +163,15 @@ class TestLogsIngestionClientAsync(AzureRecordedTestCase):
                         on_error=on_error)
 
             assert on_error.called
+        await credential.close()
+
+    @pytest.mark.asyncio
+    async def test_invalid_logs_format(self, monitor_info):
+        credential = self.get_credential(LogsIngestionClient, is_async=True)
+        client = self.create_client_from_credential(LogsIngestionClient, credential, endpoint=monitor_info['dce'])
+
+        body = {"foo": "bar"}
+        async with client:
+            with pytest.raises(ValueError):
+                await client.upload(rule_id="rule", stream_name="stream", logs=body)
         await credential.close()


### PR DESCRIPTION
In some cases, a user may pass a dictionary to the upload method where a list is expected. Since, a dictionary is still iterable, the keys of the dictionary will be looped through, gzipped, and sent to the service. The user will still get a 204 response, but the data won't show in the workspace because the data was mangled in the gzipping process.

This adds a check to the upload method that will let users know if their input isn't the correct type.

Closes: #32562
