### PR TITLE
Exclude azureml packages from azure packages

### DIFF
--- a/eng/tox/create_package_and_install.py
+++ b/eng/tox/create_package_and_install.py
@@ -192,7 +192,7 @@ if __name__ == "__main__":
                 requirements = ParsedSetup.from_path(
                     os.path.join(os.path.abspath(args.target_setup), "setup.py")
                 ).requires
-                azure_requirements = [req.split(";")[0] for req in requirements if req.startswith("azure")]
+                azure_requirements = [req.split(";")[0] for req in requirements if req.startswith("azure") and not req.startswith("azureml")]
 
                 if azure_requirements:
                     logging.info(

--- a/eng/tox/create_package_and_install.py
+++ b/eng/tox/create_package_and_install.py
@@ -192,7 +192,7 @@ if __name__ == "__main__":
                 requirements = ParsedSetup.from_path(
                     os.path.join(os.path.abspath(args.target_setup), "setup.py")
                 ).requires
-                azure_requirements = [req.split(";")[0] for req in requirements if req.startswith("azure") and not req.startswith("azureml")]
+                azure_requirements = [req.split(";")[0] for req in requirements if req.startswith("azure-")]
 
                 if azure_requirements:
                     logging.info(


### PR DESCRIPTION
# Description

This pull request fixes an issue where non-Azure SDKs, e.g `azureml-telemetry`, can be treated like an `azure` dependency and attempted to be fetched from an internal index that they aren't present in.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
