### PR TITLE
open mypy issue regardless of opt-in/out status

### DIFF
--- a/eng/tox/run_mypy.py
+++ b/eng/tox/run_mypy.py
@@ -100,7 +100,7 @@ if __name__ == "__main__":
             except CalledProcessError as sample_err:
                 sample_code_error = sample_err
 
-    if args.next and in_ci() and is_check_enabled(args.target_package, "mypy") and not is_typing_ignored(package_name):
+    if args.next and in_ci() and not is_typing_ignored(package_name):
         if src_code_error or sample_code_error:
             create_vnext_issue(package_name, "mypy")
 


### PR DESCRIPTION
Mypy becomes a mandatory check in January. We need to flip a lot of libraries from opting out to getting mypy clean. This change ensures that a GH issue is opened if a library is failing next-mypy, regardless of their opt-in/opt-out status.