### PR TITLE
Allow registered component to be passed into the sdk. 

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_deployment/pipeline_component_batch_deployment.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_deployment/pipeline_component_batch_deployment.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Dict, Optional, Union
 
 from azure.ai.ml.entities._component.component import Component
+from azure.ai.ml.entities._builders import BaseNode
 from azure.ai.ml._schema._deployment.batch.pipeline_component_batch_deployment_schema import (
     PipelineComponentBatchDeploymentSchema,
 )  # pylint: disable=line-too-long
@@ -39,6 +40,8 @@ class PipelineComponentBatchDeployment(Deployment):
     :type description: Optional[str]
     :param tags: A set of tags. The tags which will be applied to the job.
     :type tags: Optional[Dict[str, Any]]
+    :param job_definition: Arm ID or PipelineJob entity of an existing pipeline job.
+    :param job_definition: Optional[Dict[str, ~azure.ai.ml.entities._builders.BaseNode]]
     """
 
     def __init__(
@@ -48,12 +51,13 @@ class PipelineComponentBatchDeployment(Deployment):
         endpoint_name: Optional[str] = None,
         component: Optional[Union[Component, str]] = None,
         settings: Optional[Dict[str, str]] = None,
+        job_definition: Optional[Dict[str, BaseNode]] = None,
         **kwargs,  # pylint: disable=unused-argument
     ):
-        self.job_definition = kwargs.pop("job_definition", None)
         super().__init__(endpoint_name=endpoint_name, name=name, **kwargs)
         self.component = component
         self.settings = settings
+        self.job_definition = job_definition
 
     def _to_rest_object(self, location: str) -> "RestBatchDeployment":  # pylint: disable=arguments-differ
         if isinstance(self.component, PipelineComponent):

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_batch_deployment_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_batch_deployment_operations.py
@@ -338,7 +338,7 @@ class BatchDeploymentOperations(_ScopeDependentOperations):
                     name=deployment.component.name, version=deployment.component.version
                 )
                 deployment.component = registered_component.id
-            except Exception as err: # pylint: disable=broad-except
+            except Exception as err:  # pylint: disable=broad-except
                 if isinstance(err, ResourceNotFoundError) or isinstance(err, HttpResponseError):
                     deployment.component = self._all_operations.all_operations[
                         AzureMLResourceType.COMPONENT

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_batch_deployment_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_batch_deployment_operations.py
@@ -338,7 +338,7 @@ class BatchDeploymentOperations(_ScopeDependentOperations):
                     name=deployment.component.name, version=deployment.component.version
                 )
                 deployment.component = registered_component.id
-            except ResourceNotFoundError as err:
+            except ResourceNotFoundError:
                 deployment.component = self._all_operations.all_operations[
                     AzureMLResourceType.COMPONENT
                 ].create_or_update(

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_batch_deployment_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_batch_deployment_operations.py
@@ -339,7 +339,7 @@ class BatchDeploymentOperations(_ScopeDependentOperations):
                 )
                 deployment.component = registered_component.id
             except Exception as err:  # pylint: disable=broad-except
-                if isinstance(err, ResourceNotFoundError) or isinstance(err, HttpResponseError):
+                if isinstance(err, (ResourceNotFoundError, HttpResponseError)):
                     deployment.component = self._all_operations.all_operations[
                         AzureMLResourceType.COMPONENT
                     ].create_or_update(
@@ -350,7 +350,6 @@ class BatchDeploymentOperations(_ScopeDependentOperations):
                         version=deployment.component.version,
                         **self._init_kwargs,
                     )
-                    pass
                 else:
                     raise err
         elif isinstance(deployment.component, str):


### PR DESCRIPTION


When the user returns a registered deployment doing either a get or create on a component they will be able to pass that PipelineComponent value into the deployment to create a PipelineComponentBatchDeployment

Please add an informative description that covers that changes made by the pull request and link all relevant issues.

If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
