### PR TITLE
Fix connection e2e tests.

### DIFF
--- a/sdk/ml/azure-ai-ml/assets.json
+++ b/sdk/ml/azure-ai-ml/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "python",
   "TagPrefix": "python/ml/azure-ai-ml",
-  "Tag": "python/ml/azure-ai-ml_42bd3be96a"
+  "Tag": "python/ml/azure-ai-ml_f6837db0ab"
 }

--- a/sdk/ml/azure-ai-ml/tests/workspace/e2etests/test_workspace_connections.py
+++ b/sdk/ml/azure-ai-ml/tests/workspace/e2etests/test_workspace_connections.py
@@ -16,7 +16,6 @@ from azure.ai.ml._utils.utils import camel_to_snake
 @pytest.mark.core_sdk_test
 @pytest.mark.usefixtures("recorded_test")
 class TestWorkspaceConnections(AzureRecordedTestCase):
-    @pytest.mark.skip(reason="TODO: Message: e2e recording not working")
     def test_workspace_connections_create_update_and_delete_python_feed(
         self,
         client: MLClient,
@@ -64,7 +63,6 @@ class TestWorkspaceConnections(AzureRecordedTestCase):
         for conn in connection_list:
             print(conn)
 
-    @pytest.mark.skip(reason="TODO: Message: e2e recording not working")
     def test_workspace_connections_create_update_and_delete_git_pat(
         self,
         client: MLClient,
@@ -109,7 +107,6 @@ class TestWorkspaceConnections(AzureRecordedTestCase):
         for conn in connection_list:
             print(conn)
 
-    @pytest.mark.skip(reason="TODO: Message: e2e recording not working")
     def test_workspace_connections_create_update_and_delete_cr_msi(
         self,
         client: MLClient,
@@ -157,7 +154,6 @@ class TestWorkspaceConnections(AzureRecordedTestCase):
         for conn in connection_list:
             print(conn)
 
-    @pytest.mark.skip(reason="TODO: Message: e2e recording not working")
     def test_workspace_connections_create_update_and_delete_git_user_pwd(
         self,
         client: MLClient,
@@ -204,7 +200,6 @@ class TestWorkspaceConnections(AzureRecordedTestCase):
         for conn in connection_list:
             print(conn)
 
-    @pytest.mark.skip(reason="TODO: Message: e2e recording not working")
     def test_workspace_connections_create_update_and_delete_snowflake_user_pwd(
         self,
         client: MLClient,
@@ -249,7 +244,6 @@ class TestWorkspaceConnections(AzureRecordedTestCase):
         for conn in connection_list:
             print(conn)
 
-    @pytest.mark.skip(reason="TODO: Message: e2e recording not working")
     def test_workspace_connections_create_update_and_delete_s3_access_key(
         self,
         client: MLClient,
@@ -294,7 +288,6 @@ class TestWorkspaceConnections(AzureRecordedTestCase):
         for conn in connection_list:
             print(conn)
 
-    @pytest.mark.skip(reason="TODO: Message: e2e recording not working")
     def test_workspace_connections_create_update_and_delete_open_ai_conn(
         self,
         client: MLClient,
@@ -313,7 +306,7 @@ class TestWorkspaceConnections(AzureRecordedTestCase):
         assert wps_connection.type == camel_to_snake(ConnectionCategory.AZURE_OPEN_AI)
         assert wps_connection.tags is not None
         assert wps_connection.tags["hello"] == "world"
-        assert wps_connection.api_type == "some_type"
+        assert wps_connection.api_type == "Azure"
         assert wps_connection.api_version == "some_version"
 
         client.connections.delete(name=wps_connection_name)
@@ -326,7 +319,6 @@ class TestWorkspaceConnections(AzureRecordedTestCase):
         for conn in connection_list:
             print(conn)
 
-    @pytest.mark.skip(reason="TODO: Message: e2e recording not working")
     def test_workspace_connections_create_update_and_delete_cog_search_conn(
         self,
         client: MLClient,
@@ -356,7 +348,6 @@ class TestWorkspaceConnections(AzureRecordedTestCase):
         for conn in connection_list:
             print(conn)
 
-    @pytest.mark.skip(reason="TODO: Message: e2e recording not working")
     def test_workspace_connections_create_update_and_delete_cog_service_conn(
         self,
         client: MLClient,


### PR DESCRIPTION
Re-enable the workspace connection e2e tests after figuring out why my recordings were being recorded in a broken state. Apparently the workspace name `mlholland-testing-ws` broke a parse somewhere due to the multiple dashes, except a **separate** parser in playback mode worker properly, resulting in a slight difference between the sanitized workspace name and the expected workspace name in playback mode. 

Also fixed a 1-line assertion that changed as a result of shared files from the unit tests being modified.