### PR TITLE
[ml] use and enforce same restclient for all workspaces types

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_ml_client.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_ml_client.py
@@ -585,7 +585,7 @@ class MLClient:
 
         self._featurestores = FeatureStoreOperations(
             self._operation_scope,
-            self._service_client_06_2023_preview,
+            self._service_client_08_2023_preview,
             self._operation_container,
             self._credential,
             **app_insights_handler_kwargs,
@@ -609,7 +609,7 @@ class MLClient:
 
         self._workspace_hubs = WorkspaceHubOperations(
             self._operation_scope,
-            self._service_client_06_2023_preview,
+            self._service_client_08_2023_preview,
             self._operation_container,
             self._credential,
             **app_insights_handler_kwargs,

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_feature_store/feature_store.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_feature_store/feature_store.py
@@ -9,7 +9,7 @@ from os import PathLike
 from pathlib import Path
 from typing import Dict, Optional, Union
 
-from azure.ai.ml._restclient.v2023_04_01_preview.models import Workspace as RestWorkspace
+from azure.ai.ml._restclient.v2023_08_01_preview.models import Workspace as RestWorkspace
 from azure.ai.ml._schema._feature_store.feature_store_schema import FeatureStoreSchema
 from azure.ai.ml.constants._common import BASE_PATH_CONTEXT_KEY, PARAMS_OVERRIDE_KEY
 from azure.ai.ml.entities._credentials import IdentityConfiguration, ManagedIdentityConfiguration

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_workspace_hub/workspace_hub.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_workspace_hub/workspace_hub.py
@@ -9,8 +9,8 @@ from os import PathLike
 from pathlib import Path
 from typing import Dict, List, Optional, Union
 
-from azure.ai.ml._restclient.v2023_06_01_preview.models import Workspace as RestWorkspace
-from azure.ai.ml._restclient.v2023_06_01_preview.models import WorkspaceHubConfig as RestWorkspaceHubConfig
+from azure.ai.ml._restclient.v2023_08_01_preview.models import Workspace as RestWorkspace
+from azure.ai.ml._restclient.v2023_08_01_preview.models import WorkspaceHubConfig as RestWorkspaceHubConfig
 
 from azure.ai.ml._schema._workspace_hub.workspace_hub import WorkspaceHubSchema
 from azure.ai.ml.entities._workspace_hub.workspace_hub_config import WorkspaceHubConfig

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_workspace_hub_operation.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_workspace_hub_operation.py
@@ -6,7 +6,7 @@
 
 from typing import Dict, Iterable, Optional
 
-from azure.ai.ml._restclient.v2023_06_01_preview import AzureMachineLearningWorkspaces as ServiceClient062023Preview
+from azure.ai.ml._restclient.v2023_08_01_preview import AzureMachineLearningServices as ServiceClient082023Preview
 from azure.ai.ml._scope_dependent_operations import OperationsContainer, OperationScope
 from azure.ai.ml._telemetry import ActivityType, monitor_with_activity
 from azure.ai.ml._utils._logger_utils import OpsLogger
@@ -35,7 +35,7 @@ class WorkspaceHubOperations(WorkspaceOperationsBase):
     def __init__(
         self,
         operation_scope: OperationScope,
-        service_client: ServiceClient062023Preview,
+        service_client: ServiceClient082023Preview,
         all_operations: OperationsContainer,
         credentials: Optional[TokenCredential] = None,
         **kwargs: Dict,

--- a/sdk/ml/azure-ai-ml/tests/workspace/unittests/test_workspace_entity.py
+++ b/sdk/ml/azure-ai-ml/tests/workspace/unittests/test_workspace_entity.py
@@ -7,20 +7,6 @@ from azure.ai.ml import load_workspace
 from azure.ai.ml.entities import (
     ServerlessComputeSettings,
     Workspace,
-    FqdnDestination,
-    ServiceTagDestination,
-    PrivateEndpointDestination,
-)
-
-from azure.ai.ml._restclient.v2023_08_01_preview.models import (
-    Workspace as RestWorkspace,
-    ManagedNetworkSettings as RestManagedNetwork,
-    FqdnOutboundRule as RestFqdnOutboundRule,
-    PrivateEndpointOutboundRule as RestPrivateEndpointOutboundRule,
-    PrivateEndpointDestination as RestPrivateEndpointOutboundRuleDestination,
-    ServiceTagOutboundRule as RestServiceTagOutboundRule,
-    ServiceTagDestination as RestServiceTagOutboundRuleDestination,
-    ManagedNetworkProvisionStatus as RestManagedNetworkProvisionStatus,
 )
 
 from azure.ai.ml.constants._workspace import IsolationMode
@@ -29,43 +15,6 @@ from azure.ai.ml.constants._workspace import IsolationMode
 @pytest.mark.unittest
 @pytest.mark.core_sdk_test
 class TestWorkspaceEntity:
-    def test_workspace_entity_from_rest_object_managednetwork_restclient_versions_match(self):
-        rest_managed_network = RestManagedNetwork(
-            isolation_mode=IsolationMode.ALLOW_ONLY_APPROVED_OUTBOUND,
-            outbound_rules={
-                "fqdn-rule": RestFqdnOutboundRule(destination="google.com"),
-                "pe-rule": RestPrivateEndpointOutboundRule(
-                    destination=RestPrivateEndpointOutboundRuleDestination(
-                        service_resource_id="/somestorageid", spark_enabled=False, subresource_target="blob"
-                    )
-                ),
-                "servicetag-rule": RestServiceTagOutboundRule(
-                    destination=RestServiceTagOutboundRuleDestination(
-                        service_tag="sometag", protocol="*", port_ranges="1,2"
-                    )
-                ),
-            },
-            status=RestManagedNetworkProvisionStatus(status="Active", spark_ready=False),
-        )
-        rest_ws = RestWorkspace(managed_network=rest_managed_network)
-
-        sdk_ws = Workspace._from_rest_object(rest_ws)
-        assert sdk_ws.managed_network is not None
-        assert sdk_ws.managed_network.isolation_mode == IsolationMode.ALLOW_ONLY_APPROVED_OUTBOUND
-        rules = sdk_ws.managed_network.outbound_rules
-        assert isinstance(rules[0], FqdnDestination)
-        assert rules[0].destination == "google.com"
-
-        assert isinstance(rules[1], PrivateEndpointDestination)
-        assert rules[1].service_resource_id == "/somestorageid"
-        assert rules[1].spark_enabled == False
-        assert rules[1].subresource_target == "blob"
-
-        assert isinstance(rules[2], ServiceTagDestination)
-        assert rules[2].service_tag == "sometag"
-        assert rules[2].protocol == "*"
-        assert rules[2].port_ranges == "1,2"
-
     @pytest.mark.parametrize(
         "settings",
         [

--- a/sdk/ml/azure-ai-ml/tests/workspace/unittests/test_workspace_related_restclients.py
+++ b/sdk/ml/azure-ai-ml/tests/workspace/unittests/test_workspace_related_restclients.py
@@ -83,13 +83,13 @@ def get_test_rest_workspace_with_all_details() -> RestWorkspace:
 class TestWorkspaceEntity:
     """
     test description:
-    the purpose of the tests in this file is to ensure _restclient version is correct for 
+    the purpose of the tests in this file is to ensure _restclient version is correct for
     marshalling and unmarshalling between REST and SDK client objects.
 
-    if you will update the restclient version for anything that is using workspace object 
-    and related operations (currently: workspace entities, workspacehub entities, network entities, 
-    WorkspaceOperations, WorkspaceOutboundRuleOperations, FeatureStoreOperations, WorkspaceHubOperations) 
-    then you will also need to update the restclient version to match in all these locations to avoid 
+    if you will update the restclient version for anything that is using workspace object
+    and related operations (currently: workspace entities, workspacehub entities, network entities,
+    WorkspaceOperations, WorkspaceOutboundRuleOperations, FeatureStoreOperations, WorkspaceHubOperations)
+    then you will also need to update the restclient version to match in all these locations to avoid
     issues when unmarshalling.
     """
 
@@ -140,7 +140,6 @@ class TestWorkspaceEntity:
         )
         assert sdk_ws.serverless_compute.no_public_ip == True
 
-
     def test_workspace_hub_entity_from_rest_to_ensure_restclient_versions_match(self):
         rest_ws = get_test_rest_workspace_with_all_details()
 
@@ -168,7 +167,6 @@ class TestWorkspaceEntity:
         assert "sa1" in sdk_hub.workspace_hub_config.additional_workspace_storage_accounts
         assert "sa2" in sdk_hub.workspace_hub_config.additional_workspace_storage_accounts
         assert sdk_hub.workspace_hub_config.default_workspace_resource_group == "somerg"
-
 
     def test_feature_store_entity_from_rest_to_ensure_restclient_versions_match(self):
         rest_ws = get_test_rest_workspace_with_all_details()

--- a/sdk/ml/azure-ai-ml/tests/workspace/unittests/test_workspace_related_restclients.py
+++ b/sdk/ml/azure-ai-ml/tests/workspace/unittests/test_workspace_related_restclients.py
@@ -1,0 +1,198 @@
+from typing import Optional
+
+import pytest
+from azure.ai.ml.entities import (
+    Workspace,
+    FqdnDestination,
+    ServiceTagDestination,
+    PrivateEndpointDestination,
+    FeatureStore,
+    WorkspaceHub,
+)
+
+from azure.ai.ml._restclient.v2023_08_01_preview.models import (
+    Workspace as RestWorkspace,
+    ManagedNetworkSettings as RestManagedNetwork,
+    FqdnOutboundRule as RestFqdnOutboundRule,
+    PrivateEndpointOutboundRule as RestPrivateEndpointOutboundRule,
+    PrivateEndpointDestination as RestPrivateEndpointOutboundRuleDestination,
+    ServiceTagOutboundRule as RestServiceTagOutboundRule,
+    ServiceTagDestination as RestServiceTagOutboundRuleDestination,
+    ManagedNetworkProvisionStatus as RestManagedNetworkProvisionStatus,
+    FeatureStoreSettings as RestFeatureStoreSettings,
+    ManagedServiceIdentity as RestManagedServiceIdentity,
+    ServerlessComputeSettings as RestServerlessComputeSettings,
+    UserAssignedIdentity,
+    # this one only for workspace hubs
+    WorkspaceHubConfig as RestWorkspaceHubConfig,
+)
+from azure.ai.ml._restclient.v2023_08_01_preview.operations import (
+    WorkspacesOperations as RestClientWorkspacesOperations,
+    ManagedNetworkSettingsRuleOperations as RestClientManagedNetworkSettingsRuleOperations,
+)
+
+from azure.ai.ml.constants._workspace import IsolationMode
+from azure.ai.ml import (
+    MLClient,
+)
+from azure.identity import DefaultAzureCredential
+
+
+def get_test_rest_workspace_with_all_details() -> RestWorkspace:
+    rest_managed_network = RestManagedNetwork(
+        isolation_mode=IsolationMode.ALLOW_ONLY_APPROVED_OUTBOUND,
+        outbound_rules={
+            "fqdn-rule": RestFqdnOutboundRule(destination="google.com"),
+            "pe-rule": RestPrivateEndpointOutboundRule(
+                destination=RestPrivateEndpointOutboundRuleDestination(
+                    service_resource_id="/somestorageid", spark_enabled=False, subresource_target="blob"
+                )
+            ),
+            "servicetag-rule": RestServiceTagOutboundRule(
+                destination=RestServiceTagOutboundRuleDestination(
+                    service_tag="sometag", protocol="*", port_ranges="1,2"
+                )
+            ),
+        },
+        status=RestManagedNetworkProvisionStatus(status="Active", spark_ready=False),
+    )
+    rest_hub_config = RestWorkspaceHubConfig(
+        additional_workspace_storage_accounts=["sa1", "sa2"], default_workspace_resource_group="somerg"
+    )
+    rest_feature_store_settings = RestFeatureStoreSettings(
+        offline_store_connection_name="somevalue1", online_store_connection_name="somevalue2"
+    )
+    rest_managed_service_identity = RestManagedServiceIdentity(
+        type="SystemAssigned", user_assigned_identities={"id1": UserAssignedIdentity()}
+    )
+    rest_serverless_compute = RestServerlessComputeSettings(
+        serverless_compute_custom_subnet="/subscriptions/b17253fa-f327-42d6-9686-f3e553e24763/resourcegroups/static_resources_cli_v2_e2e_tests_resources/providers/Microsoft.Network/virtualNetworks/testwsvnet/subnets/testsubnet",
+        serverless_compute_no_public_ip=True,
+    )
+    return RestWorkspace(
+        managed_network=rest_managed_network,
+        workspace_hub_config=rest_hub_config,
+        feature_store_settings=rest_feature_store_settings,
+        identity=rest_managed_service_identity,
+        serverless_compute_settings=rest_serverless_compute,
+    )
+
+
+@pytest.mark.unittest
+@pytest.mark.core_sdk_test
+class TestWorkspaceEntity:
+    """
+    test description:
+    the purpose of the tests in this file is to ensure _restclient version is correct for 
+    marshalling and unmarshalling between REST and SDK client objects.
+
+    if you will update the restclient version for anything that is using workspace object 
+    and related operations (currently: workspace entities, workspacehub entities, network entities, 
+    WorkspaceOperations, WorkspaceOutboundRuleOperations, FeatureStoreOperations, WorkspaceHubOperations) 
+    then you will also need to update the restclient version to match in all these locations to avoid 
+    issues when unmarshalling.
+    """
+
+    def test_workspace_related_operations_and_entities_match_restclient_versions(self):
+        client = MLClient(
+            credential=DefaultAzureCredential(),
+            subscription_id="fake-sub-id",
+            resource_group_name="fake-rg-name",
+        )
+
+        assert "fake-sub-id" == client.subscription_id
+        assert "fake-rg-name" == client.resource_group_name
+
+        assert isinstance(
+            client._workspace_outbound_rules._rule_operation, RestClientManagedNetworkSettingsRuleOperations
+        )
+        assert isinstance(client.workspaces._operation, RestClientWorkspacesOperations)
+        assert isinstance(client.workspace_hubs._operation, RestClientWorkspacesOperations)
+        assert isinstance(client.feature_stores._operation, RestClientWorkspacesOperations)
+
+    def test_workspace_entity_from_rest_object_managednetwork_restclient_versions_match(self):
+        rest_ws = get_test_rest_workspace_with_all_details()
+
+        sdk_ws = Workspace._from_rest_object(rest_ws)
+        assert sdk_ws.managed_network is not None
+        assert sdk_ws.managed_network.isolation_mode == IsolationMode.ALLOW_ONLY_APPROVED_OUTBOUND
+        rules = sdk_ws.managed_network.outbound_rules
+        assert isinstance(rules[0], FqdnDestination)
+        assert rules[0].destination == "google.com"
+
+        assert isinstance(rules[1], PrivateEndpointDestination)
+        assert rules[1].service_resource_id == "/somestorageid"
+        assert rules[1].spark_enabled == False
+        assert rules[1].subresource_target == "blob"
+
+        assert isinstance(rules[2], ServiceTagDestination)
+        assert rules[2].service_tag == "sometag"
+        assert rules[2].protocol == "*"
+        assert rules[2].port_ranges == "1,2"
+
+        assert sdk_ws.identity.user_assigned_identities[0] is not None
+        assert sdk_ws.identity.type == "system_assigned"
+
+        # currently it seems serverless_compute is only attribute on basic workspace (not hub/FS)
+        assert (
+            sdk_ws.serverless_compute.custom_subnet
+            == "/subscriptions/b17253fa-f327-42d6-9686-f3e553e24763/resourcegroups/static_resources_cli_v2_e2e_tests_resources/providers/Microsoft.Network/virtualNetworks/testwsvnet/subnets/testsubnet"
+        )
+        assert sdk_ws.serverless_compute.no_public_ip == True
+
+
+    def test_workspace_hub_entity_from_rest_to_ensure_restclient_versions_match(self):
+        rest_ws = get_test_rest_workspace_with_all_details()
+
+        sdk_hub = WorkspaceHub._from_rest_object(rest_ws)
+        assert sdk_hub.managed_network is not None
+        assert sdk_hub.managed_network.isolation_mode == IsolationMode.ALLOW_ONLY_APPROVED_OUTBOUND
+        rules = sdk_hub.managed_network.outbound_rules
+        assert isinstance(rules[0], FqdnDestination)
+        assert rules[0].destination == "google.com"
+
+        assert isinstance(rules[1], PrivateEndpointDestination)
+        assert rules[1].service_resource_id == "/somestorageid"
+        assert rules[1].spark_enabled == False
+        assert rules[1].subresource_target == "blob"
+
+        assert isinstance(rules[2], ServiceTagDestination)
+        assert rules[2].service_tag == "sometag"
+        assert rules[2].protocol == "*"
+        assert rules[2].port_ranges == "1,2"
+
+        assert sdk_hub.identity.user_assigned_identities[0] is not None
+        assert sdk_hub.identity.type == "system_assigned"
+
+        # specific to hub
+        assert "sa1" in sdk_hub.workspace_hub_config.additional_workspace_storage_accounts
+        assert "sa2" in sdk_hub.workspace_hub_config.additional_workspace_storage_accounts
+        assert sdk_hub.workspace_hub_config.default_workspace_resource_group == "somerg"
+
+
+    def test_feature_store_entity_from_rest_to_ensure_restclient_versions_match(self):
+        rest_ws = get_test_rest_workspace_with_all_details()
+
+        sdk_featurestore = FeatureStore._from_rest_object(rest_ws)
+        assert sdk_featurestore.managed_network is not None
+        assert sdk_featurestore.managed_network.isolation_mode == IsolationMode.ALLOW_ONLY_APPROVED_OUTBOUND
+        rules = sdk_featurestore.managed_network.outbound_rules
+        assert isinstance(rules[0], FqdnDestination)
+        assert rules[0].destination == "google.com"
+
+        assert isinstance(rules[1], PrivateEndpointDestination)
+        assert rules[1].service_resource_id == "/somestorageid"
+        assert rules[1].spark_enabled == False
+        assert rules[1].subresource_target == "blob"
+
+        assert isinstance(rules[2], ServiceTagDestination)
+        assert rules[2].service_tag == "sometag"
+        assert rules[2].protocol == "*"
+        assert rules[2].port_ranges == "1,2"
+
+        assert sdk_featurestore.identity.user_assigned_identities[0] is not None
+        assert sdk_featurestore.identity.type == "system_assigned"
+
+        # specific to feature store
+        assert sdk_featurestore._feature_store_settings.offline_store_connection_name == "somevalue1"
+        assert sdk_featurestore._feature_store_settings.online_store_connection_name == "somevalue2"


### PR DESCRIPTION
# Description

The below all rely on the restclient version when unmarshalling from REST objects. We should enforce that any type of workspace will be using the same version of the generated code to avoid such breaks (tests introduced to enforce this and avoid similar breaks in the future). Without this, certain information is dropped from the object when unmarshalling since instanceof checks are specific to restclient versioned objects

Workspace._from_rest_object (also used in by)
FeatureStore._from_rest_object
WorkspaceHub._from_rest_object

meaning that everything below needs to use the same versioned restclients

workspace entities
network entities
WorkspaceOperations
WorkspaceOutboundRuleOperations
FeatureStoreOperations
WorkspaceHubOperations

Related: [[ml] fix ws entity restclient version which impacts managed network](https://github.com/Azure/azure-sdk-for-python/pull/32872/files#diff-84f591c71d877c47f2bc04d4036e0b93603482af01214c306572995dccf9ecb8)

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
