### PR TITLE
Disable pypy39 temporarily

### DIFF
--- a/eng/pipelines/templates/stages/platform-matrix.json
+++ b/eng/pipelines/templates/stages/platform-matrix.json
@@ -10,7 +10,7 @@
       "ubuntu-20.04": { "OSVmImage": "MMSUbuntu20.04", "Pool": "azsdk-pool-mms-ubuntu-2004-general" },
       "macos-11": { "OSVmImage": "macos-11", "Pool": "Azure Pipelines" }
     },
-    "PythonVersion": [ "3.7", "pypy3.9", "3.8", "3.10", "3.11" ],
+    "PythonVersion": [ "3.7", "3.9", "3.8", "3.10", "3.11" ],
     "CoverageArg": "--disablecov",
     "TestSamples": "false"
   },

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -36,27 +36,31 @@ function Get-AllPackageInfoFromRepo ($serviceDirectory)
     Pop-Location
   }
 
-  foreach ($line in $allPkgPropLines)
-  {
-    $pkgInfo = ($line -Split " ")
-    $packageName = $pkgInfo[0]
-    $packageVersion = $pkgInfo[1]
-    $isNewSdk = ($pkgInfo[2] -eq "True")
-    $pkgDirectoryPath = $pkgInfo[3]
-    $serviceDirectoryName = Split-Path (Split-Path -Path $pkgDirectoryPath -Parent) -Leaf
-    if ($packageName -match "mgmt")
+  Write-Host $allPkgPropLines
+
+  if ($allPkgPropLines) {
+    foreach ($line in $allPkgPropLines)
     {
-      $sdkType = "mgmt"
+      $pkgInfo = ($line -Split " ")
+      $packageName = $pkgInfo[0]
+      $packageVersion = $pkgInfo[1]
+      $isNewSdk = ($pkgInfo[2] -eq "True")
+      $pkgDirectoryPath = $pkgInfo[3]
+      $serviceDirectoryName = Split-Path (Split-Path -Path $pkgDirectoryPath -Parent) -Leaf
+      if ($packageName -match "mgmt")
+      {
+        $sdkType = "mgmt"
+      }
+      else
+      {
+        $sdkType = "client"
+      }
+      $pkgProp = [PackageProps]::new($packageName, $packageVersion, $pkgDirectoryPath, $serviceDirectoryName)
+      $pkgProp.IsNewSdk = $isNewSdk
+      $pkgProp.SdkType = $sdkType
+      $pkgProp.ArtifactName = $packageName
+      $allPackageProps += $pkgProp
     }
-    else
-    {
-      $sdkType = "client"
-    }
-    $pkgProp = [PackageProps]::new($packageName, $packageVersion, $pkgDirectoryPath, $serviceDirectoryName)
-    $pkgProp.IsNewSdk = $isNewSdk
-    $pkgProp.SdkType = $sdkType
-    $pkgProp.ArtifactName = $packageName
-    $allPackageProps += $pkgProp
   }
   return $allPackageProps
 }

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -36,31 +36,27 @@ function Get-AllPackageInfoFromRepo ($serviceDirectory)
     Pop-Location
   }
 
-  Write-Host $allPkgPropLines
-
-  if ($allPkgPropLines) {
-    foreach ($line in $allPkgPropLines)
+  foreach ($line in $allPkgPropLines)
+  {
+    $pkgInfo = ($line -Split " ")
+    $packageName = $pkgInfo[0]
+    $packageVersion = $pkgInfo[1]
+    $isNewSdk = ($pkgInfo[2] -eq "True")
+    $pkgDirectoryPath = $pkgInfo[3]
+    $serviceDirectoryName = Split-Path (Split-Path -Path $pkgDirectoryPath -Parent) -Leaf
+    if ($packageName -match "mgmt")
     {
-      $pkgInfo = ($line -Split " ")
-      $packageName = $pkgInfo[0]
-      $packageVersion = $pkgInfo[1]
-      $isNewSdk = ($pkgInfo[2] -eq "True")
-      $pkgDirectoryPath = $pkgInfo[3]
-      $serviceDirectoryName = Split-Path (Split-Path -Path $pkgDirectoryPath -Parent) -Leaf
-      if ($packageName -match "mgmt")
-      {
-        $sdkType = "mgmt"
-      }
-      else
-      {
-        $sdkType = "client"
-      }
-      $pkgProp = [PackageProps]::new($packageName, $packageVersion, $pkgDirectoryPath, $serviceDirectoryName)
-      $pkgProp.IsNewSdk = $isNewSdk
-      $pkgProp.SdkType = $sdkType
-      $pkgProp.ArtifactName = $packageName
-      $allPackageProps += $pkgProp
+      $sdkType = "mgmt"
     }
+    else
+    {
+      $sdkType = "client"
+    }
+    $pkgProp = [PackageProps]::new($packageName, $packageVersion, $pkgDirectoryPath, $serviceDirectoryName)
+    $pkgProp.IsNewSdk = $isNewSdk
+    $pkgProp.SdkType = $sdkType
+    $pkgProp.ArtifactName = $packageName
+    $allPackageProps += $pkgProp
   }
   return $allPackageProps
 }

--- a/sdk/storage/platform-matrix-all-versions.json
+++ b/sdk/storage/platform-matrix-all-versions.json
@@ -22,18 +22,5 @@
             "V2020_06_12",
             "V2020_08_04"
         ]
-    },
-    "include": [
-      {
-        "CoverageConfig": {
-          "ubuntu2004_pypy39": {
-            "OSVmImage": "MMSUbuntu20.04",
-            "Pool": "azsdk-pool-mms-ubuntu-2004-general",
-            "PythonVersion": "pypy3.9",
-            "CoverageArg": "--disablecov",
-            "TestSamples": "false"
-          }
-        }
-      }
-    ]
+    }
 }


### PR DESCRIPTION
[teams thread for context](https://teams.microsoft.com/l/message/19:b97d98e6d22c41e0970a1150b484d935@thread.skype/1698430784155?tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&groupId=3e17dcb0-4257-4a30-b843-77f47f1d4121&parentMessageId=1698430784155&teamName=Azure%20SDK&channelName=Language%20-%20Python&createdTime=1698430784155&allowXTenantAccess=false)

Unfortunately an azure devops update has totally broken the `pypy 3.9` run at `Dump Package Properties` and I can't for the _life_ of me figure out what the heck is breaking. This will unblock all the blocked builds on this error.