### PR TITLE
Update API review parser version to 0.3.10

### DIFF
--- a/eng/apiview_reqs.txt
+++ b/eng/apiview_reqs.txt
@@ -1,3 +1,3 @@
-apiview-stub-generator==0.3.8
+apiview-stub-generator==0.3.10
 azure-pylint-guidelines-checker==0.0.7
 pylint<3.0.0


### PR DESCRIPTION
Update Python API review parser to 0.3.10 to include package version in API review code file.