### PR TITLE
Remove pin of opentelemetry-api from azure-core-tracing-opentelemetry

### DIFF
--- a/eng/tox/install_depend_packages.py
+++ b/eng/tox/install_depend_packages.py
@@ -61,11 +61,7 @@ MINIMUM_VERSION_SPECIFIC_OVERRIDES = {
     "azure-identity": {"msal": "1.23.0"},
 }
 
-MAXIMUM_VERSION_SPECIFIC_OVERRIDES = {
-    "azure-core-tracing-opentelemetry": {
-        "opentelemetry-api": "1.19.0"
-    }
-}
+MAXIMUM_VERSION_SPECIFIC_OVERRIDES = {}
 
 # PLATFORM SPECIFIC OVERRIDES provide additional generic (EG not tied to the package whos dependencies are being processed)
 # filtering on a _per platform_ basis. Primarily used to limit certain packages due to platform compatbility


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-python/issues/31965

Due to the now released version of: https://pypi.org/project/opentelemetry-instrumentation-requests/, the below combination of libraries should be able to be successfully installed.

```
opentelemetry-api==v1.20.0
opentelemetry-api==v1.20.0
opentelemetry-instrumentation-requests==v0.41b0
```