### PR TITLE
[Core] Update flask server stream endpoint

### DIFF
--- a/sdk/core/azure-core/tests/testserver_tests/coretestserver/coretestserver/test_routes/streams.py
+++ b/sdk/core/azure-core/tests/testserver_tests/coretestserver/coretestserver/test_routes/streams.py
@@ -4,9 +4,9 @@
 # Licensed under the MIT License. See LICENSE.txt in the project root for
 # license information.
 # -------------------------------------------------------------------------
-import os
 import gzip
 import tempfile
+
 from flask import (
     Response,
     Blueprint,
@@ -39,16 +39,6 @@ def stream_compressed_header_error():
     yield b"test"
 
 
-def stream_compressed_no_header():
-    with gzip.open("test.tar.gz", "wb") as f:
-        f.write(b"test")
-
-    with open(os.path.join(os.path.abspath("test.tar.gz")), "rb") as fd:
-        yield fd.read()
-
-    os.remove("test.tar.gz")
-
-
 @streams_api.route("/basic", methods=["GET"])
 def basic():
     return Response(streaming_body(), status=200)
@@ -71,7 +61,7 @@ def string():
 
 @streams_api.route("/compressed_no_header", methods=["GET"])
 def compressed_no_header():
-    return Response(stream_compressed_no_header(), status=300)
+    return Response(compressed_stream(), status=300)
 
 
 @streams_api.route("/compressed", methods=["GET"])

--- a/sdk/core/corehttp/tests/testserver_tests/coretestserver/coretestserver/test_routes/streams.py
+++ b/sdk/core/corehttp/tests/testserver_tests/coretestserver/coretestserver/test_routes/streams.py
@@ -3,9 +3,9 @@
 # Licensed under the MIT License. See LICENSE.txt in the project root for
 # license information.
 # -------------------------------------------------------------------------
-import os
 import gzip
 import tempfile
+
 from flask import (
     Response,
     Blueprint,
@@ -38,16 +38,6 @@ def stream_compressed_header_error():
     yield b"test"
 
 
-def stream_compressed_no_header():
-    with gzip.open("test.tar.gz", "wb") as f:
-        f.write(b"test")
-
-    with open(os.path.join(os.path.abspath("test.tar.gz")), "rb") as fd:
-        yield fd.read()
-
-    os.remove("test.tar.gz")
-
-
 @streams_api.route("/basic", methods=["GET"])
 def basic():
     return Response(streaming_body(), status=200)
@@ -70,7 +60,7 @@ def string():
 
 @streams_api.route("/compressed_no_header", methods=["GET"])
 def compressed_no_header():
-    return Response(stream_compressed_no_header(), status=300)
+    return Response(compressed_stream(), status=300)
 
 
 @streams_api.route("/compressed", methods=["GET"])


### PR DESCRIPTION
Addresses potential race when stream endpoint is hit in parallel.

Sometimes the azure-core/corehttp `test_streaming.py::test_compress_compressed_no_header_offline` test fails with something like: 

```
PermissionError: [WinError 32] The process cannot access the file because it is being used by another process: 'test.tar.gz'
```
