### PR TITLE
[Core] Fix aiohttp test failures

### DIFF
--- a/sdk/core/azure-core/tests/async_tests/test_universal_http_async.py
+++ b/sdk/core/azure-core/tests/async_tests/test_universal_http_async.py
@@ -104,6 +104,7 @@ def _create_aiohttp_response(http_response, body_bytes, headers=None):
             self._body = body_bytes
             self._headers = headers
             self._cache = {}
+            self._loop = None
             self.status = 200
             self.reason = "OK"
 

--- a/sdk/core/corehttp/tests/async_tests/test_universal_http_async.py
+++ b/sdk/core/corehttp/tests/async_tests/test_universal_http_async.py
@@ -42,6 +42,7 @@ def _create_aiohttp_response(http_response, body_bytes, headers=None):
             self._body = body_bytes
             self._headers = headers
             self._cache = {}
+            self._loop = None
             self.status = 200
             self.reason = "OK"
 


### PR DESCRIPTION
Since aiohttp 3.9.0 was recently released, one of our mock objects is now missing an attribute. This adds that attribute to avoid failing on an AttributeError.

The core pipelines have been failing with:

```
self = <[AttributeError("'MockAiohttpClientResponse' object has no attribute '_url'") raised in repr()] MockAiohttpClientResponse object at 0x7f9c970b44d0>

    def close(self) -> None:
        if not self._released:
            self._notify_content()
    
        self._closed = True
>       if self._loop is None or self._loop.is_closed():
E       AttributeError: 'MockAiohttpClientResponse' object has no attribute '_loop'

```