### PR TITLE
[Storage] `serialize_iso` settable `decimals` place input

### DIFF
--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_generated/_serialization.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_generated/_serialization.py
@@ -1149,9 +1149,11 @@ class Serializer(object):
         """Serialize Datetime object into ISO-8601 formatted string.
 
         :param Datetime attr: Object to be serialized.
+        :keyword int decimals: Number of decimal places to truncate to. Default value is 3.
         :rtype: str
         :raises: SerializationError if format invalid.
         """
+        decimals = kwargs.pop('decimals', 3)
         if isinstance(attr, str):
             attr = isodate.parse_datetime(attr)
         try:
@@ -1161,7 +1163,7 @@ class Serializer(object):
             if utc.tm_year > 9999 or utc.tm_year < 1:
                 raise OverflowError("Hit max or min date")
 
-            microseconds = str(attr.microsecond).rjust(6, "0").rstrip("0").ljust(3, "0")
+            microseconds = str(attr.microsecond).rjust(6, "0").rstrip("0").ljust(decimals, "0")
             if microseconds:
                 microseconds = "." + microseconds
             date = "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}".format(

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_parser.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_parser.py
@@ -5,6 +5,7 @@
 # --------------------------------------------------------------------------
 
 from datetime import datetime, timedelta
+from ._generated._serialization import Serializer
 
 _ERROR_TOO_MANY_FILE_PERMISSIONS = 'file_permission and file_permission_key should not be set at the same time'
 _FILE_PERMISSION_TOO_LONG = 'Size of file_permission is too large. file_permission should be <=8KB, else' \
@@ -41,4 +42,7 @@ def _parse_datetime_from_str(string_datetime):
 def _datetime_to_str(datetime_obj):
     if not datetime_obj:
         return None
-    return datetime_obj if isinstance(datetime_obj, str) else datetime_obj.isoformat() + '0Z'
+    if isinstance(datetime_obj, str):
+        return datetime_obj
+    ret = Serializer.serialize_iso(datetime_obj, decimals=7)
+    return ret

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_parser.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_parser.py
@@ -42,7 +42,4 @@ def _parse_datetime_from_str(string_datetime):
 def _datetime_to_str(datetime_obj):
     if not datetime_obj:
         return None
-    if isinstance(datetime_obj, str):
-        return datetime_obj
-    ret = Serializer.serialize_iso(datetime_obj, decimals=7)
-    return ret
+    return datetime_obj if isinstance(datetime_obj, str) else Serializer.serialize_iso(datetime_obj, decimals=7)

--- a/sdk/storage/azure-storage-file-share/tests/test_file.py
+++ b/sdk/storage/azure-storage-file-share/tests/test_file.py
@@ -833,6 +833,37 @@ class TestStorageFile(StorageRecordedTestCase):
 
     @FileSharePreparer()
     @recorded_by_proxy
+    def test_set_datetime_all_ms_precision(self, **kwargs):
+        storage_account_name = kwargs.pop("storage_account_name")
+        storage_account_key = kwargs.pop("storage_account_key")
+
+        self._setup(storage_account_name, storage_account_key)
+        file_client = self._create_file()
+
+        date_times = [
+            datetime(3005, 5, 11, 12, 24, 7),
+            datetime(3005, 5, 11, 12, 24, 7, 0),
+            datetime(3005, 5, 11, 12, 24, 7, 1),
+            datetime(3005, 5, 11, 12, 24, 7, 12),
+            datetime(3005, 5, 11, 12, 24, 7, 123),
+            datetime(3005, 5, 11, 12, 24, 7, 1234),
+            datetime(3005, 5, 11, 12, 24, 7, 12345),
+            datetime(3005, 5, 11, 12, 24, 7, 123456)
+        ]
+
+        # Act / Assert
+        content_settings = ContentSettings(
+            content_language='spanish',
+            content_disposition='inline')
+        for date1, date2 in zip(date_times[::2], date_times[1::2]):
+            file_client.set_http_headers(
+                content_settings=content_settings,
+                file_creation_time=date1,
+                file_last_write_time=date2
+            )
+
+    @FileSharePreparer()
+    @recorded_by_proxy
     def test_set_file_properties_trailing_dot(self, **kwargs):
         storage_account_name = kwargs.pop("storage_account_name")
         storage_account_key = kwargs.pop("storage_account_key")

--- a/sdk/storage/azure-storage-file-share/tests/test_file.py
+++ b/sdk/storage/azure-storage-file-share/tests/test_file.py
@@ -7,7 +7,7 @@ import base64
 import os
 import tempfile
 import uuid
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import pytest
 import requests
@@ -848,7 +848,9 @@ class TestStorageFile(StorageRecordedTestCase):
             datetime(3005, 5, 11, 12, 24, 7, 123),
             datetime(3005, 5, 11, 12, 24, 7, 1234),
             datetime(3005, 5, 11, 12, 24, 7, 12345),
-            datetime(3005, 5, 11, 12, 24, 7, 123456)
+            datetime(3005, 5, 11, 12, 24, 7, 123456),
+            datetime(2023, 12, 8, tzinfo=timezone(-timedelta(hours=7))),
+            datetime(2023, 12, 8, tzinfo=timezone(-timedelta(hours=8))),
         ]
 
         # Act / Assert

--- a/sdk/storage/azure-storage-file-share/tests/test_file_async.py
+++ b/sdk/storage/azure-storage-file-share/tests/test_file_async.py
@@ -9,7 +9,7 @@ import base64
 import os
 import tempfile
 import uuid
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import pytest
 import requests
@@ -861,7 +861,9 @@ class TestStorageFileAsync(AsyncStorageRecordedTestCase):
             datetime(3005, 5, 11, 12, 24, 7, 123),
             datetime(3005, 5, 11, 12, 24, 7, 1234),
             datetime(3005, 5, 11, 12, 24, 7, 12345),
-            datetime(3005, 5, 11, 12, 24, 7, 123456)
+            datetime(3005, 5, 11, 12, 24, 7, 123456),
+            datetime(2023, 12, 8, tzinfo=timezone(-timedelta(hours=7))),
+            datetime(2023, 12, 8, tzinfo=timezone(-timedelta(hours=8))),
         ]
 
         # Act / Assert

--- a/sdk/storage/azure-storage-file-share/tests/test_file_async.py
+++ b/sdk/storage/azure-storage-file-share/tests/test_file_async.py
@@ -846,6 +846,37 @@ class TestStorageFileAsync(AsyncStorageRecordedTestCase):
 
     @FileSharePreparer()
     @recorded_by_proxy_async
+    async def test_set_datetime_all_ms_precision(self, **kwargs):
+        storage_account_name = kwargs.pop("storage_account_name")
+        storage_account_key = kwargs.pop("storage_account_key")
+
+        self._setup(storage_account_name, storage_account_key)
+        file_client = await self._create_file(storage_account_name, storage_account_key)
+
+        date_times = [
+            datetime(3005, 5, 11, 12, 24, 7),
+            datetime(3005, 5, 11, 12, 24, 7, 0),
+            datetime(3005, 5, 11, 12, 24, 7, 1),
+            datetime(3005, 5, 11, 12, 24, 7, 12),
+            datetime(3005, 5, 11, 12, 24, 7, 123),
+            datetime(3005, 5, 11, 12, 24, 7, 1234),
+            datetime(3005, 5, 11, 12, 24, 7, 12345),
+            datetime(3005, 5, 11, 12, 24, 7, 123456)
+        ]
+
+        # Act / Assert
+        content_settings = ContentSettings(
+            content_language='spanish',
+            content_disposition='inline')
+        for date1, date2 in zip(date_times[::2], date_times[1::2]):
+            await file_client.set_http_headers(
+                content_settings=content_settings,
+                file_creation_time=date1,
+                file_last_write_time=date2
+            )
+
+    @FileSharePreparer()
+    @recorded_by_proxy_async
     async def test_set_file_properties_trailing_dot(self, **kwargs):
         storage_account_name = kwargs.pop("storage_account_name")
         storage_account_key = kwargs.pop("storage_account_key")


### PR DESCRIPTION
This is the proposed proof of concept code change that would allows us to re-use a well-written and sophisticated utility that already exists rather than home-rolling our own solution. I also added a sample test case (but no recordings, we can add recordings when we add these tests _after_ generated code changes roll out)

Sample test case output:
```
'3005-05-11T12:24:07.0000000Z'
'3005-05-11T12:24:07.0000000Z'
'3005-05-11T12:24:07.0000010Z'
'3005-05-11T12:24:07.0000120Z'
'3005-05-11T12:24:07.0001230Z'
'3005-05-11T12:24:07.0012340Z'
'3005-05-11T12:24:07.0123450Z'
'3005-05-11T12:24:07.1234560Z'
'2023-12-08T07:00:00.0000000Z'
'2023-12-08T08:00:00.0000000Z'
```
As expected, 😄 properly expanding the microseconds width (with last 2 being time-zone aware PST inputs). And all network calls not being rejected server side!