### PR TITLE
Add strict-sphinx to the analyze weekly job

### DIFF
--- a/eng/pipelines/templates/stages/python-analyze-weekly.yml
+++ b/eng/pipelines/templates/stages/python-analyze-weekly.yml
@@ -95,5 +95,4 @@ stages:
               arguments: >-
                 ${{ parameters.BuildTargetingString }}
                 --service="${{ parameters.ServiceDirectory }}" 
-                --toxenv=sphinx
-                --strict=true
+                --toxenv="strict-sphinx"

--- a/eng/pipelines/templates/stages/python-analyze-weekly.yml
+++ b/eng/pipelines/templates/stages/python-analyze-weekly.yml
@@ -86,3 +86,14 @@ stages:
                 --disablecov
             env:
               GH_TOKEN: $(azuresdk-github-pat)
+
+          - task: PythonScript@0
+            displayName: 'Generate Docs'
+            continueOnError: true
+            inputs:
+              scriptPath: 'scripts/devops_tasks/dispatch_tox.py'
+              arguments: >-
+                ${{ parameters.BuildTargetingString }}
+                --service="${{ parameters.ServiceDirectory }}" 
+                --toxenv=sphinx
+                --strict=true

--- a/eng/tox/run_sphinx_build.py
+++ b/eng/tox/run_sphinx_build.py
@@ -105,6 +105,12 @@ if __name__ == "__main__":
         default=False
     )
 
+    parser.add_argument(
+        "--strict",
+        dest="strict",
+        default=False
+    )
+
     args = parser.parse_args()
 
     output_dir = os.path.abspath(args.output_directory)
@@ -114,7 +120,7 @@ if __name__ == "__main__":
     pkg_details = ParsedSetup.from_path(package_dir)
 
     if should_build_docs(pkg_details.name):
-        fail_on_warning = get_config_setting(args.package_root, "strict_sphinx", default=False)
+        fail_on_warning = args.strict or get_config_setting(args.package_root, "strict_sphinx", default=False)
 
         sphinx_build(target_dir, output_dir, fail_on_warning=fail_on_warning)
 

--- a/eng/tox/tox.ini
+++ b/eng/tox/tox.ini
@@ -364,7 +364,7 @@ commands =
   python {repository_root}/eng/tox/run_sphinx_build.py \
     -w {envtmpdir}/dist/unzipped/docgen \
     -o {envtmpdir}/dist/site \
-    -r {tox_root}
+    -r {tox_root} \
     --strict true
 
 [testenv:depends]

--- a/eng/tox/tox.ini
+++ b/eng/tox/tox.ini
@@ -339,6 +339,34 @@ commands =
     -r {tox_root}
 
 
+[testenv:strict-sphinx]
+description="Builds a package's documentation with strict sphinx"
+skipsdist = true
+skip_install = true
+passenv = *
+setenv =
+  {[testenv]setenv}
+  PROXY_URL=http://localhost:5023
+deps =
+  {[base]deps}
+  sphinx==6.2.1
+  sphinx_rtd_theme==1.3.0
+  myst_parser==2.0.0
+  sphinxcontrib-jquery==4.1
+commands =
+  python {repository_root}/eng/tox/create_package_and_install.py \
+    -d {envtmpdir}/dist \
+    -p {tox_root} \
+    -w {envtmpdir} \
+    --package-type sdist
+  python {repository_root}/eng/tox/prep_sphinx_env.py -d {envtmpdir}/dist -t {tox_root}
+  python {repository_root}/eng/tox/run_sphinx_apidoc.py -w {envtmpdir}/dist -r {tox_root}
+  python {repository_root}/eng/tox/run_sphinx_build.py \
+    -w {envtmpdir}/dist/unzipped/docgen \
+    -o {envtmpdir}/dist/site \
+    -r {tox_root}
+    --strict true
+
 [testenv:depends]
 description = Ensures all modules in a target package can be successfully imported
 setenv =


### PR DESCRIPTION
Strict sphinx is another CI check we want to turn on for all libraries by mid next year. This PR adds strict-sphinx to the analyze weekly job so we can monitor status / open issues against libraries that are failing it.

Test here: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3315968&view=results