### PR TITLE
[Corehttp] Misc fixes + cleanup

### DIFF
--- a/sdk/core/corehttp/CHANGELOG.md
+++ b/sdk/core/corehttp/CHANGELOG.md
@@ -14,6 +14,8 @@
 ### Bugs Fixed
 
 - Fixed an issue with `multipart/form-data` in the async transport where `data` was not getting encoded into the request body. [#32473](https://github.com/Azure/azure-sdk-for-python/pull/32473)
+- Fixed an issue with `connection_verify`, `connection_cert`, and `connection_timeout` not being propagated to underlying transports.  [#33057](https://github.com/Azure/azure-sdk-for-python/pull/33057)
+- Fixed an issue with the `aiohttp` transport not using SSL by default. [#33057](https://github.com/Azure/azure-sdk-for-python/pull/33057)
 
 ### Other Changes
 

--- a/sdk/core/corehttp/corehttp/transport/httpx/_httpx.py
+++ b/sdk/core/corehttp/corehttp/transport/httpx/_httpx.py
@@ -59,8 +59,8 @@ class HttpXTransport(HttpTransport):
         if self.client is None:
             self.client = httpx.Client(
                 trust_env=self._use_env_settings,
-                verify=self.connection_config.get("verify", True),
-                cert=self.connection_config.get("cert"),
+                verify=self.connection_config.get("connection_verify", True),
+                cert=self.connection_config.get("connection_cert"),
             )
 
     def close(self) -> None:
@@ -91,7 +91,7 @@ class HttpXTransport(HttpTransport):
         """
         self.open()
         stream_response = kwargs.pop("stream", False)
-        connect_timeout = kwargs.pop("connection_timeout", self.connection_config.get("timeout"))
+        connect_timeout = kwargs.pop("connection_timeout", self.connection_config.get("connection_timeout"))
         read_timeout = kwargs.pop("read_timeout", self.connection_config.get("read_timeout"))
         # not needed here as its already handled during init
         kwargs.pop("connection_verify", None)
@@ -153,8 +153,8 @@ class AsyncHttpXTransport(AsyncHttpTransport):
         if self.client is None:
             self.client = httpx.AsyncClient(
                 trust_env=self._use_env_settings,
-                verify=self.connection_config.get("verify", True),
-                cert=self.connection_config.get("cert"),
+                verify=self.connection_config.get("connection_verify", True),
+                cert=self.connection_config.get("connection_cert"),
             )
 
     async def close(self) -> None:
@@ -180,7 +180,7 @@ class AsyncHttpXTransport(AsyncHttpTransport):
         """
         await self.open()
         stream_response = kwargs.pop("stream", False)
-        connect_timeout = kwargs.pop("connection_timeout", self.connection_config.get("timeout"))
+        connect_timeout = kwargs.pop("connection_timeout", self.connection_config.get("connection_timeout"))
         read_timeout = kwargs.pop("read_timeout", self.connection_config.get("read_timeout"))
         # not needed here as its already handled during init
         kwargs.pop("connection_verify", None)

--- a/sdk/core/corehttp/corehttp/transport/requests/_requests_basic.py
+++ b/sdk/core/corehttp/corehttp/transport/requests/_requests_basic.py
@@ -135,7 +135,7 @@ class RequestsTransport(HttpTransport):
         error: Optional[BaseErrorUnion] = None
 
         try:
-            connection_timeout = kwargs.pop("connection_timeout", self.connection_config.get("timeout"))
+            connection_timeout = kwargs.pop("connection_timeout", self.connection_config.get("connection_timeout"))
 
             if isinstance(connection_timeout, tuple):
                 if "read_timeout" in kwargs:
@@ -150,9 +150,9 @@ class RequestsTransport(HttpTransport):
                 headers=request.headers,
                 data=request._data,  # pylint: disable=protected-access
                 files=request._files,  # pylint: disable=protected-access
-                verify=kwargs.pop("connection_verify", self.connection_config.get("verify")),
+                verify=kwargs.pop("connection_verify", self.connection_config.get("connection_verify")),
                 timeout=timeout,
-                cert=kwargs.pop("connection_cert", self.connection_config.get("cert")),
+                cert=kwargs.pop("connection_cert", self.connection_config.get("connection_cert")),
                 allow_redirects=False,
                 **kwargs
             )

--- a/sdk/core/corehttp/tests/async_tests/test_rest_http_response_async.py
+++ b/sdk/core/corehttp/tests/async_tests/test_rest_http_response_async.py
@@ -10,7 +10,6 @@ import io
 import pytest
 
 from corehttp.rest import HttpRequest, AsyncHttpResponse
-from corehttp.rest._aiohttp import RestAioHttpTransportResponse
 from corehttp.exceptions import HttpResponseError
 from utils import ASYNC_TRANSPORTS, readonly_checks
 

--- a/sdk/core/corehttp/tests/async_tests/test_retry_policy_async.py
+++ b/sdk/core/corehttp/tests/async_tests/test_retry_policy_async.py
@@ -13,6 +13,7 @@ from itertools import product
 from unittest.mock import Mock
 
 import pytest
+from corehttp.rest import HttpRequest
 from corehttp.exceptions import (
     BaseError,
     ServiceRequestError,
@@ -27,7 +28,7 @@ from corehttp.runtime.policies import (
 from corehttp.runtime.pipeline import AsyncPipeline, PipelineResponse, PipelineRequest
 from corehttp.transport import AsyncHttpTransport
 
-from utils import HTTP_REQUESTS, ASYNC_HTTP_RESPONSES, create_http_response, request_and_responses_product
+from utils import ASYNC_HTTP_RESPONSES, create_http_response
 
 
 def test_retry_code_class_variables():
@@ -55,12 +56,12 @@ def test_retry_types():
 
 
 @pytest.mark.parametrize(
-    "retry_after_input,http_request,http_response",
-    product(["0", "800", "1000", "1200"], HTTP_REQUESTS, ASYNC_HTTP_RESPONSES),
+    "retry_after_input,http_response",
+    product(["0", "800", "1000", "1200"], ASYNC_HTTP_RESPONSES),
 )
-def test_retry_after(retry_after_input, http_request, http_response):
+def test_retry_after(retry_after_input, http_response):
     retry_policy = AsyncRetryPolicy()
-    request = http_request("GET", "http://localhost")
+    request = HttpRequest("GET", "http://localhost")
     response = create_http_response(http_response, request, None, headers={"Retry-After": retry_after_input})
     pipeline_response = PipelineResponse(request, response, None)
     retry_after = retry_policy.get_retry_after(pipeline_response)
@@ -69,8 +70,8 @@ def test_retry_after(retry_after_input, http_request, http_response):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("http_request,http_response", request_and_responses_product(ASYNC_HTTP_RESPONSES))
-async def test_retry_on_429(http_request, http_response):
+@pytest.mark.parametrize("http_response", ASYNC_HTTP_RESPONSES)
+async def test_retry_on_429(http_response):
     class MockTransport(AsyncHttpTransport):
         def __init__(self):
             self._count = 0
@@ -89,7 +90,7 @@ async def test_retry_on_429(http_request, http_response):
             response = create_http_response(http_response, request, None, status_code=429)
             return response
 
-    http_request = http_request("GET", "http://localhost/")
+    http_request = HttpRequest("GET", "http://localhost/")
     http_retry = AsyncRetryPolicy(retry_total=1)
     transport = MockTransport()
     pipeline = AsyncPipeline(transport, [http_retry])
@@ -98,8 +99,8 @@ async def test_retry_on_429(http_request, http_response):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("http_request,http_response", request_and_responses_product(ASYNC_HTTP_RESPONSES))
-async def test_no_retry_on_201(http_request, http_response):
+@pytest.mark.parametrize("http_response", ASYNC_HTTP_RESPONSES)
+async def test_no_retry_on_201(http_response):
     class MockTransport(AsyncHttpTransport):
         def __init__(self):
             self._count = 0
@@ -118,7 +119,7 @@ async def test_no_retry_on_201(http_request, http_response):
             response = create_http_response(http_response, request, None, status_code=201, headers={"Retry-After": "1"})
             return response
 
-    http_request = http_request("GET", "http://localhost/")
+    http_request = HttpRequest("GET", "http://localhost/")
     http_retry = AsyncRetryPolicy(retry_total=1)
     transport = MockTransport()
     pipeline = AsyncPipeline(transport, [http_retry])
@@ -127,8 +128,8 @@ async def test_no_retry_on_201(http_request, http_response):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("http_request,http_response", request_and_responses_product(ASYNC_HTTP_RESPONSES))
-async def test_retry_seekable_stream(http_request, http_response):
+@pytest.mark.parametrize("http_response", ASYNC_HTTP_RESPONSES)
+async def test_retry_seekable_stream(http_response):
     class MockTransport(AsyncHttpTransport):
         def __init__(self):
             self._first = True
@@ -153,15 +154,15 @@ async def test_retry_seekable_stream(http_request, http_response):
             return response
 
     data = BytesIO(b"Lots of dataaaa")
-    http_request = http_request("GET", "http://localhost/", content=data)
+    http_request = HttpRequest("GET", "http://localhost/", content=data)
     http_retry = AsyncRetryPolicy(retry_total=1)
     pipeline = AsyncPipeline(MockTransport(), [http_retry])
     await pipeline.run(http_request)
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("http_request,http_response", request_and_responses_product(ASYNC_HTTP_RESPONSES))
-async def test_retry_seekable_file(http_request, http_response):
+@pytest.mark.parametrize("http_response", ASYNC_HTTP_RESPONSES)
+async def test_retry_seekable_file(http_response):
     class MockTransport(AsyncHttpTransport):
         def __init__(self):
             self._first = True
@@ -200,7 +201,7 @@ async def test_retry_seekable_file(http_request, http_response):
             "fileContent": f,
             "fileName": f.name,
         }
-        http_request = http_request("GET", "http://localhost/", headers=headers, files=form_data_content)
+        http_request = HttpRequest("GET", "http://localhost/", headers=headers, files=form_data_content)
         http_retry = AsyncRetryPolicy(retry_total=1)
         pipeline = AsyncPipeline(MockTransport(), [http_retry])
         await pipeline.run(http_request)
@@ -208,8 +209,7 @@ async def test_retry_seekable_file(http_request, http_response):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("http_request", HTTP_REQUESTS)
-async def test_retry_timeout(http_request):
+async def test_retry_timeout():
     timeout = 1
 
     def send(request, **kwargs):
@@ -225,12 +225,12 @@ async def test_retry_timeout(http_request):
     pipeline = AsyncPipeline(transport, [AsyncRetryPolicy(timeout=timeout)])
 
     with pytest.raises(ServiceResponseTimeoutError):
-        await pipeline.run(http_request("GET", "http://localhost/"))
+        await pipeline.run(HttpRequest("GET", "http://localhost/"))
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("http_request,http_response", request_and_responses_product(ASYNC_HTTP_RESPONSES))
-async def test_timeout_defaults(http_request, http_response):
+@pytest.mark.parametrize("http_response", ASYNC_HTTP_RESPONSES)
+async def test_timeout_defaults(http_response):
     """When "timeout" is not set, the policy should not override the transport's timeout configuration"""
 
     async def send(request, **kwargs):
@@ -246,7 +246,7 @@ async def test_timeout_defaults(http_request, http_response):
     )
     pipeline = AsyncPipeline(transport, [AsyncRetryPolicy()])
 
-    await pipeline.run(http_request("GET", "http://localhost/"))
+    await pipeline.run(HttpRequest("GET", "http://localhost/"))
     assert transport.send.call_count == 1, "policy should not retry: its first send succeeded"
 
 
@@ -254,11 +254,8 @@ combinations = [(ServiceRequestError, ServiceRequestTimeoutError), (ServiceRespo
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "combinations,http_request",
-    product(combinations, HTTP_REQUESTS),
-)
-async def test_does_not_sleep_after_timeout(combinations, http_request):
+@pytest.mark.parametrize("combinations", combinations)
+async def test_does_not_sleep_after_timeout(combinations):
     # With default settings policy will sleep twice before exhausting its retries: 1.6s, 3.2s.
     # It should not sleep the second time when given timeout=1
     transport_error, expected_timeout_error = combinations
@@ -272,6 +269,6 @@ async def test_does_not_sleep_after_timeout(combinations, http_request):
     pipeline = AsyncPipeline(transport, [AsyncRetryPolicy(timeout=timeout)])
 
     with pytest.raises(expected_timeout_error):
-        await pipeline.run(http_request("GET", "http://localhost/"))
+        await pipeline.run(HttpRequest("GET", "http://localhost/"))
 
     assert transport.sleep.call_count == 1

--- a/sdk/core/corehttp/tests/async_tests/test_testserver_async.py
+++ b/sdk/core/corehttp/tests/async_tests/test_testserver_async.py
@@ -4,16 +4,15 @@
 # license information.
 # -------------------------------------------------------------------------
 import pytest
+from corehttp.rest import HttpRequest
 from corehttp.transport.aiohttp import AioHttpTransport
-from utils import HTTP_REQUESTS
 
 """This file does a simple call to the testserver to make sure we can use the testserver"""
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("http_request", HTTP_REQUESTS)
-async def test_smoke(port, http_request):
-    request = http_request(method="GET", url="http://localhost:{}/basic/string".format(port))
+async def test_smoke(port):
+    request = HttpRequest(method="GET", url="http://localhost:{}/basic/string".format(port))
     async with AioHttpTransport() as sender:
         response = await sender.send(request)
         response.raise_for_status()

--- a/sdk/core/corehttp/tests/async_tests/test_universal_http_async.py
+++ b/sdk/core/corehttp/tests/async_tests/test_universal_http_async.py
@@ -8,14 +8,16 @@ from corehttp.transport.aiohttp import AioHttpTransport
 import aiohttp
 
 import pytest
-from utils import HTTP_REQUESTS, AIOHTTP_TRANSPORT_RESPONSES, create_transport_response
+from corehttp.rest import HttpRequest
+from corehttp.rest._aiohttp import RestAioHttpTransportResponse
+
+from utils import create_transport_response
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("http_request", HTTP_REQUESTS)
-async def test_basic_aiohttp(port, http_request):
+async def test_basic_aiohttp(port):
 
-    request = http_request("GET", "http://localhost:{}/basic/string".format(port))
+    request = HttpRequest("GET", "http://localhost:{}/basic/string".format(port))
     async with AioHttpTransport() as sender:
         response = await sender.send(request)
         assert response.content is not None
@@ -25,10 +27,9 @@ async def test_basic_aiohttp(port, http_request):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("http_request", HTTP_REQUESTS)
-async def test_aiohttp_auto_headers(port, http_request):
+async def test_aiohttp_auto_headers(port):
 
-    request = http_request("POST", "http://localhost:{}/basic/string".format(port))
+    request = HttpRequest("POST", "http://localhost:{}/basic/string".format(port))
     async with AioHttpTransport() as sender:
         response = await sender.send(request)
         auto_headers = response._internal_response.request_info.headers
@@ -53,22 +54,20 @@ def _create_aiohttp_response(http_response, body_bytes, headers=None):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("http_response", AIOHTTP_TRANSPORT_RESPONSES)
-async def test_aiohttp_response_text(http_response):
+async def test_aiohttp_response_text():
 
     for encoding in ["utf-8", "utf-8-sig", None]:
 
-        res = _create_aiohttp_response(http_response, b"\xef\xbb\xbf56", {"Content-Type": "text/plain"})
+        res = _create_aiohttp_response(RestAioHttpTransportResponse, b"\xef\xbb\xbf56", {"Content-Type": "text/plain"})
         await res.read()
         assert res.text(encoding) == "56", "Encoding {} didn't work".format(encoding)
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("http_response", AIOHTTP_TRANSPORT_RESPONSES)
-async def test_aiohttp_response_decompression(http_response):
+async def test_aiohttp_response_decompression():
     # cSpell:disable
     res = _create_aiohttp_response(
-        http_response,
+        RestAioHttpTransportResponse,
         b"\x1f\x8b\x08\x00\x00\x00\x00\x00\x04\x00\x8d\x8d\xb1n\xc30\x0cD"
         b"\xff\x85s\x14HVlY\xda\x8av.\n4\x1d\x9a\x8d\xa1\xe5D\x80m\x01\x12="
         b"\x14A\xfe\xbd\x92\x81d\xceB\x1c\xef\xf8\x8e7\x08\x038\xf0\xa67Fj+"
@@ -92,13 +91,12 @@ async def test_aiohttp_response_decompression(http_response):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("http_response", AIOHTTP_TRANSPORT_RESPONSES)
-async def test_aiohttp_response_decompression_negative(http_response):
+async def test_aiohttp_response_decompression_negative():
     import zlib
 
     # cSpell:disable
     res = _create_aiohttp_response(
-        http_response,
+        RestAioHttpTransportResponse,
         b"\xff\x85s\x14HVlY\xda\x8av.\n4\x1d\x9a\x8d\xa1\xe5D\x80m\x01\x12="
         b"\x14A\xfe\xbd\x92\x81d\xceB\x1c\xef\xf8\x8e7\x08\x038\xf0\xa67Fj+"
         b"\x946\x9d8\x0c4\x08{\x96(\x94mzkh\x1cM/a\x07\x94<\xb2\x1f>\xca8\x86"
@@ -114,9 +112,8 @@ async def test_aiohttp_response_decompression_negative(http_response):
         res.content()
 
 
-@pytest.mark.parametrize("http_response", AIOHTTP_TRANSPORT_RESPONSES)
-def test_repr(http_response):
-    res = _create_aiohttp_response(http_response, b"\xef\xbb\xbf56", {"content-type": "text/plain"})
+def test_repr():
+    res = _create_aiohttp_response(RestAioHttpTransportResponse, b"\xef\xbb\xbf56", {"content-type": "text/plain"})
 
     class_name = "AsyncHttpResponse"
     assert repr(res) == f"<{class_name}: 200 OK, Content-Type: text/plain>"

--- a/sdk/core/corehttp/tests/test_error_map.py
+++ b/sdk/core/corehttp/tests/test_error_map.py
@@ -4,45 +4,46 @@
 # license information.
 # -------------------------------------------------------------------------
 import pytest
+from corehttp.rest import HttpRequest
 from corehttp.exceptions import (
     ResourceNotFoundError,
     ResourceExistsError,
     map_error,
     ErrorMap,
 )
-from utils import request_and_responses_product, create_http_response, HTTP_RESPONSES
+from utils import create_http_response, HTTP_RESPONSES
 
 
-@pytest.mark.parametrize("http_request,http_response", request_and_responses_product(HTTP_RESPONSES))
-def test_error_map(http_request, http_response):
-    request = http_request("GET", "")
+@pytest.mark.parametrize("http_response", HTTP_RESPONSES)
+def test_error_map(http_response):
+    request = HttpRequest("GET", "")
     response = create_http_response(http_response, request, None)
     error_map = {404: ResourceNotFoundError}
     with pytest.raises(ResourceNotFoundError):
         map_error(404, response, error_map)
 
 
-@pytest.mark.parametrize("http_request,http_response", request_and_responses_product(HTTP_RESPONSES))
-def test_error_map_no_default(http_request, http_response):
-    request = http_request("GET", "")
+@pytest.mark.parametrize("http_response", HTTP_RESPONSES)
+def test_error_map_no_default(http_response):
+    request = HttpRequest("GET", "")
     response = create_http_response(http_response, request, None)
     error_map = ErrorMap({404: ResourceNotFoundError})
     with pytest.raises(ResourceNotFoundError):
         map_error(404, response, error_map)
 
 
-@pytest.mark.parametrize("http_request,http_response", request_and_responses_product(HTTP_RESPONSES))
-def test_error_map_with_default(http_request, http_response):
-    request = http_request("GET", "")
+@pytest.mark.parametrize("http_response", HTTP_RESPONSES)
+def test_error_map_with_default(http_response):
+    request = HttpRequest("GET", "")
     response = create_http_response(http_response, request, None)
     error_map = ErrorMap({404: ResourceNotFoundError}, default_error=ResourceExistsError)
     with pytest.raises(ResourceExistsError):
         map_error(401, response, error_map)
 
 
-@pytest.mark.parametrize("http_request,http_response", request_and_responses_product(HTTP_RESPONSES))
-def test_only_default(http_request, http_response):
-    request = http_request("GET", "")
+@pytest.mark.parametrize("http_response", HTTP_RESPONSES)
+def test_only_default(http_response):
+    request = HttpRequest("GET", "")
     response = create_http_response(http_response, request, None)
     error_map = ErrorMap(default_error=ResourceExistsError)
     with pytest.raises(ResourceExistsError):

--- a/sdk/core/corehttp/tests/test_rest_context_manager.py
+++ b/sdk/core/corehttp/tests/test_rest_context_manager.py
@@ -8,7 +8,7 @@ from corehttp.rest import HttpRequest
 from corehttp.exceptions import ResponseNotReadError
 
 
-def test_normal_call(client, port):
+def test_normal_call(client):
     def _raise_and_get_text(response):
         response.raise_for_status()
         assert response.text() == "Hello, world!"

--- a/sdk/core/corehttp/tests/test_retry_policy.py
+++ b/sdk/core/corehttp/tests/test_retry_policy.py
@@ -25,8 +25,9 @@ from corehttp.runtime.policies import (
 )
 from corehttp.runtime.pipeline import Pipeline, PipelineResponse, PipelineRequest
 from corehttp.transport import HttpTransport
+from corehttp.rest import HttpRequest
 
-from utils import HTTP_REQUESTS, request_and_responses_product, HTTP_RESPONSES, create_http_response
+from utils import HTTP_RESPONSES, create_http_response
 
 
 def test_retry_code_class_variables():
@@ -53,12 +54,10 @@ def test_retry_types():
     assert backoff_time == 4
 
 
-@pytest.mark.parametrize(
-    "retry_after_input,http_request,http_response", product(["0", "800", "1000", "1200"], HTTP_REQUESTS, HTTP_RESPONSES)
-)
-def test_retry_after(retry_after_input, http_request, http_response):
+@pytest.mark.parametrize("retry_after_input,http_response", product(["0", "800", "1000", "1200"], HTTP_RESPONSES))
+def test_retry_after(retry_after_input, http_response):
     retry_policy = RetryPolicy()
-    request = http_request("GET", "http://localhost")
+    request = HttpRequest("GET", "http://localhost")
     response = create_http_response(http_response, request, None, headers={"Retry-After": retry_after_input})
     pipeline_response = PipelineResponse(request, response, None)
     retry_after = retry_policy.get_retry_after(pipeline_response)
@@ -66,8 +65,8 @@ def test_retry_after(retry_after_input, http_request, http_response):
     assert retry_after == seconds
 
 
-@pytest.mark.parametrize("http_request,http_response", request_and_responses_product(HTTP_RESPONSES))
-def test_retry_on_429(http_request, http_response):
+@pytest.mark.parametrize("http_response", HTTP_RESPONSES)
+def test_retry_on_429(http_response):
     class MockTransport(HttpTransport):
         def __init__(self):
             self._count = 0
@@ -86,7 +85,7 @@ def test_retry_on_429(http_request, http_response):
             response = create_http_response(http_response, request, None, status_code=429)
             return response
 
-    http_request = http_request("GET", "http://localhost/")
+    http_request = HttpRequest("GET", "http://localhost/")
     http_retry = RetryPolicy(retry_total=1)
     transport = MockTransport()
     pipeline = Pipeline(transport, [http_retry])
@@ -94,8 +93,8 @@ def test_retry_on_429(http_request, http_response):
     assert transport._count == 2
 
 
-@pytest.mark.parametrize("http_request,http_response", request_and_responses_product(HTTP_RESPONSES))
-def test_no_retry_on_201(http_request, http_response):
+@pytest.mark.parametrize("http_response", HTTP_RESPONSES)
+def test_no_retry_on_201(http_response):
     class MockTransport(HttpTransport):
         def __init__(self):
             self._count = 0
@@ -114,7 +113,7 @@ def test_no_retry_on_201(http_request, http_response):
             response = create_http_response(http_response, request, None, status_code=201, headers={"Retry-After": "1"})
             return response
 
-    http_request = http_request("GET", "http://localhost/")
+    http_request = HttpRequest("GET", "http://localhost/")
     http_retry = RetryPolicy(retry_total=1)
     transport = MockTransport()
     pipeline = Pipeline(transport, [http_retry])
@@ -122,8 +121,8 @@ def test_no_retry_on_201(http_request, http_response):
     assert transport._count == 1
 
 
-@pytest.mark.parametrize("http_request,http_response", request_and_responses_product(HTTP_RESPONSES))
-def test_retry_seekable_stream(http_request, http_response):
+@pytest.mark.parametrize("http_response", HTTP_RESPONSES)
+def test_retry_seekable_stream(http_response):
     class MockTransport(HttpTransport):
         def __init__(self):
             self._first = True
@@ -148,14 +147,14 @@ def test_retry_seekable_stream(http_request, http_response):
             return response
 
     data = BytesIO(b"Lots of dataaaa")
-    http_request = http_request("GET", "http://localhost/", content=data)
+    http_request = HttpRequest("GET", "http://localhost/", content=data)
     http_retry = RetryPolicy(retry_total=1)
     pipeline = Pipeline(MockTransport(), [http_retry])
     pipeline.run(http_request)
 
 
-@pytest.mark.parametrize("http_request,http_response", request_and_responses_product(HTTP_RESPONSES))
-def test_retry_seekable_file(http_request, http_response):
+@pytest.mark.parametrize("http_response", HTTP_RESPONSES)
+def test_retry_seekable_file(http_response):
     class MockTransport(HttpTransport):
         def __init__(self):
             self._first = True
@@ -194,7 +193,7 @@ def test_retry_seekable_file(http_request, http_response):
             "fileContent": f,
             "fileName": f.name,
         }
-        http_request = http_request("GET", "http://localhost/", headers=headers, files=form_data_content)
+        http_request = HttpRequest("GET", "http://localhost/", headers=headers, files=form_data_content)
 
         http_retry = RetryPolicy(retry_total=1)
         pipeline = Pipeline(MockTransport(), [http_retry])
@@ -202,8 +201,7 @@ def test_retry_seekable_file(http_request, http_response):
     os.unlink(f.name)
 
 
-@pytest.mark.parametrize("http_request", HTTP_REQUESTS)
-def test_retry_timeout(http_request):
+def test_retry_timeout():
     timeout = 1
 
     def send(request, **kwargs):
@@ -219,11 +217,11 @@ def test_retry_timeout(http_request):
     pipeline = Pipeline(transport, [RetryPolicy(timeout=timeout)])
 
     with pytest.raises(ServiceResponseTimeoutError):
-        response = pipeline.run(http_request("GET", "http://localhost/"))
+        response = pipeline.run(HttpRequest("GET", "http://localhost/"))
 
 
-@pytest.mark.parametrize("http_request,http_response", request_and_responses_product(HTTP_RESPONSES))
-def test_timeout_defaults(http_request, http_response):
+@pytest.mark.parametrize("http_response", HTTP_RESPONSES)
+def test_timeout_defaults(http_response):
     """When "timeout" is not set, the policy should not override the transport's timeout configuration"""
 
     def send(request, **kwargs):
@@ -239,18 +237,15 @@ def test_timeout_defaults(http_request, http_response):
     )
     pipeline = Pipeline(transport, [RetryPolicy()])
 
-    pipeline.run(http_request("GET", "http://localhost/"))
+    pipeline.run(HttpRequest("GET", "http://localhost/"))
     assert transport.send.call_count == 1, "policy should not retry: its first send succeeded"
 
 
 combinations = [(ServiceRequestError, ServiceRequestTimeoutError), (ServiceResponseError, ServiceResponseTimeoutError)]
 
 
-@pytest.mark.parametrize(
-    "combinations,http_request",
-    product(combinations, HTTP_REQUESTS),
-)
-def test_does_not_sleep_after_timeout(combinations, http_request):
+@pytest.mark.parametrize("combinations", combinations)
+def test_does_not_sleep_after_timeout(combinations):
     # With default settings policy will sleep twice before exhausting its retries: 1.6s, 3.2s.
     # It should not sleep the second time when given timeout=1
     transport_error, expected_timeout_error = combinations
@@ -264,6 +259,6 @@ def test_does_not_sleep_after_timeout(combinations, http_request):
     pipeline = Pipeline(transport, [RetryPolicy(timeout=timeout)])
 
     with pytest.raises(expected_timeout_error):
-        pipeline.run(http_request("GET", "http://localhost/"))
+        pipeline.run(HttpRequest("GET", "http://localhost/"))
 
     assert transport.sleep.call_count == 1

--- a/sdk/core/corehttp/tests/test_testserver.py
+++ b/sdk/core/corehttp/tests/test_testserver.py
@@ -4,15 +4,14 @@
 # license information.
 # -------------------------------------------------------------------------
 import pytest
+from corehttp.rest import HttpRequest
 from corehttp.transport.requests import RequestsTransport
-from utils import HTTP_REQUESTS
 
 """This file does a simple call to the testserver to make sure we can use the testserver"""
 
 
-@pytest.mark.parametrize("http_request", HTTP_REQUESTS)
-def test_smoke(port, http_request):
-    request = http_request(method="GET", url="http://localhost:{}/basic/string".format(port))
+def test_smoke(port):
+    request = HttpRequest(method="GET", url="http://localhost:{}/basic/string".format(port))
     with RequestsTransport() as sender:
         response = sender.send(request)
         response.raise_for_status()

--- a/sdk/core/corehttp/tests/test_user_agent_policy.py
+++ b/sdk/core/corehttp/tests/test_user_agent_policy.py
@@ -3,19 +3,15 @@
 # Licensed under the MIT License.
 # ------------------------------------
 """Tests for the user agent policy."""
+from unittest import mock
+
+from corehttp.rest import HttpRequest
 from corehttp.runtime.policies import UserAgentPolicy
 from corehttp.runtime.pipeline import PipelineRequest, PipelineContext
-
-try:
-    from unittest import mock
-except ImportError:
-    import mock
 import pytest
-from utils import HTTP_REQUESTS
 
 
-@pytest.mark.parametrize("http_request", HTTP_REQUESTS)
-def test_user_agent_policy(http_request):
+def test_user_agent_policy():
     user_agent = UserAgentPolicy(base_user_agent="foo")
     assert user_agent._user_agent == "foo"
 
@@ -25,7 +21,7 @@ def test_user_agent_policy(http_request):
     user_agent = UserAgentPolicy(base_user_agent="foo", user_agent="bar", user_agent_use_env=False)
     assert user_agent._user_agent == "bar foo"
 
-    request = http_request("GET", "http://localhost/")
+    request = HttpRequest("GET", "http://localhost/")
     pipeline_request = PipelineRequest(request, PipelineContext(None))
 
     pipeline_request.context.options["user_agent"] = "xyz"
@@ -33,13 +29,12 @@ def test_user_agent_policy(http_request):
     assert request.headers["User-Agent"] == "xyz bar foo"
 
 
-@pytest.mark.parametrize("http_request", HTTP_REQUESTS)
-def test_user_agent_environ(http_request):
+def test_user_agent_environ():
 
     with mock.patch.dict("os.environ", {"CORE_HTTP_USER_AGENT": "mytools"}):
         policy = UserAgentPolicy(None)
         assert policy.user_agent.endswith("mytools")
 
-        request = http_request("GET", "http://localhost/")
+        request = HttpRequest("GET", "http://localhost/")
         policy.on_request(PipelineRequest(request, PipelineContext(None)))
         assert request.headers["user-agent"].endswith("mytools")

--- a/sdk/core/corehttp/tests/utils.py
+++ b/sdk/core/corehttp/tests/utils.py
@@ -7,21 +7,23 @@ import pytest
 import types
 
 ############################## LISTS USED TO PARAMETERIZE TESTS ##############################
-from corehttp.rest import HttpRequest as RestHttpRequest
+from corehttp.rest import HttpRequest
+from corehttp.rest._http_response_impl import HttpResponseImpl as RestHttpResponse
+from corehttp.rest._http_response_impl_async import AsyncHttpResponseImpl as RestAsyncHttpResponse
 
 
 SYNC_TRANSPORTS = []
 ASYNC_TRANSPORTS = []
 
-AIOHTTP_TRANSPORT_RESPONSES = []
-REQUESTS_TRANSPORT_RESPONSES = []
+SYNC_TRANSPORT_RESPONSES = []
+ASYNC_TRANSPORT_RESPONSES = []
 
 try:
     from corehttp.rest._requests_basic import RestRequestsTransportResponse
     from corehttp.transport.requests import RequestsTransport
 
     SYNC_TRANSPORTS.append(RequestsTransport)
-    REQUESTS_TRANSPORT_RESPONSES = [RestRequestsTransportResponse]
+    SYNC_TRANSPORT_RESPONSES.append(RestRequestsTransportResponse)
 except (ImportError, SyntaxError):
     pass
 
@@ -30,59 +32,25 @@ try:
     from corehttp.transport.aiohttp import AioHttpTransport
 
     ASYNC_TRANSPORTS.append(AioHttpTransport)
-    AIOHTTP_TRANSPORT_RESPONSES = [RestAioHttpTransportResponse]
+    ASYNC_TRANSPORT_RESPONSES.append(RestAioHttpTransportResponse)
 except (ImportError, SyntaxError):
     pass
 
 try:
+    from corehttp.rest._httpx import HttpXTransportResponse, AsyncHttpXTransportResponse
     from corehttp.transport.httpx import HttpXTransport, AsyncHttpXTransport
 
     SYNC_TRANSPORTS.append(HttpXTransport)
+    SYNC_TRANSPORT_RESPONSES.append(HttpXTransportResponse)
     ASYNC_TRANSPORTS.append(AsyncHttpXTransport)
+    ASYNC_TRANSPORT_RESPONSES.append(AsyncHttpXTransportResponse)
 except (ImportError, SyntaxError):
     pass
-
-HTTP_REQUESTS = [RestHttpRequest]
-
-from corehttp.rest._http_response_impl import HttpResponseImpl as RestHttpResponse
 
 HTTP_RESPONSES = [RestHttpResponse]
-
-ASYNC_HTTP_RESPONSES = []
-
-try:
-    from corehttp.rest._http_response_impl_async import AsyncHttpResponseImpl as RestAsyncHttpResponse
-
-    ASYNC_HTTP_RESPONSES = [RestAsyncHttpResponse]
-except (ImportError, SyntaxError):
-    pass
+ASYNC_HTTP_RESPONSES = [RestAsyncHttpResponse]
 
 ############################## HELPER FUNCTIONS ##############################
-
-
-def request_and_responses_product(*args):
-    rest = tuple([RestHttpRequest]) + tuple(arg[0] for arg in args)
-    return [rest]
-
-
-def create_http_request(http_request, *args, **kwargs):
-    if hasattr(http_request, "content"):
-        method = args[0]
-        url = args[1]
-        try:
-            headers = args[2]
-        except IndexError:
-            headers = None
-        try:
-            files = args[3]
-        except IndexError:
-            files = None
-        try:
-            data = args[4]
-        except IndexError:
-            data = None
-        return http_request(method=method, url=url, headers=headers, files=files, data=data, **kwargs)
-    return http_request(*args, **kwargs)
 
 
 def create_transport_response(http_response, *args, **kwargs):
@@ -115,7 +83,7 @@ def create_http_response(http_response, *args, **kwargs):
 
 def readonly_checks(response):
     # We want these properties to be completely readonly.
-    assert isinstance(response.request, RestHttpRequest)
+    assert isinstance(response.request, HttpRequest)
     assert isinstance(response.status_code, int)
     assert response.headers
     assert response.content_type == "text/html; charset=utf-8"


### PR DESCRIPTION
- Fixed a parameter mismatch in the connection config
- Added the aiohttp fix that was added to azure-core (Ref: https://github.com/Azure/azure-sdk-for-python/pull/32540)
- Cleaned up tests a bit to remove constructs that were used for backcompat testing.
