### PR TITLE
[Corehttp] Additional cleanup

### DIFF
--- a/sdk/core/corehttp/corehttp/rest/_aiohttp.py
+++ b/sdk/core/corehttp/corehttp/rest/_aiohttp.py
@@ -30,7 +30,7 @@ import logging
 from itertools import groupby
 from typing import Iterator, cast, TYPE_CHECKING
 from multidict import CIMultiDict
-import aiohttp.client_exceptions  # pylint: disable=networking-import-outside-azure-core-transport
+import aiohttp.client_exceptions  # pylint: disable=all
 
 from ._http_response_impl_async import AsyncHttpResponseImpl
 from ..exceptions import (

--- a/sdk/core/corehttp/corehttp/rest/_requests_basic.py
+++ b/sdk/core/corehttp/corehttp/rest/_requests_basic.py
@@ -27,8 +27,8 @@ from __future__ import annotations
 import logging
 import collections.abc as collections
 from typing import TYPE_CHECKING, Any
-import requests  # pylint: disable=networking-import-outside-azure-core-transport
-from requests.structures import CaseInsensitiveDict  # pylint: disable=networking-import-outside-azure-core-transport
+import requests  # pylint: disable=all
+from requests.structures import CaseInsensitiveDict  # pylint: disable=all
 from urllib3.exceptions import (
     DecodeError as CoreDecodeError,
     ReadTimeoutError,

--- a/sdk/core/corehttp/corehttp/runtime/policies/_retry.py
+++ b/sdk/core/corehttp/corehttp/runtime/policies/_retry.py
@@ -263,7 +263,7 @@ class RetryPolicyBase:
          True if more retry attempts available, False otherwise
         :rtype: bool
         """
-        # FIXME This code is not None safe: https://github.com/Azure/azure-sdk-for-python/issues/31528
+        # FIXME This code is not None safe.
         response = cast(
             Union[PipelineRequest[HttpRequest], PipelineResponse[HttpRequest, AllHttpResponseType]], response
         )
@@ -348,7 +348,6 @@ class RetryPolicyBase:
         # ("connection_config" isn't defined on Async/HttpTransport but all implementations in this library have it)
         elif hasattr(request.context.transport, "connection_config"):
             # FIXME This is fragile, should be refactored. Casting my way for mypy
-            # https://github.com/Azure/azure-sdk-for-python/issues/31530
             connection_config = cast(
                 MutableMapping[str, Any], request.context.transport.connection_config  # type: ignore
             )

--- a/sdk/core/corehttp/corehttp/runtime/policies/_universal.py
+++ b/sdk/core/corehttp/corehttp/runtime/policies/_universal.py
@@ -35,7 +35,7 @@ import platform
 import xml.etree.ElementTree as ET
 import types
 import re
-from typing import IO, cast, Union, Optional, AnyStr, Dict, Any, Set, Mapping, TYPE_CHECKING
+from typing import IO, cast, Union, Optional, AnyStr, Dict, Any, Mapping, TYPE_CHECKING
 
 from ... import __version__ as core_version
 from ...exceptions import DecodeError
@@ -99,10 +99,6 @@ class HeadersPolicy(SansIOHTTPPolicy[HTTPRequestType, HTTPResponseType]):
             request.http_request.headers.update(additional_headers)
 
 
-class _Unset:
-    pass
-
-
 class UserAgentPolicy(SansIOHTTPPolicy[HTTPRequestType, HTTPResponseType]):
     """User-Agent Policy. Allows custom values to be added to the User-Agent header.
 
@@ -112,7 +108,7 @@ class UserAgentPolicy(SansIOHTTPPolicy[HTTPRequestType, HTTPResponseType]):
     :keyword bool user_agent_use_env: Gets user-agent from environment. Defaults to True.
     :keyword str user_agent: If specified, this will be added in front of the user agent string.
     :keyword str sdk_moniker: If specified, the user agent string will be
-        azsdk-python-[sdk_moniker] Python/[python_version] ([platform_version])
+        python-[sdk_moniker] Python/[python_version] ([platform_version])
     """
 
     _USERAGENT = "User-Agent"
@@ -276,19 +272,6 @@ class NetworkTraceLoggingPolicy(SansIOHTTPPolicy[HTTPRequestType, HTTPResponseTy
                 _LOGGER.debug(log_string)
         except Exception as err:  # pylint: disable=broad-except
             _LOGGER.debug("Failed to log response: %s", repr(err))
-
-
-class _HiddenClassProperties(type):
-    # Backward compatible for DEFAULT_HEADERS_WHITELIST
-    # https://github.com/Azure/azure-sdk-for-python/issues/26331
-
-    @property
-    def DEFAULT_HEADERS_WHITELIST(cls) -> Set[str]:
-        return cls.DEFAULT_HEADERS_ALLOWLIST
-
-    @DEFAULT_HEADERS_WHITELIST.setter
-    def DEFAULT_HEADERS_WHITELIST(cls, value: Set[str]) -> None:
-        cls.DEFAULT_HEADERS_ALLOWLIST = value
 
 
 class ContentDecodePolicy(SansIOHTTPPolicy[HTTPRequestType, HTTPResponseType]):

--- a/sdk/core/corehttp/corehttp/transport/aiohttp/_aiohttp.py
+++ b/sdk/core/corehttp/corehttp/transport/aiohttp/_aiohttp.py
@@ -29,8 +29,8 @@ from types import TracebackType
 
 import logging
 import asyncio
-import aiohttp  # pylint: disable=networking-import-outside-azure-core-transport
-import aiohttp.client_exceptions  # pylint: disable=networking-import-outside-azure-core-transport
+import aiohttp  # pylint: disable=all
+import aiohttp.client_exceptions  # pylint: disable=all
 
 from ...exceptions import (
     ServiceRequestError,

--- a/sdk/core/corehttp/corehttp/transport/requests/_bigger_block_size_http_adapters.py
+++ b/sdk/core/corehttp/corehttp/transport/requests/_bigger_block_size_http_adapters.py
@@ -25,7 +25,7 @@
 # --------------------------------------------------------------------------
 
 import sys
-from requests.adapters import HTTPAdapter  # pylint: disable=networking-import-outside-azure-core-transport
+from requests.adapters import HTTPAdapter  # pylint: disable=all
 
 
 class BiggerBlockSizeHTTPAdapter(HTTPAdapter):

--- a/sdk/core/corehttp/corehttp/transport/requests/_requests_basic.py
+++ b/sdk/core/corehttp/corehttp/transport/requests/_requests_basic.py
@@ -31,7 +31,7 @@ from urllib3.exceptions import (
     NewConnectionError,
     ConnectTimeoutError,
 )
-import requests  # pylint: disable=networking-import-outside-azure-core-transport
+import requests  # pylint: disable=all
 
 from ...exceptions import (
     ServiceRequestError,

--- a/sdk/core/corehttp/sdk_packaging.toml
+++ b/sdk/core/corehttp/sdk_packaging.toml
@@ -4,5 +4,4 @@ package_pprint_name = "CoreHTTP"
 package_doc_id = ""
 is_stable = false
 is_arm = false
-need_msrestazure = false
 auto_update = false

--- a/sdk/core/corehttp/tests/async_tests/conftest.py
+++ b/sdk/core/corehttp/tests/async_tests/conftest.py
@@ -23,72 +23,11 @@
 # IN THE SOFTWARE.
 #
 # --------------------------------------------------------------------------
-import time
 import pytest
-import signal
-import os
-import subprocess
-import random
-import urllib
 
-from rest_client_async import AsyncTestRestClient
-
-
-def is_port_available(port_num):
-    req = urllib.request.Request("http://localhost:{}/health".format(port_num))
-    try:
-        return urllib.request.urlopen(req).code != 200
-    except Exception as e:
-        return True
-
-
-def get_port():
-    count = 3
-    for _ in range(count):
-        port_num = random.randrange(3000, 5000)
-        if is_port_available(port_num):
-            return port_num
-    raise TypeError("Tried {} times, can't find an open port".format(count))
-
-
-@pytest.fixture
-def port():
-    return os.environ["FLASK_PORT"]
-
-
-def start_testserver():
-    port = get_port()
-    os.environ["FLASK_APP"] = "coretestserver"
-    os.environ["FLASK_PORT"] = str(port)
-    cmd = "flask run -p {}".format(port)
-    if os.name == "nt":  # On windows, subprocess creation works without being in the shell
-        child_process = subprocess.Popen(cmd, env=dict(os.environ))
-    else:
-        # On linux, have to set shell=True
-        child_process = subprocess.Popen(cmd, shell=True, preexec_fn=os.setsid, env=dict(os.environ))
-    count = 5
-    for _ in range(count):
-        if not is_port_available(port):
-            return child_process
-        time.sleep(1)
-    raise ValueError("Didn't start!")
-
-
-def terminate_testserver(process):
-    if os.name == "nt":
-        process.kill()
-    else:
-        os.killpg(os.getpgid(process.pid), signal.SIGTERM)  # Send the signal to all the process groups
-
-
-@pytest.fixture(autouse=True, scope="package")
-def testserver():
-    """Start the Autorest testserver."""
-    server = start_testserver()
-    yield
-    terminate_testserver(server)
+from rest_client_async import AsyncMockRestClient
 
 
 @pytest.fixture
 def client(port):
-    return AsyncTestRestClient(port)
+    return AsyncMockRestClient(port)

--- a/sdk/core/corehttp/tests/async_tests/rest_client_async.py
+++ b/sdk/core/corehttp/tests/async_tests/rest_client_async.py
@@ -10,7 +10,7 @@ from copy import deepcopy
 from corehttp.runtime import AsyncPipelineClient
 
 
-class AsyncTestRestClient(object):
+class AsyncMockRestClient(object):
     def __init__(self, port, **kwargs):
         kwargs.setdefault("sdk_moniker", "autorestswaggerbatfileservice/1.0.0b1")
 
@@ -23,7 +23,7 @@ class AsyncTestRestClient(object):
         <HttpRequest [GET], url: 'http://localhost:3000/helloWorld'>
         >>> response = await client.send_request(request)
         <AsyncHttpResponse: 200 OK>
-        For more information on this code flow, see https://aka.ms/azsdk/python/protocol/quickstart
+
         :param request: The network request you want to make. Required.
         :type request: ~corehttp.rest.HttpRequest
         :keyword bool stream: Whether the response payload will be streamed. Defaults to False.

--- a/sdk/core/corehttp/tests/conftest.py
+++ b/sdk/core/corehttp/tests/conftest.py
@@ -12,7 +12,7 @@ import random
 import platform
 import urllib
 
-from rest_client import TestRestClient
+from rest_client import MockRestClient
 
 
 def is_port_available(port_num):
@@ -77,4 +77,4 @@ def testserver():
 
 @pytest.fixture
 def client(port):
-    return TestRestClient(port)
+    return MockRestClient(port)

--- a/sdk/core/corehttp/tests/rest_client.py
+++ b/sdk/core/corehttp/tests/rest_client.py
@@ -7,7 +7,7 @@ from corehttp.runtime import PipelineClient
 from copy import deepcopy
 
 
-class TestRestClient(object):
+class MockRestClient(object):
     def __init__(self, port, **kwargs):
         kwargs.setdefault("sdk_moniker", "corehttp/1.0.0b1")
         self._client = PipelineClient(endpoint="http://localhost:{}/".format(port), **kwargs)
@@ -19,7 +19,7 @@ class TestRestClient(object):
         <HttpRequest [GET], url: 'http://localhost:3000/helloWorld'>
         >>> response = client.send_request(request)
         <HttpResponse: 200 OK>
-        For more information on this code flow, see https://aka.ms/azsdk/python/protocol/quickstart
+
         :param request: The network request you want to make. Required.
         :type request: ~corehttp.rest.HttpRequest
         :keyword bool stream: Whether the response payload will be streamed. Defaults to False.

--- a/sdk/core/corehttp/tests/test_authentication.py
+++ b/sdk/core/corehttp/tests/test_authentication.py
@@ -265,7 +265,7 @@ def test_bearer_policy_calls_sansio_methods(http_request):
 
 
 @pytest.mark.parametrize("http_request", HTTP_REQUESTS)
-def test_azure_key_credential_policy(http_request):
+def test_service_key_credential_policy(http_request):
     """Tests to see if we can create an ServiceKeyCredentialPolicy"""
 
     key_header = "api_key"
@@ -282,7 +282,7 @@ def test_azure_key_credential_policy(http_request):
     pipeline.run(http_request("GET", "https://test_key_credential"))
 
 
-def test_azure_key_credential_policy_raises():
+def test_service_key_credential_policy_raises():
     """Tests ServiceKeyCredential and ServiceKeyCredentialPolicy raises with non-compliant input parameters."""
     api_key = 1234
     key_header = 5678
@@ -297,7 +297,7 @@ def test_azure_key_credential_policy_raises():
         credential_policy = ServiceKeyCredentialPolicy(credential=str(api_key), name=key_header)
 
 
-def test_azure_key_credential_updates():
+def test_service_key_credential_updates():
     """Tests ServiceKeyCredential updates"""
     api_key = "original"
 
@@ -337,7 +337,7 @@ combinations = [
 ]
 
 
-def test_azure_named_key_credential():
+def test_service_named_key_credential():
     cred = ServiceNamedKeyCredential("sample_name", "samplekey")
 
     assert cred.named_key.name == "sample_name"
@@ -350,7 +350,7 @@ def test_azure_named_key_credential():
     assert isinstance(cred.named_key, tuple)
 
 
-def test_azure_named_key_credential_raises():
+def test_service_named_key_credential_raises():
     with pytest.raises(TypeError, match="Both name and key must be strings."):
         cred = ServiceNamedKeyCredential("sample_name", 123345)
 
@@ -363,8 +363,8 @@ def test_azure_named_key_credential_raises():
 
 
 @pytest.mark.parametrize("http_request", HTTP_REQUESTS)
-def test_azure_http_credential_policy(http_request):
-    """Tests to see if we can create an AzureHttpKeyCredentialPolicy"""
+def test_service_http_credential_policy(http_request):
+    """Tests to see if we can create an ServiceKeyCredentialPolicy"""
 
     prefix = "SharedAccessKey"
     api_key = "test_key"

--- a/sdk/core/corehttp/tests/test_pipeline.py
+++ b/sdk/core/corehttp/tests/test_pipeline.py
@@ -146,7 +146,6 @@ def test_format_url_single_brace():
 
 
 def test_format_incorrect_endpoint():
-    # https://github.com/Azure/azure-sdk-for-python/pull/12106
     client = PipelineClientBase("{Endpoint}/text/analytics/v3.0")
     with pytest.raises(ValueError) as exp:
         client.format_url("foo/bar")

--- a/sdk/core/corehttp/tests/test_rest_http_request.py
+++ b/sdk/core/corehttp/tests/test_rest_http_request.py
@@ -18,7 +18,7 @@ except ImportError:
 
 from corehttp.rest import HttpRequest
 from corehttp.runtime.policies import SansIOHTTPPolicy
-from rest_client import TestRestClient
+from rest_client import MockRestClient
 
 
 @pytest.fixture
@@ -370,7 +370,7 @@ def test_request_policies_chain(port):
 
     policies = [NewPolicyOne(), NewPolicyModifyHeaders(), NewPolicyValidateRequest()]
     request = HttpRequest("DELETE", "/container0/blob0")
-    client = TestRestClient(port="5000", policies=policies)
+    client = MockRestClient(port="5000", policies=policies)
     with pytest.raises(ValueError) as ex:
         client.send_request(
             request,

--- a/sdk/core/corehttp/tests/test_stream_generator.py
+++ b/sdk/core/corehttp/tests/test_stream_generator.py
@@ -74,7 +74,6 @@ def test_connection_error_response(http_request, http_response):
 
 @pytest.mark.parametrize("http_response", REQUESTS_TRANSPORT_RESPONSES)
 def test_response_streaming_error_behavior(http_response):
-    # Test to reproduce https://github.com/Azure/azure-sdk-for-python/issues/16723
     block_size = 103
     total_response_size = 500
     req_response = requests.Response()

--- a/sdk/core/corehttp/tests/testserver_tests/coretestserver/setup.py
+++ b/sdk/core/corehttp/tests/testserver_tests/coretestserver/setup.py
@@ -18,7 +18,7 @@ setup(
     license="MIT License",
     author="Microsoft Corporation",
     author_email="azpysdkhelp@microsoft.com",
-    url="https://github.com/iscai-msft/core.testserver",
+    url="https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/core/corehttp/tests/testserver_tests/coretestserver",
     classifiers=[
         "Development Status :: 4 - Beta",
         "Programming Language :: Python",


### PR DESCRIPTION
- Remove *any* reference to azure in the code (this includes the pylint rules)
- Remove unused internal classes
- Rename TestRestClient to not start with Test to get rid of pytest warnings.
- Remove duplicate test setup code in conftest.py of async tests.
