### PR TITLE
ACR and AppIn creation on hub creation

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_arm_deployments/arm_templates/workspace_base.json
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_arm_deployments/arm_templates/workspace_base.json
@@ -742,7 +742,7 @@
             }
         },
         {
-            "condition": "[and(variables('enablePE'), equals(parameters('applicationInsightsOption'), 'new'), not(variables('isWorkspaceHub')))]",
+            "condition": "[and(variables('enablePE'), equals(parameters('applicationInsightsOption'), 'new'))]",
             "type": "Microsoft.OperationalInsights/workspaces",
             "tags": "[parameters('tagValues')]",
             "apiVersion": "2020-08-01",
@@ -754,7 +754,7 @@
             }
         },
         {
-            "condition": "[and(variables('enablePE'), equals(parameters('applicationInsightsOption'), 'new'), not(variables('isWorkspaceHub')))]",
+            "condition": "[and(variables('enablePE'), equals(parameters('applicationInsightsOption'), 'new'))]",
             "type": "Microsoft.Insights/components",
             "tags": "[parameters('tagValues')]",
             "apiVersion": "2020-02-02-preview",
@@ -789,7 +789,7 @@
                 "description": "[parameters('description')]",
                 "storageAccount": "[variables('storageAccount')]",
                 "keyVault": "[variables('keyVault')]",
-                "applicationInsights": "[if(variables('isWorkspaceHub'), json('null'), variables('applicationInsights'))]",
+                "applicationInsights": "[variables('applicationInsights')]",
                 "containerRegistry": "[if(not(equals(parameters('containerRegistryOption'), 'none')), variables('containerRegistry'), json('null'))]",
                 "hbiWorkspace": "[parameters('confidential_data')]",
                 "imageBuildCompute": "[parameters('imageBuildCompute')]",

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/constants/_common.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/constants/_common.py
@@ -334,6 +334,7 @@ class ArmConstants:
     APP_INSIGHTS = "AppInsights"
     LOG_ANALYTICS = "LogAnalytics"
     WORKSPACE = "Workspace"
+    CONTAINER_REGISTRY = "ContainerRegistry"
 
     AZURE_MGMT_RESOURCE_API_VERSION = "2020-06-01"
     AZURE_MGMT_STORAGE_API_VERSION = "2019-06-01"

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_workspace_operations_base.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_workspace_operations_base.py
@@ -1,3 +1,4 @@
+# pylint: disable=too-many-lines
 # ---------------------------------------------------------
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
@@ -911,6 +912,7 @@ def _generate_app_insights(name: str, resources_being_deployed: dict) -> str:
         None,
     )
     return app_insights
+
 
 def _generate_container_registry(name: str, resources_being_deployed: dict) -> str:
     """Generates a name for a container registry resource to be created with workspace based on workspace name,

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_workspace_operations_base.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_workspace_operations_base.py
@@ -716,6 +716,13 @@ class WorkspaceOperationsBase(ABC):
                 _set_val(param["endpoint_resource_id"], endpoint_resource_id)
                 _set_val(param["endpoint_kind"], endpoint_kind)
 
+            # Hubs must have an azure container registry on-provision. If none was provided, create one.
+            if not workspace.container_registry:
+                _set_val(param["containerRegistryOption"], "new")
+                container_registry = _generate_container_registry(workspace.name, resources_being_deployed)
+                _set_val(param["containerRegistryName"], container_registry)
+                _set_val(param["containerRegistryResourceGroupName"], self._resource_group_name)
+
         # Lean related param
         if workspace._kind and workspace._kind.lower() == PROJECT_WORKSPACE_KIND:
             if workspace.workspace_hub:
@@ -904,6 +911,26 @@ def _generate_app_insights(name: str, resources_being_deployed: dict) -> str:
         None,
     )
     return app_insights
+
+def _generate_container_registry(name: str, resources_being_deployed: dict) -> str:
+    """Generates a name for a container registry resource to be created with workspace based on workspace name,
+    sets name and type in resources_being_deployed.
+
+    :param name: The name for the related workspace.
+    :type name: str
+    :param resources_being_deployed: Dict for resources being deployed.
+    :type resources_being_deployed: dict
+    :return: String for name of container registry.
+    :rtype: str
+    """
+    # Application name only allows alphanumeric characters, periods, underscores,
+    # hyphens and parenthesis and cannot end in a period
+    con_reg = get_name_for_dependent_resource(name, "containerRegistry")
+    resources_being_deployed[con_reg] = (
+        ArmConstants.CONTAINER_REGISTRY,
+        None,
+    )
+    return con_reg
 
 
 class CustomArmTemplateDeploymentPollingMethod(PollingMethod):


### PR DESCRIPTION
It was realized that workspace hubs need to produce both an Application Insights and a Container Registry resource for themselves on creation by default. This PR accomplishes those things. In the following ways:

Application Insights were thankfully easy to manage. The code to create them by default was already in place, just gated to exclude workspace hubs. This exclusion was removed.

The container registry had code to create new registries that was unused and had a few bugs. I fixed the bugs by properly provided generated names for the new ACR resource, and set the code to ask for a new ACR when it recognized that the workspace in question is a hub.