### PR TITLE
[Monitor] Fix ssl errors in live tests

### DIFF
--- a/sdk/monitor/tests.yml
+++ b/sdk/monitor/tests.yml
@@ -4,7 +4,6 @@ stages:
   - template: /eng/pipelines/templates/stages/archetype-sdk-tests.yml
     parameters:
       ServiceDirectory: monitor
-      TestProxy: true
       TestTimeoutInMinutes: 300
       BuildTargetingString: azure-monitor-*
       EnvVars:


### PR DESCRIPTION
Going through Test Proxy is setting SSL_CERT_DIR (or whatever setting aiohttp uses) to an invalid value in the context of live tests. This removes that setting from the live test configuration.