### PR TITLE
allow for 'path' to be included in string inputs

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_inputs_outputs/input.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_inputs_outputs/input.py
@@ -155,6 +155,7 @@ class Input(_InputOutputBase):  # pylint: disable=too-many-instance-attributes
         default: Optional[str] = None,
         optional: Optional[bool] = None,
         description: Optional[str] = None,
+        path: Optional[str] = None,
         **kwargs,
     ) -> None:
         """Initialize a string input.


### PR DESCRIPTION
# Description

Allow for 'path' to be included as a parameter for Inputs entities when "type" is a string. This will allow for models to be submitted as inputs on batch endpoint invoke

If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
