### PR TITLE
PATCH nows acts as POST and requires full update

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/workspace/serverless_compute.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/workspace/serverless_compute.py
@@ -2,9 +2,9 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 from marshmallow import fields
-from marshmallow.decorators import post_load
+from marshmallow.decorators import post_load, validates
 
-from azure.ai.ml._schema._utils.utils import validate_arm_str
+from azure.ai.ml._schema._utils.utils import ArmId
 from azure.ai.ml._schema.core.schema import PathAwareSchema
 from azure.ai.ml.entities._workspace.serverless_compute import ServerlessComputeSettings
 
@@ -13,12 +13,12 @@ class ServerlessComputeSettingsSchema(PathAwareSchema):
     """Schema for ServerlessComputeSettings.
 
     :param custom_subnet: The custom subnet to use for serverless computes created in the workspace.
-    :type custom_subnet: str. Formatted as ARM ID.
+    :type custom_subnet: Optional[ArmId]
     :param no_public_ip: Whether to disable public ip for the compute. Only valid if custom_subnet is defined.
     :type no_public_ip: bool
     """
 
-    custom_subnet = fields.Str(validate=validate_arm_str)
+    custom_subnet = fields.Str(allow_none=True)
     no_public_ip = fields.Bool(load_default=False)
 
     @post_load
@@ -31,5 +31,22 @@ class ServerlessComputeSettingsSchema(PathAwareSchema):
         :rtype: azure.ai.ml.entities._workspace.serverless_compute.ServerlessComputeSettings
         """
         custom_subnet = data.pop("custom_subnet", None)
+        if custom_subnet == "None":
+            custom_subnet = None  # For loading from YAML when the user wants to trigger a removal
         no_public_ip = data.pop("no_public_ip", False)
         return ServerlessComputeSettings(custom_subnet, no_public_ip)
+
+    @validates("custom_subnet")
+    def validate_custom_subnet(self, data: str, **_kwargs):
+        """Validates the custom_subnet field matches the ARM ID format or is a None-recognizable value.
+
+        :param data: The candidate custom_subnet to validate.
+        :type data: str
+        :raises ValidationError: If the custom_subnet is not formatted as an ARM ID.
+        """
+        if data == "None" or data is None:
+            # If the string is literally "None", then it should be deserialized to None
+            pass
+        else:
+            # Verify that we can transform it to an ArmId if it is not None.
+            ArmId(data)

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_workspace/serverless_compute.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_workspace/serverless_compute.py
@@ -20,7 +20,7 @@ class ServerlessComputeSettings:
     :type no_public_ip: bool
     """
 
-    custom_subnet: ArmId
+    custom_subnet: Optional[ArmId]
     no_public_ip: bool = False
 
     def __init__(self, custom_subnet: Optional[Union[str, ArmId]] = None, no_public_ip: bool = False) -> None:
@@ -52,7 +52,7 @@ class ServerlessComputeSettings:
 
     @classmethod
     def _from_rest_object(cls, obj: RestServerlessComputeSettings) -> "ServerlessComputeSettings":
-        return ServerlessComputeSettings(
+        return cls(
             custom_subnet=obj.serverless_compute_custom_subnet,
             no_public_ip=obj.serverless_compute_no_public_ip,
         )

--- a/sdk/ml/azure-ai-ml/tests/test_configs/workspace/workspace_removing_serverless.yaml
+++ b/sdk/ml/azure-ai-ml/tests/test_configs/workspace/workspace_removing_serverless.yaml
@@ -1,0 +1,4 @@
+name: ws_min_serverless
+serverless_compute:
+  custom_subnet: None
+  no_public_ip: false

--- a/sdk/ml/azure-ai-ml/tests/workspace/unittests/test_workspace_operations.py
+++ b/sdk/ml/azure-ai-ml/tests/workspace/unittests/test_workspace_operations.py
@@ -224,38 +224,13 @@ class TestWorkspaceOperation:
             RestServerlessComputeSettings.deserialize(settings) == serverless_compute_settings._to_rest_object()
 
     @pytest.mark.parametrize(
-        "serverless_compute_settings",
-        [
-            None,
-            ServerlessComputeSettings(gen_subnet_name(vnet="testvnet", subnet_name="testsubnet")),
-            ServerlessComputeSettings(gen_subnet_name(subnet_name="npip"), no_public_ip=True),
-        ],
-    )
-    def test_update_workspace_with_serverless_custom_vnet(
-        self,
-        serverless_compute_settings: ServerlessComputeSettings,
-        mock_workspace_operation_aug_2023_preview: WorkspaceOperations,
-        mocker: MockFixture,
-    ) -> None:
-        ws = Workspace(name="name", location="test", serverless_compute=serverless_compute_settings)
-        spy = mocker.spy(mock_workspace_operation_aug_2023_preview._operation, "begin_update")
-        mock_workspace_operation_aug_2023_preview.begin_update(ws)
-        if serverless_compute_settings is None:
-            assert spy.call_args[0][2].serverless_compute_settings is None
-        else:
-            assert (
-                ServerlessComputeSettings._from_rest_object(spy.call_args[0][2].serverless_compute_settings)
-                == serverless_compute_settings
-            )
-
-    @pytest.mark.parametrize(
         "new_settings",
         [
-            ServerlessComputeSettings(gen_subnet_name(vnet="testvnet", subnet_name="testsubnet")),
-            ServerlessComputeSettings(no_public_ip=True),
+            ServerlessComputeSettings(gen_subnet_name(vnet="testvnet", subnet_name="testsubnet"), no_public_ip=False),
+            ServerlessComputeSettings(gen_subnet_name(vnet="testvnet", subnet_name="testsubnet"), no_public_ip=True),
         ],
     )
-    def test_can_perform_partial_update_of_serverless_compute_settings(
+    def test_can_update_of_serverless_compute_settings(
         self,
         new_settings: ServerlessComputeSettings,
         mock_workspace_operation_aug_2023_preview: WorkspaceOperations,
@@ -280,4 +255,52 @@ class TestWorkspaceOperation:
         mock_workspace_operation_aug_2023_preview.begin_update(ws)
         assert (
             ServerlessComputeSettings._from_rest_object(spy.call_args[0][2].serverless_compute_settings) == new_settings
+        )
+
+    def test_can_remove_serverless_compute_settings_via_none_subnet_and_false_npip(
+        self, mock_workspace_operation_aug_2023_preview: WorkspaceOperations, mocker: MockFixture
+    ) -> None:
+        original_settings = ServerlessComputeSettings(
+            gen_subnet_name(vnet="testvnet", subnet_name="default"), no_public_ip=False
+        )
+        removal_settings = ServerlessComputeSettings(None, no_public_ip=False)
+        wsname = "fake"
+        ws = Workspace(name=wsname, location="test", serverless_compute=removal_settings)
+
+        key = CustomerManagedKey()
+        original_workspace = Workspace(
+            name=wsname,
+            location="test",
+            serverless_compute=original_settings,
+            customer_managed_key=key,
+        )
+        rest_workspace: RestWorkspace = original_workspace._to_rest_object()  # pylint: disable=protected-access
+        mock_workspace_operation_aug_2023_preview._operation.get = MagicMock(return_value=rest_workspace)
+        spy = mocker.spy(mock_workspace_operation_aug_2023_preview._operation, "begin_update")
+        mock_workspace_operation_aug_2023_preview.begin_update(ws)
+        assert (
+            ServerlessComputeSettings._from_rest_object(spy.call_args[0][2].serverless_compute_settings)
+            == ServerlessComputeSettings()
+        )
+
+    def test_can_remove_via_file(
+        self, mock_workspace_operation_aug_2023_preview: WorkspaceOperations, mocker: MockFixture
+    ) -> None:
+        import os
+
+        removal_settings = ServerlessComputeSettings(None, no_public_ip=False)
+        wsname = "fake"
+        config_dir = os.path.join("tests", "test_configs", "workspace")
+        default_source = os.path.join(config_dir, "workspace_min_with_serverless.yaml")
+        ws = load_workspace(source=default_source)
+        assert ws.serverless_compute.custom_subnet is not None
+        assert ws.serverless_compute.no_public_ip
+        rest_workspace = ws._to_rest_object()  # pylint: disable=protected-access
+        mock_workspace_operation_aug_2023_preview._operation.get = MagicMock(return_value=rest_workspace)
+        spy = mocker.spy(mock_workspace_operation_aug_2023_preview._operation, "begin_update")
+        ws_update = load_workspace(source=os.path.join(config_dir, "workspace_removing_serverless.yaml"))
+        mock_workspace_operation_aug_2023_preview.begin_update(ws_update)
+        assert (
+            ServerlessComputeSettings._from_rest_object(spy.call_args[0][2].serverless_compute_settings)
+            == ServerlessComputeSettings()
         )


### PR DESCRIPTION
Require both fields in ServerlessComputeSettings to be provided on update.

# Description

Please add an informative description that covers that changes made by the pull request and link all relevant issues.

If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
