### PR TITLE
[cosmos] Fix bug in aio create_container

### DIFF
--- a/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_database.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_database.py
@@ -158,7 +158,6 @@ class DatabaseProxy(object):
         offer_throughput=None,  # type: Optional[Union[int, ThroughputProperties]]
         unique_key_policy=None,  # type: Optional[Dict[str, Any]]
         conflict_resolution_policy=None,  # type: Optional[Dict[str, Any]]
-        **kwargs  # type: Any
         **kwargs: Any
     ) -> ContainerProxy:
         """Create a new container with the given ID (name).

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_database.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_database.py
@@ -153,6 +153,12 @@ class DatabaseProxy(object):
         self,
         id: str,  # pylint: disable=redefined-builtin
         partition_key: PartitionKey,
+        indexing_policy=None,  # type: Optional[Dict[str, Any]]
+        default_ttl=None,  # type: Optional[int]
+        offer_throughput=None,  # type: Optional[Union[int, ThroughputProperties]]
+        unique_key_policy=None,  # type: Optional[Dict[str, Any]]
+        conflict_resolution_policy=None,  # type: Optional[Dict[str, Any]]
+        **kwargs  # type: Any
         **kwargs: Any
     ) -> ContainerProxy:
         """Create a new container with the given ID (name).
@@ -205,7 +211,6 @@ class DatabaseProxy(object):
         definition: Dict[str, Any] = dict(id=id)
         if partition_key is not None:
             definition["partitionKey"] = partition_key
-        indexing_policy = kwargs.pop('indexing_policy', None)
         if indexing_policy is not None:
             if indexing_policy.get("indexingMode") is IndexingMode.Lazy:
                 warnings.warn(
@@ -213,13 +218,10 @@ class DatabaseProxy(object):
                     DeprecationWarning
                 )
             definition["indexingPolicy"] = indexing_policy
-        default_ttl = kwargs.pop('default_ttl', None)
         if default_ttl is not None:
             definition["defaultTtl"] = default_ttl
-        unique_key_policy = kwargs.pop('unique_key_policy', None)
         if unique_key_policy is not None:
             definition["uniqueKeyPolicy"] = unique_key_policy
-        conflict_resolution_policy = kwargs.pop('conflict_resolution_policy', None)
         if conflict_resolution_policy is not None:
             definition["conflictResolutionPolicy"] = conflict_resolution_policy
         analytical_storage_ttl = kwargs.pop("analytical_storage_ttl", None)
@@ -228,7 +230,6 @@ class DatabaseProxy(object):
 
         request_options = _build_options(kwargs)
         response_hook = kwargs.pop('response_hook', None)
-        offer_throughput = kwargs.pop('offer_throughput', None)
         _set_throughput_options(offer=offer_throughput, request_options=request_options)
 
         data = await self.client_connection.CreateContainer(


### PR DESCRIPTION
# Description

The aio variant of create_container has a bug that it uses kwargs for some parameters instead of explicitly declaring them. By doing this offer_throughput was incorrectly being directly passed to the request options  by _build_options and thus use of ThroughputProperties was broken. Fix this by copying the definition form the non-aio variant.

# All SDK Contribution checklist:
- [Y] **The pull request does not introduce [breaking changes]**
- [?] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [Y] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- Y ] Title of the pull request is clear and informative.
- [Y] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
