### PR TITLE
Move away from `azure-devtools` test exceptions

### DIFF
--- a/sdk/batch/azure-batch/tests/batch_preparers.py
+++ b/sdk/batch/azure-batch/tests/batch_preparers.py
@@ -9,13 +9,7 @@ from azure.mgmt.batch import models
 import azure.batch
 from azure.batch.batch_auth import SharedKeyCredentials
 
-from azure_devtools.scenario_tests.preparers import (
-    AbstractPreparer,
-    SingleValueReplacer,
-)
-from azure_devtools.scenario_tests.exceptions import AzureTestError
-
-from devtools_testutils import AzureMgmtPreparer, ResourceGroupPreparer, FakeResource
+from devtools_testutils import AzureMgmtPreparer, AzureTestError, ResourceGroupPreparer, FakeResource
 from devtools_testutils.fake_credentials import BATCH_TEST_PASSWORD
 from devtools_testutils.resource_testcase import RESOURCE_GROUP_PARAM
 

--- a/sdk/batch/azure-mgmt-batch/tests/mgmt_batch_preparers.py
+++ b/sdk/batch/azure-mgmt-batch/tests/mgmt_batch_preparers.py
@@ -4,13 +4,7 @@ import os
 import azure.mgmt.keyvault
 import azure.mgmt.batch
 
-from azure_devtools.scenario_tests.preparers import (
-    AbstractPreparer,
-    SingleValueReplacer,
-)
-from azure_devtools.scenario_tests.exceptions import AzureTestError
-
-from devtools_testutils import AzureMgmtPreparer, ResourceGroupPreparer, FakeResource
+from devtools_testutils import AzureMgmtPreparer, AzureTestError, ResourceGroupPreparer, FakeResource
 from devtools_testutils.resource_testcase import RESOURCE_GROUP_PARAM
 
 

--- a/sdk/cognitiveservices/azure-cognitiveservices-language-spellcheck/tests/disable_test_spell_check.py
+++ b/sdk/cognitiveservices/azure-cognitiveservices-language-spellcheck/tests/disable_test_spell_check.py
@@ -14,13 +14,12 @@ import unittest
 from azure.cognitiveservices.language.spellcheck import SpellCheckClient
 from msrest.authentication import CognitiveServicesCredentials
 
-from azure_devtools.scenario_tests import ReplayableTest, AzureTestError
-
+from devtools_testutils import AzureRecordedTestCase, AzureTestError
 from devtools_testutils import mgmt_settings_fake as fake_settings
 
 
-class SpellCheckTest(ReplayableTest):
-    FILTER_HEADERS = ReplayableTest.FILTER_HEADERS + ['Ocp-Apim-Subscription-Key']
+class SpellCheckTest(AzureRecordedTestCase):
+    #FILTER_HEADERS = ReplayableTest.FILTER_HEADERS + ['Ocp-Apim-Subscription-Key']
 
     def __init__(self, method_name):
         self._fake_settings, self._real_settings = self._load_settings()

--- a/sdk/cognitiveservices/azure-cognitiveservices-search-entitysearch/tests/disable_test_entity_search.py
+++ b/sdk/cognitiveservices/azure-cognitiveservices-search-entitysearch/tests/disable_test_entity_search.py
@@ -14,13 +14,12 @@ import unittest
 from azure.cognitiveservices.search.entitysearch import EntitySearchClient
 from msrest.authentication import CognitiveServicesCredentials
 
-from azure_devtools.scenario_tests import ReplayableTest, AzureTestError
-
+from devtools_testutils import AzureRecordedTestCase, AzureTestError
 from devtools_testutils import mgmt_settings_fake as fake_settings
 
 
-class EntitySearchTest(ReplayableTest):
-    FILTER_HEADERS = ReplayableTest.FILTER_HEADERS + ['Ocp-Apim-Subscription-Key']
+class EntitySearchTest(AzureRecordedTestCase):
+    #FILTER_HEADERS = ReplayableTest.FILTER_HEADERS + ['Ocp-Apim-Subscription-Key']
 
     def __init__(self, method_name):
         self._fake_settings, self._real_settings = self._load_settings()

--- a/sdk/cognitiveservices/azure-cognitiveservices-search-videosearch/tests/disable_test_video_search.py
+++ b/sdk/cognitiveservices/azure-cognitiveservices-search-videosearch/tests/disable_test_video_search.py
@@ -14,13 +14,12 @@ import unittest
 from azure.cognitiveservices.search.videosearch import VideoSearchClient
 from msrest.authentication import CognitiveServicesCredentials
 
-from azure_devtools.scenario_tests import ReplayableTest, AzureTestError
-
+from devtools_testutils import AzureRecordedTestCase, AzureTestError
 from devtools_testutils import mgmt_settings_fake as fake_settings
 
 
-class VideoSearchTest(ReplayableTest):
-    FILTER_HEADERS = ReplayableTest.FILTER_HEADERS + ['Ocp-Apim-Subscription-Key']
+class VideoSearchTest(AzureRecordedTestCase):
+    #FILTER_HEADERS = ReplayableTest.FILTER_HEADERS + ['Ocp-Apim-Subscription-Key']
 
     def __init__(self, method_name):
         self._fake_settings, self._real_settings = self._load_settings()

--- a/sdk/cognitiveservices/azure-cognitiveservices-vision-face/tests/disable_test_face.py
+++ b/sdk/cognitiveservices/azure-cognitiveservices-vision-face/tests/disable_test_face.py
@@ -15,14 +15,13 @@ from azure.cognitiveservices.vision.face import FaceClient
 from azure.cognitiveservices.vision.face.models import Gender
 from msrest.authentication import CognitiveServicesCredentials
 
-from azure_devtools.scenario_tests import ReplayableTest, AzureTestError
-
+from devtools_testutils import AzureRecordedTestCase, AzureTestError
 from devtools_testutils import mgmt_settings_fake as fake_settings
 
 CWD = dirname(realpath(__file__))
 
-class FaceTest(ReplayableTest):
-    FILTER_HEADERS = ReplayableTest.FILTER_HEADERS + ['Ocp-Apim-Subscription-Key']
+class FaceTest(AzureRecordedTestCase):
+    #FILTER_HEADERS = ReplayableTest.FILTER_HEADERS + ['Ocp-Apim-Subscription-Key']
 
     def __init__(self, method_name):
         self._fake_settings, self._real_settings = self._load_settings()

--- a/sdk/eventgrid/azure-eventgrid/tests/eventgrid_preparer.py
+++ b/sdk/eventgrid/azure-eventgrid/tests/eventgrid_preparer.py
@@ -2,7 +2,6 @@ import functools
 from devtools_testutils import PowerShellPreparer
 
 from azure.mgmt.eventgrid.models import Topic, InputSchema, JsonInputSchemaMapping, JsonField, JsonFieldWithDefault
-from azure_devtools.scenario_tests.exceptions import AzureTestError
 
 from devtools_testutils.resource_testcase import RESOURCE_GROUP_PARAM
 

--- a/sdk/eventhub/azure-eventhub/tests/eventhub_preparer.py
+++ b/sdk/eventhub/azure-eventhub/tests/eventhub_preparer.py
@@ -12,11 +12,7 @@ import functools
 from azure.mgmt.eventhub import EventHubManagementClient
 from azure.mgmt.eventhub.models import Eventhub, AccessRights
 
-from azure_devtools.scenario_tests.exceptions import AzureTestError
-
-from devtools_testutils import (
-    ResourceGroupPreparer, AzureMgmtPreparer, FakeResource
-)
+from devtools_testutils import ResourceGroupPreparer, AzureMgmtPreparer, AzureTestError, FakeResource
 
 from devtools_testutils.resource_testcase import RESOURCE_GROUP_PARAM
 

--- a/sdk/hdinsight/azure-mgmt-hdinsight/test/mgmt_hdinsight_preparers.py
+++ b/sdk/hdinsight/azure-mgmt-hdinsight/test/mgmt_hdinsight_preparers.py
@@ -7,13 +7,8 @@ import time
 from azure.mgmt.keyvault import KeyVaultManagementClient
 from azure.mgmt.keyvault.models import SecretPermissions, KeyPermissions, CertificatePermissions, StoragePermissions, \
     Permissions, Sku, SkuName, AccessPolicyEntry, VaultProperties, VaultCreateOrUpdateParameters
-from azure_devtools.scenario_tests.preparers import (
-    AbstractPreparer,
-    SingleValueReplacer,
-)
-from azure_devtools.scenario_tests.exceptions import AzureTestError
 
-from devtools_testutils import AzureMgmtPreparer, ResourceGroupPreparer, FakeResource
+from devtools_testutils import AzureMgmtPreparer, AzureTestError, ResourceGroupPreparer
 from devtools_testutils.resource_testcase import RESOURCE_GROUP_PARAM
 
 VAULT_PARAM = 'vault'

--- a/sdk/search/azure-search-documents/tests/search_service_preparer.py
+++ b/sdk/search/azure-search-documents/tests/search_service_preparer.py
@@ -11,8 +11,7 @@ import inspect
 import json
 import requests
 
-from devtools_testutils import EnvironmentVariableLoader
-from azure_devtools.scenario_tests.exceptions import AzureTestError
+from devtools_testutils import AzureTestError, EnvironmentVariableLoader
 
 from azure.core.credentials import AzureKeyCredential
 from azure.core.exceptions import HttpResponseError

--- a/sdk/servicebus/azure-servicebus/tests/servicebus_preparer.py
+++ b/sdk/servicebus/azure-servicebus/tests/servicebus_preparer.py
@@ -5,16 +5,18 @@ import datetime
 import logging
 
 from azure.core.exceptions import HttpResponseError
-from azure_devtools.scenario_tests import AzureTestError, ReservedResourceNameError
 from azure.mgmt.resource import ResourceManagementClient
 
 from azure.mgmt.servicebus import ServiceBusManagementClient
 from azure.mgmt.servicebus.models import SBQueue, SBSubscription, AccessRights, SBAuthorizationRule
 
-from azure_devtools.scenario_tests.exceptions import AzureTestError
-
 from devtools_testutils import (
-    AzureMgmtPreparer, FakeResource, get_region_override, add_general_regex_sanitizer
+    AzureMgmtPreparer,
+    AzureTestError,
+    FakeResource,
+    get_region_override,
+    add_general_regex_sanitizer,
+    ReservedResourceNameError
 )
 from devtools_testutils.resource_testcase import RESOURCE_GROUP_PARAM
 

--- a/sdk/tables/azure-data-tables/tests/_shared/cosmos_testcase.py
+++ b/sdk/tables/azure-data-tables/tests/_shared/cosmos_testcase.py
@@ -12,9 +12,7 @@ from azure.mgmt.cosmosdb.models import (
     Capability,
 )
 
-from azure_devtools.scenario_tests.exceptions import AzureTestError
-
-from devtools_testutils import AzureMgmtPreparer, ResourceGroupPreparer, FakeResource
+from devtools_testutils import AzureMgmtPreparer, AzureTestError, ResourceGroupPreparer, FakeResource
 
 FakeCosmosAccount = FakeResource
 RESOURCE_GROUP_PARAM = "resource_group"

--- a/tools/azure-sdk-tools/devtools_testutils/__init__.py
+++ b/tools/azure-sdk-tools/devtools_testutils/__init__.py
@@ -17,8 +17,7 @@ from .storage_testcase import (
 
 # cSpell:disable
 from .envvariable_loader import EnvironmentVariableLoader
-
-PowerShellPreparer = EnvironmentVariableLoader  # Backward compat
+from .exceptions import AzureTestError, ReservedResourceNameError
 from .proxy_fixtures import environment_variables, recorded_test, variable_recorder
 from .proxy_startup import start_test_proxy, stop_test_proxy, test_proxy
 from .proxy_testcase import recorded_by_proxy
@@ -53,6 +52,8 @@ from .cert import create_combined_bundle
 from .helpers import ResponseCallback, RetryCounter, is_live_and_not_recording
 from .fake_credentials import FakeTokenCredential
 
+PowerShellPreparer = EnvironmentVariableLoader  # Backward compat
+
 __all__ = [
     "add_api_version_transform",
     "add_body_key_sanitizer",
@@ -75,7 +76,9 @@ __all__ = [
     "AzureMgmtPreparer",
     "AzureMgmtRecordedTestCase",
     "AzureRecordedTestCase",
+    "AzureTestError",
     "FakeResource",
+    "ReservedResourceNameError",
     "ResourceGroupPreparer",
     "StorageAccountPreparer",
     "BlobAccountPreparer",

--- a/tools/azure-sdk-tools/devtools_testutils/exceptions.py
+++ b/tools/azure-sdk-tools/devtools_testutils/exceptions.py
@@ -1,0 +1,16 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+
+class AzureTestError(Exception):
+    def __init__(self, error_message):
+        message = f"An error caused by the Azure test harness failed the test: {error_message}"
+        super(AzureTestError, self).__init__(message)
+
+
+class ReservedResourceNameError(Exception):
+    def __init__(self, rg_name):
+        message = f"The resource name {rg_name} or a part of the name is trademarked / reserved"
+        super(ReservedResourceNameError, self).__init__(message)


### PR DESCRIPTION
# Description

This PR moves test-specific exceptions away from `azure-devtools` and into `devtools_testutils`. In the process, a few outdated references to `azure-devtools` are also removed from some test infrastructure.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
