### PR TITLE
App Config Provider - Refresh Lock Fix

### DIFF
--- a/sdk/appconfiguration/azure-appconfiguration-provider/tests/testcase.py
+++ b/sdk/appconfiguration/azure-appconfiguration-provider/tests/testcase.py
@@ -133,11 +133,10 @@ def get_configs(keyvault_secret_url):
     configs.append(create_config_setting("refresh_message", "\0", "original value"))
     configs.append(create_config_setting("non_refreshed_message", "\0", "Static"))
     configs.append(
-        create_config_setting(
-            ".appconfig.featureflag/Alpha",
+        create_feature_flag_config_setting(
+            "Alpha",
             "\0",
-            '{	"id": "Alpha", "description": "", "enabled": false, "conditions": {	"client_filters": []	}}',
-            "application/vnd.microsoft.appconfig.ff+json;charset=utf-8",
+            True,
         )
     )
     if keyvault_secret_url:


### PR DESCRIPTION
# Description

Fixes an issue where the callback was inside the lock, causing issues if you tried to access keys in the callback.

# All SDK Contribution checklist:
- [X] **The pull request does not introduce [breaking changes]**
- [X] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [X] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [X] Title of the pull request is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [X] Pull request includes test coverage for the included changes.
