### PR TITLE
[Core] Add anyio dependency for lock handling

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -160,6 +160,7 @@
     "alru",
     "amqp",
     "amqps",
+    "anyio",
     "apim",
     "Asal",
     "asgi",

--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -8,7 +8,12 @@
 
 ### Bugs Fixed
 
+- Adjusted `AsyncBearerTokenCredentialPolicy` lock initialization logic to use `anyio`.  ([#33307](https://github.com/Azure/azure-sdk-for-python/pull/33307))
+
 ### Other Changes
+
+- Added dependency on `anyio` >=3.0,<5.0
+- Bumped minimum dependency on `requests` to 2.21.0.
 
 ## 1.29.5 (2023-10-19)
 

--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bugs Fixed
 
-- Adjusted `AsyncBearerTokenCredentialPolicy` lock initialization logic to use `anyio`.  ([#33307](https://github.com/Azure/azure-sdk-for-python/pull/33307))
+- Adjusted `AsyncBearerTokenCredentialPolicy` to work properly with `trio` concurrency mechanisms.   ([#33307](https://github.com/Azure/azure-sdk-for-python/pull/33307))
 
 ### Other Changes
 

--- a/sdk/core/azure-core/azure/core/pipeline/policies/_authentication_async.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/_authentication_async.py
@@ -3,10 +3,10 @@
 # Licensed under the MIT License. See LICENSE.txt in the project root for
 # license information.
 # -------------------------------------------------------------------------
-import asyncio
 import time
 from typing import TYPE_CHECKING, Any, Awaitable, Optional, cast, TypeVar
 
+from anyio import Lock
 from azure.core.credentials import AccessToken
 from azure.core.pipeline import PipelineRequest, PipelineResponse
 from azure.core.pipeline.policies import AsyncHTTPPolicy
@@ -38,7 +38,7 @@ class AsyncBearerTokenCredentialPolicy(AsyncHTTPPolicy[HTTPRequestType, AsyncHTT
     def __init__(self, credential: "AsyncTokenCredential", *scopes: str, **kwargs: Any) -> None:
         super().__init__()
         self._credential = credential
-        self._lock = asyncio.Lock()
+        self._lock = Lock()
         self._scopes = scopes
         self._token: Optional["AccessToken"] = None
         self._enable_cae: bool = kwargs.get("enable_cae", False)

--- a/sdk/core/azure-core/setup.py
+++ b/sdk/core/azure-core/setup.py
@@ -69,7 +69,8 @@ setup(
     },
     python_requires=">=3.7",
     install_requires=[
-        "requests>=2.18.4",
+        "anyio>=3.0,<5.0",
+        "requests>=2.21.0",
         "six>=1.11.0",
         "typing-extensions>=4.6.0",
     ],

--- a/shared_requirements.txt
+++ b/shared_requirements.txt
@@ -1,4 +1,5 @@
 msrest
+anyio
 azure-ai-ml
 azure-ai-resources
 azure-common


### PR DESCRIPTION
- This introduces `anyio` as a dependency to `azure-core`, and we leverage its `Lock` class in `AsyncBearerTokenCredentialPolicy` to allow it to work with both asyncio and trio concurrency mechanisms.
- `requests` was also bumped to allow the `mindependency` check to pass with the minimum version of `anyio`.


Closes: https://github.com/Azure/azure-sdk-for-python/issues/32968
