### PR TITLE
[AMQP] Fix Filter Set Encoding For 2 Char Length Session id

### DIFF
--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/_encode.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/_encode.py
@@ -765,14 +765,13 @@ def encode_filter_set(value):
         else:
             if isinstance(name, str):
                 name = name.encode("utf-8")  # type: ignore
-            try:
+            if len(data) == 2 and not isinstance(data, (str, bytes)):
                 descriptor, filter_value = data
                 described_filter = {
                     TYPE: AMQPTypes.described,
                     VALUE: ({TYPE: AMQPTypes.symbol, VALUE: descriptor}, filter_value),
                 }
-            except ValueError:
-                described_filter = data
+            described_filter = data
 
         cast(List, fields[VALUE]).append(
             ({TYPE: AMQPTypes.symbol, VALUE: name}, described_filter)

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/_encode.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/_encode.py
@@ -765,14 +765,15 @@ def encode_filter_set(value):
         else:
             if isinstance(name, str):
                 name = name.encode("utf-8")  # type: ignore
-            if len(data) == 2 and not isinstance(data, (str, bytes)):
+            if isinstance(data, (str, bytes)):
+                described_filter = data
+            # handle the situation when data is a tuple or list of length 2
+            else:
                 descriptor, filter_value = data
                 described_filter = {
                     TYPE: AMQPTypes.described,
                     VALUE: ({TYPE: AMQPTypes.symbol, VALUE: descriptor}, filter_value),
                 }
-            else:
-                described_filter = data
 
         cast(List, fields[VALUE]).append(
             ({TYPE: AMQPTypes.symbol, VALUE: name}, described_filter)

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/_encode.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/_encode.py
@@ -773,7 +773,7 @@ def encode_filter_set(value):
                 }
             else:
                 described_filter = data
-            
+
         cast(List, fields[VALUE]).append(
             ({TYPE: AMQPTypes.symbol, VALUE: name}, described_filter)
         )

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/_encode.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/_encode.py
@@ -771,8 +771,9 @@ def encode_filter_set(value):
                     TYPE: AMQPTypes.described,
                     VALUE: ({TYPE: AMQPTypes.symbol, VALUE: descriptor}, filter_value),
                 }
-            described_filter = data
-
+            else:
+                described_filter = data
+            
         cast(List, fields[VALUE]).append(
             ({TYPE: AMQPTypes.symbol, VALUE: name}, described_filter)
         )

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/_encode.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/_encode.py
@@ -776,7 +776,7 @@ def encode_filter_set(value):
                         VALUE: ({TYPE: AMQPTypes.symbol, VALUE: descriptor}, filter_value),
                     }
                 # if its not a type that is known, raise the error from the server
-                except Exception:
+                except (ValueError, TypeError):
                     described_filter = data
 
         cast(List, fields[VALUE]).append(

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/_encode.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/_encode.py
@@ -766,7 +766,7 @@ def encode_filter_set(value):
             if isinstance(name, str):
                 name = name.encode("utf-8")  # type: ignore
             if isinstance(data, (str, bytes)):
-                described_filter = data
+                described_filter = data # type: ignore
             # handle the situation when data is a tuple or list of length 2
             else:
                 try:
@@ -775,10 +775,9 @@ def encode_filter_set(value):
                         TYPE: AMQPTypes.described,
                         VALUE: ({TYPE: AMQPTypes.symbol, VALUE: descriptor}, filter_value),
                     }
-                except ValueError:
-                    raise ValueError(
-                        "Filter value must be a tuple or list of length 2."
-                    )
+                # if its not a type that is known, raise the error from the server
+                except Exception:
+                    described_filter = data
 
         cast(List, fields[VALUE]).append(
             ({TYPE: AMQPTypes.symbol, VALUE: name}, described_filter)

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/_encode.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/_encode.py
@@ -769,11 +769,16 @@ def encode_filter_set(value):
                 described_filter = data
             # handle the situation when data is a tuple or list of length 2
             else:
-                descriptor, filter_value = data
-                described_filter = {
-                    TYPE: AMQPTypes.described,
-                    VALUE: ({TYPE: AMQPTypes.symbol, VALUE: descriptor}, filter_value),
-                }
+                try:
+                    descriptor, filter_value = data
+                    described_filter = {
+                        TYPE: AMQPTypes.described,
+                        VALUE: ({TYPE: AMQPTypes.symbol, VALUE: descriptor}, filter_value),
+                    }
+                except ValueError:
+                    raise ValueError(
+                        "Filter value must be a tuple or list of length 2."
+                    )
 
         cast(List, fields[VALUE]).append(
             ({TYPE: AMQPTypes.symbol, VALUE: name}, described_filter)

--- a/sdk/eventhub/azure-eventhub/tests/pyamqp_tests/unittest/test_encode.py
+++ b/sdk/eventhub/azure-eventhub/tests/pyamqp_tests/unittest/test_encode.py
@@ -7,14 +7,11 @@ from azure.eventhub._pyamqp._encode import encode_filter_set
     ({b'com.microsoft:session-filter': 'aba'}, 'aba'),
     ({b'com.microsoft:session-filter': 'ab'}, 'ab'),
     ({b'com.microsoft:session-filter': 'a'}, 'a'),
+    ({b'com.microsoft:session-filter': 1}, 1),
 ])
 def test_valid_filter_encode(value, expected):
     fields = encode_filter_set(value)
     assert len(fields) == 2
     assert fields['VALUE'][0][1] == expected
-
-def test_invalid_filter_encode():
-    value = {b'com.microsoft:session-filter': 1}
-    pytest.raises(TypeError, encode_filter_set, value)
 
 

--- a/sdk/eventhub/azure-eventhub/tests/pyamqp_tests/unittest/test_encode.py
+++ b/sdk/eventhub/azure-eventhub/tests/pyamqp_tests/unittest/test_encode.py
@@ -1,0 +1,20 @@
+import pytest
+from azure.eventhub._pyamqp._encode import encode_filter_set
+
+@pytest.mark.parametrize("value,expected", [
+    ({b'com.microsoft:session-filter': 'ababa'}, 'ababa'),
+    ({b'com.microsoft:session-filter': 'abab'}, 'abab'),
+    ({b'com.microsoft:session-filter': 'aba'}, 'aba'),
+    ({b'com.microsoft:session-filter': 'ab'}, 'ab'),
+    ({b'com.microsoft:session-filter': 'a'}, 'a'),
+])
+def test_valid_filter_encode(value, expected):
+    fields = encode_filter_set(value)
+    assert len(fields) == 2
+    assert fields['VALUE'][0][1] == expected
+
+def test_invalid_filter_encode():
+    value = {b'com.microsoft:session-filter': 1}
+    pytest.raises(TypeError, encode_filter_set, value)
+
+

--- a/sdk/servicebus/azure-servicebus/CHANGELOG.md
+++ b/sdk/servicebus/azure-servicebus/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 7.11.4 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 7.11.4 (2023-11-13)
 
 ### Bugs Fixed
 
-### Other Changes
+- Fixed a bug where a two character count session id was being incorrectly parsed by azure amqp.
 
 ## 7.11.3 (2023-10-11)
 

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/_encode.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/_encode.py
@@ -765,14 +765,14 @@ def encode_filter_set(value):
         else:
             if isinstance(name, str):
                 name = name.encode("utf-8")  # type: ignore
-            try:
-                descriptor, filter_value = data
+            if len(data) == 2 and not isinstance(data, (str, bytes)):
+                descriptor, filter_value = data # k,a
                 described_filter = {
                     TYPE: AMQPTypes.described,
                     VALUE: ({TYPE: AMQPTypes.symbol, VALUE: descriptor}, filter_value),
                 }
-            except ValueError:
-                described_filter = data
+            
+            described_filter = data
 
         cast(List, fields[VALUE]).append(
             ({TYPE: AMQPTypes.symbol, VALUE: name}, described_filter)

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/_encode.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/_encode.py
@@ -765,14 +765,15 @@ def encode_filter_set(value):
         else:
             if isinstance(name, str):
                 name = name.encode("utf-8")  # type: ignore
-            if len(data) == 2 and not isinstance(data, (str, bytes)):
+            if isinstance(data, (str, bytes)):
+                described_filter = data
+            # handle the situation when data is a tuple or list of length 2
+            else:
                 descriptor, filter_value = data
                 described_filter = {
                     TYPE: AMQPTypes.described,
                     VALUE: ({TYPE: AMQPTypes.symbol, VALUE: descriptor}, filter_value),
                 }
-            else:
-                described_filter = data
 
         cast(List, fields[VALUE]).append(
             ({TYPE: AMQPTypes.symbol, VALUE: name}, described_filter)

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/_encode.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/_encode.py
@@ -773,7 +773,7 @@ def encode_filter_set(value):
                 }
             else:
                 described_filter = data
-            
+
         cast(List, fields[VALUE]).append(
             ({TYPE: AMQPTypes.symbol, VALUE: name}, described_filter)
         )

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/_encode.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/_encode.py
@@ -771,8 +771,9 @@ def encode_filter_set(value):
                     TYPE: AMQPTypes.described,
                     VALUE: ({TYPE: AMQPTypes.symbol, VALUE: descriptor}, filter_value),
                 }
-            described_filter = data
-
+            else:
+                described_filter = data
+            
         cast(List, fields[VALUE]).append(
             ({TYPE: AMQPTypes.symbol, VALUE: name}, described_filter)
         )

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/_encode.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/_encode.py
@@ -776,7 +776,7 @@ def encode_filter_set(value):
                         VALUE: ({TYPE: AMQPTypes.symbol, VALUE: descriptor}, filter_value),
                     }
                 # if its not a type that is known, raise the error from the server
-                except Exception:
+                except (ValueError, TypeError):
                     described_filter = data
 
         cast(List, fields[VALUE]).append(

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/_encode.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/_encode.py
@@ -766,7 +766,7 @@ def encode_filter_set(value):
             if isinstance(name, str):
                 name = name.encode("utf-8")  # type: ignore
             if isinstance(data, (str, bytes)):
-                described_filter = data
+                described_filter = data # type: ignore
             # handle the situation when data is a tuple or list of length 2
             else:
                 try:
@@ -775,10 +775,9 @@ def encode_filter_set(value):
                         TYPE: AMQPTypes.described,
                         VALUE: ({TYPE: AMQPTypes.symbol, VALUE: descriptor}, filter_value),
                     }
-                except ValueError:
-                    raise ValueError(
-                        "Filter value must be a tuple or list of length 2."
-                    )
+                # if its not a type that is known, raise the error from the server
+                except Exception:
+                    described_filter = data
 
         cast(List, fields[VALUE]).append(
             ({TYPE: AMQPTypes.symbol, VALUE: name}, described_filter)

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/_encode.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/_encode.py
@@ -769,11 +769,16 @@ def encode_filter_set(value):
                 described_filter = data
             # handle the situation when data is a tuple or list of length 2
             else:
-                descriptor, filter_value = data
-                described_filter = {
-                    TYPE: AMQPTypes.described,
-                    VALUE: ({TYPE: AMQPTypes.symbol, VALUE: descriptor}, filter_value),
-                }
+                try:
+                    descriptor, filter_value = data
+                    described_filter = {
+                        TYPE: AMQPTypes.described,
+                        VALUE: ({TYPE: AMQPTypes.symbol, VALUE: descriptor}, filter_value),
+                    }
+                except ValueError:
+                    raise ValueError(
+                        "Filter value must be a tuple or list of length 2."
+                    )
 
         cast(List, fields[VALUE]).append(
             ({TYPE: AMQPTypes.symbol, VALUE: name}, described_filter)

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/_encode.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/_encode.py
@@ -766,12 +766,11 @@ def encode_filter_set(value):
             if isinstance(name, str):
                 name = name.encode("utf-8")  # type: ignore
             if len(data) == 2 and not isinstance(data, (str, bytes)):
-                descriptor, filter_value = data # k,a
+                descriptor, filter_value = data
                 described_filter = {
                     TYPE: AMQPTypes.described,
                     VALUE: ({TYPE: AMQPTypes.symbol, VALUE: descriptor}, filter_value),
                 }
-            
             described_filter = data
 
         cast(List, fields[VALUE]).append(


### PR DESCRIPTION
Fix for the case when a session id was of length 2. There was a logic error in encode that would try to do try/except on the passed in data and improperly split the values leading to an error from the service

`The link contains invalid filter type. System only support Jms or Apache selector filter type but we found type 'Microsoft.ServiceBus.Messaging.Amqp.Encoding.DescribedType' associated with key 'com.microsoft:session-filter'.`

* if session id is (6, 671, 6712, .....) , line 769 raises a ValueError which gets handled on line 774 and described_filter = 671 as excepted
* if session id is of length 2 ( 67, ka ) line 769 unpacks making descriptor = 6, filter_value = 7 , making the value borked

The fix was to make sure strs or bytes would not be attempted to be unpacked.