### PR TITLE
Add Index metrics to python sdk

### DIFF
--- a/sdk/cosmos/azure-cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 4.5.2b3 (Unreleased)
 
 #### Features Added
+* Added support for Index Metrics. See [PR 33034](https://github.com/Azure/azure-sdk-for-python/pull/33034)
 
 #### Breaking Changes
 

--- a/sdk/cosmos/azure-cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### 4.5.2b3 (Unreleased)
 
 #### Features Added
-* Added support for Index Metrics. See [PR 33034](https://github.com/Azure/azure-sdk-for-python/pull/33034)
+* Added support for capturing Index Metrics in query operations. See [PR 33034](https://github.com/Azure/azure-sdk-for-python/pull/33034)
 
 #### Breaking Changes
 

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_base.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_base.py
@@ -229,6 +229,9 @@ def GetHeaders(  # pylint: disable=too-many-statements,too-many-branches
     if options.get("populateQueryMetrics"):
         headers[http_constants.HttpHeaders.PopulateQueryMetrics] = options["populateQueryMetrics"]
 
+    if options.get("populateIndexMetrics"):
+        headers[http_constants.HttpHeaders.PopulateIndexMetrics] = options["populateIndexMetrics"]
+
     if options.get("responseContinuationTokenLimitInKb"):
         headers[http_constants.HttpHeaders.ResponseContinuationTokenLimitInKb] = options[
             "responseContinuationTokenLimitInKb"]

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_cosmos_client_connection.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_cosmos_client_connection.py
@@ -2596,6 +2596,10 @@ class CosmosClientConnection(object):  # pylint: disable=too-many-public-methods
                 return __GetBodiesFromQueryResult(results)
 
         result, self.last_response_headers = self.__Post(path, request_params, query, req_headers, **kwargs)
+        if http_constants.HttpHeaders.IndexUtilization in self.last_response_headers:
+            INDEX_METRICS_HEADER = http_constants.HttpHeaders.IndexUtilization
+            index_metrics_raw = self.last_response_headers[INDEX_METRICS_HEADER]
+            self.last_response_headers[INDEX_METRICS_HEADER] = _utils.get_index_metrics_info(index_metrics_raw)
 
         if response_hook:
             response_hook(self.last_response_headers, result)

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_cosmos_client_connection.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_cosmos_client_connection.py
@@ -2596,7 +2596,7 @@ class CosmosClientConnection(object):  # pylint: disable=too-many-public-methods
                 return __GetBodiesFromQueryResult(results)
 
         result, self.last_response_headers = self.__Post(path, request_params, query, req_headers, **kwargs)
-        if http_constants.HttpHeaders.IndexUtilization in self.last_response_headers:
+        if self.last_response_headers.get(http_constants.HttpHeaders.IndexUtilization) is not None:
             INDEX_METRICS_HEADER = http_constants.HttpHeaders.IndexUtilization
             index_metrics_raw = self.last_response_headers[INDEX_METRICS_HEADER]
             self.last_response_headers[INDEX_METRICS_HEADER] = _utils.get_index_metrics_info(index_metrics_raw)

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_utils.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_utils.py
@@ -25,6 +25,8 @@
 import platform
 import re
 from ._version import VERSION
+import base64
+import json
 
 
 def get_user_agent():
@@ -49,3 +51,20 @@ def safe_user_agent_header(s):
     if not s:
         s = "unknown"
     return s
+
+
+def get_index_metrics_info(delimited_string):
+    if delimited_string is None:
+        return {}
+
+    try:
+        # Decode the base64 string to bytes
+        bytes_string = base64.b64decode(delimited_string)
+        # Decode the bytes to a string using UTF-8 encoding
+        decoded_string = bytes_string.decode('utf-8')
+
+        # Python's json.loads method is used for deserialization
+        result = json.loads(decoded_string) or {}
+        return result
+    except (json.JSONDecodeError, ValueError):
+        return {}

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_container.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_container.py
@@ -333,6 +333,9 @@ class ContainerProxy(object):
         :keyword bool enable_scan_in_query: Allow scan on the queries which couldn't be served as
             indexing was opted out on the requested paths.
         :keyword bool populate_query_metrics: Enable returning query metrics in response headers.
+        :keyword bool populate_index_metrics: Used to obtain the index metrics to understand how the query engine used
+            existing indexes and how it could use potential new indexes. Please note that this options will incur
+            overhead, so it should be enabled only when debugging slow queries.
         :keyword str session_token: Token for use with Session consistency.
         :keyword dict[str, str] initial_headers: Initial headers to be sent as part of the request.
         :keyword response_hook: A callable invoked with the response metadata.
@@ -375,6 +378,9 @@ class ContainerProxy(object):
         populate_query_metrics = kwargs.pop('populate_query_metrics', None)
         if populate_query_metrics is not None:
             feed_options["populateQueryMetrics"] = populate_query_metrics
+        populate_index_metrics = kwargs.pop("populate_index_metrics", None)
+        if populate_index_metrics is not None:
+            feed_options["populateIndexMetrics"] = populate_index_metrics
         enable_scan_in_query = kwargs.pop('enable_scan_in_query', None)
         if enable_scan_in_query is not None:
             feed_options["enableScanInQuery"] = enable_scan_in_query

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_cosmos_client_connection_async.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_cosmos_client_connection_async.py
@@ -2384,7 +2384,7 @@ class CosmosClientConnection(object):  # pylint: disable=too-many-public-methods
                 return __GetBodiesFromQueryResult(results)
 
         result, self.last_response_headers = await self.__Post(path, request_params, query, req_headers, **kwargs)
-        if http_constants.HttpHeaders.IndexUtilization in self.last_response_headers:
+        if self.last_response_headers.get(http_constants.HttpHeaders.IndexUtilization) is not None:
             INDEX_METRICS_HEADER = http_constants.HttpHeaders.IndexUtilization
             index_metrics_raw = self.last_response_headers[INDEX_METRICS_HEADER]
             self.last_response_headers[INDEX_METRICS_HEADER] = _utils.get_index_metrics_info(index_metrics_raw)

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_cosmos_client_connection_async.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_cosmos_client_connection_async.py
@@ -2384,7 +2384,10 @@ class CosmosClientConnection(object):  # pylint: disable=too-many-public-methods
                 return __GetBodiesFromQueryResult(results)
 
         result, self.last_response_headers = await self.__Post(path, request_params, query, req_headers, **kwargs)
-
+        if http_constants.HttpHeaders.IndexUtilization in self.last_response_headers:
+            INDEX_METRICS_HEADER = http_constants.HttpHeaders.IndexUtilization
+            index_metrics_raw = self.last_response_headers[INDEX_METRICS_HEADER]
+            self.last_response_headers[INDEX_METRICS_HEADER] = _utils.get_index_metrics_info(index_metrics_raw)
         if response_hook:
             response_hook(self.last_response_headers, result)
 

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/container.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/container.py
@@ -347,6 +347,7 @@ class ContainerProxy(object):
         max_item_count=None,  # type: Optional[int]
         enable_scan_in_query=None,  # type: Optional[bool]
         populate_query_metrics=None,  # type: Optional[bool] # pylint:disable=docstring-missing-param
+        populate_index_metrics=None, # type: Optional[bool]
         **kwargs  # type: Any
     ):
         # type: (...) -> Iterable[Dict[str, Any]]
@@ -371,6 +372,9 @@ class ContainerProxy(object):
         :param bool enable_scan_in_query: Allow scan on the queries which couldn't be served as
             indexing was opted out on the requested paths.
         :param bool populate_query_metrics: Enable returning query metrics in response headers.
+        :param bool populate_index_metrics: Used to obtain the index metrics to understand how the query engine used
+            existing indexes and how it could use potential new indexes. Please note that this options will incur
+            overhead, so it should be enabled only when debugging slow queries.
         :keyword str session_token: Token for use with Session consistency.
         :keyword Dict[str, str] initial_headers: Initial headers to be sent as part of the request.
         :keyword Callable response_hook: A callable invoked with the response metadata.
@@ -412,6 +416,8 @@ class ContainerProxy(object):
             feed_options["maxItemCount"] = max_item_count
         if populate_query_metrics is not None:
             feed_options["populateQueryMetrics"] = populate_query_metrics
+        if populate_index_metrics is not None:
+            feed_options["populateIndexMetrics"] = populate_index_metrics
         if partition_key is not None:
             if self.__is_prefix_partitionkey(partition_key):
                 kwargs["isPrefixPartitionQuery"] = True

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/container.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/container.py
@@ -372,9 +372,6 @@ class ContainerProxy(object):
         :param bool enable_scan_in_query: Allow scan on the queries which couldn't be served as
             indexing was opted out on the requested paths.
         :param bool populate_query_metrics: Enable returning query metrics in response headers.
-        :param bool populate_index_metrics: Used to obtain the index metrics to understand how the query engine used
-            existing indexes and how it could use potential new indexes. Please note that this options will incur
-            overhead, so it should be enabled only when debugging slow queries.
         :keyword str session_token: Token for use with Session consistency.
         :keyword Dict[str, str] initial_headers: Initial headers to be sent as part of the request.
         :keyword Callable response_hook: A callable invoked with the response metadata.
@@ -387,6 +384,9 @@ class ContainerProxy(object):
         :keyword Literal["High", "Low"] priority_level: Priority based execution allows users to set a priority for each
             request. Once the user has reached their provisioned throughput, low priority requests are throttled
             before high priority requests start getting throttled. Feature must first be enabled at the account level.
+        :keyword bool populate_index_metrics: Used to obtain the index metrics to understand how the query engine used
+            existing indexes and how it could use potential new indexes. Please note that this options will incur
+            overhead, so it should be enabled only when debugging slow queries.
         :returns: An Iterable of items (dicts).
         :rtype: ItemPaged[Dict[str, Any]]
 
@@ -416,6 +416,7 @@ class ContainerProxy(object):
             feed_options["maxItemCount"] = max_item_count
         if populate_query_metrics is not None:
             feed_options["populateQueryMetrics"] = populate_query_metrics
+        populate_index_metrics = kwargs.pop("populate_index_metrics", None)
         if populate_index_metrics is not None:
             feed_options["populateIndexMetrics"] = populate_index_metrics
         if partition_key is not None:

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/container.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/container.py
@@ -347,7 +347,6 @@ class ContainerProxy(object):
         max_item_count=None,  # type: Optional[int]
         enable_scan_in_query=None,  # type: Optional[bool]
         populate_query_metrics=None,  # type: Optional[bool] # pylint:disable=docstring-missing-param
-        populate_index_metrics=None, # type: Optional[bool]
         **kwargs  # type: Any
     ):
         # type: (...) -> Iterable[Dict[str, Any]]

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/http_constants.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/http_constants.py
@@ -100,6 +100,7 @@ class HttpHeaders(object):
     QueryVersion = "x-ms-cosmos-query-version"
     QueryMetrics = "x-ms-documentdb-query-metrics"
     QueryExecutionInfo = "x-ms-cosmos-query-execution-info"
+    IndexUtilization = "x-ms-cosmos-index-utilization"
 
     # Our custom DocDB headers
     Continuation = "x-ms-continuation"
@@ -130,6 +131,7 @@ class HttpHeaders(object):
     ContentPath = "x-ms-content-path"
     IsContinuationExpected = "x-ms-documentdb-query-iscontinuationexpected"
     PopulateQueryMetrics = "x-ms-documentdb-populatequerymetrics"
+    PopulateIndexMetrics = "x-ms-cosmos-populateindexmetrics"
     ResourceQuota = "x-ms-resource-quota"
     ResourceUsage = "x-ms-resource-usage"
 


### PR DESCRIPTION
This PR adds Index Metrics to Python SDK.

You can capture index metrics by passing in the populate_index_metrics keyword in query items.
`query_items = container.query_items(query="Select * from c", populate_index_metrics=True)`

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
