### PR TITLE
match exact package name for vnext issues

### DIFF
--- a/tools/azure-sdk-tools/gh_tools/vnext_issue_creator.py
+++ b/tools/azure-sdk-tools/gh_tools/vnext_issue_creator.py
@@ -96,7 +96,7 @@ def create_vnext_issue(package_name: str, check_type: Literal["mypy", "pylint", 
     repo = g.get_repo("Azure/azure-sdk-for-python")
 
     issues = repo.get_issues(state="open", labels=[check_type], creator="azure-sdk")
-    vnext_issue = [issue for issue in issues if issue.body.find(package_name) != -1]
+    vnext_issue = [issue for issue in issues if issue.title.split("needs")[0].strip() == package_name]
 
     version = get_version_running(check_type)
     build_link = get_build_link(check_type)


### PR DESCRIPTION
Turns out azure-core is a substring of azure-core-experimental, etc etc 😄 