### PR TITLE
[EH] pyproject update

### DIFF
--- a/sdk/eventhub/azure-eventhub/pyproject.toml
+++ b/sdk/eventhub/azure-eventhub/pyproject.toml
@@ -3,3 +3,4 @@ pyright = false
 type_check_samples = true
 verifytypes = true
 pylint = true
+whl_no_aio = false


### PR DESCRIPTION
Removing aio whl from pyproject.toml to release azure-eventhub, b/c checkpointstoreblob-aio is failing b/c aiohttp hasn't been released for Python 3.12 yet.