### PR TITLE
Re-Enable `pypy39`

### DIFF
--- a/eng/pipelines/templates/stages/platform-matrix.json
+++ b/eng/pipelines/templates/stages/platform-matrix.json
@@ -10,7 +10,7 @@
       "ubuntu-20.04": { "OSVmImage": "MMSUbuntu20.04", "Pool": "azsdk-pool-mms-ubuntu-2004-general" },
       "macos-11": { "OSVmImage": "macos-11", "Pool": "Azure Pipelines" }
     },
-    "PythonVersion": [ "3.7", "3.9", "3.8", "3.10", "3.11" ],
+    "PythonVersion": [ "3.7", "pypy3.9", "3.8", "3.10", "3.11" ],
     "CoverageArg": "--disablecov",
     "TestSamples": "false"
   },

--- a/sdk/storage/platform-matrix-all-versions.json
+++ b/sdk/storage/platform-matrix-all-versions.json
@@ -22,5 +22,18 @@
             "V2020_06_12",
             "V2020_08_04"
         ]
-    }
+    },
+    "include": [
+      {
+        "CoverageConfig": {
+          "ubuntu2004_pypy39": {
+            "OSVmImage": "MMSUbuntu20.04",
+            "Pool": "azsdk-pool-mms-ubuntu-2004-general",
+            "PythonVersion": "pypy3.9",
+            "CoverageArg": "--disablecov",
+            "TestSamples": "false"
+          }
+        }
+      }
+    ]
 }


### PR DESCRIPTION
This reverts commit dfc14ae07b9607f9911da6c132998ea0f56db368 which was committed from #32801

I believe I ran down the wonky issue with `Dump-PackageProperties` that was blowing up on `pypy3.9`. Re-enabling pypy that we temporarily disabled.