### PR TITLE
Store global instance of statsbeatmetric

### DIFF
--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
@@ -10,6 +10,9 @@
 
 ### Other Changes
 
+- Store global instance of `StatsbeatMetric`
+    ([#33163](https://github.com/Azure/azure-sdk-for-python/pull/33163))
+
 ## 1.0.0b19 (2023-11-20)
 
 ### Bugs Fixed

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/statsbeat/_statsbeat.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/statsbeat/_statsbeat.py
@@ -33,15 +33,15 @@ _EU_ENDPOINTS = [
     "ukwest",
 ]
 
-_STATSBEAT_METER_PROVIDER = None
+_STATSBEAT_METRICS = None
 _STATSBEAT_LOCK = threading.Lock()
 
 # pylint: disable=global-statement
 # pylint: disable=protected-access
 def collect_statsbeat_metrics(exporter) -> None:
-    global _STATSBEAT_METER_PROVIDER
+    global _STATSBEAT_METRICS
     # Only start statsbeat if did not exist before
-    if _STATSBEAT_METER_PROVIDER is None:
+    if _STATSBEAT_METRICS is None:
         with _STATSBEAT_LOCK:
             statsbeat_exporter = _StatsBeatExporter(
                 connection_string=_get_stats_connection_string(exporter._endpoint),
@@ -51,12 +51,12 @@ def collect_statsbeat_metrics(exporter) -> None:
                 statsbeat_exporter,
                 export_interval_millis=_get_stats_short_export_interval() * 1000,  # 15m by default
             )
-            _STATSBEAT_METER_PROVIDER = MeterProvider(metric_readers=[reader])
+            mp = MeterProvider(metric_readers=[reader])
             # long_interval_threshold represents how many collects for short interval
             # should have passed before a long interval collect
             long_interval_threshold = _get_stats_long_export_interval() // _get_stats_short_export_interval()
-            metrics = _StatsbeatMetrics(
-                _STATSBEAT_METER_PROVIDER,
+            _STATSBEAT_METRICS = _StatsbeatMetrics(
+                mp,
                 exporter._instrumentation_key,
                 exporter._endpoint,
                 exporter._disable_offline_storage,
@@ -64,20 +64,21 @@ def collect_statsbeat_metrics(exporter) -> None:
                 exporter._credential is not None,
             )
         # Export some initial stats on program start
-        _STATSBEAT_METER_PROVIDER.force_flush()
+        mp.force_flush()
         # initialize non-initial stats
-        metrics.init_non_initial_metrics()
+        _STATSBEAT_METRICS.init_non_initial_metrics()
 
 
 def shutdown_statsbeat_metrics() -> None:
-    global _STATSBEAT_METER_PROVIDER
+    global _STATSBEAT_METRICS
     shutdown_success = False
-    if _STATSBEAT_METER_PROVIDER is not None:
+    if _STATSBEAT_METRICS is not None:
         with _STATSBEAT_LOCK:
             try:
-                _STATSBEAT_METER_PROVIDER.shutdown()
-                _STATSBEAT_METER_PROVIDER = None
-                shutdown_success = True
+                if _STATSBEAT_METRICS._meter_provider is not None:
+                    _STATSBEAT_METRICS._meter_provider.shutdown()
+                    _STATSBEAT_METRICS = None
+                    shutdown_success = True
             except:  # pylint: disable=bare-except
                 pass
         if shutdown_success:

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/statsbeat/_statsbeat_metrics.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/statsbeat/_statsbeat_metrics.py
@@ -103,7 +103,8 @@ class _StatsbeatMetrics:
         if has_credential:
             self._feature |= _StatsbeatFeature.AAD
         self._ikey = instrumentation_key
-        self._meter = meter_provider.get_meter(__name__)
+        self._meter_provider = meter_provider
+        self._meter = self._meter_provider.get_meter(__name__)
         self._long_interval_threshold = long_interval_threshold
         # Start internal count at the max size for initial statsbeat export
         self._long_interval_count_map = {
@@ -392,7 +393,6 @@ class _StatsbeatMetrics:
                     _REQUESTS_MAP[_REQ_EXCEPTION_NAME[1]][code] = 0 # type: ignore
         return observations
 
-# cSpell:enable
 
 def _shorten_host(host: str) -> str:
     if not host:
@@ -401,3 +401,5 @@ def _shorten_host(host: str) -> str:
     if match:
         host = match.group(1)
     return host
+
+# cSpell:enable


### PR DESCRIPTION
Stores global instance of StatsbeatMetric instead of the MeterProvider to allow for future runtime changes related to statsbeat.