### PR TITLE
[Storage] Add input validation for SAS generation

### DIFF
--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared_access_signature.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared_access_signature.py
@@ -311,7 +311,7 @@ def generate_account_sas(
         account_key,  # type: str
         resource_types,  # type: Union[ResourceTypes, str]
         permission,  # type: Union[AccountSasPermissions, str]
-        expiry,  # type: Optional[Union[datetime, str]]
+        expiry,  # type: Union[datetime, str]
         start=None,  # type: Optional[Union[datetime, str]]
         ip=None,  # type: Optional[str]
         **kwargs # type: Any
@@ -475,8 +475,11 @@ def generate_container_sas(
             :dedent: 12
             :caption: Generating a sas token.
     """
-    if not policy_id and not (expiry and permission):
-        raise ValueError("Both expiry and permission must be provided when not using a stored access policy.")
+    if not policy_id:
+        if not expiry:
+            raise ValueError("'expiry' parameter must be provided when not using a stored access policy.")
+        if not permission:
+            raise ValueError("'permission' parameter must be provided when not using a stored access policy.")
     if not user_delegation_key and not account_key:
         raise ValueError("Either user_delegation_key or account_key must be provided.")
     if isinstance(account_key, UserDelegationKey):
@@ -598,8 +601,11 @@ def generate_blob_sas(
     :return: A Shared Access Signature (sas) token.
     :rtype: str
     """
-    if not policy_id and not (expiry and permission):
-        raise ValueError("Both expiry and permission must be provided when not using a stored access policy.")
+    if not policy_id:
+        if not expiry:
+            raise ValueError("'expiry' parameter must be provided when not using a stored access policy.")
+        if not permission:
+            raise ValueError("'permission' parameter must be provided when not using a stored access policy.")
     if not user_delegation_key and not account_key:
         raise ValueError("Either user_delegation_key or account_key must be provided.")
     if isinstance(account_key, UserDelegationKey):

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared_access_signature.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared_access_signature.py
@@ -331,17 +331,11 @@ def generate_account_sas(
     :param permission:
         The permissions associated with the shared access signature. The
         user is restricted to operations allowed by the permissions.
-        Required unless an id is given referencing a stored access policy
-        which contains this field. This field must be omitted if it has been
-        specified in an associated stored access policy.
     :type permission: str or ~azure.storage.blob.AccountSasPermissions
     :param expiry:
         The time at which the shared access signature becomes invalid.
-        Required unless an id is given referencing a stored access policy
-        which contains this field. This field must be omitted if it has
-        been specified in an associated stored access policy. Azure will always
-        convert values to UTC. If a date is passed in without timezone info, it
-        is assumed to be UTC.
+        Azure will always convert values to UTC. If a date is passed in
+        without timezone info, it is assumed to be UTC.
     :type expiry: ~datetime.datetime or str
     :param start:
         The time at which the shared access signature becomes valid. If

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared_access_signature.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared_access_signature.py
@@ -481,6 +481,8 @@ def generate_container_sas(
             :dedent: 12
             :caption: Generating a sas token.
     """
+    if not policy_id and not (expiry and permission):
+        raise ValueError("Both expiry and permission must be provided when not using a stored access policy.")
     if not user_delegation_key and not account_key:
         raise ValueError("Either user_delegation_key or account_key must be provided.")
     if isinstance(account_key, UserDelegationKey):
@@ -602,6 +604,8 @@ def generate_blob_sas(
     :return: A Shared Access Signature (sas) token.
     :rtype: str
     """
+    if not policy_id and not (expiry and permission):
+        raise ValueError("Both expiry and permission must be provided when not using a stored access policy.")
     if not user_delegation_key and not account_key:
         raise ValueError("Either user_delegation_key or account_key must be provided.")
     if isinstance(account_key, UserDelegationKey):

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared_access_signature.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared_access_signature.py
@@ -44,17 +44,11 @@ def generate_account_sas(
     :param permission:
         The permissions associated with the shared access signature. The
         user is restricted to operations allowed by the permissions.
-        Required unless an id is given referencing a stored access policy
-        which contains this field. This field must be omitted if it has been
-        specified in an associated stored access policy.
     :type permission: str or ~azure.storage.filedatalake.AccountSasPermissions
     :param expiry:
         The time at which the shared access signature becomes invalid.
-        Required unless an id is given referencing a stored access policy
-        which contains this field. This field must be omitted if it has
-        been specified in an associated stored access policy. Azure will always
-        convert values to UTC. If a date is passed in without timezone info, it
-        is assumed to be UTC.
+        Azure will always convert values to UTC. If a date is passed in
+        without timezone info, it is assumed to be UTC.
     :type expiry: ~datetime.datetime or str
     :keyword start:
         The time at which the shared access signature becomes valid. If

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared_access_signature.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared_access_signature.py
@@ -26,7 +26,7 @@ def generate_account_sas(
         account_key,  # type: str
         resource_types,  # type: Union[ResourceTypes, str]
         permission,  # type: Union[AccountSasPermissions, str]
-        expiry,  # type: Optional[Union[datetime, str]]
+        expiry,  # type: Union[datetime, str]
         **kwargs # type: Any
     ):  # type: (...) -> str
     """Generates a shared access signature for the DataLake service.
@@ -86,8 +86,6 @@ def generate_file_system_sas(
         credential,  # type: Union[str, UserDelegationKey]
         permission=None,  # type: Optional[Union[FileSystemSasPermissions, str]]
         expiry=None,  # type: Optional[Union[datetime, str]]
-        start=None,  # type: Optional[Union[datetime, str]]
-        policy_id=None,  # type: Optional[str]
         **kwargs # type: Any
     ):
     # type: (...) -> str
@@ -135,7 +133,7 @@ def generate_file_system_sas(
     :keyword str policy_id:
         A unique value up to 64 characters in length that correlates to a
         stored access policy. To create a stored access policy, use
-        :func:`~azure.storage.queue.QueueClient.set_queue_access_policy`.
+        :func:`~azure.storage.filedatalake.FileSystemClient.set_file_system_access_policy`.
     :keyword str ip:
         Specifies an IP address or a range of IP addresses from which to accept requests.
         If the IP address from which the request originates does not match the IP address
@@ -177,8 +175,6 @@ def generate_file_system_sas(
     :return: A Shared Access Signature (sas) token.
     :rtype: str
     """
-    if not policy_id and not (expiry and permission):
-        raise ValueError("Both expiry and permission must be provided when not using a stored access policy.")
     return generate_container_sas(
         account_name=account_name,
         container_name=file_system_name,
@@ -186,8 +182,6 @@ def generate_file_system_sas(
         user_delegation_key=credential if not isinstance(credential, str) else None,
         permission=permission,
         expiry=expiry,
-        start=start,
-        policy_id=policy_id,
         **kwargs)
 
 
@@ -249,7 +243,7 @@ def generate_directory_sas(
     :keyword str policy_id:
         A unique value up to 64 characters in length that correlates to a
         stored access policy. To create a stored access policy, use
-        :func:`~azure.storage.queue.QueueClient.set_queue_access_policy`.
+        :func:`~azure.storage.filedatalake.FileSystemClient.set_file_system_access_policy`.
     :keyword str ip:
         Specifies an IP address or a range of IP addresses from which to accept requests.
         If the IP address from which the request originates does not match the IP address
@@ -368,7 +362,7 @@ def generate_file_sas(
     :keyword str policy_id:
         A unique value up to 64 characters in length that correlates to a
         stored access policy. To create a stored access policy, use
-        :func:`~azure.storage.queue.QueueClient.set_queue_access_policy`.
+        :func:`~azure.storage.filedatalake.FileSystemClient.set_file_system_access_policy`.
     :keyword str ip:
         Specifies an IP address or a range of IP addresses from which to accept requests.
         If the IP address from which the request originates does not match the IP address

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared_access_signature.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared_access_signature.py
@@ -92,6 +92,8 @@ def generate_file_system_sas(
         credential,  # type: Union[str, UserDelegationKey]
         permission=None,  # type: Optional[Union[FileSystemSasPermissions, str]]
         expiry=None,  # type: Optional[Union[datetime, str]]
+        start=None,  # type: Optional[Union[datetime, str]]
+        policy_id=None,  # type: Optional[str]
         **kwargs # type: Any
     ):
     # type: (...) -> str
@@ -136,6 +138,10 @@ def generate_file_system_sas(
         to UTC. If a date is passed in without timezone info, it is assumed to
         be UTC.
     :paramtype start: datetime or str
+    :keyword str policy_id:
+        A unique value up to 64 characters in length that correlates to a
+        stored access policy. To create a stored access policy, use
+        :func:`~azure.storage.queue.QueueClient.set_queue_access_policy`.
     :keyword str ip:
         Specifies an IP address or a range of IP addresses from which to accept requests.
         If the IP address from which the request originates does not match the IP address
@@ -177,6 +183,8 @@ def generate_file_system_sas(
     :return: A Shared Access Signature (sas) token.
     :rtype: str
     """
+    if not policy_id and not (expiry and permission):
+        raise ValueError("Both expiry and permission must be provided when not using a stored access policy.")
     return generate_container_sas(
         account_name=account_name,
         container_name=file_system_name,
@@ -184,6 +192,8 @@ def generate_file_system_sas(
         user_delegation_key=credential if not isinstance(credential, str) else None,
         permission=permission,
         expiry=expiry,
+        start=start,
+        policy_id=policy_id,
         **kwargs)
 
 
@@ -194,6 +204,8 @@ def generate_directory_sas(
         credential,  # type: Union[str, UserDelegationKey]
         permission=None,  # type: Optional[Union[DirectorySasPermissions, str]]
         expiry=None,  # type: Optional[Union[datetime, str]]
+        start=None,  # type: Optional[Union[datetime, str]]
+        policy_id=None,  # type: Optional[str]
         **kwargs # type: Any
     ):
     # type: (...) -> str
@@ -240,6 +252,10 @@ def generate_directory_sas(
         to UTC. If a date is passed in without timezone info, it is assumed to
         be UTC.
     :paramtype start: ~datetime.datetime or str
+    :keyword str policy_id:
+        A unique value up to 64 characters in length that correlates to a
+        stored access policy. To create a stored access policy, use
+        :func:`~azure.storage.queue.QueueClient.set_queue_access_policy`.
     :keyword str ip:
         Specifies an IP address or a range of IP addresses from which to accept requests.
         If the IP address from which the request originates does not match the IP address
@@ -290,6 +306,8 @@ def generate_directory_sas(
         user_delegation_key=credential if not isinstance(credential, str) else None,
         permission=permission,
         expiry=expiry,
+        start=start,
+        policy_id=policy_id,
         sdd=depth,
         is_directory=True,
         **kwargs)
@@ -303,6 +321,8 @@ def generate_file_sas(
         credential,  # type: Union[str, UserDelegationKey]
         permission=None,  # type: Optional[Union[FileSasPermissions, str]]
         expiry=None,  # type: Optional[Union[datetime, str]]
+        start=None,  # type: Optional[Union[datetime, str]]
+        policy_id=None,  # type: Optional[str]
         **kwargs  # type: Any
     ):
     # type: (...) -> str
@@ -351,6 +371,10 @@ def generate_file_sas(
         to UTC. If a date is passed in without timezone info, it is assumed to
         be UTC.
     :paramtype start: ~datetime.datetime or str
+    :keyword str policy_id:
+        A unique value up to 64 characters in length that correlates to a
+        stored access policy. To create a stored access policy, use
+        :func:`~azure.storage.queue.QueueClient.set_queue_access_policy`.
     :keyword str ip:
         Specifies an IP address or a range of IP addresses from which to accept requests.
         If the IP address from which the request originates does not match the IP address
@@ -404,4 +428,6 @@ def generate_file_sas(
         user_delegation_key=credential if not isinstance(credential, str) else None,
         permission=permission,
         expiry=expiry,
+        start=start,
+        policy_id=policy_id,
         **kwargs)

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared_access_signature.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared_access_signature.py
@@ -192,8 +192,6 @@ def generate_directory_sas(
         credential,  # type: Union[str, UserDelegationKey]
         permission=None,  # type: Optional[Union[DirectorySasPermissions, str]]
         expiry=None,  # type: Optional[Union[datetime, str]]
-        start=None,  # type: Optional[Union[datetime, str]]
-        policy_id=None,  # type: Optional[str]
         **kwargs # type: Any
     ):
     # type: (...) -> str
@@ -294,8 +292,6 @@ def generate_directory_sas(
         user_delegation_key=credential if not isinstance(credential, str) else None,
         permission=permission,
         expiry=expiry,
-        start=start,
-        policy_id=policy_id,
         sdd=depth,
         is_directory=True,
         **kwargs)
@@ -309,8 +305,6 @@ def generate_file_sas(
         credential,  # type: Union[str, UserDelegationKey]
         permission=None,  # type: Optional[Union[FileSasPermissions, str]]
         expiry=None,  # type: Optional[Union[datetime, str]]
-        start=None,  # type: Optional[Union[datetime, str]]
-        policy_id=None,  # type: Optional[str]
         **kwargs  # type: Any
     ):
     # type: (...) -> str
@@ -416,6 +410,4 @@ def generate_file_sas(
         user_delegation_key=credential if not isinstance(credential, str) else None,
         permission=permission,
         expiry=expiry,
-        start=start,
-        policy_id=policy_id,
         **kwargs)

--- a/sdk/storage/azure-storage-file-share/assets.json
+++ b/sdk/storage/azure-storage-file-share/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "python",
   "TagPrefix": "python/storage/azure-storage-file-share",
-  "Tag": "python/storage/azure-storage-file-share_b5ba675aa8"
+  "Tag": "python/storage/azure-storage-file-share_acf7679e5b"
 }

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared_access_signature.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared_access_signature.py
@@ -245,7 +245,7 @@ def generate_account_sas(
         account_key,  # type: str
         resource_types,  # type: Union[ResourceTypes, str]
         permission,  # type: Union[AccountSasPermissions, str]
-        expiry,  # type: Optional[Union[datetime, str]]
+        expiry,  # type: Union[datetime, str]
         start=None,  # type: Optional[Union[datetime, str]]
         ip=None,  # type: Optional[str]
         **kwargs  # type: Any
@@ -384,8 +384,11 @@ def generate_share_sas(
     :return: A Shared Access Signature (sas) token.
     :rtype: str
     """
-    if not policy_id and not (expiry and permission):
-        raise ValueError("Both expiry and permission must be provided when not using a stored access policy.")
+    if not policy_id:
+        if not expiry:
+            raise ValueError("'expiry' parameter must be provided when not using a stored access policy.")
+        if not permission:
+            raise ValueError("'permission' parameter must be provided when not using a stored access policy.")
     sas = FileSharedAccessSignature(account_name, account_key)
     return sas.generate_share(
         share_name=share_name,
@@ -477,8 +480,11 @@ def generate_file_sas(
     :return: A Shared Access Signature (sas) token.
     :rtype: str
     """
-    if not policy_id and not (expiry and permission):
-        raise ValueError("Both expiry and permission must be provided when not using a stored access policy.")
+    if not policy_id:
+        if not expiry:
+            raise ValueError("'expiry' parameter must be provided when not using a stored access policy.")
+        if not permission:
+            raise ValueError("'permission' parameter must be provided when not using a stored access policy.")
     sas = FileSharedAccessSignature(account_name, account_key)
     if len(file_path) > 1:
         dir_path = '/'.join(file_path[:-1])

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared_access_signature.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared_access_signature.py
@@ -265,16 +265,10 @@ def generate_account_sas(
     :param ~azure.storage.fileshare.AccountSasPermissions permission:
         The permissions associated with the shared access signature. The
         user is restricted to operations allowed by the permissions.
-        Required unless an id is given referencing a stored access policy
-        which contains this field. This field must be omitted if it has been
-        specified in an associated stored access policy.
     :param expiry:
         The time at which the shared access signature becomes invalid.
-        Required unless an id is given referencing a stored access policy
-        which contains this field. This field must be omitted if it has
-        been specified in an associated stored access policy. Azure will always
-        convert values to UTC. If a date is passed in without timezone info, it
-        is assumed to be UTC.
+        Azure will always convert values to UTC. If a date is passed in without
+        timezone info, it is assumed to be UTC.
     :type expiry: ~datetime.datetime or str
     :param start:
         The time at which the shared access signature becomes valid. If

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared_access_signature.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared_access_signature.py
@@ -390,6 +390,8 @@ def generate_share_sas(
     :return: A Shared Access Signature (sas) token.
     :rtype: str
     """
+    if not policy_id and not (expiry and permission):
+        raise ValueError("Both expiry and permission must be provided when not using a stored access policy.")
     sas = FileSharedAccessSignature(account_name, account_key)
     return sas.generate_share(
         share_name=share_name,
@@ -481,6 +483,8 @@ def generate_file_sas(
     :return: A Shared Access Signature (sas) token.
     :rtype: str
     """
+    if not policy_id and not (expiry and permission):
+        raise ValueError("Both expiry and permission must be provided when not using a stored access policy.")
     sas = FileSharedAccessSignature(account_name, account_key)
     if len(file_path) > 1:
         dir_path = '/'.join(file_path[:-1])

--- a/sdk/storage/azure-storage-file-share/tests/test_file.py
+++ b/sdk/storage/azure-storage-file-share/tests/test_file.py
@@ -1446,6 +1446,8 @@ class TestStorageFile(StorageRecordedTestCase):
             source_file_client.share_name,
             source_file_client.file_path,
             source_file_client.credential.account_key,
+            FileSasPermissions(read=True),
+            expiry=datetime.utcnow() + timedelta(hours=1)
         )
 
         source_file_url = source_file_client.url + '?' + sas_token_for_source_file

--- a/sdk/storage/azure-storage-file-share/tests/test_file_async.py
+++ b/sdk/storage/azure-storage-file-share/tests/test_file_async.py
@@ -1472,7 +1472,10 @@ class TestStorageFileAsync(AsyncStorageRecordedTestCase):
             source_file_client.account_name,
             source_file_client.share_name,
             source_file_client.file_path,
-            source_file_client.credential.account_key)
+            source_file_client.credential.account_key,
+            FileSasPermissions(read=True),
+            expiry=datetime.utcnow() + timedelta(hours=1)
+        )
 
         source_file_url = source_file_client.url + '?' + sas_token_for_source_file
 

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_shared_access_signature.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_shared_access_signature.py
@@ -130,7 +130,7 @@ def generate_account_sas(
         account_key,  # type: str
         resource_types,  # type: Union[ResourceTypes, str]
         permission,  # type: Union[AccountSasPermissions, str]
-        expiry,  # type: Optional[Union[datetime, str]]
+        expiry,  # type: Union[datetime, str]
         start=None,  # type: Optional[Union[datetime, str]]
         ip=None,  # type: Optional[str]
         **kwargs  # type: "Any"
@@ -249,8 +249,11 @@ def generate_queue_sas(
             :dedent: 12
             :caption: Generate a sas token.
     """
-    if not policy_id and not (expiry and permission):
-        raise ValueError("Both expiry and permission must be provided when not using a stored access policy.")
+    if not policy_id:
+        if not expiry:
+            raise ValueError("'expiry' parameter must be provided when not using a stored access policy.")
+        if not permission:
+            raise ValueError("'permission' parameter must be provided when not using a stored access policy.")
     sas = QueueSharedAccessSignature(account_name, account_key)
     return sas.generate_queue(
         queue_name,

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_shared_access_signature.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_shared_access_signature.py
@@ -150,11 +150,8 @@ def generate_account_sas(
         user is restricted to operations allowed by the permissions.
     :param expiry:
         The time at which the shared access signature becomes invalid.
-        Required unless an id is given referencing a stored access policy
-        which contains this field. This field must be omitted if it has
-        been specified in an associated stored access policy. Azure will always
-        convert values to UTC. If a date is passed in without timezone info, it
-        is assumed to be UTC.
+        Azure will always convert values to UTC. If a date is passed in
+        without timezone info, it is assumed to be UTC.
     :type expiry: ~datetime.datetime or str
     :param start:
         The time at which the shared access signature becomes valid. If

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_shared_access_signature.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_shared_access_signature.py
@@ -252,6 +252,8 @@ def generate_queue_sas(
             :dedent: 12
             :caption: Generate a sas token.
     """
+    if not policy_id and not (expiry and permission):
+        raise ValueError("Both expiry and permission must be provided when not using a stored access policy.")
     sas = QueueSharedAccessSignature(account_name, account_key)
     return sas.generate_queue(
         queue_name,


### PR DESCRIPTION
This PR adds some input validation to help improve SAS token generation and usage experience.

From the [AccessPolicy documentation](https://learn.microsoft.com/en-us/python/api/azure-storage-file-datalake/azure.storage.filedatalake.accesspolicy?view=azure-python):
"Together the Shared Access Signature and the stored access policy must include all fields required to authenticate the signature. If any required fields are missing, the request will fail. Likewise, if a field is specified both in the Shared Access Signature URL and in the stored access policy, the request will fail with status code 400 (Bad Request)."

And so if stored access policy is provided, we cannot make any guarantees on the outputted SAS token. However, if no stored access policy ID is provided, then we can perform standard input validation (expiry time, permissions, and some sort of authentication).

This PR specifically addresses the following:

1. Input validation of expiry and permission when stored access policy is not being used
2. Adding kwargs `start` and `policy_id` to Datalake. These are Blobs package backed calls and so these kwargs always worked, but we should be surfacing them as kwarg typehints
3. Updating docstrings for account SAS to drop any mention of stored access policy (as they are not available for account SAS)
4. Fixing some wonky tests to assert the correct failure