### PR TITLE
Fix - Get ACS index endpoint from config if possible

### DIFF
--- a/sdk/ai/azure-ai-generative/azure/ai/generative/index/_utils/connections.py
+++ b/sdk/ai/azure-ai-generative/azure/ai/generative/index/_utils/connections.py
@@ -37,17 +37,6 @@ def get_pinecone_environment(config, credential: Optional[TokenCredential] = Non
     connection = get_connection_by_id_v2(connection_id, credential=credential)
     return get_metadata_from_connection(connection)["environment"]
 
-def get_metadata_from_connection(connection: Union[dict, WorkspaceConnection, BaseConnection]) -> dict:
-    """Get a connection metadata from a connection."""
-    if isinstance(connection, dict):
-        return connection["properties"]["metadata"]
-    elif isinstance(connection, WorkspaceConnection):
-        return connection.metadata
-    elif isinstance(connection, Connection):
-        return connection.metadata
-    else:
-        raise ValueError(f"Unknown connection type: {type(connection)}")
-
 
 def get_connection_credential(config, credential: Optional[TokenCredential] = None):
     """Get a credential for a connection."""


### PR DESCRIPTION
# Description

This PR contains 2 bug fixes
 - moving index_endpoint out of "if (version condition) else..." clause, so it can be used in both.
 - removing dup definetion of get_metadata_from_connection

If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
