### PR TITLE
Redirect references to `kwargs`-trimming utility

### DIFF
--- a/sdk/agrifood/azure-agrifood-farming/tests/testcase_async.py
+++ b/sdk/agrifood/azure-agrifood-farming/tests/testcase_async.py
@@ -7,8 +7,7 @@
 import asyncio
 import functools
 
-from devtools_testutils import AzureRecordedTestCase
-from azure_devtools.scenario_tests.utilities import trim_kwargs_from_test_function
+from devtools_testutils import AzureRecordedTestCase, trim_kwargs_from_test_function
 from azure.agrifood.farming.aio import FarmBeatsClient
 
 class FarmBeatsAsyncTestCase(AzureRecordedTestCase):

--- a/sdk/attestation/azure-security-attestation/tests/test_attestation_async.py
+++ b/sdk/attestation/azure-security-attestation/tests/test_attestation_async.py
@@ -9,7 +9,6 @@
 from typing import Any, Dict
 import pytest
 
-from azure_devtools.scenario_tests.utilities import trim_kwargs_from_test_function
 from devtools_testutils.azure_testcase import _is_autorest_v3
 from devtools_testutils import AzureRecordedTestCase
 from devtools_testutils.aio import recorded_by_proxy_async

--- a/sdk/search/azure-search-documents/tests/async_tests/test_search_index_client_async.py
+++ b/sdk/search/azure-search-documents/tests/async_tests/test_search_index_client_async.py
@@ -6,10 +6,10 @@ import asyncio
 import functools
 import pytest
 from unittest import mock
-from azure_devtools.scenario_tests.utilities import trim_kwargs_from_test_function
 from azure.core.credentials import AzureKeyCredential
 from azure.search.documents.aio import SearchClient
 from azure.search.documents.indexes.aio import SearchIndexClient, SearchIndexerClient
+from devtools_testutils import trim_kwargs_from_test_function
 
 CREDENTIAL = AzureKeyCredential(key="test_api_key")
 


### PR DESCRIPTION
# Description

Now that the utility function `trim_kwargs_from_test_function` is supported in `devtools_testutils`, this PR redirects imports of the method from `azure_devtools` to be from `devtools_testutils`. This is part of the ongoing effort to remove the deprecated `azure-devtools` package.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
