### PR TITLE
[ml] fix drop required rules from workspace update request

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_workspace_operations_base.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_workspace_operations_base.py
@@ -258,6 +258,13 @@ class WorkspaceOperationsBase(ABC):
         if isinstance(managed_network, str):
             managed_network = ManagedNetwork(isolation_mode=managed_network)._to_rest_object()
         elif isinstance(managed_network, ManagedNetwork):
+            if managed_network.outbound_rules is not None:
+                # drop recommended and required rules from the update request since it would result in bad request
+                managed_network.outbound_rules = [
+                    rule
+                    for rule in workspace.managed_network.outbound_rules
+                    if rule.category not in (OutboundRuleCategory.REQUIRED, OutboundRuleCategory.RECOMMENDED)
+                ]
             managed_network = workspace.managed_network._to_rest_object()
 
         container_registry = kwargs.get("container_registry", workspace.container_registry)
@@ -330,14 +337,6 @@ class WorkspaceOperationsBase(ABC):
                     key_identifier=customer_managed_key_uri,
                 )
             )
-
-        if workspace.managed_network is not None and workspace.managed_network.outbound_rules is not None:
-            # drop recommended and required rules from the update request since it would result in bad request
-            workspace.managed_network.outbound_rules = [
-                rule
-                for rule in workspace.managed_network.outbound_rules
-                if rule.category not in (OutboundRuleCategory.REQUIRED, OutboundRuleCategory.RECOMMENDED)
-            ]
 
         update_role_assignment = (
             kwargs.get("update_workspace_role_assignment", None)

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_workspace_operations_base.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_workspace_operations_base.py
@@ -262,10 +262,10 @@ class WorkspaceOperationsBase(ABC):
                 # drop recommended and required rules from the update request since it would result in bad request
                 managed_network.outbound_rules = [
                     rule
-                    for rule in workspace.managed_network.outbound_rules
+                    for rule in managed_network.outbound_rules
                     if rule.category not in (OutboundRuleCategory.REQUIRED, OutboundRuleCategory.RECOMMENDED)
                 ]
-            managed_network = workspace.managed_network._to_rest_object()
+            managed_network = managed_network._to_rest_object()
 
         container_registry = kwargs.get("container_registry", workspace.container_registry)
         # Empty string is for erasing the value of container_registry, None is to be ignored value


### PR DESCRIPTION
# Description

Fix to correctly drop managed network required outbound rules from update request that would result in a 400 response anyways. [Bug 2773851](https://dev.azure.com/msdata/Vienna/_workitems/edit/2773851): [SDK] NMS drop required outbound rules in client side to avoid 400 

If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
