### PR TITLE
[Corehttp] Add custom hook policy

### DIFF
--- a/sdk/core/corehttp/corehttp/runtime/_pipeline_client.py
+++ b/sdk/core/corehttp/corehttp/runtime/_pipeline_client.py
@@ -33,6 +33,7 @@ from ._base import PipelineClientBase
 from ..transport import HttpTransport
 from .policies import (
     ContentDecodePolicy,
+    CustomHookPolicy,
     RetryPolicy,
     HeadersPolicy,
     UserAgentPolicy,
@@ -104,6 +105,7 @@ class PipelineClient(PipelineClientBase, Generic[HTTPRequestType, HTTPResponseTy
                 ContentDecodePolicy(**kwargs),
                 kwargs.get("retry_policy") or RetryPolicy(**kwargs),
                 kwargs.get("authentication_policy"),
+                kwargs.get("custom_hook_policy") or CustomHookPolicy(**kwargs),
                 kwargs.get("logging_policy") or NetworkTraceLoggingPolicy(**kwargs),
             ]
         if isinstance(per_call_policies, Iterable):

--- a/sdk/core/corehttp/corehttp/runtime/_pipeline_client_async.py
+++ b/sdk/core/corehttp/corehttp/runtime/_pipeline_client_async.py
@@ -43,6 +43,7 @@ from .pipeline import AsyncPipeline
 from ._base import PipelineClientBase
 from .policies import (
     ContentDecodePolicy,
+    CustomHookPolicy,
     AsyncRetryPolicy,
     HeadersPolicy,
     UserAgentPolicy,
@@ -188,6 +189,7 @@ class AsyncPipelineClient(
                 ContentDecodePolicy(**kwargs),
                 kwargs.get("retry_policy") or AsyncRetryPolicy(**kwargs),
                 kwargs.get("authentication_policy"),
+                kwargs.get("custom_hook_policy") or CustomHookPolicy(**kwargs),
                 kwargs.get("logging_policy") or NetworkTraceLoggingPolicy(**kwargs),
             ]
 

--- a/sdk/core/corehttp/corehttp/runtime/policies/__init__.py
+++ b/sdk/core/corehttp/corehttp/runtime/policies/__init__.py
@@ -29,6 +29,7 @@ from ._authentication import (
     BearerTokenCredentialPolicy,
     ServiceKeyCredentialPolicy,
 )
+from ._custom_hook import CustomHookPolicy
 from ._retry import RetryPolicy, RetryMode
 from ._universal import (
     HeadersPolicy,
@@ -50,6 +51,7 @@ __all__ = [
     "UserAgentPolicy",
     "NetworkTraceLoggingPolicy",
     "ContentDecodePolicy",
+    "CustomHookPolicy",
     "RetryMode",
     "RetryPolicy",
     "ProxyPolicy",

--- a/sdk/core/corehttp/corehttp/runtime/policies/_custom_hook.py
+++ b/sdk/core/corehttp/corehttp/runtime/policies/_custom_hook.py
@@ -1,0 +1,77 @@
+# --------------------------------------------------------------------------
+#
+# Copyright (c) Microsoft Corporation. All rights reserved.
+#
+# The MIT License (MIT)
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the ""Software""), to
+# deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+# sell copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+#
+# --------------------------------------------------------------------------
+from typing import TypeVar, Any
+
+from ..pipeline import PipelineRequest, PipelineResponse
+from ...rest import HttpResponse, HttpRequest, AsyncHttpResponse
+from ._base import SansIOHTTPPolicy
+
+HttpResponseTypes = TypeVar("HttpResponseTypes", HttpResponse, AsyncHttpResponse)
+
+
+class CustomHookPolicy(SansIOHTTPPolicy[HttpRequest, HttpResponseTypes]):
+    """A simple policy that calls the given callback(s) on the pipeline request and response.
+
+    :keyword callable raw_request_hook: Callback function. Will be invoked on request.
+    :keyword callable raw_response_hook: Callback function. Will be invoked on response.
+    """
+
+    def __init__(self, **kwargs: Any):  # pylint: disable=unused-argument,super-init-not-called
+        self._request_callback = kwargs.get("raw_request_hook")
+        self._response_callback = kwargs.get("raw_response_hook")
+
+    def on_request(self, request: PipelineRequest[HttpRequest]) -> None:
+        """This is executed before sending the request to the next policy.
+
+        :param request: The PipelineRequest object.
+        :type request: ~corehttp.runtime.pipeline.PipelineRequest
+        """
+        request_callback = request.context.options.pop("raw_request_hook", None)
+        if request_callback:
+            request.context["raw_request_hook"] = request_callback
+            request_callback(request)
+        elif self._request_callback:
+            self._request_callback(request)
+
+        response_callback = request.context.options.pop("raw_response_hook", None)
+        if response_callback:
+            request.context["raw_response_hook"] = response_callback
+
+    def on_response(
+        self, request: PipelineRequest[HttpRequest], response: PipelineResponse[HttpRequest, HttpResponseTypes]
+    ) -> None:
+        """This is executed after the request comes back from the policy.
+
+        :param request: The PipelineRequest object.
+        :type request: ~corehttp.runtime.pipeline.PipelineRequest
+        :param response: The PipelineResponse object.
+        :type response: ~corehttp.runtime.pipeline.PipelineRequest
+        """
+        response_callback = response.context.get("raw_response_hook")
+        if response_callback:
+            response_callback(response)
+        elif self._response_callback:
+            self._response_callback(response)

--- a/sdk/core/corehttp/tests/async_tests/test_custom_hook_policy_async.py
+++ b/sdk/core/corehttp/tests/async_tests/test_custom_hook_policy_async.py
@@ -1,0 +1,108 @@
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+"""Tests for the custom hook policy."""
+from unittest import mock
+
+from corehttp.rest import HttpRequest
+from corehttp.runtime import AsyncPipelineClient
+from corehttp.runtime.policies import CustomHookPolicy, UserAgentPolicy
+from corehttp.transport import AsyncHttpTransport
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_response_hook_policy_in_init():
+    def test_callback(response):
+        raise ValueError()
+
+    transport = mock.MagicMock(spec=AsyncHttpTransport)
+    url = "http://localhost"
+    custom_hook_policy = CustomHookPolicy(raw_response_hook=test_callback)
+    policies = [UserAgentPolicy("myuseragent"), custom_hook_policy]
+    client = AsyncPipelineClient(endpoint=url, policies=policies, transport=transport)
+    request = HttpRequest("GET", url)
+    with pytest.raises(ValueError):
+        await client.send_request(request)
+
+
+@pytest.mark.asyncio
+async def test_response_hook_policy_in_request():
+    def test_callback(response):
+        raise ValueError()
+
+    transport = mock.MagicMock(spec=AsyncHttpTransport)
+    url = "http://localhost"
+    custom_hook_policy = CustomHookPolicy()
+    policies = [UserAgentPolicy("myuseragent"), custom_hook_policy]
+    client = AsyncPipelineClient(endpoint=url, policies=policies, transport=transport)
+    request = HttpRequest("GET", url)
+    with pytest.raises(ValueError):
+        await client.send_request(request, raw_response_hook=test_callback)
+
+
+@pytest.mark.asyncio
+async def test_response_hook_policy_in_both():
+    def test_callback(response):
+        raise ValueError()
+
+    def test_callback_request(response):
+        raise TypeError()
+
+    transport = mock.MagicMock(spec=AsyncHttpTransport)
+    url = "http://localhost"
+    custom_hook_policy = CustomHookPolicy(raw_response_hook=test_callback)
+    policies = [UserAgentPolicy("myuseragent"), custom_hook_policy]
+    client = AsyncPipelineClient(endpoint=url, policies=policies, transport=transport)
+    request = HttpRequest("GET", url)
+    with pytest.raises(TypeError):
+        await client.send_request(request, raw_response_hook=test_callback_request)
+
+
+@pytest.mark.asyncio
+async def test_request_hook_policy_in_init():
+    def test_callback(response):
+        raise ValueError()
+
+    transport = mock.MagicMock(spec=AsyncHttpTransport)
+    url = "http://localhost"
+    custom_hook_policy = CustomHookPolicy(raw_request_hook=test_callback)
+    policies = [UserAgentPolicy("myuseragent"), custom_hook_policy]
+    client = AsyncPipelineClient(endpoint=url, policies=policies, transport=transport)
+    request = HttpRequest("GET", url)
+    with pytest.raises(ValueError):
+        await client.send_request(request)
+
+
+@pytest.mark.asyncio
+async def test_request_hook_policy_in_request():
+    def test_callback(response):
+        raise ValueError()
+
+    transport = mock.MagicMock(spec=AsyncHttpTransport)
+    url = "http://localhost"
+    custom_hook_policy = CustomHookPolicy()
+    policies = [UserAgentPolicy("myuseragent"), custom_hook_policy]
+    client = AsyncPipelineClient(endpoint=url, policies=policies, transport=transport)
+    request = HttpRequest("GET", url)
+    with pytest.raises(ValueError):
+        await client.send_request(request, raw_request_hook=test_callback)
+
+
+@pytest.mark.asyncio
+async def test_request_hook_policy_in_both():
+    def test_callback(response):
+        raise ValueError()
+
+    def test_callback_request(response):
+        raise TypeError()
+
+    transport = mock.MagicMock(spec=AsyncHttpTransport)
+    url = "http://localhost"
+    custom_hook_policy = CustomHookPolicy(raw_request_hook=test_callback)
+    policies = [UserAgentPolicy("myuseragent"), custom_hook_policy]
+    client = AsyncPipelineClient(endpoint=url, policies=policies, transport=transport)
+    request = HttpRequest("GET", url)
+    with pytest.raises(TypeError):
+        await client.send_request(request, raw_request_hook=test_callback_request)

--- a/sdk/core/corehttp/tests/test_custom_hook_policy.py
+++ b/sdk/core/corehttp/tests/test_custom_hook_policy.py
@@ -1,0 +1,102 @@
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+"""Tests for the custom hook policy."""
+from unittest import mock
+
+from corehttp.rest import HttpRequest
+from corehttp.runtime import PipelineClient
+from corehttp.runtime.policies import CustomHookPolicy, UserAgentPolicy
+from corehttp.transport import HttpTransport
+import pytest
+
+
+def test_response_hook_policy_in_init():
+    def test_callback(response):
+        raise ValueError()
+
+    transport = mock.MagicMock(spec=HttpTransport)
+    url = "http://localhost"
+    custom_hook_policy = CustomHookPolicy(raw_response_hook=test_callback)
+    policies = [UserAgentPolicy("myuseragent"), custom_hook_policy]
+    client = PipelineClient(endpoint=url, policies=policies, transport=transport)
+    request = HttpRequest("GET", url)
+    with pytest.raises(ValueError):
+        client.send_request(request)
+
+
+def test_response_hook_policy_in_request():
+    def test_callback(response):
+        raise ValueError()
+
+    transport = mock.MagicMock(spec=HttpTransport)
+    url = "http://localhost"
+    custom_hook_policy = CustomHookPolicy()
+    policies = [UserAgentPolicy("myuseragent"), custom_hook_policy]
+    client = PipelineClient(endpoint=url, policies=policies, transport=transport)
+    request = HttpRequest("GET", url)
+    with pytest.raises(ValueError):
+        client.send_request(request, raw_response_hook=test_callback)
+
+
+def test_response_hook_policy_in_both():
+    def test_callback(response):
+        raise ValueError()
+
+    def test_callback_request(response):
+        raise TypeError()
+
+    transport = mock.MagicMock(spec=HttpTransport)
+    url = "http://localhost"
+    custom_hook_policy = CustomHookPolicy(raw_response_hook=test_callback)
+    policies = [UserAgentPolicy("myuseragent"), custom_hook_policy]
+    client = PipelineClient(endpoint=url, policies=policies, transport=transport)
+    request = HttpRequest("GET", url)
+    with pytest.raises(TypeError):
+        client.send_request(request, raw_response_hook=test_callback_request)
+
+
+def test_request_hook_policy_in_init():
+    def test_callback(response):
+        raise ValueError()
+
+    transport = mock.MagicMock(spec=HttpTransport)
+    url = "http://localhost"
+    custom_hook_policy = CustomHookPolicy(raw_request_hook=test_callback)
+    policies = [UserAgentPolicy("myuseragent"), custom_hook_policy]
+    client = PipelineClient(endpoint=url, policies=policies, transport=transport)
+    request = HttpRequest("GET", url)
+    with pytest.raises(ValueError):
+        client.send_request(request)
+
+
+def test_request_hook_policy_in_request():
+    def test_callback(response):
+        raise ValueError()
+
+    transport = mock.MagicMock(spec=HttpTransport)
+    url = "http://localhost"
+    custom_hook_policy = CustomHookPolicy()
+    policies = [UserAgentPolicy("myuseragent"), custom_hook_policy]
+    client = PipelineClient(endpoint=url, policies=policies, transport=transport)
+    request = HttpRequest("GET", url)
+    with pytest.raises(ValueError):
+        client.send_request(request, raw_request_hook=test_callback)
+
+
+def test_request_hook_policy_in_both():
+    def test_callback(response):
+        raise ValueError()
+
+    def test_callback_request(response):
+        raise TypeError()
+
+    transport = mock.MagicMock(spec=HttpTransport)
+    url = "http://localhost"
+    custom_hook_policy = CustomHookPolicy(raw_request_hook=test_callback)
+    policies = [UserAgentPolicy("myuseragent"), custom_hook_policy]
+    client = PipelineClient(endpoint=url, policies=policies, transport=transport)
+    request = HttpRequest("GET", url)
+    with pytest.raises(TypeError):
+        client.send_request(request, raw_request_hook=test_callback_request)


### PR DESCRIPTION
`CustomHookPolicy` is a straightforward policy that is commonly used in SDK code. This adds it to `corehttp`.
