### PR TITLE
run typecheckers with py3.8

### DIFF
--- a/eng/tox/run_mypy.py
+++ b/eng/tox/run_mypy.py
@@ -55,7 +55,7 @@ if __name__ == "__main__":
 
     pkg_details = ParsedSetup.from_path(package_dir)
     top_level_module = pkg_details.namespace.split(".")[0]
-    python_version = "3.8" if args.next else "3.7"
+    python_version = "3.8"
     commands = [
         sys.executable,
         "-m",

--- a/eng/tox/run_pyright.py
+++ b/eng/tox/run_pyright.py
@@ -51,8 +51,6 @@ def get_pyright_config_path(args):
     else:
         config.update({"executionEnvironments": [{"root": args.target_package}]})
 
-    if args.next:
-        config["pythonVersion"] = "3.8"
     # write the pyrightconfig.json to the tox environment and return the path so we can point to it
     pyright_env = "pyright" if not args.next else "next-pyright"
     pyright_config_path = os.path.join(args.target_package, ".tox", pyright_env, "tmp", "pyrightconfig.json")

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,5 +1,5 @@
 {
   "reportTypeCommentUsage": true,
   "reportMissingImports": false,
-  "pythonVersion": "3.7"
+  "pythonVersion": "3.8"
 }


### PR DESCRIPTION
Remove py37->py38 transitional code so we run type checkers with 3.8 only for checks and next-checks