### PR TITLE
Default resource detector env var and add auto-instrumentation resource detector

### DIFF
--- a/sdk/monitor/azure-monitor-opentelemetry/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-opentelemetry/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Features Added
 
 - Default Resource Detector environment variable to allow for customization. Add App Service Resource Detector to Auto-Instrumentation.
-    ([#33340](https://github.com/Azure/azure-sdk-for-python/pull/XXXXX))
+    ([#33340](https://github.com/Azure/azure-sdk-for-python/pull/33340))
 
 ### Breaking Changes
 

--- a/sdk/monitor/azure-monitor-opentelemetry/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-opentelemetry/CHANGELOG.md
@@ -4,12 +4,12 @@
 
 ### Features Added
 
+- Default Resource Detector environment variable to allow for customization. Add App Service Resource Detector to Auto-Instrumentation.
+    ([#33340](https://github.com/Azure/azure-sdk-for-python/pull/XXXXX))
+
 ### Breaking Changes
 
 ### Bugs Fixed
-
-- Remove VM Resource Detector for hotfix
-    ([#33305](https://github.com/Azure/azure-sdk-for-python/pull/33305))
 
 ### Other Changes
 

--- a/sdk/monitor/azure-monitor-opentelemetry/README.md
+++ b/sdk/monitor/azure-monitor-opentelemetry/README.md
@@ -232,7 +232,7 @@ contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additio
 [ot_instrumentation_urllib3]: https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-urllib3
 [ot_instrumentation_urllib3_version]: https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/instrumentation/opentelemetry-instrumentation-urllib3/src/opentelemetry/instrumentation/urllib3/package.py#L16
 [ot_python_resource_detectors]: https://opentelemetry-python.readthedocs.io/en/latest/sdk/environment_variables.html#opentelemetry.sdk.environment_variables.OTEL_EXPERIMENTAL_RESOURCE_DETECTORS
-[ot_resource_detector_azure]: https://pypi.org/project/ot_resource_detector_azure/
+[ot_resource_detector_azure]: https://pypi.org/project/opentelemetry_resource_detector_azure/
 [ot_spec_resource]: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/sdk.md#resource-sdk
 [ot_spec_resource_attributes]: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/sdk.md#specifying-resource-information-via-an-environment-variable
 [ot_spec_service_name]: https://github.com/open-telemetry/semantic-conventions/blob/main/docs/resource/README.md#service

--- a/sdk/monitor/azure-monitor-opentelemetry/README.md
+++ b/sdk/monitor/azure-monitor-opentelemetry/README.md
@@ -65,7 +65,7 @@ You can use `configure_azure_monitor` to set up instrumentation for your app to 
 You can configure further with [OpenTelemetry environment variables][ot_env_vars] such as:
 | Environment Variable | Description |
 |-------------|----------------------|
-| [OTEL_SERVICE_NAME][opentelemetry_spec_service_name], [OTEL_RESOURCE_ATTRIBUTES][opentelemetry_spec_resource_attributes] | Specifies the OpenTelemetry [resource][opentelemetry_spec_resource] associated with your application. |
+| [OTEL_SERVICE_NAME][ot_spec_service_name], [OTEL_RESOURCE_ATTRIBUTES][ot_spec_resource_attributes] | Specifies the OpenTelemetry [resource][ot_spec_resource] associated with your application. |
 | `OTEL_LOGS_EXPORTER` | If set to `None`, disables collection and export of logging telemetry. |
 | `OTEL_METRICS_EXPORTER` | If set to `None`, disables collection and export of metric telemetry. |
 | `OTEL_TRACES_EXPORTER` | If set to `None`, disables collection and export of distributed tracing telemetry. |
@@ -73,6 +73,7 @@ You can configure further with [OpenTelemetry environment variables][ot_env_vars
 | `OTEL_BSP_SCHEDULE_DELAY` | Specifies the distributed tracing export interval in milliseconds. Defaults to 5000. |
 | `OTEL_TRACES_SAMPLER_ARG` | Specifies the ratio of distributed tracing telemetry to be [sampled][application_insights_sampling]. Accepted values are in the range [0,1]. Defaults to 1.0, meaning no telemetry is sampled out. |
 | `OTEL_PYTHON_DISABLED_INSTRUMENTATIONS` | Specifies which of the supported instrumentations to disable. Disabled instrumentations will not be instrumented as part of `configure_azure_monitor`. However, they can still be manually instrumented with `instrument()` directly. Accepts a comma-separated list of lowercase [Library Names](#officially-supported-instrumentations). For example, set to `"psycopg2,fastapi"` to disable the Psycopg2 and FastAPI instrumentations. Defaults to an empty list, enabling all supported instrumentations. |
+| `OTEL_EXPERIMENTAL_RESOURCE_DETECTORS` | Specifies OpenTelemetry Resource Detectors to be used to generate Resource Attributes. Defaults to "azure_app_service,azure_vm" to enable the [Azure Resource Detectors][ot_resource_detector_azure] for Azure App Service and Azure VM. See the [OpenTelemetry Python Resource Detector Documentation][ot_python_resource_detectors] for more. |
 
 #### Azure monitor OpenTelemetry Exporter configurations
 
@@ -230,10 +231,12 @@ contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additio
 [ot_instrumentation_urllib]: https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-urllib3
 [ot_instrumentation_urllib3]: https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-urllib3
 [ot_instrumentation_urllib3_version]: https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/instrumentation/opentelemetry-instrumentation-urllib3/src/opentelemetry/instrumentation/urllib3/package.py#L16
-[opentelemetry_spec_resource]: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/sdk.md#resource-sdk
-[opentelemetry_spec_resource_attributes]: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/sdk.md#specifying-resource-information-via-an-environment-variable
-[opentelemetry_spec_service_name]: https://github.com/open-telemetry/semantic-conventions/blob/main/docs/resource/README.md#service
-[opentelemetry_spec_view]: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#view
+[ot_python_resource_detectors]: https://opentelemetry-python.readthedocs.io/en/latest/sdk/environment_variables.html#opentelemetry.sdk.environment_variables.OTEL_EXPERIMENTAL_RESOURCE_DETECTORS
+[ot_resource_detector_azure]: https://pypi.org/project/ot_resource_detector_azure/
+[ot_spec_resource]: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/sdk.md#resource-sdk
+[ot_spec_resource_attributes]: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/sdk.md#specifying-resource-information-via-an-environment-variable
+[ot_spec_service_name]: https://github.com/open-telemetry/semantic-conventions/blob/main/docs/resource/README.md#service
+[ot_spec_view]: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#view
 [pip]: https://pypi.org/project/pip/
 [pypi_django]: https://pypi.org/project/Django/
 [pypi_fastapi]: https://pypi.org/project/fastapi/

--- a/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_autoinstrumentation/distro.py
+++ b/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_autoinstrumentation/distro.py
@@ -16,12 +16,14 @@ from opentelemetry.instrumentation.distro import ( # type: ignore
 )
 from opentelemetry.sdk.environment_variables import (
     _OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED,
+    OTEL_EXPERIMENTAL_RESOURCE_DETECTORS,
 )
 
 from azure.core.settings import settings
 from azure.core.tracing.ext.opentelemetry_span import OpenTelemetrySpan
 from azure.monitor.opentelemetry._constants import (
     _is_attach_enabled,
+    _AZURE_APP_SERVICE_RESOURCE_DETECTOR_NAME,
     _AZURE_SDK_INSTRUMENTATION_NAME,
     _PREVIEW_ENTRY_POINT_WARNING,
 )
@@ -70,6 +72,9 @@ def _configure_auto_instrumentation() -> None:
     )
     environ.setdefault(
         _OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED, "true"
+    )
+    environ.setdefault(
+        OTEL_EXPERIMENTAL_RESOURCE_DETECTORS, _AZURE_APP_SERVICE_RESOURCE_DETECTOR_NAME
     )
     otel_disabled_instrumentations = _get_otel_disabled_instrumentations()
     if _AZURE_SDK_INSTRUMENTATION_NAME not in otel_disabled_instrumentations:

--- a/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_configure.py
+++ b/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_configure.py
@@ -30,7 +30,9 @@ from azure.core.settings import settings
 from azure.core.tracing.ext.opentelemetry_span import OpenTelemetrySpan
 from azure.monitor.opentelemetry._constants import (
     _ALL_SUPPORTED_INSTRUMENTED_LIBRARIES,
+    _AZURE_APP_SERVICE_RESOURCE_DETECTOR_NAME,
     _AZURE_SDK_INSTRUMENTATION_NAME,
+    _AZURE_VM_RESOURCE_DETECTOR_NAME,
     DISABLE_LOGGING_ARG,
     DISABLE_METRICS_ARG,
     DISABLE_TRACING_ARG,
@@ -51,7 +53,8 @@ from azure.monitor.opentelemetry._util.configurations import (
 
 
 _SUPPORTED_RESOURCE_DETECTORS = (
-    "azure_app_service",
+    _AZURE_APP_SERVICE_RESOURCE_DETECTOR_NAME,
+    _AZURE_VM_RESOURCE_DETECTOR_NAME,
 )
 
 _logger = getLogger(__name__)
@@ -101,11 +104,10 @@ def configure_azure_monitor(**kwargs) -> None:
     _setup_instrumentations(configurations)
 
 def _setup_resources():
-    detectors = os.environ.get(OTEL_EXPERIMENTAL_RESOURCE_DETECTORS, "")
-    if detectors:
-        detectors = detectors + ","
-    detectors += ",".join(_SUPPORTED_RESOURCE_DETECTORS)
-    os.environ[OTEL_EXPERIMENTAL_RESOURCE_DETECTORS] = detectors
+    os.environ.setdefault(
+        OTEL_EXPERIMENTAL_RESOURCE_DETECTORS,
+        ",".join(_SUPPORTED_RESOURCE_DETECTORS)
+    )
 
 
 def _setup_tracing(configurations: Dict[str, ConfigurationValue]):

--- a/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_constants.py
+++ b/sdk/monitor/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_constants.py
@@ -97,3 +97,6 @@ _ALL_SUPPORTED_INSTRUMENTED_LIBRARIES = _FULLY_SUPPORTED_INSTRUMENTED_LIBRARIES 
 
 def _is_attach_enabled():
     return isdir("/agents/python/")
+
+_AZURE_APP_SERVICE_RESOURCE_DETECTOR_NAME = "azure_app_service"
+_AZURE_VM_RESOURCE_DETECTOR_NAME = "azure_vm"

--- a/sdk/monitor/azure-monitor-opentelemetry/tests/configuration/test_configure.py
+++ b/sdk/monitor/azure-monitor-opentelemetry/tests/configuration/test_configure.py
@@ -194,13 +194,12 @@ class TestConfigure(unittest.TestCase):
         metrics_mock.assert_not_called()
         instrumentation_mock.assert_called_once_with(configurations)
 
-    @patch.dict("os.environ", {"OTEL_EXPERIMENTAL_RESOURCE_DETECTORS": ""})
+    @patch.dict("os.environ", {}, clear=True)
     def test_setup_resources(self):
         _setup_resources()
         self.assertEqual(
             os.environ["OTEL_EXPERIMENTAL_RESOURCE_DETECTORS"],
-            # TODO: Change back to "azure_app_service,azure_vm" after VM Resource Detector fix for https://github.com/Azure/azure-sdk-for-python/issues/33295
-            "azure_app_service"
+            "azure_app_service,azure_vm"
         )
 
     @patch.dict("os.environ", {"OTEL_EXPERIMENTAL_RESOURCE_DETECTORS": "test_detector"})
@@ -208,8 +207,15 @@ class TestConfigure(unittest.TestCase):
         _setup_resources()
         self.assertEqual(
             os.environ["OTEL_EXPERIMENTAL_RESOURCE_DETECTORS"],
-            # TODO: Change back to "azure_app_service,azure_vm" after VM Resource Detector fix for https://github.com/Azure/azure-sdk-for-python/issues/33295
-            "test_detector,azure_app_service"
+            "test_detector"
+        )
+
+    @patch.dict("os.environ", {"OTEL_EXPERIMENTAL_RESOURCE_DETECTORS": "test_detector,azure_vm"})
+    def test_setup_resources_existing_with_azure_detectors(self):
+        _setup_resources()
+        self.assertEqual(
+            os.environ["OTEL_EXPERIMENTAL_RESOURCE_DETECTORS"],
+            "test_detector,azure_vm"
         )
 
     @patch(


### PR DESCRIPTION
# Description

Follow up to #33305 and fix for #33295, and #33253. Changed resource detector behavior to only default the env var. This will allow customers to customize resource detectors and disable any that may cause issues.

Also, adding the app service detector to auto-insturmentation

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
