### PR TITLE
[Test Proxy] Update recording migration guide

### DIFF
--- a/doc/dev/recording_migration_guide.md
+++ b/doc/dev/recording_migration_guide.md
@@ -47,17 +47,13 @@ A [PowerShell script][transition_script] in the `azure-sdk-tools` repository wil
 assets repo, removing recordings from the language repo, and creating an `assets.json` file for the package you're
 migrating.
 
-This script -- [`generate-assets-json.ps1`][generate_assets_json] -- should be run once per package, and can be used
-either directly from an `azure-sdk-tools` repo clone or with a local download of the script. To download the script to
-your current working directory, use the following PowerShell command:
-
-```PowerShell
-Invoke-WebRequest -OutFile "generate-assets-json.ps1" https://raw.githubusercontent.com/Azure/azure-sdk-for-python/main/eng/common/testproxy/transition-scripts/generate-assets-json.ps1
-```
+This script -- [`generate-assets-json.ps1`][generate_assets_json] -- should be run once per package.
 
 ### Migration script prerequisites
 
 - The targeted library is already migrated to use the test proxy.
+- The test proxy is available locally, with an executable inside a `.proxy` folder at the root of your Python repo.
+  - If the tool isn't present, it'll be automatically set up by running the library's tests in playback mode.
 - Git version > 2.30.0 is to on the machine and in the path. Git is used by the script and test proxy.
 - [PowerShell Core][powershell] >= 7.0 is installed.
 - Global [git config settings][git_setup] are configured for `user.name` and `user.email`.
@@ -68,16 +64,24 @@ Invoke-WebRequest -OutFile "generate-assets-json.ps1" https://raw.githubusercont
 
 In a PowerShell window:
 
-1. Set your working directory to the root of the package you're migrating (`sdk/{service}/{package}`) -- for example:
+1. Add the test proxy executable to `PATH` if it's not already present. This can be done by adding the path to the
+  `.proxy` folder at the base of your Python repo. For example, if the Python repo is at `C:\azure-sdk-for-python`,
+  you can add the test proxy to `PATH` for the current session by running:
+
+```PowerShell
+$env:Path += ';C:\azure-sdk-for-python\.proxy'
+```
+
+2. Set your working directory to the root of the package you're migrating (`sdk/{service}/{package}`) -- for example:
 
 ```PowerShell
 cd C:\azure-sdk-for-python\sdk\keyvault\azure-keyvault-keys
 ```
 
-2. Run the following command:
+3. Run the following command:
 
 ```PowerShell
-<path-to-script>/generate-assets-json.ps1 -InitialPush
+..\..\..\eng\common\testproxy\onboarding\generate-assets-json.ps1 -InitialPush
 ```
 
 If you run `git status` from within the language repo, you should see:


### PR DESCRIPTION
# Description

This PR updates the recording migration guide in three areas:

1. Now that `generate-assets-json.ps1` is in the Python repo, we point to it there instead of referencing or downloading it from `azure-sdk-tools`.
2. A local test proxy standalone executable is now explicitly mentioned as a prerequisite for running the script.
3. Users are asked to add the test proxy executable to `PATH` before running the script.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
