### PR TITLE
[Key Vault] Resolve `next-pylint` and `next-mypy` errors

### DIFF
--- a/sdk/keyvault/azure-keyvault-administration/README.md
+++ b/sdk/keyvault/azure-keyvault-administration/README.md
@@ -300,7 +300,11 @@ to the library's [credential documentation][sas_docs]. Alternatively, it is poss
 <!-- SNIPPET:backup_restore_operations.begin_restore -->
 
 ```python
+SAS_TOKEN = os.environ["SAS_TOKEN"]
+
+# `backup_result` is the KeyVaultBackupResult returned by `begin_backup`
 client.begin_restore(backup_result.folder_url, sas_token=SAS_TOKEN).wait()
+print("Vault restored successfully.")
 ```
 
 <!-- END SNIPPET -->

--- a/sdk/keyvault/azure-keyvault-administration/README.md
+++ b/sdk/keyvault/azure-keyvault-administration/README.md
@@ -278,7 +278,7 @@ to the library's [credential documentation][sas_docs]. Alternatively, it is poss
 CONTAINER_URL = os.environ["CONTAINER_URL"]
 SAS_TOKEN = os.environ["SAS_TOKEN"]
 
-backup_result: KeyVaultBackupResult = client.begin_backup(CONTAINER_URL, SAS_TOKEN).result()
+backup_result: KeyVaultBackupResult = client.begin_backup(CONTAINER_URL, sas_token=SAS_TOKEN).result()
 print(f"Azure Storage Blob URL of the backup: {backup_result.folder_url}")
 ```
 
@@ -297,14 +297,10 @@ For more details on creating a SAS token using a `BlobServiceClient` from [`azur
 to the library's [credential documentation][sas_docs]. Alternatively, it is possible to
 [generate a SAS token in Storage Explorer][storage_explorer].
 
-<!-- SNIPPET:backup_restore_operations.begin_backup -->
+<!-- SNIPPET:backup_restore_operations.begin_restore -->
 
 ```python
-CONTAINER_URL = os.environ["CONTAINER_URL"]
-SAS_TOKEN = os.environ["SAS_TOKEN"]
-
-backup_result: KeyVaultBackupResult = client.begin_backup(CONTAINER_URL, SAS_TOKEN).result()
-print(f"Azure Storage Blob URL of the backup: {backup_result.folder_url}")
+client.begin_restore(backup_result.folder_url, sas_token=SAS_TOKEN).wait()
 ```
 
 <!-- END SNIPPET -->

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_access_control_client.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_access_control_client.py
@@ -2,21 +2,16 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
-from typing import TYPE_CHECKING
-from uuid import uuid4
+from typing import Union
+from uuid import UUID, uuid4
 
 from azure.core.exceptions import ResourceNotFoundError
+from azure.core.paging import ItemPaged
 from azure.core.tracing.decorator import distributed_trace
 
+from ._enums import KeyVaultRoleScope
 from ._models import KeyVaultRoleAssignment, KeyVaultRoleDefinition
 from ._internal import KeyVaultClientBase
-
-if TYPE_CHECKING:
-    # pylint:disable=ungrouped-imports
-    from typing import Union
-    from uuid import UUID
-    from azure.core.paging import ItemPaged
-    from ._enums import KeyVaultRoleScope
 
 
 class KeyVaultAccessControlClient(KeyVaultClientBase):
@@ -39,7 +34,7 @@ class KeyVaultAccessControlClient(KeyVaultClientBase):
 
     @distributed_trace
     def create_role_assignment(
-        self, scope: "Union[str, KeyVaultRoleScope]", definition_id: str, principal_id: str, **kwargs
+        self, scope: Union[str, KeyVaultRoleScope], definition_id: str, principal_id: str, **kwargs
     ) -> KeyVaultRoleAssignment:
         """Create a role assignment.
 
@@ -74,7 +69,7 @@ class KeyVaultAccessControlClient(KeyVaultClientBase):
 
     @distributed_trace
     def delete_role_assignment(
-        self, scope: "Union[str, KeyVaultRoleScope]", name: "Union[str, UUID]", **kwargs
+        self, scope: Union[str, KeyVaultRoleScope], name: Union[str, UUID], **kwargs
     ) -> None:
         """Delete a role assignment.
 
@@ -96,7 +91,7 @@ class KeyVaultAccessControlClient(KeyVaultClientBase):
 
     @distributed_trace
     def get_role_assignment(
-        self, scope: "Union[str, KeyVaultRoleScope]", name: "Union[str, UUID]", **kwargs
+        self, scope: Union[str, KeyVaultRoleScope], name: Union[str, UUID], **kwargs
     ) -> KeyVaultRoleAssignment:
         """Get a role assignment.
 
@@ -116,8 +111,8 @@ class KeyVaultAccessControlClient(KeyVaultClientBase):
 
     @distributed_trace
     def list_role_assignments(
-        self, scope: "Union[str, KeyVaultRoleScope]", **kwargs
-    ) -> "ItemPaged[KeyVaultRoleAssignment]":
+        self, scope: Union[str, KeyVaultRoleScope], **kwargs
+    ) -> ItemPaged[KeyVaultRoleAssignment]:
         """List all role assignments for a scope.
 
         :param scope: scope of the role assignments. :class:`KeyVaultRoleScope` defines common broad scopes.
@@ -136,8 +131,8 @@ class KeyVaultAccessControlClient(KeyVaultClientBase):
 
     @distributed_trace
     def set_role_definition(
-        self, scope: "Union[str, KeyVaultRoleScope]", **kwargs
-    ) -> "KeyVaultRoleDefinition":
+        self, scope: Union[str, KeyVaultRoleScope], **kwargs
+    ) -> KeyVaultRoleDefinition:
         """Creates or updates a custom role definition.
 
         To update a role definition, specify the definition's ``name``.
@@ -194,8 +189,8 @@ class KeyVaultAccessControlClient(KeyVaultClientBase):
 
     @distributed_trace
     def get_role_definition(
-        self, scope: "Union[str, KeyVaultRoleScope]", name: "Union[str, UUID]", **kwargs
-    ) -> "KeyVaultRoleDefinition":
+        self, scope: Union[str, KeyVaultRoleScope], name: Union[str, UUID], **kwargs
+    ) -> KeyVaultRoleDefinition:
         """Get the specified role definition.
 
         :param scope: scope of the role definition. :class:`KeyVaultRoleScope` defines common broad scopes.
@@ -214,7 +209,7 @@ class KeyVaultAccessControlClient(KeyVaultClientBase):
 
     @distributed_trace
     def delete_role_definition(
-        self, scope: "Union[str, KeyVaultRoleScope]", name: "Union[str, UUID]", **kwargs
+        self, scope: Union[str, KeyVaultRoleScope], name: Union[str, UUID], **kwargs
     ) -> None:
         """Deletes a custom role definition.
 
@@ -236,8 +231,8 @@ class KeyVaultAccessControlClient(KeyVaultClientBase):
 
     @distributed_trace
     def list_role_definitions(
-        self, scope: "Union[str, KeyVaultRoleScope]", **kwargs
-    ) -> "ItemPaged[KeyVaultRoleDefinition]":
+        self, scope: Union[str, KeyVaultRoleScope], **kwargs
+    ) -> ItemPaged[KeyVaultRoleDefinition]:
         """List all role definitions applicable at and above a scope.
 
         :param scope: scope of the role definitions. :class:`KeyVaultRoleScope` defines common broad scopes.

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_access_control_client.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_access_control_client.py
@@ -69,7 +69,7 @@ class KeyVaultAccessControlClient(KeyVaultClientBase):
 
     @distributed_trace
     def delete_role_assignment(
-        self, scope: Union[str, KeyVaultRoleScope], name: Union[str, UUID], **kwargs
+        self, scope: Union[str, KeyVaultRoleScope], name: Union[str, UUID], **kwargs: Any
     ) -> None:
         """Delete a role assignment.
 
@@ -91,7 +91,7 @@ class KeyVaultAccessControlClient(KeyVaultClientBase):
 
     @distributed_trace
     def get_role_assignment(
-        self, scope: Union[str, KeyVaultRoleScope], name: Union[str, UUID], **kwargs
+        self, scope: Union[str, KeyVaultRoleScope], name: Union[str, UUID], **kwargs: Any
     ) -> KeyVaultRoleAssignment:
         """Get a role assignment.
 
@@ -111,7 +111,7 @@ class KeyVaultAccessControlClient(KeyVaultClientBase):
 
     @distributed_trace
     def list_role_assignments(
-        self, scope: Union[str, KeyVaultRoleScope], **kwargs
+        self, scope: Union[str, KeyVaultRoleScope], **kwargs: Any
     ) -> ItemPaged[KeyVaultRoleAssignment]:
         """List all role assignments for a scope.
 
@@ -131,7 +131,7 @@ class KeyVaultAccessControlClient(KeyVaultClientBase):
 
     @distributed_trace
     def set_role_definition(
-        self, scope: Union[str, KeyVaultRoleScope], **kwargs
+        self, scope: Union[str, KeyVaultRoleScope], **kwargs: Any
     ) -> KeyVaultRoleDefinition:
         """Creates or updates a custom role definition.
 
@@ -189,7 +189,7 @@ class KeyVaultAccessControlClient(KeyVaultClientBase):
 
     @distributed_trace
     def get_role_definition(
-        self, scope: Union[str, KeyVaultRoleScope], name: Union[str, UUID], **kwargs
+        self, scope: Union[str, KeyVaultRoleScope], name: Union[str, UUID], **kwargs: Any
     ) -> KeyVaultRoleDefinition:
         """Get the specified role definition.
 
@@ -209,7 +209,7 @@ class KeyVaultAccessControlClient(KeyVaultClientBase):
 
     @distributed_trace
     def delete_role_definition(
-        self, scope: Union[str, KeyVaultRoleScope], name: Union[str, UUID], **kwargs
+        self, scope: Union[str, KeyVaultRoleScope], name: Union[str, UUID], **kwargs: Any
     ) -> None:
         """Deletes a custom role definition.
 
@@ -231,7 +231,7 @@ class KeyVaultAccessControlClient(KeyVaultClientBase):
 
     @distributed_trace
     def list_role_definitions(
-        self, scope: Union[str, KeyVaultRoleScope], **kwargs
+        self, scope: Union[str, KeyVaultRoleScope], **kwargs: Any
     ) -> ItemPaged[KeyVaultRoleDefinition]:
         """List all role definitions applicable at and above a scope.
 

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_access_control_client.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_access_control_client.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
-from typing import Union
+from typing import Any, Union
 from uuid import UUID, uuid4
 
 from azure.core.exceptions import ResourceNotFoundError
@@ -34,7 +34,7 @@ class KeyVaultAccessControlClient(KeyVaultClientBase):
 
     @distributed_trace
     def create_role_assignment(
-        self, scope: Union[str, KeyVaultRoleScope], definition_id: str, principal_id: str, **kwargs
+        self, scope: Union[str, KeyVaultRoleScope], definition_id: str, principal_id: str, **kwargs: Any
     ) -> KeyVaultRoleAssignment:
         """Create a role assignment.
 

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_access_control_client.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_access_control_client.py
@@ -27,7 +27,7 @@ class KeyVaultAccessControlClient(KeyVaultClientBase):
         See https://aka.ms/azsdk/blog/vault-uri for details.
     :param credential: An object which can provide an access token for the vault, such as a credential from
         :mod:`azure.identity`
-    :type credential: :class:`~azure.core.credentials.TokenCredential`
+    :type credential: ~azure.core.credentials.TokenCredential
 
     :keyword api_version: Version of the service API to use. Defaults to the most recent.
     :paramtype api_version: ~azure.keyvault.administration.ApiVersion or str

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_backup_client.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_backup_client.py
@@ -139,7 +139,7 @@ class KeyVaultBackupClient(KeyVaultClientBase):
         key_name: Optional[str] = None,
         continuation_token: Optional[str] = None,
         **kwargs: Any,
-    ) -> LROPoller:
+    ) -> LROPoller[None]:
         ...
 
     @overload
@@ -151,11 +151,11 @@ class KeyVaultBackupClient(KeyVaultClientBase):
         key_name: Optional[str] = None,
         continuation_token: Optional[str] = None,
         **kwargs: Any,
-    ) -> LROPoller:
+    ) -> LROPoller[None]:
         ...
 
     @distributed_trace
-    def begin_restore(self, folder_url: str, *args: str, **kwargs: Any) -> LROPoller:
+    def begin_restore(self, folder_url: str, *args: str, **kwargs: Any) -> LROPoller[None]:
         """Restore a Key Vault backup.
 
         This method restores either a complete Key Vault backup or when ``key_name`` has a value, a single key.

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_backup_client.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_backup_client.py
@@ -35,7 +35,7 @@ class KeyVaultBackupClient(KeyVaultClientBase):
         See https://aka.ms/azsdk/blog/vault-uri for details.
     :param credential: An object which can provide an access token for the vault, such as a credential from
         :mod:`azure.identity`
-    :type credential: :class:`~azure.core.credentials.TokenCredential`
+    :type credential: ~azure.core.credentials.TokenCredential
 
     :keyword api_version: Version of the service API to use. Defaults to the most recent.
     :paramtype api_version: ~azure.keyvault.administration.ApiVersion or str
@@ -80,7 +80,7 @@ class KeyVaultBackupClient(KeyVaultClientBase):
         :paramtype use_managed_identity: Literal[True]
         :keyword str continuation_token: A continuation token to restart polling from a saved state.
 
-        :returns: An :class:`~azure.core.polling.LROPoller` instance. Call `result()` on this object to wait for the
+        :returns: An azure.core.polling.LROPoller instance. Call `result()` on this object to wait for the
             operation to complete and get a :class:`KeyVaultBackupResult`.
         :rtype: ~azure.core.polling.LROPoller[~azure.keyvault.administration.KeyVaultBackupResult]
 
@@ -176,7 +176,7 @@ class KeyVaultBackupClient(KeyVaultClientBase):
         :keyword str key_name: Name of a single key in the backup. When set, only this key will be restored.
         :keyword str continuation_token: A continuation token to restart polling from a saved state.
 
-        :returns: An :class:`~azure.core.polling.LROPoller` instance. Call `wait()` or `result()` on this object to wait
+        :returns: An azure.core.polling.LROPoller instance. Call `wait()` or `result()` on this object to wait
             for the operation to complete (the return value is None in either case).
         :rtype: ~azure.core.polling.LROPoller
 

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_backup_client.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_backup_client.py
@@ -5,20 +5,17 @@
 import base64
 import functools
 import pickle
-from typing import Any, Optional, overload, TYPE_CHECKING
+from typing import Any, Optional, overload
 from urllib.parse import urlparse
 
 from typing_extensions import Literal
 
+from azure.core.polling import LROPoller
 from azure.core.tracing.decorator import distributed_trace
 
 from ._models import KeyVaultBackupResult
 from ._internal import KeyVaultClientBase, parse_folder_url
 from ._internal.polling import KeyVaultBackupClientPolling, KeyVaultBackupClientPollingMethod
-
-if TYPE_CHECKING:
-    # pylint:disable=unused-import
-    from azure.core.polling import LROPoller
 
 
 def _parse_status_url(url):
@@ -51,7 +48,7 @@ class KeyVaultBackupClient(KeyVaultClientBase):
         use_managed_identity: Literal[True],
         continuation_token: Optional[str] = None,
         **kwargs: Any,
-    ) -> "LROPoller[KeyVaultBackupResult]":
+    ) -> LROPoller[KeyVaultBackupResult]:
         ...
 
     @overload
@@ -62,11 +59,11 @@ class KeyVaultBackupClient(KeyVaultClientBase):
         sas_token: str,
         continuation_token: Optional[str] = None,
         **kwargs: Any,
-    ) -> "LROPoller[KeyVaultBackupResult]":
+    ) -> LROPoller[KeyVaultBackupResult]:
         ...
 
     @distributed_trace
-    def begin_backup(self, blob_storage_url: str, *args: str, **kwargs: Any) -> "LROPoller[KeyVaultBackupResult]":
+    def begin_backup(self, blob_storage_url: str, *args: str, **kwargs: Any) -> LROPoller[KeyVaultBackupResult]:
         """Begin a full backup of the Key Vault.
 
         :param str blob_storage_url: URL of the blob storage container in which the backup will be stored, for example
@@ -80,7 +77,7 @@ class KeyVaultBackupClient(KeyVaultClientBase):
         :paramtype use_managed_identity: Literal[True]
         :keyword str continuation_token: A continuation token to restart polling from a saved state.
 
-        :returns: An azure.core.polling.LROPoller instance. Call `result()` on this object to wait for the
+        :returns: An :class:`~azure.core.polling.LROPoller` instance. Call `result()` on this object to wait for the
             operation to complete and get a :class:`KeyVaultBackupResult`.
         :rtype: ~azure.core.polling.LROPoller[~azure.keyvault.administration.KeyVaultBackupResult]
 
@@ -142,7 +139,7 @@ class KeyVaultBackupClient(KeyVaultClientBase):
         key_name: Optional[str] = None,
         continuation_token: Optional[str] = None,
         **kwargs: Any,
-    ) -> "LROPoller":
+    ) -> LROPoller:
         ...
 
     @overload
@@ -154,11 +151,11 @@ class KeyVaultBackupClient(KeyVaultClientBase):
         key_name: Optional[str] = None,
         continuation_token: Optional[str] = None,
         **kwargs: Any,
-    ) -> "LROPoller":
+    ) -> LROPoller:
         ...
 
     @distributed_trace
-    def begin_restore(self, folder_url: str, *args: str, **kwargs: Any) -> "LROPoller":
+    def begin_restore(self, folder_url: str, *args: str, **kwargs: Any) -> LROPoller:
         """Restore a Key Vault backup.
 
         This method restores either a complete Key Vault backup or when ``key_name`` has a value, a single key.
@@ -176,7 +173,7 @@ class KeyVaultBackupClient(KeyVaultClientBase):
         :keyword str key_name: Name of a single key in the backup. When set, only this key will be restored.
         :keyword str continuation_token: A continuation token to restart polling from a saved state.
 
-        :returns: An azure.core.polling.LROPoller instance. Call `wait()` or `result()` on this object to wait
+        :returns: An :class:`~azure.core.polling.LROPoller` instance. Call `wait()` or `result()` on this object to wait
             for the operation to complete (the return value is None in either case).
         :rtype: ~azure.core.polling.LROPoller
 

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/async_challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/async_challenge_auth_policy.py
@@ -35,7 +35,7 @@ class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
 
     :param credential: An object which can provide an access token for the vault, such as a credential from
         :mod:`azure.identity.aio`
-    :type credential: :class:`~azure.core.credentials_async.AsyncTokenCredential`
+    :type credential: ~azure.core.credentials_async.AsyncTokenCredential
     """
 
     def __init__(self, credential: "AsyncTokenCredential", *scopes: str, **kwargs) -> None:

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/async_challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/async_challenge_auth_policy.py
@@ -15,19 +15,16 @@ protocol again.
 """
 
 import time
-from typing import TYPE_CHECKING
+from typing import Any, Optional
 from urllib.parse import urlparse
 
+from azure.core.credentials import AccessToken
+from azure.core.credentials_async import AsyncTokenCredential
+from azure.core.pipeline import PipelineRequest, PipelineResponse
 from azure.core.pipeline.policies import AsyncBearerTokenCredentialPolicy
 
 from . import http_challenge_cache as ChallengeCache
 from .challenge_auth_policy import _enforce_tls, _update_challenge
-
-if TYPE_CHECKING:
-    from typing import Optional
-    from azure.core.credentials import AccessToken
-    from azure.core.credentials_async import AsyncTokenCredential
-    from azure.core.pipeline import PipelineRequest, PipelineResponse
 
 
 class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
@@ -38,13 +35,13 @@ class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
     :type credential: ~azure.core.credentials_async.AsyncTokenCredential
     """
 
-    def __init__(self, credential: "AsyncTokenCredential", *scopes: str, **kwargs) -> None:
+    def __init__(self, credential: AsyncTokenCredential, *scopes: str, **kwargs: Any) -> None:
         super().__init__(credential, *scopes, **kwargs)
         self._credential = credential
-        self._token: "Optional[AccessToken]" = None
+        self._token: Optional[AccessToken] = None
         self._verify_challenge_resource = kwargs.pop("verify_challenge_resource", True)
 
-    async def on_request(self, request: "PipelineRequest") -> None:
+    async def on_request(self, request: PipelineRequest) -> None:
         _enforce_tls(request)
         challenge = ChallengeCache.get_challenge_for_url(request.http_request.url)
         if challenge:
@@ -68,7 +65,7 @@ class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
             request.http_request.headers["Content-Length"] = "0"
 
 
-    async def on_challenge(self, request: "PipelineRequest", response: "PipelineResponse") -> bool:
+    async def on_challenge(self, request: PipelineRequest, response: PipelineResponse) -> bool:
         try:
             challenge = _update_challenge(request, response)
             # azure-identity credentials require an AADv2 scope but the challenge may specify an AADv1 resource

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/async_client_base.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/async_client_base.py
@@ -2,9 +2,11 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
-from typing import TYPE_CHECKING
+from typing import Any, Awaitable
 
+from azure.core.credentials_async import AsyncTokenCredential
 from azure.core.pipeline.policies import HttpLoggingPolicy
+from azure.core.rest import AsyncHttpResponse, HttpRequest
 from azure.core.tracing.decorator_async import distributed_trace_async
 
 from . import AsyncChallengeAuthPolicy
@@ -13,16 +15,10 @@ from .._sdk_moniker import SDK_MONIKER
 from .._generated.aio import KeyVaultClient as _KeyVaultClient
 from .._generated import models as _models
 
-if TYPE_CHECKING:
-    # pylint:disable=unused-import
-    from typing import Any, Awaitable
-    from azure.core.credentials_async import AsyncTokenCredential
-    from azure.core.rest import AsyncHttpResponse, HttpRequest
-
 
 class AsyncKeyVaultClientBase(object):
     # pylint:disable=protected-access
-    def __init__(self, vault_url: str, credential: "AsyncTokenCredential", **kwargs) -> None:
+    def __init__(self, vault_url: str, credential: AsyncTokenCredential, **kwargs: Any) -> None:
         if not credential:
             raise ValueError(
                 "credential should be an object supporting the AsyncTokenCredential protocol, "
@@ -88,7 +84,9 @@ class AsyncKeyVaultClientBase(object):
         await self._client.close()
 
     @distributed_trace_async
-    def send_request(self, request: "HttpRequest", *, stream: bool = False, **kwargs) -> "Awaitable[AsyncHttpResponse]":
+    def send_request(
+        self, request: HttpRequest, *, stream: bool = False, **kwargs: Any
+    ) -> Awaitable[AsyncHttpResponse]:
         """Runs a network request using the client's existing pipeline.
 
         The request URL can be relative to the vault URL. The service API version used for the request is the same as

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/challenge_auth_policy.py
@@ -42,9 +42,9 @@ def _update_challenge(request: PipelineRequest, challenger: "PipelineResponse") 
     """Parse challenge from a challenge response, cache it, and return it.
 
     :param request: The pipeline request that prompted the challenge response.
-    :type request: :class:`~azure.core.pipeline.PipelineRequest`
+    :type request: ~azure.core.pipeline.PipelineRequest
     :param challenger: The pipeline response containing the authentication challenge.
-    :type challenger: :class:`~azure.core.pipeline.PipelineResponse`
+    :type challenger: ~azure.core.pipeline.PipelineResponse
 
     :returns: An HttpChallenge object representing the authentication challenge.
     :rtype: HttpChallenge
@@ -64,7 +64,7 @@ class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
 
     :param credential: An object which can provide an access token for the vault, such as a credential from
         :mod:`azure.identity`
-    :type credential: :class:`~azure.core.credentials.TokenCredential`
+    :type credential: ~azure.core.credentials.TokenCredential
     """
 
     def __init__(self, credential: "TokenCredential", *scopes: str, **kwargs) -> None:

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/challenge_auth_policy.py
@@ -15,20 +15,16 @@ protocol again.
 """
 
 import time
-from typing import TYPE_CHECKING
+from typing import Any, Optional
 from urllib.parse import urlparse
 
+from azure.core.credentials import AccessToken, TokenCredential
 from azure.core.exceptions import ServiceRequestError
-from azure.core.pipeline import PipelineRequest
+from azure.core.pipeline import PipelineRequest, PipelineResponse
 from azure.core.pipeline.policies import BearerTokenCredentialPolicy
 
 from .http_challenge import HttpChallenge
 from . import http_challenge_cache as ChallengeCache
-
-if TYPE_CHECKING:
-    from typing import Optional
-    from azure.core.credentials import AccessToken, TokenCredential
-    from azure.core.pipeline import PipelineResponse
 
 
 def _enforce_tls(request: PipelineRequest) -> None:
@@ -38,7 +34,7 @@ def _enforce_tls(request: PipelineRequest) -> None:
         )
 
 
-def _update_challenge(request: PipelineRequest, challenger: "PipelineResponse") -> HttpChallenge:
+def _update_challenge(request: PipelineRequest, challenger: PipelineResponse) -> HttpChallenge:
     """Parse challenge from a challenge response, cache it, and return it.
 
     :param request: The pipeline request that prompted the challenge response.
@@ -67,7 +63,7 @@ class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
     :type credential: ~azure.core.credentials.TokenCredential
     """
 
-    def __init__(self, credential: "TokenCredential", *scopes: str, **kwargs) -> None:
+    def __init__(self, credential: TokenCredential, *scopes: str, **kwargs: Any) -> None:
         super(ChallengeAuthPolicy, self).__init__(credential, *scopes, **kwargs)
         self._credential = credential
         self._token: "Optional[AccessToken]" = None
@@ -96,7 +92,7 @@ class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
             request.http_request.set_json_body(None)
             request.http_request.headers["Content-Length"] = "0"
 
-    def on_challenge(self, request: PipelineRequest, response: "PipelineResponse") -> bool:
+    def on_challenge(self, request: PipelineRequest, response: PipelineResponse) -> bool:
         try:
             challenge = _update_challenge(request, response)
             # azure-identity credentials require an AADv2 scope but the challenge may specify an AADv1 resource

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/client_base.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/client_base.py
@@ -3,12 +3,14 @@
 # Licensed under the MIT License.
 # ------------------------------------
 from copy import deepcopy
-from typing import TYPE_CHECKING
 from enum import Enum
+from typing import Any
 from urllib.parse import urlparse
 
 from azure.core import CaseInsensitiveEnumMeta
+from azure.core.credentials import TokenCredential
 from azure.core.pipeline.policies import HttpLoggingPolicy
+from azure.core.rest import HttpRequest, HttpResponse
 from azure.core.tracing.decorator import distributed_trace
 
 from . import ChallengeAuthPolicy
@@ -16,12 +18,6 @@ from .._generated import KeyVaultClient as _KeyVaultClient
 from .._generated import models as _models
 from .._generated._serialization import Serializer
 from .._sdk_moniker import SDK_MONIKER
-
-if TYPE_CHECKING:
-    # pylint:disable=unused-import,ungrouped-imports
-    from typing import Any
-    from azure.core.credentials import TokenCredential
-    from azure.core.rest import HttpRequest, HttpResponse
 
 
 class ApiVersion(str, Enum, metaclass=CaseInsensitiveEnumMeta):
@@ -40,7 +36,7 @@ _SERIALIZER = Serializer()
 _SERIALIZER.client_side_validation = False
 
 
-def _format_api_version(request: "HttpRequest", api_version: str) -> "HttpRequest":
+def _format_api_version(request: HttpRequest, api_version: str) -> HttpRequest:
     """Returns a request copy that includes an api-version query parameter if one wasn't originally present.
 
     :param request: The HTTP request being sent.
@@ -70,7 +66,7 @@ def _format_api_version(request: "HttpRequest", api_version: str) -> "HttpReques
 
 class KeyVaultClientBase(object):
     # pylint:disable=protected-access
-    def __init__(self, vault_url: str, credential: "TokenCredential", **kwargs) -> None:
+    def __init__(self, vault_url: str, credential: TokenCredential, **kwargs: Any) -> None:
         if not credential:
             raise ValueError(
                 "credential should be an object supporting the TokenCredential protocol, "
@@ -132,7 +128,7 @@ class KeyVaultClientBase(object):
         self._client.close()
 
     @distributed_trace
-    def send_request(self, request: "HttpRequest", *, stream: bool = False, **kwargs) -> "HttpResponse":
+    def send_request(self, request: HttpRequest, *, stream: bool = False, **kwargs: Any) -> HttpResponse:
         """Runs a network request using the client's existing pipeline.
 
         The request URL can be relative to the vault URL. The service API version used for the request is the same as

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/client_base.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/client_base.py
@@ -44,11 +44,11 @@ def _format_api_version(request: "HttpRequest", api_version: str) -> "HttpReques
     """Returns a request copy that includes an api-version query parameter if one wasn't originally present.
 
     :param request: The HTTP request being sent.
-    :type request: :class:`~azure.core.rest.HttpRequest`
+    :type request: ~azure.core.rest.HttpRequest
     :param str api_version: The service API version that the request should include.
 
     :returns: A copy of the request that includes an api-version query parameter.
-    :rtype: :class:`~azure.core.rest.HttpRequest`
+    :rtype: ~azure.core.rest.HttpRequest
     """
     request_copy = deepcopy(request)
     params = {"api-version": api_version}  # By default, we want to use the client's API version

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_models.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_models.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
-from typing import Dict, Optional, Union
+from typing import Any, Dict, Optional, Union
 
 from azure.core.rest import HttpResponse
 
@@ -29,7 +29,7 @@ class KeyVaultPermission(object):
      other role definitions assigned to a principal.
     """
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, **kwargs: Any) -> None:
         self.actions = kwargs.get("actions")
         self.not_actions = kwargs.get("not_actions")
         self.data_actions = kwargs.get("data_actions")
@@ -54,7 +54,7 @@ class KeyVaultRoleAssignment(object):
     :ivar str type: type of the assignment
     """
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, **kwargs: Any) -> None:
         self.name = kwargs.get("name")
         self.properties = kwargs.get("properties")
         self.role_assignment_id = kwargs.get("role_assignment_id")
@@ -85,7 +85,7 @@ class KeyVaultRoleAssignmentProperties(object):
     :ivar str scope: the scope of the assignment
     """
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, **kwargs: Any) -> None:
         self.principal_id = kwargs.get("principal_id")
         self.role_definition_id = kwargs.get("role_definition_id")
         self.scope = kwargs.get("scope")
@@ -123,7 +123,7 @@ class KeyVaultRoleDefinition(object):
     :ivar str type: type of the role definition
     """
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, **kwargs: Any) -> None:
         self.assignable_scopes = kwargs.get("assignable_scopes")
         self.description = kwargs.get("description")
         self.id = kwargs.get("id")
@@ -159,7 +159,7 @@ class KeyVaultBackupResult(object):
 
     # pylint:disable=unused-argument
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, **kwargs: Any) -> None:
         self.folder_url: Optional[str] = kwargs.get("folder_url")
 
     @classmethod
@@ -207,7 +207,7 @@ class KeyVaultSetting(object):
         :returns: The account setting value as a boolean.
         :rtype: bool
 
-        :raises: ValueError if the ``setting_type`` is not boolean or the value cannot be represented as a boolean.
+        :raises ValueError: if the ``setting_type`` is not boolean or the value cannot be represented as a boolean.
         """
         if self.setting_type == KeyVaultSettingType.BOOLEAN:
             if self.value == "true":

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_settings_client.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_settings_client.py
@@ -33,7 +33,7 @@ class KeyVaultSettingsClient(KeyVaultClientBase):
 
         :param str name: The name of the account setting.
 
-        :returns: The account setting, as a azure.keyvault.administration.KeyVaultSetting.
+        :returns: The account setting, as a :class:`~azure.keyvault.administration.KeyVaultSetting`.
         :rtype: ~azure.keyvault.administration.KeyVaultSetting
         :raises: azure.core.exceptions.HttpResponseError
         """
@@ -68,7 +68,7 @@ class KeyVaultSettingsClient(KeyVaultClientBase):
             the provided name will be updated to have the provided value.
         :type setting: ~azure.keyvault.administration.KeyVaultSetting
 
-        :returns: The updated account setting, as a azure.keyvault.administration.KeyVaultSetting.
+        :returns: The updated account setting, as a :class:`~azure.keyvault.administration.KeyVaultSetting`.
         :rtype: ~azure.keyvault.administration.KeyVaultSetting
         :raises: azure.core.exceptions.HttpResponseError
         """

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_settings_client.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_settings_client.py
@@ -2,6 +2,8 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
+from typing import Any
+
 from azure.core.paging import ItemPaged
 from azure.core.tracing.decorator import distributed_trace
 
@@ -28,25 +30,25 @@ class KeyVaultSettingsClient(KeyVaultClientBase):
     # pylint:disable=protected-access
 
     @distributed_trace
-    def get_setting(self, name: str, **kwargs) -> KeyVaultSetting:
+    def get_setting(self, name: str, **kwargs: Any) -> KeyVaultSetting:
         """Gets the setting with the specified name.
 
         :param str name: The name of the account setting.
 
         :returns: The account setting, as a :class:`~azure.keyvault.administration.KeyVaultSetting`.
         :rtype: ~azure.keyvault.administration.KeyVaultSetting
-        :raises: azure.core.exceptions.HttpResponseError
+        :raises ~azure.core.exceptions.HttpResponseError:
         """
         result = self._client.get_setting(vault_base_url=self._vault_url, setting_name=name, **kwargs)
         return KeyVaultSetting._from_generated(result)
 
     @distributed_trace
-    def list_settings(self, **kwargs) -> ItemPaged[KeyVaultSetting]:
+    def list_settings(self, **kwargs: Any) -> ItemPaged[KeyVaultSetting]:
         """Lists all account settings.
 
         :returns: A paged object containing the account's settings.
         :rtype: ~azure.core.paging.ItemPaged[~azure.keyvault.administration.KeyVaultSetting]
-        :raises: azure.core.exceptions.HttpResponseError
+        :raises ~azure.core.exceptions.HttpResponseError:
         """
         result = self._client.get_settings(vault_base_url=self._vault_url, *kwargs)
         converted_result = [KeyVaultSetting._from_generated(setting) for setting in result.settings]
@@ -61,7 +63,7 @@ class KeyVaultSettingsClient(KeyVaultClientBase):
         return ItemPaged(get_next, extract_data)
 
     @distributed_trace
-    def update_setting(self, setting: KeyVaultSetting, **kwargs) -> KeyVaultSetting:
+    def update_setting(self, setting: KeyVaultSetting, **kwargs: Any) -> KeyVaultSetting:
         """Updates the named account setting with the provided value.
 
         :param setting: A azure.keyvault.administration.KeyVaultSetting to update. The account setting with
@@ -70,7 +72,7 @@ class KeyVaultSettingsClient(KeyVaultClientBase):
 
         :returns: The updated account setting, as a :class:`~azure.keyvault.administration.KeyVaultSetting`.
         :rtype: ~azure.keyvault.administration.KeyVaultSetting
-        :raises: azure.core.exceptions.HttpResponseError
+        :raises ~azure.core.exceptions.HttpResponseError:
         """
         parameters = UpdateSettingRequest(value=setting.value)
         result = self._client.update_setting(

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_settings_client.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_settings_client.py
@@ -18,7 +18,7 @@ class KeyVaultSettingsClient(KeyVaultClientBase):
         See https://aka.ms/azsdk/blog/vault-uri for details.
     :param credential: An object which can provide an access token for the vault, such as a credential from
         :mod:`azure.identity`
-    :type credential: :class:`~azure.core.credentials.TokenCredential`
+    :type credential: ~azure.core.credentials.TokenCredential
 
     :keyword api_version: Version of the service API to use. Defaults to the most recent.
     :paramtype api_version: ~azure.keyvault.administration.ApiVersion or str
@@ -33,9 +33,9 @@ class KeyVaultSettingsClient(KeyVaultClientBase):
 
         :param str name: The name of the account setting.
 
-        :returns: The account setting, as a :class:`~azure.keyvault.administration.KeyVaultSetting`.
+        :returns: The account setting, as a azure.keyvault.administration.KeyVaultSetting.
         :rtype: ~azure.keyvault.administration.KeyVaultSetting
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises: azure.core.exceptions.HttpResponseError
         """
         result = self._client.get_setting(vault_base_url=self._vault_url, setting_name=name, **kwargs)
         return KeyVaultSetting._from_generated(result)
@@ -46,7 +46,7 @@ class KeyVaultSettingsClient(KeyVaultClientBase):
 
         :returns: A paged object containing the account's settings.
         :rtype: ~azure.core.paging.ItemPaged[~azure.keyvault.administration.KeyVaultSetting]
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises: azure.core.exceptions.HttpResponseError
         """
         result = self._client.get_settings(vault_base_url=self._vault_url, *kwargs)
         converted_result = [KeyVaultSetting._from_generated(setting) for setting in result.settings]
@@ -64,13 +64,13 @@ class KeyVaultSettingsClient(KeyVaultClientBase):
     def update_setting(self, setting: KeyVaultSetting, **kwargs) -> KeyVaultSetting:
         """Updates the named account setting with the provided value.
 
-        :param setting: A :class:`~azure.keyvault.administration.KeyVaultSetting` to update. The account setting with
+        :param setting: A azure.keyvault.administration.KeyVaultSetting to update. The account setting with
             the provided name will be updated to have the provided value.
         :type setting: ~azure.keyvault.administration.KeyVaultSetting
 
-        :returns: The updated account setting, as a :class:`~azure.keyvault.administration.KeyVaultSetting`.
+        :returns: The updated account setting, as a azure.keyvault.administration.KeyVaultSetting.
         :rtype: ~azure.keyvault.administration.KeyVaultSetting
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises: azure.core.exceptions.HttpResponseError
         """
         parameters = UpdateSettingRequest(value=setting.value)
         result = self._client.update_setting(

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/aio/_access_control_client.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/aio/_access_control_client.py
@@ -2,22 +2,17 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
-from typing import TYPE_CHECKING
-from uuid import uuid4
+from typing import Any, Union
+from uuid import UUID, uuid4
 
+from azure.core.async_paging import AsyncItemPaged
 from azure.core.exceptions import ResourceNotFoundError
 from azure.core.tracing.decorator import distributed_trace
 from azure.core.tracing.decorator_async import distributed_trace_async
 
+from .._enums import KeyVaultRoleScope
 from .._models import KeyVaultRoleAssignment, KeyVaultRoleDefinition
 from .._internal import AsyncKeyVaultClientBase
-
-if TYPE_CHECKING:
-    # pylint:disable=ungrouped-imports
-    from typing import Union
-    from uuid import UUID
-    from azure.core.async_paging import AsyncItemPaged
-    from .._enums import KeyVaultRoleScope
 
 
 class KeyVaultAccessControlClient(AsyncKeyVaultClientBase):
@@ -40,7 +35,7 @@ class KeyVaultAccessControlClient(AsyncKeyVaultClientBase):
 
     @distributed_trace_async
     async def create_role_assignment(
-        self, scope: "Union[str, KeyVaultRoleScope]", definition_id: str, principal_id: str, **kwargs
+        self, scope: Union[str, KeyVaultRoleScope], definition_id: str, principal_id: str, **kwargs: Any
     ) -> KeyVaultRoleAssignment:
         """Create a role assignment.
 
@@ -75,7 +70,7 @@ class KeyVaultAccessControlClient(AsyncKeyVaultClientBase):
 
     @distributed_trace_async
     async def delete_role_assignment(
-        self, scope: "Union[str, KeyVaultRoleScope]", name: "Union[str, UUID]", **kwargs
+        self, scope: Union[str, KeyVaultRoleScope], name: Union[str, UUID], **kwargs
     ) -> None:
         """Delete a role assignment.
 
@@ -97,7 +92,7 @@ class KeyVaultAccessControlClient(AsyncKeyVaultClientBase):
 
     @distributed_trace_async
     async def get_role_assignment(
-        self, scope: "Union[str, KeyVaultRoleScope]", name: "Union[str, UUID]", **kwargs
+        self, scope: Union[str, KeyVaultRoleScope], name: Union[str, UUID], **kwargs
     ) -> KeyVaultRoleAssignment:
         """Get a role assignment.
 
@@ -117,8 +112,8 @@ class KeyVaultAccessControlClient(AsyncKeyVaultClientBase):
 
     @distributed_trace
     def list_role_assignments(
-        self, scope: "Union[str, KeyVaultRoleScope]", **kwargs
-    ) -> "AsyncItemPaged[KeyVaultRoleAssignment]":
+        self, scope: Union[str, KeyVaultRoleScope], **kwargs
+    ) -> AsyncItemPaged[KeyVaultRoleAssignment]:
         """List all role assignments for a scope.
 
         :param scope: scope of the role assignments. :class:`KeyVaultRoleScope` defines common broad
@@ -137,8 +132,8 @@ class KeyVaultAccessControlClient(AsyncKeyVaultClientBase):
 
     @distributed_trace_async
     async def set_role_definition(
-        self, scope: "Union[str, KeyVaultRoleScope]", **kwargs
-    ) -> "KeyVaultRoleDefinition":
+        self, scope: Union[str, KeyVaultRoleScope], **kwargs
+    ) -> KeyVaultRoleDefinition:
         """Creates or updates a custom role definition.
 
         To update a role definition, specify the definition's ``name``.
@@ -195,8 +190,8 @@ class KeyVaultAccessControlClient(AsyncKeyVaultClientBase):
 
     @distributed_trace_async
     async def get_role_definition(
-        self, scope: "Union[str, KeyVaultRoleScope]", name: "Union[str, UUID]", **kwargs
-    ) -> "KeyVaultRoleDefinition":
+        self, scope: Union[str, KeyVaultRoleScope], name: Union[str, UUID], **kwargs
+    ) -> KeyVaultRoleDefinition:
         """Get the specified role definition.
 
         :param scope: scope of the role definition. :class:`KeyVaultRoleScope` defines common broad scopes.
@@ -215,7 +210,7 @@ class KeyVaultAccessControlClient(AsyncKeyVaultClientBase):
 
     @distributed_trace_async
     async def delete_role_definition(
-        self, scope: "Union[str, KeyVaultRoleScope]", name: "Union[str, UUID]", **kwargs
+        self, scope: Union[str, KeyVaultRoleScope], name: Union[str, UUID], **kwargs
     ) -> None:
         """Deletes a custom role definition.
 
@@ -237,8 +232,8 @@ class KeyVaultAccessControlClient(AsyncKeyVaultClientBase):
 
     @distributed_trace
     def list_role_definitions(
-        self, scope: "Union[str, KeyVaultRoleScope]", **kwargs
-    ) -> "AsyncItemPaged[KeyVaultRoleDefinition]":
+        self, scope: Union[str, KeyVaultRoleScope], **kwargs
+    ) -> AsyncItemPaged[KeyVaultRoleDefinition]:
         """List all role definitions applicable at and above a scope.
 
         :param scope: scope of the role definitions. :class:`KeyVaultRoleScope` defines common broad

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/aio/_access_control_client.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/aio/_access_control_client.py
@@ -28,7 +28,7 @@ class KeyVaultAccessControlClient(AsyncKeyVaultClientBase):
         See https://aka.ms/azsdk/blog/vault-uri for details.
     :param credential: An object which can provide an access token for the vault, such as a credential from
         :mod:`azure.identity.aio`
-    :type credential: :class:`~azure.core.credentials_async.AsyncTokenCredential`
+    :type credential: ~azure.core.credentials_async.AsyncTokenCredential
 
     :keyword api_version: Version of the service API to use. Defaults to the most recent.
     :paramtype api_version: ~azure.keyvault.administration.ApiVersion or str

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/aio/_access_control_client.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/aio/_access_control_client.py
@@ -70,7 +70,7 @@ class KeyVaultAccessControlClient(AsyncKeyVaultClientBase):
 
     @distributed_trace_async
     async def delete_role_assignment(
-        self, scope: Union[str, KeyVaultRoleScope], name: Union[str, UUID], **kwargs
+        self, scope: Union[str, KeyVaultRoleScope], name: Union[str, UUID], **kwargs: Any
     ) -> None:
         """Delete a role assignment.
 
@@ -92,7 +92,7 @@ class KeyVaultAccessControlClient(AsyncKeyVaultClientBase):
 
     @distributed_trace_async
     async def get_role_assignment(
-        self, scope: Union[str, KeyVaultRoleScope], name: Union[str, UUID], **kwargs
+        self, scope: Union[str, KeyVaultRoleScope], name: Union[str, UUID], **kwargs: Any
     ) -> KeyVaultRoleAssignment:
         """Get a role assignment.
 
@@ -112,7 +112,7 @@ class KeyVaultAccessControlClient(AsyncKeyVaultClientBase):
 
     @distributed_trace
     def list_role_assignments(
-        self, scope: Union[str, KeyVaultRoleScope], **kwargs
+        self, scope: Union[str, KeyVaultRoleScope], **kwargs: Any
     ) -> AsyncItemPaged[KeyVaultRoleAssignment]:
         """List all role assignments for a scope.
 
@@ -132,7 +132,7 @@ class KeyVaultAccessControlClient(AsyncKeyVaultClientBase):
 
     @distributed_trace_async
     async def set_role_definition(
-        self, scope: Union[str, KeyVaultRoleScope], **kwargs
+        self, scope: Union[str, KeyVaultRoleScope], **kwargs: Any
     ) -> KeyVaultRoleDefinition:
         """Creates or updates a custom role definition.
 
@@ -190,7 +190,7 @@ class KeyVaultAccessControlClient(AsyncKeyVaultClientBase):
 
     @distributed_trace_async
     async def get_role_definition(
-        self, scope: Union[str, KeyVaultRoleScope], name: Union[str, UUID], **kwargs
+        self, scope: Union[str, KeyVaultRoleScope], name: Union[str, UUID], **kwargs: Any
     ) -> KeyVaultRoleDefinition:
         """Get the specified role definition.
 
@@ -210,7 +210,7 @@ class KeyVaultAccessControlClient(AsyncKeyVaultClientBase):
 
     @distributed_trace_async
     async def delete_role_definition(
-        self, scope: Union[str, KeyVaultRoleScope], name: Union[str, UUID], **kwargs
+        self, scope: Union[str, KeyVaultRoleScope], name: Union[str, UUID], **kwargs: Any
     ) -> None:
         """Deletes a custom role definition.
 
@@ -232,7 +232,7 @@ class KeyVaultAccessControlClient(AsyncKeyVaultClientBase):
 
     @distributed_trace
     def list_role_definitions(
-        self, scope: Union[str, KeyVaultRoleScope], **kwargs
+        self, scope: Union[str, KeyVaultRoleScope], **kwargs: Any
     ) -> AsyncItemPaged[KeyVaultRoleDefinition]:
         """List all role definitions applicable at and above a scope.
 

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/aio/_backup_client.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/aio/_backup_client.py
@@ -5,10 +5,11 @@
 import base64
 import functools
 import pickle
-from typing import Any, Optional, overload, TYPE_CHECKING
+from typing import Any, Optional, overload
 
 from typing_extensions import Literal
 
+from azure.core.polling import AsyncLROPoller
 from azure.core.tracing.decorator_async import distributed_trace_async
 
 from .._backup_client import _parse_status_url
@@ -16,10 +17,6 @@ from .._internal import AsyncKeyVaultClientBase, parse_folder_url
 from .._internal.async_polling import KeyVaultAsyncBackupClientPollingMethod
 from .._internal.polling import KeyVaultBackupClientPolling
 from .._models import KeyVaultBackupResult
-
-if TYPE_CHECKING:
-    # pylint:disable=unused-import
-    from azure.core.polling import AsyncLROPoller
 
 
 class KeyVaultBackupClient(AsyncKeyVaultClientBase):
@@ -45,8 +42,8 @@ class KeyVaultBackupClient(AsyncKeyVaultClientBase):
         *,
         use_managed_identity: Literal[True],
         continuation_token: Optional[str] = None,
-        **kwargs,
-    ) -> "AsyncLROPoller[KeyVaultBackupResult]":
+        **kwargs: Any,
+    ) -> AsyncLROPoller[KeyVaultBackupResult]:
         ...
 
     @overload
@@ -57,13 +54,13 @@ class KeyVaultBackupClient(AsyncKeyVaultClientBase):
         sas_token: str,
         continuation_token: Optional[str] = None,
         **kwargs: Any,
-    ) -> "AsyncLROPoller[KeyVaultBackupResult]":
+    ) -> AsyncLROPoller[KeyVaultBackupResult]:
         ...
 
     @distributed_trace_async
     async def begin_backup(
         self, blob_storage_url: str, *args: str, **kwargs: Any
-    ) -> "AsyncLROPoller[KeyVaultBackupResult]":
+    ) -> AsyncLROPoller[KeyVaultBackupResult]:
         """Begin a full backup of the Key Vault.
 
         :param str blob_storage_url: URL of the blob storage container in which the backup will be stored, for example
@@ -138,7 +135,7 @@ class KeyVaultBackupClient(AsyncKeyVaultClientBase):
         key_name: Optional[str] = None,
         continuation_token: Optional[str] = None,
         **kwargs: Any,
-    ) -> "AsyncLROPoller":
+    ) -> AsyncLROPoller[None]:
         ...
 
     @overload
@@ -150,11 +147,11 @@ class KeyVaultBackupClient(AsyncKeyVaultClientBase):
         key_name: Optional[str] = None,
         continuation_token: Optional[str] = None,
         **kwargs: Any,
-    ) -> "AsyncLROPoller":
+    ) -> AsyncLROPoller[None]:
         ...
 
     @distributed_trace_async
-    async def begin_restore(self, folder_url: str, *args: str, **kwargs: Any) -> "AsyncLROPoller":
+    async def begin_restore(self, folder_url: str, *args: str, **kwargs: Any) -> AsyncLROPoller[None]:
         """Restore a Key Vault backup.
 
         This method restores either a complete Key Vault backup or when ``key_name`` has a value, a single key.

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/aio/_backup_client.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/aio/_backup_client.py
@@ -30,7 +30,7 @@ class KeyVaultBackupClient(AsyncKeyVaultClientBase):
         See https://aka.ms/azsdk/blog/vault-uri for details.
     :param credential: An object which can provide an access token for the vault, such as a credential from
         :mod:`azure.identity.aio`
-    :type credential: :class:`~azure.core.credentials_async.AsyncTokenCredential`
+    :type credential: ~azure.core.credentials_async.AsyncTokenCredential
 
     :keyword api_version: Version of the service API to use. Defaults to the most recent.
     :paramtype api_version: ~azure.keyvault.administration.ApiVersion or str

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/aio/_settings_client.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/aio/_settings_client.py
@@ -34,7 +34,7 @@ class KeyVaultSettingsClient(AsyncKeyVaultClientBase):
 
         :param str name: The name of the account setting.
 
-        :returns: The account setting, as a azure.keyvault.administration.KeyVaultSetting.
+        :returns: The account setting, as a :class:`~azure.keyvault.administration.KeyVaultSetting`.
         :rtype: ~azure.keyvault.administration.KeyVaultSetting
         :raises: azure.core.exceptions.HttpResponseError
         """
@@ -45,7 +45,7 @@ class KeyVaultSettingsClient(AsyncKeyVaultClientBase):
     def list_settings(self, **kwargs) -> AsyncItemPaged[KeyVaultSetting]:
         """Lists all account settings.
 
-        :returns: A azure.keyvault.administration.GetSettingsResult object containing the account's settings.
+        :returns: A paged object containing the account's settings.
         :rtype: ~azure.core.async_paging.AsyncItemPaged[~azure.keyvault.administration.KeyVaultSetting]
         :raises: azure.core.exceptions.HttpResponseError
         """
@@ -71,7 +71,7 @@ class KeyVaultSettingsClient(AsyncKeyVaultClientBase):
             the provided name will be updated to have the provided value.
         :type setting: ~azure.keyvault.administration.KeyVaultSetting
 
-        :returns: The updated account setting, as a azure.keyvault.administration.KeyVaultSetting.
+        :returns: The updated account setting, as a :class:`~azure.keyvault.administration.KeyVaultSetting`.
         :rtype: ~azure.keyvault.administration.KeyVaultSetting
         :raises: azure.core.exceptions.HttpResponseError
         """

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/aio/_settings_client.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/aio/_settings_client.py
@@ -2,6 +2,8 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
+from typing import Any
+
 from azure.core.async_paging import AsyncItemPaged, AsyncList
 from azure.core.tracing.decorator import distributed_trace
 from azure.core.tracing.decorator_async import distributed_trace_async
@@ -29,25 +31,25 @@ class KeyVaultSettingsClient(AsyncKeyVaultClientBase):
     # pylint:disable=protected-access
 
     @distributed_trace_async
-    async def get_setting(self, name: str, **kwargs) -> KeyVaultSetting:
+    async def get_setting(self, name: str, **kwargs: Any) -> KeyVaultSetting:
         """Gets the setting with the specified name.
 
         :param str name: The name of the account setting.
 
         :returns: The account setting, as a :class:`~azure.keyvault.administration.KeyVaultSetting`.
         :rtype: ~azure.keyvault.administration.KeyVaultSetting
-        :raises: azure.core.exceptions.HttpResponseError
+        :raises ~azure.core.exceptions.HttpResponseError:
         """
         result = await self._client.get_setting(vault_base_url=self._vault_url, setting_name=name, **kwargs)
         return KeyVaultSetting._from_generated(result)
 
     @distributed_trace
-    def list_settings(self, **kwargs) -> AsyncItemPaged[KeyVaultSetting]:
+    def list_settings(self, **kwargs: Any) -> AsyncItemPaged[KeyVaultSetting]:
         """Lists all account settings.
 
         :returns: A paged object containing the account's settings.
         :rtype: ~azure.core.async_paging.AsyncItemPaged[~azure.keyvault.administration.KeyVaultSetting]
-        :raises: azure.core.exceptions.HttpResponseError
+        :raises ~azure.core.exceptions.HttpResponseError:
         """
         result = self._client.get_settings(vault_base_url=self._vault_url, *kwargs)
 
@@ -64,7 +66,7 @@ class KeyVaultSettingsClient(AsyncKeyVaultClientBase):
         return AsyncItemPaged(get_next, extract_data)
 
     @distributed_trace_async
-    async def update_setting(self, setting: KeyVaultSetting, **kwargs) -> KeyVaultSetting:
+    async def update_setting(self, setting: KeyVaultSetting, **kwargs: Any) -> KeyVaultSetting:
         """Updates the named account setting with the provided value.
 
         :param setting: A azure.keyvault.administration.KeyVaultSetting to update. The account setting with
@@ -73,7 +75,7 @@ class KeyVaultSettingsClient(AsyncKeyVaultClientBase):
 
         :returns: The updated account setting, as a :class:`~azure.keyvault.administration.KeyVaultSetting`.
         :rtype: ~azure.keyvault.administration.KeyVaultSetting
-        :raises: azure.core.exceptions.HttpResponseError
+        :raises ~azure.core.exceptions.HttpResponseError:
         """
         parameters = UpdateSettingRequest(value=setting.value)
         result = await self._client.update_setting(

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/aio/_settings_client.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/aio/_settings_client.py
@@ -19,7 +19,7 @@ class KeyVaultSettingsClient(AsyncKeyVaultClientBase):
         See https://aka.ms/azsdk/blog/vault-uri for details.
     :param credential: An object which can provide an access token for the vault, such as a credential from
         :mod:`azure.identity.aio`
-    :type credential: :class:`~azure.core.credentials_async.AsyncTokenCredential`
+    :type credential: ~azure.core.credentials_async.AsyncTokenCredential
 
     :keyword api_version: Version of the service API to use. Defaults to the most recent.
     :paramtype api_version: ~azure.keyvault.administration.ApiVersion or str
@@ -34,9 +34,9 @@ class KeyVaultSettingsClient(AsyncKeyVaultClientBase):
 
         :param str name: The name of the account setting.
 
-        :returns: The account setting, as a :class:`~azure.keyvault.administration.KeyVaultSetting`.
+        :returns: The account setting, as a azure.keyvault.administration.KeyVaultSetting.
         :rtype: ~azure.keyvault.administration.KeyVaultSetting
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises: azure.core.exceptions.HttpResponseError
         """
         result = await self._client.get_setting(vault_base_url=self._vault_url, setting_name=name, **kwargs)
         return KeyVaultSetting._from_generated(result)
@@ -45,9 +45,9 @@ class KeyVaultSettingsClient(AsyncKeyVaultClientBase):
     def list_settings(self, **kwargs) -> AsyncItemPaged[KeyVaultSetting]:
         """Lists all account settings.
 
-        :returns: A :class:`~azure.keyvault.administration.GetSettingsResult` object containing the account's settings.
+        :returns: A azure.keyvault.administration.GetSettingsResult object containing the account's settings.
         :rtype: ~azure.core.async_paging.AsyncItemPaged[~azure.keyvault.administration.KeyVaultSetting]
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises: azure.core.exceptions.HttpResponseError
         """
         result = self._client.get_settings(vault_base_url=self._vault_url, *kwargs)
 
@@ -67,13 +67,13 @@ class KeyVaultSettingsClient(AsyncKeyVaultClientBase):
     async def update_setting(self, setting: KeyVaultSetting, **kwargs) -> KeyVaultSetting:
         """Updates the named account setting with the provided value.
 
-        :param setting: A :class:`~azure.keyvault.administration.KeyVaultSetting` to update. The account setting with
+        :param setting: A azure.keyvault.administration.KeyVaultSetting to update. The account setting with
             the provided name will be updated to have the provided value.
         :type setting: ~azure.keyvault.administration.KeyVaultSetting
 
-        :returns: The updated account setting, as a :class:`~azure.keyvault.administration.KeyVaultSetting`.
+        :returns: The updated account setting, as a azure.keyvault.administration.KeyVaultSetting.
         :rtype: ~azure.keyvault.administration.KeyVaultSetting
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises: azure.core.exceptions.HttpResponseError
         """
         parameters = UpdateSettingRequest(value=setting.value)
         result = await self._client.update_setting(

--- a/sdk/keyvault/azure-keyvault-administration/samples/backup_restore_operations.py
+++ b/sdk/keyvault/azure-keyvault-administration/samples/backup_restore_operations.py
@@ -63,6 +63,9 @@ assert backup_result.folder_url
 # To restore a single key from the backed up vault instead, pass the key_name keyword argument.
 print("\n.. Restore the full vault")
 # [START begin_restore]
+SAS_TOKEN = os.environ["SAS_TOKEN"]
+
+# `backup_result` is the KeyVaultBackupResult returned by `begin_backup`
 client.begin_restore(backup_result.folder_url, sas_token=SAS_TOKEN).wait()
-# [END begin_restore]
 print("Vault restored successfully.")
+# [END begin_restore]

--- a/sdk/keyvault/azure-keyvault-administration/samples/backup_restore_operations.py
+++ b/sdk/keyvault/azure-keyvault-administration/samples/backup_restore_operations.py
@@ -52,7 +52,7 @@ print("\n.. Back up the vault")
 CONTAINER_URL = os.environ["CONTAINER_URL"]
 SAS_TOKEN = os.environ["SAS_TOKEN"]
 
-backup_result: KeyVaultBackupResult = client.begin_backup(CONTAINER_URL, SAS_TOKEN).result()
+backup_result: KeyVaultBackupResult = client.begin_backup(CONTAINER_URL, sas_token=SAS_TOKEN).result()
 print(f"Azure Storage Blob URL of the backup: {backup_result.folder_url}")
 # [END begin_backup]
 print("Vault backed up successfully.")
@@ -63,6 +63,6 @@ assert backup_result.folder_url
 # To restore a single key from the backed up vault instead, pass the key_name keyword argument.
 print("\n.. Restore the full vault")
 # [START begin_restore]
-client.begin_restore(backup_result.folder_url, SAS_TOKEN).wait()
+client.begin_restore(backup_result.folder_url, sas_token=SAS_TOKEN).wait()
 # [END begin_restore]
 print("Vault restored successfully.")

--- a/sdk/keyvault/azure-keyvault-administration/samples/backup_restore_operations_async.py
+++ b/sdk/keyvault/azure-keyvault-administration/samples/backup_restore_operations_async.py
@@ -49,7 +49,7 @@ async def run_sample():
     # a KeyVaultBackupResult that contains the URL of the backup after the operation completes. Calling wait() on
     # the poller will wait until the operation is complete.
     print("\n.. Back up the vault")
-    backup_poller = await client.begin_backup(CONTAINER_URL, SAS_TOKEN)
+    backup_poller = await client.begin_backup(CONTAINER_URL, sas_token=SAS_TOKEN)
     backup_result = await backup_poller.result()
     print("Vault backed up successfully.")
     assert backup_result.folder_url
@@ -58,7 +58,7 @@ async def run_sample():
     # return None after the operation completes. Calling wait() on the poller will wait until the operation is
     # complete. To restore a single key from the backed up vault instead, pass the key_name keyword argument.
     print("\n.. Restore the full vault")
-    restore_poller = await client.begin_restore(backup_result.folder_url, SAS_TOKEN)
+    restore_poller = await client.begin_restore(backup_result.folder_url, sas_token=SAS_TOKEN)
     await restore_poller.wait()
     print("Vault restored successfully.")
 

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_client.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_client.py
@@ -37,7 +37,7 @@ class CertificateClient(KeyVaultClientBase):
         for details.
     :param credential: An object which can provide an access token for the vault, such as a credential from
         :mod:`azure.identity`
-    :type credential: :class:`~azure.core.credentials.TokenCredential`
+    :type credential: ~azure.core.credentials.TokenCredential
 
     :keyword api_version: Version of the service API to use. Defaults to the most recent.
     :paramtype api_version: ~azure.keyvault.certificates.ApiVersion or str
@@ -64,7 +64,7 @@ class CertificateClient(KeyVaultClientBase):
         If this is the first version, the certificate resource is created. This operation requires the
         certificates/create permission. Waiting on the returned poller requires the certificates/get permission and
         gives you the certificate if creation is successful, or the CertificateOperation if not -- otherwise, it raises
-        an :class:`~azure.core.exceptions.HttpResponseError`.
+        an azure.core.exceptions.HttpResponseError.
 
         :param str certificate_name: The name of the certificate.
         :param policy: The management policy for the certificate. Either subject or one of the subject alternative
@@ -82,7 +82,7 @@ class CertificateClient(KeyVaultClientBase):
 
         :raises:
             :class:`ValueError` if the certificate policy is invalid,
-            :class:`~azure.core.exceptions.HttpResponseError` for other errors.
+            azure.core.exceptions.HttpResponseError for other errors.
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates.py
@@ -143,8 +143,8 @@ class CertificateClient(KeyVaultClientBase):
         :rtype: ~azure.keyvault.certificates.KeyVaultCertificate
 
         :raises:
-            :class:`~azure.core.exceptions.ResourceNotFoundError` if the certificate doesn't exist,
-            :class:`~azure.core.exceptions.HttpResponseError` for other errors
+            azure.core.exceptions.ResourceNotFoundError if the certificate doesn't exist,
+            azure.core.exceptions.HttpResponseError for other errors
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates.py
@@ -173,8 +173,8 @@ class CertificateClient(KeyVaultClientBase):
         :rtype: ~azure.keyvault.certificates.KeyVaultCertificate
 
         :raises:
-            :class:`~azure.core.exceptions.ResourceNotFoundError` if the certificate doesn't exist,
-            :class:`~azure.core.exceptions.HttpResponseError` for other errors
+            azure.core.exceptions.ResourceNotFoundError if the certificate doesn't exist,
+            azure.core.exceptions.HttpResponseError for other errors
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates.py
@@ -200,15 +200,15 @@ class CertificateClient(KeyVaultClientBase):
         :param str certificate_name: The name of the certificate to delete.
 
         :returns: A poller for the delete certificate operation. The poller's `result` method returns the
-            :class:`~azure.keyvault.certificates.DeletedCertificate` without waiting for deletion to complete. If the
+            azure.keyvault.certificates.DeletedCertificate without waiting for deletion to complete. If the
             vault has soft-delete enabled and you want to immediately, permanently delete the certificate with
             :func:`purge_deleted_certificate`, call the poller's `wait` method first. It will block until the deletion
             is complete. The `wait` method requires certificates/get permission.
         :rtype: ~azure.core.polling.LROPoller[~azure.keyvault.certificates.DeletedCertificate]
 
         :raises:
-            :class:`~azure.core.exceptions.ResourceNotFoundError` if the certificate doesn't exist,
-            :class:`~azure.core.exceptions.HttpResponseError` for other errors
+            azure.core.exceptions.ResourceNotFoundError if the certificate doesn't exist,
+            azure.core.exceptions.HttpResponseError for other errors
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates.py
@@ -249,8 +249,8 @@ class CertificateClient(KeyVaultClientBase):
         :rtype: ~azure.keyvault.certificates.DeletedCertificate
 
         :raises:
-            :class:`~azure.core.exceptions.ResourceNotFoundError` if the certificate doesn't exist,
-            :class:`~azure.core.exceptions.HttpResponseError` for other errors
+            azure.core.exceptions.ResourceNotFoundError if the certificate doesn't exist,
+            azure.core.exceptions.HttpResponseError for other errors
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates.py
@@ -280,7 +280,7 @@ class CertificateClient(KeyVaultClientBase):
         :return: None
         :rtype: None
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises: azure.core.exceptions.HttpResponseError
         """
         self._client.purge_deleted_certificate(
             vault_base_url=self.vault_url, certificate_name=certificate_name, **kwargs
@@ -298,12 +298,12 @@ class CertificateClient(KeyVaultClientBase):
         :param str certificate_name: The name of the deleted certificate to recover
 
         :returns: A poller for the recovery operation. The poller's `result` method returns the recovered
-            :class:`~azure.keyvault.certificates.KeyVaultCertificate` without waiting for recovery to complete. If you
+            azure.keyvault.certificates.KeyVaultCertificate without waiting for recovery to complete. If you
             want to use the recovered certificate immediately, call the poller's `wait` method, which blocks until the
             certificate is ready to use. The `wait` method requires certificate/get permission.
         :rtype: ~azure.core.polling.LROPoller[~azure.keyvault.certificates.KeyVaultCertificate]
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises: azure.core.exceptions.HttpResponseError
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates.py
@@ -355,7 +355,7 @@ class CertificateClient(KeyVaultClientBase):
         :returns: The imported KeyVaultCertificate
         :rtype: ~azure.keyvault.certificates.KeyVaultCertificate
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises: azure.core.exceptions.HttpResponseError
         """
 
         enabled = kwargs.pop("enabled", None)
@@ -391,7 +391,7 @@ class CertificateClient(KeyVaultClientBase):
         :return: The certificate policy
         :rtype: ~azure.keyvault.certificates.CertificatePolicy
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises: azure.core.exceptions.HttpResponseError
         """
         bundle = self._client.get_certificate_policy(
             vault_base_url=self.vault_url, certificate_name=certificate_name, **kwargs
@@ -413,7 +413,7 @@ class CertificateClient(KeyVaultClientBase):
         :return: The certificate policy
         :rtype: ~azure.keyvault.certificates.CertificatePolicy
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises: azure.core.exceptions.HttpResponseError
         """
         bundle = self._client.update_certificate_policy(
             vault_base_url=self.vault_url,
@@ -439,7 +439,7 @@ class CertificateClient(KeyVaultClientBase):
         :returns: The updated KeyVaultCertificate
         :rtype: ~azure.keyvault.certificates.KeyVaultCertificate
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises: azure.core.exceptions.HttpResponseError
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates.py
@@ -485,8 +485,8 @@ class CertificateClient(KeyVaultClientBase):
         :rtype: bytes
 
         :raises:
-            :class:`~azure.core.exceptions.ResourceNotFoundError` if the certificate doesn't exist,
-            :class:`~azure.core.exceptions.HttpResponseError` for other errors
+            azure.core.exceptions.ResourceNotFoundError if the certificate doesn't exist,
+            azure.core.exceptions.HttpResponseError for other errors
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates.py
@@ -514,7 +514,7 @@ class CertificateClient(KeyVaultClientBase):
         :return: The restored KeyVaultCertificate
         :rtype: ~azure.keyvault.certificates.KeyVaultCertificate
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises: azure.core.exceptions.HttpResponseError
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates.py
@@ -547,7 +547,7 @@ class CertificateClient(KeyVaultClientBase):
         :return: An iterator-like instance of DeletedCertificate
         :rtype: ~azure.core.paging.ItemPaged[~azure.keyvault.certificates.DeletedCertificate]
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises: azure.core.exceptions.HttpResponseError
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates.py
@@ -592,7 +592,7 @@ class CertificateClient(KeyVaultClientBase):
         :returns: An iterator-like instance of CertificateProperties
         :rtype: ~azure.core.paging.ItemPaged[~azure.keyvault.certificates.CertificateProperties]
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises: azure.core.exceptions.HttpResponseError
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates.py
@@ -633,7 +633,7 @@ class CertificateClient(KeyVaultClientBase):
         :returns: An iterator-like instance of CertificateProperties
         :rtype: ~azure.core.paging.ItemPaged[~azure.keyvault.certificates.CertificateProperties]
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises: azure.core.exceptions.HttpResponseError
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates.py
@@ -662,7 +662,7 @@ class CertificateClient(KeyVaultClientBase):
         :returns: The created list of contacts
         :rtype: list[~azure.keyvault.certificates.CertificateContact]
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises: azure.core.exceptions.HttpResponseError
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates.py
@@ -688,7 +688,7 @@ class CertificateClient(KeyVaultClientBase):
         :return: The certificate contacts for the key vault.
         :rtype: list[~azure.keyvault.certificates.CertificateContact]
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises: azure.core.exceptions.HttpResponseError
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates.py
@@ -708,7 +708,7 @@ class CertificateClient(KeyVaultClientBase):
         :return: The deleted contacts for the key vault.
         :rtype: list[~azure.keyvault.certificates.CertificateContact]
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises: azure.core.exceptions.HttpResponseError
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates.py
@@ -731,8 +731,8 @@ class CertificateClient(KeyVaultClientBase):
         :rtype: ~azure.keyvault.certificates.CertificateOperation
 
         :raises:
-            :class:`~azure.core.exceptions.ResourceNotFoundError` if the certificate doesn't exist,
-            :class:`~azure.core.exceptions.HttpResponseError` for other errors
+            azure.core.exceptions.ResourceNotFoundError if the certificate doesn't exist,
+            azure.core.exceptions.HttpResponseError for other errors
         """
 
         bundle = self._client.get_certificate_operation(
@@ -751,7 +751,7 @@ class CertificateClient(KeyVaultClientBase):
         :return: The deleted CertificateOperation
         :rtype: ~azure.keyvault.certificates.CertificateOperation
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises: azure.core.exceptions.HttpResponseError
         """
         bundle = self._client.delete_certificate_operation(
             vault_base_url=self.vault_url, certificate_name=certificate_name, **kwargs
@@ -767,7 +767,7 @@ class CertificateClient(KeyVaultClientBase):
         :returns: The cancelled certificate operation
         :rtype: ~azure.keyvault.certificates.CertificateOperation
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises: azure.core.exceptions.HttpResponseError
         """
         bundle = self._client.update_certificate_operation(
             vault_base_url=self.vault_url,
@@ -800,7 +800,7 @@ class CertificateClient(KeyVaultClientBase):
         :return: The merged certificate
         :rtype: ~azure.keyvault.certificates.KeyVaultCertificate
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises: azure.core.exceptions.HttpResponseError
         """
 
         enabled = kwargs.pop("enabled", None)
@@ -829,8 +829,8 @@ class CertificateClient(KeyVaultClientBase):
         :rtype: ~azure.keyvault.certificates.CertificateIssuer
 
         :raises:
-            :class:`~azure.core.exceptions.ResourceNotFoundError` if the issuer doesn't exist,
-            :class:`~azure.core.exceptions.HttpResponseError` for other errors
+            azure.core.exceptions.ResourceNotFoundError if the issuer doesn't exist,
+            azure.core.exceptions.HttpResponseError for other errors
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates.py
@@ -863,7 +863,7 @@ class CertificateClient(KeyVaultClientBase):
         :returns: The created CertificateIssuer
         :rtype: ~azure.keyvault.certificates.CertificateIssuer
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises: azure.core.exceptions.HttpResponseError
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates.py
@@ -934,7 +934,7 @@ class CertificateClient(KeyVaultClientBase):
         :return: The updated issuer
         :rtype: ~azure.keyvault.certificates.CertificateIssuer
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises: azure.core.exceptions.HttpResponseError
         """
 
         enabled = kwargs.pop("enabled", None)
@@ -991,7 +991,7 @@ class CertificateClient(KeyVaultClientBase):
         :return: CertificateIssuer
         :rtype: ~azure.keyvault.certificates.CertificateIssuer
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises: azure.core.exceptions.HttpResponseError
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates.py
@@ -1015,7 +1015,7 @@ class CertificateClient(KeyVaultClientBase):
         :return: An iterator-like instance of Issuers
         :rtype: ~azure.core.paging.ItemPaged[~azure.keyvault.certificates.CertificateIssuer]
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises: azure.core.exceptions.HttpResponseError
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates.py

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_client.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_client.py
@@ -57,7 +57,7 @@ class CertificateClient(KeyVaultClientBase):
 
     @distributed_trace
     def begin_create_certificate(
-        self, certificate_name: str, policy: CertificatePolicy, **kwargs
+        self, certificate_name: str, policy: CertificatePolicy, **kwargs: Any
     ) -> LROPoller[Union[KeyVaultCertificate, CertificateOperation]]:
         """Creates a new certificate.
 
@@ -80,9 +80,8 @@ class CertificateClient(KeyVaultClientBase):
         :rtype: ~azure.core.polling.LROPoller[~azure.keyvault.certificates.KeyVaultCertificate or
             ~azure.keyvault.certificates.CertificateOperation]
 
-        :raises:
-            :class:`ValueError` if the certificate policy is invalid,
-            :class:`~azure.core.exceptions.HttpResponseError` for other errors.
+        :raises ValueError or ~azure.core.exceptions.HttpResponseError:
+            the former if the certificate policy is invalid; the latter for other errors
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates.py
@@ -131,7 +130,7 @@ class CertificateClient(KeyVaultClientBase):
         return LROPoller(command, create_certificate_operation, no_op, create_certificate_polling)
 
     @distributed_trace
-    def get_certificate(self, certificate_name: str, **kwargs) -> KeyVaultCertificate:
+    def get_certificate(self, certificate_name: str, **kwargs: Any) -> KeyVaultCertificate:
         """Gets a certificate with its management policy attached. Requires certificates/get permission.
 
         Does not accept the version of the certificate as a parameter. To get a specific version of the
@@ -142,9 +141,8 @@ class CertificateClient(KeyVaultClientBase):
         :returns: An instance of KeyVaultCertificate
         :rtype: ~azure.keyvault.certificates.KeyVaultCertificate
 
-        :raises:
-            :class:`~azure.core.exceptions.ResourceNotFoundError` if the certificate doesn't exist,
-            :class:`~azure.core.exceptions.HttpResponseError` for other errors
+        :raises ~azure.core.exceptions.ResourceNotFoundError or ~azure.core.exceptions.HttpResponseError:
+            the former if the certificate doesn't exist; the latter for other errors
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates.py
@@ -160,7 +158,7 @@ class CertificateClient(KeyVaultClientBase):
         return KeyVaultCertificate._from_certificate_bundle(certificate_bundle=bundle)
 
     @distributed_trace
-    def get_certificate_version(self, certificate_name: str, version: str, **kwargs) -> KeyVaultCertificate:
+    def get_certificate_version(self, certificate_name: str, version: str, **kwargs: Any) -> KeyVaultCertificate:
         """Gets a specific version of a certificate without returning its management policy.
 
         Requires certificates/get permission. To get the latest version of the certificate, or to get the certificate's
@@ -172,9 +170,8 @@ class CertificateClient(KeyVaultClientBase):
         :returns: An instance of KeyVaultCertificate
         :rtype: ~azure.keyvault.certificates.KeyVaultCertificate
 
-        :raises:
-            :class:`~azure.core.exceptions.ResourceNotFoundError` if the certificate doesn't exist,
-            :class:`~azure.core.exceptions.HttpResponseError` for other errors
+        :raises ~azure.core.exceptions.ResourceNotFoundError or ~azure.core.exceptions.HttpResponseError:
+            the former if the certificate doesn't exist; the latter for other errors
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates.py
@@ -190,7 +187,7 @@ class CertificateClient(KeyVaultClientBase):
         return KeyVaultCertificate._from_certificate_bundle(certificate_bundle=bundle)
 
     @distributed_trace
-    def begin_delete_certificate(self, certificate_name: str, **kwargs) -> LROPoller[DeletedCertificate]:
+    def begin_delete_certificate(self, certificate_name: str, **kwargs: Any) -> LROPoller[DeletedCertificate]:
         """Delete all versions of a certificate. Requires certificates/delete permission.
 
         When this method returns Key Vault has begun deleting the certificate. Deletion may take several seconds in a
@@ -206,9 +203,8 @@ class CertificateClient(KeyVaultClientBase):
             is complete. The `wait` method requires certificates/get permission.
         :rtype: ~azure.core.polling.LROPoller[~azure.keyvault.certificates.DeletedCertificate]
 
-        :raises:
-            :class:`~azure.core.exceptions.ResourceNotFoundError` if the certificate doesn't exist,
-            :class:`~azure.core.exceptions.HttpResponseError` for other errors
+        :raises ~azure.core.exceptions.ResourceNotFoundError or ~azure.core.exceptions.HttpResponseError:
+            the former if the certificate doesn't exist; the latter for other errors
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates.py
@@ -237,7 +233,7 @@ class CertificateClient(KeyVaultClientBase):
         return KeyVaultOperationPoller(polling_method)
 
     @distributed_trace
-    def get_deleted_certificate(self, certificate_name: str, **kwargs) -> DeletedCertificate:
+    def get_deleted_certificate(self, certificate_name: str, **kwargs: Any) -> DeletedCertificate:
         """Get a deleted certificate. Possible only in a vault with soft-delete enabled.
 
         Requires certificates/get permission. Retrieves the deleted certificate information plus its attributes, such as
@@ -248,9 +244,8 @@ class CertificateClient(KeyVaultClientBase):
         :return: The deleted certificate
         :rtype: ~azure.keyvault.certificates.DeletedCertificate
 
-        :raises:
-            :class:`~azure.core.exceptions.ResourceNotFoundError` if the certificate doesn't exist,
-            :class:`~azure.core.exceptions.HttpResponseError` for other errors
+        :raises ~azure.core.exceptions.ResourceNotFoundError or ~azure.core.exceptions.HttpResponseError:
+            the former if the certificate doesn't exist; the latter for other errors
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates.py
@@ -266,7 +261,7 @@ class CertificateClient(KeyVaultClientBase):
         return DeletedCertificate._from_deleted_certificate_bundle(deleted_certificate_bundle=bundle)
 
     @distributed_trace
-    def purge_deleted_certificate(self, certificate_name: str, **kwargs) -> None:
+    def purge_deleted_certificate(self, certificate_name: str, **kwargs: Any) -> None:
         """Permanently deletes a deleted certificate. Possible only in vaults with soft-delete enabled.
 
         Requires certificates/purge permission. Performs an irreversible deletion of the specified certificate, without
@@ -280,14 +275,14 @@ class CertificateClient(KeyVaultClientBase):
         :return: None
         :rtype: None
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises ~azure.core.exceptions.HttpResponseError:
         """
         self._client.purge_deleted_certificate(
             vault_base_url=self.vault_url, certificate_name=certificate_name, **kwargs
         )
 
     @distributed_trace
-    def begin_recover_deleted_certificate(self, certificate_name: str, **kwargs) -> LROPoller[KeyVaultCertificate]:
+    def begin_recover_deleted_certificate(self, certificate_name: str, **kwargs: Any) -> LROPoller[KeyVaultCertificate]:
         """Recover a deleted certificate to its latest version. Possible only in a vault with soft-delete enabled.
 
         Requires certificates/recover permission. When this method returns Key Vault has begun recovering the
@@ -303,7 +298,7 @@ class CertificateClient(KeyVaultClientBase):
             certificate is ready to use. The `wait` method requires certificate/get permission.
         :rtype: ~azure.core.polling.LROPoller[~azure.keyvault.certificates.KeyVaultCertificate]
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises ~azure.core.exceptions.HttpResponseError:
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates.py
@@ -329,7 +324,7 @@ class CertificateClient(KeyVaultClientBase):
         return KeyVaultOperationPoller(polling_method)
 
     @distributed_trace
-    def import_certificate(self, certificate_name: str, certificate_bytes: bytes, **kwargs) -> KeyVaultCertificate:
+    def import_certificate(self, certificate_name: str, certificate_bytes: bytes, **kwargs: Any) -> KeyVaultCertificate:
         """Import a certificate created externally. Requires certificates/import permission.
 
         Imports an existing valid certificate, containing a private key, into Azure Key Vault. The certificate to be
@@ -355,7 +350,7 @@ class CertificateClient(KeyVaultClientBase):
         :returns: The imported KeyVaultCertificate
         :rtype: ~azure.keyvault.certificates.KeyVaultCertificate
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises ~azure.core.exceptions.HttpResponseError:
         """
 
         enabled = kwargs.pop("enabled", None)
@@ -381,7 +376,7 @@ class CertificateClient(KeyVaultClientBase):
         return KeyVaultCertificate._from_certificate_bundle(certificate_bundle=bundle)
 
     @distributed_trace
-    def get_certificate_policy(self, certificate_name: str, **kwargs) -> CertificatePolicy:
+    def get_certificate_policy(self, certificate_name: str, **kwargs: Any) -> CertificatePolicy:
         """Gets the policy for a certificate. Requires certificates/get permission.
 
         Returns the specified certificate policy resources in the key vault.
@@ -391,7 +386,7 @@ class CertificateClient(KeyVaultClientBase):
         :return: The certificate policy
         :rtype: ~azure.keyvault.certificates.CertificatePolicy
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises ~azure.core.exceptions.HttpResponseError:
         """
         bundle = self._client.get_certificate_policy(
             vault_base_url=self.vault_url, certificate_name=certificate_name, **kwargs
@@ -400,7 +395,7 @@ class CertificateClient(KeyVaultClientBase):
 
     @distributed_trace
     def update_certificate_policy(
-        self, certificate_name: str, policy: CertificatePolicy, **kwargs
+        self, certificate_name: str, policy: CertificatePolicy, **kwargs: Any
     ) -> CertificatePolicy:
         """Updates the policy for a certificate. Requires certificates/update permission.
 
@@ -413,7 +408,7 @@ class CertificateClient(KeyVaultClientBase):
         :return: The certificate policy
         :rtype: ~azure.keyvault.certificates.CertificatePolicy
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises ~azure.core.exceptions.HttpResponseError:
         """
         bundle = self._client.update_certificate_policy(
             vault_base_url=self.vault_url,
@@ -425,7 +420,7 @@ class CertificateClient(KeyVaultClientBase):
 
     @distributed_trace
     def update_certificate_properties(
-        self, certificate_name: str, version: "Optional[str]" = None, **kwargs
+        self, certificate_name: str, version: "Optional[str]" = None, **kwargs: Any
     ) -> KeyVaultCertificate:
         """Change a certificate's properties. Requires certificates/update permission.
 
@@ -439,7 +434,7 @@ class CertificateClient(KeyVaultClientBase):
         :returns: The updated KeyVaultCertificate
         :rtype: ~azure.keyvault.certificates.KeyVaultCertificate
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises ~azure.core.exceptions.HttpResponseError:
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates.py
@@ -471,7 +466,7 @@ class CertificateClient(KeyVaultClientBase):
         return KeyVaultCertificate._from_certificate_bundle(certificate_bundle=bundle)
 
     @distributed_trace
-    def backup_certificate(self, certificate_name: str, **kwargs) -> bytes:
+    def backup_certificate(self, certificate_name: str, **kwargs: Any) -> bytes:
         """Back up a certificate in a protected form useable only by Azure Key Vault.
 
         Requires certificates/backup permission. This is intended to allow copying a certificate from one vault to
@@ -484,9 +479,8 @@ class CertificateClient(KeyVaultClientBase):
         :return: The backup blob containing the backed up certificate.
         :rtype: bytes
 
-        :raises:
-            :class:`~azure.core.exceptions.ResourceNotFoundError` if the certificate doesn't exist,
-            :class:`~azure.core.exceptions.HttpResponseError` for other errors
+        :raises ~azure.core.exceptions.ResourceNotFoundError or ~azure.core.exceptions.HttpResponseError:
+            the former if the certificate doesn't exist; the latter for other errors
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates.py
@@ -502,7 +496,7 @@ class CertificateClient(KeyVaultClientBase):
         return backup_result.value
 
     @distributed_trace
-    def restore_certificate_backup(self, backup: bytes, **kwargs) -> KeyVaultCertificate:
+    def restore_certificate_backup(self, backup: bytes, **kwargs: Any) -> KeyVaultCertificate:
         """Restore a certificate backup to the vault. Requires certificates/restore permission.
 
         This restores all versions of the certificate, with its name, attributes, and access control policies. If the
@@ -514,7 +508,7 @@ class CertificateClient(KeyVaultClientBase):
         :return: The restored KeyVaultCertificate
         :rtype: ~azure.keyvault.certificates.KeyVaultCertificate
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises ~azure.core.exceptions.HttpResponseError:
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates.py
@@ -533,7 +527,7 @@ class CertificateClient(KeyVaultClientBase):
 
     @distributed_trace
     def list_deleted_certificates(
-        self, *, include_pending: Optional[bool] = None, **kwargs
+        self, *, include_pending: Optional[bool] = None, **kwargs: Any
     ) -> ItemPaged[DeletedCertificate]:
         """Lists the currently-recoverable deleted certificates. Possible only if vault is soft-delete enabled.
 
@@ -547,7 +541,7 @@ class CertificateClient(KeyVaultClientBase):
         :return: An iterator-like instance of DeletedCertificate
         :rtype: ~azure.core.paging.ItemPaged[~azure.keyvault.certificates.DeletedCertificate]
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises ~azure.core.exceptions.HttpResponseError:
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates.py
@@ -579,7 +573,7 @@ class CertificateClient(KeyVaultClientBase):
 
     @distributed_trace
     def list_properties_of_certificates(
-        self, *, include_pending: Optional[bool] = None, **kwargs
+        self, *, include_pending: Optional[bool] = None, **kwargs: Any
     ) -> ItemPaged[CertificateProperties]:
         """List identifiers and properties of all certificates in the vault.
 
@@ -592,7 +586,7 @@ class CertificateClient(KeyVaultClientBase):
         :returns: An iterator-like instance of CertificateProperties
         :rtype: ~azure.core.paging.ItemPaged[~azure.keyvault.certificates.CertificateProperties]
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises ~azure.core.exceptions.HttpResponseError:
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates.py
@@ -622,7 +616,7 @@ class CertificateClient(KeyVaultClientBase):
 
     @distributed_trace
     def list_properties_of_certificate_versions(
-        self, certificate_name: str, **kwargs
+        self, certificate_name: str, **kwargs: Any
     ) -> ItemPaged[CertificateProperties]:
         """List the identifiers and properties of a certificate's versions.
 
@@ -633,7 +627,7 @@ class CertificateClient(KeyVaultClientBase):
         :returns: An iterator-like instance of CertificateProperties
         :rtype: ~azure.core.paging.ItemPaged[~azure.keyvault.certificates.CertificateProperties]
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises ~azure.core.exceptions.HttpResponseError:
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates.py
@@ -653,7 +647,7 @@ class CertificateClient(KeyVaultClientBase):
         )
 
     @distributed_trace
-    def set_contacts(self, contacts: "List[CertificateContact]", **kwargs) -> "List[CertificateContact]":
+    def set_contacts(self, contacts: "List[CertificateContact]", **kwargs: Any) -> "List[CertificateContact]":
         """Sets the certificate contacts for the key vault. Requires certificates/managecontacts permission.
 
         :param contacts: The contact list for the vault certificates.
@@ -662,7 +656,7 @@ class CertificateClient(KeyVaultClientBase):
         :returns: The created list of contacts
         :rtype: list[~azure.keyvault.certificates.CertificateContact]
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises ~azure.core.exceptions.HttpResponseError:
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates.py
@@ -682,13 +676,13 @@ class CertificateClient(KeyVaultClientBase):
         ]
 
     @distributed_trace
-    def get_contacts(self, **kwargs) -> "List[CertificateContact]":
+    def get_contacts(self, **kwargs: Any) -> "List[CertificateContact]":
         """Gets the certificate contacts for the key vault. Requires the certificates/managecontacts permission.
 
         :return: The certificate contacts for the key vault.
         :rtype: list[~azure.keyvault.certificates.CertificateContact]
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises ~azure.core.exceptions.HttpResponseError:
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates.py
@@ -702,13 +696,13 @@ class CertificateClient(KeyVaultClientBase):
         return [CertificateContact._from_certificate_contacts_item(contact_item=item) for item in contacts.contact_list]
 
     @distributed_trace
-    def delete_contacts(self, **kwargs) -> "List[CertificateContact]":
+    def delete_contacts(self, **kwargs: Any) -> "List[CertificateContact]":
         """Deletes the certificate contacts for the key vault. Requires the certificates/managecontacts permission.
 
         :return: The deleted contacts for the key vault.
         :rtype: list[~azure.keyvault.certificates.CertificateContact]
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises ~azure.core.exceptions.HttpResponseError:
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates.py
@@ -722,7 +716,7 @@ class CertificateClient(KeyVaultClientBase):
         return [CertificateContact._from_certificate_contacts_item(contact_item=item) for item in contacts.contact_list]
 
     @distributed_trace
-    def get_certificate_operation(self, certificate_name: str, **kwargs) -> CertificateOperation:
+    def get_certificate_operation(self, certificate_name: str, **kwargs: Any) -> CertificateOperation:
         """Gets the creation operation of a certificate. Requires the certificates/get permission.
 
         :param str certificate_name: The name of the certificate.
@@ -730,9 +724,8 @@ class CertificateClient(KeyVaultClientBase):
         :returns: The created CertificateOperation
         :rtype: ~azure.keyvault.certificates.CertificateOperation
 
-        :raises:
-            :class:`~azure.core.exceptions.ResourceNotFoundError` if the certificate doesn't exist,
-            :class:`~azure.core.exceptions.HttpResponseError` for other errors
+        :raises ~azure.core.exceptions.ResourceNotFoundError or ~azure.core.exceptions.HttpResponseError:
+            the former if the certificate doesn't exist; the latter for other errors
         """
 
         bundle = self._client.get_certificate_operation(
@@ -741,7 +734,7 @@ class CertificateClient(KeyVaultClientBase):
         return CertificateOperation._from_certificate_operation_bundle(certificate_operation_bundle=bundle)
 
     @distributed_trace
-    def delete_certificate_operation(self, certificate_name: str, **kwargs) -> CertificateOperation:
+    def delete_certificate_operation(self, certificate_name: str, **kwargs: Any) -> CertificateOperation:
         """Deletes and stops the creation operation for a specific certificate.
 
         Requires the certificates/update permission.
@@ -751,7 +744,7 @@ class CertificateClient(KeyVaultClientBase):
         :return: The deleted CertificateOperation
         :rtype: ~azure.keyvault.certificates.CertificateOperation
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises ~azure.core.exceptions.HttpResponseError:
         """
         bundle = self._client.delete_certificate_operation(
             vault_base_url=self.vault_url, certificate_name=certificate_name, **kwargs
@@ -759,7 +752,7 @@ class CertificateClient(KeyVaultClientBase):
         return CertificateOperation._from_certificate_operation_bundle(certificate_operation_bundle=bundle)
 
     @distributed_trace
-    def cancel_certificate_operation(self, certificate_name: str, **kwargs) -> CertificateOperation:
+    def cancel_certificate_operation(self, certificate_name: str, **kwargs: Any) -> CertificateOperation:
         """Cancels an in-progress certificate operation. Requires the certificates/update permission.
 
         :param str certificate_name: The name of the certificate.
@@ -767,7 +760,7 @@ class CertificateClient(KeyVaultClientBase):
         :returns: The cancelled certificate operation
         :rtype: ~azure.keyvault.certificates.CertificateOperation
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises ~azure.core.exceptions.HttpResponseError:
         """
         bundle = self._client.update_certificate_operation(
             vault_base_url=self.vault_url,
@@ -779,7 +772,7 @@ class CertificateClient(KeyVaultClientBase):
 
     @distributed_trace
     def merge_certificate(
-        self, certificate_name: str, x509_certificates: "List[bytes]", **kwargs
+        self, certificate_name: str, x509_certificates: "List[bytes]", **kwargs: Any
     ) -> KeyVaultCertificate:
         """Merges a certificate or a certificate chain with a key pair existing on the server.
 
@@ -800,7 +793,7 @@ class CertificateClient(KeyVaultClientBase):
         :return: The merged certificate
         :rtype: ~azure.keyvault.certificates.KeyVaultCertificate
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises ~azure.core.exceptions.HttpResponseError:
         """
 
         enabled = kwargs.pop("enabled", None)
@@ -820,7 +813,7 @@ class CertificateClient(KeyVaultClientBase):
         return KeyVaultCertificate._from_certificate_bundle(certificate_bundle=bundle)
 
     @distributed_trace
-    def get_issuer(self, issuer_name: str, **kwargs) -> CertificateIssuer:
+    def get_issuer(self, issuer_name: str, **kwargs: Any) -> CertificateIssuer:
         """Gets the specified certificate issuer. Requires certificates/manageissuers/getissuers permission.
 
         :param str issuer_name: The name of the issuer.
@@ -828,9 +821,8 @@ class CertificateClient(KeyVaultClientBase):
         :return: The specified certificate issuer.
         :rtype: ~azure.keyvault.certificates.CertificateIssuer
 
-        :raises:
-            :class:`~azure.core.exceptions.ResourceNotFoundError` if the issuer doesn't exist,
-            :class:`~azure.core.exceptions.HttpResponseError` for other errors
+        :raises ~azure.core.exceptions.ResourceNotFoundError or ~azure.core.exceptions.HttpResponseError:
+            the former if the issuer doesn't exist; the latter for other errors
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates.py
@@ -846,7 +838,7 @@ class CertificateClient(KeyVaultClientBase):
         return CertificateIssuer._from_issuer_bundle(issuer_bundle=issuer_bundle)
 
     @distributed_trace
-    def create_issuer(self, issuer_name: str, provider: str, **kwargs) -> CertificateIssuer:
+    def create_issuer(self, issuer_name: str, provider: str, **kwargs: Any) -> CertificateIssuer:
         """Sets the specified certificate issuer. Requires certificates/setissuers permission.
 
         :param str issuer_name: The name of the issuer.
@@ -863,7 +855,7 @@ class CertificateClient(KeyVaultClientBase):
         :returns: The created CertificateIssuer
         :rtype: ~azure.keyvault.certificates.CertificateIssuer
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises ~azure.core.exceptions.HttpResponseError:
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates.py
@@ -918,7 +910,7 @@ class CertificateClient(KeyVaultClientBase):
         return CertificateIssuer._from_issuer_bundle(issuer_bundle=issuer_bundle)
 
     @distributed_trace
-    def update_issuer(self, issuer_name: str, **kwargs) -> CertificateIssuer:
+    def update_issuer(self, issuer_name: str, **kwargs: Any) -> CertificateIssuer:
         """Updates the specified certificate issuer. Requires certificates/setissuers permission.
 
         :param str issuer_name: The name of the issuer.
@@ -934,7 +926,7 @@ class CertificateClient(KeyVaultClientBase):
         :return: The updated issuer
         :rtype: ~azure.keyvault.certificates.CertificateIssuer
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises ~azure.core.exceptions.HttpResponseError:
         """
 
         enabled = kwargs.pop("enabled", None)
@@ -981,7 +973,7 @@ class CertificateClient(KeyVaultClientBase):
         return CertificateIssuer._from_issuer_bundle(issuer_bundle=issuer_bundle)
 
     @distributed_trace
-    def delete_issuer(self, issuer_name: str, **kwargs) -> CertificateIssuer:
+    def delete_issuer(self, issuer_name: str, **kwargs: Any) -> CertificateIssuer:
         """Deletes the specified certificate issuer.
 
         Requires certificates/manageissuers/deleteissuers permission.
@@ -991,7 +983,7 @@ class CertificateClient(KeyVaultClientBase):
         :return: CertificateIssuer
         :rtype: ~azure.keyvault.certificates.CertificateIssuer
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises ~azure.core.exceptions.HttpResponseError:
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates.py
@@ -1007,7 +999,7 @@ class CertificateClient(KeyVaultClientBase):
         return CertificateIssuer._from_issuer_bundle(issuer_bundle=issuer_bundle)
 
     @distributed_trace
-    def list_properties_of_issuers(self, **kwargs) -> ItemPaged[IssuerProperties]:
+    def list_properties_of_issuers(self, **kwargs: Any) -> ItemPaged[IssuerProperties]:
         """Lists properties of the certificate issuers for the key vault.
 
         Requires the certificates/manageissuers/getissuers permission.
@@ -1015,7 +1007,7 @@ class CertificateClient(KeyVaultClientBase):
         :return: An iterator-like instance of Issuers
         :rtype: ~azure.core.paging.ItemPaged[~azure.keyvault.certificates.CertificateIssuer]
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises ~azure.core.exceptions.HttpResponseError:
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates.py

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_client.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_client.py
@@ -64,7 +64,7 @@ class CertificateClient(KeyVaultClientBase):
         If this is the first version, the certificate resource is created. This operation requires the
         certificates/create permission. Waiting on the returned poller requires the certificates/get permission and
         gives you the certificate if creation is successful, or the CertificateOperation if not -- otherwise, it raises
-        an azure.core.exceptions.HttpResponseError.
+        an :class:`~azure.core.exceptions.HttpResponseError`.
 
         :param str certificate_name: The name of the certificate.
         :param policy: The management policy for the certificate. Either subject or one of the subject alternative
@@ -82,7 +82,7 @@ class CertificateClient(KeyVaultClientBase):
 
         :raises:
             :class:`ValueError` if the certificate policy is invalid,
-            azure.core.exceptions.HttpResponseError for other errors.
+            :class:`~azure.core.exceptions.HttpResponseError` for other errors.
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates.py
@@ -143,8 +143,8 @@ class CertificateClient(KeyVaultClientBase):
         :rtype: ~azure.keyvault.certificates.KeyVaultCertificate
 
         :raises:
-            azure.core.exceptions.ResourceNotFoundError if the certificate doesn't exist,
-            azure.core.exceptions.HttpResponseError for other errors
+            :class:`~azure.core.exceptions.ResourceNotFoundError` if the certificate doesn't exist,
+            :class:`~azure.core.exceptions.HttpResponseError` for other errors
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates.py
@@ -173,8 +173,8 @@ class CertificateClient(KeyVaultClientBase):
         :rtype: ~azure.keyvault.certificates.KeyVaultCertificate
 
         :raises:
-            azure.core.exceptions.ResourceNotFoundError if the certificate doesn't exist,
-            azure.core.exceptions.HttpResponseError for other errors
+            :class:`~azure.core.exceptions.ResourceNotFoundError` if the certificate doesn't exist,
+            :class:`~azure.core.exceptions.HttpResponseError` for other errors
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates.py
@@ -200,15 +200,15 @@ class CertificateClient(KeyVaultClientBase):
         :param str certificate_name: The name of the certificate to delete.
 
         :returns: A poller for the delete certificate operation. The poller's `result` method returns the
-            azure.keyvault.certificates.DeletedCertificate without waiting for deletion to complete. If the
+            :class:`~azure.keyvault.certificates.DeletedCertificate` without waiting for deletion to complete. If the
             vault has soft-delete enabled and you want to immediately, permanently delete the certificate with
             :func:`purge_deleted_certificate`, call the poller's `wait` method first. It will block until the deletion
             is complete. The `wait` method requires certificates/get permission.
         :rtype: ~azure.core.polling.LROPoller[~azure.keyvault.certificates.DeletedCertificate]
 
         :raises:
-            azure.core.exceptions.ResourceNotFoundError if the certificate doesn't exist,
-            azure.core.exceptions.HttpResponseError for other errors
+            :class:`~azure.core.exceptions.ResourceNotFoundError` if the certificate doesn't exist,
+            :class:`~azure.core.exceptions.HttpResponseError` for other errors
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates.py
@@ -249,8 +249,8 @@ class CertificateClient(KeyVaultClientBase):
         :rtype: ~azure.keyvault.certificates.DeletedCertificate
 
         :raises:
-            azure.core.exceptions.ResourceNotFoundError if the certificate doesn't exist,
-            azure.core.exceptions.HttpResponseError for other errors
+            :class:`~azure.core.exceptions.ResourceNotFoundError` if the certificate doesn't exist,
+            :class:`~azure.core.exceptions.HttpResponseError` for other errors
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates.py
@@ -280,7 +280,7 @@ class CertificateClient(KeyVaultClientBase):
         :return: None
         :rtype: None
 
-        :raises: azure.core.exceptions.HttpResponseError
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
         """
         self._client.purge_deleted_certificate(
             vault_base_url=self.vault_url, certificate_name=certificate_name, **kwargs
@@ -298,12 +298,12 @@ class CertificateClient(KeyVaultClientBase):
         :param str certificate_name: The name of the deleted certificate to recover
 
         :returns: A poller for the recovery operation. The poller's `result` method returns the recovered
-            azure.keyvault.certificates.KeyVaultCertificate without waiting for recovery to complete. If you
+            :class:`~azure.keyvault.certificates.KeyVaultCertificate` without waiting for recovery to complete. If you
             want to use the recovered certificate immediately, call the poller's `wait` method, which blocks until the
             certificate is ready to use. The `wait` method requires certificate/get permission.
         :rtype: ~azure.core.polling.LROPoller[~azure.keyvault.certificates.KeyVaultCertificate]
 
-        :raises: azure.core.exceptions.HttpResponseError
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates.py
@@ -355,7 +355,7 @@ class CertificateClient(KeyVaultClientBase):
         :returns: The imported KeyVaultCertificate
         :rtype: ~azure.keyvault.certificates.KeyVaultCertificate
 
-        :raises: azure.core.exceptions.HttpResponseError
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
         """
 
         enabled = kwargs.pop("enabled", None)
@@ -391,7 +391,7 @@ class CertificateClient(KeyVaultClientBase):
         :return: The certificate policy
         :rtype: ~azure.keyvault.certificates.CertificatePolicy
 
-        :raises: azure.core.exceptions.HttpResponseError
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
         """
         bundle = self._client.get_certificate_policy(
             vault_base_url=self.vault_url, certificate_name=certificate_name, **kwargs
@@ -413,7 +413,7 @@ class CertificateClient(KeyVaultClientBase):
         :return: The certificate policy
         :rtype: ~azure.keyvault.certificates.CertificatePolicy
 
-        :raises: azure.core.exceptions.HttpResponseError
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
         """
         bundle = self._client.update_certificate_policy(
             vault_base_url=self.vault_url,
@@ -439,7 +439,7 @@ class CertificateClient(KeyVaultClientBase):
         :returns: The updated KeyVaultCertificate
         :rtype: ~azure.keyvault.certificates.KeyVaultCertificate
 
-        :raises: azure.core.exceptions.HttpResponseError
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates.py
@@ -485,8 +485,8 @@ class CertificateClient(KeyVaultClientBase):
         :rtype: bytes
 
         :raises:
-            azure.core.exceptions.ResourceNotFoundError if the certificate doesn't exist,
-            azure.core.exceptions.HttpResponseError for other errors
+            :class:`~azure.core.exceptions.ResourceNotFoundError` if the certificate doesn't exist,
+            :class:`~azure.core.exceptions.HttpResponseError` for other errors
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates.py
@@ -514,7 +514,7 @@ class CertificateClient(KeyVaultClientBase):
         :return: The restored KeyVaultCertificate
         :rtype: ~azure.keyvault.certificates.KeyVaultCertificate
 
-        :raises: azure.core.exceptions.HttpResponseError
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates.py
@@ -547,7 +547,7 @@ class CertificateClient(KeyVaultClientBase):
         :return: An iterator-like instance of DeletedCertificate
         :rtype: ~azure.core.paging.ItemPaged[~azure.keyvault.certificates.DeletedCertificate]
 
-        :raises: azure.core.exceptions.HttpResponseError
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates.py
@@ -592,7 +592,7 @@ class CertificateClient(KeyVaultClientBase):
         :returns: An iterator-like instance of CertificateProperties
         :rtype: ~azure.core.paging.ItemPaged[~azure.keyvault.certificates.CertificateProperties]
 
-        :raises: azure.core.exceptions.HttpResponseError
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates.py
@@ -633,7 +633,7 @@ class CertificateClient(KeyVaultClientBase):
         :returns: An iterator-like instance of CertificateProperties
         :rtype: ~azure.core.paging.ItemPaged[~azure.keyvault.certificates.CertificateProperties]
 
-        :raises: azure.core.exceptions.HttpResponseError
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates.py
@@ -662,7 +662,7 @@ class CertificateClient(KeyVaultClientBase):
         :returns: The created list of contacts
         :rtype: list[~azure.keyvault.certificates.CertificateContact]
 
-        :raises: azure.core.exceptions.HttpResponseError
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates.py
@@ -688,7 +688,7 @@ class CertificateClient(KeyVaultClientBase):
         :return: The certificate contacts for the key vault.
         :rtype: list[~azure.keyvault.certificates.CertificateContact]
 
-        :raises: azure.core.exceptions.HttpResponseError
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates.py
@@ -708,7 +708,7 @@ class CertificateClient(KeyVaultClientBase):
         :return: The deleted contacts for the key vault.
         :rtype: list[~azure.keyvault.certificates.CertificateContact]
 
-        :raises: azure.core.exceptions.HttpResponseError
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates.py
@@ -731,8 +731,8 @@ class CertificateClient(KeyVaultClientBase):
         :rtype: ~azure.keyvault.certificates.CertificateOperation
 
         :raises:
-            azure.core.exceptions.ResourceNotFoundError if the certificate doesn't exist,
-            azure.core.exceptions.HttpResponseError for other errors
+            :class:`~azure.core.exceptions.ResourceNotFoundError` if the certificate doesn't exist,
+            :class:`~azure.core.exceptions.HttpResponseError` for other errors
         """
 
         bundle = self._client.get_certificate_operation(
@@ -751,7 +751,7 @@ class CertificateClient(KeyVaultClientBase):
         :return: The deleted CertificateOperation
         :rtype: ~azure.keyvault.certificates.CertificateOperation
 
-        :raises: azure.core.exceptions.HttpResponseError
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
         """
         bundle = self._client.delete_certificate_operation(
             vault_base_url=self.vault_url, certificate_name=certificate_name, **kwargs
@@ -767,7 +767,7 @@ class CertificateClient(KeyVaultClientBase):
         :returns: The cancelled certificate operation
         :rtype: ~azure.keyvault.certificates.CertificateOperation
 
-        :raises: azure.core.exceptions.HttpResponseError
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
         """
         bundle = self._client.update_certificate_operation(
             vault_base_url=self.vault_url,
@@ -800,7 +800,7 @@ class CertificateClient(KeyVaultClientBase):
         :return: The merged certificate
         :rtype: ~azure.keyvault.certificates.KeyVaultCertificate
 
-        :raises: azure.core.exceptions.HttpResponseError
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
         """
 
         enabled = kwargs.pop("enabled", None)
@@ -829,8 +829,8 @@ class CertificateClient(KeyVaultClientBase):
         :rtype: ~azure.keyvault.certificates.CertificateIssuer
 
         :raises:
-            azure.core.exceptions.ResourceNotFoundError if the issuer doesn't exist,
-            azure.core.exceptions.HttpResponseError for other errors
+            :class:`~azure.core.exceptions.ResourceNotFoundError` if the issuer doesn't exist,
+            :class:`~azure.core.exceptions.HttpResponseError` for other errors
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates.py
@@ -863,7 +863,7 @@ class CertificateClient(KeyVaultClientBase):
         :returns: The created CertificateIssuer
         :rtype: ~azure.keyvault.certificates.CertificateIssuer
 
-        :raises: azure.core.exceptions.HttpResponseError
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates.py
@@ -934,7 +934,7 @@ class CertificateClient(KeyVaultClientBase):
         :return: The updated issuer
         :rtype: ~azure.keyvault.certificates.CertificateIssuer
 
-        :raises: azure.core.exceptions.HttpResponseError
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
         """
 
         enabled = kwargs.pop("enabled", None)
@@ -991,7 +991,7 @@ class CertificateClient(KeyVaultClientBase):
         :return: CertificateIssuer
         :rtype: ~azure.keyvault.certificates.CertificateIssuer
 
-        :raises: azure.core.exceptions.HttpResponseError
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates.py
@@ -1015,7 +1015,7 @@ class CertificateClient(KeyVaultClientBase):
         :return: An iterator-like instance of Issuers
         :rtype: ~azure.core.paging.ItemPaged[~azure.keyvault.certificates.CertificateIssuer]
 
-        :raises: azure.core.exceptions.HttpResponseError
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates.py

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_models.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_models.py
@@ -131,7 +131,7 @@ class CertificateOperationError(object):
         """The error itself.
 
         :returns: The error itself.
-        :rtype: :class:`~azure.keyvault.certificates.CertificateOperationError`
+        :rtype: ~azure.keyvault.certificates.CertificateOperationError
         """
         return self._inner_error
 
@@ -619,7 +619,7 @@ class CertificateOperation(object):
         """Any error associated with the certificate operation.
 
         :returns: Any error associated with the operation, as a
-            :class:`~azure.keyvault.certificates.CertificateOperationError`.
+            azure.keyvault.certificates.CertificateOperationError.
         :rtype: ~azure.keyvault.certificates.CertificateOperationError or None"""
         return self._error
 
@@ -1371,10 +1371,10 @@ class LifetimeAction(object):
 
     @property
     def action(self) -> "Union[str, CertificatePolicyAction, None]":
-        """The type of action that will be executed; see :class:`~azure.keyvault.certificates.CertificatePolicyAction`.
+        """The type of action that will be executed; see azure.keyvault.certificates.CertificatePolicyAction.
 
         :returns: The type of action that will be executed; see
-            :class:`~azure.keyvault.certificates.CertificatePolicyAction`.
+            azure.keyvault.certificates.CertificatePolicyAction.
         :rtype: str or ~azure.keyvault.certificates.CertificatePolicyAction or None
         """
         return self._action

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_models.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_models.py
@@ -619,7 +619,7 @@ class CertificateOperation(object):
         """Any error associated with the certificate operation.
 
         :returns: Any error associated with the operation, as a
-            azure.keyvault.certificates.CertificateOperationError.
+            :class:`~azure.keyvault.certificates.CertificateOperationError`.
         :rtype: ~azure.keyvault.certificates.CertificateOperationError or None"""
         return self._error
 
@@ -1371,10 +1371,10 @@ class LifetimeAction(object):
 
     @property
     def action(self) -> "Union[str, CertificatePolicyAction, None]":
-        """The type of action that will be executed; see azure.keyvault.certificates.CertificatePolicyAction.
+        """The type of action that will be executed; see :class:`~azure.keyvault.certificates.CertificatePolicyAction`.
 
         :returns: The type of action that will be executed; see
-            azure.keyvault.certificates.CertificatePolicyAction.
+            :class:`~azure.keyvault.certificates.CertificatePolicyAction`.
         :rtype: str or ~azure.keyvault.certificates.CertificatePolicyAction or None
         """
         return self._action

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_models.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_models.py
@@ -3,7 +3,8 @@
 # Licensed under the MIT License.
 # ------------------------------------
 # pylint: disable=too-many-lines,too-many-public-methods
-from typing import TYPE_CHECKING
+from datetime import datetime
+from typing import Any, Dict, Optional, Union, List
 
 from ._generated import models
 from ._shared import parse_key_vault_id
@@ -15,10 +16,6 @@ from ._enums import(
     CertificateContentType,
     WellKnownIssuerNames
 )
-
-if TYPE_CHECKING:
-    from typing import Dict, Optional, Union, List
-    from datetime import datetime
 
 
 class AdministratorContact(object):
@@ -36,10 +33,10 @@ class AdministratorContact(object):
 
     def __init__(
         self,
-        first_name: "Optional[str]" = None,
-        last_name: "Optional[str]" = None,
-        email: "Optional[str]" = None,
-        phone: "Optional[str]" = None,
+        first_name: Optional[str] = None,
+        last_name: Optional[str] = None,
+        email: Optional[str] = None,
+        phone: Optional[str] = None,
     ) -> None:
         self._first_name = first_name
         self._last_name = last_name
@@ -63,22 +60,22 @@ class AdministratorContact(object):
         )
 
     @property
-    def email(self) -> "Optional[str]":
+    def email(self) -> Optional[str]:
         """:rtype: str or None"""
         return self._email
 
     @property
-    def first_name(self) -> "Optional[str]":
+    def first_name(self) -> Optional[str]:
         """:rtype: str or None"""
         return self._first_name
 
     @property
-    def last_name(self) -> "Optional[str]":
+    def last_name(self) -> Optional[str]:
         """:rtype: str or None"""
         return self._last_name
 
     @property
-    def phone(self) -> "Optional[str]":
+    def phone(self) -> Optional[str]:
         """:rtype: str or None"""
         return self._phone
 
@@ -139,7 +136,7 @@ class CertificateOperationError(object):
 class CertificateProperties(object):
     """Certificate properties consists of a certificates metadata."""
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, **kwargs: Any) -> None:
         self._attributes = kwargs.pop("attributes", None)
         self._id = kwargs.pop("cert_id", None)
         self._vault_id = KeyVaultCertificateIdentifier(self._id)
@@ -151,7 +148,7 @@ class CertificateProperties(object):
 
     @classmethod
     def _from_certificate_item(
-        cls, certificate_item: "Union[models.CertificateItem, models.CertificateBundle]"
+        cls, certificate_item: Union[models.CertificateItem, models.CertificateBundle]
     ) -> "CertificateProperties":
         return cls(
             attributes=certificate_item.attributes,
@@ -179,7 +176,7 @@ class CertificateProperties(object):
         return self._vault_id.name
 
     @property
-    def enabled(self) -> "Optional[bool]":
+    def enabled(self) -> Optional[bool]:
         """Whether the certificate is enabled or not.
 
         :returns: True if the certificate is enabled; False otherwise.
@@ -188,7 +185,7 @@ class CertificateProperties(object):
         return self._attributes.enabled if self._attributes else None
 
     @property
-    def not_before(self) -> "Optional[datetime]":
+    def not_before(self) -> Optional[datetime]:
         """The datetime before which the certificate is not valid.
 
         :returns: A datetime representing the point in time when the certificate becomes valid.
@@ -197,7 +194,7 @@ class CertificateProperties(object):
         return self._attributes.not_before if self._attributes else None
 
     @property
-    def expires_on(self) -> "Optional[datetime]":
+    def expires_on(self) -> Optional[datetime]:
         """The datetime when the certificate expires.
 
         :returns: A datetime representing the point in time when the certificate expires.
@@ -206,7 +203,7 @@ class CertificateProperties(object):
         return self._attributes.expires if self._attributes else None
 
     @property
-    def created_on(self) -> "Optional[datetime]":
+    def created_on(self) -> Optional[datetime]:
         """The datetime when the certificate is created.
 
         :returns: A datetime representing the certificate's creation time.
@@ -215,7 +212,7 @@ class CertificateProperties(object):
         return self._attributes.created if self._attributes else None
 
     @property
-    def updated_on(self) -> "Optional[datetime]":
+    def updated_on(self) -> Optional[datetime]:
         """The datetime when the certificate was last updated.
 
         :returns: A datetime representing the time of the certificate's most recent update.
@@ -224,7 +221,7 @@ class CertificateProperties(object):
         return self._attributes.updated if self._attributes else None
 
     @property
-    def recoverable_days(self) -> "Optional[int]":
+    def recoverable_days(self) -> Optional[int]:
         """The number of days the certificate is retained before being deleted from a soft-delete enabled Key Vault.
 
         :returns: The number of days remaining where the certificate can be restored.
@@ -236,7 +233,7 @@ class CertificateProperties(object):
         return None
 
     @property
-    def recovery_level(self) -> "Optional[models.DeletionRecoveryLevel]":
+    def recovery_level(self) -> Optional[models.DeletionRecoveryLevel]:
         """The deletion recovery level currently in effect for the certificate.
 
         :returns: The deletion recovery level currently in effect for the certificate.
@@ -274,7 +271,7 @@ class CertificateProperties(object):
         return self._x509_thumbprint.hex().upper()
 
     @property
-    def tags(self) -> "Optional[Dict[str, str]]":
+    def tags(self) -> Optional[Dict[str, str]]:
         """Application specific metadata in the form of key-value pairs.
 
         :returns: A dictionary of tags attached to the certificate.
@@ -283,7 +280,7 @@ class CertificateProperties(object):
         return self._tags
 
     @property
-    def version(self) -> "Optional[str]":
+    def version(self) -> Optional[str]:
         """The version of the certificate.
 
         :returns: The version of the certificate.
@@ -306,9 +303,9 @@ class KeyVaultCertificate(object):
     def __init__(
         self,
         policy: "Optional[CertificatePolicy]" = None,
-        properties: "Optional[CertificateProperties]" = None,
-        cer: "Optional[bytearray]" = None,
-        **kwargs,
+        properties: Optional[CertificateProperties] = None,
+        cer: Optional[bytearray] = None,
+        **kwargs: Any,
     ) -> None:
         self._properties = properties
         self._key_id = kwargs.get("key_id", None)
@@ -324,7 +321,7 @@ class KeyVaultCertificate(object):
         # pylint:disable=protected-access
 
         if certificate_bundle.policy:
-            policy: "Optional[CertificatePolicy]" = CertificatePolicy._from_certificate_policy_bundle(
+            policy: Optional[CertificatePolicy] = CertificatePolicy._from_certificate_policy_bundle(
                 certificate_bundle.policy
             )
         else:
@@ -339,7 +336,7 @@ class KeyVaultCertificate(object):
         )
 
     @property
-    def id(self) -> "Optional[str]":
+    def id(self) -> Optional[str]:
         """The certificate identifier.
 
         :returns: The certificate identifier.
@@ -348,7 +345,7 @@ class KeyVaultCertificate(object):
         return self._properties.id if self._properties else None
 
     @property
-    def name(self) -> "Optional[str]":
+    def name(self) -> Optional[str]:
         """The name of the certificate.
 
         :returns: The name of the certificate.
@@ -357,7 +354,7 @@ class KeyVaultCertificate(object):
         return self._properties.name if self._properties else None
 
     @property
-    def properties(self) -> "Optional[CertificateProperties]":
+    def properties(self) -> Optional[CertificateProperties]:
         """The certificate's properties.
 
         :returns: The certificate's properties.
@@ -366,7 +363,7 @@ class KeyVaultCertificate(object):
         return self._properties
 
     @property
-    def key_id(self) -> "Optional[str]":
+    def key_id(self) -> Optional[str]:
         """The ID of the key associated with the certificate.
 
         :returns: The ID of the key associated with the certificate.
@@ -375,7 +372,7 @@ class KeyVaultCertificate(object):
         return self._key_id
 
     @property
-    def secret_id(self) -> "Optional[str]":
+    def secret_id(self) -> Optional[str]:
         """The ID of the secret associated with the certificate.
 
         :returns: The ID of the secret associated with the certificate.
@@ -393,7 +390,7 @@ class KeyVaultCertificate(object):
         return self._policy
 
     @property
-    def cer(self) -> "Optional[bytearray]":
+    def cer(self) -> Optional[bytearray]:
         """The CER contents of the certificate.
 
         :returns: The CER contents of the certificate.
@@ -434,7 +431,7 @@ class KeyVaultCertificateIdentifier(object):
         return self._resource_id.name
 
     @property
-    def version(self) -> "Optional[str]":
+    def version(self) -> Optional[str]:
         return self._resource_id.version
 
 
@@ -470,17 +467,17 @@ class CertificateOperation(object):
 
     def __init__(
         self,
-        cert_operation_id: "Optional[str]" = None,
-        issuer_name: "Optional[Union[str, WellKnownIssuerNames]]" = None,
-        certificate_type: "Optional[str]" = None,
-        certificate_transparency: "Optional[bool]" = False,
-        csr: "Optional[bytes]" = None,
-        cancellation_requested: "Optional[bool]" = False,
-        status: "Optional[str]" = None,
-        status_details: "Optional[str]" = None,
-        error: "Optional[CertificateOperationError]" = None,
-        target: "Optional[str]" = None,
-        request_id: "Optional[str]" = None,
+        cert_operation_id: Optional[str] = None,
+        issuer_name: Optional[Union[str, WellKnownIssuerNames]] = None,
+        certificate_type: Optional[str] = None,
+        certificate_transparency: Optional[bool] = False,
+        csr: Optional[bytes] = None,
+        cancellation_requested: Optional[bool] = False,
+        status: Optional[str] = None,
+        status_details: Optional[str] = None,
+        error: Optional[CertificateOperationError] = None,
+        target: Optional[str] = None,
+        request_id: Optional[str] = None,
     ) -> None:
         self._id = cert_operation_id
         self._vault_id = parse_key_vault_id(cert_operation_id) if cert_operation_id else None
@@ -525,7 +522,7 @@ class CertificateOperation(object):
         )
 
     @property
-    def id(self) -> "Optional[str]":
+    def id(self) -> Optional[str]:
         """The certificate ID.
 
         :returns: The certificate ID.
@@ -534,7 +531,7 @@ class CertificateOperation(object):
         return self._id
 
     @property
-    def name(self) -> "Optional[str]":
+    def name(self) -> Optional[str]:
         """The certificate name.
 
         :returns: The certificate name.
@@ -543,7 +540,7 @@ class CertificateOperation(object):
         return self._vault_id.name if self._vault_id else None
 
     @property
-    def vault_url(self) -> "Optional[str]":
+    def vault_url(self) -> Optional[str]:
         """URL of the vault performing the certificate operation.
 
         :returns: URL of the vault performing the certificate operation.
@@ -552,7 +549,7 @@ class CertificateOperation(object):
         return self._vault_id.vault_url if self._vault_id else None
 
     @property
-    def issuer_name(self) -> "Union[str, WellKnownIssuerNames, None]":
+    def issuer_name(self) -> Union[str, WellKnownIssuerNames, None]:
         """The name of the certificate issuer.
 
         :returns: The name of the certificate issuer.
@@ -561,7 +558,7 @@ class CertificateOperation(object):
         return self._issuer_name
 
     @property
-    def certificate_type(self) -> "Optional[str]":
+    def certificate_type(self) -> Optional[str]:
         """Type of certificate to be requested from the issuer provider.
 
         :returns: Type of certificate to be requested from the issuer provider.
@@ -570,7 +567,7 @@ class CertificateOperation(object):
         return self._certificate_type
 
     @property
-    def certificate_transparency(self) -> "Optional[bool]":
+    def certificate_transparency(self) -> Optional[bool]:
         """Whether certificates generated under this policy should be published to certificate transparency logs.
 
         :returns: True if the certificates should be published to transparency logs; False otherwise.
@@ -579,7 +576,7 @@ class CertificateOperation(object):
         return self._certificate_transparency
 
     @property
-    def csr(self) -> "Optional[bytes]":
+    def csr(self) -> Optional[bytes]:
         """The certificate signing request that is being used in this certificate operation.
 
         :returns: The certificate signing request that is being used in this certificate operation.
@@ -588,7 +585,7 @@ class CertificateOperation(object):
         return self._csr
 
     @property
-    def cancellation_requested(self) -> "Optional[bool]":
+    def cancellation_requested(self) -> Optional[bool]:
         """Whether cancellation was requested on the certificate operation.
 
         :returns: True if cancellation was requested; False otherwise.
@@ -597,7 +594,7 @@ class CertificateOperation(object):
         return self._cancellation_requested
 
     @property
-    def status(self) -> "Optional[str]":
+    def status(self) -> Optional[str]:
         """The operation status.
 
         :returns: The operation status.
@@ -606,7 +603,7 @@ class CertificateOperation(object):
         return self._status
 
     @property
-    def status_details(self) -> "Optional[str]":
+    def status_details(self) -> Optional[str]:
         """Details of the operation status.
 
         :returns: Details of the operation status.
@@ -615,7 +612,7 @@ class CertificateOperation(object):
         return self._status_details
 
     @property
-    def error(self) -> "Optional[CertificateOperationError]":
+    def error(self) -> Optional[CertificateOperationError]:
         """Any error associated with the certificate operation.
 
         :returns: Any error associated with the operation, as a
@@ -624,7 +621,7 @@ class CertificateOperation(object):
         return self._error
 
     @property
-    def target(self) -> "Optional[str]":
+    def target(self) -> Optional[str]:
         """Location which contains the result of the certificate operation.
 
         :returns: Location which contains the result of the certificate operation.
@@ -633,7 +630,7 @@ class CertificateOperation(object):
         return self._target
 
     @property
-    def request_id(self) -> "Optional[str]":
+    def request_id(self) -> Optional[str]:
         """Identifier for the certificate operation.
 
         :returns: Identifier for the certificate operation.
@@ -694,8 +691,8 @@ class CertificatePolicy(object):
     # pylint:disable=too-many-instance-attributes
     def __init__(
         self,
-        issuer_name: "Optional[str]" = None,
-        **kwargs,
+        issuer_name: Optional[str] = None,
+        **kwargs: Any,
     ) -> None:
         self._issuer_name = issuer_name
         self._subject = kwargs.pop("subject", None)
@@ -725,7 +722,7 @@ class CertificatePolicy(object):
 
     def _to_certificate_policy_bundle(self) -> models.CertificatePolicy:
         if self.issuer_name or self.certificate_type or self.certificate_transparency:
-            issuer_parameters: "Optional[models.IssuerParameters]" = models.IssuerParameters(
+            issuer_parameters: Optional[models.IssuerParameters] = models.IssuerParameters(
                 name=self.issuer_name,
                 certificate_type=self.certificate_type,
                 certificate_transparency=self.certificate_transparency,  # 2016-10-01 model will ignore this
@@ -773,13 +770,13 @@ class CertificatePolicy(object):
             or self.validity_in_months
         ):
             if self.key_usage:
-                key_usage: "Optional[List[Union[str, KeyUsageType]]]" = [
+                key_usage: Optional[List[Union[str, KeyUsageType]]] = [
                     k.value if not isinstance(k, str) else k for k in self.key_usage
                 ]
             else:
                 key_usage = None
 
-            x509_properties: "Optional[models.X509CertificateProperties]" = models.X509CertificateProperties(
+            x509_properties: Optional[models.X509CertificateProperties] = models.X509CertificateProperties(
                 subject=self.subject,
                 ekus=self.enhanced_key_usage,
                 subject_alternative_names=models.SubjectAlternativeNames(
@@ -792,7 +789,7 @@ class CertificatePolicy(object):
             x509_properties = None
 
         if self.exportable or self.key_type or self.key_size or self.reuse_key or self.key_curve_name:
-            key_properties: "Optional[models.KeyProperties]" = models.KeyProperties(
+            key_properties: Optional[models.KeyProperties] = models.KeyProperties(
                 exportable=self.exportable,
                 key_type=self.key_type,
                 key_size=self.key_size,
@@ -803,7 +800,7 @@ class CertificatePolicy(object):
             key_properties = None
 
         if self.content_type:
-            secret_properties: "Optional[models.SecretProperties]" = models.SecretProperties(
+            secret_properties: Optional[models.SecretProperties] = models.SecretProperties(
                 content_type=self.content_type
             )
         else:
@@ -821,13 +818,13 @@ class CertificatePolicy(object):
 
     @classmethod
     def _from_certificate_policy_bundle(
-        cls, certificate_policy_bundle: "Optional[models.CertificatePolicy]"
+        cls, certificate_policy_bundle: Optional[models.CertificatePolicy]
     ) -> "CertificatePolicy":
         if certificate_policy_bundle is None:
             return cls()
 
         if certificate_policy_bundle.lifetime_actions:
-            lifetime_actions: "Optional[List[LifetimeAction]]" = [
+            lifetime_actions: Optional[List[LifetimeAction]] = [
                 LifetimeAction(
                     action=CertificatePolicyAction(item.action.action_type) if item.action else None,
                     lifetime_percentage=item.trigger.lifetime_percentage if item.trigger else None,
@@ -839,7 +836,7 @@ class CertificatePolicy(object):
             lifetime_actions = None
         x509_certificate_properties = certificate_policy_bundle.x509_certificate_properties
         if x509_certificate_properties and x509_certificate_properties.key_usage:
-            key_usage: "Optional[List[KeyUsageType]]" = [
+            key_usage: Optional[List[KeyUsageType]] = [
                 KeyUsageType(k) for k in x509_certificate_properties.key_usage
             ]
         else:
@@ -892,7 +889,7 @@ class CertificatePolicy(object):
         )
 
     @property
-    def exportable(self) -> "Optional[bool]":
+    def exportable(self) -> Optional[bool]:
         """Whether the private key can be exported.
 
         :returns: True if the private key can be exported; False otherwise.
@@ -901,7 +898,7 @@ class CertificatePolicy(object):
         return self._exportable
 
     @property
-    def key_type(self) -> "Optional[KeyType]":
+    def key_type(self) -> Optional[KeyType]:
         """The type of key pair to be used for the certificate.
 
         :returns: The type of key pair to be used for the certificate.
@@ -910,7 +907,7 @@ class CertificatePolicy(object):
         return self._key_type
 
     @property
-    def key_size(self) -> "Optional[int]":
+    def key_size(self) -> Optional[int]:
         """The key size in bits.
 
         :returns: The key size in bits.
@@ -919,7 +916,7 @@ class CertificatePolicy(object):
         return self._key_size
 
     @property
-    def reuse_key(self) -> "Optional[bool]":
+    def reuse_key(self) -> Optional[bool]:
         """Whether the same key pair will be used on certificate renewal.
 
         :returns: True if the same key pair will be used on certificate renewal; False otherwise.
@@ -928,7 +925,7 @@ class CertificatePolicy(object):
         return self._reuse_key
 
     @property
-    def key_curve_name(self) -> "Optional[KeyCurveName]":
+    def key_curve_name(self) -> Optional[KeyCurveName]:
         """Elliptic curve name.
 
         :returns: Elliptic curve name.
@@ -937,7 +934,7 @@ class CertificatePolicy(object):
         return self._key_curve_name
 
     @property
-    def enhanced_key_usage(self) -> "Optional[List[str]]":
+    def enhanced_key_usage(self) -> Optional[List[str]]:
         """The enhanced key usage.
 
         :returns: The enhanced key usage.
@@ -946,7 +943,7 @@ class CertificatePolicy(object):
         return self._enhanced_key_usage
 
     @property
-    def key_usage(self) -> "Optional[List[KeyUsageType]]":
+    def key_usage(self) -> Optional[List[KeyUsageType]]:
         """List of key usages.
 
         :returns: List of key usages.
@@ -955,7 +952,7 @@ class CertificatePolicy(object):
         return self._key_usage
 
     @property
-    def content_type(self) -> "Optional[CertificateContentType]":
+    def content_type(self) -> Optional[CertificateContentType]:
         """The media type (MIME type).
 
         :returns: The media type (MIME type).
@@ -964,7 +961,7 @@ class CertificatePolicy(object):
         return self._content_type
 
     @property
-    def subject(self) -> "Optional[str]":
+    def subject(self) -> Optional[str]:
         """The subject name of the certificate.
 
         :returns: The subject name of the certificate.
@@ -973,7 +970,7 @@ class CertificatePolicy(object):
         return self._subject
 
     @property
-    def san_emails(self) -> "Optional[List[str]]":
+    def san_emails(self) -> Optional[List[str]]:
         """The subject alternative email addresses.
 
         :returns: The subject alternative email addresses, as a list.
@@ -982,7 +979,7 @@ class CertificatePolicy(object):
         return self._san_emails
 
     @property
-    def san_dns_names(self) -> "Optional[List[str]]":
+    def san_dns_names(self) -> Optional[List[str]]:
         """The subject alternative domain names.
 
         :returns: The subject alternative domain names, as a list.
@@ -991,7 +988,7 @@ class CertificatePolicy(object):
         return self._san_dns_names
 
     @property
-    def san_user_principal_names(self) -> "Optional[List[str]]":
+    def san_user_principal_names(self) -> Optional[List[str]]:
         """The subject alternative user principal names.
 
         :returns: The subject alternative user principal names, as a list.
@@ -1000,7 +997,7 @@ class CertificatePolicy(object):
         return self._san_user_principal_names
 
     @property
-    def validity_in_months(self) -> "Optional[int]":
+    def validity_in_months(self) -> Optional[int]:
         """The duration that the certificate is valid for in months.
 
         :returns: The duration that the certificate is valid for in months.
@@ -1018,7 +1015,7 @@ class CertificatePolicy(object):
         return self._lifetime_actions
 
     @property
-    def issuer_name(self) -> "Optional[str]":
+    def issuer_name(self) -> Optional[str]:
         """Name of the referenced issuer object or reserved names for the issuer of the certificate.
 
         :returns: Name of the referenced issuer object or reserved names for the issuer of the certificate.
@@ -1027,7 +1024,7 @@ class CertificatePolicy(object):
         return self._issuer_name
 
     @property
-    def certificate_type(self) -> "Optional[str]":
+    def certificate_type(self) -> Optional[str]:
         """Type of certificate requested from the issuer provider.
 
         :returns: Type of certificate requested from the issuer provider.
@@ -1036,7 +1033,7 @@ class CertificatePolicy(object):
         return self._certificate_type
 
     @property
-    def certificate_transparency(self) -> "Optional[bool]":
+    def certificate_transparency(self) -> Optional[bool]:
         """Whether the certificates generated under this policy should be published to certificate transparency logs.
 
         :returns: True if the certificates should be published to transparency logs; False otherwise.
@@ -1045,7 +1042,7 @@ class CertificatePolicy(object):
         return self._certificate_transparency
 
     @property
-    def enabled(self) -> "Optional[bool]":
+    def enabled(self) -> Optional[bool]:
         """Whether the certificate is enabled or not.
 
         :returns: True if the certificate is enabled; False otherwise.
@@ -1054,7 +1051,7 @@ class CertificatePolicy(object):
         return self._attributes.enabled if self._attributes else None
 
     @property
-    def created_on(self) -> "Optional[datetime]":
+    def created_on(self) -> Optional[datetime]:
         """The datetime when the certificate is created.
 
         :returns: The datetime when the certificate is created.
@@ -1063,7 +1060,7 @@ class CertificatePolicy(object):
         return self._attributes.created if self._attributes else None
 
     @property
-    def updated_on(self) -> "Optional[datetime]":
+    def updated_on(self) -> Optional[datetime]:
         """The datetime when the certificate was last updated.
 
         :returns: The datetime when the certificate was last updated.
@@ -1084,7 +1081,7 @@ class CertificateContact(object):
     """
 
     def __init__(
-        self, email: "Optional[str]" = None, name: "Optional[str]" = None, phone: "Optional[str]" = None
+        self, email: Optional[str] = None, name: Optional[str] = None, phone: Optional[str] = None
     ) -> None:
         self._email = email
         self._name = name
@@ -1101,17 +1098,17 @@ class CertificateContact(object):
         return cls(email=contact_item.email_address, name=contact_item.name, phone=contact_item.phone)
 
     @property
-    def email(self) -> "Optional[str]":
+    def email(self) -> Optional[str]:
         """:rtype: str or None"""
         return self._email
 
     @property
-    def name(self) -> "Optional[str]":
+    def name(self) -> Optional[str]:
         """:rtype: str or None"""
         return self._name
 
     @property
-    def phone(self) -> "Optional[str]":
+    def phone(self) -> Optional[str]:
         """:rtype: str or None"""
         return self._phone
 
@@ -1123,7 +1120,7 @@ class IssuerProperties(object):
     :type provider: str or None
     """
 
-    def __init__(self, provider: "Optional[str]" = None, **kwargs) -> None:
+    def __init__(self, provider: Optional[str] = None, **kwargs: Any) -> None:
         self._id = kwargs.pop("issuer_id", None)
         self._vault_id = parse_key_vault_id(self._id)
         self._provider = provider
@@ -1133,12 +1130,12 @@ class IssuerProperties(object):
 
     @classmethod
     def _from_issuer_item(
-        cls, issuer_item: "Union[models.CertificateIssuerItem, models.IssuerBundle]"
+        cls, issuer_item: Union[models.CertificateIssuerItem, models.IssuerBundle]
     ) -> "IssuerProperties":
         return cls(issuer_id=issuer_item.id, provider=issuer_item.provider)
 
     @property
-    def id(self) -> "Optional[str]":
+    def id(self) -> Optional[str]:
         """The issuer ID.
 
         :returns: The issuer ID.
@@ -1147,7 +1144,7 @@ class IssuerProperties(object):
         return self._id
 
     @property
-    def name(self) -> "Optional[str]":
+    def name(self) -> Optional[str]:
         """The issuer name.
 
         :returns: The issuer name.
@@ -1157,7 +1154,7 @@ class IssuerProperties(object):
         return self._vault_id.version
 
     @property
-    def provider(self) -> "Optional[str]":
+    def provider(self) -> Optional[str]:
         """The issuer provider.
 
         :returns: The issuer provider.
@@ -1185,14 +1182,14 @@ class CertificateIssuer(object):
 
     def __init__(
         self,
-        provider: "Optional[str]",
-        attributes: "Optional[models.IssuerAttributes]" = None,
-        account_id: "Optional[str]" = None,
+        provider: Optional[str],
+        attributes: Optional[models.IssuerAttributes] = None,
+        account_id: Optional[str] = None,
         # [SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Typedef, not string.")]
-        password: "Optional[str]" = None,
-        organization_id: "Optional[str]" = None,
-        admin_contacts: "Optional[List[AdministratorContact]]" = None,
-        **kwargs,
+        password: Optional[str] = None,
+        organization_id: Optional[str] = None,
+        admin_contacts: Optional[List[AdministratorContact]] = None,
+        **kwargs: Any,
     ) -> None:
         self._provider = provider
         self._attributes = attributes
@@ -1227,7 +1224,7 @@ class CertificateIssuer(object):
         )
 
     @property
-    def id(self) -> "Optional[str]":
+    def id(self) -> Optional[str]:
         """The issuer ID.
 
         :returns: The issuer ID.
@@ -1236,7 +1233,7 @@ class CertificateIssuer(object):
         return self._id
 
     @property
-    def name(self) -> "Optional[str]":
+    def name(self) -> Optional[str]:
         """The issuer name.
 
         :returns: The issuer name.
@@ -1249,7 +1246,7 @@ class CertificateIssuer(object):
         return self._vault_id.version
 
     @property
-    def provider(self) -> "Optional[str]":
+    def provider(self) -> Optional[str]:
         """The issuer provider.
 
         :returns: The issuer provider.
@@ -1258,7 +1255,7 @@ class CertificateIssuer(object):
         return self._provider
 
     @property
-    def enabled(self) -> "Optional[bool]":
+    def enabled(self) -> Optional[bool]:
         """Whether the certificate is enabled or not.
 
         :returns: True if the certificate is enabled; False otherwise.
@@ -1267,7 +1264,7 @@ class CertificateIssuer(object):
         return self._attributes.enabled if self._attributes else None
 
     @property
-    def created_on(self) -> "Optional[datetime]":
+    def created_on(self) -> Optional[datetime]:
         """The datetime when the certificate is created.
 
         :returns: The datetime when the certificate is created.
@@ -1276,7 +1273,7 @@ class CertificateIssuer(object):
         return self._attributes.created if self._attributes else None
 
     @property
-    def updated_on(self) -> "Optional[datetime]":
+    def updated_on(self) -> Optional[datetime]:
         """The datetime when the certificate was last updated.
 
         :returns: The datetime when the certificate was last updated.
@@ -1285,7 +1282,7 @@ class CertificateIssuer(object):
         return self._attributes.updated if self._attributes else None
 
     @property
-    def account_id(self) -> "Optional[str]":
+    def account_id(self) -> Optional[str]:
         """The username / account name / account id.
 
         :returns: The username / account name / account id.
@@ -1294,7 +1291,7 @@ class CertificateIssuer(object):
         return self._account_id
 
     @property
-    def password(self) -> "Optional[str]":
+    def password(self) -> Optional[str]:
         """The password / secret / account key.
 
         :returns: The password / secret / account key.
@@ -1303,7 +1300,7 @@ class CertificateIssuer(object):
         return self._password
 
     @property
-    def organization_id(self) -> "Optional[str]":
+    def organization_id(self) -> Optional[str]:
         """The issuer organization ID.
 
         :returns: The issuer organization ID.
@@ -1312,7 +1309,7 @@ class CertificateIssuer(object):
         return self._organization_id
 
     @property
-    def admin_contacts(self) -> "Optional[List[AdministratorContact]]":
+    def admin_contacts(self) -> Optional[List[AdministratorContact]]:
         """Contact details of the organization administrator(s) of this issuer.
 
         :returns: Contact details of the organization administrator(s) of this issuer.
@@ -1336,9 +1333,9 @@ class LifetimeAction(object):
 
     def __init__(
         self,
-        action: "Union[str, CertificatePolicyAction, None]",
-        lifetime_percentage: "Optional[int]" = None,
-        days_before_expiry: "Optional[int]" = None,
+        action: Union[str, CertificatePolicyAction, None],
+        lifetime_percentage: Optional[int] = None,
+        days_before_expiry: Optional[int] = None,
     ) -> None:
         self._lifetime_percentage = lifetime_percentage
         self._days_before_expiry = days_before_expiry
@@ -1352,7 +1349,7 @@ class LifetimeAction(object):
         return result[:1024]
 
     @property
-    def lifetime_percentage(self) -> "Optional[int]":
+    def lifetime_percentage(self) -> Optional[int]:
         """Percentage of lifetime at which to trigger.
 
         :returns: Percentage of lifetime at which to trigger.
@@ -1361,7 +1358,7 @@ class LifetimeAction(object):
         return self._lifetime_percentage
 
     @property
-    def days_before_expiry(self) -> "Optional[int]":
+    def days_before_expiry(self) -> Optional[int]:
         """Days before expiry to attempt renewal.
 
         :returns: Days before expiry to attempt renewal.
@@ -1370,7 +1367,7 @@ class LifetimeAction(object):
         return self._days_before_expiry
 
     @property
-    def action(self) -> "Union[str, CertificatePolicyAction, None]":
+    def action(self) -> Union[str, CertificatePolicyAction, None]:
         """The type of action that will be executed; see :class:`~azure.keyvault.certificates.CertificatePolicyAction`.
 
         :returns: The type of action that will be executed; see
@@ -1400,10 +1397,10 @@ class DeletedCertificate(KeyVaultCertificate):
 
     def __init__(
         self,
-        properties: "Optional[CertificateProperties]" = None,
-        policy: "Optional[CertificatePolicy]" = None,
-        cer: "Optional[bytearray]" = None,
-        **kwargs,
+        properties: Optional[CertificateProperties] = None,
+        policy: Optional[CertificatePolicy] = None,
+        cer: Optional[bytearray] = None,
+        **kwargs: Any,
     ) -> None:
         super(DeletedCertificate, self).__init__(properties=properties, policy=policy, cer=cer, **kwargs)
         self._deleted_on = kwargs.get("deleted_on", None)
@@ -1447,7 +1444,7 @@ class DeletedCertificate(KeyVaultCertificate):
         )
 
     @property
-    def deleted_on(self) -> "Optional[datetime]":
+    def deleted_on(self) -> Optional[datetime]:
         """The datetime when the certificate was deleted.
 
         :returns: The datetime when the certificate was deleted.
@@ -1456,7 +1453,7 @@ class DeletedCertificate(KeyVaultCertificate):
         return self._deleted_on
 
     @property
-    def recovery_id(self) -> "Optional[str]":
+    def recovery_id(self) -> Optional[str]:
         """The URL of the recovery object, used to identify and recover the deleted certificate.
 
         :returns: The URL of the recovery object, used to identify and recover the deleted certificate.
@@ -1465,7 +1462,7 @@ class DeletedCertificate(KeyVaultCertificate):
         return self._recovery_id
 
     @property
-    def scheduled_purge_date(self) -> "Optional[datetime]":
+    def scheduled_purge_date(self) -> Optional[datetime]:
         """The datetime when the certificate is scheduled to be purged.
 
         :returns: The datetime when the certificate is scheduled to be purged.

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/async_challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/async_challenge_auth_policy.py
@@ -35,7 +35,7 @@ class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
 
     :param credential: An object which can provide an access token for the vault, such as a credential from
         :mod:`azure.identity.aio`
-    :type credential: :class:`~azure.core.credentials_async.AsyncTokenCredential`
+    :type credential: ~azure.core.credentials_async.AsyncTokenCredential
     """
 
     def __init__(self, credential: "AsyncTokenCredential", *scopes: str, **kwargs) -> None:

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/async_challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/async_challenge_auth_policy.py
@@ -15,20 +15,16 @@ protocol again.
 """
 
 import time
-from typing import TYPE_CHECKING
+from typing import Any, Optional
 from urllib.parse import urlparse
 
+from azure.core.credentials import AccessToken
+from azure.core.credentials_async import AsyncTokenCredential
+from azure.core.pipeline import PipelineRequest, PipelineResponse
 from azure.core.pipeline.policies import AsyncBearerTokenCredentialPolicy
 
 from . import http_challenge_cache as ChallengeCache
 from .challenge_auth_policy import _enforce_tls, _update_challenge
-
-if TYPE_CHECKING:
-    from typing import Optional
-    from azure.core.credentials import AccessToken
-    from azure.core.credentials_async import AsyncTokenCredential
-    from azure.core.pipeline import PipelineRequest, PipelineResponse
-
 
 class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
     """Policy for handling HTTP authentication challenges.
@@ -38,13 +34,13 @@ class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
     :type credential: ~azure.core.credentials_async.AsyncTokenCredential
     """
 
-    def __init__(self, credential: "AsyncTokenCredential", *scopes: str, **kwargs) -> None:
+    def __init__(self, credential: AsyncTokenCredential, *scopes: str, **kwargs: Any) -> None:
         super().__init__(credential, *scopes, **kwargs)
         self._credential = credential
-        self._token: "Optional[AccessToken]" = None
+        self._token: Optional[AccessToken] = None
         self._verify_challenge_resource = kwargs.pop("verify_challenge_resource", True)
 
-    async def on_request(self, request: "PipelineRequest") -> None:
+    async def on_request(self, request: PipelineRequest) -> None:
         _enforce_tls(request)
         challenge = ChallengeCache.get_challenge_for_url(request.http_request.url)
         if challenge:
@@ -68,7 +64,7 @@ class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
             request.http_request.headers["Content-Length"] = "0"
 
 
-    async def on_challenge(self, request: "PipelineRequest", response: "PipelineResponse") -> bool:
+    async def on_challenge(self, request: PipelineRequest, response: PipelineResponse) -> bool:
         try:
             challenge = _update_challenge(request, response)
             # azure-identity credentials require an AADv2 scope but the challenge may specify an AADv1 resource

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/async_client_base.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/async_client_base.py
@@ -2,9 +2,11 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
-from typing import TYPE_CHECKING
+from typing import Any, Awaitable
 
+from azure.core.credentials_async import AsyncTokenCredential
 from azure.core.pipeline.policies import HttpLoggingPolicy
+from azure.core.rest import AsyncHttpResponse, HttpRequest
 from azure.core.tracing.decorator_async import distributed_trace_async
 
 from . import AsyncChallengeAuthPolicy
@@ -13,16 +15,10 @@ from .._sdk_moniker import SDK_MONIKER
 from .._generated.aio import KeyVaultClient as _KeyVaultClient
 from .._generated import models as _models
 
-if TYPE_CHECKING:
-    # pylint:disable=unused-import
-    from typing import Any, Awaitable
-    from azure.core.credentials_async import AsyncTokenCredential
-    from azure.core.rest import AsyncHttpResponse, HttpRequest
-
 
 class AsyncKeyVaultClientBase(object):
     # pylint:disable=protected-access
-    def __init__(self, vault_url: str, credential: "AsyncTokenCredential", **kwargs) -> None:
+    def __init__(self, vault_url: str, credential: AsyncTokenCredential, **kwargs: Any) -> None:
         if not credential:
             raise ValueError(
                 "credential should be an object supporting the AsyncTokenCredential protocol, "
@@ -74,7 +70,7 @@ class AsyncKeyVaultClientBase(object):
         await self._client.__aenter__()
         return self
 
-    async def __aexit__(self, *args: "Any") -> None:
+    async def __aexit__(self, *args: Any) -> None:
         await self._client.__aexit__(*args)
 
     async def close(self) -> None:
@@ -85,7 +81,9 @@ class AsyncKeyVaultClientBase(object):
         await self._client.close()
 
     @distributed_trace_async
-    def send_request(self, request: "HttpRequest", *, stream: bool = False, **kwargs) -> "Awaitable[AsyncHttpResponse]":
+    def send_request(
+        self, request: HttpRequest, *, stream: bool = False, **kwargs: Any
+    ) -> Awaitable[AsyncHttpResponse]:
         """Runs a network request using the client's existing pipeline.
 
         The request URL can be relative to the vault URL. The service API version used for the request is the same as

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/challenge_auth_policy.py
@@ -42,9 +42,9 @@ def _update_challenge(request: PipelineRequest, challenger: "PipelineResponse") 
     """Parse challenge from a challenge response, cache it, and return it.
 
     :param request: The pipeline request that prompted the challenge response.
-    :type request: :class:`~azure.core.pipeline.PipelineRequest`
+    :type request: ~azure.core.pipeline.PipelineRequest
     :param challenger: The pipeline response containing the authentication challenge.
-    :type challenger: :class:`~azure.core.pipeline.PipelineResponse`
+    :type challenger: ~azure.core.pipeline.PipelineResponse
 
     :returns: An HttpChallenge object representing the authentication challenge.
     :rtype: HttpChallenge
@@ -64,7 +64,7 @@ class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
 
     :param credential: An object which can provide an access token for the vault, such as a credential from
         :mod:`azure.identity`
-    :type credential: :class:`~azure.core.credentials.TokenCredential`
+    :type credential: ~azure.core.credentials.TokenCredential
     """
 
     def __init__(self, credential: "TokenCredential", *scopes: str, **kwargs) -> None:

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/client_base.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/client_base.py
@@ -3,12 +3,14 @@
 # Licensed under the MIT License.
 # ------------------------------------
 from copy import deepcopy
-from typing import TYPE_CHECKING
 from enum import Enum
+from typing import Any
 from urllib.parse import urlparse
 
 from azure.core import CaseInsensitiveEnumMeta
+from azure.core.credentials import TokenCredential
 from azure.core.pipeline.policies import HttpLoggingPolicy
+from azure.core.rest import HttpRequest, HttpResponse
 from azure.core.tracing.decorator import distributed_trace
 
 from . import ChallengeAuthPolicy
@@ -16,12 +18,6 @@ from .._generated import KeyVaultClient as _KeyVaultClient
 from .._generated import models as _models
 from .._generated._serialization import Serializer
 from .._sdk_moniker import SDK_MONIKER
-
-if TYPE_CHECKING:
-    # pylint:disable=unused-import,ungrouped-imports
-    from typing import Any
-    from azure.core.credentials import TokenCredential
-    from azure.core.rest import HttpRequest, HttpResponse
 
 
 class ApiVersion(str, Enum, metaclass=CaseInsensitiveEnumMeta):
@@ -43,7 +39,7 @@ _SERIALIZER = Serializer()
 _SERIALIZER.client_side_validation = False
 
 
-def _format_api_version(request: "HttpRequest", api_version: str) -> "HttpRequest":
+def _format_api_version(request: HttpRequest, api_version: str) -> HttpRequest:
     """Returns a request copy that includes an api-version query parameter if one wasn't originally present.
 
     :param request: The HTTP request being sent.
@@ -73,7 +69,7 @@ def _format_api_version(request: "HttpRequest", api_version: str) -> "HttpReques
 
 class KeyVaultClientBase(object):
     # pylint:disable=protected-access
-    def __init__(self, vault_url: str, credential: "TokenCredential", **kwargs) -> None:
+    def __init__(self, vault_url: str, credential: TokenCredential, **kwargs: Any) -> None:
         if not credential:
             raise ValueError(
                 "credential should be an object supporting the TokenCredential protocol, "
@@ -125,7 +121,7 @@ class KeyVaultClientBase(object):
         self._client.__enter__()
         return self
 
-    def __exit__(self, *args: "Any") -> None:
+    def __exit__(self, *args: Any) -> None:
         self._client.__exit__(*args)
 
     def close(self) -> None:
@@ -136,7 +132,7 @@ class KeyVaultClientBase(object):
         self._client.close()
 
     @distributed_trace
-    def send_request(self, request: "HttpRequest", *, stream: bool = False, **kwargs) -> "HttpResponse":
+    def send_request(self, request: HttpRequest, *, stream: bool = False, **kwargs: Any) -> HttpResponse:
         """Runs a network request using the client's existing pipeline.
 
         The request URL can be relative to the vault URL. The service API version used for the request is the same as

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/client_base.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/client_base.py
@@ -47,11 +47,11 @@ def _format_api_version(request: "HttpRequest", api_version: str) -> "HttpReques
     """Returns a request copy that includes an api-version query parameter if one wasn't originally present.
 
     :param request: The HTTP request being sent.
-    :type request: :class:`~azure.core.rest.HttpRequest`
+    :type request: ~azure.core.rest.HttpRequest
     :param str api_version: The service API version that the request should include.
 
     :returns: A copy of the request that includes an api-version query parameter.
-    :rtype: :class:`~azure.core.rest.HttpRequest`
+    :rtype: azure.core.rest.HttpRequest
     """
     request_copy = deepcopy(request)
     params = {"api-version": api_version}  # By default, we want to use the client's API version

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/aio/_client.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/aio/_client.py
@@ -36,7 +36,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         for details.
     :param credential: An object which can provide an access token for the vault, such as a credential from
         :mod:`azure.identity.aio`
-    :type credential: :class:`~azure.core.credentials_async.AsyncTokenCredential`
+    :type credential: ~azure.core.credentials_async.AsyncTokenCredential
 
     :keyword api_version: Version of the service API to use. Defaults to the most recent.
     :paramtype api_version: ~azure.keyvault.certificates.ApiVersion or str
@@ -61,7 +61,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
 
         If this is the first version, the certificate resource is created. This operation requires the
         certificates/create permission. The poller requires the certificates/get permission, otherwise raises an
-        :class:`~azure.core.exceptions.HttpResponseError`
+        azure.core.exceptions.HttpResponseError
 
         :param str certificate_name: The name of the certificate.
         :param policy: The management policy for the certificate. Either subject or one of the subject alternative
@@ -78,7 +78,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
 
         :raises:
             :class:`ValueError` if the certificate policy is invalid,
-            :class:`~azure.core.exceptions.HttpResponseError` for other errors.
+            azure.core.exceptions.HttpResponseError for other errors.
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates_async.py
@@ -140,8 +140,8 @@ class CertificateClient(AsyncKeyVaultClientBase):
         :rtype: ~azure.keyvault.certificates.KeyVaultCertificate
 
         :raises:
-            :class:`~azure.core.exceptions.ResourceNotFoundError` if the certificate doesn't exist,
-            :class:`~azure.core.exceptions.HttpResponseError` for other errors
+            azure.core.exceptions.ResourceNotFoundError if the certificate doesn't exist,
+            azure.core.exceptions.HttpResponseError for other errors
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates_async.py
@@ -175,8 +175,8 @@ class CertificateClient(AsyncKeyVaultClientBase):
         :rtype: ~azure.keyvault.certificates.KeyVaultCertificate
 
         :raises:
-            :class:`~azure.core.exceptions.ResourceNotFoundError` if the certificate doesn't exist,
-            :class:`~azure.core.exceptions.HttpResponseError` for other errors
+            azure.core.exceptions.ResourceNotFoundError if the certificate doesn't exist,
+            azure.core.exceptions.HttpResponseError for other errors
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates_async.py
@@ -206,8 +206,8 @@ class CertificateClient(AsyncKeyVaultClientBase):
         :rtype: ~azure.keyvault.certificates.DeletedCertificate
 
         :raises:
-            :class:`~azure.core.exceptions.ResourceNotFoundError` if the certificate doesn't exist,
-            :class:`~azure.core.exceptions.HttpResponseError` for other errors
+            azure.core.exceptions.ResourceNotFoundError if the certificate doesn't exist,
+            azure.core.exceptions.HttpResponseError for other errors
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates_async.py
@@ -249,8 +249,8 @@ class CertificateClient(AsyncKeyVaultClientBase):
         :rtype: ~azure.keyvault.certificates.DeletedCertificate
 
         :raises:
-            :class:`~azure.core.exceptions.ResourceNotFoundError` if the certificate doesn't exist,
-            :class:`~azure.core.exceptions.HttpResponseError` for other errors
+            azure.core.exceptions.ResourceNotFoundError if the certificate doesn't exist,
+            azure.core.exceptions.HttpResponseError for other errors
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates_async.py
@@ -280,7 +280,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         :return: None
         :rtype: None
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises: azure.core.exceptions.HttpResponseError
         """
         await self._client.purge_deleted_certificate(
             vault_base_url=self.vault_url, certificate_name=certificate_name, **kwargs
@@ -299,7 +299,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         :returns: The recovered certificate
         :rtype: ~azure.keyvault.certificates.KeyVaultCertificate
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises: azure.core.exceptions.HttpResponseError
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates_async.py
@@ -354,7 +354,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         :returns: The imported KeyVaultCertificate
         :rtype: ~azure.keyvault.certificates.KeyVaultCertificate
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises: azure.core.exceptions.HttpResponseError
         """
 
         enabled = kwargs.pop("enabled", None)
@@ -393,7 +393,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         :return: The certificate policy
         :rtype: ~azure.keyvault.certificates.CertificatePolicy
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises: azure.core.exceptions.HttpResponseError
         """
         bundle = await self._client.get_certificate_policy(
             vault_base_url=self.vault_url, certificate_name=certificate_name, **kwargs
@@ -415,7 +415,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         :return: The certificate policy
         :rtype: ~azure.keyvault.certificates.CertificatePolicy
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises: azure.core.exceptions.HttpResponseError
         """
         bundle = await self._client.update_certificate_policy(
             vault_base_url=self.vault_url,
@@ -441,7 +441,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         :returns: The updated KeyVaultCertificate
         :rtype: ~azure.keyvault.certificates.KeyVaultCertificate
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises: azure.core.exceptions.HttpResponseError
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates_async.py
@@ -487,8 +487,8 @@ class CertificateClient(AsyncKeyVaultClientBase):
         :rtype: bytes
 
         :raises:
-            :class:`~azure.core.exceptions.ResourceNotFoundError` if the certificate doesn't exist,
-            :class:`~azure.core.exceptions.HttpResponseError` for other errors
+            azure.core.exceptions.ResourceNotFoundError if the certificate doesn't exist,
+            azure.core.exceptions.HttpResponseError for other errors
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates_async.py
@@ -516,7 +516,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         :return: The restored KeyVaultCertificate
         :rtype: ~azure.keyvault.certificates.KeyVaultCertificate
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises: azure.core.exceptions.HttpResponseError
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates_async.py
@@ -549,7 +549,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         :return: An iterator-like instance of DeletedCertificate
         :rtype: ~azure.core.paging.ItemPaged[~azure.keyvault.certificates.DeletedCertificate]
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises: azure.core.exceptions.HttpResponseError
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates_async.py
@@ -592,7 +592,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         :returns: An iterator-like instance of CertificateProperties
         :rtype: ~azure.core.paging.ItemPaged[~azure.keyvault.certificates.CertificateProperties]
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises: azure.core.exceptions.HttpResponseError
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates_async.py
@@ -633,7 +633,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         :returns: An iterator-like instance of CertificateProperties
         :rtype: ~azure.core.paging.ItemPaged[~azure.keyvault.certificates.CertificateProperties]
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises: azure.core.exceptions.HttpResponseError
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates_async.py
@@ -662,7 +662,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         :returns: The created list of contacts
         :rtype: list[~azure.keyvault.certificates.CertificateContact]
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises: azure.core.exceptions.HttpResponseError
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates_async.py
@@ -688,7 +688,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         :return: The certificate contacts for the key vault.
         :rtype: list[azure.keyvault.certificates.CertificateContact]
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises: azure.core.exceptions.HttpResponseError
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates_async.py
@@ -710,7 +710,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         :return: The deleted contacts for the key vault.
         :rtype: list[~azure.keyvault.certificates.CertificateContact]
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises: azure.core.exceptions.HttpResponseError
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates_async.py
@@ -735,8 +735,8 @@ class CertificateClient(AsyncKeyVaultClientBase):
         :rtype: ~azure.keyvault.certificates.CertificateOperation
 
         :raises:
-            :class:`~azure.core.exceptions.ResourceNotFoundError` if the certificate doesn't exist,
-            :class:`~azure.core.exceptions.HttpResponseError` for other errors
+            azure.core.exceptions.ResourceNotFoundError if the certificate doesn't exist,
+            azure.core.exceptions.HttpResponseError for other errors
         """
 
         bundle = await self._client.get_certificate_operation(
@@ -756,8 +756,8 @@ class CertificateClient(AsyncKeyVaultClientBase):
         :rtype: ~azure.keyvault.certificates.CertificateOperation
 
         :raises:
-            :class:`~azure.core.exceptions.ResourceNotFoundError` if the operation doesn't exist,
-            :class:`~azure.core.exceptions.HttpResponseError` for other errors
+            azure.core.exceptions.ResourceNotFoundError if the operation doesn't exist,
+            azure.core.exceptions.HttpResponseError for other errors
         """
         bundle = await self._client.delete_certificate_operation(
             vault_base_url=self.vault_url, certificate_name=certificate_name, **kwargs
@@ -773,7 +773,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         :returns: The cancelled certificate operation
         :rtype: ~azure.keyvault.certificates.CertificateOperation
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises: azure.core.exceptions.HttpResponseError
         """
         bundle = await self._client.update_certificate_operation(
             vault_base_url=self.vault_url,
@@ -805,7 +805,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         :return: The merged certificate operation
         :rtype: ~azure.keyvault.certificates.CertificateOperation
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises: azure.core.exceptions.HttpResponseError
         """
 
         enabled = kwargs.pop("enabled", None)
@@ -837,8 +837,8 @@ class CertificateClient(AsyncKeyVaultClientBase):
         :rtype: ~azure.keyvault.certificates.CertificateIssuer
 
         :raises:
-            :class:`~azure.core.exceptions.ResourceNotFoundError` if the issuer doesn't exist,
-            :class:`~azure.core.exceptions.HttpResponseError` for other errors
+            azure.core.exceptions.ResourceNotFoundError if the issuer doesn't exist,
+            azure.core.exceptions.HttpResponseError for other errors
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates_async.py
@@ -871,7 +871,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         :returns: The created CertificateIssuer
         :rtype: ~azure.keyvault.certificates.CertificateIssuer
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises: azure.core.exceptions.HttpResponseError
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates_async.py
@@ -943,7 +943,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         :return: The updated issuer
         :rtype: ~azure.keyvault.certificates.CertificateIssuer
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises: azure.core.exceptions.HttpResponseError
         """
 
         enabled = kwargs.pop("enabled", None)
@@ -1000,7 +1000,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         :return: CertificateIssuer
         :rtype: ~azure.keyvault.certificates.CertificateIssuer
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises: azure.core.exceptions.HttpResponseError
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates_async.py
@@ -1024,7 +1024,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         :return: An iterator-like instance of Issuers
         :rtype: ~azure.core.paging.ItemPaged[~azure.keyvault.certificates.CertificateIssuer]
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises: azure.core.exceptions.HttpResponseError
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates_async.py

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/aio/_client.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/aio/_client.py
@@ -55,7 +55,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
     # pylint:disable=protected-access
     @distributed_trace_async
     async def create_certificate(
-        self, certificate_name: str, policy: CertificatePolicy, **kwargs
+        self, certificate_name: str, policy: CertificatePolicy, **kwargs: Any
     ) -> Union[KeyVaultCertificate, CertificateOperation]:
         """Creates a new certificate.
 
@@ -76,9 +76,8 @@ class CertificateClient(AsyncKeyVaultClientBase):
             KeyVaultCertificate if creation is successful, or the CertificateOperation if not.
         :rtype: ~azure.keyvault.certificates.KeyVaultCertificate or ~azure.keyvault.certificates.CertificateOperation
 
-        :raises:
-            :class:`ValueError` if the certificate policy is invalid,
-            :class:`~azure.core.exceptions.HttpResponseError` for other errors.
+        :raises ValueError or ~azure.core.exceptions.HttpResponseError:
+            the former if the certificate policy is invalid; the latter for other errors
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates_async.py
@@ -128,7 +127,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         return await async_poller(command, create_certificate_operation, no_op, create_certificate_polling)
 
     @distributed_trace_async
-    async def get_certificate(self, certificate_name: str, **kwargs) -> KeyVaultCertificate:
+    async def get_certificate(self, certificate_name: str, **kwargs: Any) -> KeyVaultCertificate:
         """Gets a certificate with its management policy attached. Requires certificates/get permission.
 
         Does not accept the version of the certificate as a parameter. To get a specific version of the
@@ -139,9 +138,8 @@ class CertificateClient(AsyncKeyVaultClientBase):
         :returns: An instance of KeyVaultCertificate
         :rtype: ~azure.keyvault.certificates.KeyVaultCertificate
 
-        :raises:
-            :class:`~azure.core.exceptions.ResourceNotFoundError` if the certificate doesn't exist,
-            :class:`~azure.core.exceptions.HttpResponseError` for other errors
+        :raises ~azure.core.exceptions.ResourceNotFoundError or ~azure.core.exceptions.HttpResponseError:
+            the former if the certificate doesn't exist; the latter for other errors
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates_async.py
@@ -161,7 +159,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
 
     @distributed_trace_async
     async def get_certificate_version(
-        self, certificate_name: str, version: str, **kwargs
+        self, certificate_name: str, version: str, **kwargs: Any
     ) -> KeyVaultCertificate:
         """Gets a specific version of a certificate without returning its management policy.
 
@@ -174,9 +172,8 @@ class CertificateClient(AsyncKeyVaultClientBase):
         :returns: An instance of KeyVaultCertificate
         :rtype: ~azure.keyvault.certificates.KeyVaultCertificate
 
-        :raises:
-            :class:`~azure.core.exceptions.ResourceNotFoundError` if the certificate doesn't exist,
-            :class:`~azure.core.exceptions.HttpResponseError` for other errors
+        :raises ~azure.core.exceptions.ResourceNotFoundError or ~azure.core.exceptions.HttpResponseError:
+            the former if the certificate doesn't exist; the latter for other errors
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates_async.py
@@ -195,7 +192,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         return KeyVaultCertificate._from_certificate_bundle(certificate_bundle=bundle)
 
     @distributed_trace_async
-    async def delete_certificate(self, certificate_name: str, **kwargs) -> DeletedCertificate:
+    async def delete_certificate(self, certificate_name: str, **kwargs: Any) -> DeletedCertificate:
         """Delete all versions of a certificate. Requires certificates/delete permission.
 
         If the vault has soft-delete enabled, deletion may take several seconds to complete.
@@ -205,9 +202,8 @@ class CertificateClient(AsyncKeyVaultClientBase):
         :returns: The deleted certificate
         :rtype: ~azure.keyvault.certificates.DeletedCertificate
 
-        :raises:
-            :class:`~azure.core.exceptions.ResourceNotFoundError` if the certificate doesn't exist,
-            :class:`~azure.core.exceptions.HttpResponseError` for other errors
+        :raises ~azure.core.exceptions.ResourceNotFoundError or ~azure.core.exceptions.HttpResponseError:
+            the former if the certificate doesn't exist; the latter for other errors
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates_async.py
@@ -237,7 +233,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         return polling_method.resource()
 
     @distributed_trace_async
-    async def get_deleted_certificate(self, certificate_name: str, **kwargs) -> DeletedCertificate:
+    async def get_deleted_certificate(self, certificate_name: str, **kwargs: Any) -> DeletedCertificate:
         """Get a deleted certificate. Possible only in a vault with soft-delete enabled.
 
         Requires certificates/get permission. Retrieves the deleted certificate information plus its attributes, such as
@@ -248,9 +244,8 @@ class CertificateClient(AsyncKeyVaultClientBase):
         :return: The deleted certificate
         :rtype: ~azure.keyvault.certificates.DeletedCertificate
 
-        :raises:
-            :class:`~azure.core.exceptions.ResourceNotFoundError` if the certificate doesn't exist,
-            :class:`~azure.core.exceptions.HttpResponseError` for other errors
+        :raises ~azure.core.exceptions.ResourceNotFoundError or ~azure.core.exceptions.HttpResponseError:
+            the former if the certificate doesn't exist; the latter for other errors
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates_async.py
@@ -266,7 +261,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         return DeletedCertificate._from_deleted_certificate_bundle(deleted_certificate_bundle=bundle)
 
     @distributed_trace_async
-    async def purge_deleted_certificate(self, certificate_name: str, **kwargs) -> None:
+    async def purge_deleted_certificate(self, certificate_name: str, **kwargs: Any) -> None:
         """Permanently deletes a deleted certificate. Possible only in vaults with soft-delete enabled.
 
         Requires certificates/purge permission. Performs an irreversible deletion of the specified certificate, without
@@ -280,14 +275,14 @@ class CertificateClient(AsyncKeyVaultClientBase):
         :return: None
         :rtype: None
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises ~azure.core.exceptions.HttpResponseError:
         """
         await self._client.purge_deleted_certificate(
             vault_base_url=self.vault_url, certificate_name=certificate_name, **kwargs
         )
 
     @distributed_trace_async
-    async def recover_deleted_certificate(self, certificate_name: str, **kwargs) -> KeyVaultCertificate:
+    async def recover_deleted_certificate(self, certificate_name: str, **kwargs: Any) -> KeyVaultCertificate:
         """Recover a deleted certificate to its latest version. Possible only in a vault with soft-delete enabled.
 
         Requires certificates/recover permission. If the vault does not have soft-delete enabled,
@@ -299,7 +294,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         :returns: The recovered certificate
         :rtype: ~azure.keyvault.certificates.KeyVaultCertificate
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises ~azure.core.exceptions.HttpResponseError:
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates_async.py
@@ -327,7 +322,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
 
     @distributed_trace_async
     async def import_certificate(
-        self, certificate_name: str, certificate_bytes: bytes, **kwargs
+        self, certificate_name: str, certificate_bytes: bytes, **kwargs: Any
     ) -> KeyVaultCertificate:
         """Import a certificate created externally. Requires certificates/import permission.
 
@@ -354,7 +349,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         :returns: The imported KeyVaultCertificate
         :rtype: ~azure.keyvault.certificates.KeyVaultCertificate
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises ~azure.core.exceptions.HttpResponseError:
         """
 
         enabled = kwargs.pop("enabled", None)
@@ -383,7 +378,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         return KeyVaultCertificate._from_certificate_bundle(certificate_bundle=bundle)
 
     @distributed_trace_async
-    async def get_certificate_policy(self, certificate_name: str, **kwargs) -> CertificatePolicy:
+    async def get_certificate_policy(self, certificate_name: str, **kwargs: Any) -> CertificatePolicy:
         """Gets the policy for a certificate. Requires certificates/get permission.
 
         Returns the specified certificate policy resources in the key vault.
@@ -393,7 +388,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         :return: The certificate policy
         :rtype: ~azure.keyvault.certificates.CertificatePolicy
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises ~azure.core.exceptions.HttpResponseError:
         """
         bundle = await self._client.get_certificate_policy(
             vault_base_url=self.vault_url, certificate_name=certificate_name, **kwargs
@@ -402,7 +397,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
 
     @distributed_trace_async
     async def update_certificate_policy(
-        self, certificate_name: str, policy: CertificatePolicy, **kwargs
+        self, certificate_name: str, policy: CertificatePolicy, **kwargs: Any
     ) -> CertificatePolicy:
         """Updates the policy for a certificate. Requires certificates/update permission.
 
@@ -415,7 +410,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         :return: The certificate policy
         :rtype: ~azure.keyvault.certificates.CertificatePolicy
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises ~azure.core.exceptions.HttpResponseError:
         """
         bundle = await self._client.update_certificate_policy(
             vault_base_url=self.vault_url,
@@ -427,7 +422,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
 
     @distributed_trace_async
     async def update_certificate_properties(
-        self, certificate_name: str, version: Optional[str] = None, **kwargs
+        self, certificate_name: str, version: Optional[str] = None, **kwargs: Any
     ) -> KeyVaultCertificate:
         """Change a certificate's properties. Requires certificates/update permission.
 
@@ -441,7 +436,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         :returns: The updated KeyVaultCertificate
         :rtype: ~azure.keyvault.certificates.KeyVaultCertificate
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises ~azure.core.exceptions.HttpResponseError:
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates_async.py
@@ -473,7 +468,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         return KeyVaultCertificate._from_certificate_bundle(certificate_bundle=bundle)
 
     @distributed_trace_async
-    async def backup_certificate(self, certificate_name: str, **kwargs) -> bytes:
+    async def backup_certificate(self, certificate_name: str, **kwargs: Any) -> bytes:
         """Back up a certificate in a protected form useable only by Azure Key Vault.
 
         Requires certificates/backup permission. This is intended to allow copying a certificate from one vault to
@@ -486,9 +481,8 @@ class CertificateClient(AsyncKeyVaultClientBase):
         :return: The backup blob containing the backed up certificate.
         :rtype: bytes
 
-        :raises:
-            :class:`~azure.core.exceptions.ResourceNotFoundError` if the certificate doesn't exist,
-            :class:`~azure.core.exceptions.HttpResponseError` for other errors
+        :raises ~azure.core.exceptions.ResourceNotFoundError or ~azure.core.exceptions.HttpResponseError:
+            the former if the certificate doesn't exist; the latter for other errors
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates_async.py
@@ -504,7 +498,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         return backup_result.value
 
     @distributed_trace_async
-    async def restore_certificate_backup(self, backup: bytes, **kwargs) -> KeyVaultCertificate:
+    async def restore_certificate_backup(self, backup: bytes, **kwargs: Any) -> KeyVaultCertificate:
         """Restore a certificate backup to the vault. Requires certificates/restore permission.
 
         This restores all versions of the certificate, with its name, attributes, and access control policies. If the
@@ -516,7 +510,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         :return: The restored KeyVaultCertificate
         :rtype: ~azure.keyvault.certificates.KeyVaultCertificate
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises ~azure.core.exceptions.HttpResponseError:
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates_async.py
@@ -535,7 +529,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
 
     @distributed_trace
     def list_deleted_certificates(
-        self, *, include_pending: Optional[bool] = None, **kwargs
+        self, *, include_pending: Optional[bool] = None, **kwargs: Any
     ) -> AsyncItemPaged[DeletedCertificate]:
         """Lists the currently-recoverable deleted certificates. Possible only if vault is soft-delete enabled.
 
@@ -549,7 +543,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         :return: An iterator-like instance of DeletedCertificate
         :rtype: ~azure.core.paging.ItemPaged[~azure.keyvault.certificates.DeletedCertificate]
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises ~azure.core.exceptions.HttpResponseError:
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates_async.py
@@ -579,7 +573,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
 
     @distributed_trace
     def list_properties_of_certificates(
-        self, *, include_pending: Optional[bool] = None, **kwargs
+        self, *, include_pending: Optional[bool] = None, **kwargs: Any
     ) -> AsyncItemPaged[CertificateProperties]:
         """List identifiers and properties of all certificates in the vault.
 
@@ -592,7 +586,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         :returns: An iterator-like instance of CertificateProperties
         :rtype: ~azure.core.paging.ItemPaged[~azure.keyvault.certificates.CertificateProperties]
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises ~azure.core.exceptions.HttpResponseError:
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates_async.py
@@ -622,7 +616,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
 
     @distributed_trace
     def list_properties_of_certificate_versions(
-        self, certificate_name: str, **kwargs
+        self, certificate_name: str, **kwargs: Any
     ) -> AsyncItemPaged[CertificateProperties]:
         """List the identifiers and properties of a certificate's versions.
 
@@ -633,7 +627,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         :returns: An iterator-like instance of CertificateProperties
         :rtype: ~azure.core.paging.ItemPaged[~azure.keyvault.certificates.CertificateProperties]
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises ~azure.core.exceptions.HttpResponseError:
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates_async.py
@@ -653,7 +647,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         )
 
     @distributed_trace_async
-    async def set_contacts(self, contacts: List[CertificateContact], **kwargs) -> List[CertificateContact]:
+    async def set_contacts(self, contacts: List[CertificateContact], **kwargs: Any) -> List[CertificateContact]:
         """Sets the certificate contacts for the key vault. Requires certificates/managecontacts permission.
 
         :param contacts: The contact list for the vault certificates.
@@ -662,7 +656,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         :returns: The created list of contacts
         :rtype: list[~azure.keyvault.certificates.CertificateContact]
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises ~azure.core.exceptions.HttpResponseError:
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates_async.py
@@ -682,13 +676,13 @@ class CertificateClient(AsyncKeyVaultClientBase):
         ]
 
     @distributed_trace_async
-    async def get_contacts(self, **kwargs) -> List[CertificateContact]:
+    async def get_contacts(self, **kwargs: Any) -> List[CertificateContact]:
         """Gets the certificate contacts for the key vault. Requires the certificates/managecontacts permission.
 
         :return: The certificate contacts for the key vault.
         :rtype: list[azure.keyvault.certificates.CertificateContact]
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises ~azure.core.exceptions.HttpResponseError:
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates_async.py
@@ -704,13 +698,13 @@ class CertificateClient(AsyncKeyVaultClientBase):
         return [CertificateContact._from_certificate_contacts_item(contact_item=item) for item in contacts.contact_list]
 
     @distributed_trace_async
-    async def delete_contacts(self, **kwargs) -> List[CertificateContact]:
+    async def delete_contacts(self, **kwargs: Any) -> List[CertificateContact]:
         """Deletes the certificate contacts for the key vault. Requires the certificates/managecontacts permission.
 
         :return: The deleted contacts for the key vault.
         :rtype: list[~azure.keyvault.certificates.CertificateContact]
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises ~azure.core.exceptions.HttpResponseError:
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates_async.py
@@ -726,7 +720,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         return [CertificateContact._from_certificate_contacts_item(contact_item=item) for item in contacts.contact_list]
 
     @distributed_trace_async
-    async def get_certificate_operation(self, certificate_name: str, **kwargs) -> CertificateOperation:
+    async def get_certificate_operation(self, certificate_name: str, **kwargs: Any) -> CertificateOperation:
         """Gets the creation operation of a certificate. Requires the certificates/get permission.
 
         :param str certificate_name: The name of the certificate.
@@ -734,9 +728,8 @@ class CertificateClient(AsyncKeyVaultClientBase):
         :returns: The created CertificateOperation
         :rtype: ~azure.keyvault.certificates.CertificateOperation
 
-        :raises:
-            :class:`~azure.core.exceptions.ResourceNotFoundError` if the certificate doesn't exist,
-            :class:`~azure.core.exceptions.HttpResponseError` for other errors
+        :raises ~azure.core.exceptions.ResourceNotFoundError or ~azure.core.exceptions.HttpResponseError:
+            the former if the certificate doesn't exist; the latter for other errors
         """
 
         bundle = await self._client.get_certificate_operation(
@@ -745,7 +738,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         return CertificateOperation._from_certificate_operation_bundle(certificate_operation_bundle=bundle)
 
     @distributed_trace_async
-    async def delete_certificate_operation(self, certificate_name: str, **kwargs) -> CertificateOperation:
+    async def delete_certificate_operation(self, certificate_name: str, **kwargs: Any) -> CertificateOperation:
         """Deletes and stops the creation operation for a specific certificate.
 
         Requires the certificates/update permission.
@@ -755,9 +748,8 @@ class CertificateClient(AsyncKeyVaultClientBase):
         :return: The deleted CertificateOperation
         :rtype: ~azure.keyvault.certificates.CertificateOperation
 
-        :raises:
-            :class:`~azure.core.exceptions.ResourceNotFoundError` if the operation doesn't exist,
-            :class:`~azure.core.exceptions.HttpResponseError` for other errors
+        :raises ~azure.core.exceptions.ResourceNotFoundError or ~azure.core.exceptions.HttpResponseError:
+            the former if the operation doesn't exist; the latter for other errors
         """
         bundle = await self._client.delete_certificate_operation(
             vault_base_url=self.vault_url, certificate_name=certificate_name, **kwargs
@@ -765,7 +757,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         return CertificateOperation._from_certificate_operation_bundle(certificate_operation_bundle=bundle)
 
     @distributed_trace_async
-    async def cancel_certificate_operation(self, certificate_name: str, **kwargs) -> CertificateOperation:
+    async def cancel_certificate_operation(self, certificate_name: str, **kwargs: Any) -> CertificateOperation:
         """Cancels an in-progress certificate operation. Requires the certificates/update permission.
 
         :param str certificate_name: The name of the certificate.
@@ -773,7 +765,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         :returns: The cancelled certificate operation
         :rtype: ~azure.keyvault.certificates.CertificateOperation
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises ~azure.core.exceptions.HttpResponseError:
         """
         bundle = await self._client.update_certificate_operation(
             vault_base_url=self.vault_url,
@@ -785,7 +777,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
 
     @distributed_trace_async
     async def merge_certificate(
-        self, certificate_name: str, x509_certificates: List[bytes], **kwargs
+        self, certificate_name: str, x509_certificates: List[bytes], **kwargs: Any
     ) -> KeyVaultCertificate:
         """Merges a certificate or a certificate chain with a key pair existing on the server.
 
@@ -805,7 +797,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         :return: The merged certificate operation
         :rtype: ~azure.keyvault.certificates.CertificateOperation
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises ~azure.core.exceptions.HttpResponseError:
         """
 
         enabled = kwargs.pop("enabled", None)
@@ -828,7 +820,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         return KeyVaultCertificate._from_certificate_bundle(certificate_bundle=bundle)
 
     @distributed_trace_async
-    async def get_issuer(self, issuer_name: str, **kwargs) -> CertificateIssuer:
+    async def get_issuer(self, issuer_name: str, **kwargs: Any) -> CertificateIssuer:
         """Gets the specified certificate issuer. Requires certificates/manageissuers/getissuers permission.
 
         :param str issuer_name: The name of the issuer.
@@ -836,9 +828,8 @@ class CertificateClient(AsyncKeyVaultClientBase):
         :return: The specified certificate issuer.
         :rtype: ~azure.keyvault.certificates.CertificateIssuer
 
-        :raises:
-            :class:`~azure.core.exceptions.ResourceNotFoundError` if the issuer doesn't exist,
-            :class:`~azure.core.exceptions.HttpResponseError` for other errors
+        :raises ~azure.core.exceptions.ResourceNotFoundError or ~azure.core.exceptions.HttpResponseError:
+            the former if the issuer doesn't exist; the latter for other errors
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates_async.py
@@ -854,7 +845,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         return CertificateIssuer._from_issuer_bundle(issuer_bundle=issuer_bundle)
 
     @distributed_trace_async
-    async def create_issuer(self, issuer_name: str, provider: str, **kwargs) -> CertificateIssuer:
+    async def create_issuer(self, issuer_name: str, provider: str, **kwargs: Any) -> CertificateIssuer:
         """Sets the specified certificate issuer. Requires certificates/setissuers permission.
 
         :param str issuer_name: The name of the issuer.
@@ -871,7 +862,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         :returns: The created CertificateIssuer
         :rtype: ~azure.keyvault.certificates.CertificateIssuer
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises ~azure.core.exceptions.HttpResponseError:
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates_async.py
@@ -926,7 +917,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         return CertificateIssuer._from_issuer_bundle(issuer_bundle=issuer_bundle)
 
     @distributed_trace_async
-    async def update_issuer(self, issuer_name: str, **kwargs) -> CertificateIssuer:
+    async def update_issuer(self, issuer_name: str, **kwargs: Any) -> CertificateIssuer:
         """Updates the specified certificate issuer. Requires certificates/setissuers permission.
 
         :param str issuer_name: The name of the issuer.
@@ -943,7 +934,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         :return: The updated issuer
         :rtype: ~azure.keyvault.certificates.CertificateIssuer
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises ~azure.core.exceptions.HttpResponseError:
         """
 
         enabled = kwargs.pop("enabled", None)
@@ -990,7 +981,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         return CertificateIssuer._from_issuer_bundle(issuer_bundle=issuer_bundle)
 
     @distributed_trace_async
-    async def delete_issuer(self, issuer_name: str, **kwargs) -> CertificateIssuer:
+    async def delete_issuer(self, issuer_name: str, **kwargs: Any) -> CertificateIssuer:
         """Deletes the specified certificate issuer.
 
         Requires certificates/manageissuers/deleteissuers permission.
@@ -1000,7 +991,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         :return: CertificateIssuer
         :rtype: ~azure.keyvault.certificates.CertificateIssuer
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises ~azure.core.exceptions.HttpResponseError:
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates_async.py
@@ -1016,7 +1007,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         return CertificateIssuer._from_issuer_bundle(issuer_bundle=issuer_bundle)
 
     @distributed_trace
-    def list_properties_of_issuers(self, **kwargs) -> AsyncItemPaged[IssuerProperties]:
+    def list_properties_of_issuers(self, **kwargs: Any) -> AsyncItemPaged[IssuerProperties]:
         """Lists properties of the certificate issuers for the key vault.
 
         Requires the certificates/manageissuers/getissuers permission.
@@ -1024,7 +1015,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         :return: An iterator-like instance of Issuers
         :rtype: ~azure.core.paging.ItemPaged[~azure.keyvault.certificates.CertificateIssuer]
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises ~azure.core.exceptions.HttpResponseError:
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates_async.py

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/aio/_client.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/aio/_client.py
@@ -61,7 +61,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
 
         If this is the first version, the certificate resource is created. This operation requires the
         certificates/create permission. The poller requires the certificates/get permission, otherwise raises an
-        azure.core.exceptions.HttpResponseError
+        :class:`~azure.core.exceptions.HttpResponseError`.
 
         :param str certificate_name: The name of the certificate.
         :param policy: The management policy for the certificate. Either subject or one of the subject alternative
@@ -78,7 +78,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
 
         :raises:
             :class:`ValueError` if the certificate policy is invalid,
-            azure.core.exceptions.HttpResponseError for other errors.
+            :class:`~azure.core.exceptions.HttpResponseError` for other errors.
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates_async.py
@@ -140,8 +140,8 @@ class CertificateClient(AsyncKeyVaultClientBase):
         :rtype: ~azure.keyvault.certificates.KeyVaultCertificate
 
         :raises:
-            azure.core.exceptions.ResourceNotFoundError if the certificate doesn't exist,
-            azure.core.exceptions.HttpResponseError for other errors
+            :class:`~azure.core.exceptions.ResourceNotFoundError` if the certificate doesn't exist,
+            :class:`~azure.core.exceptions.HttpResponseError` for other errors
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates_async.py
@@ -175,8 +175,8 @@ class CertificateClient(AsyncKeyVaultClientBase):
         :rtype: ~azure.keyvault.certificates.KeyVaultCertificate
 
         :raises:
-            azure.core.exceptions.ResourceNotFoundError if the certificate doesn't exist,
-            azure.core.exceptions.HttpResponseError for other errors
+            :class:`~azure.core.exceptions.ResourceNotFoundError` if the certificate doesn't exist,
+            :class:`~azure.core.exceptions.HttpResponseError` for other errors
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates_async.py
@@ -206,8 +206,8 @@ class CertificateClient(AsyncKeyVaultClientBase):
         :rtype: ~azure.keyvault.certificates.DeletedCertificate
 
         :raises:
-            azure.core.exceptions.ResourceNotFoundError if the certificate doesn't exist,
-            azure.core.exceptions.HttpResponseError for other errors
+            :class:`~azure.core.exceptions.ResourceNotFoundError` if the certificate doesn't exist,
+            :class:`~azure.core.exceptions.HttpResponseError` for other errors
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates_async.py
@@ -249,8 +249,8 @@ class CertificateClient(AsyncKeyVaultClientBase):
         :rtype: ~azure.keyvault.certificates.DeletedCertificate
 
         :raises:
-            azure.core.exceptions.ResourceNotFoundError if the certificate doesn't exist,
-            azure.core.exceptions.HttpResponseError for other errors
+            :class:`~azure.core.exceptions.ResourceNotFoundError` if the certificate doesn't exist,
+            :class:`~azure.core.exceptions.HttpResponseError` for other errors
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates_async.py
@@ -280,7 +280,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         :return: None
         :rtype: None
 
-        :raises: azure.core.exceptions.HttpResponseError
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
         """
         await self._client.purge_deleted_certificate(
             vault_base_url=self.vault_url, certificate_name=certificate_name, **kwargs
@@ -299,7 +299,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         :returns: The recovered certificate
         :rtype: ~azure.keyvault.certificates.KeyVaultCertificate
 
-        :raises: azure.core.exceptions.HttpResponseError
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates_async.py
@@ -354,7 +354,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         :returns: The imported KeyVaultCertificate
         :rtype: ~azure.keyvault.certificates.KeyVaultCertificate
 
-        :raises: azure.core.exceptions.HttpResponseError
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
         """
 
         enabled = kwargs.pop("enabled", None)
@@ -393,7 +393,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         :return: The certificate policy
         :rtype: ~azure.keyvault.certificates.CertificatePolicy
 
-        :raises: azure.core.exceptions.HttpResponseError
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
         """
         bundle = await self._client.get_certificate_policy(
             vault_base_url=self.vault_url, certificate_name=certificate_name, **kwargs
@@ -415,7 +415,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         :return: The certificate policy
         :rtype: ~azure.keyvault.certificates.CertificatePolicy
 
-        :raises: azure.core.exceptions.HttpResponseError
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
         """
         bundle = await self._client.update_certificate_policy(
             vault_base_url=self.vault_url,
@@ -441,7 +441,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         :returns: The updated KeyVaultCertificate
         :rtype: ~azure.keyvault.certificates.KeyVaultCertificate
 
-        :raises: azure.core.exceptions.HttpResponseError
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates_async.py
@@ -487,8 +487,8 @@ class CertificateClient(AsyncKeyVaultClientBase):
         :rtype: bytes
 
         :raises:
-            azure.core.exceptions.ResourceNotFoundError if the certificate doesn't exist,
-            azure.core.exceptions.HttpResponseError for other errors
+            :class:`~azure.core.exceptions.ResourceNotFoundError` if the certificate doesn't exist,
+            :class:`~azure.core.exceptions.HttpResponseError` for other errors
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates_async.py
@@ -516,7 +516,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         :return: The restored KeyVaultCertificate
         :rtype: ~azure.keyvault.certificates.KeyVaultCertificate
 
-        :raises: azure.core.exceptions.HttpResponseError
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates_async.py
@@ -549,7 +549,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         :return: An iterator-like instance of DeletedCertificate
         :rtype: ~azure.core.paging.ItemPaged[~azure.keyvault.certificates.DeletedCertificate]
 
-        :raises: azure.core.exceptions.HttpResponseError
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates_async.py
@@ -592,7 +592,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         :returns: An iterator-like instance of CertificateProperties
         :rtype: ~azure.core.paging.ItemPaged[~azure.keyvault.certificates.CertificateProperties]
 
-        :raises: azure.core.exceptions.HttpResponseError
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates_async.py
@@ -633,7 +633,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         :returns: An iterator-like instance of CertificateProperties
         :rtype: ~azure.core.paging.ItemPaged[~azure.keyvault.certificates.CertificateProperties]
 
-        :raises: azure.core.exceptions.HttpResponseError
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates_async.py
@@ -662,7 +662,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         :returns: The created list of contacts
         :rtype: list[~azure.keyvault.certificates.CertificateContact]
 
-        :raises: azure.core.exceptions.HttpResponseError
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates_async.py
@@ -688,7 +688,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         :return: The certificate contacts for the key vault.
         :rtype: list[azure.keyvault.certificates.CertificateContact]
 
-        :raises: azure.core.exceptions.HttpResponseError
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates_async.py
@@ -710,7 +710,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         :return: The deleted contacts for the key vault.
         :rtype: list[~azure.keyvault.certificates.CertificateContact]
 
-        :raises: azure.core.exceptions.HttpResponseError
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates_async.py
@@ -735,8 +735,8 @@ class CertificateClient(AsyncKeyVaultClientBase):
         :rtype: ~azure.keyvault.certificates.CertificateOperation
 
         :raises:
-            azure.core.exceptions.ResourceNotFoundError if the certificate doesn't exist,
-            azure.core.exceptions.HttpResponseError for other errors
+            :class:`~azure.core.exceptions.ResourceNotFoundError` if the certificate doesn't exist,
+            :class:`~azure.core.exceptions.HttpResponseError` for other errors
         """
 
         bundle = await self._client.get_certificate_operation(
@@ -756,8 +756,8 @@ class CertificateClient(AsyncKeyVaultClientBase):
         :rtype: ~azure.keyvault.certificates.CertificateOperation
 
         :raises:
-            azure.core.exceptions.ResourceNotFoundError if the operation doesn't exist,
-            azure.core.exceptions.HttpResponseError for other errors
+            :class:`~azure.core.exceptions.ResourceNotFoundError` if the operation doesn't exist,
+            :class:`~azure.core.exceptions.HttpResponseError` for other errors
         """
         bundle = await self._client.delete_certificate_operation(
             vault_base_url=self.vault_url, certificate_name=certificate_name, **kwargs
@@ -773,7 +773,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         :returns: The cancelled certificate operation
         :rtype: ~azure.keyvault.certificates.CertificateOperation
 
-        :raises: azure.core.exceptions.HttpResponseError
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
         """
         bundle = await self._client.update_certificate_operation(
             vault_base_url=self.vault_url,
@@ -805,7 +805,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         :return: The merged certificate operation
         :rtype: ~azure.keyvault.certificates.CertificateOperation
 
-        :raises: azure.core.exceptions.HttpResponseError
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
         """
 
         enabled = kwargs.pop("enabled", None)
@@ -837,8 +837,8 @@ class CertificateClient(AsyncKeyVaultClientBase):
         :rtype: ~azure.keyvault.certificates.CertificateIssuer
 
         :raises:
-            azure.core.exceptions.ResourceNotFoundError if the issuer doesn't exist,
-            azure.core.exceptions.HttpResponseError for other errors
+            :class:`~azure.core.exceptions.ResourceNotFoundError` if the issuer doesn't exist,
+            :class:`~azure.core.exceptions.HttpResponseError` for other errors
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates_async.py
@@ -871,7 +871,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         :returns: The created CertificateIssuer
         :rtype: ~azure.keyvault.certificates.CertificateIssuer
 
-        :raises: azure.core.exceptions.HttpResponseError
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates_async.py
@@ -943,7 +943,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         :return: The updated issuer
         :rtype: ~azure.keyvault.certificates.CertificateIssuer
 
-        :raises: azure.core.exceptions.HttpResponseError
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
         """
 
         enabled = kwargs.pop("enabled", None)
@@ -1000,7 +1000,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         :return: CertificateIssuer
         :rtype: ~azure.keyvault.certificates.CertificateIssuer
 
-        :raises: azure.core.exceptions.HttpResponseError
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates_async.py
@@ -1024,7 +1024,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
         :return: An iterator-like instance of Issuers
         :rtype: ~azure.core.paging.ItemPaged[~azure.keyvault.certificates.CertificateIssuer]
 
-        :raises: azure.core.exceptions.HttpResponseError
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example:
             .. literalinclude:: ../tests/test_examples_certificates_async.py

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_client.py
@@ -39,7 +39,7 @@ class KeyClient(KeyVaultClientBase):
         See https://aka.ms/azsdk/blog/vault-uri for details.
     :param credential: An object which can provide an access token for the vault, such as a credential from
         :mod:`azure.identity`
-    :type credential: :class:`~azure.core.credentials.TokenCredential`
+    :type credential: ~azure.core.credentials.TokenCredential
 
     :keyword api_version: Version of the service API to use. Defaults to the most recent.
     :paramtype api_version: ~azure.keyvault.keys.ApiVersion or str
@@ -84,18 +84,24 @@ class KeyClient(KeyVaultClientBase):
             )
         return None
 
-    def get_cryptography_client(self, key_name: str, **kwargs) -> CryptographyClient:
-        """Gets a :class:`~azure.keyvault.keys.crypto.CryptographyClient` for the given key.
+    def get_cryptography_client(
+            self,
+            key_name: str,
+            *,
+            key_version: "Optional[str]" = None,
+        ) -> CryptographyClient:
+        """Gets a azure.keyvault.keys.crypto.CryptographyClient for the given key.
 
         :param str key_name: The name of the key used to perform cryptographic operations.
 
-        :keyword str key_version: Optional version of the key used to perform cryptographic operations.
+        :keyword key_version: Optional version of the key used to perform cryptographic operations.
+        :paramtype key_version: str or None
 
-        :returns: A :class:`~azure.keyvault.keys.crypto.CryptographyClient` using the same options, credentials, and
-            HTTP client as this :class:`~azure.keyvault.keys.KeyClient`.
+        :returns: A azure.keyvault.keys.crypto.CryptographyClient using the same options, credentials, and
+            HTTP client as this azure.keyvault.keys.KeyClient.
         :rtype: ~azure.keyvault.keys.crypto.CryptographyClient
         """
-        key_id = _get_key_id(self._vault_url, key_name, kwargs.get("key_version"))
+        key_id = _get_key_id(self._vault_url, key_name, key_version)
 
         # We provide a fake credential because the generated client already has the KeyClient's real credential
         return CryptographyClient(
@@ -138,7 +144,7 @@ class KeyClient(KeyVaultClientBase):
         :returns: The created key
         :rtype: ~azure.keyvault.keys.KeyVaultKey
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises: azure.core.exceptions.HttpResponseError
 
         Example:
             .. literalinclude:: ../tests/test_samples_keys.py
@@ -210,7 +216,7 @@ class KeyClient(KeyVaultClientBase):
         :returns: The created key
         :rtype: ~azure.keyvault.keys.KeyVaultKey
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises: azure.core.exceptions.HttpResponseError
 
         Example:
             .. literalinclude:: ../tests/test_samples_keys.py
@@ -254,7 +260,7 @@ class KeyClient(KeyVaultClientBase):
         :returns: The created key
         :rtype: ~azure.keyvault.keys.KeyVaultKey
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises: azure.core.exceptions.HttpResponseError
 
         Example:
             .. literalinclude:: ../tests/test_samples_keys.py
@@ -297,7 +303,7 @@ class KeyClient(KeyVaultClientBase):
 
         :returns: The created key
         :rtype: ~azure.keyvault.keys.KeyVaultKey
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises: azure.core.exceptions.HttpResponseError
 
         Example:
             .. literalinclude:: ../tests/test_samples_keys.py
@@ -321,15 +327,15 @@ class KeyClient(KeyVaultClientBase):
         :param str name: The name of the key to delete.
 
         :returns: A poller for the delete key operation. The poller's `result` method returns the
-            :class:`~azure.keyvault.keys.DeletedKey` without waiting for deletion to complete. If the vault has
+            azure.keyvault.keys.DeletedKey without waiting for deletion to complete. If the vault has
             soft-delete enabled and you want to permanently delete the key with :func:`purge_deleted_key`, call the
             poller's `wait` method first. It will block until the deletion is complete. The `wait` method requires
             keys/get permission.
         :rtype: ~azure.core.polling.LROPoller[~azure.keyvault.keys.DeletedKey]
 
         :raises:
-            :class:`~azure.core.exceptions.ResourceNotFoundError` if the key doesn't exist,
-            :class:`~azure.core.exceptions.HttpResponseError` for other errors
+            azure.core.exceptions.ResourceNotFoundError if the key doesn't exist,
+            azure.core.exceptions.HttpResponseError for other errors
 
         Example:
             .. literalinclude:: ../tests/test_samples_keys.py
@@ -371,8 +377,8 @@ class KeyClient(KeyVaultClientBase):
         :rtype: ~azure.keyvault.keys.KeyVaultKey
 
         :raises:
-            :class:`~azure.core.exceptions.ResourceNotFoundError` if the key doesn't exist,
-            :class:`~azure.core.exceptions.HttpResponseError` for other errors
+            azure.core.exceptions.ResourceNotFoundError if the key doesn't exist,
+            azure.core.exceptions.HttpResponseError for other errors
 
         Example:
             .. literalinclude:: ../tests/test_samples_keys.py
@@ -397,8 +403,8 @@ class KeyClient(KeyVaultClientBase):
         :rtype: ~azure.keyvault.keys.DeletedKey
 
         :raises:
-            :class:`~azure.core.exceptions.ResourceNotFoundError` if the key doesn't exist,
-            :class:`~azure.core.exceptions.HttpResponseError` for other errors
+            azure.core.exceptions.ResourceNotFoundError if the key doesn't exist,
+            azure.core.exceptions.HttpResponseError for other errors
 
         Example:
             .. literalinclude:: ../tests/test_samples_keys.py
@@ -501,7 +507,7 @@ class KeyClient(KeyVaultClientBase):
 
         :returns: None
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises: azure.core.exceptions.HttpResponseError
 
         Example:
             .. code-block:: python
@@ -526,12 +532,12 @@ class KeyClient(KeyVaultClientBase):
         :param str name: The name of the deleted key to recover
 
         :returns: A poller for the recovery operation. The poller's `result` method returns the recovered
-            :class:`~azure.keyvault.keys.KeyVaultKey` without waiting for recovery to complete. If you want to use the
+            azure.keyvault.keys.KeyVaultKey without waiting for recovery to complete. If you want to use the
             recovered key immediately, call the poller's `wait` method, which blocks until the key is ready to use. The
             `wait` method requires keys/get permission.
         :rtype: ~azure.core.polling.LROPoller[~azure.keyvault.keys.KeyVaultKey]
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises: azure.core.exceptions.HttpResponseError
 
         Example:
             .. literalinclude:: ../tests/test_samples_keys.py
@@ -586,8 +592,8 @@ class KeyClient(KeyVaultClientBase):
         :rtype: ~azure.keyvault.keys.KeyVaultKey
 
         :raises:
-            :class:`~azure.core.exceptions.ResourceNotFoundError` if the key doesn't exist,
-            :class:`~azure.core.exceptions.HttpResponseError` for other errors
+            azure.core.exceptions.ResourceNotFoundError if the key doesn't exist,
+            azure.core.exceptions.HttpResponseError for other errors
 
         Example:
             .. literalinclude:: ../tests/test_samples_keys.py
@@ -635,8 +641,8 @@ class KeyClient(KeyVaultClientBase):
         :rtype: bytes
 
         :raises:
-            :class:`~azure.core.exceptions.ResourceNotFoundError` if the key doesn't exist,
-            :class:`~azure.core.exceptions.HttpResponseError` for other errors
+            azure.core.exceptions.ResourceNotFoundError if the key doesn't exist,
+            azure.core.exceptions.HttpResponseError for other errors
 
         Example:
             .. literalinclude:: ../tests/test_samples_keys.py
@@ -665,8 +671,8 @@ class KeyClient(KeyVaultClientBase):
         :rtype: ~azure.keyvault.keys.KeyVaultKey
 
         :raises:
-            :class:`~azure.core.exceptions.ResourceExistsError` if the backed up key's name is already in use,
-            :class:`~azure.core.exceptions.HttpResponseError` for other errors
+            azure.core.exceptions.ResourceExistsError if the backed up key's name is already in use,
+            azure.core.exceptions.HttpResponseError for other errors
 
         Example:
             .. literalinclude:: ../tests/test_samples_keys.py
@@ -711,7 +717,7 @@ class KeyClient(KeyVaultClientBase):
         :returns: The imported key
         :rtype: ~azure.keyvault.keys.KeyVaultKey
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises: azure.core.exceptions.HttpResponseError
         """
         enabled = kwargs.pop("enabled", None)
         not_before = kwargs.pop("not_before", None)
@@ -757,7 +763,7 @@ class KeyClient(KeyVaultClientBase):
         :return: The result of the key release.
         :rtype: ~azure.keyvault.keys.ReleaseKeyResult
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises: azure.core.exceptions.HttpResponseError
         """
         version = kwargs.pop("version", None)
         result = self._client.release(
@@ -784,7 +790,7 @@ class KeyClient(KeyVaultClientBase):
 
         :raises:
             :class:`ValueError` if less than one random byte is requested,
-            :class:`~azure.core.exceptions.HttpResponseError` for other errors
+            azure.core.exceptions.HttpResponseError for other errors
 
         Example:
             .. literalinclude:: ../tests/test_key_client.py
@@ -825,7 +831,7 @@ class KeyClient(KeyVaultClientBase):
         :return: The new version of the rotated key.
         :rtype: ~azure.keyvault.keys.KeyVaultKey
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises: azure.core.exceptions.HttpResponseError
         """
         bundle = self._client.rotate_key(vault_base_url=self._vault_url, key_name=name, **kwargs)
         return KeyVaultKey._from_key_bundle(bundle)
@@ -853,7 +859,7 @@ class KeyClient(KeyVaultClientBase):
         :return: The updated rotation policy.
         :rtype: ~azure.keyvault.keys.KeyRotationPolicy
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises: azure.core.exceptions.HttpResponseError
         """
         lifetime_actions = kwargs.pop("lifetime_actions", policy.lifetime_actions)
         if lifetime_actions:

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_client.py
@@ -103,7 +103,7 @@ class KeyClient(KeyVaultClientBase):
         )
 
     @distributed_trace
-    def create_key(self, name: str, key_type: Union[str, KeyType], **kwargs) -> KeyVaultKey:
+    def create_key(self, name: str, key_type: Union[str, KeyType], **kwargs: Any) -> KeyVaultKey:
         """Create a key or, if ``name`` is already in use, create a new version of the key.
 
         Requires keys/create permission.

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_client.py
@@ -4,7 +4,7 @@
 # ------------------------------------
 from datetime import datetime
 from functools import partial
-from typing import Optional, Union
+from typing import Any, Optional, Union
 
 from azure.core.paging import ItemPaged
 from azure.core.polling import LROPoller
@@ -138,7 +138,7 @@ class KeyClient(KeyVaultClientBase):
         :returns: The created key
         :rtype: ~azure.keyvault.keys.KeyVaultKey
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises ~azure.core.exceptions.HttpResponseError:
 
         Example:
             .. literalinclude:: ../tests/test_samples_keys.py
@@ -178,7 +178,7 @@ class KeyClient(KeyVaultClientBase):
         return KeyVaultKey._from_key_bundle(bundle)
 
     @distributed_trace
-    def create_rsa_key(self, name: str, **kwargs) -> KeyVaultKey:
+    def create_rsa_key(self, name: str, **kwargs: Any) -> KeyVaultKey:
         """Create a new RSA key or, if ``name`` is already in use, create a new version of the key
 
         Requires the keys/create permission.
@@ -210,7 +210,7 @@ class KeyClient(KeyVaultClientBase):
         :returns: The created key
         :rtype: ~azure.keyvault.keys.KeyVaultKey
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises ~azure.core.exceptions.HttpResponseError:
 
         Example:
             .. literalinclude:: ../tests/test_samples_keys.py
@@ -224,7 +224,7 @@ class KeyClient(KeyVaultClientBase):
         return self.create_key(name, key_type="RSA-HSM" if hsm else "RSA", **kwargs)
 
     @distributed_trace
-    def create_ec_key(self, name: str, **kwargs) -> KeyVaultKey:
+    def create_ec_key(self, name: str, **kwargs: Any) -> KeyVaultKey:
         """Create a new elliptic curve key or, if ``name`` is already in use, create a new version of the key.
 
         Requires the keys/create permission.
@@ -254,7 +254,7 @@ class KeyClient(KeyVaultClientBase):
         :returns: The created key
         :rtype: ~azure.keyvault.keys.KeyVaultKey
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises ~azure.core.exceptions.HttpResponseError:
 
         Example:
             .. literalinclude:: ../tests/test_samples_keys.py
@@ -268,7 +268,7 @@ class KeyClient(KeyVaultClientBase):
         return self.create_key(name, key_type="EC-HSM" if hsm else "EC", **kwargs)
 
     @distributed_trace
-    def create_oct_key(self, name: str, **kwargs) -> KeyVaultKey:
+    def create_oct_key(self, name: str, **kwargs: Any) -> KeyVaultKey:
         """Create a new octet sequence (symmetric) key or, if ``name`` is in use, create a new version of the key.
 
         Requires the keys/create permission.
@@ -297,7 +297,7 @@ class KeyClient(KeyVaultClientBase):
 
         :returns: The created key
         :rtype: ~azure.keyvault.keys.KeyVaultKey
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises ~azure.core.exceptions.HttpResponseError:
 
         Example:
             .. literalinclude:: ../tests/test_samples_keys.py
@@ -311,7 +311,7 @@ class KeyClient(KeyVaultClientBase):
         return self.create_key(name, key_type="oct-HSM" if hsm else "oct", **kwargs)
 
     @distributed_trace
-    def begin_delete_key(self, name: str, **kwargs) -> LROPoller[DeletedKey]:  # pylint:disable=bad-option-value,delete-operation-wrong-return-type
+    def begin_delete_key(self, name: str, **kwargs: Any) -> LROPoller[DeletedKey]:  # pylint:disable=bad-option-value,delete-operation-wrong-return-type
         """Delete all versions of a key and its cryptographic material.
 
         Requires keys/delete permission. When this method returns Key Vault has begun deleting the key. Deletion may
@@ -327,9 +327,8 @@ class KeyClient(KeyVaultClientBase):
             keys/get permission.
         :rtype: ~azure.core.polling.LROPoller[~azure.keyvault.keys.DeletedKey]
 
-        :raises:
-            :class:`~azure.core.exceptions.ResourceNotFoundError` if the key doesn't exist,
-            :class:`~azure.core.exceptions.HttpResponseError` for other errors
+        :raises ~azure.core.exceptions.ResourceNotFoundError or ~azure.core.exceptions.HttpResponseError:
+            the former if the key doesn't exist; the latter for other errors
 
         Example:
             .. literalinclude:: ../tests/test_samples_keys.py
@@ -357,7 +356,7 @@ class KeyClient(KeyVaultClientBase):
         return KeyVaultOperationPoller(polling_method)
 
     @distributed_trace
-    def get_key(self, name: str, version: Optional[str] = None, **kwargs) -> KeyVaultKey:
+    def get_key(self, name: str, version: Optional[str] = None, **kwargs: Any) -> KeyVaultKey:
         """Get a key's attributes and, if it's an asymmetric key, its public material.
 
         Requires keys/get permission.
@@ -370,9 +369,8 @@ class KeyClient(KeyVaultClientBase):
         :returns: The fetched key.
         :rtype: ~azure.keyvault.keys.KeyVaultKey
 
-        :raises:
-            :class:`~azure.core.exceptions.ResourceNotFoundError` if the key doesn't exist,
-            :class:`~azure.core.exceptions.HttpResponseError` for other errors
+        :raises ~azure.core.exceptions.ResourceNotFoundError or ~azure.core.exceptions.HttpResponseError:
+            the former if the key doesn't exist; the latter for other errors
 
         Example:
             .. literalinclude:: ../tests/test_samples_keys.py
@@ -386,7 +384,7 @@ class KeyClient(KeyVaultClientBase):
         return KeyVaultKey._from_key_bundle(bundle)
 
     @distributed_trace
-    def get_deleted_key(self, name: str, **kwargs) -> DeletedKey:
+    def get_deleted_key(self, name: str, **kwargs: Any) -> DeletedKey:
         """Get a deleted key. Possible only in a vault with soft-delete enabled.
 
         Requires keys/get permission.
@@ -396,9 +394,8 @@ class KeyClient(KeyVaultClientBase):
         :returns: The deleted key
         :rtype: ~azure.keyvault.keys.DeletedKey
 
-        :raises:
-            :class:`~azure.core.exceptions.ResourceNotFoundError` if the key doesn't exist,
-            :class:`~azure.core.exceptions.HttpResponseError` for other errors
+        :raises ~azure.core.exceptions.ResourceNotFoundError or ~azure.core.exceptions.HttpResponseError:
+            the former if the key doesn't exist; the latter for other errors
 
         Example:
             .. literalinclude:: ../tests/test_samples_keys.py
@@ -412,7 +409,7 @@ class KeyClient(KeyVaultClientBase):
         return DeletedKey._from_deleted_key_bundle(bundle)
 
     @distributed_trace
-    def list_deleted_keys(self, **kwargs) -> ItemPaged[DeletedKey]:
+    def list_deleted_keys(self, **kwargs: Any) -> ItemPaged[DeletedKey]:
         """List all deleted keys, including the public part of each. Possible only in a vault with soft-delete enabled.
 
         Requires keys/list permission.
@@ -436,7 +433,7 @@ class KeyClient(KeyVaultClientBase):
         )
 
     @distributed_trace
-    def list_properties_of_keys(self, **kwargs) -> ItemPaged[KeyProperties]:
+    def list_properties_of_keys(self, **kwargs: Any) -> ItemPaged[KeyProperties]:
         """List identifiers and properties of all keys in the vault.
 
         Requires keys/list permission.
@@ -460,7 +457,7 @@ class KeyClient(KeyVaultClientBase):
         )
 
     @distributed_trace
-    def list_properties_of_key_versions(self, name: str, **kwargs) -> ItemPaged[KeyProperties]:
+    def list_properties_of_key_versions(self, name: str, **kwargs: Any) -> ItemPaged[KeyProperties]:
         """List the identifiers and properties of a key's versions.
 
         Requires keys/list permission.
@@ -487,7 +484,7 @@ class KeyClient(KeyVaultClientBase):
         )
 
     @distributed_trace
-    def purge_deleted_key(self, name: str, **kwargs) -> None:
+    def purge_deleted_key(self, name: str, **kwargs: Any) -> None:
         """Permanently deletes a deleted key. Only possible in a vault with soft-delete enabled.
 
         Performs an irreversible deletion of the specified key, without possibility for recovery. The operation is not
@@ -501,7 +498,7 @@ class KeyClient(KeyVaultClientBase):
 
         :returns: None
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises ~azure.core.exceptions.HttpResponseError:
 
         Example:
             .. code-block:: python
@@ -514,7 +511,7 @@ class KeyClient(KeyVaultClientBase):
         self._client.purge_deleted_key(vault_base_url=self.vault_url, key_name=name, **kwargs)
 
     @distributed_trace
-    def begin_recover_deleted_key(self, name: str, **kwargs) -> LROPoller[KeyVaultKey]:
+    def begin_recover_deleted_key(self, name: str, **kwargs: Any) -> LROPoller[KeyVaultKey]:
         """Recover a deleted key to its latest version. Possible only in a vault with soft-delete enabled.
 
         Requires keys/recover permission.
@@ -531,7 +528,7 @@ class KeyClient(KeyVaultClientBase):
             `wait` method requires keys/get permission.
         :rtype: ~azure.core.polling.LROPoller[~azure.keyvault.keys.KeyVaultKey]
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises ~azure.core.exceptions.HttpResponseError:
 
         Example:
             .. literalinclude:: ../tests/test_samples_keys.py
@@ -560,7 +557,7 @@ class KeyClient(KeyVaultClientBase):
         return KeyVaultOperationPoller(polling_method)
 
     @distributed_trace
-    def update_key_properties(self, name: str, version: Optional[str] = None, **kwargs) -> KeyVaultKey:
+    def update_key_properties(self, name: str, version: Optional[str] = None, **kwargs: Any) -> KeyVaultKey:
         """Change a key's properties (not its cryptographic material).
 
         Requires keys/update permission.
@@ -585,9 +582,8 @@ class KeyClient(KeyVaultClientBase):
         :returns: The updated key
         :rtype: ~azure.keyvault.keys.KeyVaultKey
 
-        :raises:
-            :class:`~azure.core.exceptions.ResourceNotFoundError` if the key doesn't exist,
-            :class:`~azure.core.exceptions.HttpResponseError` for other errors
+        :raises ~azure.core.exceptions.ResourceNotFoundError or ~azure.core.exceptions.HttpResponseError:
+            the former if the key doesn't exist; the latter for other errors
 
         Example:
             .. literalinclude:: ../tests/test_samples_keys.py
@@ -620,7 +616,7 @@ class KeyClient(KeyVaultClientBase):
         return KeyVaultKey._from_key_bundle(bundle)
 
     @distributed_trace
-    def backup_key(self, name: str, **kwargs) -> bytes:
+    def backup_key(self, name: str, **kwargs: Any) -> bytes:
         """Back up a key in a protected form useable only by Azure Key Vault.
 
         Requires keys/backup permission.
@@ -634,9 +630,8 @@ class KeyClient(KeyVaultClientBase):
         :returns: The key backup result, in a protected bytes format that can only be used by Azure Key Vault.
         :rtype: bytes
 
-        :raises:
-            :class:`~azure.core.exceptions.ResourceNotFoundError` if the key doesn't exist,
-            :class:`~azure.core.exceptions.HttpResponseError` for other errors
+        :raises ~azure.core.exceptions.ResourceNotFoundError or ~azure.core.exceptions.HttpResponseError:
+            the former if the key doesn't exist; the latter for other errors
 
         Example:
             .. literalinclude:: ../tests/test_samples_keys.py
@@ -650,7 +645,7 @@ class KeyClient(KeyVaultClientBase):
         return backup_result.value
 
     @distributed_trace
-    def restore_key_backup(self, backup: bytes, **kwargs) -> KeyVaultKey:
+    def restore_key_backup(self, backup: bytes, **kwargs: Any) -> KeyVaultKey:
         """Restore a key backup to the vault.
 
         Requires keys/restore permission.
@@ -664,9 +659,8 @@ class KeyClient(KeyVaultClientBase):
         :returns: The restored key
         :rtype: ~azure.keyvault.keys.KeyVaultKey
 
-        :raises:
-            :class:`~azure.core.exceptions.ResourceExistsError` if the backed up key's name is already in use,
-            :class:`~azure.core.exceptions.HttpResponseError` for other errors
+        :raises ~azure.core.exceptions.ResourceExistsError or ~azure.core.exceptions.HttpResponseError:
+            the former if the backed up key's name is already in use; the latter for other errors
 
         Example:
             .. literalinclude:: ../tests/test_samples_keys.py
@@ -684,7 +678,7 @@ class KeyClient(KeyVaultClientBase):
         return KeyVaultKey._from_key_bundle(bundle)
 
     @distributed_trace
-    def import_key(self, name: str, key: JsonWebKey, **kwargs) -> KeyVaultKey:
+    def import_key(self, name: str, key: JsonWebKey, **kwargs: Any) -> KeyVaultKey:
         """Import a key created externally.
 
         Requires keys/import permission. If ``name`` is already in use, the key will be imported as a new version.
@@ -711,7 +705,7 @@ class KeyClient(KeyVaultClientBase):
         :returns: The imported key
         :rtype: ~azure.keyvault.keys.KeyVaultKey
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises ~azure.core.exceptions.HttpResponseError:
         """
         enabled = kwargs.pop("enabled", None)
         not_before = kwargs.pop("not_before", None)
@@ -738,7 +732,7 @@ class KeyClient(KeyVaultClientBase):
         return KeyVaultKey._from_key_bundle(bundle)
 
     @distributed_trace
-    def release_key(self, name: str, target_attestation_token: str, **kwargs) -> ReleaseKeyResult:
+    def release_key(self, name: str, target_attestation_token: str, **kwargs: Any) -> ReleaseKeyResult:
         """Releases a key.
 
         The release key operation is applicable to all key types. The target key must be marked
@@ -757,7 +751,7 @@ class KeyClient(KeyVaultClientBase):
         :return: The result of the key release.
         :rtype: ~azure.keyvault.keys.ReleaseKeyResult
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises ~azure.core.exceptions.HttpResponseError:
         """
         version = kwargs.pop("version", None)
         result = self._client.release(
@@ -774,7 +768,7 @@ class KeyClient(KeyVaultClientBase):
         return ReleaseKeyResult(result.value)
 
     @distributed_trace
-    def get_random_bytes(self, count: int, **kwargs) -> bytes:
+    def get_random_bytes(self, count: int, **kwargs: Any) -> bytes:
         """Get the requested number of random bytes from a managed HSM.
 
         :param int count: The requested number of random bytes.
@@ -782,9 +776,8 @@ class KeyClient(KeyVaultClientBase):
         :return: The random bytes.
         :rtype: bytes
 
-        :raises:
-            :class:`ValueError` if less than one random byte is requested,
-            :class:`~azure.core.exceptions.HttpResponseError` for other errors
+        :raises ValueError or ~azure.core.exceptions.HttpResponseError:
+            the former if less than one random byte is requested; the latter for other errors
 
         Example:
             .. literalinclude:: ../tests/test_key_client.py
@@ -801,7 +794,7 @@ class KeyClient(KeyVaultClientBase):
         return result.value
 
     @distributed_trace
-    def get_key_rotation_policy(self, key_name: str, **kwargs) -> KeyRotationPolicy:
+    def get_key_rotation_policy(self, key_name: str, **kwargs: Any) -> KeyRotationPolicy:
         """Get the rotation policy of a Key Vault key.
 
         :param str key_name: The name of the key.
@@ -809,13 +802,13 @@ class KeyClient(KeyVaultClientBase):
         :return: The key rotation policy.
         :rtype: ~azure.keyvault.keys.KeyRotationPolicy
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises ~azure.core.exceptions.HttpResponseError:
         """
         policy = self._client.get_key_rotation_policy(vault_base_url=self._vault_url, key_name=key_name, **kwargs)
         return KeyRotationPolicy._from_generated(policy)
 
     @distributed_trace
-    def rotate_key(self, name: str, **kwargs) -> KeyVaultKey:
+    def rotate_key(self, name: str, **kwargs: Any) -> KeyVaultKey:
         """Rotate the key based on the key policy by generating a new version of the key.
 
         This operation requires the keys/rotate permission.
@@ -825,14 +818,14 @@ class KeyClient(KeyVaultClientBase):
         :return: The new version of the rotated key.
         :rtype: ~azure.keyvault.keys.KeyVaultKey
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises ~azure.core.exceptions.HttpResponseError:
         """
         bundle = self._client.rotate_key(vault_base_url=self._vault_url, key_name=name, **kwargs)
         return KeyVaultKey._from_key_bundle(bundle)
 
     @distributed_trace
     def update_key_rotation_policy(
-        self, key_name: str, policy: KeyRotationPolicy, **kwargs
+        self, key_name: str, policy: KeyRotationPolicy, **kwargs: Any
     ) -> KeyRotationPolicy:
         """Updates the rotation policy of a Key Vault key.
 
@@ -853,7 +846,7 @@ class KeyClient(KeyVaultClientBase):
         :return: The updated rotation policy.
         :rtype: ~azure.keyvault.keys.KeyRotationPolicy
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises ~azure.core.exceptions.HttpResponseError:
         """
         lifetime_actions = kwargs.pop("lifetime_actions", policy.lifetime_actions)
         if lifetime_actions:

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_models.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_models.py
@@ -3,17 +3,16 @@
 # Licensed under the MIT License.
 # -------------------------------------
 from collections import namedtuple
-from typing import TYPE_CHECKING
+from datetime import datetime
+from typing import Any, Dict, List, Optional, Union, TYPE_CHECKING
 
+from ._enums import KeyOperation, KeyRotationPolicyAction, KeyType
 from ._shared import parse_key_vault_id
 from ._generated.models import JsonWebKey as _JsonWebKey
 
 if TYPE_CHECKING:
     # pylint:disable=unused-import
-    from typing import Any, Dict, List, Optional, Union
-    from datetime import datetime
     from ._generated import models as _models
-    from ._enums import KeyOperation, KeyRotationPolicyAction, KeyType
 
 KeyOperationResult = namedtuple("KeyOperationResult", ["id", "value"])
 
@@ -132,7 +131,7 @@ class KeyProperties(object):
         return self._vault_id.name
 
     @property
-    def version(self) -> "Optional[str]":
+    def version(self) -> Optional[str]:
         """The key version.
 
         :returns: The key version.
@@ -141,7 +140,7 @@ class KeyProperties(object):
         return self._vault_id.version
 
     @property
-    def enabled(self) -> "Optional[bool]":
+    def enabled(self) -> Optional[bool]:
         """Whether the key is enabled for use.
 
         :returns: True if the key is enabled for use; False otherwise.
@@ -150,7 +149,7 @@ class KeyProperties(object):
         return self._attributes.enabled if self._attributes else None
 
     @property
-    def not_before(self) -> "Optional[datetime]":
+    def not_before(self) -> Optional[datetime]:
         """The time before which the key can not be used, in UTC.
 
         :returns: The time before which the key can not be used, in UTC.
@@ -159,7 +158,7 @@ class KeyProperties(object):
         return self._attributes.not_before if self._attributes else None
 
     @property
-    def expires_on(self) -> "Optional[datetime]":
+    def expires_on(self) -> Optional[datetime]:
         """When the key will expire, in UTC.
 
         :returns: When the key will expire, in UTC.
@@ -168,7 +167,7 @@ class KeyProperties(object):
         return self._attributes.expires if self._attributes else None
 
     @property
-    def created_on(self) -> "Optional[datetime]":
+    def created_on(self) -> Optional[datetime]:
         """When the key was created, in UTC.
 
         :returns: When the key was created, in UTC.
@@ -177,7 +176,7 @@ class KeyProperties(object):
         return self._attributes.created if self._attributes else None
 
     @property
-    def updated_on(self) -> "Optional[datetime]":
+    def updated_on(self) -> Optional[datetime]:
         """When the key was last updated, in UTC.
 
         :returns: When the key was last updated, in UTC.
@@ -195,7 +194,7 @@ class KeyProperties(object):
         return self._vault_id.vault_url
 
     @property
-    def recoverable_days(self) -> "Optional[int]":
+    def recoverable_days(self) -> Optional[int]:
         """The number of days the key is retained before being deleted from a soft-delete enabled Key Vault.
 
         :returns: The number of days the key is retained before being deleted from a soft-delete enabled Key Vault.
@@ -207,7 +206,7 @@ class KeyProperties(object):
         return None
 
     @property
-    def recovery_level(self) -> "Optional[str]":
+    def recovery_level(self) -> Optional[str]:
         """The vault's deletion recovery level for keys.
 
         :returns: The vault's deletion recovery level for keys.
@@ -216,7 +215,7 @@ class KeyProperties(object):
         return self._attributes.recovery_level if self._attributes else None
 
     @property
-    def tags(self) -> "Dict[str, str]":
+    def tags(self) -> Dict[str, str]:
         """Application specific metadata in the form of key-value pairs.
 
         :returns: A dictionary of tags attached to the key.
@@ -225,7 +224,7 @@ class KeyProperties(object):
         return self._tags
 
     @property
-    def managed(self) -> "Optional[bool]":
+    def managed(self) -> Optional[bool]:
         """Whether the key's lifetime is managed by Key Vault. If the key backs a certificate, this will be true.
 
         :returns: True if the key's lifetime is managed by Key Vault; False otherwise.
@@ -234,7 +233,7 @@ class KeyProperties(object):
         return self._managed
 
     @property
-    def exportable(self) -> "Optional[bool]":
+    def exportable(self) -> Optional[bool]:
         """Whether the private key can be exported.
 
         :returns: True if the private key can be exported; False otherwise.
@@ -247,7 +246,7 @@ class KeyProperties(object):
 
     @property
     def release_policy(self) -> "Optional[KeyReleasePolicy]":
-        """The azure.keyvault.keys.KeyReleasePolicy specifying the rules under which the key can be exported.
+        """The :class:`~azure.keyvault.keys.KeyReleasePolicy` specifying the rules under which the key can be exported.
 
         :returns: The key's release policy specifying the rules for exporting.
         :rtype: ~azure.keyvault.keys.KeyReleasePolicy or None
@@ -255,7 +254,7 @@ class KeyProperties(object):
         return self._release_policy
 
     @property
-    def hsm_platform(self) -> "Optional[str]":
+    def hsm_platform(self) -> Optional[str]:
         """The underlying HSM platform.
 
         :returns: The underlying HSM platform.
@@ -312,10 +311,10 @@ class KeyRotationLifetimeAction(object):
     :paramtype time_before_expiry: str or None
     """
 
-    def __init__(self, action: "Union[KeyRotationPolicyAction, str]", **kwargs) -> None:
+    def __init__(self, action: Union[KeyRotationPolicyAction, str], **kwargs) -> None:
         self.action = action
-        self.time_after_create: "Optional[str]" = kwargs.get("time_after_create", None)
-        self.time_before_expiry: "Optional[str]" = kwargs.get("time_before_expiry", None)
+        self.time_after_create: Optional[str] = kwargs.get("time_after_create", None)
+        self.time_before_expiry: Optional[str] = kwargs.get("time_before_expiry", None)
 
     @classmethod
     def _from_generated(cls, lifetime_action: "_models.LifetimeActions") -> "KeyRotationLifetimeAction":
@@ -349,7 +348,7 @@ class KeyRotationPolicy(object):
 
     def __init__(self, **kwargs) -> None:
         self.id = kwargs.get("policy_id", None)
-        self.lifetime_actions: "List[KeyRotationLifetimeAction]" = kwargs.get("lifetime_actions", [])
+        self.lifetime_actions: List[KeyRotationLifetimeAction] = kwargs.get("lifetime_actions", [])
         self.expires_in = kwargs.get("expires_in", None)
         self.created_on = kwargs.get("created_on", None)
         self.updated_on = kwargs.get("updated_on", None)
@@ -378,7 +377,7 @@ class KeyVaultKey(object):
     :param str key_id: Key Vault's identifier for the key. Typically a URI, e.g.
         https://myvault.vault.azure.net/keys/my-key/version
     :param jwk: The key's cryptographic material as a JSON Web Key (https://tools.ietf.org/html/rfc7517). This may be
-        provided as a dictionary or keyword arguments. See azure.keyvault.keys.models.JsonWebKey for field
+        provided as a dictionary or keyword arguments. See :class:`~azure.keyvault.keys.models.JsonWebKey` for field
         names.
     :type jwk: Dict[str, Any]
 
@@ -405,7 +404,7 @@ class KeyVaultKey(object):
 
     """
 
-    def __init__(self, key_id: str, jwk: "Optional[Dict[str, Any]]" = None, **kwargs) -> None:
+    def __init__(self, key_id: str, jwk: Optional[Dict[str, Any]] = None, **kwargs) -> None:
         self._properties: KeyProperties = kwargs.pop("properties", None) or KeyProperties(key_id, **kwargs)
         if isinstance(jwk, dict):
             if any(field in kwargs for field in JsonWebKey._FIELDS):  # pylint:disable=protected-access
@@ -465,20 +464,20 @@ class KeyVaultKey(object):
         return self._key_material
 
     @property
-    def key_type(self) -> "Union[str, KeyType]":
-        """The key's type. See azure.keyvault.keys.KeyType for possible values.
+    def key_type(self) -> Union[str, KeyType]:
+        """The key's type. See :class:`~azure.keyvault.keys.KeyType` for possible values.
 
-        :returns: The key's type. See azure.keyvault.keys.KeyType for possible values.
+        :returns: The key's type. See :class:`~azure.keyvault.keys.KeyType` for possible values.
         :rtype: ~azure.keyvault.keys.KeyType or str
         """
         # pylint:disable=no-member
         return self._key_material.kty  # type: ignore[attr-defined]
 
     @property
-    def key_operations(self) -> "List[Union[str, KeyOperation]]":
-        """Permitted operations. See azure.keyvault.keys.KeyOperation for possible values.
+    def key_operations(self) -> List[Union[str, KeyOperation]]:
+        """Permitted operations. See :class:`~azure.keyvault.keys.KeyOperation` for possible values.
 
-        :returns: Permitted operations. See azure.keyvault.keys.KeyOperation for possible values.
+        :returns: Permitted operations. See :class:`~azure.keyvault.keys.KeyOperation` for possible values.
         :rtype: List[~azure.keyvault.keys.KeyOperation or str]
         """
         # pylint:disable=no-member
@@ -517,7 +516,7 @@ class KeyVaultKeyIdentifier(object):
         return self._resource_id.name
 
     @property
-    def version(self) -> "Optional[str]":
+    def version(self) -> Optional[str]:
         return self._resource_id.version
 
 
@@ -540,9 +539,9 @@ class DeletedKey(KeyVaultKey):
     def __init__(
         self,
         properties: KeyProperties,
-        deleted_date: "Optional[datetime]" = None,
-        recovery_id: "Optional[str]" = None,
-        scheduled_purge_date: "Optional[datetime]" = None,
+        deleted_date: Optional[datetime] = None,
+        recovery_id: Optional[str] = None,
+        scheduled_purge_date: Optional[datetime] = None,
         **kwargs,
     ) -> None:
         super(DeletedKey, self).__init__(properties=properties, **kwargs)
@@ -576,7 +575,7 @@ class DeletedKey(KeyVaultKey):
         )
 
     @property
-    def deleted_date(self) -> "Optional[datetime]":
+    def deleted_date(self) -> Optional[datetime]:
         """When the key was deleted, in UTC.
 
         :returns: When the key was deleted, in UTC.
@@ -585,7 +584,7 @@ class DeletedKey(KeyVaultKey):
         return self._deleted_date
 
     @property
-    def recovery_id(self) -> "Optional[str]":
+    def recovery_id(self) -> Optional[str]:
         """An identifier used to recover the deleted key. Returns ``None`` if soft-delete is disabled.
 
         :returns: An identifier used to recover the deleted key. Returns ``None`` if soft-delete is disabled.
@@ -594,7 +593,7 @@ class DeletedKey(KeyVaultKey):
         return self._recovery_id
 
     @property
-    def scheduled_purge_date(self) -> "Optional[datetime]":
+    def scheduled_purge_date(self) -> Optional[datetime]:
         """When the key is scheduled to be purged, in UTC. Returns ``None`` if soft-delete is disabled.
 
         :returns: When the key is scheduled to be purged, in UTC. Returns ``None`` if soft-delete is disabled.

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_models.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_models.py
@@ -311,7 +311,7 @@ class KeyRotationLifetimeAction(object):
     :paramtype time_before_expiry: str or None
     """
 
-    def __init__(self, action: Union[KeyRotationPolicyAction, str], **kwargs) -> None:
+    def __init__(self, action: Union[KeyRotationPolicyAction, str], **kwargs: Any) -> None:
         self.action = action
         self.time_after_create: Optional[str] = kwargs.get("time_after_create", None)
         self.time_before_expiry: Optional[str] = kwargs.get("time_before_expiry", None)

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_models.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_models.py
@@ -44,7 +44,7 @@ class JsonWebKey(object):
 
     _FIELDS = ("kid", "kty", "key_ops", "n", "e", "d", "dp", "dq", "qi", "p", "q", "k", "t", "crv", "x", "y")
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, **kwargs: Any) -> None:
         for field in self._FIELDS:
             setattr(self, field, kwargs.get(field))
 
@@ -70,7 +70,7 @@ class KeyProperties(object):
     :paramtype release_policy: ~azure.keyvault.keys.KeyReleasePolicy
     """
 
-    def __init__(self, key_id: str, attributes: "Optional[_models.KeyAttributes]" = None, **kwargs) -> None:
+    def __init__(self, key_id: str, attributes: "Optional[_models.KeyAttributes]" = None, **kwargs: Any) -> None:
         self._attributes = attributes
         self._id = key_id
         self._vault_id = KeyVaultKeyIdentifier(key_id)
@@ -279,7 +279,7 @@ class KeyReleasePolicy(object):
         updated after being marked immutable. Release policies are mutable by default.
     """
 
-    def __init__(self, encoded_policy: bytes, **kwargs) -> None:
+    def __init__(self, encoded_policy: bytes, **kwargs: Any) -> None:
         self.encoded_policy = encoded_policy
         self.content_type = kwargs.get("content_type", None)
         self.immutable = kwargs.get("immutable", None)
@@ -346,7 +346,7 @@ class KeyRotationPolicy(object):
     :vartype updated_on: ~datetime.datetime or None
     """
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, **kwargs: Any) -> None:
         self.id = kwargs.get("policy_id", None)
         self.lifetime_actions: List[KeyRotationLifetimeAction] = kwargs.get("lifetime_actions", [])
         self.expires_in = kwargs.get("expires_in", None)
@@ -542,7 +542,7 @@ class DeletedKey(KeyVaultKey):
         deleted_date: Optional[datetime] = None,
         recovery_id: Optional[str] = None,
         scheduled_purge_date: Optional[datetime] = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> None:
         super(DeletedKey, self).__init__(properties=properties, **kwargs)
         self._deleted_date = deleted_date

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_models.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_models.py
@@ -66,7 +66,7 @@ class KeyProperties(object):
     :keyword bool managed: Whether the key's lifetime is managed by Key Vault.
     :keyword tags: Application specific metadata in the form of key-value pairs.
     :paramtype tags: dict[str, str]
-    :keyword release_policy: The :class:`~azure.keyvault.keys.KeyReleasePolicy` specifying the rules under which the key
+    :keyword release_policy: The azure.keyvault.keys.KeyReleasePolicy specifying the rules under which the key
         can be exported.
     :paramtype release_policy: ~azure.keyvault.keys.KeyReleasePolicy
     """
@@ -247,7 +247,7 @@ class KeyProperties(object):
 
     @property
     def release_policy(self) -> "Optional[KeyReleasePolicy]":
-        """The :class:`~azure.keyvault.keys.KeyReleasePolicy` specifying the rules under which the key can be exported.
+        """The azure.keyvault.keys.KeyReleasePolicy specifying the rules under which the key can be exported.
 
         :returns: The key's release policy specifying the rules for exporting.
         :rtype: ~azure.keyvault.keys.KeyReleasePolicy or None
@@ -378,7 +378,7 @@ class KeyVaultKey(object):
     :param str key_id: Key Vault's identifier for the key. Typically a URI, e.g.
         https://myvault.vault.azure.net/keys/my-key/version
     :param jwk: The key's cryptographic material as a JSON Web Key (https://tools.ietf.org/html/rfc7517). This may be
-        provided as a dictionary or keyword arguments. See :class:`~azure.keyvault.keys.models.JsonWebKey` for field
+        provided as a dictionary or keyword arguments. See azure.keyvault.keys.models.JsonWebKey for field
         names.
     :type jwk: Dict[str, Any]
 
@@ -466,9 +466,9 @@ class KeyVaultKey(object):
 
     @property
     def key_type(self) -> "Union[str, KeyType]":
-        """The key's type. See :class:`~azure.keyvault.keys.KeyType` for possible values.
+        """The key's type. See azure.keyvault.keys.KeyType for possible values.
 
-        :returns: The key's type. See :class:`~azure.keyvault.keys.KeyType` for possible values.
+        :returns: The key's type. See azure.keyvault.keys.KeyType for possible values.
         :rtype: ~azure.keyvault.keys.KeyType or str
         """
         # pylint:disable=no-member
@@ -476,9 +476,9 @@ class KeyVaultKey(object):
 
     @property
     def key_operations(self) -> "List[Union[str, KeyOperation]]":
-        """Permitted operations. See :class:`~azure.keyvault.keys.KeyOperation` for possible values.
+        """Permitted operations. See azure.keyvault.keys.KeyOperation for possible values.
 
-        :returns: Permitted operations. See :class:`~azure.keyvault.keys.KeyOperation` for possible values.
+        :returns: Permitted operations. See azure.keyvault.keys.KeyOperation for possible values.
         :rtype: List[~azure.keyvault.keys.KeyOperation or str]
         """
         # pylint:disable=no-member

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/async_challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/async_challenge_auth_policy.py
@@ -35,7 +35,7 @@ class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
 
     :param credential: An object which can provide an access token for the vault, such as a credential from
         :mod:`azure.identity.aio`
-    :type credential: :class:`~azure.core.credentials_async.AsyncTokenCredential`
+    :type credential: ~azure.core.credentials_async.AsyncTokenCredential
     """
 
     def __init__(self, credential: "AsyncTokenCredential", *scopes: str, **kwargs) -> None:

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/async_challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/async_challenge_auth_policy.py
@@ -15,20 +15,16 @@ protocol again.
 """
 
 import time
-from typing import TYPE_CHECKING
+from typing import Any, Optional
 from urllib.parse import urlparse
 
+from azure.core.credentials import AccessToken
+from azure.core.credentials_async import AsyncTokenCredential
+from azure.core.pipeline import PipelineRequest, PipelineResponse
 from azure.core.pipeline.policies import AsyncBearerTokenCredentialPolicy
 
 from . import http_challenge_cache as ChallengeCache
 from .challenge_auth_policy import _enforce_tls, _update_challenge
-
-if TYPE_CHECKING:
-    from typing import Optional
-    from azure.core.credentials import AccessToken
-    from azure.core.credentials_async import AsyncTokenCredential
-    from azure.core.pipeline import PipelineRequest, PipelineResponse
-
 
 class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
     """Policy for handling HTTP authentication challenges.
@@ -38,13 +34,13 @@ class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
     :type credential: ~azure.core.credentials_async.AsyncTokenCredential
     """
 
-    def __init__(self, credential: "AsyncTokenCredential", *scopes: str, **kwargs) -> None:
+    def __init__(self, credential: AsyncTokenCredential, *scopes: str, **kwargs: Any) -> None:
         super().__init__(credential, *scopes, **kwargs)
         self._credential = credential
-        self._token: "Optional[AccessToken]" = None
+        self._token: Optional[AccessToken] = None
         self._verify_challenge_resource = kwargs.pop("verify_challenge_resource", True)
 
-    async def on_request(self, request: "PipelineRequest") -> None:
+    async def on_request(self, request: PipelineRequest) -> None:
         _enforce_tls(request)
         challenge = ChallengeCache.get_challenge_for_url(request.http_request.url)
         if challenge:
@@ -68,7 +64,7 @@ class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
             request.http_request.headers["Content-Length"] = "0"
 
 
-    async def on_challenge(self, request: "PipelineRequest", response: "PipelineResponse") -> bool:
+    async def on_challenge(self, request: PipelineRequest, response: PipelineResponse) -> bool:
         try:
             challenge = _update_challenge(request, response)
             # azure-identity credentials require an AADv2 scope but the challenge may specify an AADv1 resource

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/async_client_base.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/async_client_base.py
@@ -2,9 +2,11 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
-from typing import TYPE_CHECKING
+from typing import Any, Awaitable
 
+from azure.core.credentials_async import AsyncTokenCredential
 from azure.core.pipeline.policies import HttpLoggingPolicy
+from azure.core.rest import AsyncHttpResponse, HttpRequest
 from azure.core.tracing.decorator_async import distributed_trace_async
 
 from . import AsyncChallengeAuthPolicy
@@ -13,16 +15,10 @@ from .._sdk_moniker import SDK_MONIKER
 from .._generated.aio import KeyVaultClient as _KeyVaultClient
 from .._generated import models as _models
 
-if TYPE_CHECKING:
-    # pylint:disable=unused-import
-    from typing import Any, Awaitable
-    from azure.core.credentials_async import AsyncTokenCredential
-    from azure.core.rest import AsyncHttpResponse, HttpRequest
-
 
 class AsyncKeyVaultClientBase(object):
     # pylint:disable=protected-access
-    def __init__(self, vault_url: str, credential: "AsyncTokenCredential", **kwargs) -> None:
+    def __init__(self, vault_url: str, credential: AsyncTokenCredential, **kwargs: Any) -> None:
         if not credential:
             raise ValueError(
                 "credential should be an object supporting the AsyncTokenCredential protocol, "
@@ -74,7 +70,7 @@ class AsyncKeyVaultClientBase(object):
         await self._client.__aenter__()
         return self
 
-    async def __aexit__(self, *args: "Any") -> None:
+    async def __aexit__(self, *args: Any) -> None:
         await self._client.__aexit__(*args)
 
     async def close(self) -> None:
@@ -85,7 +81,9 @@ class AsyncKeyVaultClientBase(object):
         await self._client.close()
 
     @distributed_trace_async
-    def send_request(self, request: "HttpRequest", *, stream: bool = False, **kwargs) -> "Awaitable[AsyncHttpResponse]":
+    def send_request(
+        self, request: HttpRequest, *, stream: bool = False, **kwargs: Any
+    ) -> Awaitable[AsyncHttpResponse]:
         """Runs a network request using the client's existing pipeline.
 
         The request URL can be relative to the vault URL. The service API version used for the request is the same as

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/challenge_auth_policy.py
@@ -42,9 +42,9 @@ def _update_challenge(request: PipelineRequest, challenger: "PipelineResponse") 
     """Parse challenge from a challenge response, cache it, and return it.
 
     :param request: The pipeline request that prompted the challenge response.
-    :type request: :class:`~azure.core.pipeline.PipelineRequest`
+    :type request: ~azure.core.pipeline.PipelineRequest
     :param challenger: The pipeline response containing the authentication challenge.
-    :type challenger: :class:`~azure.core.pipeline.PipelineResponse`
+    :type challenger: ~azure.core.pipeline.PipelineResponse
 
     :returns: An HttpChallenge object representing the authentication challenge.
     :rtype: HttpChallenge
@@ -64,7 +64,7 @@ class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
 
     :param credential: An object which can provide an access token for the vault, such as a credential from
         :mod:`azure.identity`
-    :type credential: :class:`~azure.core.credentials.TokenCredential`
+    :type credential: ~azure.core.credentials.TokenCredential
     """
 
     def __init__(self, credential: "TokenCredential", *scopes: str, **kwargs) -> None:

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/client_base.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/client_base.py
@@ -47,11 +47,11 @@ def _format_api_version(request: "HttpRequest", api_version: str) -> "HttpReques
     """Returns a request copy that includes an api-version query parameter if one wasn't originally present.
 
     :param request: The HTTP request being sent.
-    :type request: :class:`~azure.core.rest.HttpRequest`
+    :type request: ~azure.core.rest.HttpRequest
     :param str api_version: The service API version that the request should include.
 
     :returns: A copy of the request that includes an api-version query parameter.
-    :rtype: :class:`~azure.core.rest.HttpRequest`
+    :rtype: ~azure.core.rest.HttpRequest
     """
     request_copy = deepcopy(request)
     params = {"api-version": api_version}  # By default, we want to use the client's API version

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/client_base.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/client_base.py
@@ -3,12 +3,14 @@
 # Licensed under the MIT License.
 # ------------------------------------
 from copy import deepcopy
-from typing import TYPE_CHECKING
 from enum import Enum
+from typing import Any
 from urllib.parse import urlparse
 
 from azure.core import CaseInsensitiveEnumMeta
+from azure.core.credentials import TokenCredential
 from azure.core.pipeline.policies import HttpLoggingPolicy
+from azure.core.rest import HttpRequest, HttpResponse
 from azure.core.tracing.decorator import distributed_trace
 
 from . import ChallengeAuthPolicy
@@ -16,12 +18,6 @@ from .._generated import KeyVaultClient as _KeyVaultClient
 from .._generated import models as _models
 from .._generated._serialization import Serializer
 from .._sdk_moniker import SDK_MONIKER
-
-if TYPE_CHECKING:
-    # pylint:disable=unused-import,ungrouped-imports
-    from typing import Any
-    from azure.core.credentials import TokenCredential
-    from azure.core.rest import HttpRequest, HttpResponse
 
 
 class ApiVersion(str, Enum, metaclass=CaseInsensitiveEnumMeta):
@@ -43,7 +39,7 @@ _SERIALIZER = Serializer()
 _SERIALIZER.client_side_validation = False
 
 
-def _format_api_version(request: "HttpRequest", api_version: str) -> "HttpRequest":
+def _format_api_version(request: HttpRequest, api_version: str) -> HttpRequest:
     """Returns a request copy that includes an api-version query parameter if one wasn't originally present.
 
     :param request: The HTTP request being sent.
@@ -51,7 +47,7 @@ def _format_api_version(request: "HttpRequest", api_version: str) -> "HttpReques
     :param str api_version: The service API version that the request should include.
 
     :returns: A copy of the request that includes an api-version query parameter.
-    :rtype: ~azure.core.rest.HttpRequest
+    :rtype: azure.core.rest.HttpRequest
     """
     request_copy = deepcopy(request)
     params = {"api-version": api_version}  # By default, we want to use the client's API version
@@ -73,7 +69,7 @@ def _format_api_version(request: "HttpRequest", api_version: str) -> "HttpReques
 
 class KeyVaultClientBase(object):
     # pylint:disable=protected-access
-    def __init__(self, vault_url: str, credential: "TokenCredential", **kwargs) -> None:
+    def __init__(self, vault_url: str, credential: TokenCredential, **kwargs: Any) -> None:
         if not credential:
             raise ValueError(
                 "credential should be an object supporting the TokenCredential protocol, "
@@ -125,7 +121,7 @@ class KeyVaultClientBase(object):
         self._client.__enter__()
         return self
 
-    def __exit__(self, *args: "Any") -> None:
+    def __exit__(self, *args: Any) -> None:
         self._client.__exit__(*args)
 
     def close(self) -> None:
@@ -136,7 +132,7 @@ class KeyVaultClientBase(object):
         self._client.close()
 
     @distributed_trace
-    def send_request(self, request: "HttpRequest", *, stream: bool = False, **kwargs) -> "HttpResponse":
+    def send_request(self, request: HttpRequest, *, stream: bool = False, **kwargs: Any) -> HttpResponse:
         """Runs a network request using the client's existing pipeline.
 
         The request URL can be relative to the vault URL. The service API version used for the request is the same as

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/aio/_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/aio/_client.py
@@ -2,14 +2,17 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
-from typing import TYPE_CHECKING
+from datetime import datetime
 from functools import partial
+from typing import Optional, Union
 
+from azure.core.async_paging import AsyncItemPaged
 from azure.core.tracing.decorator import distributed_trace
 from azure.core.tracing.decorator_async import distributed_trace_async
 
 from ..crypto.aio import CryptographyClient
 from .._client import _get_key_id
+from .._generated.models import KeyAttributes
 from .._shared._polling_async import AsyncDeleteRecoverPollingMethod
 from .._shared import AsyncKeyVaultClientBase
 from .. import (
@@ -17,17 +20,10 @@ from .. import (
     JsonWebKey,
     KeyProperties,
     KeyRotationPolicy,
+    KeyType,
     KeyVaultKey,
     ReleaseKeyResult,
 )
-
-if TYPE_CHECKING:
-    # pylint:disable=ungrouped-imports
-    from datetime import datetime
-    from typing import Optional, Union
-    from azure.core.async_paging import AsyncItemPaged
-    from .. import KeyType
-    from .._generated.models import KeyAttributes
 
 
 class KeyClient(AsyncKeyVaultClientBase):
@@ -58,11 +54,11 @@ class KeyClient(AsyncKeyVaultClientBase):
 
     def _get_attributes(
         self,
-        enabled: "Optional[bool]",
-        not_before: "Optional[datetime]",
-        expires_on: "Optional[datetime]",
-        exportable: "Optional[bool]" = None,
-    ) -> "Optional[KeyAttributes]":
+        enabled: Optional[bool],
+        not_before: Optional[datetime],
+        expires_on: Optional[datetime],
+        exportable: Optional[bool] = None,
+    ) -> Optional[KeyAttributes]:
         """Return a KeyAttributes object if non-None attributes are provided, or None otherwise.
 
         :param enabled: Whether the key is enabled.
@@ -87,17 +83,18 @@ class KeyClient(AsyncKeyVaultClientBase):
             self,
             key_name: str,
             *,
-            key_version: "Optional[str]" = None,
+            key_version: Optional[str] = None,
+            **kwargs,  # pylint: disable=unused-argument
         ) -> CryptographyClient:
-        """Gets a azure.keyvault.keys.crypto.aio.CryptographyClient for the given key.
+        """Gets a :class:`~azure.keyvault.keys.crypto.aio.CryptographyClient` for the given key.
 
         :param str key_name: The name of the key used to perform cryptographic operations.
 
         :keyword key_version: Optional version of the key used to perform cryptographic operations.
         :paramtype key_version: str or None
 
-        :returns: A azure.keyvault.keys.crypto.aio.CryptographyClient using the same options, credentials, and
-            HTTP client as this azure.keyvault.keys.aio.KeyClient.
+        :returns: A :class:`~azure.keyvault.keys.crypto.aio.CryptographyClient` using the same options, credentials, and
+            HTTP client as this :class:`~azure.keyvault.keys.aio.KeyClient`.
         :rtype: ~azure.keyvault.keys.crypto.aio.CryptographyClient
         """
         key_id = _get_key_id(self._vault_url, key_name, key_version)
@@ -108,7 +105,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         )
 
     @distributed_trace_async
-    async def create_key(self, name: str, key_type: "Union[str, KeyType]", **kwargs) -> KeyVaultKey:
+    async def create_key(self, name: str, key_type: Union[str, KeyType], **kwargs) -> KeyVaultKey:
         """Create a key or, if ``name`` is already in use, create a new version of the key.
 
         Requires keys/create permission.
@@ -143,7 +140,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         :returns: The created key
         :rtype: ~azure.keyvault.keys.KeyVaultKey
 
-        :raises: azure.core.exceptions.HttpResponseError
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example:
             .. literalinclude:: ../tests/test_samples_keys_async.py
@@ -218,7 +215,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         :returns: The created key
         :rtype: ~azure.keyvault.keys.KeyVaultKey
 
-        :raises: azure.core.exceptions.HttpResponseError
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example:
             .. literalinclude:: ../tests/test_samples_keys_async.py
@@ -262,7 +259,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         :returns: The created key
         :rtype: ~azure.keyvault.keys.KeyVaultKey
 
-        :raises: azure.core.exceptions.HttpResponseError
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example:
             .. literalinclude:: ../tests/test_samples_keys_async.py
@@ -306,7 +303,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         :returns: The created key
         :rtype: ~azure.keyvault.keys.KeyVaultKey
 
-        :raises: azure.core.exceptions.HttpResponseError
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example:
             .. literalinclude:: ../tests/test_samples_keys_async.py
@@ -332,8 +329,8 @@ class KeyClient(AsyncKeyVaultClientBase):
         :rtype: ~azure.keyvault.keys.DeletedKey
 
         :raises:
-            azure.core.exceptions.ResourceNotFoundError if the key doesn't exist,
-            azure.core.exceptions.HttpResponseError for other errors
+            :class:`~azure.core.exceptions.ResourceNotFoundError` if the key doesn't exist,
+            :class:`~azure.core.exceptions.HttpResponseError` for other errors
 
         Example:
             .. literalinclude:: ../tests/test_samples_keys_async.py
@@ -362,7 +359,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         return polling_method.resource()
 
     @distributed_trace_async
-    async def get_key(self, name: str, version: "Optional[str]" = None, **kwargs) -> KeyVaultKey:
+    async def get_key(self, name: str, version: Optional[str] = None, **kwargs) -> KeyVaultKey:
         """Get a key's attributes and, if it's an asymmetric key, its public material.
 
         Requires keys/get permission.
@@ -376,8 +373,8 @@ class KeyClient(AsyncKeyVaultClientBase):
         :rtype: ~azure.keyvault.keys.KeyVaultKey
 
         :raises:
-            azure.core.exceptions.ResourceNotFoundError if the key doesn't exist,
-            azure.core.exceptions.HttpResponseError for other errors
+            :class:`~azure.core.exceptions.ResourceNotFoundError` if the key doesn't exist,
+            :class:`~azure.core.exceptions.HttpResponseError` for other errors
 
         Example:
             .. literalinclude:: ../tests/test_samples_keys_async.py
@@ -405,8 +402,8 @@ class KeyClient(AsyncKeyVaultClientBase):
         :rtype: ~azure.keyvault.keys.DeletedKey
 
         :raises:
-            azure.core.exceptions.ResourceNotFoundError if the key doesn't exist,
-            azure.core.exceptions.HttpResponseError for other errors
+            :class:`~azure.core.exceptions.ResourceNotFoundError` if the key doesn't exist,
+            :class:`~azure.core.exceptions.HttpResponseError` for other errors
 
         Example:
             .. literalinclude:: ../tests/test_samples_keys_async.py
@@ -420,7 +417,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         return DeletedKey._from_deleted_key_bundle(bundle)
 
     @distributed_trace
-    def list_deleted_keys(self, **kwargs) -> "AsyncItemPaged[DeletedKey]":
+    def list_deleted_keys(self, **kwargs) -> AsyncItemPaged[DeletedKey]:
         """List all deleted keys, including the public part of each. Possible only in a vault with soft-delete enabled.
 
         Requires keys/list permission.
@@ -444,7 +441,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         )
 
     @distributed_trace
-    def list_properties_of_keys(self, **kwargs) -> "AsyncItemPaged[KeyProperties]":
+    def list_properties_of_keys(self, **kwargs) -> AsyncItemPaged[KeyProperties]:
         """List identifiers and properties of all keys in the vault.
 
         Requires keys/list permission.
@@ -468,7 +465,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         )
 
     @distributed_trace
-    def list_properties_of_key_versions(self, name: str, **kwargs) -> "AsyncItemPaged[KeyProperties]":
+    def list_properties_of_key_versions(self, name: str, **kwargs) -> AsyncItemPaged[KeyProperties]:
         """List the identifiers and properties of a key's versions.
 
         Requires keys/list permission.
@@ -509,7 +506,7 @@ class KeyClient(AsyncKeyVaultClientBase):
 
         :returns: None
 
-        :raises: azure.core.exceptions.HttpResponseError
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example:
             .. code-block:: python
@@ -534,7 +531,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         :returns: The recovered key
         :rtype: ~azure.keyvault.keys.KeyVaultKey
 
-        :raises: azure.core.exceptions.HttpResponseError
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example:
             .. literalinclude:: ../tests/test_samples_keys_async.py
@@ -560,7 +557,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         return polling_method.resource()
 
     @distributed_trace_async
-    async def update_key_properties(self, name: str, version: "Optional[str]" = None, **kwargs) -> KeyVaultKey:
+    async def update_key_properties(self, name: str, version: Optional[str] = None, **kwargs) -> KeyVaultKey:
         """Change a key's properties (not its cryptographic material).
 
         Requires keys/update permission.
@@ -586,8 +583,8 @@ class KeyClient(AsyncKeyVaultClientBase):
         :rtype: ~azure.keyvault.keys.KeyVaultKey
 
         :raises:
-            azure.core.exceptions.ResourceNotFoundError if the key doesn't exist,
-            azure.core.exceptions.HttpResponseError for other errors
+            :class:`~azure.core.exceptions.ResourceNotFoundError` if the key doesn't exist,
+            :class:`~azure.core.exceptions.HttpResponseError` for other errors
 
         Example:
             .. literalinclude:: ../tests/test_samples_keys_async.py
@@ -637,8 +634,8 @@ class KeyClient(AsyncKeyVaultClientBase):
         :rtype: bytes
 
         :raises:
-            azure.core.exceptions.ResourceNotFoundError if the key doesn't exist,
-            azure.core.exceptions.HttpResponseError for other errors
+            :class:`~azure.core.exceptions.ResourceNotFoundError` if the key doesn't exist,
+            :class:`~azure.core.exceptions.HttpResponseError` for other errors
 
         Example:
             .. literalinclude:: ../tests/test_samples_keys_async.py
@@ -665,8 +662,8 @@ class KeyClient(AsyncKeyVaultClientBase):
         :rtype: ~azure.keyvault.keys.KeyVaultKey
 
         :raises:
-            azure.core.exceptions.ResourceExistsError if the backed up key's name is already in use,
-            azure.core.exceptions.HttpResponseError for other errors
+            :class:`~azure.core.exceptions.ResourceExistsError` if the backed up key's name is already in use,
+            :class:`~azure.core.exceptions.HttpResponseError` for other errors
 
         Example:
             .. literalinclude:: ../tests/test_samples_keys_async.py
@@ -711,7 +708,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         :returns: The imported key
         :rtype: ~azure.keyvault.keys.KeyVaultKey
 
-        :raises: azure.core.exceptions.HttpResponseError
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
         """
         enabled = kwargs.pop("enabled", None)
         not_before = kwargs.pop("not_before", None)
@@ -759,7 +756,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         :return: The result of the key release.
         :rtype: ~azure.keyvault.keys.ReleaseKeyResult
 
-        :raises: azure.core.exceptions.HttpResponseError
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
         """
         version = kwargs.pop("version", None)
         result = await self._client.release(
@@ -786,7 +783,7 @@ class KeyClient(AsyncKeyVaultClientBase):
 
         :raises:
             :class:`ValueError` if less than one random byte is requested,
-            azure.core.exceptions.HttpResponseError for other errors
+            :class:`~azure.core.exceptions.HttpResponseError` for other errors
 
         Example:
             .. literalinclude:: ../tests/test_keys_async.py
@@ -803,7 +800,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         return result.value
 
     @distributed_trace_async
-    async def get_key_rotation_policy(self, key_name: str, **kwargs) -> "KeyRotationPolicy":
+    async def get_key_rotation_policy(self, key_name: str, **kwargs) -> KeyRotationPolicy:
         """Get the rotation policy of a Key Vault key.
 
         :param str key_name: The name of the key.
@@ -811,7 +808,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         :return: The key rotation policy.
         :rtype: ~azure.keyvault.keys.KeyRotationPolicy
 
-        :raises: azure.core.exceptions.HttpResponseError
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
         """
         policy = await self._client.get_key_rotation_policy(vault_base_url=self._vault_url, key_name=key_name, **kwargs)
         return KeyRotationPolicy._from_generated(policy)
@@ -827,7 +824,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         :return: The new version of the rotated key.
         :rtype: ~azure.keyvault.keys.KeyVaultKey
 
-        :raises: azure.core.exceptions.HttpResponseError
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
         """
         bundle = await self._client.rotate_key(vault_base_url=self._vault_url, key_name=name, **kwargs)
         return KeyVaultKey._from_key_bundle(bundle)
@@ -855,7 +852,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         :return: The updated rotation policy.
         :rtype: ~azure.keyvault.keys.KeyRotationPolicy
 
-        :raises: azure.core.exceptions.HttpResponseError
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
         """
         lifetime_actions = kwargs.pop("lifetime_actions", policy.lifetime_actions)
         if lifetime_actions:

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/aio/_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/aio/_client.py
@@ -38,7 +38,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         See https://aka.ms/azsdk/blog/vault-uri for details.
     :param credential: An object which can provide an access token for the vault, such as a credential from
         :mod:`azure.identity.aio`
-    :type credential: :class:`~azure.core.credentials_async.AsyncTokenCredential`
+    :type credential: ~azure.core.credentials_async.AsyncTokenCredential
 
     :keyword api_version: Version of the service API to use. Defaults to the most recent.
     :paramtype api_version: ~azure.keyvault.keys.ApiVersion or str
@@ -83,18 +83,24 @@ class KeyClient(AsyncKeyVaultClientBase):
             )
         return None
 
-    def get_cryptography_client(self, key_name: str, **kwargs) -> CryptographyClient:
-        """Gets a :class:`~azure.keyvault.keys.crypto.aio.CryptographyClient` for the given key.
+    def get_cryptography_client(
+            self,
+            key_name: str,
+            *,
+            key_version: "Optional[str]" = None,
+        ) -> CryptographyClient:
+        """Gets a azure.keyvault.keys.crypto.aio.CryptographyClient for the given key.
 
         :param str key_name: The name of the key used to perform cryptographic operations.
 
-        :keyword str key_version: Optional version of the key used to perform cryptographic operations.
+        :keyword key_version: Optional version of the key used to perform cryptographic operations.
+        :paramtype key_version: str or None
 
-        :returns: A :class:`~azure.keyvault.keys.crypto.aio.CryptographyClient` using the same options, credentials, and
-            HTTP client as this :class:`~azure.keyvault.keys.aio.KeyClient`.
+        :returns: A azure.keyvault.keys.crypto.aio.CryptographyClient using the same options, credentials, and
+            HTTP client as this azure.keyvault.keys.aio.KeyClient.
         :rtype: ~azure.keyvault.keys.crypto.aio.CryptographyClient
         """
-        key_id = _get_key_id(self._vault_url, key_name, kwargs.get("key_version"))
+        key_id = _get_key_id(self._vault_url, key_name, key_version)
 
         # We provide a fake credential because the generated client already has the KeyClient's real credential
         return CryptographyClient(
@@ -137,7 +143,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         :returns: The created key
         :rtype: ~azure.keyvault.keys.KeyVaultKey
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises: azure.core.exceptions.HttpResponseError
 
         Example:
             .. literalinclude:: ../tests/test_samples_keys_async.py
@@ -212,7 +218,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         :returns: The created key
         :rtype: ~azure.keyvault.keys.KeyVaultKey
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises: azure.core.exceptions.HttpResponseError
 
         Example:
             .. literalinclude:: ../tests/test_samples_keys_async.py
@@ -256,7 +262,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         :returns: The created key
         :rtype: ~azure.keyvault.keys.KeyVaultKey
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises: azure.core.exceptions.HttpResponseError
 
         Example:
             .. literalinclude:: ../tests/test_samples_keys_async.py
@@ -300,7 +306,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         :returns: The created key
         :rtype: ~azure.keyvault.keys.KeyVaultKey
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises: azure.core.exceptions.HttpResponseError
 
         Example:
             .. literalinclude:: ../tests/test_samples_keys_async.py
@@ -326,8 +332,8 @@ class KeyClient(AsyncKeyVaultClientBase):
         :rtype: ~azure.keyvault.keys.DeletedKey
 
         :raises:
-            :class:`~azure.core.exceptions.ResourceNotFoundError` if the key doesn't exist,
-            :class:`~azure.core.exceptions.HttpResponseError` for other errors
+            azure.core.exceptions.ResourceNotFoundError if the key doesn't exist,
+            azure.core.exceptions.HttpResponseError for other errors
 
         Example:
             .. literalinclude:: ../tests/test_samples_keys_async.py
@@ -370,8 +376,8 @@ class KeyClient(AsyncKeyVaultClientBase):
         :rtype: ~azure.keyvault.keys.KeyVaultKey
 
         :raises:
-            :class:`~azure.core.exceptions.ResourceNotFoundError` if the key doesn't exist,
-            :class:`~azure.core.exceptions.HttpResponseError` for other errors
+            azure.core.exceptions.ResourceNotFoundError if the key doesn't exist,
+            azure.core.exceptions.HttpResponseError for other errors
 
         Example:
             .. literalinclude:: ../tests/test_samples_keys_async.py
@@ -399,8 +405,8 @@ class KeyClient(AsyncKeyVaultClientBase):
         :rtype: ~azure.keyvault.keys.DeletedKey
 
         :raises:
-            :class:`~azure.core.exceptions.ResourceNotFoundError` if the key doesn't exist,
-            :class:`~azure.core.exceptions.HttpResponseError` for other errors
+            azure.core.exceptions.ResourceNotFoundError if the key doesn't exist,
+            azure.core.exceptions.HttpResponseError for other errors
 
         Example:
             .. literalinclude:: ../tests/test_samples_keys_async.py
@@ -503,7 +509,7 @@ class KeyClient(AsyncKeyVaultClientBase):
 
         :returns: None
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises: azure.core.exceptions.HttpResponseError
 
         Example:
             .. code-block:: python
@@ -528,7 +534,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         :returns: The recovered key
         :rtype: ~azure.keyvault.keys.KeyVaultKey
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises: azure.core.exceptions.HttpResponseError
 
         Example:
             .. literalinclude:: ../tests/test_samples_keys_async.py
@@ -580,8 +586,8 @@ class KeyClient(AsyncKeyVaultClientBase):
         :rtype: ~azure.keyvault.keys.KeyVaultKey
 
         :raises:
-            :class:`~azure.core.exceptions.ResourceNotFoundError` if the key doesn't exist,
-            :class:`~azure.core.exceptions.HttpResponseError` for other errors
+            azure.core.exceptions.ResourceNotFoundError if the key doesn't exist,
+            azure.core.exceptions.HttpResponseError for other errors
 
         Example:
             .. literalinclude:: ../tests/test_samples_keys_async.py
@@ -631,8 +637,8 @@ class KeyClient(AsyncKeyVaultClientBase):
         :rtype: bytes
 
         :raises:
-            :class:`~azure.core.exceptions.ResourceNotFoundError` if the key doesn't exist,
-            :class:`~azure.core.exceptions.HttpResponseError` for other errors
+            azure.core.exceptions.ResourceNotFoundError if the key doesn't exist,
+            azure.core.exceptions.HttpResponseError for other errors
 
         Example:
             .. literalinclude:: ../tests/test_samples_keys_async.py
@@ -659,8 +665,8 @@ class KeyClient(AsyncKeyVaultClientBase):
         :rtype: ~azure.keyvault.keys.KeyVaultKey
 
         :raises:
-            :class:`~azure.core.exceptions.ResourceExistsError` if the backed up key's name is already in use,
-            :class:`~azure.core.exceptions.HttpResponseError` for other errors
+            azure.core.exceptions.ResourceExistsError if the backed up key's name is already in use,
+            azure.core.exceptions.HttpResponseError for other errors
 
         Example:
             .. literalinclude:: ../tests/test_samples_keys_async.py
@@ -705,7 +711,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         :returns: The imported key
         :rtype: ~azure.keyvault.keys.KeyVaultKey
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises: azure.core.exceptions.HttpResponseError
         """
         enabled = kwargs.pop("enabled", None)
         not_before = kwargs.pop("not_before", None)
@@ -753,7 +759,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         :return: The result of the key release.
         :rtype: ~azure.keyvault.keys.ReleaseKeyResult
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises: azure.core.exceptions.HttpResponseError
         """
         version = kwargs.pop("version", None)
         result = await self._client.release(
@@ -780,7 +786,7 @@ class KeyClient(AsyncKeyVaultClientBase):
 
         :raises:
             :class:`ValueError` if less than one random byte is requested,
-            :class:`~azure.core.exceptions.HttpResponseError` for other errors
+            azure.core.exceptions.HttpResponseError for other errors
 
         Example:
             .. literalinclude:: ../tests/test_keys_async.py
@@ -805,7 +811,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         :return: The key rotation policy.
         :rtype: ~azure.keyvault.keys.KeyRotationPolicy
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises: azure.core.exceptions.HttpResponseError
         """
         policy = await self._client.get_key_rotation_policy(vault_base_url=self._vault_url, key_name=key_name, **kwargs)
         return KeyRotationPolicy._from_generated(policy)
@@ -821,7 +827,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         :return: The new version of the rotated key.
         :rtype: ~azure.keyvault.keys.KeyVaultKey
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises: azure.core.exceptions.HttpResponseError
         """
         bundle = await self._client.rotate_key(vault_base_url=self._vault_url, key_name=name, **kwargs)
         return KeyVaultKey._from_key_bundle(bundle)
@@ -849,7 +855,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         :return: The updated rotation policy.
         :rtype: ~azure.keyvault.keys.KeyRotationPolicy
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises: azure.core.exceptions.HttpResponseError
         """
         lifetime_actions = kwargs.pop("lifetime_actions", policy.lifetime_actions)
         if lifetime_actions:

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/aio/_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/aio/_client.py
@@ -4,7 +4,7 @@
 # ------------------------------------
 from datetime import datetime
 from functools import partial
-from typing import Optional, Union
+from typing import Any, Optional, Union
 
 from azure.core.async_paging import AsyncItemPaged
 from azure.core.tracing.decorator import distributed_trace
@@ -140,7 +140,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         :returns: The created key
         :rtype: ~azure.keyvault.keys.KeyVaultKey
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises ~azure.core.exceptions.HttpResponseError:
 
         Example:
             .. literalinclude:: ../tests/test_samples_keys_async.py
@@ -183,7 +183,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         return KeyVaultKey._from_key_bundle(bundle)
 
     @distributed_trace_async
-    async def create_rsa_key(self, name: str, **kwargs) -> KeyVaultKey:
+    async def create_rsa_key(self, name: str, **kwargs: Any) -> KeyVaultKey:
         """Create a new RSA key or, if ``name`` is already in use, create a new version of the key
 
         Requires the keys/create permission.
@@ -215,7 +215,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         :returns: The created key
         :rtype: ~azure.keyvault.keys.KeyVaultKey
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises ~azure.core.exceptions.HttpResponseError:
 
         Example:
             .. literalinclude:: ../tests/test_samples_keys_async.py
@@ -229,7 +229,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         return await self.create_key(name, key_type="RSA-HSM" if hsm else "RSA", **kwargs)
 
     @distributed_trace_async
-    async def create_ec_key(self, name: str, **kwargs) -> KeyVaultKey:
+    async def create_ec_key(self, name: str, **kwargs: Any) -> KeyVaultKey:
         """Create a new elliptic curve key or, if ``name`` is already in use, create a new version of the key.
 
         Requires the keys/create permission.
@@ -259,7 +259,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         :returns: The created key
         :rtype: ~azure.keyvault.keys.KeyVaultKey
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises ~azure.core.exceptions.HttpResponseError:
 
         Example:
             .. literalinclude:: ../tests/test_samples_keys_async.py
@@ -273,7 +273,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         return await self.create_key(name, key_type="EC-HSM" if hsm else "EC", **kwargs)
 
     @distributed_trace_async
-    async def create_oct_key(self, name: str, **kwargs) -> KeyVaultKey:
+    async def create_oct_key(self, name: str, **kwargs: Any) -> KeyVaultKey:
         """Create a new octet sequence (symmetric) key or, if ``name`` is in use, create a new version of the key.
 
         Requires the keys/create permission.
@@ -303,7 +303,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         :returns: The created key
         :rtype: ~azure.keyvault.keys.KeyVaultKey
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises ~azure.core.exceptions.HttpResponseError:
 
         Example:
             .. literalinclude:: ../tests/test_samples_keys_async.py
@@ -317,7 +317,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         return await self.create_key(name, key_type="oct-HSM" if hsm else "oct", **kwargs)
 
     @distributed_trace_async
-    async def delete_key(self, name: str, **kwargs) -> DeletedKey:
+    async def delete_key(self, name: str, **kwargs: Any) -> DeletedKey:
         """Delete all versions of a key and its cryptographic material.
 
         Requires keys/delete permission. If the vault has soft-delete enabled, deletion may take several seconds to
@@ -328,9 +328,8 @@ class KeyClient(AsyncKeyVaultClientBase):
         :returns: The deleted key
         :rtype: ~azure.keyvault.keys.DeletedKey
 
-        :raises:
-            :class:`~azure.core.exceptions.ResourceNotFoundError` if the key doesn't exist,
-            :class:`~azure.core.exceptions.HttpResponseError` for other errors
+        :raises ~azure.core.exceptions.ResourceNotFoundError or ~azure.core.exceptions.HttpResponseError:
+            the former if the key doesn't exist; the latter for other errors
 
         Example:
             .. literalinclude:: ../tests/test_samples_keys_async.py
@@ -359,7 +358,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         return polling_method.resource()
 
     @distributed_trace_async
-    async def get_key(self, name: str, version: Optional[str] = None, **kwargs) -> KeyVaultKey:
+    async def get_key(self, name: str, version: Optional[str] = None, **kwargs: Any) -> KeyVaultKey:
         """Get a key's attributes and, if it's an asymmetric key, its public material.
 
         Requires keys/get permission.
@@ -372,9 +371,8 @@ class KeyClient(AsyncKeyVaultClientBase):
         :returns: The fetched key.
         :rtype: ~azure.keyvault.keys.KeyVaultKey
 
-        :raises:
-            :class:`~azure.core.exceptions.ResourceNotFoundError` if the key doesn't exist,
-            :class:`~azure.core.exceptions.HttpResponseError` for other errors
+        :raises ~azure.core.exceptions.ResourceNotFoundError or ~azure.core.exceptions.HttpResponseError:
+            the former if the key doesn't exist; the latter for other errors
 
         Example:
             .. literalinclude:: ../tests/test_samples_keys_async.py
@@ -391,7 +389,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         return KeyVaultKey._from_key_bundle(bundle)
 
     @distributed_trace_async
-    async def get_deleted_key(self, name: str, **kwargs) -> DeletedKey:
+    async def get_deleted_key(self, name: str, **kwargs: Any) -> DeletedKey:
         """Get a deleted key. Possible only in a vault with soft-delete enabled.
 
         Requires keys/get permission.
@@ -401,9 +399,8 @@ class KeyClient(AsyncKeyVaultClientBase):
         :returns: The deleted key
         :rtype: ~azure.keyvault.keys.DeletedKey
 
-        :raises:
-            :class:`~azure.core.exceptions.ResourceNotFoundError` if the key doesn't exist,
-            :class:`~azure.core.exceptions.HttpResponseError` for other errors
+        :raises ~azure.core.exceptions.ResourceNotFoundError or ~azure.core.exceptions.HttpResponseError:
+            the former if the key doesn't exist; the latter for other errors
 
         Example:
             .. literalinclude:: ../tests/test_samples_keys_async.py
@@ -417,7 +414,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         return DeletedKey._from_deleted_key_bundle(bundle)
 
     @distributed_trace
-    def list_deleted_keys(self, **kwargs) -> AsyncItemPaged[DeletedKey]:
+    def list_deleted_keys(self, **kwargs: Any) -> AsyncItemPaged[DeletedKey]:
         """List all deleted keys, including the public part of each. Possible only in a vault with soft-delete enabled.
 
         Requires keys/list permission.
@@ -441,7 +438,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         )
 
     @distributed_trace
-    def list_properties_of_keys(self, **kwargs) -> AsyncItemPaged[KeyProperties]:
+    def list_properties_of_keys(self, **kwargs: Any) -> AsyncItemPaged[KeyProperties]:
         """List identifiers and properties of all keys in the vault.
 
         Requires keys/list permission.
@@ -465,7 +462,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         )
 
     @distributed_trace
-    def list_properties_of_key_versions(self, name: str, **kwargs) -> AsyncItemPaged[KeyProperties]:
+    def list_properties_of_key_versions(self, name: str, **kwargs: Any) -> AsyncItemPaged[KeyProperties]:
         """List the identifiers and properties of a key's versions.
 
         Requires keys/list permission.
@@ -492,7 +489,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         )
 
     @distributed_trace_async
-    async def purge_deleted_key(self, name: str, **kwargs) -> None:
+    async def purge_deleted_key(self, name: str, **kwargs: Any) -> None:
         """Permanently deletes a deleted key. Only possible in a vault with soft-delete enabled.
 
         Performs an irreversible deletion of the specified key, without possibility for recovery. The operation is not
@@ -506,7 +503,7 @@ class KeyClient(AsyncKeyVaultClientBase):
 
         :returns: None
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises ~azure.core.exceptions.HttpResponseError:
 
         Example:
             .. code-block:: python
@@ -519,7 +516,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         await self._client.purge_deleted_key(self.vault_url, name, **kwargs)
 
     @distributed_trace_async
-    async def recover_deleted_key(self, name: str, **kwargs) -> KeyVaultKey:
+    async def recover_deleted_key(self, name: str, **kwargs: Any) -> KeyVaultKey:
         """Recover a deleted key to its latest version. Possible only in a vault with soft-delete enabled.
 
         Requires keys/recover permission. If the vault does not have soft-delete enabled, :func:`delete_key` is
@@ -531,7 +528,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         :returns: The recovered key
         :rtype: ~azure.keyvault.keys.KeyVaultKey
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises ~azure.core.exceptions.HttpResponseError:
 
         Example:
             .. literalinclude:: ../tests/test_samples_keys_async.py
@@ -557,7 +554,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         return polling_method.resource()
 
     @distributed_trace_async
-    async def update_key_properties(self, name: str, version: Optional[str] = None, **kwargs) -> KeyVaultKey:
+    async def update_key_properties(self, name: str, version: Optional[str] = None, **kwargs: Any) -> KeyVaultKey:
         """Change a key's properties (not its cryptographic material).
 
         Requires keys/update permission.
@@ -582,9 +579,8 @@ class KeyClient(AsyncKeyVaultClientBase):
         :returns: The updated key
         :rtype: ~azure.keyvault.keys.KeyVaultKey
 
-        :raises:
-            :class:`~azure.core.exceptions.ResourceNotFoundError` if the key doesn't exist,
-            :class:`~azure.core.exceptions.HttpResponseError` for other errors
+        :raises ~azure.core.exceptions.ResourceNotFoundError or ~azure.core.exceptions.HttpResponseError:
+            the former if the key doesn't exist; the latter for other errors
 
         Example:
             .. literalinclude:: ../tests/test_samples_keys_async.py
@@ -621,7 +617,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         return KeyVaultKey._from_key_bundle(bundle)
 
     @distributed_trace_async
-    async def backup_key(self, name: str, **kwargs) -> bytes:
+    async def backup_key(self, name: str, **kwargs: Any) -> bytes:
         """Back up a key in a protected form useable only by Azure Key Vault.
 
         Requires key/backup permission. This is intended to allow copying a key from one vault to another. Both vaults
@@ -633,9 +629,8 @@ class KeyClient(AsyncKeyVaultClientBase):
         :returns: The key backup result, in a protected bytes format that can only be used by Azure Key Vault.
         :rtype: bytes
 
-        :raises:
-            :class:`~azure.core.exceptions.ResourceNotFoundError` if the key doesn't exist,
-            :class:`~azure.core.exceptions.HttpResponseError` for other errors
+        :raises ~azure.core.exceptions.ResourceNotFoundError or ~azure.core.exceptions.HttpResponseError:
+            the former if the key doesn't exist; the latter for other errors
 
         Example:
             .. literalinclude:: ../tests/test_samples_keys_async.py
@@ -649,7 +644,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         return backup_result.value
 
     @distributed_trace_async
-    async def restore_key_backup(self, backup: bytes, **kwargs) -> KeyVaultKey:
+    async def restore_key_backup(self, backup: bytes, **kwargs: Any) -> KeyVaultKey:
         """Restore a key backup to the vault.
 
         Requires keys/restore permission. This imports all versions of the key, with its name, attributes, and access
@@ -661,9 +656,8 @@ class KeyClient(AsyncKeyVaultClientBase):
         :returns: The restored key
         :rtype: ~azure.keyvault.keys.KeyVaultKey
 
-        :raises:
-            :class:`~azure.core.exceptions.ResourceExistsError` if the backed up key's name is already in use,
-            :class:`~azure.core.exceptions.HttpResponseError` for other errors
+        :raises ~azure.core.exceptions.ResourceExistsError or ~azure.core.exceptions.HttpResponseError:
+            the former if the backed up key's name is already in use; the latter for other errors
 
         Example:
             .. literalinclude:: ../tests/test_samples_keys_async.py
@@ -681,7 +675,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         return KeyVaultKey._from_key_bundle(bundle)
 
     @distributed_trace_async
-    async def import_key(self, name: str, key: JsonWebKey, **kwargs) -> KeyVaultKey:
+    async def import_key(self, name: str, key: JsonWebKey, **kwargs: Any) -> KeyVaultKey:
         """Import a key created externally.
 
         Requires keys/import permission. If ``name`` is already in use, the key will be imported as a new version.
@@ -708,7 +702,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         :returns: The imported key
         :rtype: ~azure.keyvault.keys.KeyVaultKey
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises ~azure.core.exceptions.HttpResponseError:
         """
         enabled = kwargs.pop("enabled", None)
         not_before = kwargs.pop("not_before", None)
@@ -737,7 +731,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         return KeyVaultKey._from_key_bundle(bundle)
 
     @distributed_trace_async
-    async def release_key(self, name: str, target_attestation_token: str, **kwargs) -> ReleaseKeyResult:
+    async def release_key(self, name: str, target_attestation_token: str, **kwargs: Any) -> ReleaseKeyResult:
         """Releases a key.
 
         The release key operation is applicable to all key types. The target key must be marked
@@ -756,7 +750,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         :return: The result of the key release.
         :rtype: ~azure.keyvault.keys.ReleaseKeyResult
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises ~azure.core.exceptions.HttpResponseError:
         """
         version = kwargs.pop("version", None)
         result = await self._client.release(
@@ -773,7 +767,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         return ReleaseKeyResult(result.value)
 
     @distributed_trace_async
-    async def get_random_bytes(self, count: int, **kwargs) -> bytes:
+    async def get_random_bytes(self, count: int, **kwargs: Any) -> bytes:
         """Get the requested number of random bytes from a managed HSM.
 
         :param int count: The requested number of random bytes.
@@ -781,9 +775,8 @@ class KeyClient(AsyncKeyVaultClientBase):
         :return: The random bytes.
         :rtype: bytes
 
-        :raises:
-            :class:`ValueError` if less than one random byte is requested,
-            :class:`~azure.core.exceptions.HttpResponseError` for other errors
+        :raises ValueError or ~azure.core.exceptions.HttpResponseError:
+            the former if less than one random byte is requested; the latter for other errors
 
         Example:
             .. literalinclude:: ../tests/test_keys_async.py
@@ -800,7 +793,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         return result.value
 
     @distributed_trace_async
-    async def get_key_rotation_policy(self, key_name: str, **kwargs) -> KeyRotationPolicy:
+    async def get_key_rotation_policy(self, key_name: str, **kwargs: Any) -> KeyRotationPolicy:
         """Get the rotation policy of a Key Vault key.
 
         :param str key_name: The name of the key.
@@ -808,13 +801,13 @@ class KeyClient(AsyncKeyVaultClientBase):
         :return: The key rotation policy.
         :rtype: ~azure.keyvault.keys.KeyRotationPolicy
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises ~azure.core.exceptions.HttpResponseError:
         """
         policy = await self._client.get_key_rotation_policy(vault_base_url=self._vault_url, key_name=key_name, **kwargs)
         return KeyRotationPolicy._from_generated(policy)
 
     @distributed_trace_async
-    async def rotate_key(self, name: str, **kwargs) -> KeyVaultKey:
+    async def rotate_key(self, name: str, **kwargs: Any) -> KeyVaultKey:
         """Rotate the key based on the key policy by generating a new version of the key.
 
         This operation requires the keys/rotate permission.
@@ -824,14 +817,14 @@ class KeyClient(AsyncKeyVaultClientBase):
         :return: The new version of the rotated key.
         :rtype: ~azure.keyvault.keys.KeyVaultKey
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises ~azure.core.exceptions.HttpResponseError:
         """
         bundle = await self._client.rotate_key(vault_base_url=self._vault_url, key_name=name, **kwargs)
         return KeyVaultKey._from_key_bundle(bundle)
 
     @distributed_trace_async
     async def update_key_rotation_policy(
-        self, key_name: str, policy: KeyRotationPolicy, **kwargs
+        self, key_name: str, policy: KeyRotationPolicy, **kwargs: Any
     ) -> KeyRotationPolicy:
         """Updates the rotation policy of a Key Vault key.
 
@@ -852,7 +845,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         :return: The updated rotation policy.
         :rtype: ~azure.keyvault.keys.KeyRotationPolicy
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises ~azure.core.exceptions.HttpResponseError:
         """
         lifetime_actions = kwargs.pop("lifetime_actions", policy.lifetime_actions)
         if lifetime_actions:

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/aio/_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/aio/_client.py
@@ -105,7 +105,7 @@ class KeyClient(AsyncKeyVaultClientBase):
         )
 
     @distributed_trace_async
-    async def create_key(self, name: str, key_type: Union[str, KeyType], **kwargs) -> KeyVaultKey:
+    async def create_key(self, name: str, key_type: Union[str, KeyType], **kwargs: Any) -> KeyVaultKey:
         """Create a key or, if ``name`` is already in use, create a new version of the key.
 
         Requires keys/create permission.

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_client.py
@@ -116,7 +116,7 @@ class CryptographyClient(KeyVaultClientBase):
 
     # pylint:disable=protected-access
 
-    def __init__(self, key: Union[KeyVaultKey, str], credential: TokenCredential, **kwargs) -> None:
+    def __init__(self, key: Union[KeyVaultKey, str], credential: TokenCredential, **kwargs: Any) -> None:
         self._jwk = kwargs.pop("_jwk", False)
         self._not_before: Optional[datetime] = None
         self._expires_on: Optional[datetime] = None
@@ -193,7 +193,7 @@ class CryptographyClient(KeyVaultClientBase):
         return cls(jwk, object(), _jwk=True)  # type: ignore
 
     @distributed_trace
-    def _initialize(self, **kwargs) -> None:
+    def _initialize(self, **kwargs: Any) -> None:
         if self._initialized:
             return
 
@@ -247,7 +247,7 @@ class CryptographyClient(KeyVaultClientBase):
         return KeyVaultRSAPublicKey(client=self, key_material=cast(JsonWebKey, self._key))
 
     @distributed_trace
-    def encrypt(self, algorithm: EncryptionAlgorithm, plaintext: bytes, **kwargs) -> EncryptResult:
+    def encrypt(self, algorithm: EncryptionAlgorithm, plaintext: bytes, **kwargs: Any) -> EncryptResult:
         """Encrypt bytes using the client's key.
 
         Requires the keys/encrypt permission. This method encrypts only a single block of data, whose size depends on
@@ -323,7 +323,7 @@ class CryptographyClient(KeyVaultClientBase):
         )
 
     @distributed_trace
-    def decrypt(self, algorithm: EncryptionAlgorithm, ciphertext: bytes, **kwargs) -> DecryptResult:
+    def decrypt(self, algorithm: EncryptionAlgorithm, ciphertext: bytes, **kwargs: Any) -> DecryptResult:
         """Decrypt a single block of encrypted data using the client's key.
 
         Requires the keys/decrypt permission. This method decrypts only a single block of data, whose size depends on
@@ -387,7 +387,7 @@ class CryptographyClient(KeyVaultClientBase):
         return DecryptResult(key_id=self.key_id, algorithm=algorithm, plaintext=operation_result.result)
 
     @distributed_trace
-    def wrap_key(self, algorithm: KeyWrapAlgorithm, key: bytes, **kwargs) -> WrapResult:
+    def wrap_key(self, algorithm: KeyWrapAlgorithm, key: bytes, **kwargs: Any) -> WrapResult:
         """Wrap a key with the client's key.
 
         Requires the keys/wrapKey permission.
@@ -431,7 +431,7 @@ class CryptographyClient(KeyVaultClientBase):
         return WrapResult(key_id=self.key_id, algorithm=algorithm, encrypted_key=operation_result.result)
 
     @distributed_trace
-    def unwrap_key(self, algorithm: KeyWrapAlgorithm, encrypted_key: bytes, **kwargs) -> UnwrapResult:
+    def unwrap_key(self, algorithm: KeyWrapAlgorithm, encrypted_key: bytes, **kwargs: Any) -> UnwrapResult:
         """Unwrap a key previously wrapped with the client's key.
 
         Requires the keys/unwrapKey permission.
@@ -473,7 +473,7 @@ class CryptographyClient(KeyVaultClientBase):
         return UnwrapResult(key_id=self.key_id, algorithm=algorithm, key=operation_result.result)
 
     @distributed_trace
-    def sign(self, algorithm: SignatureAlgorithm, digest: bytes, **kwargs) -> SignResult:
+    def sign(self, algorithm: SignatureAlgorithm, digest: bytes, **kwargs: Any) -> SignResult:
         """Create a signature from a digest using the client's key.
 
         Requires the keys/sign permission.
@@ -517,7 +517,7 @@ class CryptographyClient(KeyVaultClientBase):
         return SignResult(key_id=self.key_id, algorithm=algorithm, signature=operation_result.result)
 
     @distributed_trace
-    def verify(self, algorithm: SignatureAlgorithm, digest: bytes, signature: bytes, **kwargs) -> VerifyResult:
+    def verify(self, algorithm: SignatureAlgorithm, digest: bytes, signature: bytes, **kwargs: Any) -> VerifyResult:
         """Verify a signature using the client's key.
 
         Requires the keys/verify permission.

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_models.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_models.py
@@ -252,8 +252,8 @@ class KeyVaultRSAPublicKey(RSAPublicKey):
         :rtype: bytes
         :raises:
             NotImplementedError if the local version of `cryptography` doesn't support this method.
-            cryptography.exceptions.InvalidSignature if the signature is invalid.
-            cryptography.exceptions.UnsupportedAlgorithm if the signature data recovery is not supported with
+            :class:`~cryptography.exceptions.InvalidSignature` if the signature is invalid.
+            :class:`~cryptography.exceptions.UnsupportedAlgorithm` if the signature data recovery is not supported with
                 the provided `padding` type.
         """
         public_key = self.public_numbers().public_key()

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_models.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_models.py
@@ -50,7 +50,7 @@ def get_encryption_algorithm(padding: AsymmetricPadding) -> EncryptionAlgorithm:
     """Maps an `AsymmetricPadding` to an encryption algorithm.
 
     :param padding: The padding to use.
-    :type padding: :class:`~cryptography.hazmat.primitives.asymmetric.padding.AsymmetricPadding`
+    :type padding: ~cryptography.hazmat.primitives.asymmetric.padding.AsymmetricPadding
 
     :returns: The corresponding Key Vault encryption algorithm.
     :rtype: EncryptionAlgorithm
@@ -86,9 +86,9 @@ def get_signature_algorithm(padding: AsymmetricPadding, algorithm: HashAlgorithm
     """Maps an `AsymmetricPadding` and `HashAlgorithm` to a signature algorithm.
 
     :param padding: The padding to use.
-    :type padding: :class:`~cryptography.hazmat.primitives.asymmetric.padding.AsymmetricPadding`
+    :type padding: ~cryptography.hazmat.primitives.asymmetric.padding.AsymmetricPadding
     :param algorithm: The algorithm to use.
-    :type algorithm: :class:`~cryptography.hazmat.primitives.hashes.HashAlgorithm`
+    :type algorithm: ~cryptography.hazmat.primitives.hashes.HashAlgorithm
 
     :returns: The corresponding Key Vault signature algorithm.
     :rtype: SignatureAlgorithm
@@ -127,9 +127,9 @@ class KeyVaultRSAPublicKey(RSAPublicKey):
         """Creates a `KeyVaultRSAPublicKey` from a `CryptographyClient` and key.
 
         :param client: The client that will be used to communicate with Key Vault.
-        :type client: :class:`~azure.keyvault.keys.crypto.CryptographyClient`
+        :type client: ~azure.keyvault.keys.crypto.CryptographyClient
         :param key_material: They Key Vault key's material, as a `JsonWebKey`.
-        :type key_material: :class:`~azure.keyvault.keys.JsonWebKey`
+        :type key_material: ~azure.keyvault.keys.JsonWebKey
         """
         self._client: "CryptographyClient" = client
         self._key: JsonWebKey = key_material
@@ -141,7 +141,7 @@ class KeyVaultRSAPublicKey(RSAPublicKey):
         :param padding: The padding to use. Supported paddings are `OAEP` and `PKCS1v15`. For `OAEP` padding, supported
             hash algorithms are `SHA1` and `SHA256`. The only supported mask generation function is `MGF1`. See
             https://learn.microsoft.com/azure/key-vault/keys/about-keys-details for details.
-        :type padding: :class:`~cryptography.hazmat.primitives.asymmetric.padding.AsymmetricPadding`
+        :type padding: ~cryptography.hazmat.primitives.asymmetric.padding.AsymmetricPadding
 
         :returns: The encrypted ciphertext, as bytes.
         :rtype: bytes
@@ -178,9 +178,9 @@ class KeyVaultRSAPublicKey(RSAPublicKey):
         serialization.
 
         :param encoding: A value from the `Encoding` enum.
-        :type encoding: :class:`~cryptography.hazmat.primitives.serialization.Encoding`
+        :type encoding: ~cryptography.hazmat.primitives.serialization.Encoding
         :param format: A value from the `PublicFormat` enum.
-        :type format: :class:`~cryptography.hazmat.primitives.serialization.PublicFormat`
+        :type format: ~cryptography.hazmat.primitives.serialization.PublicFormat
 
         :returns: The serialized key.
         :rtype: bytes
@@ -202,11 +202,11 @@ class KeyVaultRSAPublicKey(RSAPublicKey):
         :param padding: The padding to use. Supported paddings are `PKCS1v15` and `PSS`. For `PSS`, the only supported
             mask generation function is `MGF1`. See https://learn.microsoft.com/azure/key-vault/keys/about-keys-details
             for details.
-        :type padding: :class:`~cryptography.hazmat.primitives.asymmetric.padding.AsymmetricPadding`
+        :type padding: ~cryptography.hazmat.primitives.asymmetric.padding.AsymmetricPadding
         :param algorithm: The algorithm to sign with. Only `HashAlgorithm`s are supported -- specifically, `SHA256`,
             `SHA384`, and `SHA512`.
-        :type algorithm: :class:`~cryptography.hazmat.primitives.asymmetric.utils.Prehashed` or
-            :class:`~cryptography.hazmat.primitives.hashes.HashAlgorithm`
+        :type algorithm: ~cryptography.hazmat.primitives.asymmetric.utils.Prehashed or
+            cryptography.hazmat.primitives.hashes.HashAlgorithm
 
         :raises InvalidSignature: If the signature does not validate.
         """
@@ -244,16 +244,16 @@ class KeyVaultRSAPublicKey(RSAPublicKey):
 
         :param bytes signature: The signature.
         :param padding: An instance of `AsymmetricPadding`. Recovery is only supported with some of the padding types.
-        :type padding: :class:`~cryptography.hazmat.primitives.asymmetric.padding.AsymmetricPadding`
+        :type padding: ~cryptography.hazmat.primitives.asymmetric.padding.AsymmetricPadding
         :param algorithm: An instance of `HashAlgorithm`. Can be None to return all the data present in the signature.
-        :type algorithm: :class:`~cryptography.hazmat.primitives.hashes.HashAlgorithm`
+        :type algorithm: ~cryptography.hazmat.primitives.hashes.HashAlgorithm
 
         :returns: The signed data.
         :rtype: bytes
         :raises:
             NotImplementedError if the local version of `cryptography` doesn't support this method.
-            :class:`~cryptography.exceptions.InvalidSignature` if the signature is invalid.
-            :class:`~cryptography.exceptions.UnsupportedAlgorithm` if the signature data recovery is not supported with
+            cryptography.exceptions.InvalidSignature if the signature is invalid.
+            cryptography.exceptions.UnsupportedAlgorithm if the signature data recovery is not supported with
                 the provided `padding` type.
         """
         public_key = self.public_numbers().public_key()
@@ -296,9 +296,9 @@ class KeyVaultRSAPrivateKey(RSAPrivateKey):
         """Creates a `KeyVaultRSAPrivateKey` from a `CryptographyClient` and key.
 
         :param client: The client that will be used to communicate with Key Vault.
-        :type client: :class:`~azure.keyvault.keys.crypto.CryptographyClient`
+        :type client: ~azure.keyvault.keys.crypto.CryptographyClient
         :param key_material: They Key Vault key's material, as a `JsonWebKey`.
-        :type key_material: :class:`~azure.keyvault.keys.JsonWebKey`
+        :type key_material: ~azure.keyvault.keys.JsonWebKey
         """
         self._client: "CryptographyClient" = client
         self._key: JsonWebKey = key_material
@@ -310,7 +310,7 @@ class KeyVaultRSAPrivateKey(RSAPrivateKey):
         :param padding: The padding to use. Supported paddings are `OAEP` and `PKCS1v15`. For `OAEP` padding, supported
             hash algorithms are `SHA1` and `SHA256`. The only supported mask generation function is `MGF1`. See
             https://learn.microsoft.com/azure/key-vault/keys/about-keys-details for details.
-        :type padding: :class:`~cryptography.hazmat.primitives.asymmetric.padding.AsymmetricPadding`
+        :type padding: ~cryptography.hazmat.primitives.asymmetric.padding.AsymmetricPadding
 
         :returns: The decrypted plaintext, as bytes.
         :rtype: bytes
@@ -336,7 +336,7 @@ class KeyVaultRSAPrivateKey(RSAPrivateKey):
         The public key implementation will use the same underlying cryptography client as this private key.
 
         :returns: The `KeyVaultRSAPublicKey` associated with the key.
-        :rtype: :class:`~azure.keyvault.keys.crypto.KeyVaultRSAPublicKey`
+        :rtype: ~azure.keyvault.keys.crypto.KeyVaultRSAPublicKey
         """
         return KeyVaultRSAPublicKey(self._client, self._key)
 
@@ -352,11 +352,11 @@ class KeyVaultRSAPrivateKey(RSAPrivateKey):
         :param padding: The padding to use. Supported paddings are `PKCS1v15` and `PSS`. For `PSS`, the only supported
             mask generation function is `MGF1`. See https://learn.microsoft.com/azure/key-vault/keys/about-keys-details
             for details.
-        :type padding: :class:`~cryptography.hazmat.primitives.asymmetric.padding.AsymmetricPadding`
+        :type padding: ~cryptography.hazmat.primitives.asymmetric.padding.AsymmetricPadding
         :param algorithm: The algorithm to sign with. Only `HashAlgorithm`s are supported -- specifically, `SHA256`,
             `SHA384`, and `SHA512`.
-        :type algorithm: :class:`~cryptography.hazmat.primitives.asymmetric.utils.Prehashed` or
-            :class:`~cryptography.hazmat.primitives.hashes.HashAlgorithm`
+        :type algorithm: ~cryptography.hazmat.primitives.asymmetric.utils.Prehashed or
+            cryptography.hazmat.primitives.hashes.HashAlgorithm
 
         :returns: The signature, as bytes.
         :rtype: bytes
@@ -373,7 +373,7 @@ class KeyVaultRSAPrivateKey(RSAPrivateKey):
         """Returns an `RSAPrivateNumbers` representing the key's private numbers.
 
         :returns: The private numbers of the key.
-        :rtype: :class:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPrivateNumbers`
+        :rtype: ~cryptography.hazmat.primitives.asymmetric.rsa.RSAPrivateNumbers
         """
         # Fetch public numbers from JWK
         e = int.from_bytes(self._key.e, "big")  # type: ignore[attr-defined]
@@ -412,11 +412,11 @@ class KeyVaultRSAPrivateKey(RSAPrivateKey):
         (such as `BestAvailableEncryption` or `NoEncryption`) are chosen to define the exact serialization.
 
         :param encoding: A value from the `Encoding` enum.
-        :type encoding: :class:`~cryptography.hazmat.primitives.serialization.Encoding`
+        :type encoding: ~cryptography.hazmat.primitives.serialization.Encoding
         :param format: A value from the `PrivateFormat` enum.
-        :type format: :class:`~cryptography.hazmat.primitives.serialization.PrivateFormat`
+        :type format: ~cryptography.hazmat.primitives.serialization.PrivateFormat
         :param encryption_algorithm: An instance of an object conforming to the `KeySerializationEncryption` interface.
-        :type encryption_algorithm: :class:`~cryptography.hazmat.primitives.serialization.KeySerializationEncryption`
+        :type encryption_algorithm: ~cryptography.hazmat.primitives.serialization.KeySerializationEncryption
 
         :returns: The serialized key.
         :rtype: bytes

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_models.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_models.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
-from typing import cast, Optional, NoReturn, Union, TYPE_CHECKING
+from typing import Any, cast, Optional, NoReturn, Union, TYPE_CHECKING
 
 from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.primitives.asymmetric.padding import AsymmetricPadding, OAEP, PKCS1v15, PSS, MGF1
@@ -465,7 +465,7 @@ class EncryptResult:
         authenticated algorithm
     """
 
-    def __init__(self, key_id: Optional[str], algorithm: EncryptionAlgorithm, ciphertext: bytes, **kwargs) -> None:
+    def __init__(self, key_id: Optional[str], algorithm: EncryptionAlgorithm, ciphertext: bytes, **kwargs: Any) -> None:
         self.key_id = key_id
         self.algorithm = algorithm
         self.ciphertext = ciphertext

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/aio/_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/aio/_client.py
@@ -61,7 +61,7 @@ class CryptographyClient(AsyncKeyVaultClientBase):
 
     # pylint:disable=protected-access
 
-    def __init__(self, key: Union[KeyVaultKey, str], credential: AsyncTokenCredential, **kwargs) -> None:
+    def __init__(self, key: Union[KeyVaultKey, str], credential: AsyncTokenCredential, **kwargs: Any) -> None:
         self._jwk = kwargs.pop("_jwk", False)
         self._not_before: Optional[datetime] = None
         self._expires_on: Optional[datetime] = None
@@ -136,7 +136,7 @@ class CryptographyClient(AsyncKeyVaultClientBase):
         return cls(jwk, object(), _jwk=True)  # type: ignore
 
     @distributed_trace_async
-    async def _initialize(self, **kwargs) -> None:
+    async def _initialize(self, **kwargs: Any) -> None:
         if self._initialized:
             return
 
@@ -166,7 +166,7 @@ class CryptographyClient(AsyncKeyVaultClientBase):
             self._initialized = self._keys_get_forbidden
 
     @distributed_trace_async
-    async def encrypt(self, algorithm: EncryptionAlgorithm, plaintext: bytes, **kwargs) -> EncryptResult:
+    async def encrypt(self, algorithm: EncryptionAlgorithm, plaintext: bytes, **kwargs: Any) -> EncryptResult:
         """Encrypt bytes using the client's key.
 
         Requires the keys/encrypt permission. This method encrypts only a single block of data, whose size depends on
@@ -242,7 +242,7 @@ class CryptographyClient(AsyncKeyVaultClientBase):
         )
 
     @distributed_trace_async
-    async def decrypt(self, algorithm: EncryptionAlgorithm, ciphertext: bytes, **kwargs) -> DecryptResult:
+    async def decrypt(self, algorithm: EncryptionAlgorithm, ciphertext: bytes, **kwargs: Any) -> DecryptResult:
         """Decrypt a single block of encrypted data using the client's key.
 
         Requires the keys/decrypt permission. This method decrypts only a single block of data, whose size depends on
@@ -306,7 +306,7 @@ class CryptographyClient(AsyncKeyVaultClientBase):
         return DecryptResult(key_id=self.key_id, algorithm=algorithm, plaintext=operation_result.result)
 
     @distributed_trace_async
-    async def wrap_key(self, algorithm: KeyWrapAlgorithm, key: bytes, **kwargs) -> WrapResult:
+    async def wrap_key(self, algorithm: KeyWrapAlgorithm, key: bytes, **kwargs: Any) -> WrapResult:
         """Wrap a key with the client's key.
 
         Requires the keys/wrapKey permission.
@@ -350,7 +350,7 @@ class CryptographyClient(AsyncKeyVaultClientBase):
         return WrapResult(key_id=self.key_id, algorithm=algorithm, encrypted_key=operation_result.result)
 
     @distributed_trace_async
-    async def unwrap_key(self, algorithm: KeyWrapAlgorithm, encrypted_key: bytes, **kwargs) -> UnwrapResult:
+    async def unwrap_key(self, algorithm: KeyWrapAlgorithm, encrypted_key: bytes, **kwargs: Any) -> UnwrapResult:
         """Unwrap a key previously wrapped with the client's key.
 
         Requires the keys/unwrapKey permission.
@@ -393,7 +393,7 @@ class CryptographyClient(AsyncKeyVaultClientBase):
         return UnwrapResult(key_id=self.key_id, algorithm=algorithm, key=operation_result.result)
 
     @distributed_trace_async
-    async def sign(self, algorithm: SignatureAlgorithm, digest: bytes, **kwargs) -> SignResult:
+    async def sign(self, algorithm: SignatureAlgorithm, digest: bytes, **kwargs: Any) -> SignResult:
         """Create a signature from a digest using the client's key.
 
         Requires the keys/sign permission.
@@ -438,7 +438,7 @@ class CryptographyClient(AsyncKeyVaultClientBase):
 
     @distributed_trace_async
     async def verify(
-        self, algorithm: SignatureAlgorithm, digest: bytes, signature: bytes, **kwargs
+        self, algorithm: SignatureAlgorithm, digest: bytes, signature: bytes, **kwargs: Any
     ) -> VerifyResult:
         """Verify a signature using the client's key.
 

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/aio/_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/aio/_client.py
@@ -34,13 +34,13 @@ class CryptographyClient(AsyncKeyVaultClientBase):
     that material from Key Vault. When the required key material is unavailable, cryptographic operations are performed
     by the Key Vault service.
 
-    :param key: Either a :class:`~azure.keyvault.keys.KeyVaultKey` instance as returned by
+    :param key: Either a azure.keyvault.keys.KeyVaultKey instance as returned by
         :func:`~azure.keyvault.keys.aio.KeyClient.get_key`, or a string.
         If a string, the value must be the identifier of an Azure Key Vault key. Including a version is recommended.
-    :type key: str or :class:`~azure.keyvault.keys.KeyVaultKey`
+    :type key: str or azure.keyvault.keys.KeyVaultKey
     :param credential: An object which can provide an access token for the vault, such as a credential from
         :mod:`azure.identity.aio`
-    :type credential: :class:`~azure.core.credentials_async.AsyncTokenCredential`
+    :type credential: ~azure.core.credentials_async.AsyncTokenCredential
 
     :keyword api_version: Version of the service API to use. Defaults to the most recent.
     :paramtype api_version: ~azure.keyvault.keys.ApiVersion or str
@@ -169,7 +169,7 @@ class CryptographyClient(AsyncKeyVaultClientBase):
         the key and encryption algorithm.
 
         :param algorithm: Encryption algorithm to use
-        :type algorithm: :class:`~azure.keyvault.keys.crypto.EncryptionAlgorithm`
+        :type algorithm: ~azure.keyvault.keys.crypto.EncryptionAlgorithm
         :param bytes plaintext: Bytes to encrypt
 
         :keyword iv: Initialization vector. Required for only AES-CBC(PAD) encryption. If you pass your own IV,
@@ -182,7 +182,7 @@ class CryptographyClient(AsyncKeyVaultClientBase):
         :paramtype additional_authenticated_data: bytes or None
 
         :returns: The result of the encryption operation.
-        :rtype: :class:`~azure.keyvault.keys.crypto.EncryptResult`
+        :rtype: ~azure.keyvault.keys.crypto.EncryptResult
 
         :raises ValueError: if parameters that are incompatible with the specified algorithm are provided, or if
             generating an IV fails on the current platform.
@@ -245,7 +245,7 @@ class CryptographyClient(AsyncKeyVaultClientBase):
         the key and encryption algorithm.
 
         :param algorithm: Encryption algorithm to use
-        :type algorithm: :class:`~azure.keyvault.keys.crypto.EncryptionAlgorithm`
+        :type algorithm: ~azure.keyvault.keys.crypto.EncryptionAlgorithm
         :param bytes ciphertext: Encrypted bytes to decrypt. Microsoft recommends you not use CBC without first ensuring
             the integrity of the ciphertext using, for example, an HMAC. See
             https://docs.microsoft.com/dotnet/standard/security/vulnerabilities-cbc-mode for more information.
@@ -260,7 +260,7 @@ class CryptographyClient(AsyncKeyVaultClientBase):
         :paramtype additional_authenticated_data: bytes or None
 
         :returns: The result of the decryption operation.
-        :rtype: :class:`~azure.keyvault.keys.crypto.DecryptResult`
+        :rtype: ~azure.keyvault.keys.crypto.DecryptResult
 
         :raises ValueError: If parameters that are incompatible with the specified algorithm are provided.
 
@@ -308,11 +308,11 @@ class CryptographyClient(AsyncKeyVaultClientBase):
         Requires the keys/wrapKey permission.
 
         :param algorithm: wrapping algorithm to use
-        :type algorithm: :class:`~azure.keyvault.keys.crypto.KeyWrapAlgorithm`
+        :type algorithm: ~azure.keyvault.keys.crypto.KeyWrapAlgorithm
         :param bytes key: key to wrap
 
         :returns: The result of the wrapping operation.
-        :rtype: :class:`~azure.keyvault.keys.crypto.WrapResult`
+        :rtype: ~azure.keyvault.keys.crypto.WrapResult
 
         .. literalinclude:: ../tests/test_examples_crypto_async.py
             :start-after: [START wrap_key]
@@ -352,11 +352,11 @@ class CryptographyClient(AsyncKeyVaultClientBase):
         Requires the keys/unwrapKey permission.
 
         :param algorithm: wrapping algorithm to use
-        :type algorithm: :class:`~azure.keyvault.keys.crypto.KeyWrapAlgorithm`
+        :type algorithm: ~azure.keyvault.keys.crypto.KeyWrapAlgorithm
         :param bytes encrypted_key: the wrapped key
 
         :returns: The result of the unwrapping operation.
-        :rtype: :class:`~azure.keyvault.keys.crypto.UnwrapResult`
+        :rtype: ~azure.keyvault.keys.crypto.UnwrapResult
 
         .. literalinclude:: ../tests/test_examples_crypto_async.py
             :start-after: [START unwrap_key]
@@ -395,11 +395,11 @@ class CryptographyClient(AsyncKeyVaultClientBase):
         Requires the keys/sign permission.
 
         :param algorithm: signing algorithm
-        :type algorithm: :class:`~azure.keyvault.keys.crypto.SignatureAlgorithm`
+        :type algorithm: ~azure.keyvault.keys.crypto.SignatureAlgorithm
         :param bytes digest: hashed bytes to sign
 
         :returns: The result of the signing operation.
-        :rtype: :class:`~azure.keyvault.keys.crypto.SignResult`
+        :rtype: ~azure.keyvault.keys.crypto.SignResult
 
         .. literalinclude:: ../tests/test_examples_crypto_async.py
             :start-after: [START sign]
@@ -441,13 +441,13 @@ class CryptographyClient(AsyncKeyVaultClientBase):
         Requires the keys/verify permission.
 
         :param algorithm: verification algorithm
-        :type algorithm: :class:`~azure.keyvault.keys.crypto.SignatureAlgorithm`
+        :type algorithm: ~azure.keyvault.keys.crypto.SignatureAlgorithm
         :param bytes digest: Pre-hashed digest corresponding to **signature**. The hash algorithm used must be
             compatible with ``algorithm``.
         :param bytes signature: signature to verify
 
         :returns: The result of the verifying operation.
-        :rtype: :class:`~azure.keyvault.keys.crypto.VerifyResult`
+        :rtype: ~azure.keyvault.keys.crypto.VerifyResult
 
         .. literalinclude:: ../tests/test_examples_crypto_async.py
             :start-after: [START verify]

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_client.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_client.py
@@ -3,19 +3,15 @@
 # Licensed under the MIT License.
 # ------------------------------------
 from functools import partial
-from typing import TYPE_CHECKING
+from typing import Optional
 
+from azure.core.paging import ItemPaged
+from azure.core.polling import LROPoller
 from azure.core.tracing.decorator import distributed_trace
 
 from ._models import KeyVaultSecret, DeletedSecret, SecretProperties
 from ._shared import KeyVaultClientBase
 from ._shared._polling import DeleteRecoverPollingMethod, KeyVaultOperationPoller
-
-if TYPE_CHECKING:
-    # pylint:disable=unused-import
-    from typing import Optional
-    from azure.core.paging import ItemPaged
-    from azure.core.polling import LROPoller
 
 
 class SecretClient(KeyVaultClientBase):
@@ -45,7 +41,7 @@ class SecretClient(KeyVaultClientBase):
     # pylint:disable=protected-access
 
     @distributed_trace
-    def get_secret(self, name: str, version: "Optional[str]" = None, **kwargs) -> KeyVaultSecret:
+    def get_secret(self, name: str, version: Optional[str] = None, **kwargs) -> KeyVaultSecret:
         """Get a secret. Requires the secrets/get permission.
 
         :param str name: The name of the secret
@@ -55,8 +51,8 @@ class SecretClient(KeyVaultClientBase):
         :rtype: ~azure.keyvault.secrets.KeyVaultSecret
 
         :raises:
-            azure.core.exceptions.ResourceNotFoundError if the secret doesn't exist,
-            azure.core.exceptions.HttpResponseError for other errors
+            :class:`~azure.core.exceptions.ResourceNotFoundError` if the secret doesn't exist,
+            :class:`~azure.core.exceptions.HttpResponseError` for other errors
 
         Example:
             .. literalinclude:: ../tests/test_samples_secrets.py
@@ -93,7 +89,7 @@ class SecretClient(KeyVaultClientBase):
         :returns: The created or updated secret.
         :rtype: ~azure.keyvault.secrets.KeyVaultSecret
 
-        :raises: azure.core.exceptions.HttpResponseError
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example:
             .. literalinclude:: ../tests/test_samples_secrets.py
@@ -131,7 +127,7 @@ class SecretClient(KeyVaultClientBase):
         return KeyVaultSecret._from_secret_bundle(bundle)
 
     @distributed_trace
-    def update_secret_properties(self, name: str, version: "Optional[str]" = None, **kwargs) -> SecretProperties:
+    def update_secret_properties(self, name: str, version: Optional[str] = None, **kwargs) -> SecretProperties:
         """Update properties of a secret other than its value. Requires secrets/set permission.
 
         This method updates properties of the secret, such as whether it's enabled, but can't change the secret's
@@ -151,8 +147,8 @@ class SecretClient(KeyVaultClientBase):
         :rtype: ~azure.keyvault.secrets.SecretProperties
 
         :raises:
-            azure.core.exceptions.ResourceNotFoundError if the secret doesn't exist,
-            azure.core.exceptions.HttpResponseError for other errors
+            :class:`~azure.core.exceptions.ResourceNotFoundError` if the secret doesn't exist,
+            :class:`~azure.core.exceptions.HttpResponseError` for other errors
 
         Example:
             .. literalinclude:: ../tests/test_samples_secrets.py
@@ -190,7 +186,7 @@ class SecretClient(KeyVaultClientBase):
         return SecretProperties._from_secret_bundle(bundle)  # pylint: disable=protected-access
 
     @distributed_trace
-    def list_properties_of_secrets(self, **kwargs) -> "ItemPaged[SecretProperties]":
+    def list_properties_of_secrets(self, **kwargs) -> ItemPaged[SecretProperties]:
         """List identifiers and attributes of all secrets in the vault. Requires secrets/list permission.
 
         List items don't include secret values. Use :func:`get_secret` to get a secret's value.
@@ -215,7 +211,7 @@ class SecretClient(KeyVaultClientBase):
         )
 
     @distributed_trace
-    def list_properties_of_secret_versions(self, name: str, **kwargs) -> "ItemPaged[SecretProperties]":
+    def list_properties_of_secret_versions(self, name: str, **kwargs) -> ItemPaged[SecretProperties]:
         """List properties of all versions of a secret, excluding their values. Requires secrets/list permission.
 
         List items don't include secret values. Use :func:`get_secret` to get a secret's value.
@@ -252,8 +248,8 @@ class SecretClient(KeyVaultClientBase):
         :rtype: bytes
 
         :raises:
-            azure.core.exceptions.ResourceNotFoundError if the secret doesn't exist,
-            azure.core.exceptions.HttpResponseError for other errors
+            :class:`~azure.core.exceptions.ResourceNotFoundError` if the secret doesn't exist,
+            :class:`~azure.core.exceptions.HttpResponseError` for other errors
 
         Example:
             .. literalinclude:: ../tests/test_samples_secrets.py
@@ -277,8 +273,8 @@ class SecretClient(KeyVaultClientBase):
         :rtype: ~azure.keyvault.secrets.SecretProperties
 
         :raises:
-            azure.core.exceptions.ResourceExistsError if the secret's name is already in use,
-            azure.core.exceptions.HttpResponseError for other errors
+            :class:`~azure.core.exceptions.ResourceExistsError` if the secret's name is already in use,
+            :class:`~azure.core.exceptions.HttpResponseError` for other errors
 
         Example:
             .. literalinclude:: ../tests/test_samples_secrets.py
@@ -297,7 +293,7 @@ class SecretClient(KeyVaultClientBase):
         return SecretProperties._from_secret_bundle(bundle)
 
     @distributed_trace
-    def begin_delete_secret(self, name: str, **kwargs) -> "LROPoller[DeletedSecret]":  # pylint:disable=bad-option-value,delete-operation-wrong-return-type
+    def begin_delete_secret(self, name: str, **kwargs) -> LROPoller[DeletedSecret]:  # pylint:disable=bad-option-value,delete-operation-wrong-return-type
         """Delete all versions of a secret. Requires secrets/delete permission.
 
         When this method returns Key Vault has begun deleting the secret. Deletion may take several seconds in a vault
@@ -306,15 +302,15 @@ class SecretClient(KeyVaultClientBase):
         :param str name: Name of the secret to delete.
 
         :returns: A poller for the delete operation. The poller's `result` method returns the
-            azure.keyvault.secrets.DeletedSecret without waiting for deletion to complete. If the vault has
+            :class:`~azure.keyvault.secrets.DeletedSecret` without waiting for deletion to complete. If the vault has
             soft-delete enabled and you want to permanently delete the secret with :func:`purge_deleted_secret`, call
             the poller's `wait` method first. It will block until the deletion is complete. The `wait` method requires
             secrets/get permission.
         :rtype: ~azure.core.polling.LROPoller[~azure.keyvault.secrets.DeletedSecret]
 
         :raises:
-            azure.core.exceptions.ResourceNotFoundError if the secret doesn't exist,
-            azure.core.exceptions.HttpResponseError for other errors
+            :class:`~azure.core.exceptions.ResourceNotFoundError` if the secret doesn't exist,
+            :class:`~azure.core.exceptions.HttpResponseError` for other errors
 
         Example:
             .. literalinclude:: ../tests/test_samples_secrets.py
@@ -352,8 +348,8 @@ class SecretClient(KeyVaultClientBase):
         :rtype: ~azure.keyvault.secrets.DeletedSecret
 
         :raises:
-            azure.core.exceptions.ResourceNotFoundError if the deleted secret doesn't exist,
-            azure.core.exceptions.HttpResponseError for other errors
+            :class:`~azure.core.exceptions.ResourceNotFoundError` if the deleted secret doesn't exist,
+            :class:`~azure.core.exceptions.HttpResponseError` for other errors
 
         Example:
             .. literalinclude:: ../tests/test_samples_secrets.py
@@ -368,7 +364,7 @@ class SecretClient(KeyVaultClientBase):
         return DeletedSecret._from_deleted_secret_bundle(bundle)
 
     @distributed_trace
-    def list_deleted_secrets(self, **kwargs) -> "ItemPaged[DeletedSecret]":
+    def list_deleted_secrets(self, **kwargs) -> ItemPaged[DeletedSecret]:
         """Lists all deleted secrets. Possible only in vaults with soft-delete enabled.
 
         Requires secrets/list permission.
@@ -407,7 +403,7 @@ class SecretClient(KeyVaultClientBase):
 
         :returns: None
 
-        :raises: azure.core.exceptions.HttpResponseError
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example:
             .. code-block:: python
@@ -420,7 +416,7 @@ class SecretClient(KeyVaultClientBase):
         self._client.purge_deleted_secret(self.vault_url, name, **kwargs)
 
     @distributed_trace
-    def begin_recover_deleted_secret(self, name: str, **kwargs) -> "LROPoller[SecretProperties]":
+    def begin_recover_deleted_secret(self, name: str, **kwargs) -> LROPoller[SecretProperties]:
         """Recover a deleted secret to its latest version. Possible only in a vault with soft-delete enabled.
 
         Requires the secrets/recover permission. If the vault does not have soft-delete enabled,
@@ -433,12 +429,12 @@ class SecretClient(KeyVaultClientBase):
         :param str name: Name of the deleted secret to recover
 
         :returns: A poller for the recovery operation. The poller's `result` method returns the recovered secret's
-            azure.keyvault.secrets.SecretProperties without waiting for recovery to complete. If you want to
+            :class:`~azure.keyvault.secrets.SecretProperties` without waiting for recovery to complete. If you want to
             use the recovered secret immediately, call the poller's `wait` method, which blocks until the secret is
             ready to use. The `wait` method requires secrets/get permission.
         :rtype: ~azure.core.polling.LROPoller[~azure.keyvault.secrets.SecretProperties]
 
-        :raises: azure.core.exceptions.HttpResponseError
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example:
             .. literalinclude:: ../tests/test_samples_secrets.py

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_client.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_client.py
@@ -3,7 +3,7 @@
 # Licensed under the MIT License.
 # ------------------------------------
 from functools import partial
-from typing import Optional
+from typing import Any, Optional
 
 from azure.core.paging import ItemPaged
 from azure.core.polling import LROPoller
@@ -41,7 +41,7 @@ class SecretClient(KeyVaultClientBase):
     # pylint:disable=protected-access
 
     @distributed_trace
-    def get_secret(self, name: str, version: Optional[str] = None, **kwargs) -> KeyVaultSecret:
+    def get_secret(self, name: str, version: Optional[str] = None, **kwargs: Any) -> KeyVaultSecret:
         """Get a secret. Requires the secrets/get permission.
 
         :param str name: The name of the secret
@@ -50,9 +50,8 @@ class SecretClient(KeyVaultClientBase):
         :returns: The fetched secret.
         :rtype: ~azure.keyvault.secrets.KeyVaultSecret
 
-        :raises:
-            :class:`~azure.core.exceptions.ResourceNotFoundError` if the secret doesn't exist,
-            :class:`~azure.core.exceptions.HttpResponseError` for other errors
+        :raises ~azure.core.exceptions.ResourceNotFoundError or ~azure.core.exceptions.HttpResponseError:
+            the former if the secret doesn't exist; the latter for other errors
 
         Example:
             .. literalinclude:: ../tests/test_samples_secrets.py
@@ -71,7 +70,7 @@ class SecretClient(KeyVaultClientBase):
         return KeyVaultSecret._from_secret_bundle(bundle)
 
     @distributed_trace
-    def set_secret(self, name: str, value: str, **kwargs) -> KeyVaultSecret:
+    def set_secret(self, name: str, value: str, **kwargs: Any) -> KeyVaultSecret:
         """Set a secret value. If `name` is in use, create a new version of the secret. If not, create a new secret.
 
         Requires secrets/set permission.
@@ -89,7 +88,7 @@ class SecretClient(KeyVaultClientBase):
         :returns: The created or updated secret.
         :rtype: ~azure.keyvault.secrets.KeyVaultSecret
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises ~azure.core.exceptions.HttpResponseError:
 
         Example:
             .. literalinclude:: ../tests/test_samples_secrets.py
@@ -127,7 +126,7 @@ class SecretClient(KeyVaultClientBase):
         return KeyVaultSecret._from_secret_bundle(bundle)
 
     @distributed_trace
-    def update_secret_properties(self, name: str, version: Optional[str] = None, **kwargs) -> SecretProperties:
+    def update_secret_properties(self, name: str, version: Optional[str] = None, **kwargs: Any) -> SecretProperties:
         """Update properties of a secret other than its value. Requires secrets/set permission.
 
         This method updates properties of the secret, such as whether it's enabled, but can't change the secret's
@@ -146,9 +145,8 @@ class SecretClient(KeyVaultClientBase):
         :returns: The updated secret properties.
         :rtype: ~azure.keyvault.secrets.SecretProperties
 
-        :raises:
-            :class:`~azure.core.exceptions.ResourceNotFoundError` if the secret doesn't exist,
-            :class:`~azure.core.exceptions.HttpResponseError` for other errors
+        :raises ~azure.core.exceptions.ResourceNotFoundError or ~azure.core.exceptions.HttpResponseError:
+            the former if the secret doesn't exist; the latter for other errors
 
         Example:
             .. literalinclude:: ../tests/test_samples_secrets.py
@@ -186,7 +184,7 @@ class SecretClient(KeyVaultClientBase):
         return SecretProperties._from_secret_bundle(bundle)  # pylint: disable=protected-access
 
     @distributed_trace
-    def list_properties_of_secrets(self, **kwargs) -> ItemPaged[SecretProperties]:
+    def list_properties_of_secrets(self, **kwargs: Any) -> ItemPaged[SecretProperties]:
         """List identifiers and attributes of all secrets in the vault. Requires secrets/list permission.
 
         List items don't include secret values. Use :func:`get_secret` to get a secret's value.
@@ -211,7 +209,7 @@ class SecretClient(KeyVaultClientBase):
         )
 
     @distributed_trace
-    def list_properties_of_secret_versions(self, name: str, **kwargs) -> ItemPaged[SecretProperties]:
+    def list_properties_of_secret_versions(self, name: str, **kwargs: Any) -> ItemPaged[SecretProperties]:
         """List properties of all versions of a secret, excluding their values. Requires secrets/list permission.
 
         List items don't include secret values. Use :func:`get_secret` to get a secret's value.
@@ -239,7 +237,7 @@ class SecretClient(KeyVaultClientBase):
         )
 
     @distributed_trace
-    def backup_secret(self, name: str, **kwargs) -> bytes:
+    def backup_secret(self, name: str, **kwargs: Any) -> bytes:
         """Back up a secret in a protected form useable only by Azure Key Vault. Requires secrets/backup permission.
 
         :param str name: Name of the secret to back up
@@ -247,9 +245,8 @@ class SecretClient(KeyVaultClientBase):
         :returns: The backup result, in a protected bytes format that can only be used by Azure Key Vault.
         :rtype: bytes
 
-        :raises:
-            :class:`~azure.core.exceptions.ResourceNotFoundError` if the secret doesn't exist,
-            :class:`~azure.core.exceptions.HttpResponseError` for other errors
+        :raises ~azure.core.exceptions.ResourceNotFoundError or ~azure.core.exceptions.HttpResponseError:
+            the former if the secret doesn't exist; the latter for other errors
 
         Example:
             .. literalinclude:: ../tests/test_samples_secrets.py
@@ -264,7 +261,7 @@ class SecretClient(KeyVaultClientBase):
         return backup_result.value
 
     @distributed_trace
-    def restore_secret_backup(self, backup: bytes, **kwargs) -> SecretProperties:
+    def restore_secret_backup(self, backup: bytes, **kwargs: Any) -> SecretProperties:
         """Restore a backed up secret. Requires the secrets/restore permission.
 
         :param bytes backup: A secret backup as returned by :func:`backup_secret`
@@ -272,9 +269,8 @@ class SecretClient(KeyVaultClientBase):
         :returns: The restored secret
         :rtype: ~azure.keyvault.secrets.SecretProperties
 
-        :raises:
-            :class:`~azure.core.exceptions.ResourceExistsError` if the secret's name is already in use,
-            :class:`~azure.core.exceptions.HttpResponseError` for other errors
+        :raises ~azure.core.exceptions.ResourceExistsError or ~azure.core.exceptions.HttpResponseError:
+            the former if the secret's name is already in use; the latter for other errors
 
         Example:
             .. literalinclude:: ../tests/test_samples_secrets.py
@@ -293,7 +289,7 @@ class SecretClient(KeyVaultClientBase):
         return SecretProperties._from_secret_bundle(bundle)
 
     @distributed_trace
-    def begin_delete_secret(self, name: str, **kwargs) -> LROPoller[DeletedSecret]:  # pylint:disable=bad-option-value,delete-operation-wrong-return-type
+    def begin_delete_secret(self, name: str, **kwargs: Any) -> LROPoller[DeletedSecret]:  # pylint:disable=bad-option-value,delete-operation-wrong-return-type
         """Delete all versions of a secret. Requires secrets/delete permission.
 
         When this method returns Key Vault has begun deleting the secret. Deletion may take several seconds in a vault
@@ -308,9 +304,8 @@ class SecretClient(KeyVaultClientBase):
             secrets/get permission.
         :rtype: ~azure.core.polling.LROPoller[~azure.keyvault.secrets.DeletedSecret]
 
-        :raises:
-            :class:`~azure.core.exceptions.ResourceNotFoundError` if the secret doesn't exist,
-            :class:`~azure.core.exceptions.HttpResponseError` for other errors
+        :raises ~azure.core.exceptions.ResourceNotFoundError or ~azure.core.exceptions.HttpResponseError:
+            the former if the secret doesn't exist; the latter for other errors
 
         Example:
             .. literalinclude:: ../tests/test_samples_secrets.py
@@ -339,7 +334,7 @@ class SecretClient(KeyVaultClientBase):
         return KeyVaultOperationPoller(polling_method)
 
     @distributed_trace
-    def get_deleted_secret(self, name: str, **kwargs) -> DeletedSecret:
+    def get_deleted_secret(self, name: str, **kwargs: Any) -> DeletedSecret:
         """Get a deleted secret. Possible only in vaults with soft-delete enabled. Requires secrets/get permission.
 
         :param str name: Name of the deleted secret
@@ -347,9 +342,8 @@ class SecretClient(KeyVaultClientBase):
         :returns: The deleted secret.
         :rtype: ~azure.keyvault.secrets.DeletedSecret
 
-        :raises:
-            :class:`~azure.core.exceptions.ResourceNotFoundError` if the deleted secret doesn't exist,
-            :class:`~azure.core.exceptions.HttpResponseError` for other errors
+        :raises ~azure.core.exceptions.ResourceNotFoundError or ~azure.core.exceptions.HttpResponseError:
+            the former if the deleted secret doesn't exist; the latter for other errors
 
         Example:
             .. literalinclude:: ../tests/test_samples_secrets.py
@@ -364,7 +358,7 @@ class SecretClient(KeyVaultClientBase):
         return DeletedSecret._from_deleted_secret_bundle(bundle)
 
     @distributed_trace
-    def list_deleted_secrets(self, **kwargs) -> ItemPaged[DeletedSecret]:
+    def list_deleted_secrets(self, **kwargs: Any) -> ItemPaged[DeletedSecret]:
         """Lists all deleted secrets. Possible only in vaults with soft-delete enabled.
 
         Requires secrets/list permission.
@@ -389,7 +383,7 @@ class SecretClient(KeyVaultClientBase):
         )
 
     @distributed_trace
-    def purge_deleted_secret(self, name: str, **kwargs) -> None:
+    def purge_deleted_secret(self, name: str, **kwargs: Any) -> None:
         """Permanently deletes a deleted secret. Possible only in vaults with soft-delete enabled.
 
         Performs an irreversible deletion of the specified secret, without possibility for recovery. The operation is
@@ -403,7 +397,7 @@ class SecretClient(KeyVaultClientBase):
 
         :returns: None
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises ~azure.core.exceptions.HttpResponseError:
 
         Example:
             .. code-block:: python
@@ -416,7 +410,7 @@ class SecretClient(KeyVaultClientBase):
         self._client.purge_deleted_secret(self.vault_url, name, **kwargs)
 
     @distributed_trace
-    def begin_recover_deleted_secret(self, name: str, **kwargs) -> LROPoller[SecretProperties]:
+    def begin_recover_deleted_secret(self, name: str, **kwargs: Any) -> LROPoller[SecretProperties]:
         """Recover a deleted secret to its latest version. Possible only in a vault with soft-delete enabled.
 
         Requires the secrets/recover permission. If the vault does not have soft-delete enabled,
@@ -434,7 +428,7 @@ class SecretClient(KeyVaultClientBase):
             ready to use. The `wait` method requires secrets/get permission.
         :rtype: ~azure.core.polling.LROPoller[~azure.keyvault.secrets.SecretProperties]
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises ~azure.core.exceptions.HttpResponseError:
 
         Example:
             .. literalinclude:: ../tests/test_samples_secrets.py

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_client.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_client.py
@@ -26,7 +26,7 @@ class SecretClient(KeyVaultClientBase):
         for details.
     :param credential: An object which can provide an access token for the vault, such as a credential from
         :mod:`azure.identity`
-    :type credential: :class:`~azure.core.credentials.TokenCredential`
+    :type credential: ~azure.core.credentials.TokenCredential
 
     :keyword api_version: Version of the service API to use. Defaults to the most recent.
     :paramtype api_version: ~azure.keyvault.secrets.ApiVersion or str
@@ -55,8 +55,8 @@ class SecretClient(KeyVaultClientBase):
         :rtype: ~azure.keyvault.secrets.KeyVaultSecret
 
         :raises:
-            :class:`~azure.core.exceptions.ResourceNotFoundError` if the secret doesn't exist,
-            :class:`~azure.core.exceptions.HttpResponseError` for other errors
+            azure.core.exceptions.ResourceNotFoundError if the secret doesn't exist,
+            azure.core.exceptions.HttpResponseError for other errors
 
         Example:
             .. literalinclude:: ../tests/test_samples_secrets.py
@@ -93,7 +93,7 @@ class SecretClient(KeyVaultClientBase):
         :returns: The created or updated secret.
         :rtype: ~azure.keyvault.secrets.KeyVaultSecret
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises: azure.core.exceptions.HttpResponseError
 
         Example:
             .. literalinclude:: ../tests/test_samples_secrets.py
@@ -151,8 +151,8 @@ class SecretClient(KeyVaultClientBase):
         :rtype: ~azure.keyvault.secrets.SecretProperties
 
         :raises:
-            :class:`~azure.core.exceptions.ResourceNotFoundError` if the secret doesn't exist,
-            :class:`~azure.core.exceptions.HttpResponseError` for other errors
+            azure.core.exceptions.ResourceNotFoundError if the secret doesn't exist,
+            azure.core.exceptions.HttpResponseError for other errors
 
         Example:
             .. literalinclude:: ../tests/test_samples_secrets.py
@@ -252,8 +252,8 @@ class SecretClient(KeyVaultClientBase):
         :rtype: bytes
 
         :raises:
-            :class:`~azure.core.exceptions.ResourceNotFoundError` if the secret doesn't exist,
-            :class:`~azure.core.exceptions.HttpResponseError` for other errors
+            azure.core.exceptions.ResourceNotFoundError if the secret doesn't exist,
+            azure.core.exceptions.HttpResponseError for other errors
 
         Example:
             .. literalinclude:: ../tests/test_samples_secrets.py
@@ -277,8 +277,8 @@ class SecretClient(KeyVaultClientBase):
         :rtype: ~azure.keyvault.secrets.SecretProperties
 
         :raises:
-            :class:`~azure.core.exceptions.ResourceExistsError` if the secret's name is already in use,
-            :class:`~azure.core.exceptions.HttpResponseError` for other errors
+            azure.core.exceptions.ResourceExistsError if the secret's name is already in use,
+            azure.core.exceptions.HttpResponseError for other errors
 
         Example:
             .. literalinclude:: ../tests/test_samples_secrets.py
@@ -306,15 +306,15 @@ class SecretClient(KeyVaultClientBase):
         :param str name: Name of the secret to delete.
 
         :returns: A poller for the delete operation. The poller's `result` method returns the
-            :class:`~azure.keyvault.secrets.DeletedSecret` without waiting for deletion to complete. If the vault has
+            azure.keyvault.secrets.DeletedSecret without waiting for deletion to complete. If the vault has
             soft-delete enabled and you want to permanently delete the secret with :func:`purge_deleted_secret`, call
             the poller's `wait` method first. It will block until the deletion is complete. The `wait` method requires
             secrets/get permission.
         :rtype: ~azure.core.polling.LROPoller[~azure.keyvault.secrets.DeletedSecret]
 
         :raises:
-            :class:`~azure.core.exceptions.ResourceNotFoundError` if the secret doesn't exist,
-            :class:`~azure.core.exceptions.HttpResponseError` for other errors
+            azure.core.exceptions.ResourceNotFoundError if the secret doesn't exist,
+            azure.core.exceptions.HttpResponseError for other errors
 
         Example:
             .. literalinclude:: ../tests/test_samples_secrets.py
@@ -352,8 +352,8 @@ class SecretClient(KeyVaultClientBase):
         :rtype: ~azure.keyvault.secrets.DeletedSecret
 
         :raises:
-            :class:`~azure.core.exceptions.ResourceNotFoundError` if the deleted secret doesn't exist,
-            :class:`~azure.core.exceptions.HttpResponseError` for other errors
+            azure.core.exceptions.ResourceNotFoundError if the deleted secret doesn't exist,
+            azure.core.exceptions.HttpResponseError for other errors
 
         Example:
             .. literalinclude:: ../tests/test_samples_secrets.py
@@ -407,7 +407,7 @@ class SecretClient(KeyVaultClientBase):
 
         :returns: None
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises: azure.core.exceptions.HttpResponseError
 
         Example:
             .. code-block:: python
@@ -433,12 +433,12 @@ class SecretClient(KeyVaultClientBase):
         :param str name: Name of the deleted secret to recover
 
         :returns: A poller for the recovery operation. The poller's `result` method returns the recovered secret's
-            :class:`~azure.keyvault.secrets.SecretProperties` without waiting for recovery to complete. If you want to
+            azure.keyvault.secrets.SecretProperties without waiting for recovery to complete. If you want to
             use the recovered secret immediately, call the poller's `wait` method, which blocks until the secret is
             ready to use. The `wait` method requires secrets/get permission.
         :rtype: ~azure.core.polling.LROPoller[~azure.keyvault.secrets.SecretProperties]
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises: azure.core.exceptions.HttpResponseError
 
         Example:
             .. literalinclude:: ../tests/test_samples_secrets.py

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_models.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_models.py
@@ -2,15 +2,12 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
-from typing import TYPE_CHECKING
+from datetime import datetime
 
+from typing import Any, Dict, Optional
+
+from ._generated import models as _models
 from ._shared import parse_key_vault_id
-
-if TYPE_CHECKING:
-    # pylint:disable=unused-import
-    from typing import Dict, Optional
-    from datetime import datetime
-    from ._generated import models as _models
 
 
 class SecretProperties(object):
@@ -31,7 +28,7 @@ class SecretProperties(object):
     """
 
     def __init__(
-        self, attributes: "Optional[_models.SecretAttributes]", secret_id: "Optional[str]", **kwargs
+        self, attributes: Optional[_models.SecretAttributes], secret_id: Optional[str], **kwargs: Any
     ) -> None:
         self._attributes = attributes
         self._id = secret_id
@@ -45,7 +42,7 @@ class SecretProperties(object):
         return f"<SecretProperties [{self.id}]>"[:1024]
 
     @classmethod
-    def _from_secret_bundle(cls, secret_bundle: "_models.SecretBundle") -> "SecretProperties":
+    def _from_secret_bundle(cls, secret_bundle: _models.SecretBundle) -> "SecretProperties":
         return cls(
             secret_bundle.attributes,
             secret_bundle.id,
@@ -56,7 +53,7 @@ class SecretProperties(object):
         )
 
     @classmethod
-    def _from_secret_item(cls, secret_item: "_models.SecretItem") -> "SecretProperties":
+    def _from_secret_item(cls, secret_item: _models.SecretItem) -> "SecretProperties":
         return cls(
             secret_item.attributes,
             secret_item.id,
@@ -66,7 +63,7 @@ class SecretProperties(object):
         )
 
     @property
-    def content_type(self) -> "Optional[str]":
+    def content_type(self) -> Optional[str]:
         """An arbitrary string indicating the type of the secret.
 
         :returns: The content type of the secret.
@@ -75,7 +72,7 @@ class SecretProperties(object):
         return self._content_type
 
     @property
-    def id(self) -> "Optional[str]":
+    def id(self) -> Optional[str]:
         """The secret's ID.
 
         :returns: The secret's ID.
@@ -84,7 +81,7 @@ class SecretProperties(object):
         return self._id
 
     @property
-    def key_id(self) -> "Optional[str]":
+    def key_id(self) -> Optional[str]:
         """If this secret backs a certificate, this property is the identifier of the corresponding key.
 
         :returns: The ID of the key backing the certificate that's backed by this secret. If the secret isn't backing a
@@ -94,7 +91,7 @@ class SecretProperties(object):
         return self._key_id
 
     @property
-    def enabled(self) -> "Optional[bool]":
+    def enabled(self) -> Optional[bool]:
         """Whether the secret is enabled for use.
 
         :returns: True if the secret is enabled for use; False otherwise.
@@ -103,7 +100,7 @@ class SecretProperties(object):
         return self._attributes.enabled if self._attributes else None
 
     @property
-    def not_before(self) -> "Optional[datetime]":
+    def not_before(self) -> Optional[datetime]:
         """The time before which the secret cannot be used, in UTC.
 
         :returns: The time before which the secret cannot be used, in UTC.
@@ -112,7 +109,7 @@ class SecretProperties(object):
         return self._attributes.not_before if self._attributes else None
 
     @property
-    def expires_on(self) -> "Optional[datetime]":
+    def expires_on(self) -> Optional[datetime]:
         """When the secret expires, in UTC.
 
         :returns: When the secret expires, in UTC.
@@ -121,7 +118,7 @@ class SecretProperties(object):
         return self._attributes.expires if self._attributes else None
 
     @property
-    def created_on(self) -> "Optional[datetime]":
+    def created_on(self) -> Optional[datetime]:
         """When the secret was created, in UTC.
 
         :returns: When the secret was created, in UTC.
@@ -130,7 +127,7 @@ class SecretProperties(object):
         return self._attributes.created if self._attributes else None
 
     @property
-    def updated_on(self) -> "Optional[datetime]":
+    def updated_on(self) -> Optional[datetime]:
         """When the secret was last updated, in UTC.
 
         :returns: When the secret was last updated, in UTC.
@@ -139,7 +136,7 @@ class SecretProperties(object):
         return self._attributes.updated if self._attributes else None
 
     @property
-    def recoverable_days(self) -> "Optional[int]":
+    def recoverable_days(self) -> Optional[int]:
         """The number of days the key is retained before being deleted from a soft-delete enabled Key Vault.
 
         :returns: The number of days the key is retained before being deleted from a soft-delete enabled Key Vault.
@@ -151,7 +148,7 @@ class SecretProperties(object):
         return None
 
     @property
-    def recovery_level(self) -> "Optional[str]":
+    def recovery_level(self) -> Optional[str]:
         """The vault's deletion recovery level for secrets.
 
         :returns: The vault's deletion recovery level for secrets.
@@ -160,7 +157,7 @@ class SecretProperties(object):
         return self._attributes.recovery_level if self._attributes else None
 
     @property
-    def vault_url(self) -> "Optional[str]":
+    def vault_url(self) -> Optional[str]:
         """URL of the vault containing the secret.
 
         :returns: URL of the vault containing the secret.
@@ -169,7 +166,7 @@ class SecretProperties(object):
         return self._vault_id.vault_url if self._vault_id else None
 
     @property
-    def name(self) -> "Optional[str]":
+    def name(self) -> Optional[str]:
         """The secret's name.
 
         :returns: The secret's name.
@@ -178,7 +175,7 @@ class SecretProperties(object):
         return self._vault_id.name if self._vault_id else None
 
     @property
-    def version(self) -> "Optional[str]":
+    def version(self) -> Optional[str]:
         """The secret's version.
 
         :returns: The secret's version.
@@ -187,7 +184,7 @@ class SecretProperties(object):
         return self._vault_id.version if self._vault_id else None
 
     @property
-    def tags(self) -> "Optional[Dict[str, str]]":
+    def tags(self) -> Optional[Dict[str, str]]:
         """Application specific metadata in the form of key-value pairs.
 
         :returns: A dictionary of tags attached to this secret.
@@ -196,7 +193,7 @@ class SecretProperties(object):
         return self._tags
 
     @property
-    def managed(self) -> "Optional[bool]":
+    def managed(self) -> Optional[bool]:
         """Whether the secret's lifetime is managed by Key Vault. If the secret backs a certificate, this will be true.
 
         :returns: True if the secret's lifetime is managed by Key Vault; False otherwise.
@@ -214,7 +211,7 @@ class KeyVaultSecret(object):
     :type value: str or None
     """
 
-    def __init__(self, properties: SecretProperties, value: "Optional[str]") -> None:
+    def __init__(self, properties: SecretProperties, value: Optional[str]) -> None:
         self._properties = properties
         self._value = value
 
@@ -222,14 +219,14 @@ class KeyVaultSecret(object):
         return f"<KeyVaultSecret [{self.id}]>"[:1024]
 
     @classmethod
-    def _from_secret_bundle(cls, secret_bundle: "_models.SecretBundle") -> "KeyVaultSecret":
+    def _from_secret_bundle(cls, secret_bundle: _models.SecretBundle) -> "KeyVaultSecret":
         return cls(
             properties=SecretProperties._from_secret_bundle(secret_bundle),  # pylint: disable=protected-access
             value=secret_bundle.value,
         )
 
     @property
-    def name(self) -> "Optional[str]":
+    def name(self) -> Optional[str]:
         """The secret's name.
 
         :returns: The secret's name.
@@ -238,7 +235,7 @@ class KeyVaultSecret(object):
         return self._properties.name
 
     @property
-    def id(self) -> "Optional[str]":
+    def id(self) -> Optional[str]:
         """The secret's ID.
 
         :returns: The secret's ID.
@@ -256,7 +253,7 @@ class KeyVaultSecret(object):
         return self._properties
 
     @property
-    def value(self) -> "Optional[str]":
+    def value(self) -> Optional[str]:
         """The secret's value.
 
         :returns: The secret's value.
@@ -297,7 +294,7 @@ class KeyVaultSecretIdentifier(object):
         return self._resource_id.name
 
     @property
-    def version(self) -> "Optional[str]":
+    def version(self) -> Optional[str]:
         return self._resource_id.version
 
 
@@ -319,9 +316,9 @@ class DeletedSecret(object):
     def __init__(
         self,
         properties: SecretProperties,
-        deleted_date: "Optional[datetime]" = None,
-        recovery_id: "Optional[str]" = None,
-        scheduled_purge_date: "Optional[datetime]" = None,
+        deleted_date: Optional[datetime] = None,
+        recovery_id: Optional[str] = None,
+        scheduled_purge_date: Optional[datetime] = None,
     ) -> None:
         self._properties = properties
         self._deleted_date = deleted_date
@@ -332,7 +329,7 @@ class DeletedSecret(object):
         return f"<DeletedSecret [{self.id}]>"[:1024]
 
     @classmethod
-    def _from_deleted_secret_bundle(cls, deleted_secret_bundle: "_models.DeletedSecretBundle") -> "DeletedSecret":
+    def _from_deleted_secret_bundle(cls, deleted_secret_bundle: _models.DeletedSecretBundle) -> "DeletedSecret":
         return cls(
             properties=SecretProperties._from_secret_bundle(deleted_secret_bundle),  # pylint: disable=protected-access
             deleted_date=deleted_secret_bundle.deleted_date,
@@ -341,7 +338,7 @@ class DeletedSecret(object):
         )
 
     @classmethod
-    def _from_deleted_secret_item(cls, deleted_secret_item: "_models.DeletedSecretItem") -> "DeletedSecret":
+    def _from_deleted_secret_item(cls, deleted_secret_item: _models.DeletedSecretItem) -> "DeletedSecret":
         return cls(
             properties=SecretProperties._from_secret_item(deleted_secret_item),  # pylint: disable=protected-access
             deleted_date=deleted_secret_item.deleted_date,
@@ -350,7 +347,7 @@ class DeletedSecret(object):
         )
 
     @property
-    def name(self) -> "Optional[str]":
+    def name(self) -> Optional[str]:
         """The secret's name.
 
         :returns: The secret's name.
@@ -359,7 +356,7 @@ class DeletedSecret(object):
         return self._properties.name
 
     @property
-    def id(self) -> "Optional[str]":
+    def id(self) -> Optional[str]:
         """The secret's ID.
 
         :returns: The secret's ID.
@@ -377,7 +374,7 @@ class DeletedSecret(object):
         return self._properties
 
     @property
-    def deleted_date(self) -> "Optional[datetime]":
+    def deleted_date(self) -> Optional[datetime]:
         """When the secret was deleted, in UTC.
 
         :returns: When the secret was deleted, in UTC.
@@ -386,7 +383,7 @@ class DeletedSecret(object):
         return self._deleted_date
 
     @property
-    def recovery_id(self) -> "Optional[str]":
+    def recovery_id(self) -> Optional[str]:
         """An identifier used to recover the deleted secret.
 
         :returns: An identifier used to recover the deleted secret.
@@ -395,7 +392,7 @@ class DeletedSecret(object):
         return self._recovery_id
 
     @property
-    def scheduled_purge_date(self) -> "Optional[datetime]":
+    def scheduled_purge_date(self) -> Optional[datetime]:
         """When the secret is scheduled to be purged by Key Vault, in UTC.
 
         :returns: When the secret is scheduled to be purged by Key Vault, in UTC.

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/async_challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/async_challenge_auth_policy.py
@@ -35,7 +35,7 @@ class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
 
     :param credential: An object which can provide an access token for the vault, such as a credential from
         :mod:`azure.identity.aio`
-    :type credential: :class:`~azure.core.credentials_async.AsyncTokenCredential`
+    :type credential: ~azure.core.credentials_async.AsyncTokenCredential
     """
 
     def __init__(self, credential: "AsyncTokenCredential", *scopes: str, **kwargs) -> None:

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/async_challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/async_challenge_auth_policy.py
@@ -15,20 +15,16 @@ protocol again.
 """
 
 import time
-from typing import TYPE_CHECKING
+from typing import Any, Optional
 from urllib.parse import urlparse
 
+from azure.core.credentials import AccessToken
+from azure.core.credentials_async import AsyncTokenCredential
+from azure.core.pipeline import PipelineRequest, PipelineResponse
 from azure.core.pipeline.policies import AsyncBearerTokenCredentialPolicy
 
 from . import http_challenge_cache as ChallengeCache
 from .challenge_auth_policy import _enforce_tls, _update_challenge
-
-if TYPE_CHECKING:
-    from typing import Optional
-    from azure.core.credentials import AccessToken
-    from azure.core.credentials_async import AsyncTokenCredential
-    from azure.core.pipeline import PipelineRequest, PipelineResponse
-
 
 class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
     """Policy for handling HTTP authentication challenges.
@@ -38,13 +34,13 @@ class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
     :type credential: ~azure.core.credentials_async.AsyncTokenCredential
     """
 
-    def __init__(self, credential: "AsyncTokenCredential", *scopes: str, **kwargs) -> None:
+    def __init__(self, credential: AsyncTokenCredential, *scopes: str, **kwargs: Any) -> None:
         super().__init__(credential, *scopes, **kwargs)
         self._credential = credential
-        self._token: "Optional[AccessToken]" = None
+        self._token: Optional[AccessToken] = None
         self._verify_challenge_resource = kwargs.pop("verify_challenge_resource", True)
 
-    async def on_request(self, request: "PipelineRequest") -> None:
+    async def on_request(self, request: PipelineRequest) -> None:
         _enforce_tls(request)
         challenge = ChallengeCache.get_challenge_for_url(request.http_request.url)
         if challenge:
@@ -68,7 +64,7 @@ class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
             request.http_request.headers["Content-Length"] = "0"
 
 
-    async def on_challenge(self, request: "PipelineRequest", response: "PipelineResponse") -> bool:
+    async def on_challenge(self, request: PipelineRequest, response: PipelineResponse) -> bool:
         try:
             challenge = _update_challenge(request, response)
             # azure-identity credentials require an AADv2 scope but the challenge may specify an AADv1 resource

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/async_client_base.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/async_client_base.py
@@ -2,9 +2,11 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
-from typing import TYPE_CHECKING
+from typing import Any, Awaitable
 
+from azure.core.credentials_async import AsyncTokenCredential
 from azure.core.pipeline.policies import HttpLoggingPolicy
+from azure.core.rest import AsyncHttpResponse, HttpRequest
 from azure.core.tracing.decorator_async import distributed_trace_async
 
 from . import AsyncChallengeAuthPolicy
@@ -13,16 +15,10 @@ from .._sdk_moniker import SDK_MONIKER
 from .._generated.aio import KeyVaultClient as _KeyVaultClient
 from .._generated import models as _models
 
-if TYPE_CHECKING:
-    # pylint:disable=unused-import
-    from typing import Any, Awaitable
-    from azure.core.credentials_async import AsyncTokenCredential
-    from azure.core.rest import AsyncHttpResponse, HttpRequest
-
 
 class AsyncKeyVaultClientBase(object):
     # pylint:disable=protected-access
-    def __init__(self, vault_url: str, credential: "AsyncTokenCredential", **kwargs) -> None:
+    def __init__(self, vault_url: str, credential: AsyncTokenCredential, **kwargs: Any) -> None:
         if not credential:
             raise ValueError(
                 "credential should be an object supporting the AsyncTokenCredential protocol, "
@@ -74,7 +70,7 @@ class AsyncKeyVaultClientBase(object):
         await self._client.__aenter__()
         return self
 
-    async def __aexit__(self, *args: "Any") -> None:
+    async def __aexit__(self, *args: Any) -> None:
         await self._client.__aexit__(*args)
 
     async def close(self) -> None:
@@ -85,7 +81,9 @@ class AsyncKeyVaultClientBase(object):
         await self._client.close()
 
     @distributed_trace_async
-    def send_request(self, request: "HttpRequest", *, stream: bool = False, **kwargs) -> "Awaitable[AsyncHttpResponse]":
+    def send_request(
+        self, request: HttpRequest, *, stream: bool = False, **kwargs: Any
+    ) -> Awaitable[AsyncHttpResponse]:
         """Runs a network request using the client's existing pipeline.
 
         The request URL can be relative to the vault URL. The service API version used for the request is the same as

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/challenge_auth_policy.py
@@ -42,9 +42,9 @@ def _update_challenge(request: PipelineRequest, challenger: "PipelineResponse") 
     """Parse challenge from a challenge response, cache it, and return it.
 
     :param request: The pipeline request that prompted the challenge response.
-    :type request: :class:`~azure.core.pipeline.PipelineRequest`
+    :type request: ~azure.core.pipeline.PipelineRequest
     :param challenger: The pipeline response containing the authentication challenge.
-    :type challenger: :class:`~azure.core.pipeline.PipelineResponse`
+    :type challenger: ~azure.core.pipeline.PipelineResponse
 
     :returns: An HttpChallenge object representing the authentication challenge.
     :rtype: HttpChallenge
@@ -64,7 +64,7 @@ class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
 
     :param credential: An object which can provide an access token for the vault, such as a credential from
         :mod:`azure.identity`
-    :type credential: :class:`~azure.core.credentials.TokenCredential`
+    :type credential: ~azure.core.credentials.TokenCredential
     """
 
     def __init__(self, credential: "TokenCredential", *scopes: str, **kwargs) -> None:

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/client_base.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/client_base.py
@@ -3,12 +3,14 @@
 # Licensed under the MIT License.
 # ------------------------------------
 from copy import deepcopy
-from typing import TYPE_CHECKING
 from enum import Enum
+from typing import Any
 from urllib.parse import urlparse
 
 from azure.core import CaseInsensitiveEnumMeta
+from azure.core.credentials import TokenCredential
 from azure.core.pipeline.policies import HttpLoggingPolicy
+from azure.core.rest import HttpRequest, HttpResponse
 from azure.core.tracing.decorator import distributed_trace
 
 from . import ChallengeAuthPolicy
@@ -16,12 +18,6 @@ from .._generated import KeyVaultClient as _KeyVaultClient
 from .._generated import models as _models
 from .._generated._serialization import Serializer
 from .._sdk_moniker import SDK_MONIKER
-
-if TYPE_CHECKING:
-    # pylint:disable=unused-import,ungrouped-imports
-    from typing import Any
-    from azure.core.credentials import TokenCredential
-    from azure.core.rest import HttpRequest, HttpResponse
 
 
 class ApiVersion(str, Enum, metaclass=CaseInsensitiveEnumMeta):
@@ -43,7 +39,7 @@ _SERIALIZER = Serializer()
 _SERIALIZER.client_side_validation = False
 
 
-def _format_api_version(request: "HttpRequest", api_version: str) -> "HttpRequest":
+def _format_api_version(request: HttpRequest, api_version: str) -> HttpRequest:
     """Returns a request copy that includes an api-version query parameter if one wasn't originally present.
 
     :param request: The HTTP request being sent.
@@ -73,7 +69,7 @@ def _format_api_version(request: "HttpRequest", api_version: str) -> "HttpReques
 
 class KeyVaultClientBase(object):
     # pylint:disable=protected-access
-    def __init__(self, vault_url: str, credential: "TokenCredential", **kwargs) -> None:
+    def __init__(self, vault_url: str, credential: TokenCredential, **kwargs: Any) -> None:
         if not credential:
             raise ValueError(
                 "credential should be an object supporting the TokenCredential protocol, "
@@ -125,7 +121,7 @@ class KeyVaultClientBase(object):
         self._client.__enter__()
         return self
 
-    def __exit__(self, *args: "Any") -> None:
+    def __exit__(self, *args: Any) -> None:
         self._client.__exit__(*args)
 
     def close(self) -> None:
@@ -136,7 +132,7 @@ class KeyVaultClientBase(object):
         self._client.close()
 
     @distributed_trace
-    def send_request(self, request: "HttpRequest", *, stream: bool = False, **kwargs) -> "HttpResponse":
+    def send_request(self, request: HttpRequest, *, stream: bool = False, **kwargs: Any) -> HttpResponse:
         """Runs a network request using the client's existing pipeline.
 
         The request URL can be relative to the vault URL. The service API version used for the request is the same as

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/client_base.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/client_base.py
@@ -47,11 +47,11 @@ def _format_api_version(request: "HttpRequest", api_version: str) -> "HttpReques
     """Returns a request copy that includes an api-version query parameter if one wasn't originally present.
 
     :param request: The HTTP request being sent.
-    :type request: :class:`~azure.core.rest.HttpRequest`
+    :type request: ~azure.core.rest.HttpRequest
     :param str api_version: The service API version that the request should include.
 
     :returns: A copy of the request that includes an api-version query parameter.
-    :rtype: :class:`~azure.core.rest.HttpRequest`
+    :rtype: azure.core.rest.HttpRequest
     """
     request_copy = deepcopy(request)
     params = {"api-version": api_version}  # By default, we want to use the client's API version

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/aio/_client.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/aio/_client.py
@@ -51,8 +51,8 @@ class SecretClient(AsyncKeyVaultClientBase):
         :rtype: ~azure.keyvault.secrets.KeyVaultSecret
 
         :raises:
-            azure.core.exceptions.ResourceNotFoundError if the secret doesn't exist,
-            azure.core.exceptions.HttpResponseError for other errors
+            :class:`~azure.core.exceptions.ResourceNotFoundError` if the secret doesn't exist,
+            :class:`~azure.core.exceptions.HttpResponseError` for other errors
 
         Example:
             .. literalinclude:: ../tests/test_samples_secrets_async.py
@@ -84,7 +84,7 @@ class SecretClient(AsyncKeyVaultClientBase):
         :returns: The created or updated secret.
         :rtype: ~azure.keyvault.secrets.KeyVaultSecret
 
-        :raises: azure.core.exceptions.HttpResponseError
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example:
             .. literalinclude:: ../tests/test_samples_secrets_async.py
@@ -141,8 +141,8 @@ class SecretClient(AsyncKeyVaultClientBase):
         :rtype: ~azure.keyvault.secrets.SecretProperties
 
         :raises:
-            azure.core.exceptions.ResourceNotFoundError if the secret doesn't exist,
-            azure.core.exceptions.HttpResponseError for other errors
+            :class:`~azure.core.exceptions.ResourceNotFoundError` if the secret doesn't exist,
+            :class:`~azure.core.exceptions.HttpResponseError` for other errors
 
         Example:
             .. literalinclude:: ../tests/test_samples_secrets_async.py
@@ -237,8 +237,8 @@ class SecretClient(AsyncKeyVaultClientBase):
         :rtype: bytes
 
         :raises:
-            azure.core.exceptions.ResourceNotFoundError if the secret doesn't exist,
-            azure.core.exceptions.HttpResponseError for other errors
+            :class:`~azure.core.exceptions.ResourceNotFoundError` if the secret doesn't exist,
+            :class:`~azure.core.exceptions.HttpResponseError` for other errors
 
         Example:
             .. literalinclude:: ../tests/test_samples_secrets_async.py
@@ -261,8 +261,8 @@ class SecretClient(AsyncKeyVaultClientBase):
         :rtype: ~azure.keyvault.secrets.SecretProperties
 
         :raises:
-            azure.core.exceptions.ResourceExistsError if the secret's name is already in use,
-            azure.core.exceptions.HttpResponseError for other errors
+            :class:`~azure.core.exceptions.ResourceExistsError` if the secret's name is already in use,
+            :class:`~azure.core.exceptions.HttpResponseError` for other errors
 
         Example:
             .. literalinclude:: ../tests/test_samples_secrets_async.py
@@ -291,8 +291,8 @@ class SecretClient(AsyncKeyVaultClientBase):
         :rtype: ~azure.keyvault.secrets.DeletedSecret
 
         :raises:
-            azure.core.exceptions.ResourceNotFoundError if the secret doesn't exist,
-            azure.core.exceptions.HttpResponseError for other errors
+            :class:`~azure.core.exceptions.ResourceNotFoundError` if the secret doesn't exist,
+            :class:`~azure.core.exceptions.HttpResponseError` for other errors
 
         Example:
             .. literalinclude:: ../tests/test_samples_secrets_async.py
@@ -330,8 +330,8 @@ class SecretClient(AsyncKeyVaultClientBase):
         :rtype: ~azure.keyvault.secrets.DeletedSecret
 
         :raises:
-            azure.core.exceptions.ResourceNotFoundError if the deleted secret doesn't exist,
-            azure.core.exceptions.HttpResponseError for other errors
+            :class:`~azure.core.exceptions.ResourceNotFoundError` if the deleted secret doesn't exist,
+            :class:`~azure.core.exceptions.HttpResponseError` for other errors
 
         Example:
             .. literalinclude:: ../tests/test_samples_secrets_async.py
@@ -383,7 +383,7 @@ class SecretClient(AsyncKeyVaultClientBase):
 
         :returns: None
 
-        :raises: azure.core.exceptions.HttpResponseError
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example:
             .. code-block:: python
@@ -408,7 +408,7 @@ class SecretClient(AsyncKeyVaultClientBase):
         :returns: The recovered secret's properties.
         :rtype: ~azure.keyvault.secrets.SecretProperties
 
-        :raises: azure.core.exceptions.HttpResponseError
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
 
         Example:
             .. literalinclude:: ../tests/test_samples_secrets_async.py

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/aio/_client.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/aio/_client.py
@@ -22,7 +22,7 @@ class SecretClient(AsyncKeyVaultClientBase):
         for details.
     :param credential: An object which can provide an access token for the vault, such as a credential from
         :mod:`azure.identity.aio`
-    :type credential: :class:`~azure.core.credentials_async.AsyncTokenCredential`
+    :type credential: ~azure.core.credentials_async.AsyncTokenCredential
 
     :keyword api_version: Version of the service API to use. Defaults to the most recent.
     :paramtype api_version: ~azure.keyvault.secrets.ApiVersion or str
@@ -51,8 +51,8 @@ class SecretClient(AsyncKeyVaultClientBase):
         :rtype: ~azure.keyvault.secrets.KeyVaultSecret
 
         :raises:
-            :class:`~azure.core.exceptions.ResourceNotFoundError` if the secret doesn't exist,
-            :class:`~azure.core.exceptions.HttpResponseError` for other errors
+            azure.core.exceptions.ResourceNotFoundError if the secret doesn't exist,
+            azure.core.exceptions.HttpResponseError for other errors
 
         Example:
             .. literalinclude:: ../tests/test_samples_secrets_async.py
@@ -84,7 +84,7 @@ class SecretClient(AsyncKeyVaultClientBase):
         :returns: The created or updated secret.
         :rtype: ~azure.keyvault.secrets.KeyVaultSecret
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises: azure.core.exceptions.HttpResponseError
 
         Example:
             .. literalinclude:: ../tests/test_samples_secrets_async.py
@@ -141,8 +141,8 @@ class SecretClient(AsyncKeyVaultClientBase):
         :rtype: ~azure.keyvault.secrets.SecretProperties
 
         :raises:
-            :class:`~azure.core.exceptions.ResourceNotFoundError` if the secret doesn't exist,
-            :class:`~azure.core.exceptions.HttpResponseError` for other errors
+            azure.core.exceptions.ResourceNotFoundError if the secret doesn't exist,
+            azure.core.exceptions.HttpResponseError for other errors
 
         Example:
             .. literalinclude:: ../tests/test_samples_secrets_async.py
@@ -237,8 +237,8 @@ class SecretClient(AsyncKeyVaultClientBase):
         :rtype: bytes
 
         :raises:
-            :class:`~azure.core.exceptions.ResourceNotFoundError` if the secret doesn't exist,
-            :class:`~azure.core.exceptions.HttpResponseError` for other errors
+            azure.core.exceptions.ResourceNotFoundError if the secret doesn't exist,
+            azure.core.exceptions.HttpResponseError for other errors
 
         Example:
             .. literalinclude:: ../tests/test_samples_secrets_async.py
@@ -261,8 +261,8 @@ class SecretClient(AsyncKeyVaultClientBase):
         :rtype: ~azure.keyvault.secrets.SecretProperties
 
         :raises:
-            :class:`~azure.core.exceptions.ResourceExistsError` if the secret's name is already in use,
-            :class:`~azure.core.exceptions.HttpResponseError` for other errors
+            azure.core.exceptions.ResourceExistsError if the secret's name is already in use,
+            azure.core.exceptions.HttpResponseError for other errors
 
         Example:
             .. literalinclude:: ../tests/test_samples_secrets_async.py
@@ -291,8 +291,8 @@ class SecretClient(AsyncKeyVaultClientBase):
         :rtype: ~azure.keyvault.secrets.DeletedSecret
 
         :raises:
-            :class:`~azure.core.exceptions.ResourceNotFoundError` if the secret doesn't exist,
-            :class:`~azure.core.exceptions.HttpResponseError` for other errors
+            azure.core.exceptions.ResourceNotFoundError if the secret doesn't exist,
+            azure.core.exceptions.HttpResponseError for other errors
 
         Example:
             .. literalinclude:: ../tests/test_samples_secrets_async.py
@@ -330,8 +330,8 @@ class SecretClient(AsyncKeyVaultClientBase):
         :rtype: ~azure.keyvault.secrets.DeletedSecret
 
         :raises:
-            :class:`~azure.core.exceptions.ResourceNotFoundError` if the deleted secret doesn't exist,
-            :class:`~azure.core.exceptions.HttpResponseError` for other errors
+            azure.core.exceptions.ResourceNotFoundError if the deleted secret doesn't exist,
+            azure.core.exceptions.HttpResponseError for other errors
 
         Example:
             .. literalinclude:: ../tests/test_samples_secrets_async.py
@@ -383,7 +383,7 @@ class SecretClient(AsyncKeyVaultClientBase):
 
         :returns: None
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises: azure.core.exceptions.HttpResponseError
 
         Example:
             .. code-block:: python
@@ -408,7 +408,7 @@ class SecretClient(AsyncKeyVaultClientBase):
         :returns: The recovered secret's properties.
         :rtype: ~azure.keyvault.secrets.SecretProperties
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises: azure.core.exceptions.HttpResponseError
 
         Example:
             .. literalinclude:: ../tests/test_samples_secrets_async.py

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/aio/_client.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/aio/_client.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
-from typing import Optional
+from typing import Any, Optional
 from functools import partial
 
 from azure.core.tracing.decorator import distributed_trace
@@ -41,7 +41,7 @@ class SecretClient(AsyncKeyVaultClientBase):
     # pylint:disable=protected-access
 
     @distributed_trace_async
-    async def get_secret(self, name: str, version: Optional[str] = None, **kwargs) -> KeyVaultSecret:
+    async def get_secret(self, name: str, version: Optional[str] = None, **kwargs: Any) -> KeyVaultSecret:
         """Get a secret. Requires the secrets/get permission.
 
         :param str name: The name of the secret
@@ -50,9 +50,8 @@ class SecretClient(AsyncKeyVaultClientBase):
         :returns: The fetched secret.
         :rtype: ~azure.keyvault.secrets.KeyVaultSecret
 
-        :raises:
-            :class:`~azure.core.exceptions.ResourceNotFoundError` if the secret doesn't exist,
-            :class:`~azure.core.exceptions.HttpResponseError` for other errors
+        :raises ~azure.core.exceptions.ResourceNotFoundError or ~azure.core.exceptions.HttpResponseError:
+            the former if the secret doesn't exist; the latter for other errors
 
         Example:
             .. literalinclude:: ../tests/test_samples_secrets_async.py
@@ -66,7 +65,7 @@ class SecretClient(AsyncKeyVaultClientBase):
         return KeyVaultSecret._from_secret_bundle(bundle)
 
     @distributed_trace_async
-    async def set_secret(self, name: str, value: str, **kwargs) -> KeyVaultSecret:
+    async def set_secret(self, name: str, value: str, **kwargs: Any) -> KeyVaultSecret:
         """Set a secret value. If `name` is in use, create a new version of the secret. If not, create a new secret.
 
         Requires secrets/set permission.
@@ -84,7 +83,7 @@ class SecretClient(AsyncKeyVaultClientBase):
         :returns: The created or updated secret.
         :rtype: ~azure.keyvault.secrets.KeyVaultSecret
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises ~azure.core.exceptions.HttpResponseError:
 
         Example:
             .. literalinclude:: ../tests/test_samples_secrets_async.py
@@ -120,7 +119,7 @@ class SecretClient(AsyncKeyVaultClientBase):
 
     @distributed_trace_async
     async def update_secret_properties(
-        self, name: str, version: Optional[str] = None, **kwargs
+        self, name: str, version: Optional[str] = None, **kwargs: Any
     ) -> SecretProperties:
         """Update properties of a secret other than its value. Requires secrets/set permission.
 
@@ -140,9 +139,8 @@ class SecretClient(AsyncKeyVaultClientBase):
         :returns: The updated secret properties.
         :rtype: ~azure.keyvault.secrets.SecretProperties
 
-        :raises:
-            :class:`~azure.core.exceptions.ResourceNotFoundError` if the secret doesn't exist,
-            :class:`~azure.core.exceptions.HttpResponseError` for other errors
+        :raises ~azure.core.exceptions.ResourceNotFoundError or ~azure.core.exceptions.HttpResponseError:
+            the former if the secret doesn't exist; the latter for other errors
 
         Example:
             .. literalinclude:: ../tests/test_samples_secrets_async.py
@@ -177,7 +175,7 @@ class SecretClient(AsyncKeyVaultClientBase):
         return SecretProperties._from_secret_bundle(bundle)  # pylint: disable=protected-access
 
     @distributed_trace
-    def list_properties_of_secrets(self, **kwargs) -> AsyncItemPaged[SecretProperties]:
+    def list_properties_of_secrets(self, **kwargs: Any) -> AsyncItemPaged[SecretProperties]:
         """List identifiers and attributes of all secrets in the vault. Requires secrets/list permission.
 
         List items don't include secret values. Use :func:`get_secret` to get a secret's value.
@@ -201,7 +199,7 @@ class SecretClient(AsyncKeyVaultClientBase):
         )
 
     @distributed_trace
-    def list_properties_of_secret_versions(self, name: str, **kwargs) -> AsyncItemPaged[SecretProperties]:
+    def list_properties_of_secret_versions(self, name: str, **kwargs: Any) -> AsyncItemPaged[SecretProperties]:
         """List properties of all versions of a secret, excluding their values. Requires secrets/list permission.
 
         List items don't include secret values. Use :func:`get_secret` to get a secret's value.
@@ -228,7 +226,7 @@ class SecretClient(AsyncKeyVaultClientBase):
         )
 
     @distributed_trace_async
-    async def backup_secret(self, name: str, **kwargs) -> bytes:
+    async def backup_secret(self, name: str, **kwargs: Any) -> bytes:
         """Back up a secret in a protected form useable only by Azure Key Vault. Requires secrets/backup permission.
 
         :param str name: Name of the secret to back up
@@ -236,9 +234,8 @@ class SecretClient(AsyncKeyVaultClientBase):
         :returns: The backup result, in a protected bytes format that can only be used by Azure Key Vault.
         :rtype: bytes
 
-        :raises:
-            :class:`~azure.core.exceptions.ResourceNotFoundError` if the secret doesn't exist,
-            :class:`~azure.core.exceptions.HttpResponseError` for other errors
+        :raises ~azure.core.exceptions.ResourceNotFoundError or ~azure.core.exceptions.HttpResponseError:
+            the former if the secret doesn't exist; the latter for other errors
 
         Example:
             .. literalinclude:: ../tests/test_samples_secrets_async.py
@@ -252,7 +249,7 @@ class SecretClient(AsyncKeyVaultClientBase):
         return backup_result.value
 
     @distributed_trace_async
-    async def restore_secret_backup(self, backup: bytes, **kwargs) -> SecretProperties:
+    async def restore_secret_backup(self, backup: bytes, **kwargs: Any) -> SecretProperties:
         """Restore a backed up secret. Requires the secrets/restore permission.
 
         :param bytes backup: A secret backup as returned by :func:`backup_secret`
@@ -260,9 +257,8 @@ class SecretClient(AsyncKeyVaultClientBase):
         :returns: The restored secret
         :rtype: ~azure.keyvault.secrets.SecretProperties
 
-        :raises:
-            :class:`~azure.core.exceptions.ResourceExistsError` if the secret's name is already in use,
-            :class:`~azure.core.exceptions.HttpResponseError` for other errors
+        :raises ~azure.core.exceptions.ResourceExistsError or ~azure.core.exceptions.HttpResponseError:
+            the former if the secret's name is already in use; the latter for other errors
 
         Example:
             .. literalinclude:: ../tests/test_samples_secrets_async.py
@@ -280,7 +276,7 @@ class SecretClient(AsyncKeyVaultClientBase):
         return SecretProperties._from_secret_bundle(bundle)
 
     @distributed_trace_async
-    async def delete_secret(self, name: str, **kwargs) -> DeletedSecret:
+    async def delete_secret(self, name: str, **kwargs: Any) -> DeletedSecret:
         """Delete all versions of a secret. Requires secrets/delete permission.
 
         If the vault has soft-delete enabled, deletion may take several seconds to complete.
@@ -290,9 +286,8 @@ class SecretClient(AsyncKeyVaultClientBase):
         :returns: The deleted secret.
         :rtype: ~azure.keyvault.secrets.DeletedSecret
 
-        :raises:
-            :class:`~azure.core.exceptions.ResourceNotFoundError` if the secret doesn't exist,
-            :class:`~azure.core.exceptions.HttpResponseError` for other errors
+        :raises ~azure.core.exceptions.ResourceNotFoundError or ~azure.core.exceptions.HttpResponseError:
+            the former if the secret doesn't exist; the latter for other errors
 
         Example:
             .. literalinclude:: ../tests/test_samples_secrets_async.py
@@ -321,7 +316,7 @@ class SecretClient(AsyncKeyVaultClientBase):
         return polling_method.resource()
 
     @distributed_trace_async
-    async def get_deleted_secret(self, name: str, **kwargs) -> DeletedSecret:
+    async def get_deleted_secret(self, name: str, **kwargs: Any) -> DeletedSecret:
         """Get a deleted secret. Possible only in vaults with soft-delete enabled. Requires secrets/get permission.
 
         :param str name: Name of the deleted secret
@@ -329,9 +324,8 @@ class SecretClient(AsyncKeyVaultClientBase):
         :returns: The deleted secret.
         :rtype: ~azure.keyvault.secrets.DeletedSecret
 
-        :raises:
-            :class:`~azure.core.exceptions.ResourceNotFoundError` if the deleted secret doesn't exist,
-            :class:`~azure.core.exceptions.HttpResponseError` for other errors
+        :raises ~azure.core.exceptions.ResourceNotFoundError or ~azure.core.exceptions.HttpResponseError:
+            the former if the deleted secret doesn't exist; the latter for other errors
 
         Example:
             .. literalinclude:: ../tests/test_samples_secrets_async.py
@@ -345,7 +339,7 @@ class SecretClient(AsyncKeyVaultClientBase):
         return DeletedSecret._from_deleted_secret_bundle(bundle)
 
     @distributed_trace
-    def list_deleted_secrets(self, **kwargs) -> AsyncItemPaged[DeletedSecret]:
+    def list_deleted_secrets(self, **kwargs: Any) -> AsyncItemPaged[DeletedSecret]:
         """Lists all deleted secrets. Possible only in vaults with soft-delete enabled.
 
         Requires secrets/list permission.
@@ -369,7 +363,7 @@ class SecretClient(AsyncKeyVaultClientBase):
         )
 
     @distributed_trace_async
-    async def purge_deleted_secret(self, name: str, **kwargs) -> None:
+    async def purge_deleted_secret(self, name: str, **kwargs: Any) -> None:
         """Permanently delete a deleted secret. Possible only in vaults with soft-delete enabled.
 
         Performs an irreversible deletion of the specified secret, without possibility for recovery. The operation is
@@ -383,7 +377,7 @@ class SecretClient(AsyncKeyVaultClientBase):
 
         :returns: None
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises ~azure.core.exceptions.HttpResponseError:
 
         Example:
             .. code-block:: python
@@ -396,7 +390,7 @@ class SecretClient(AsyncKeyVaultClientBase):
         await self._client.purge_deleted_secret(self.vault_url, name, **kwargs)
 
     @distributed_trace_async
-    async def recover_deleted_secret(self, name: str, **kwargs) -> SecretProperties:
+    async def recover_deleted_secret(self, name: str, **kwargs: Any) -> SecretProperties:
         """Recover a deleted secret to its latest version. This is possible only in vaults with soft-delete enabled.
 
         Requires the secrets/recover permission. If the vault does not have soft-delete enabled, :func:`delete_secret`
@@ -408,7 +402,7 @@ class SecretClient(AsyncKeyVaultClientBase):
         :returns: The recovered secret's properties.
         :rtype: ~azure.keyvault.secrets.SecretProperties
 
-        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+        :raises ~azure.core.exceptions.HttpResponseError:
 
         Example:
             .. literalinclude:: ../tests/test_samples_secrets_async.py


### PR DESCRIPTION
# Description

The majority of errors were resolved by removing `:class:` markers in docstring type hints. The `azure-keyvault-administration` README is also fixed, as it used to include a backup operation snippet where a restore operation was meant to be shown.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
