### PR TITLE
Fix connection scoping

### DIFF
--- a/sdk/ai/azure-ai-resources/azure/ai/resources/client/_ai_client.py
+++ b/sdk/ai/azure-ai-resources/azure/ai/resources/client/_ai_client.py
@@ -24,7 +24,7 @@ from azure.ai.ml.entities._credentials import ManagedIdentityConfiguration, User
 from azure.core.credentials import TokenCredential
 
 from .._project_scope import OperationScope
-from ._user_agent import USER_AGENT
+from .._user_agent import USER_AGENT
 from azure.ai.resources.operations import (
     AIResourceOperations,
     ConnectionOperations,
@@ -89,7 +89,7 @@ class AIClient:
             credential=credential,
             subscription_id=subscription_id,
             resource_group_name=resource_group_name,
-            workspace_name=ai_resource_name,
+            workspace_name=project_name,
             **kwargs,
         )
         # Client scoped to the AI Resource for operations that need AI resource-scoping
@@ -254,7 +254,7 @@ class AIClient:
         )
         return project.ml_flow_tracking_uri
 
-    def build_ml_index_on_cloud(
+    def build_index_on_cloud(
         self,
         *,
         ######## required args ##########

--- a/sdk/ai/azure-ai-resources/azure/ai/resources/client/_ai_client.py
+++ b/sdk/ai/azure-ai-resources/azure/ai/resources/client/_ai_client.py
@@ -14,7 +14,7 @@ from azure.ai.resources._restclient.v2022_10_01 import AzureMachineLearningWorks
 from azure.ai.resources._utils._ai_client_utils import find_config_file_path, get_config_info
 from azure.ai.resources._utils._open_ai_utils import build_open_ai_protocol
 from azure.ai.resources._utils._str_utils import build_connection_id
-from azure.ai.resources.constants._common import DEFAULT_OPEN_AI_CONNECTION_NAME
+from azure.ai.resources.constants._common import DEFAULT_OPEN_AI_CONNECTION_NAME, DEFAULT_CONTENT_SAFETY_CONNECTION_NAME
 from azure.ai.resources.entities.mlindex import Index as MLIndexAsset
 from azure.ai.resources.operations import ACSOutputConfig, ACSSource, GitSource, IndexDataSource, LocalSource
 from azure.ai.ml import MLClient
@@ -24,7 +24,7 @@ from azure.ai.ml.entities._credentials import ManagedIdentityConfiguration, User
 from azure.core.credentials import TokenCredential
 
 from .._project_scope import OperationScope
-from .._user_agent import USER_AGENT
+from ._user_agent import USER_AGENT
 from azure.ai.resources.operations import (
     AIResourceOperations,
     ConnectionOperations,
@@ -89,7 +89,16 @@ class AIClient:
             credential=credential,
             subscription_id=subscription_id,
             resource_group_name=resource_group_name,
-            workspace_name=project_name,
+            workspace_name=ai_resource_name,
+            **kwargs,
+        )
+        # Client scoped to the AI Resource for operations that need AI resource-scoping
+        # instead of project scoping.
+        self._ai_resource_ml_client = MLClient(
+            credential=credential,
+            subscription_id=subscription_id,
+            resource_group_name=resource_group_name,
+            workspace_name=ai_resource_name,
             **kwargs,
         )
 
@@ -107,7 +116,10 @@ class AIClient:
             ml_client=self._ml_client,
             **app_insights_handler_kwargs,
         )
-        self._connections = ConnectionOperations(self._ml_client, **app_insights_handler_kwargs)
+        # TODO add scoping to allow connections to:
+        # - Create project-scoped connections
+        # For now, connections are AI resource-scoped.
+        self._connections = ConnectionOperations(self._ai_resource_ml_client, **app_insights_handler_kwargs)
         self._mlindexes = MLIndexOperations(self._ml_client, **app_insights_handler_kwargs)
         self._ai_resources = AIResourceOperations(self._ml_client, **app_insights_handler_kwargs)
         self._deployments = DeploymentOperations(self._ml_client, self._connections, **app_insights_handler_kwargs)
@@ -154,6 +166,9 @@ class AIClient:
     @property
     def connections(self) -> ConnectionOperations:
         """A collection of connection-related operations.
+        NOTE: Unlike other operation handles, the connections handle
+        is scoped to the AIClient's AI Resource, and not the project.
+        SDK support for project-scoped connections does not exist yet.
 
         :return: Connections operations
         :rtype: ConnectionsOperations
@@ -239,7 +254,7 @@ class AIClient:
         )
         return project.ml_flow_tracking_uri
 
-    def build_index_on_cloud(
+    def build_ml_index_on_cloud(
         self,
         *,
         ######## required args ##########
@@ -420,7 +435,23 @@ class AIClient:
             raise ValueError(f"Unsupported input source type {type(input_source)}")
 
     def get_default_aoai_connection(self):
+        """Retrieves the default Azure Open AI connection associated with this AIClient's project,
+        creating it if it does not already exist.
+
+        :return: A Connection to Azure Open AI
+        :rtype: ~azure.ai.resources.entities.AzureOpenAIConnection
+        """
         return self._connections.get(DEFAULT_OPEN_AI_CONNECTION_NAME)
+    
+    def get_default_content_safety_connection(self):
+        """Retrieves a default Azure AI Service connection associated with this AIClient's project,
+        creating it if the connection does not already exist.
+        This particular AI Service connection is linked to an Azure Content Safety service.
+
+        :return: A Connection to an Azure AI Service
+        :rtype: ~azure.ai.resources.entities.AzureAIServiceConnection
+        """
+        return self._connections.get(DEFAULT_CONTENT_SAFETY_CONNECTION_NAME)
 
     def _add_user_agent(self, kwargs) -> None:
         user_agent = kwargs.pop("user_agent", None)

--- a/sdk/ai/azure-ai-resources/azure/ai/resources/constants/_common.py
+++ b/sdk/ai/azure-ai-resources/azure/ai/resources/constants/_common.py
@@ -4,6 +4,7 @@
 
 
 DEFAULT_OPEN_AI_CONNECTION_NAME = "Default_AzureOpenAI"
+DEFAULT_CONTENT_SAFETY_CONNECTION_NAME = "Default_AzureAIContentSafety"
 
 class AssetTypes:
     """AssetTypes is an enumeration of values for the asset types of a data.

--- a/sdk/ai/azure-ai-resources/azure/ai/resources/entities/connection_subtypes.py
+++ b/sdk/ai/azure-ai-resources/azure/ai/resources/entities/connection_subtypes.py
@@ -16,7 +16,9 @@ from azure.ai.ml.constants._common import (
 from .base_connection import BaseConnection
 
 class AzureOpenAIConnection(BaseConnection):
-    """A Connection for Azure Open AI.
+    """A Connection for Azure Open AI. Note: This object usually shouldn't be created manually by users.
+    To get the default AzureOpenAIConnection for an AI Resource, use an AIClient object to call the
+    'get_default_aoai_connection' function.
 
     :param name: Name of the connection.
     :type name: str
@@ -191,7 +193,9 @@ class AzureAISearchConnection(BaseConnection):
 
 
 class AzureAIServiceConnection(BaseConnection):
-    """A Connection for an Azure Cognitive Service.
+    """A Connection for an Azure Cognitive Service. Note: This object usually shouldn't be created manually by users.
+    To get the default AzureOpenAIConnection for an AI Resource, use an AIClient object to call the
+    'get_default_aoai_connection' function.
 
     :param name: Name of the connection.
     :type name: str


### PR DESCRIPTION
Connections, unlike most other scoped resources managed by the AIClient, make more sense to be AI resource-scoped by default. This PR changes the connections handle to be scoped in such a way, with eventually plans to allow the user to choose between AI Resource and project-scoping for their connections as a follow-up.


Also included are a couple connection related fixes:
- A default content safety connection function similar to the existing Open AI Conenction function
- Documentation warnings in the Open AI and AI service connection class descriptions encouraging the use of the default functions over making your own.