### PR TITLE
[Storage] Add `exists` method to `ShareFileClient`

### DIFF
--- a/sdk/storage/azure-storage-file-share/CHANGELOG.md
+++ b/sdk/storage/azure-storage-file-share/CHANGELOG.md
@@ -2,10 +2,12 @@
 
 ## 12.16.0b1 (Unreleased)
 
+### Features Added
+- Added `exists` method to `ShareFileClient` to check if a file exists.
+
 ### Bugs Fixed
 - Fixed an issue where the `ShareDirectoryClient` returned by `get_subdirectory_client` with a `ShareDirectoryClient`
 pointing to the root of the file share would raise an `InvalidResourceName` on any operations.
-
 
 ## 12.15.0 (2023-11-07)
 

--- a/sdk/storage/azure-storage-file-share/assets.json
+++ b/sdk/storage/azure-storage-file-share/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "python",
   "TagPrefix": "python/storage/azure-storage-file-share",
-  "Tag": "python/storage/azure-storage-file-share_81dadfb61f"
+  "Tag": "python/storage/azure-storage-file-share_b47b0652ef"
 }

--- a/sdk/storage/azure-storage-file-share/tests/test_file.py
+++ b/sdk/storage/azure-storage-file-share/tests/test_file.py
@@ -233,6 +233,26 @@ class TestStorageFile(StorageRecordedTestCase):
 
     @FileSharePreparer()
     @recorded_by_proxy
+    def test_exists(self, **kwargs):
+        storage_account_name = kwargs.pop("storage_account_name")
+        storage_account_key = kwargs.pop("storage_account_key")
+
+        self._setup(storage_account_name, storage_account_key)
+        file_name = self._get_file_reference()
+        file_client = ShareFileClient(
+            self.account_url(storage_account_name, "file"),
+            share_name=self.share_name,
+            file_path=file_name,
+            credential=storage_account_key)
+
+        # Act / Assert
+        assert not file_client.exists()
+
+        file_client.create_file(1024)
+        assert file_client.exists()
+
+    @FileSharePreparer()
+    @recorded_by_proxy
     def test_create_file(self, **kwargs):
         storage_account_name = kwargs.pop("storage_account_name")
         storage_account_key = kwargs.pop("storage_account_key")

--- a/sdk/storage/azure-storage-file-share/tests/test_file_async.py
+++ b/sdk/storage/azure-storage-file-share/tests/test_file_async.py
@@ -248,6 +248,27 @@ class TestStorageFileAsync(AsyncStorageRecordedTestCase):
 
     @FileSharePreparer()
     @recorded_by_proxy_async
+    async def test_exists(self, **kwargs):
+        storage_account_name = kwargs.pop("storage_account_name")
+        storage_account_key = kwargs.pop("storage_account_key")
+
+        self._setup(storage_account_name, storage_account_key)
+        await self._setup_share(storage_account_name, storage_account_key)
+        file_name = self._get_file_reference()
+        async with ShareFileClient(
+            self.account_url(storage_account_name, "file"),
+            share_name=self.share_name,
+            file_path=file_name,
+            credential=storage_account_key) as file_client:
+
+            # Act / Assert
+            assert not await file_client.exists()
+
+            await file_client.create_file(1024)
+            assert await file_client.exists()
+
+    @FileSharePreparer()
+    @recorded_by_proxy_async
     async def test_create_file(self, **kwargs):
         storage_account_name = kwargs.pop("storage_account_name")
         storage_account_key = kwargs.pop("storage_account_key")


### PR DESCRIPTION
Resolves #32969.

`ShareFileClient` was missing an `exists` method to check if a file exists without manually catching exceptions. This is present in other languages and in `ShareDirectoryClient` so it was likely just missed here.