### PR TITLE
[CI] Updates for improved `corehttp` testing

### DIFF
--- a/eng/pipelines/templates/stages/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tests.yml
@@ -155,7 +155,7 @@ stages:
         timeoutInMinutes: 90
 
         variables:
-          PythonVersion: '3.7'
+          PythonVersion: '3.8'
 
         pool:
           name: azsdk-pool-mms-ubuntu-2004-general
@@ -163,9 +163,9 @@ stages:
 
         steps:
           - task: UsePythonVersion@0
-            displayName: 'Use Python 3.7'
+            displayName: 'Use Python 3.8'
             inputs:
-             versionSpec: '3.7'
+             versionSpec: '3.8'
           - script: |
               python -m pip install setuptools==58.3.0
               python -m pip install -r eng/ci_tools.txt
@@ -176,9 +176,9 @@ stages:
             inputs:
               scriptPath: 'scripts/devops_tasks/dispatch_tox.py'
               arguments: >-
-                "azure*" 
-                --mark_arg="${{ parameters.TestMarkArgument }}" 
-                --service="${{ parameters.ServiceDirectory }}" 
+                ${{ parameters.BuildTargetingString }}
+                --mark_arg="${{ parameters.TestMarkArgument }}"
+                --service="${{ parameters.ServiceDirectory }}"
                 --toxenv="next-pylint"
                 --disablecov
                 --filter-type="Omit_management"
@@ -191,9 +191,9 @@ stages:
             inputs:
               scriptPath: 'scripts/devops_tasks/dispatch_tox.py'
               arguments: >-
-                "azure*" 
-                --mark_arg="${{ parameters.TestMarkArgument }}" 
-                --service="${{ parameters.ServiceDirectory }}" 
+                ${{ parameters.BuildTargetingString }}
+                --mark_arg="${{ parameters.TestMarkArgument }}"
+                --service="${{ parameters.ServiceDirectory }}"
                 --toxenv="next-mypy"
                 --disablecov
             env:
@@ -205,7 +205,7 @@ stages:
             inputs:
               scriptPath: 'scripts/devops_tasks/dispatch_tox.py'
               arguments: >-
-                "azure*"
+                ${{ parameters.BuildTargetingString }}
                 --mark_arg="${{ parameters.TestMarkArgument }}"
                 --service="${{ parameters.ServiceDirectory }}"
                 --toxenv="next-pyright"
@@ -219,9 +219,9 @@ stages:
             inputs:
               scriptPath: 'scripts/devops_tasks/dispatch_tox.py'
               arguments: >-
-                "azure*" 
-                --mark_arg="${{ parameters.TestMarkArgument }}" 
-                --service="${{ parameters.ServiceDirectory }}" 
+                ${{ parameters.BuildTargetingString }}
+                --mark_arg="${{ parameters.TestMarkArgument }}"
+                --service="${{ parameters.ServiceDirectory }}"
                 --toxenv="ruff"
                 --disablecov
             env: ${{ parameters.EnvVars }}

--- a/eng/pipelines/templates/steps/analyze.yml
+++ b/eng/pipelines/templates/steps/analyze.yml
@@ -29,7 +29,7 @@ steps:
     displayName: 'Set Tox Environment Skips'
     inputs:
       scriptPath: 'scripts/devops_tasks/set_tox_environment.py'
-      arguments: '--team-project="$(System.TeamProject)" --service="${{ parameters.ServiceDirectory }}"'
+      arguments: '"$(TargetingString)" --team-project="$(System.TeamProject)" --service="${{ parameters.ServiceDirectory }}"'
 
   - ${{ each artifact in parameters.Artifacts }}:
     - ${{if ne(artifact.skipVerifyChangeLog, 'true')}}:

--- a/eng/pipelines/templates/steps/run_black.yml
+++ b/eng/pipelines/templates/steps/run_black.yml
@@ -5,9 +5,9 @@ parameters:
 
 steps:
   - task: UsePythonVersion@0
-    displayName: 'Use Python 3.7'
+    displayName: 'Use Python 3.8'
     inputs:
-     versionSpec: '3.7'
+     versionSpec: '3.8'
     condition: succeededOrFailed()
 
   - script: |
@@ -20,6 +20,7 @@ steps:
     inputs:
       scriptPath: 'scripts/devops_tasks/validate_formatting.py'
       arguments: >-
+        "$(TargetingString)"
         --service_directory="${{ parameters.ServiceDirectory }}"
         --validate="${{ parameters.ValidateFormatting }}"
     env: ${{ parameters.EnvVars }}

--- a/eng/pipelines/templates/steps/run_mypy.yml
+++ b/eng/pipelines/templates/steps/run_mypy.yml
@@ -12,9 +12,9 @@ parameters:
 # Please use `$(TargetingString)` to refer to the python packages glob string. This was previously `${{ parameters.BuildTargetingString }}`.
 steps:
   - task: UsePythonVersion@0
-    displayName: 'Use Python 3.7'
+    displayName: 'Use Python 3.8'
     inputs:
-     versionSpec: '3.7'
+     versionSpec: '3.8'
     condition: and(succeededOrFailed(), ne(variables['Skip.MyPy'],'true'))
 
   - script: |
@@ -27,9 +27,9 @@ steps:
     inputs:
       scriptPath: 'scripts/devops_tasks/dispatch_tox.py'
       arguments: >-
-        "$(TargetingString)" 
-        --mark_arg="${{ parameters.TestMarkArgument }}" 
-        --service="${{ parameters.ServiceDirectory }}" 
+        "$(TargetingString)"
+        --mark_arg="${{ parameters.TestMarkArgument }}"
+        --service="${{ parameters.ServiceDirectory }}"
         --toxenv="mypy"
         --disablecov
     env: ${{ parameters.EnvVars }}

--- a/eng/pipelines/templates/steps/run_pylint.yml
+++ b/eng/pipelines/templates/steps/run_pylint.yml
@@ -11,10 +11,10 @@ parameters:
 # Please use `$(TargetingString)` to refer to the python packages glob string. This was previously `${{ parameters.BuildTargetingString }}`.
 steps:
   - task: UsePythonVersion@0
-    displayName: 'Use Python 3.7'
+    displayName: 'Use Python 3.8'
     inputs:
-     versionSpec: '3.7'
-    condition: and(succeededOrFailed(), ne(variables['Skip.Pylint'],'true'))    
+     versionSpec: '3.8'
+    condition: and(succeededOrFailed(), ne(variables['Skip.Pylint'],'true'))
 
   - script: |
       python -m pip install -r eng/ci_tools.txt
@@ -26,9 +26,9 @@ steps:
     inputs:
       scriptPath: 'scripts/devops_tasks/dispatch_tox.py'
       arguments: >-
-        "$(TargetingString)" 
-        --mark_arg="${{ parameters.TestMarkArgument }}" 
-        --service="${{ parameters.ServiceDirectory }}" 
+        "$(TargetingString)"
+        --mark_arg="${{ parameters.TestMarkArgument }}"
+        --service="${{ parameters.ServiceDirectory }}"
         --toxenv="pylint"
         --disablecov
         --filter-type="Omit_management"

--- a/eng/pipelines/templates/steps/run_pyright.yml
+++ b/eng/pipelines/templates/steps/run_pyright.yml
@@ -11,9 +11,9 @@ parameters:
 # Please use `$(TargetingString)` to refer to the python packages glob string. This was previously `${{ parameters.BuildTargetingString }}`.
 steps:
   - task: UsePythonVersion@0
-    displayName: 'Use Python 3.7'
+    displayName: 'Use Python 3.8'
     inputs:
-     versionSpec: '3.7'
+     versionSpec: '3.8'
     condition: and(succeededOrFailed(), or(ne(variables['Skip.Pyright'],'true'), ne(variables['Skip.Verifytypes'],'true')))
 
   - script: |

--- a/eng/tox/tox.ini
+++ b/eng/tox/tox.ini
@@ -77,7 +77,7 @@ commands =
 
 [testenv:pylint]
 description=Lints a package with pylint (version {[testenv:pylint]pylint_version})
-basepython = python37
+basepython = python38
 pylint_version=2.15.8
 skipsdist = true
 skip_install = true
@@ -102,7 +102,7 @@ commands =
 
 [testenv:next-pylint]
 description=Lints a package with pylint (version {[testenv:next-pylint]pylint_version})
-basepython = python37
+basepython = python38
 pylint_version=2.15.8
 skipsdist = true
 skip_install = true

--- a/scripts/devops_tasks/set_tox_environment.py
+++ b/scripts/devops_tasks/set_tox_environment.py
@@ -42,9 +42,8 @@ def remove_unsupported_values(selected_set: List[str], unsupported_values: List[
             selected_set.remove(unsupported_tox_env)
 
 
-def process_ci_skips(service: str) -> None:
+def process_ci_skips(glob_string: str, service: str ) -> None:
     checks_with_global_skip = ["pylint", "verifywhl", "verifysdist" "bandit", "mypy", "pyright", "verifytypes"]
-
     root_dir = os.path.abspath(os.path.join(os.path.abspath(__file__), "..", "..", ".."))
 
     if service:
@@ -52,7 +51,7 @@ def process_ci_skips(service: str) -> None:
     else:
         target_dir = root_dir
 
-    targeted_packages = discover_targeted_packages("azure*", target_dir)
+    targeted_packages = discover_targeted_packages(glob_string, target_dir)
 
     for check in checks_with_global_skip:
         packages_running_check = []
@@ -76,6 +75,15 @@ if __name__ == "__main__":
         description="This script is used to resolve a set of arguments (that correspond to devops runtime variables) and determine which tox environments should be run for the current job. "
         + "When running against a specific service directory, attempts to find entire analysis steps that can be skipped. EG if pylint is disabled for every package in a given service directory, that "
         + "step should never actually run."
+    )
+
+    parser.add_argument(
+        "glob_string",
+        nargs="?",
+        help=(
+            "A comma separated list of glob strings that will target the top level directories that contain packages. "
+            'Examples: All == "azure-*", Single = "azure-keyvault"'
+        ),
     )
 
     parser.add_argument("-t", "--team-project", dest="team_project", help="", required=True)
@@ -127,4 +135,4 @@ if __name__ == "__main__":
     set_devops_value(selected_set)
 
     if args.service:
-        process_ci_skips(args.service)
+        process_ci_skips(args.glob_string, args.service)

--- a/scripts/devops_tasks/validate_formatting.py
+++ b/scripts/devops_tasks/validate_formatting.py
@@ -19,12 +19,12 @@ root_dir = os.path.abspath(os.path.join(os.path.abspath(__file__), "..", "..", "
 sdk_dir = os.path.join(root_dir, "sdk")
 
 
-def run_black(service_dir):
+def run_black(glob_string, service_dir):
     results = []
     logging.info("Running black for {}".format(service_dir))
 
     discovered_packages = discover_targeted_packages(
-        "azure*", os.path.join(root_dir, "sdk", service_dir)
+        glob_string, os.path.join(root_dir, "sdk", service_dir)
     )
 
     for package in discovered_packages:
@@ -73,6 +73,15 @@ def run_black(service_dir):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Run black to verify formatted code.")
+
+    parser.add_argument(
+        "glob_string",
+        nargs="?",
+        help=(
+            "A comma separated list of glob strings that will target the top level directories that contain packages."
+            'Examples: All = "azure*", Single = "azure-keyvault", Targeted Multiple = "azure-keyvault,azure-mgmt-resource"'
+        ),
+    )
     parser.add_argument(
         "--service_directory", help="Directory of the package being tested"
     )
@@ -81,7 +90,7 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
     if args.validate != "False":
-        results = run_black(args.service_directory)
+        results = run_black(args.glob_string, args.service_directory)
 
         if len(results) > 0:
             for result in results:

--- a/sdk/core/corehttp/corehttp/transport/aiohttp/_aiohttp.py
+++ b/sdk/core/corehttp/corehttp/transport/aiohttp/_aiohttp.py
@@ -24,7 +24,6 @@
 #
 # --------------------------------------------------------------------------
 from __future__ import annotations
-import sys
 from typing import Optional, TYPE_CHECKING, Type, cast
 from types import TracebackType
 

--- a/sdk/core/corehttp/dev_requirements.txt
+++ b/sdk/core/corehttp/dev_requirements.txt
@@ -1,5 +1,7 @@
 requests
-aiohttp>=3.0
+# Aiohttp 3.8.6 triggers https://github.com/aio-libs/aiohttp/issues/4581 on pypy for some reasons
+aiohttp<3.8.6 ; platform_python_implementation == "PyPy"
+aiohttp ; platform_python_implementation != "PyPy"
 -e ../../../tools/azure-sdk-tools
 -e ../../../tools/azure-devtools
 -e tests/testserver_tests/coretestserver

--- a/sdk/core/corehttp/pyproject.toml
+++ b/sdk/core/corehttp/pyproject.toml
@@ -1,3 +1,4 @@
 [tool.azure-sdk-build]
 pyright = false
 strict_sphinx = true
+verify_keywords = false

--- a/sdk/core/corehttp/samples/sample_async_pipeline_client.py
+++ b/sdk/core/corehttp/samples/sample_async_pipeline_client.py
@@ -28,6 +28,7 @@ from corehttp.runtime.policies import (
     NetworkTraceLoggingPolicy,
 )
 
+
 async def run():
     policies: Iterable[Union[AsyncHTTPPolicy, SansIOHTTPPolicy]] = [
         HeadersPolicy(),
@@ -36,7 +37,9 @@ async def run():
         AsyncRetryPolicy(),
         NetworkTraceLoggingPolicy(),
     ]
-    client: AsyncPipelineClient[HttpRequest, AsyncHttpResponse] = AsyncPipelineClient("https://bing.com", policies=policies)
+    client: AsyncPipelineClient[HttpRequest, AsyncHttpResponse] = AsyncPipelineClient(
+        "https://bing.com", policies=policies
+    )
     request = HttpRequest("GET", "https://bing.com")
     async with client:
         response = await client.send_request(request)
@@ -45,5 +48,5 @@ async def run():
         print(pipeline_response)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     asyncio.run(run())

--- a/sdk/core/tests.yml
+++ b/sdk/core/tests.yml
@@ -4,3 +4,4 @@ stages:
   - template: /eng/pipelines/templates/stages/archetype-sdk-tests.yml
     parameters:
       ServiceDirectory: core
+      BuildTargetingString: '*'


### PR DESCRIPTION
A few changes here to improve the CI for testing `corehttp`:

- Propagated `BuildTargetingString` to several places that were using a hardcoded `azure*` glob for package name resolution.
- Bumped the Python version used in CI for many of the analyze jobs (i.e. pylint, mypyp, pyright, black). The minimum Python version needed for `corehttp` is 3.8, so we need a bump to enable these jobs to actually run against `corehttp`.
- Updated some devops script to accept and use the `TargetingString` glob.
- Fixed black/pylint in `corehttp`
- Added conditional `aiohttp` install inside the dev requirements for `corehttp`. This will allow pypy aiohttp tests to stop being failing for now. This change has already been added to `azure-core`.
- The `verify_keywords` check was disabled for `corehttp`. This is not needed for corehttp and would fail because "azure sdk" isn't in the list of keywords.