### PR TITLE
Remove VM Resource Detector until bug is fixed.

### DIFF
--- a/sdk/monitor/azure-monitor-opentelemetry/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-opentelemetry/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 ### Bugs Fixed
 
+- Remove VM Resource Detector until OpenTelemetry bug fix
+    ([#XXXXX](https://github.com/Azure/azure-sdk-for-python/pull/XXXXX))
+
 ### Other Changes
 
 ## 1.1.0 (2023-11-08)

--- a/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_configure.py
+++ b/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_configure.py
@@ -52,7 +52,6 @@ from azure.monitor.opentelemetry._util.configurations import (
 
 _SUPPORTED_RESOURCE_DETECTORS = (
     "azure_app_service",
-    "azure_vm",
 )
 
 _logger = getLogger(__name__)

--- a/sdk/monitor/azure-monitor-opentelemetry/tests/configuration/test_configure.py
+++ b/sdk/monitor/azure-monitor-opentelemetry/tests/configuration/test_configure.py
@@ -199,7 +199,8 @@ class TestConfigure(unittest.TestCase):
         _setup_resources()
         self.assertEqual(
             os.environ["OTEL_EXPERIMENTAL_RESOURCE_DETECTORS"],
-            "azure_app_service,azure_vm"
+            # TODO: Change back to "azure_app_service,azure_vm" after VM Resource Detector fix
+            "azure_app_service"
         )
 
     @patch.dict("os.environ", {"OTEL_EXPERIMENTAL_RESOURCE_DETECTORS": "test_detector"})
@@ -207,7 +208,8 @@ class TestConfigure(unittest.TestCase):
         _setup_resources()
         self.assertEqual(
             os.environ["OTEL_EXPERIMENTAL_RESOURCE_DETECTORS"],
-            "test_detector,azure_app_service,azure_vm"
+            # TODO: Change back to "azure_app_service,azure_vm" after VM Resource Detector fix
+            "test_detector,azure_app_service"
         )
 
     @patch(


### PR DESCRIPTION
# Description

The VM Resource Detector is raising exceptions for multiple customers. A potential fix is on the way, but it will take time to fully mitigate an release in OpenTelemetry. Removing the detector until then.

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
