### PR TITLE
Retry for client connection issues on batch endpoint invoke

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/constants/_endpoint.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/constants/_endpoint.py
@@ -12,6 +12,7 @@ class EndpointInvokeFields(object):
     DEFAULT_HEADER = {"Content-Type": "application/json"}
     AUTHORIZATION = "Authorization"
     MODEL_DEPLOYMENT = "azureml-model-deployment"
+    REPEATABILITY_REQUEST_ID = "repeatability_request-id"
 
 
 class EndpointGetLogsFields(object):

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_batch_endpoint_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_batch_endpoint_operations.py
@@ -4,6 +4,7 @@
 
 # pylint: disable=protected-access
 
+import uuid
 import json
 import os
 import re
@@ -53,7 +54,7 @@ from azure.ai.ml.entities import BatchEndpoint, BatchJob
 from azure.ai.ml.entities._inputs_outputs import Input
 from azure.ai.ml.exceptions import ErrorCategory, ErrorTarget, MlException, ValidationErrorType, ValidationException
 from azure.core.credentials import TokenCredential
-from azure.core.exceptions import HttpResponseError
+from azure.core.exceptions import HttpResponseError, ServiceRequestError, ServiceResponseError
 from azure.core.paging import ItemPaged
 from azure.core.polling import LROPoller
 from azure.core.tracing.decorator import distributed_trace
@@ -375,15 +376,29 @@ class BatchEndpointOperations(_ScopeDependentOperations):
         module_logger.debug("ml_audience_scopes used: `%s`\n", ml_audience_scopes)
         key = self._credentials.get_token(*ml_audience_scopes).token
         headers[EndpointInvokeFields.AUTHORIZATION] = f"Bearer {key}"
+        headers[EndpointInvokeFields.REPEATABILITY_REQUEST_ID] = str(uuid.uuid4())
 
         if deployment_name:
             headers[EndpointInvokeFields.MODEL_DEPLOYMENT] = deployment_name
 
-        response = self._requests_pipeline.post(
-            endpoint.properties.scoring_uri,
-            json=request,
-            headers=headers,
-        )
+        retry_attempts = 0
+        while retry_attempts < 5:
+            try:
+                response = self._requests_pipeline.post(
+                    endpoint.properties.scoring_uri,
+                    json=request,
+                    headers=headers,
+                )
+            except Exception as e:  # pylint: disable=broad-except
+                if isinstance(e, (ServiceRequestError, ServiceResponseError)) or e.error_code == "408":
+                    retry_attempts += 1
+                    continue
+                else:
+                    raise e
+            break
+        if retry_attempts == 5:
+            retry_msg = "Max retry attempts reached while trying to connect to server. Please check connection and invoke again."
+            raise MlException(message=retry_msg, no_personal_data_message=retry_msg, target=ErrorTarget.BATCH_ENDPOINT)
         validate_response(response)
         batch_job = json.loads(response.text())
         return BatchJobResource.deserialize(batch_job)


### PR DESCRIPTION
# Description

Certain sdk notebooks have been timing out on the client before they get to the invoke call. This PR wraps the invoke in a retry when there is a ServiceResponseError thrown.  

We also attach the retry guid to the invoke call so that it doesn't send multiple invoke calls and instead  re-sends the same call. 

![image](https://github.com/Azure/azure-sdk-for-python/assets/98433579/808b0bdf-4cf6-4560-8922-06889baabd43)


If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
