### PR TITLE
Deserialize TelemetryItem properly from local storage

### DIFF
--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 ### Bugs Fixed
 
+- Fix deserialization of `TelemetryItem` from local storage
+    ([#32327](https://github.com/Azure/azure-sdk-for-python/pull/32327))
+
 ### Other Changes
 
 ## 1.0.0b18 (2023-11-06)

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Bugs Fixed
 
 - Fix deserialization of `TelemetryItem` from local storage
-    ([#32327](https://github.com/Azure/azure-sdk-for-python/pull/32327))
+    ([#33163](https://github.com/Azure/azure-sdk-for-python/pull/33163))
 
 ### Other Changes
 

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/_base.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/_base.py
@@ -425,4 +425,5 @@ def _format_storage_telemetry_item(item: TelemetryItem) -> TelemetryItem:
                 # Apply deseralization of additional_properties and store that as base_data
                 if base_type:
                     item.data.base_data = base_type.from_dict(item.data.base_data.additional_properties)
+                    item.data.base_data.additional_properties = None
     return item

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/_base.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/_base.py
@@ -5,7 +5,7 @@ import os
 import tempfile
 import time
 from enum import Enum
-from typing import Dict, List, Optional, Any
+from typing import List, Optional, Any
 from urllib.parse import urlparse
 
 from azure.core.exceptions import HttpResponseError, ServiceRequestError
@@ -424,7 +424,6 @@ def _format_storage_telemetry_item(item: TelemetryItem) -> TelemetryItem:
                 base_type = _MONITOR_DOMAIN_MAPPING.get(item.data.base_type)
                 # Apply deserialization of additional_properties and store that as base_data
                 if base_type:
-                    # type: ignore
-                    item.data.base_data = base_type.from_dict(item.data.base_data.additional_properties)
-                    item.data.base_data.additional_properties = None
+                    item.data.base_data = base_type.from_dict(item.data.base_data.additional_properties) # type: ignore
+                    item.data.base_data.additional_properties = None # type: ignore
     return item

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/_base.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/_base.py
@@ -18,7 +18,16 @@ from azure.core.pipeline.policies import (
 )
 from azure.monitor.opentelemetry.exporter._generated import AzureMonitorClient
 from azure.monitor.opentelemetry.exporter._generated._configuration import AzureMonitorClientConfiguration
-from azure.monitor.opentelemetry.exporter._generated.models import TelemetryItem
+from azure.monitor.opentelemetry.exporter._generated.models import (
+    MessageData,
+    MetricsData,
+    MonitorDomain,
+    RemoteDependencyData,
+    RequestData,
+    TelemetryEventData,
+    TelemetryExceptionData,
+    TelemetryItem,
+)
 from azure.monitor.opentelemetry.exporter._constants import (
     _REACHED_INGESTION_STATUS_CODES,
     _REDIRECT_STATUS_CODES,
@@ -136,8 +145,8 @@ class BaseExporter:
             # give a few more seconds for blob lease operation
             # to reduce the chance of race (for perf consideration)
             if blob.lease(self._timeout + 5):
-                envelopes = [TelemetryItem.from_dict(x) for x in blob.get()]
-                result = self._transmit(list(envelopes))
+                envelopes = [_format_storage_telemetry_item(TelemetryItem.from_dict(x)) for x in blob.get()]
+                result = self._transmit(envelopes)
                 if result == ExportResult.FAILED_RETRYABLE:
                     blob.lease(1)
                 else:
@@ -172,6 +181,7 @@ class BaseExporter:
             reach_ingestion = False
             start_time = time.time()
             try:
+                print(self.client._serialize.body(envelopes, '[TelemetryItem]'))
                 track_response = self.client.track(envelopes)
                 if not track_response.errors:  # 200
                     self._consecutive_redirects = 0
@@ -205,8 +215,7 @@ class BaseExporter:
                                             for x in resend_envelopes]
                         self.storage.put(envelopes_to_store, 0)
                         self._consecutive_redirects = 0
-                        result = ExportResult.FAILED_RETRYABLE
-                    else:
+                        # Mark as not retryable because we already write to storage here
                         result = ExportResult.FAILED_NOT_RETRYABLE
             except HttpResponseError as response_error:
                 # HttpResponseError is raised when a response is received
@@ -392,3 +401,28 @@ def _update_requests_map(type_name, value=None):
             else:
                 _REQUESTS_MAP[type_name] = {}
             _REQUESTS_MAP[type_name][value] = prev + 1
+
+
+_MONITOR_DOMAIN_MAPPING = {
+    "EventData": TelemetryEventData,
+    "ExceptionData": TelemetryExceptionData,
+    "MessageData": MessageData,
+    "MetricData": MetricsData,
+    "RemoteDependencyData": RemoteDependencyData,
+    "RequestData": RequestData,
+}
+
+
+# from_dict() deserializes incorrectly, format TelemetryItem correctly after it
+# is called
+def _format_storage_telemetry_item(item: TelemetryItem) -> TelemetryItem:
+    # After TelemetryItem.from_dict, all base_data fields are stored in
+    # additional_properties as a dict instead of in item.data.base_data itself
+    # item.data.base_data is also of type MonitorDomain instead of a child class
+    if hasattr(item.data, "base_data") and isinstance(item.data.base_data, MonitorDomain):
+        if hasattr(item.data, "base_type"):
+            base_type = _MONITOR_DOMAIN_MAPPING.get(item.data.base_type)
+            # Apply deseralization of additional_properties and store that as base_data
+            if base_type:
+                item.data.base_data = base_type.from_dict(item.data.base_data.additional_properties)
+    return item

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/_base.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/_base.py
@@ -5,7 +5,7 @@ import os
 import tempfile
 import time
 from enum import Enum
-from typing import List, Optional, Any
+from typing import Dict, List, Optional, Any
 from urllib.parse import urlparse
 
 from azure.core.exceptions import HttpResponseError, ServiceRequestError
@@ -402,7 +402,7 @@ def _update_requests_map(type_name, value=None):
             _REQUESTS_MAP[type_name][value] = prev + 1
 
 
-_MONITOR_DOMAIN_MAPPING = {
+_MONITOR_DOMAIN_MAPPING: Dict[str: MonitorDomain] = {
     "EventData": TelemetryEventData,
     "ExceptionData": TelemetryExceptionData,
     "MessageData": MessageData,
@@ -418,11 +418,11 @@ def _format_storage_telemetry_item(item: TelemetryItem) -> TelemetryItem:
     # After TelemetryItem.from_dict, all base_data fields are stored in
     # additional_properties as a dict instead of in item.data.base_data itself
     # item.data.base_data is also of type MonitorDomain instead of a child class
-    if hasattr(item, "data"):
+    if hasattr(item, "data") and item.data is not None:
         if hasattr(item.data, "base_data") and isinstance(item.data.base_data, MonitorDomain):
-            if hasattr(item.data, "base_type"):
+            if hasattr(item.data, "base_type") and isinstance(item.data.base_type, str):
                 base_type = _MONITOR_DOMAIN_MAPPING.get(item.data.base_type)
-                # Apply deseralization of additional_properties and store that as base_data
+                # Apply deserialization of additional_properties and store that as base_data
                 if base_type:
                     item.data.base_data = base_type.from_dict(item.data.base_data.additional_properties)
                     item.data.base_data.additional_properties = None

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/_base.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/_base.py
@@ -181,7 +181,6 @@ class BaseExporter:
             reach_ingestion = False
             start_time = time.time()
             try:
-                print(self.client._serialize.body(envelopes, '[TelemetryItem]'))
                 track_response = self.client.track(envelopes)
                 if not track_response.errors:  # 200
                     self._consecutive_redirects = 0
@@ -215,8 +214,8 @@ class BaseExporter:
                                             for x in resend_envelopes]
                         self.storage.put(envelopes_to_store, 0)
                         self._consecutive_redirects = 0
-                        # Mark as not retryable because we already write to storage here
-                        result = ExportResult.FAILED_NOT_RETRYABLE
+                    # Mark as not retryable because we already write to storage here
+                    result = ExportResult.FAILED_NOT_RETRYABLE
             except HttpResponseError as response_error:
                 # HttpResponseError is raised when a response is received
                 if _reached_ingestion_code(response_error.status_code):
@@ -419,10 +418,11 @@ def _format_storage_telemetry_item(item: TelemetryItem) -> TelemetryItem:
     # After TelemetryItem.from_dict, all base_data fields are stored in
     # additional_properties as a dict instead of in item.data.base_data itself
     # item.data.base_data is also of type MonitorDomain instead of a child class
-    if hasattr(item.data, "base_data") and isinstance(item.data.base_data, MonitorDomain):
-        if hasattr(item.data, "base_type"):
-            base_type = _MONITOR_DOMAIN_MAPPING.get(item.data.base_type)
-            # Apply deseralization of additional_properties and store that as base_data
-            if base_type:
-                item.data.base_data = base_type.from_dict(item.data.base_data.additional_properties)
+    if hasattr(item, "data"):
+        if hasattr(item.data, "base_data") and isinstance(item.data.base_data, MonitorDomain):
+            if hasattr(item.data, "base_type"):
+                base_type = _MONITOR_DOMAIN_MAPPING.get(item.data.base_type)
+                # Apply deseralization of additional_properties and store that as base_data
+                if base_type:
+                    item.data.base_data = base_type.from_dict(item.data.base_data.additional_properties)
     return item

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/_base.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/_base.py
@@ -402,7 +402,7 @@ def _update_requests_map(type_name, value=None):
             _REQUESTS_MAP[type_name][value] = prev + 1
 
 
-_MONITOR_DOMAIN_MAPPING: Dict[str: MonitorDomain] = {
+_MONITOR_DOMAIN_MAPPING = {
     "EventData": TelemetryEventData,
     "ExceptionData": TelemetryExceptionData,
     "MessageData": MessageData,
@@ -424,6 +424,7 @@ def _format_storage_telemetry_item(item: TelemetryItem) -> TelemetryItem:
                 base_type = _MONITOR_DOMAIN_MAPPING.get(item.data.base_type)
                 # Apply deserialization of additional_properties and store that as base_data
                 if base_type:
+                    # type: ignore
                     item.data.base_data = base_type.from_dict(item.data.base_data.additional_properties)
                     item.data.base_data.additional_properties = None
     return item

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/statsbeat/test_exporter.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/statsbeat/test_exporter.py
@@ -105,7 +105,7 @@ class TestStatsbeatExporter(unittest.TestCase):
                 ],
             )
             result = self._exporter._transmit(self._envelopes_to_export)
-        self.assertEqual(result, ExportResult.FAILED_RETRYABLE)
+        self.assertEqual(result, ExportResult.FAILED_NOT_RETRYABLE)
         self.assertTrue(_STATSBEAT_STATE["INITIAL_SUCCESS"])
 
     def test_transmit_reach_ingestion_code(self):

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/test_base_exporter.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/test_base_exporter.py
@@ -10,6 +10,8 @@ from datetime import datetime
 from azure.core.exceptions import HttpResponseError, ServiceRequestError
 from azure.core.pipeline.transport import HttpResponse
 from azure.monitor.opentelemetry.exporter.export._base import (
+    _MONITOR_DOMAIN_MAPPING,
+    _format_storage_telemetry_item,
     _get_auth_policy,
     BaseExporter,
     ExportResult,
@@ -25,7 +27,16 @@ from azure.monitor.opentelemetry.exporter._constants import (
 )
 from azure.monitor.opentelemetry.exporter._generated import AzureMonitorClient
 from azure.monitor.opentelemetry.exporter._generated.models import (
+    MessageData,
+    MetricDataPoint,
+    MetricsData,
+    MonitorBase,
+    RemoteDependencyData,
+    RequestData,
     TelemetryErrorDetails,
+    TelemetryExceptionDetails,
+    TelemetryEventData,
+    TelemetryExceptionData,
     TelemetryItem,
     TrackResponse,
 )
@@ -160,6 +171,182 @@ class TestBaseExporter(unittest.TestCase):
         transmit_mock.assert_not_called()
         blob_mock.lease.assert_called_once()
         blob_mock.delete.assert_not_called()
+
+    def test_format_storage_telemetry_item(self):
+        time=datetime.now()
+        base = MonitorBase(
+            base_type="",
+            base_data=None
+        )
+        ti = TelemetryItem(
+            name="test_telemetry_item",
+            time=time,
+            version=1,
+            sample_rate=50.0,
+            sequence="test_sequence",
+            instrumentation_key="4321abcd-5678-4efa-8abc-1234567890ab",
+            tags={"tag1": "val1", "tag2": "val2"},
+            data=base
+        )
+        # MessageData
+        message_data = MessageData(
+            version=2,
+            message="test_message",
+            severity_level="Warning",
+            properties={"key1": "val1"},
+        )
+        base.base_type = "MessageData"
+        self.assertEqual(_MONITOR_DOMAIN_MAPPING.get(base.base_type), MessageData)
+        base.base_data = message_data
+        ti.data = base
+
+        # Format is called on custom serialized TelemetryItem
+        converted_ti = ti.from_dict(ti.as_dict())
+        format_ti = _format_storage_telemetry_item(converted_ti)
+        self.assertTrue(validate_telemetry_item(format_ti, ti))
+        self.assertEqual(format_ti.data.base_type, "MessageData")
+        self.assertEqual(message_data.__dict__.items(), format_ti.data.base_data.__dict__.items())
+
+        # EventData
+        event_data = TelemetryEventData(
+            version=2,
+            name="test_name",
+            properties={"key1": "val1"},
+        )
+        base.base_type = "EventData"
+        self.assertEqual(_MONITOR_DOMAIN_MAPPING.get(base.base_type), TelemetryEventData)
+        base.base_data = event_data
+        ti.data = base
+
+        # Format is called on custom serialized TelemetryItem
+        converted_ti = ti.from_dict(ti.as_dict())
+        format_ti = _format_storage_telemetry_item(converted_ti)
+        self.assertTrue(validate_telemetry_item(format_ti, ti))
+        self.assertEqual(format_ti.data.base_type, "EventData")
+        self.assertEqual(event_data.__dict__.items(), format_ti.data.base_data.__dict__.items())
+
+        # ExceptionData
+        exc_data_details = TelemetryExceptionDetails(
+            type_name="ZeroDivisionError",
+            message="division by zero",
+            has_full_stack=True,
+            stack="Traceback \n",
+        )
+        exc_data = TelemetryExceptionData(
+            version=2,
+            properties={"key1": "val1"},
+            severity_level="3",
+            exceptions=[exc_data_details]
+        )
+        base.base_type = "ExceptionData"
+        self.assertEqual(_MONITOR_DOMAIN_MAPPING.get(base.base_type), TelemetryExceptionData)
+        base.base_data = exc_data
+        ti.data = base
+
+        # Format is called on custom serialized TelemetryItem
+        converted_ti = ti.from_dict(ti.as_dict())
+        format_ti = _format_storage_telemetry_item(converted_ti)
+        self.assertTrue(validate_telemetry_item(format_ti, ti))
+        self.assertEqual(format_ti.data.base_type, "ExceptionData")
+        self.assertEqual(exc_data.version, format_ti.data.base_data.version)
+        self.assertEqual(exc_data.properties, format_ti.data.base_data.properties)
+        self.assertEqual(exc_data.severity_level, format_ti.data.base_data.severity_level)
+        self.assertEqual(exc_data.exceptions[0].type_name, format_ti.data.base_data.exceptions[0].type_name)
+        self.assertEqual(exc_data.exceptions[0].message, format_ti.data.base_data.exceptions[0].message)
+        self.assertEqual(exc_data.exceptions[0].has_full_stack, format_ti.data.base_data.exceptions[0].has_full_stack)
+        self.assertEqual(exc_data.exceptions[0].stack, format_ti.data.base_data.exceptions[0].stack)
+
+        # MetricsData
+        counter_data_point = MetricDataPoint(
+            name="counter",
+            value=1.0,
+            count=1,
+            min=None,
+            max=None,
+        )
+        hist_data_point = MetricDataPoint(
+            name="histogram",
+            value=99.0,
+            count=1,
+            min=99.0,
+            max=99.0,
+        )
+        metric_data = MetricsData(
+            version=2,
+            properties={"key1": "val1"},
+            metrics=[counter_data_point, hist_data_point],
+        )
+        base.base_type = "MetricData"
+        self.assertEqual(_MONITOR_DOMAIN_MAPPING.get(base.base_type), MetricsData)
+        base.base_data = metric_data
+        ti.data = base
+
+        # Format is called on custom serialized TelemetryItem
+        converted_ti = ti.from_dict(ti.as_dict())
+        format_ti = _format_storage_telemetry_item(converted_ti)
+        self.assertTrue(validate_telemetry_item(format_ti, ti))
+        self.assertEqual(format_ti.data.base_type, "MetricData")
+        self.assertEqual(metric_data.version, format_ti.data.base_data.version)
+        self.assertEqual(metric_data.properties, format_ti.data.base_data.properties)
+        self.assertEqual(metric_data.metrics[0].name, format_ti.data.base_data.metrics[0].name)
+        self.assertEqual(metric_data.metrics[0].value, format_ti.data.base_data.metrics[0].value)
+        self.assertEqual(metric_data.metrics[0].count, format_ti.data.base_data.metrics[0].count)
+        self.assertEqual(metric_data.metrics[0].min, format_ti.data.base_data.metrics[0].min)
+        self.assertEqual(metric_data.metrics[0].max, format_ti.data.base_data.metrics[0].max)
+        self.assertEqual(metric_data.metrics[1].name, format_ti.data.base_data.metrics[1].name)
+        self.assertEqual(metric_data.metrics[1].value, format_ti.data.base_data.metrics[1].value)
+        self.assertEqual(metric_data.metrics[1].count, format_ti.data.base_data.metrics[1].count)
+        self.assertEqual(metric_data.metrics[1].min, format_ti.data.base_data.metrics[1].min)
+        self.assertEqual(metric_data.metrics[1].max, format_ti.data.base_data.metrics[1].max)
+
+        # RemoteDependencyData
+        dep_data = RemoteDependencyData(
+            version=2,
+            id="191306b0186ce6a8",
+            name="GET /",
+            result_code="200",
+            data="https://example.com/",
+            type="HTTP",
+            target="example.com",
+            duration="0.00:00:01.143",
+            success=True,
+            properties={"key1": "val1"},
+        )
+        base.base_type = "RemoteDependencyData"
+        self.assertEqual(_MONITOR_DOMAIN_MAPPING.get(base.base_type), RemoteDependencyData)
+        base.base_data = dep_data
+        ti.data = base
+
+        # Format is called on custom serialized TelemetryItem
+        converted_ti = ti.from_dict(ti.as_dict())
+        format_ti = _format_storage_telemetry_item(converted_ti)
+        self.assertTrue(validate_telemetry_item(format_ti, ti))
+        self.assertEqual(format_ti.data.base_type, "RemoteDependencyData")
+        self.assertEqual(dep_data.__dict__.items(), format_ti.data.base_data.__dict__.items())
+
+        # RequestData
+        req_data = RequestData(
+            version=2,
+            id="04f4d2ab2b9b6825",
+            name="GET /",
+            duration="0.00:00:00.053",
+            success=True,
+            response_code="200",
+            url="http://localhost:8080/",
+            source="test source",
+            properties={"key1": "val1"},
+        )
+        base.base_type = "RequestData"
+        self.assertEqual(_MONITOR_DOMAIN_MAPPING.get(base.base_type), RequestData)
+        base.base_data = req_data
+        ti.data = base
+
+        # Format is called on custom serialized TelemetryItem
+        converted_ti = ti.from_dict(ti.as_dict())
+        format_ti = _format_storage_telemetry_item(converted_ti)
+        self.assertTrue(validate_telemetry_item(format_ti, ti))
+        self.assertEqual(format_ti.data.base_type, "RequestData")
+        self.assertEqual(req_data.__dict__.items(), format_ti.data.base_data.__dict__.items())
 
     def test_transmit_http_error_retryable(self):
         with mock.patch("azure.monitor.opentelemetry.exporter.export._base._is_retryable_code") as m:
@@ -667,6 +854,22 @@ class TestBaseExporter(unittest.TestCase):
             def invalid_get_token():
                 return "TEST_TOKEN"
         self.assertRaises(ValueError, _get_auth_policy, credential=InvalidTestCredential(), default_auth_policy=TEST_AUTH_POLICY)
+
+
+def validate_telemetry_item(item1, item2):
+    return item1.name == item2.name and \
+        item1.time.year == item2.time.year and \
+        item1.time.month == item2.time.month and \
+        item1.time.day == item2.time.day and \
+        item1.time.hour == item2.time.hour and \
+        item1.time.minute == item2.time.minute and \
+        item1.time.second == item2.time.second and \
+        item1.time.microsecond == item2.time.microsecond and \
+        item1.version == item2.version and \
+        item1.sample_rate == item2.sample_rate and \
+        item1.sequence == item2.sequence and \
+        item1.instrumentation_key == item2.instrumentation_key and \
+        item1.tags == item2.tags
 
 
 class MockResponse:


### PR DESCRIPTION
TelemetryItem.from_dict() deserializes TelemetryItem incorrectly, where the base_data field is of type MonitorDomain, not the actual class that inherits from MonitorDomain (like RequestData). The actual fields are all dumped into "additional_properties". We call as_dict() again on the actual type using additional_properties and assign that to the TelemetryItem.