### PR TITLE
[Core] Fix trio mypy errors

### DIFF
--- a/sdk/core/azure-core/azure/core/pipeline/transport/_requests_trio.py
+++ b/sdk/core/azure-core/azure/core/pipeline/transport/_requests_trio.py
@@ -110,7 +110,7 @@ class TrioStreamDownloadGenerator(AsyncIterator):
                     self.iter_content_func,
                 )
             except AttributeError:  # trio < 0.12.1
-                chunk = await trio.run_sync_in_worker_thread(  # pylint: disable=no-member
+                chunk = await trio.run_sync_in_worker_thread(  # type: ignore # pylint: disable=no-member
                     _iterate_response_content,
                     self.iter_content_func,
                 )
@@ -247,7 +247,7 @@ class TrioRequestsTransport(RequestsAsyncTransportBase):
                     limiter=trio_limiter,
                 )
             except AttributeError:  # trio < 0.12.1
-                response = await trio.run_sync_in_worker_thread(  # pylint: disable=no-member
+                response = await trio.run_sync_in_worker_thread(  # type: ignore # pylint: disable=no-member
                     functools.partial(
                         self.session.request,
                         request.method,


### PR DESCRIPTION
The latest version of `trio` removed the `run_sync_in_worker_thread` method, causing mypy to complain. This change adds a type ignore comment to places where this is called, since it'll only hit that code path if an old enough version of `trio` is used.

Mypy error:
```sh
azure/core/pipeline/transport/_requests_trio.py:250: error: Module has no attribute "run_sync_in_worker_thread"  [attr-defined]
```

However, we could also just remove the `try... except...` we have to account for the older versions, since `run_sync_in_worker_thread` is something that was deprecated in 2019, and I don't think we need to account for it anymore.