### PR TITLE
chore: Lower the urllib3 pin to 1.26.9

### DIFF
--- a/eng/ci_tools.txt
+++ b/eng/ci_tools.txt
@@ -29,7 +29,7 @@ pyopenssl==23.2.0
 python-dotenv==0.21.1; python_version <= '3.7'
 python-dotenv==1.0.0; python_version > '3.7'
 pyyaml==6.0.1
-urllib3==1.26.16
+urllib3==1.26.9
 PyGithub==1.59.1
 ConfigArgParse==1.2.3
 six==1.16.0

--- a/eng/test_tools.txt
+++ b/eng/test_tools.txt
@@ -19,7 +19,7 @@ pyopenssl==23.2.0
 python-dotenv==0.21.1; python_version <= '3.7'
 python-dotenv==1.0.0; python_version > '3.7'
 pyyaml==6.0.1
-urllib3==1.26.16
+urllib3==1.26.9
 PyGithub==1.59.1
 ConfigArgParse==1.2.3
 six==1.16.0


### PR DESCRIPTION
# Description

This pull request lowers the `urllib3` pin in `eng/ci_tools.txt` and `eng/test_tools.txt` from `1.26.16` to `1.26.9`.

This to unblock #32770, since `azure-ai-generative` depends transitively on `azureml-core` which currently has `urllib3==1.26.9` as its allowed upper bound.

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
