### PR TITLE
re add connection metadata

### DIFF
--- a/sdk/ai/azure-ai-resources/azure/ai/resources/entities/base_connection.py
+++ b/sdk/ai/azure-ai-resources/azure/ai/resources/entities/base_connection.py
@@ -207,6 +207,27 @@ class BaseConnection:
             return
         self._workspace_connection.tags = value
 
+    @property
+    def metadata(self) -> Dict[str, Any]:
+        """Deprecated. Use tags.
+
+        :return: This connection's tags/metadata.
+        :rtype: Dict[str, Any]
+        """
+        return self._workspace_connection.tags
+
+    @metadata.setter
+    def metadata(self, value: Dict[str, Any]):
+        """Deprecated. Use tags.
+
+        :param value: The new tags/metadata for connection.
+            This completely overwrites the existing tags/metadata dictionary.
+        :type value: Dict[str, Any]
+        """
+        if not value:
+            return
+        self._workspace_connection.tags = value
+
     def set_current_environment(self, credential: Optional[TokenCredential] = None):
         """Sets the current environment to use the connection. To use AAD auth for AzureOpenAI connetion, pass in a credential object.
         Only certain types of connections make use of this function. Those that don't will raise an error if this is called.

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_workspace/connections/workspace_connection.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_workspace/connections/workspace_connection.py
@@ -6,7 +6,7 @@
 
 from os import PathLike
 from pathlib import Path
-from typing import IO, AnyStr, Dict, Optional, Union, List, Type
+from typing import IO, AnyStr, Dict, Optional, Union, List, Type, Any
 
 from azure.ai.ml._restclient.v2023_06_01_preview.models import (
     AccessKeyAuthTypeWorkspaceConnectionProperties,
@@ -156,6 +156,25 @@ class WorkspaceConnection(Resource):
         ]
         """
         return self._credentials
+
+    @property
+    def metadata(self) -> Dict[str, Any]:
+        """Deprecated. Use tags.
+        :return: This connection's tags.
+        :rtype: Dict[str, Any]
+        """
+        return self.tags
+
+    @metadata.setter
+    def metadata(self, value: Dict[str, Any]):
+        """Deprecated. Use tags.
+        :param value: The new metadata for connection.
+            This completely overwrites the existing tags/metadata dictionary.
+        :type value: Dict[str, Any]
+        """
+        if not value:
+            return
+        self.tags = value
 
     def dump(self, dest: Union[str, PathLike, IO[AnyStr]], **kwargs) -> None:
         """Dump the workspace connection spec into a file in yaml format.


### PR DESCRIPTION
Resurfaces connection.metadata in the AI SDK.  Comments point users towards the non-deprecated tags value.