### PR TITLE
[engsys] ci: Fix `tox_harness.py` dropping package extras when rewriting dev_requirements.txt

### DIFF
--- a/scripts/devops_tasks/tox_harness.py
+++ b/scripts/devops_tasks/tox_harness.py
@@ -116,20 +116,22 @@ def replace_dev_reqs(file, pkg_root):
     adjusted_req_lines = []
 
     with open(file, "r") as f:
-        for line in f:
-            args = [part.strip() for part in line.split() if part and not part.strip() == "-e"]
-            amended_line = " ".join(args)
-            extras = ""
+        original_req_lines = list(line.strip() for line in f)
 
-            if amended_line.endswith("]"):
-                amended_line, extras = amended_line.rsplit("[", maxsplit=1)
-                if extras:
-                    extras = f"[{extras}"
+    for line in original_req_lines:
+        args = [part.strip() for part in line.split() if part and not part.strip() == "-e"]
+        amended_line = " ".join(args)
+        extras = ""
 
-            adjusted_req_lines.append(f"{build_whl_for_req(amended_line, pkg_root)}{extras}")
+        if amended_line.endswith("]"):
+            amended_line, extras = amended_line.rsplit("[", maxsplit=1)
+            if extras:
+                extras = f"[{extras}"
+
+        adjusted_req_lines.append(f"{build_whl_for_req(amended_line, pkg_root)}{extras}")
 
     req_file_name = os.path.basename(file)
-    logging.info("Old {0}:{1}".format(req_file_name, adjusted_req_lines))
+    logging.info("Old {0}:{1}".format(req_file_name, original_req_lines))
 
     logging.info("New {0}:{1}".format(req_file_name, adjusted_req_lines))
 

--- a/scripts/devops_tasks/tox_harness.py
+++ b/scripts/devops_tasks/tox_harness.py
@@ -119,17 +119,18 @@ def replace_dev_reqs(file, pkg_root):
         for line in f:
             args = [part.strip() for part in line.split() if part and not part.strip() == "-e"]
             amended_line = " ".join(args)
+            extras = ""
 
             if amended_line.endswith("]"):
-                trim_amount = amended_line[::-1].index("[") + 1
-                amended_line = amended_line[0 : (len(amended_line) - trim_amount)]
+                amended_line, extras = amended_line.rsplit("[", maxsplit=1)
+                if extras:
+                    extras = f"[{extras}"
 
-            adjusted_req_lines.append(amended_line)
+            adjusted_req_lines.append(f"{build_whl_for_req(amended_line, pkg_root)}{extras}")
 
     req_file_name = os.path.basename(file)
     logging.info("Old {0}:{1}".format(req_file_name, adjusted_req_lines))
 
-    adjusted_req_lines = list(map(lambda x: build_whl_for_req(x, pkg_root), adjusted_req_lines))
     logging.info("New {0}:{1}".format(req_file_name, adjusted_req_lines))
 
     with open(file, "w") as f:


### PR DESCRIPTION
# Description

This pull request fixes an issue where `scripts/devops_tasks/tox_harness.py` will rewrite requirements without any specified extras (`./path/to/package[extra,extra1,...]` -> `/path/to/package.whl`)

This pull request helps unblock #32770 

**Note**: This pull request may have the potential to cause CI failures. CI that were in a previously passing state with package extras dropped may have different behavior/fai

* Example: A couple requirements files install `azure-sdk-tools` with the `build` extra

https://github.com/Azure/azure-sdk-for-python/blob/e3bb7f2aafb10b1f87af735ce7fdf3b031b42786/eng/ci_tools.txt#L39



# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
