### PR TITLE
Spark runtime version fix

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/spark_resource_configuration.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/spark_resource_configuration.py
@@ -14,7 +14,10 @@ class SparkResourceConfigurationSchema(metaclass=PatchedSchemaMeta):
     """Schema for SparkResourceConfiguration."""
 
     instance_type = fields.Str(metadata={"description": "Optional type of VM used as supported by the compute target."})
-    runtime_version = UnionField([fields.Str(), fields.Number()])
+    runtime_version = NumberVersionField(
+        upper_bound="3.4",
+        lower_bound="3.2",
+    )
 
     @post_load
     def make(self, data, **kwargs):

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/spark_resource_configuration.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/spark_resource_configuration.py
@@ -6,7 +6,7 @@
 
 from marshmallow import fields, post_load
 
-from azure.ai.ml._schema.core.fields import NumberVersionField, StringTransformedEnum, UnionField
+from azure.ai.ml._schema.core.fields import NumberVersionField, StringTransformedEnum
 from azure.ai.ml._schema.core.schema_meta import PatchedSchemaMeta
 
 

--- a/sdk/ml/azure-ai-ml/tests/spark_job/unittests/test_spark_job_schema.py
+++ b/sdk/ml/azure-ai-ml/tests/spark_job/unittests/test_spark_job_schema.py
@@ -10,6 +10,7 @@ from azure.ai.ml.constants._common import BASE_PATH_CONTEXT_KEY
 from azure.ai.ml.entities import SparkJob
 from azure.ai.ml.entities._job.to_rest_functions import to_rest_job_object
 from azure.ai.ml.exceptions import ValidationException
+from marshmallow.exceptions import ValidationError
 
 
 @pytest.mark.unittest
@@ -35,8 +36,8 @@ class TestSparkJobSchema:
             cfg = yaml.safe_load(f)
             context = {BASE_PATH_CONTEXT_KEY: Path(test_path).parent}
             schema = SparkJobSchema(context=context)
-            internal_representation: SparkJob = SparkJob(**schema.load(cfg))
-            with pytest.raises(ValidationException) as ve:
+            with pytest.raises(ValidationError) as ve:
+                internal_representation: SparkJob = SparkJob(**schema.load(cfg))
                 source = internal_representation._to_rest_object()
                 assert ve.message == "runtime version should be either 3.2 or 3.3"
 


### PR DESCRIPTION
# Description

Prevents runtime from being parsed as a float

If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
