### PR TITLE
add api_key support

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/workspace/connections/workspace_connection.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/workspace/connections/workspace_connection.py
@@ -36,6 +36,7 @@ class WorkspaceConnectionSchema(ResourceSchema):
             ConnectionCategory.AZURE_SYNAPSE_ANALYTICS,
             ConnectionCategory.AZURE_MY_SQL_DB,
             ConnectionCategory.AZURE_POSTGRES_DB,
+            ConnectionCategory.API_KEY
         ],
         casing_transform=camel_to_snake,
         required=True,

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_workspace/connections/workspace_connection.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_workspace/connections/workspace_connection.py
@@ -71,7 +71,7 @@ class WorkspaceConnection(Resource):
     :param type: The category of external resource for this connection.
     :type type: The type of workspace connection, possible values are: "git", "python_feed", "container_registry",
         "feature_store", "s3", "snowflake", "azure_sql_db", "azure_synapse_analytics", "azure_my_sql_db",
-        "azure_postgres_db"
+        "azure_postgres_db", "api_key"
     :param credentials: The credentials for authenticating to the external resource.
     :type credentials: Union[
         ~azure.ai.ml.entities.PatTokenConfiguration, ~azure.ai.ml.entities.SasTokenConfiguration,


### PR DESCRIPTION
The UI apparently supports the new connection type "api_key", which is not to be confused with connection credential types of the same name. This change allows the SDK to at least parse these connections. Testing to follow.