### PR TITLE
Added test header to Communication PhoneNumbers SIP routing tests.

### DIFF
--- a/sdk/communication/azure-communication-phonenumbers/assets.json
+++ b/sdk/communication/azure-communication-phonenumbers/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "python",
   "TagPrefix": "python/communication/azure-communication-phonenumbers",
-  "Tag": "python/communication/azure-communication-phonenumbers_e87531dfe4"
+  "Tag": "python/communication/azure-communication-phonenumbers_8cad73bba8"
 }

--- a/sdk/communication/azure-communication-phonenumbers/assets.json
+++ b/sdk/communication/azure-communication-phonenumbers/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "python",
   "TagPrefix": "python/communication/azure-communication-phonenumbers",
-  "Tag": "python/communication/azure-communication-phonenumbers_8cad73bba8"
+  "Tag": "python/communication/azure-communication-phonenumbers_e87531dfe4"
 }

--- a/sdk/communication/azure-communication-phonenumbers/test/sip_routing_helper.py
+++ b/sdk/communication/azure-communication-phonenumbers/test/sip_routing_helper.py
@@ -7,7 +7,7 @@
 import uuid
 import os
 from azure.communication.phonenumbers.siprouting import SipRoutingClient
-from _shared.utils import get_http_logging_policy
+from _shared.utils import get_http_logging_policy, get_header_policy
 
 from devtools_testutils import is_live
 
@@ -40,7 +40,10 @@ def assert_routes_are_equal(response_routes, request_routes):
 
 def setup_configuration(connection_str,trunks=[],routes=[]):
     if is_live():
-        client = SipRoutingClient.from_connection_string(connection_str, http_logging_policy=get_http_logging_policy())
+        client = SipRoutingClient.from_connection_string(
+            connection_str,
+            http_logging_policy=get_http_logging_policy(),
+            header_policy=get_header_policy())
         client.set_routes(routes)
         client.set_trunks(trunks)
 

--- a/sdk/communication/azure-communication-phonenumbers/test/test_sip_routing_client_e2e.py
+++ b/sdk/communication/azure-communication-phonenumbers/test/test_sip_routing_client_e2e.py
@@ -6,7 +6,7 @@
 from azure.core.exceptions import HttpResponseError
 import pytest
 from phone_numbers_testcase import PhoneNumbersTestCase
-from _shared.utils import create_token_credential, get_http_logging_policy
+from _shared.utils import create_token_credential, get_http_logging_policy, get_header_policy
 from sip_routing_helper import get_unique_fqdn, assert_trunks_are_equal, assert_routes_are_equal, setup_configuration
 from devtools_testutils import recorded_by_proxy
 
@@ -23,7 +23,9 @@ class TestSipRoutingClientE2E(PhoneNumbersTestCase):
     def setup_method(self):
         super(TestSipRoutingClientE2E, self).setUp(use_dynamic_resource = True)
         self._sip_routing_client = SipRoutingClient.from_connection_string(
-            self.connection_str, http_logging_policy=get_http_logging_policy()
+            self.connection_str,
+            http_logging_policy=get_http_logging_policy(),
+            headers_policy=get_header_policy()
             )
         setup_configuration(self.connection_str,trunks=[self.first_trunk, self.second_trunk])
 
@@ -169,7 +171,9 @@ class TestSipRoutingClientE2E(PhoneNumbersTestCase):
     def _get_sip_client_managed_identity(self):
         endpoint, *_ = parse_connection_str(self.connection_str)
         credential = create_token_credential()
-        return SipRoutingClient(endpoint, credential)
+        return SipRoutingClient(endpoint, credential,
+            http_logging_policy=get_http_logging_policy(),
+            headers_policy=get_header_policy())
     
     def _get_as_list(self,iter):
         assert iter is not None, "No iterable was returned."

--- a/sdk/communication/azure-communication-phonenumbers/test/test_sip_routing_client_e2e_async.py
+++ b/sdk/communication/azure-communication-phonenumbers/test/test_sip_routing_client_e2e_async.py
@@ -7,7 +7,7 @@ import pytest
 from azure.core.exceptions import HttpResponseError
 from phone_numbers_testcase import PhoneNumbersTestCase
 from devtools_testutils.aio import recorded_by_proxy_async
-from _shared.utils import async_create_token_credential, get_http_logging_policy
+from _shared.utils import async_create_token_credential, get_http_logging_policy, get_header_policy
 from sip_routing_helper import get_unique_fqdn, assert_trunks_are_equal, assert_routes_are_equal, setup_configuration
 
 from azure.communication.phonenumbers.siprouting.aio import SipRoutingClient
@@ -26,7 +26,9 @@ class TestSipRoutingClientE2EAsync(PhoneNumbersTestCase):
     def setup_method(self):
         super(TestSipRoutingClientE2EAsync, self).setUp(use_dynamic_resource = True)
         self._sip_routing_client = SipRoutingClient.from_connection_string(
-            self.connection_str, http_logging_policy=get_http_logging_policy()
+            self.connection_str,
+            http_logging_policy=get_http_logging_policy(),
+            headers_policy=get_header_policy()
         )
         setup_configuration(self.connection_str,trunks=[self.first_trunk, self.second_trunk])
 
@@ -197,7 +199,11 @@ class TestSipRoutingClientE2EAsync(PhoneNumbersTestCase):
     def _get_sip_client_managed_identity(self):
         endpoint, *_ = parse_connection_str(self.connection_str)
         credential = async_create_token_credential()
-        return SipRoutingClient(endpoint, credential, http_logging_policy=get_http_logging_policy())
+        return SipRoutingClient(
+            endpoint,
+            credential,
+            http_logging_policy=get_http_logging_policy(),
+            headers_policy=get_header_policy())
     
     async def _get_as_list(self,iter):
         assert iter is not None, "No iterable was returned."


### PR DESCRIPTION
# Description

Updated tests for SIP routing to include the test header on each request to telephony service to be able to track these as test calls in the usage telemetry.

# All SDK Contribution checklist:
- [ x] **The pull request does not introduce [breaking changes]**
- [N/A ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
