### PR TITLE
[Core] Update async auth policy lock logic

### DIFF
--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+- Removed dependency on `anyio`.  #33282
+
 ## 1.29.6 (2023-12-14)
 
 ### Bugs Fixed

--- a/sdk/core/azure-core/azure/core/pipeline/policies/_authentication_async.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/_authentication_async.py
@@ -6,7 +6,6 @@
 import time
 from typing import TYPE_CHECKING, Any, Awaitable, Optional, cast, TypeVar
 
-from anyio import Lock
 from azure.core.credentials import AccessToken
 from azure.core.pipeline import PipelineRequest, PipelineResponse
 from azure.core.pipeline.policies import AsyncHTTPPolicy
@@ -15,6 +14,7 @@ from azure.core.pipeline.policies._authentication import (
 )
 from azure.core.pipeline.transport import AsyncHttpResponse as LegacyAsyncHttpResponse, HttpRequest as LegacyHttpRequest
 from azure.core.rest import AsyncHttpResponse, HttpRequest
+from azure.core.utils._utils import get_running_async_module
 
 from .._tools_async import await_result
 
@@ -38,7 +38,8 @@ class AsyncBearerTokenCredentialPolicy(AsyncHTTPPolicy[HTTPRequestType, AsyncHTT
     def __init__(self, credential: "AsyncTokenCredential", *scopes: str, **kwargs: Any) -> None:
         super().__init__()
         self._credential = credential
-        self._lock = Lock()
+        self._lock = get_running_async_module().Lock()
+
         self._scopes = scopes
         self._token: Optional["AccessToken"] = None
         self._enable_cae: bool = kwargs.get("enable_cae", False)

--- a/sdk/core/azure-core/azure/core/utils/_utils.py
+++ b/sdk/core/azure-core/azure/core/utils/_utils.py
@@ -166,7 +166,7 @@ class CaseInsensitiveDict(MutableMapping[str, Any]):
 
 
 def get_running_async_lock() -> AsyncContextManager:
-    """Get the name of the async library that the current context is running under.
+    """Get a lock instance from the async library that the current context is running under.
 
     :return: An instance of the running async library's Lock class.
     :rtype: AsyncContextManager

--- a/sdk/core/azure-core/azure/core/utils/_utils.py
+++ b/sdk/core/azure-core/azure/core/utils/_utils.py
@@ -6,7 +6,6 @@
 # --------------------------------------------------------------------------
 import datetime
 import sys
-from types import ModuleType
 from typing import (
     Any,
     Iterable,
@@ -165,11 +164,11 @@ class CaseInsensitiveDict(MutableMapping[str, Any]):
         return str(dict(self.items()))
 
 
-def get_running_async_module() -> ModuleType:
+def get_running_async_lock() -> Any:
     """Get the name of the async library that the current context is running under.
 
-    :return: The async library module.
-    :rtype: ModuleType
+    :return: An instance of the running async library's Lock class.
+    :rtype: Any
     :raises: RuntimeError if the current context is not running under an async library.
     """
 
@@ -177,10 +176,10 @@ def get_running_async_module() -> ModuleType:
         import asyncio
         # Check if we are running in an asyncio event loop.
         asyncio.get_running_loop()
-        return asyncio
+        return asyncio.Lock()
     except RuntimeError as err:
         # Otherwise, assume we are running in a trio event loop if it has already been imported.
         if "trio" in sys.modules:
             import trio  # pylint: disable=networking-import-outside-azure-core-transport
-            return trio
+            return trio.Lock()
         raise RuntimeError("An asyncio or trio event loop is required.") from err

--- a/sdk/core/azure-core/azure/core/utils/_utils.py
+++ b/sdk/core/azure-core/azure/core/utils/_utils.py
@@ -174,6 +174,7 @@ def get_running_async_lock() -> Any:
 
     try:
         import asyncio
+
         # Check if we are running in an asyncio event loop.
         asyncio.get_running_loop()
         return asyncio.Lock()
@@ -181,5 +182,6 @@ def get_running_async_lock() -> Any:
         # Otherwise, assume we are running in a trio event loop if it has already been imported.
         if "trio" in sys.modules:
             import trio  # pylint: disable=networking-import-outside-azure-core-transport
+
             return trio.Lock()
         raise RuntimeError("An asyncio or trio event loop is required.") from err

--- a/sdk/core/azure-core/azure/core/utils/_utils.py
+++ b/sdk/core/azure-core/azure/core/utils/_utils.py
@@ -5,6 +5,8 @@
 # license information.
 # --------------------------------------------------------------------------
 import datetime
+import sys
+from types import ModuleType
 from typing import (
     Any,
     Iterable,
@@ -161,3 +163,24 @@ class CaseInsensitiveDict(MutableMapping[str, Any]):
 
     def __repr__(self) -> str:
         return str(dict(self.items()))
+
+
+def get_running_async_module() -> ModuleType:
+    """Get the name of the async library that the current context is running under.
+
+    :return: The async library module.
+    :rtype: ModuleType
+    :raises: RuntimeError if the current context is not running under an async library.
+    """
+
+    try:
+        import asyncio
+        # Check if we are running in an asyncio event loop.
+        asyncio.get_running_loop()
+        return asyncio
+    except RuntimeError as err:
+        # Otherwise, assume we are running in a trio event loop if it has already been imported.
+        if "trio" in sys.modules:
+            import trio  # pylint: disable=networking-import-outside-azure-core-transport
+            return trio
+        raise RuntimeError("An asyncio or trio event loop is required.") from err

--- a/sdk/core/azure-core/azure/core/utils/_utils.py
+++ b/sdk/core/azure-core/azure/core/utils/_utils.py
@@ -8,6 +8,7 @@ import datetime
 import sys
 from typing import (
     Any,
+    AsyncContextManager,
     Iterable,
     Iterator,
     Mapping,
@@ -164,11 +165,11 @@ class CaseInsensitiveDict(MutableMapping[str, Any]):
         return str(dict(self.items()))
 
 
-def get_running_async_lock() -> Any:
+def get_running_async_lock() -> AsyncContextManager:
     """Get the name of the async library that the current context is running under.
 
     :return: An instance of the running async library's Lock class.
-    :rtype: Any
+    :rtype: AsyncContextManager
     :raises: RuntimeError if the current context is not running under an async library.
     """
 

--- a/sdk/core/azure-core/setup.py
+++ b/sdk/core/azure-core/setup.py
@@ -69,7 +69,6 @@ setup(
     },
     python_requires=">=3.7",
     install_requires=[
-        "anyio>=3.0,<5.0",
         "requests>=2.21.0",
         "six>=1.11.0",
         "typing-extensions>=4.6.0",

--- a/sdk/core/azure-core/tests/async_tests/test_authentication_async.py
+++ b/sdk/core/azure-core/tests/async_tests/test_authentication_async.py
@@ -4,8 +4,9 @@
 # license information.
 # -------------------------------------------------------------------------
 import asyncio
+import sys
 import time
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 from requests import Response
 
 from azure.core.credentials import AccessToken
@@ -20,11 +21,12 @@ from azure.core.pipeline.policies import (
 )
 from azure.core.pipeline.transport import AsyncHttpTransport, HttpRequest
 import pytest
+import trio
 
-pytestmark = pytest.mark.asyncio
 from utils import HTTP_REQUESTS
 
 
+@pytest.mark.asyncio
 @pytest.mark.parametrize("http_request", HTTP_REQUESTS)
 async def test_bearer_policy_adds_header(http_request):
     """The bearer token policy should add a header containing a token from its credential"""
@@ -54,6 +56,7 @@ async def test_bearer_policy_adds_header(http_request):
     assert get_token_calls == 1
 
 
+@pytest.mark.asyncio
 @pytest.mark.parametrize("http_request", HTTP_REQUESTS)
 async def test_bearer_policy_send(http_request):
     """The bearer token policy should invoke the next policy's send method and return the result"""
@@ -72,6 +75,7 @@ async def test_bearer_policy_send(http_request):
     assert response is expected_response
 
 
+@pytest.mark.asyncio
 @pytest.mark.parametrize("http_request", HTTP_REQUESTS)
 async def test_bearer_policy_sync_send(http_request):
     """The bearer token policy should invoke the next policy's send method and return the result"""
@@ -90,6 +94,7 @@ async def test_bearer_policy_sync_send(http_request):
     assert response is expected_response
 
 
+@pytest.mark.asyncio
 @pytest.mark.parametrize("http_request", HTTP_REQUESTS)
 async def test_bearer_policy_token_caching(http_request):
     good_for_one_hour = AccessToken("token", time.time() + 3600)
@@ -130,6 +135,7 @@ async def test_bearer_policy_token_caching(http_request):
     assert get_token_calls == 2  # token expired -> policy should call get_token
 
 
+@pytest.mark.asyncio
 @pytest.mark.parametrize("http_request", HTTP_REQUESTS)
 async def test_bearer_policy_optionally_enforces_https(http_request):
     """HTTPS enforcement should be controlled by a keyword argument, and enabled by default"""
@@ -158,6 +164,7 @@ async def test_bearer_policy_optionally_enforces_https(http_request):
     await pipeline.run(http_request("GET", "https://secure"))
 
 
+@pytest.mark.asyncio
 @pytest.mark.parametrize("http_request", HTTP_REQUESTS)
 async def test_bearer_policy_preserves_enforce_https_opt_out(http_request):
     """The policy should use request context to preserve an opt out from https enforcement"""
@@ -175,6 +182,7 @@ async def test_bearer_policy_preserves_enforce_https_opt_out(http_request):
     await pipeline.run(http_request("GET", "http://not.secure"), enforce_https=False)
 
 
+@pytest.mark.asyncio
 @pytest.mark.parametrize("http_request", HTTP_REQUESTS)
 async def test_bearer_policy_context_unmodified_by_default(http_request):
     """When no options for the policy accompany a request, the policy shouldn't add anything to the request context"""
@@ -192,6 +200,7 @@ async def test_bearer_policy_context_unmodified_by_default(http_request):
     await pipeline.run(http_request("GET", "https://secure"))
 
 
+@pytest.mark.asyncio
 @pytest.mark.parametrize("http_request", HTTP_REQUESTS)
 async def test_bearer_policy_calls_sansio_methods(http_request):
     """AsyncBearerTokenCredentialPolicy should call SansIOHttpPolicy methods as does _SansIOAsyncHTTPPolicyRunner"""
@@ -440,3 +449,25 @@ async def test_async_token_credential_inheritance():
 
     cred = TestTokenCredential()
     await cred.get_token("scope")
+
+
+@pytest.mark.asyncio
+async def test_async_token_credential_asyncio_lock():
+    auth_policy = AsyncBearerTokenCredentialPolicy(Mock(), "scope")
+    assert isinstance(auth_policy._lock, asyncio.Lock)
+
+
+@pytest.mark.trio
+async def test_async_token_credential_trio_lock():
+    auth_policy = AsyncBearerTokenCredentialPolicy(Mock(), "scope")
+    assert isinstance(auth_policy._lock, trio.Lock)
+
+
+def test_async_token_credential_sync():
+    auth_policy = AsyncBearerTokenCredentialPolicy(Mock(), "scope")
+    with patch.dict('sys.modules'):
+        # Ensure trio isn't in sys.modules (i.e. imported).
+        sys.modules.pop("trio", None)
+        with pytest.raises(RuntimeError):
+            AsyncBearerTokenCredentialPolicy(Mock(), "scope")
+

--- a/sdk/core/azure-core/tests/async_tests/test_authentication_async.py
+++ b/sdk/core/azure-core/tests/async_tests/test_authentication_async.py
@@ -464,10 +464,10 @@ async def test_async_token_credential_trio_lock():
 
 
 def test_async_token_credential_sync():
+    """Verify that AsyncBearerTokenCredentialPolicy can be constructed in a synchronous context."""
     auth_policy = AsyncBearerTokenCredentialPolicy(Mock(), "scope")
     with patch.dict('sys.modules'):
         # Ensure trio isn't in sys.modules (i.e. imported).
         sys.modules.pop("trio", None)
-        with pytest.raises(RuntimeError):
-            AsyncBearerTokenCredentialPolicy(Mock(), "scope")
+        AsyncBearerTokenCredentialPolicy(Mock(), "scope")
 

--- a/sdk/core/azure-core/tests/async_tests/test_authentication_async.py
+++ b/sdk/core/azure-core/tests/async_tests/test_authentication_async.py
@@ -466,8 +466,7 @@ async def test_async_token_credential_trio_lock():
 def test_async_token_credential_sync():
     """Verify that AsyncBearerTokenCredentialPolicy can be constructed in a synchronous context."""
     auth_policy = AsyncBearerTokenCredentialPolicy(Mock(), "scope")
-    with patch.dict('sys.modules'):
+    with patch.dict("sys.modules"):
         # Ensure trio isn't in sys.modules (i.e. imported).
         sys.modules.pop("trio", None)
         AsyncBearerTokenCredentialPolicy(Mock(), "scope")
-

--- a/sdk/core/azure-core/tests/test_utils.py
+++ b/sdk/core/azure-core/tests/test_utils.py
@@ -10,7 +10,6 @@ from azure.core.utils import case_insensitive_dict
 from azure.core.utils._utils import get_running_async_lock
 
 
-
 @pytest.fixture()
 def accept_cases():
     return ["accept", "Accept", "ACCEPT", "aCCePT"]
@@ -118,17 +117,19 @@ def test_case_iter():
 @pytest.mark.asyncio
 async def test_get_running_async_module_asyncio():
     import asyncio
+
     assert isinstance(get_running_async_lock(), asyncio.Lock)
 
 
 @pytest.mark.trio
 async def test_get_running_async_module_trio():
     import trio
+
     assert isinstance(get_running_async_lock(), trio.Lock)
 
 
 def test_get_running_async_module_sync():
-    with patch.dict('sys.modules'):
+    with patch.dict("sys.modules"):
         # Ensure trio isn't in sys.modules (i.e. imported).
         sys.modules.pop("trio", None)
         with pytest.raises(RuntimeError):

--- a/sdk/core/azure-core/tests/test_utils.py
+++ b/sdk/core/azure-core/tests/test_utils.py
@@ -2,8 +2,13 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
+import sys
+from unittest.mock import patch
+
 import pytest
 from azure.core.utils import case_insensitive_dict
+from azure.core.utils._utils import get_running_async_module
+
 
 
 @pytest.fixture()
@@ -108,3 +113,23 @@ def test_case_iter():
 
     for key in my_dict:
         assert key in keys
+
+
+@pytest.mark.asyncio
+async def test_get_running_async_module_asyncio():
+    import asyncio
+    assert get_running_async_module() == asyncio
+
+
+@pytest.mark.trio
+async def test_get_running_async_module_trio():
+    import trio
+    assert get_running_async_module() == trio
+
+
+def test_get_running_async_module_sync():
+    with patch.dict('sys.modules'):
+        # Ensure trio isn't in sys.modules (i.e. imported).
+        sys.modules.pop("trio", None)
+        with pytest.raises(RuntimeError):
+            assert get_running_async_module() is None

--- a/sdk/core/azure-core/tests/test_utils.py
+++ b/sdk/core/azure-core/tests/test_utils.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 
 import pytest
 from azure.core.utils import case_insensitive_dict
-from azure.core.utils._utils import get_running_async_module
+from azure.core.utils._utils import get_running_async_lock
 
 
 
@@ -118,13 +118,13 @@ def test_case_iter():
 @pytest.mark.asyncio
 async def test_get_running_async_module_asyncio():
     import asyncio
-    assert get_running_async_module() == asyncio
+    assert isinstance(get_running_async_lock(), asyncio.Lock)
 
 
 @pytest.mark.trio
 async def test_get_running_async_module_trio():
     import trio
-    assert get_running_async_module() == trio
+    assert isinstance(get_running_async_lock(), trio.Lock)
 
 
 def test_get_running_async_module_sync():
@@ -132,4 +132,4 @@ def test_get_running_async_module_sync():
         # Ensure trio isn't in sys.modules (i.e. imported).
         sys.modules.pop("trio", None)
         with pytest.raises(RuntimeError):
-            assert get_running_async_module() is None
+            get_running_async_lock()


### PR DESCRIPTION
Sometimes users might be using trio and its mechanisms for running tasks concurrently. This updates the lock initialization logic to check if the user is in an asyncio event loop and sets the lock accordingly.  If not, assume trio. We don't expect users to be in anything else other than asyncio or trio event loops.

A utility function was added that tries to determine the current async library lock that should be used.

Closes: https://github.com/Azure/azure-sdk-for-python/issues/32968
