### PR TITLE
[Test Proxy] Fix certificate trusting for async tests on latest Core

### DIFF
--- a/tools/azure-sdk-tools/devtools_testutils/proxy_startup.py
+++ b/tools/azure-sdk-tools/devtools_testutils/proxy_startup.py
@@ -195,11 +195,12 @@ def check_certificate_location(repo_root: str) -> None:
             write_dev_cert_bundle()
 
     _LOGGER.info(
-        "Setting SSL_CERT_DIR and REQUESTS_CA_BUNDLE environment variables for the current session.\n"
+        "Setting SSL_CERT_DIR, SSL_CERT_FILE, and REQUESTS_CA_BUNDLE environment variables for the current session.\n"
         f"SSL_CERT_DIR={combined_folder}\n"
-        f"REQUESTS_CA_BUNDLE={combined_location}"
+        f"SSL_CERT_FILE=REQUESTS_CA_BUNDLE={combined_location}"
     )
     os.environ["SSL_CERT_DIR"] = combined_folder
+    os.environ["SSL_CERT_FILE"] = combined_location
     os.environ["REQUESTS_CA_BUNDLE"] = combined_location
 
 


### PR DESCRIPTION
# Description

As of `azure-core` 1.29.5, async requests fall back to `aiohttp`'s SSL context. This ended up breaking async tests that go through the test proxy, at least on WSL, because SSL only seems to [honor the `SSL_CERT_FILE` environment variable](https://stackoverflow.com/questions/42982143/python-requests-how-to-use-system-ca-certificates-debian-ubuntu/75352343#75352343) on Ubuntu (and possibly on other OSes, but unsure).

We already set `SSL_CERT_DIR`, so this PR sets `SSL_CERT_FILE` as well (to the same value as `REQUESTS_CA_BUNDLE`).

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
