### PR TITLE
[Storage] Change path building logic for `get_subdirectory_client`

### DIFF
--- a/sdk/storage/azure-storage-file-share/CHANGELOG.md
+++ b/sdk/storage/azure-storage-file-share/CHANGELOG.md
@@ -3,8 +3,8 @@
 ## 12.16.0b1 (Unreleased)
 
 ### Bugs Fixed
-- Fixed an issue where calling `get_subdirectory_client` with a `ShareDirectoryClient` pointing to the root of the
-file share would raise an `InvalidResourceName` instead of returning a `ShareDirectoryClient`.
+- Fixed an issue where the `ShareDirectoryClient` returned by `get_subdirectory_client` with a `ShareDirectoryClient`
+pointing to the root of the file share would raise an `InvalidResourceName` on any operations.
 
 
 ## 12.15.0 (2023-11-07)

--- a/sdk/storage/azure-storage-file-share/CHANGELOG.md
+++ b/sdk/storage/azure-storage-file-share/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## 12.16.0b1 (Unreleased)
 
-### Features Added
+### Bugs Fixed
+- Fixed an issue where calling `get_subdirectory_client` with a `ShareDirectoryClient` pointing to the root of the
+file share would raise an `InvalidResourceName` instead of returning a `ShareDirectoryClient`.
 
 
 ## 12.15.0 (2023-11-07)

--- a/sdk/storage/azure-storage-file-share/assets.json
+++ b/sdk/storage/azure-storage-file-share/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "python",
   "TagPrefix": "python/storage/azure-storage-file-share",
-  "Tag": "python/storage/azure-storage-file-share_acf7679e5b"
+  "Tag": "python/storage/azure-storage-file-share_81dadfb61f"
 }

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_directory_client.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_directory_client.py
@@ -289,7 +289,9 @@ class ShareDirectoryClient(StorageAccountHostsMixin):
                 :dedent: 12
                 :caption: Gets the subdirectory client.
         """
-        directory_path = self.directory_path.rstrip('/') + "/" + directory_name
+        directory_path = directory_name
+        if self.directory_path:
+            directory_path = self.directory_path.rstrip('/') + "/" + directory_name
 
         _pipeline = Pipeline(
             transport=TransportWrapper(self._pipeline._transport), # pylint: disable = protected-access

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/aio/_directory_client_async.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/aio/_directory_client_async.py
@@ -167,7 +167,9 @@ class ShareDirectoryClient(AsyncStorageAccountHostsMixin, ShareDirectoryClientBa
                 :dedent: 16
                 :caption: Gets the subdirectory client.
         """
-        directory_path = self.directory_path.rstrip('/') + "/" + directory_name
+        directory_path = directory_name
+        if self.directory_path:
+            directory_path = self.directory_path.rstrip('/') + "/" + directory_name
 
         _pipeline = AsyncPipeline(
             transport=AsyncTransportWrapper(self._pipeline._transport), # pylint: disable = protected-access

--- a/sdk/storage/azure-storage-file-share/tests/test_directory.py
+++ b/sdk/storage/azure-storage-file-share/tests/test_directory.py
@@ -212,6 +212,28 @@ class TestStorageDirectory(StorageRecordedTestCase):
 
     @FileSharePreparer()
     @recorded_by_proxy
+    def test_create_subdirectory_in_root(self, **kwargs):
+        storage_account_name = kwargs.pop("storage_account_name")
+        storage_account_key = kwargs.pop("storage_account_key")
+
+        self._setup(storage_account_name, storage_account_key)
+        share_client = self.fsc.get_share_client(self.share_name)
+        share_client.create_directory('dir1')
+
+        # Act
+        rooted_directory = share_client.get_directory_client()
+        sub_dir_client = rooted_directory.get_subdirectory_client('dir2')
+        sub_dir_client.create_directory()
+
+        list_dir = list(share_client.list_directories_and_files())
+
+        # Assert
+        assert len(list_dir) == 2
+        assert list_dir[0]['name'] == 'dir1'
+        assert list_dir[1]['name'] == 'dir2'
+
+    @FileSharePreparer()
+    @recorded_by_proxy
     def test_create_file_in_directory(self, **kwargs):
         storage_account_name = kwargs.pop("storage_account_name")
         storage_account_key = kwargs.pop("storage_account_key")

--- a/sdk/storage/azure-storage-file-share/tests/test_directory_async.py
+++ b/sdk/storage/azure-storage-file-share/tests/test_directory_async.py
@@ -222,6 +222,30 @@ class TestStorageDirectoryAsync(AsyncStorageRecordedTestCase):
 
     @FileSharePreparer()
     @recorded_by_proxy_async
+    async def test_create_subdirectory_in_root(self, **kwargs):
+        storage_account_name = kwargs.pop("storage_account_name")
+        storage_account_key = kwargs.pop("storage_account_key")
+
+        await self._setup(storage_account_name, storage_account_key)
+        share_client = self.fsc.get_share_client(self.share_name)
+        await share_client.create_directory('dir1')
+
+        # Act
+        rooted_directory = share_client.get_directory_client()
+        sub_dir_client = rooted_directory.get_subdirectory_client('dir2')
+        await sub_dir_client.create_directory()
+
+        list_dir = []
+        async for d in rooted_directory.list_directories_and_files():
+            list_dir.append(d)
+
+        # Assert
+        assert len(list_dir) == 2
+        assert list_dir[0]['name'] == 'dir1'
+        assert list_dir[1]['name'] == 'dir2'
+
+    @FileSharePreparer()
+    @recorded_by_proxy_async
     async def test_create_file_in_directory(self, **kwargs):
         storage_account_name = kwargs.pop("storage_account_name")
         storage_account_key = kwargs.pop("storage_account_key")


### PR DESCRIPTION
This is my proposed solution to `get_subdirectory_client` throwing an illegal character expression. The root cause is that in our [path-building](https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_directory_client.py#L292), we don't check for an empty "main" directory name. This causes a `/` to appear as part of a file-name, and so gets caught as an illegal character.

 This change simply makes it so that the "subdirectory" client obtained when the "main" directory is pointing to the root will make a directory in the root as expected (rather than throw an illegal character exception).

This mimics the current behavior that calling `get_file_client` and creating a file from a directory_client pointing to the root as it's directory will place the file right in the root.

This issue does not seem to reproduce in any other `get_X_client` as the logic used to obtain the directory path is different in other cases.

EDIT: Should add a changelog entry for "bug fixes" for this