### PR TITLE
[Storage] Bump typing-extensions dependency for all packages

### DIFF
--- a/sdk/storage/azure-storage-blob/CHANGELOG.md
+++ b/sdk/storage/azure-storage-blob/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Features Added
 
 ### Bugs Fixed
-- Bumped dependency of `typing-extensions` to `>=4.6.0` to avoid potential `TypeError` with `typing.TypeVar` with
+- Bumped dependency of `typing-extensions` to `>=4.6.0` to avoid potential `TypeError` with `typing.TypeVar` on
 Python 3.12.
 
 ## 12.19.0 (2023-11-07)

--- a/sdk/storage/azure-storage-blob/CHANGELOG.md
+++ b/sdk/storage/azure-storage-blob/CHANGELOG.md
@@ -5,7 +5,8 @@
 ### Features Added
 
 ### Bugs Fixed
-- Bumped dependency of `typing-extensions` to `>=4.6.0` to avoid potential `TypeError` with `typing.TypeVar`.
+- Bumped dependency of `typing-extensions` to `>=4.6.0` to avoid potential `TypeError` with `typing.TypeVar` with
+Python 3.12.
 
 ## 12.19.0 (2023-11-07)
 

--- a/sdk/storage/azure-storage-blob/CHANGELOG.md
+++ b/sdk/storage/azure-storage-blob/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+### Bugs Fixed
+- Bumped dependency of `typing-extensions` to `>=4.6.0` to avoid potential `TypeError` with `typing.TypeVar`.
 
 ## 12.19.0 (2023-11-07)
 

--- a/sdk/storage/azure-storage-blob/setup.py
+++ b/sdk/storage/azure-storage-blob/setup.py
@@ -80,7 +80,7 @@ setup(
     install_requires=[
         "azure-core<2.0.0,>=1.28.0",
         "cryptography>=2.1.4",
-        "typing-extensions>=4.3.0",
+        "typing-extensions>=4.6.0",
         "isodate>=0.6.1"
     ],
     extras_require={

--- a/sdk/storage/azure-storage-file-datalake/CHANGELOG.md
+++ b/sdk/storage/azure-storage-file-datalake/CHANGELOG.md
@@ -5,7 +5,8 @@
 ### Features Added
 
 ### Bugs Fixed
-- Bumped dependency of `typing-extensions` to `>=4.6.0` to avoid potential `TypeError` with `typing.TypeVar`.
+- Bumped dependency of `typing-extensions` to `>=4.6.0` to avoid potential `TypeError` with `typing.TypeVar` with
+Python 3.12.
 
 ## 12.14.0 (2023-11-07)
 

--- a/sdk/storage/azure-storage-file-datalake/CHANGELOG.md
+++ b/sdk/storage/azure-storage-file-datalake/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+### Bugs Fixed
+- Bumped dependency of `typing-extensions` to `>=4.6.0` to avoid potential `TypeError` with `typing.TypeVar`.
 
 ## 12.14.0 (2023-11-07)
 

--- a/sdk/storage/azure-storage-file-datalake/CHANGELOG.md
+++ b/sdk/storage/azure-storage-file-datalake/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Features Added
 
 ### Bugs Fixed
-- Bumped dependency of `typing-extensions` to `>=4.6.0` to avoid potential `TypeError` with `typing.TypeVar` with
+- Bumped dependency of `typing-extensions` to `>=4.6.0` to avoid potential `TypeError` with `typing.TypeVar` on
 Python 3.12.
 
 ## 12.14.0 (2023-11-07)

--- a/sdk/storage/azure-storage-file-datalake/setup.py
+++ b/sdk/storage/azure-storage-file-datalake/setup.py
@@ -79,7 +79,7 @@ setup(
     install_requires=[
         "azure-core<2.0.0,>=1.28.0",
         "azure-storage-blob<13.0.0,>=12.20.0b1",
-        "typing-extensions>=4.3.0",
+        "typing-extensions>=4.6.0",
         "isodate>=0.6.1"
     ],
     extras_require={

--- a/sdk/storage/azure-storage-file-share/CHANGELOG.md
+++ b/sdk/storage/azure-storage-file-share/CHANGELOG.md
@@ -8,7 +8,7 @@
 ### Bugs Fixed
 - Fixed an issue where the `ShareDirectoryClient` returned by `get_subdirectory_client` with a `ShareDirectoryClient`
 pointing to the root of the file share would raise an `InvalidResourceName` on any operations.
-- Bumped dependency of `typing-extensions` to `>=4.6.0` to avoid potential `TypeError` with `typing.TypeVar` with
+- Bumped dependency of `typing-extensions` to `>=4.6.0` to avoid potential `TypeError` with `typing.TypeVar` on
 Python 3.12.
 
 ## 12.15.0 (2023-11-07)

--- a/sdk/storage/azure-storage-file-share/CHANGELOG.md
+++ b/sdk/storage/azure-storage-file-share/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Bugs Fixed
 - Fixed an issue where the `ShareDirectoryClient` returned by `get_subdirectory_client` with a `ShareDirectoryClient`
 pointing to the root of the file share would raise an `InvalidResourceName` on any operations.
+- Bumped dependency of `typing-extensions` to `>=4.6.0` to avoid potential `TypeError` with `typing.TypeVar`.
 
 ## 12.15.0 (2023-11-07)
 

--- a/sdk/storage/azure-storage-file-share/CHANGELOG.md
+++ b/sdk/storage/azure-storage-file-share/CHANGELOG.md
@@ -8,7 +8,8 @@
 ### Bugs Fixed
 - Fixed an issue where the `ShareDirectoryClient` returned by `get_subdirectory_client` with a `ShareDirectoryClient`
 pointing to the root of the file share would raise an `InvalidResourceName` on any operations.
-- Bumped dependency of `typing-extensions` to `>=4.6.0` to avoid potential `TypeError` with `typing.TypeVar`.
+- Bumped dependency of `typing-extensions` to `>=4.6.0` to avoid potential `TypeError` with `typing.TypeVar` with
+Python 3.12.
 
 ## 12.15.0 (2023-11-07)
 

--- a/sdk/storage/azure-storage-file-share/setup.py
+++ b/sdk/storage/azure-storage-file-share/setup.py
@@ -67,7 +67,7 @@ setup(
     install_requires=[
         "azure-core<2.0.0,>=1.28.0",
         "cryptography>=2.1.4",
-        "typing-extensions>=4.3.0",
+        "typing-extensions>=4.6.0",
         "isodate>=0.6.1"
     ],
     extras_require={

--- a/sdk/storage/azure-storage-queue/CHANGELOG.md
+++ b/sdk/storage/azure-storage-queue/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+### Bugs Fixed
+- Bumped dependency of `typing-extensions` to `>=4.6.0` to avoid potential `TypeError` with `typing.TypeVar`.
 
 ## 12.9.0 (2023-12-05)
 

--- a/sdk/storage/azure-storage-queue/CHANGELOG.md
+++ b/sdk/storage/azure-storage-queue/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Features Added
 
 ### Bugs Fixed
-- Bumped dependency of `typing-extensions` to `>=4.6.0` to avoid potential `TypeError` with `typing.TypeVar` with
+- Bumped dependency of `typing-extensions` to `>=4.6.0` to avoid potential `TypeError` with `typing.TypeVar` on
 Python 3.12.
 
 ## 12.9.0 (2023-12-05)

--- a/sdk/storage/azure-storage-queue/CHANGELOG.md
+++ b/sdk/storage/azure-storage-queue/CHANGELOG.md
@@ -5,7 +5,8 @@
 ### Features Added
 
 ### Bugs Fixed
-- Bumped dependency of `typing-extensions` to `>=4.6.0` to avoid potential `TypeError` with `typing.TypeVar`.
+- Bumped dependency of `typing-extensions` to `>=4.6.0` to avoid potential `TypeError` with `typing.TypeVar` with
+Python 3.12.
 
 ## 12.9.0 (2023-12-05)
 

--- a/sdk/storage/azure-storage-queue/setup.py
+++ b/sdk/storage/azure-storage-queue/setup.py
@@ -70,7 +70,7 @@ setup(
     install_requires=[
         "azure-core<2.0.0,>=1.28.0",
         "cryptography>=2.1.4",
-        "typing-extensions>=4.3.0",
+        "typing-extensions>=4.6.0",
         "isodate>=0.6.1"
     ],
     extras_require={


### PR DESCRIPTION
As brought up in #33442, there is a bug with `typing-extensions==4.4.0-4.5.0` and Python 3.12 when using `typing.TypeVar`. While it's unlikely for new installs of our packages to get a bad version of `typing-extensions` (issue fixed in >= 4.6.0), it is still possible as our dependency is only `>=4.3.0`. This change bumps our dependency to `>=4.6.0` for all Storage packages to prevent getting a bad version on new installs/upgrades.