### PR TITLE
[Monitor] Regen ingestion + query for next pylint

### DIFF
--- a/sdk/monitor/azure-monitor-ingestion/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-ingestion/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+* Bumped minimum dependency on `azure-core` to `>=1.28.0`.
+
 ## 1.0.3 (2023-11-07)
 
 ### Other Changes

--- a/sdk/monitor/azure-monitor-ingestion/azure/monitor/ingestion/_client.py
+++ b/sdk/monitor/azure-monitor-ingestion/azure/monitor/ingestion/_client.py
@@ -10,6 +10,7 @@ from copy import deepcopy
 from typing import Any, TYPE_CHECKING
 
 from azure.core import PipelineClient
+from azure.core.pipeline import policies
 from azure.core.rest import HttpRequest, HttpResponse
 
 from ._configuration import LogsIngestionClientConfiguration
@@ -37,13 +38,30 @@ class LogsIngestionClient(LogsIngestionClientOperationsMixin):  # pylint: disabl
     def __init__(self, endpoint: str, credential: "TokenCredential", **kwargs: Any) -> None:
         _endpoint = "{endpoint}"
         self._config = LogsIngestionClientConfiguration(endpoint=endpoint, credential=credential, **kwargs)
-        self._client: PipelineClient = PipelineClient(base_url=_endpoint, config=self._config, **kwargs)
+        _policies = kwargs.pop("policies", None)
+        if _policies is None:
+            _policies = [
+                policies.RequestIdPolicy(**kwargs),
+                self._config.headers_policy,
+                self._config.user_agent_policy,
+                self._config.proxy_policy,
+                policies.ContentDecodePolicy(**kwargs),
+                self._config.redirect_policy,
+                self._config.retry_policy,
+                self._config.authentication_policy,
+                self._config.custom_hook_policy,
+                self._config.logging_policy,
+                policies.DistributedTracingPolicy(**kwargs),
+                policies.SensitiveHeaderCleanupPolicy(**kwargs) if self._config.redirect_policy else None,
+                self._config.http_logging_policy,
+            ]
+        self._client: PipelineClient = PipelineClient(base_url=_endpoint, policies=_policies, **kwargs)
 
         self._serialize = Serializer()
         self._deserialize = Deserializer()
         self._serialize.client_side_validation = False
 
-    def send_request(self, request: HttpRequest, **kwargs: Any) -> HttpResponse:
+    def send_request(self, request: HttpRequest, *, stream: bool = False, **kwargs: Any) -> HttpResponse:
         """Runs the network request through the client's chained policies.
 
         >>> from azure.core.rest import HttpRequest
@@ -67,7 +85,7 @@ class LogsIngestionClient(LogsIngestionClientOperationsMixin):  # pylint: disabl
         }
 
         request_copy.url = self._client.format_url(request_copy.url, **path_format_arguments)
-        return self._client.send_request(request_copy, **kwargs)
+        return self._client.send_request(request_copy, stream=stream, **kwargs)  # type: ignore
 
     def close(self) -> None:
         self._client.close()

--- a/sdk/monitor/azure-monitor-ingestion/azure/monitor/ingestion/_configuration.py
+++ b/sdk/monitor/azure-monitor-ingestion/azure/monitor/ingestion/_configuration.py
@@ -8,7 +8,6 @@
 
 from typing import Any, TYPE_CHECKING
 
-from azure.core.configuration import Configuration
 from azure.core.pipeline import policies
 
 if TYPE_CHECKING:
@@ -18,7 +17,7 @@ if TYPE_CHECKING:
 VERSION = "unknown"
 
 
-class LogsIngestionClientConfiguration(Configuration):  # pylint: disable=too-many-instance-attributes,name-too-long
+class LogsIngestionClientConfiguration:  # pylint: disable=too-many-instance-attributes,name-too-long
     """Configuration for LogsIngestionClient.
 
     Note that all parameters used to create this instance are saved as instance
@@ -35,7 +34,6 @@ class LogsIngestionClientConfiguration(Configuration):  # pylint: disable=too-ma
     """
 
     def __init__(self, endpoint: str, credential: "TokenCredential", **kwargs: Any) -> None:
-        super(LogsIngestionClientConfiguration, self).__init__(**kwargs)
         api_version: str = kwargs.pop("api_version", "2023-01-01")
 
         if endpoint is None:
@@ -48,6 +46,7 @@ class LogsIngestionClientConfiguration(Configuration):  # pylint: disable=too-ma
         self.api_version = api_version
         self.credential_scopes = kwargs.pop("credential_scopes", ["https://monitor.azure.com//.default"])
         kwargs.setdefault("sdk_moniker", "monitor-ingestion/{}".format(VERSION))
+        self.polling_interval = kwargs.get("polling_interval", 30)
         self._configure(**kwargs)
 
     def _configure(self, **kwargs: Any) -> None:
@@ -56,9 +55,9 @@ class LogsIngestionClientConfiguration(Configuration):  # pylint: disable=too-ma
         self.proxy_policy = kwargs.get("proxy_policy") or policies.ProxyPolicy(**kwargs)
         self.logging_policy = kwargs.get("logging_policy") or policies.NetworkTraceLoggingPolicy(**kwargs)
         self.http_logging_policy = kwargs.get("http_logging_policy") or policies.HttpLoggingPolicy(**kwargs)
-        self.retry_policy = kwargs.get("retry_policy") or policies.RetryPolicy(**kwargs)
         self.custom_hook_policy = kwargs.get("custom_hook_policy") or policies.CustomHookPolicy(**kwargs)
         self.redirect_policy = kwargs.get("redirect_policy") or policies.RedirectPolicy(**kwargs)
+        self.retry_policy = kwargs.get("retry_policy") or policies.RetryPolicy(**kwargs)
         self.authentication_policy = kwargs.get("authentication_policy")
         if self.credential and not self.authentication_policy:
             self.authentication_policy = policies.BearerTokenCredentialPolicy(

--- a/sdk/monitor/azure-monitor-ingestion/azure/monitor/ingestion/_operations/_operations.py
+++ b/sdk/monitor/azure-monitor-ingestion/azure/monitor/ingestion/_operations/_operations.py
@@ -1,4 +1,4 @@
-# pylint: disable=too-many-lines
+# pylint: disable=too-many-lines,too-many-statements
 # coding=utf-8
 # --------------------------------------------------------------------------
 # Copyright (c) Microsoft Corporation. All rights reserved.
@@ -89,7 +89,7 @@ class LogsIngestionClientOperationsMixin(LogsIngestionClientMixinABC):
         self,
         rule_id: str,
         stream: str,
-        body: IO,
+        body: IO[bytes],
         *,
         content_encoding: Optional[str] = None,
         content_type: str = "application/json",
@@ -102,7 +102,7 @@ class LogsIngestionClientOperationsMixin(LogsIngestionClientMixinABC):
         self,
         rule_id: str,
         stream: str,
-        body: Union[List[JSON], IO],
+        body: Union[List[JSON], IO[bytes]],
         *,
         content_encoding: Optional[str] = None,
         **kwargs: Any
@@ -116,8 +116,8 @@ class LogsIngestionClientOperationsMixin(LogsIngestionClientMixinABC):
         :param stream: The streamDeclaration name as defined in the Data Collection Rule. Required.
         :type stream: str
         :param body: An array of objects matching the schema defined by the provided stream. Is either
-         a [JSON] type or a IO type. Required.
-        :type body: list[JSON] or IO
+         a [JSON] type or a IO[bytes] type. Required.
+        :type body: list[JSON] or IO[bytes]
         :keyword content_encoding: gzip. Default value is None.
         :paramtype content_encoding: str
         :keyword content_type: Body Parameter content-type. Known values are: 'application/json'.
@@ -149,7 +149,7 @@ class LogsIngestionClientOperationsMixin(LogsIngestionClientMixinABC):
         else:
             _json = body
 
-        request = build_logs_ingestion_upload_request(
+        _request = build_logs_ingestion_upload_request(
             rule_id=rule_id,
             stream=stream,
             content_encoding=content_encoding,
@@ -163,11 +163,11 @@ class LogsIngestionClientOperationsMixin(LogsIngestionClientMixinABC):
         path_format_arguments = {
             "endpoint": self._serialize.url("self._config.endpoint", self._config.endpoint, "str", skip_quote=True),
         }
-        request.url = self._client.format_url(request.url, **path_format_arguments)
+        _request.url = self._client.format_url(_request.url, **path_format_arguments)
 
         _stream = False
         pipeline_response: PipelineResponse = self._client._pipeline.run(  # pylint: disable=protected-access
-            request, stream=_stream, **kwargs
+            _request, stream=_stream, **kwargs
         )
 
         response = pipeline_response.http_response
@@ -179,4 +179,4 @@ class LogsIngestionClientOperationsMixin(LogsIngestionClientMixinABC):
             raise HttpResponseError(response=response)
 
         if cls:
-            return cls(pipeline_response, None, {})
+            return cls(pipeline_response, None, {})  # type: ignore

--- a/sdk/monitor/azure-monitor-ingestion/azure/monitor/ingestion/_serialization.py
+++ b/sdk/monitor/azure-monitor-ingestion/azure/monitor/ingestion/_serialization.py
@@ -63,8 +63,8 @@ import xml.etree.ElementTree as ET
 
 import isodate  # type: ignore
 
-from azure.core.exceptions import DeserializationError, SerializationError, raise_with_traceback
-from azure.core.serialization import NULL as AzureCoreNull
+from azure.core.exceptions import DeserializationError, SerializationError
+from azure.core.serialization import NULL as CoreNull
 
 _BOM = codecs.BOM_UTF8.decode(encoding="utf-8")
 
@@ -124,7 +124,7 @@ class RawDeserializer:
                     pass
 
                 return ET.fromstring(data_as_str)  # nosec
-            except ET.ParseError:
+            except ET.ParseError as err:
                 # It might be because the server has an issue, and returned JSON with
                 # content-type XML....
                 # So let's try a JSON load, and if it's still broken
@@ -143,7 +143,7 @@ class RawDeserializer:
                 # The function hack is because Py2.7 messes up with exception
                 # context otherwise.
                 _LOGGER.critical("Wasn't XML not JSON, failing")
-                raise_with_traceback(DeserializationError, "XML is invalid")
+                raise DeserializationError("XML is invalid") from err
         raise DeserializationError("Cannot deserialize content-type: {}".format(content_type))
 
     @classmethod
@@ -295,7 +295,7 @@ class Model(object):
     _validation: Dict[str, Dict[str, Any]] = {}
 
     def __init__(self, **kwargs: Any) -> None:
-        self.additional_properties: Dict[str, Any] = {}
+        self.additional_properties: Optional[Dict[str, Any]] = {}
         for k in kwargs:
             if k not in self._attribute_map:
                 _LOGGER.warning("%s is not a known attribute of class %s and will be ignored", k, self.__class__)
@@ -340,7 +340,7 @@ class Model(object):
         return _create_xml_node(xml_map.get("name", cls.__name__), xml_map.get("prefix", None), xml_map.get("ns", None))
 
     def serialize(self, keep_readonly: bool = False, **kwargs: Any) -> JSON:
-        """Return the JSON that would be sent to azure from this model.
+        """Return the JSON that would be sent to server from this model.
 
         This is an alias to `as_dict(full_restapi_key_transformer, keep_readonly=False)`.
 
@@ -351,7 +351,7 @@ class Model(object):
         :rtype: dict
         """
         serializer = Serializer(self._infer_class_models())
-        return serializer._serialize(self, keep_readonly=keep_readonly, **kwargs)
+        return serializer._serialize(self, keep_readonly=keep_readonly, **kwargs)  # type: ignore
 
     def as_dict(
         self,
@@ -390,7 +390,7 @@ class Model(object):
         :rtype: dict
         """
         serializer = Serializer(self._infer_class_models())
-        return serializer._serialize(self, key_transformer=key_transformer, keep_readonly=keep_readonly, **kwargs)
+        return serializer._serialize(self, key_transformer=key_transformer, keep_readonly=keep_readonly, **kwargs)  # type: ignore
 
     @classmethod
     def _infer_class_models(cls):
@@ -415,7 +415,7 @@ class Model(object):
         :raises: DeserializationError if something went wrong
         """
         deserializer = Deserializer(cls._infer_class_models())
-        return deserializer(cls.__name__, data, content_type=content_type)
+        return deserializer(cls.__name__, data, content_type=content_type)  # type: ignore
 
     @classmethod
     def from_dict(
@@ -445,7 +445,7 @@ class Model(object):
             if key_extractors is None
             else key_extractors
         )
-        return deserializer(cls.__name__, data, content_type=content_type)
+        return deserializer(cls.__name__, data, content_type=content_type)  # type: ignore
 
     @classmethod
     def _flatten_subtype(cls, key, objects):
@@ -668,7 +668,7 @@ class Serializer(object):
 
         except (AttributeError, KeyError, TypeError) as err:
             msg = "Attribute {} in object {} cannot be serialized.\n{}".format(attr_name, class_name, str(target_obj))
-            raise_with_traceback(SerializationError, msg, err)
+            raise SerializationError(msg) from err
         else:
             return serialized
 
@@ -710,7 +710,7 @@ class Serializer(object):
                     ]
                 data = deserializer._deserialize(data_type, data)
             except DeserializationError as err:
-                raise_with_traceback(SerializationError, "Unable to build a model: " + str(err), err)
+                raise SerializationError("Unable to build a model: " + str(err)) from err
 
         return self._serialize(data, data_type, **kwargs)
 
@@ -730,7 +730,6 @@ class Serializer(object):
 
             if kwargs.get("skip_quote") is True:
                 output = str(output)
-                # https://github.com/Azure/autorest.python/issues/2063
                 output = output.replace("{", quote("{")).replace("}", quote("}"))
             else:
                 output = quote(str(output), safe="")
@@ -746,7 +745,7 @@ class Serializer(object):
         :param str data_type: The type to be serialized from.
         :keyword bool skip_quote: Whether to skip quote the serialized result.
         Defaults to False.
-        :rtype: str
+        :rtype: str, list
         :raises: TypeError if serialization fails.
         :raises: ValueError if data is None
         """
@@ -755,7 +754,7 @@ class Serializer(object):
             if data_type.startswith("["):
                 internal_data_type = data_type[1:-1]
                 do_quote = not kwargs.get("skip_quote", False)
-                return str(self.serialize_iter(data, internal_data_type, do_quote=do_quote, **kwargs))
+                return self.serialize_iter(data, internal_data_type, do_quote=do_quote, **kwargs)
 
             # Not a list, regular serialization
             output = self.serialize_data(data, data_type, **kwargs)
@@ -806,7 +805,7 @@ class Serializer(object):
             raise ValueError("No value for given attribute")
 
         try:
-            if data is AzureCoreNull:
+            if data is CoreNull:
                 return None
             if data_type in self.basic_types.values():
                 return self.serialize_basic(data, data_type, **kwargs)
@@ -826,7 +825,7 @@ class Serializer(object):
 
         except (ValueError, TypeError) as err:
             msg = "Unable to serialize value: {!r} as type: {!r}."
-            raise_with_traceback(SerializationError, msg.format(data, data_type), err)
+            raise SerializationError(msg.format(data, data_type)) from err
         else:
             return self._serialize(data, **kwargs)
 
@@ -1172,10 +1171,10 @@ class Serializer(object):
             return date + microseconds + "Z"
         except (ValueError, OverflowError) as err:
             msg = "Unable to serialize datetime object."
-            raise_with_traceback(SerializationError, msg, err)
+            raise SerializationError(msg) from err
         except AttributeError as err:
             msg = "ISO-8601 object must be valid Datetime object."
-            raise_with_traceback(TypeError, msg, err)
+            raise TypeError(msg) from err
 
     @staticmethod
     def serialize_unix(attr, **kwargs):
@@ -1211,7 +1210,6 @@ def rest_key_extractor(attr, attr_desc, data):
         if working_data is None:
             # If at any point while following flatten JSON path see None, it means
             # that all properties under are None as well
-            # https://github.com/Azure/msrest-for-python/issues/197
             return None
         key = ".".join(dict_keys[1:])
 
@@ -1232,7 +1230,6 @@ def rest_key_case_insensitive_extractor(attr, attr_desc, data):
         if working_data is None:
             # If at any point while following flatten JSON path see None, it means
             # that all properties under are None as well
-            # https://github.com/Azure/msrest-for-python/issues/197
             return None
         key = ".".join(dict_keys[1:])
 
@@ -1483,7 +1480,7 @@ class Deserializer(object):
                 d_attrs[attr] = value
         except (AttributeError, TypeError, KeyError) as err:
             msg = "Unable to deserialize to object: " + class_name  # type: ignore
-            raise_with_traceback(DeserializationError, msg, err)
+            raise DeserializationError(msg) from err
         else:
             additional_properties = self._build_additional_properties(attributes, data)
             return self._instantiate_model(response, d_attrs, additional_properties)
@@ -1654,7 +1651,7 @@ class Deserializer(object):
         except (ValueError, TypeError, AttributeError) as err:
             msg = "Unable to deserialize response data."
             msg += " Data: {}, {}".format(data, data_type)
-            raise_with_traceback(DeserializationError, msg, err)
+            raise DeserializationError(msg) from err
         else:
             return self._deserialize(obj_type, data)
 
@@ -1810,7 +1807,6 @@ class Deserializer(object):
             data = data.value
         if isinstance(data, int):
             # Workaround. We might consider remove it in the future.
-            # https://github.com/Azure/azure-rest-api-specs/issues/141
             try:
                 return list(enum_obj.__members__.values())[data]
             except IndexError:
@@ -1864,10 +1860,10 @@ class Deserializer(object):
         if isinstance(attr, ET.Element):
             attr = attr.text
         try:
-            return decimal.Decimal(attr)  # type: ignore
+            return decimal.Decimal(str(attr))  # type: ignore
         except decimal.DecimalException as err:
             msg = "Invalid decimal {}".format(attr)
-            raise_with_traceback(DeserializationError, msg, err)
+            raise DeserializationError(msg) from err
 
     @staticmethod
     def deserialize_long(attr):
@@ -1895,7 +1891,7 @@ class Deserializer(object):
             duration = isodate.parse_duration(attr)
         except (ValueError, OverflowError, AttributeError) as err:
             msg = "Cannot deserialize duration object."
-            raise_with_traceback(DeserializationError, msg, err)
+            raise DeserializationError(msg) from err
         else:
             return duration
 
@@ -1947,7 +1943,7 @@ class Deserializer(object):
                 date_obj = date_obj.astimezone(tz=TZ_UTC)
         except ValueError as err:
             msg = "Cannot deserialize to rfc datetime object."
-            raise_with_traceback(DeserializationError, msg, err)
+            raise DeserializationError(msg) from err
         else:
             return date_obj
 
@@ -1984,7 +1980,7 @@ class Deserializer(object):
                 raise OverflowError("Hit max or min date")
         except (ValueError, OverflowError, AttributeError) as err:
             msg = "Cannot deserialize datetime object."
-            raise_with_traceback(DeserializationError, msg, err)
+            raise DeserializationError(msg) from err
         else:
             return date_obj
 
@@ -2000,9 +1996,10 @@ class Deserializer(object):
         if isinstance(attr, ET.Element):
             attr = int(attr.text)  # type: ignore
         try:
+            attr = int(attr)
             date_obj = datetime.datetime.fromtimestamp(attr, TZ_UTC)
         except ValueError as err:
             msg = "Cannot deserialize to unix datetime object."
-            raise_with_traceback(DeserializationError, msg, err)
+            raise DeserializationError(msg) from err
         else:
             return date_obj

--- a/sdk/monitor/azure-monitor-ingestion/azure/monitor/ingestion/aio/_client.py
+++ b/sdk/monitor/azure-monitor-ingestion/azure/monitor/ingestion/aio/_client.py
@@ -10,6 +10,7 @@ from copy import deepcopy
 from typing import Any, Awaitable, TYPE_CHECKING
 
 from azure.core import AsyncPipelineClient
+from azure.core.pipeline import policies
 from azure.core.rest import AsyncHttpResponse, HttpRequest
 
 from .._serialization import Deserializer, Serializer
@@ -37,13 +38,32 @@ class LogsIngestionClient(LogsIngestionClientOperationsMixin):  # pylint: disabl
     def __init__(self, endpoint: str, credential: "AsyncTokenCredential", **kwargs: Any) -> None:
         _endpoint = "{endpoint}"
         self._config = LogsIngestionClientConfiguration(endpoint=endpoint, credential=credential, **kwargs)
-        self._client: AsyncPipelineClient = AsyncPipelineClient(base_url=_endpoint, config=self._config, **kwargs)
+        _policies = kwargs.pop("policies", None)
+        if _policies is None:
+            _policies = [
+                policies.RequestIdPolicy(**kwargs),
+                self._config.headers_policy,
+                self._config.user_agent_policy,
+                self._config.proxy_policy,
+                policies.ContentDecodePolicy(**kwargs),
+                self._config.redirect_policy,
+                self._config.retry_policy,
+                self._config.authentication_policy,
+                self._config.custom_hook_policy,
+                self._config.logging_policy,
+                policies.DistributedTracingPolicy(**kwargs),
+                policies.SensitiveHeaderCleanupPolicy(**kwargs) if self._config.redirect_policy else None,
+                self._config.http_logging_policy,
+            ]
+        self._client: AsyncPipelineClient = AsyncPipelineClient(base_url=_endpoint, policies=_policies, **kwargs)
 
         self._serialize = Serializer()
         self._deserialize = Deserializer()
         self._serialize.client_side_validation = False
 
-    def send_request(self, request: HttpRequest, **kwargs: Any) -> Awaitable[AsyncHttpResponse]:
+    def send_request(
+        self, request: HttpRequest, *, stream: bool = False, **kwargs: Any
+    ) -> Awaitable[AsyncHttpResponse]:
         """Runs the network request through the client's chained policies.
 
         >>> from azure.core.rest import HttpRequest
@@ -67,7 +87,7 @@ class LogsIngestionClient(LogsIngestionClientOperationsMixin):  # pylint: disabl
         }
 
         request_copy.url = self._client.format_url(request_copy.url, **path_format_arguments)
-        return self._client.send_request(request_copy, **kwargs)
+        return self._client.send_request(request_copy, stream=stream, **kwargs)  # type: ignore
 
     async def close(self) -> None:
         await self._client.close()

--- a/sdk/monitor/azure-monitor-ingestion/azure/monitor/ingestion/aio/_configuration.py
+++ b/sdk/monitor/azure-monitor-ingestion/azure/monitor/ingestion/aio/_configuration.py
@@ -8,7 +8,6 @@
 
 from typing import Any, TYPE_CHECKING
 
-from azure.core.configuration import Configuration
 from azure.core.pipeline import policies
 
 if TYPE_CHECKING:
@@ -18,7 +17,7 @@ if TYPE_CHECKING:
 VERSION = "unknown"
 
 
-class LogsIngestionClientConfiguration(Configuration):  # pylint: disable=too-many-instance-attributes,name-too-long
+class LogsIngestionClientConfiguration:  # pylint: disable=too-many-instance-attributes,name-too-long
     """Configuration for LogsIngestionClient.
 
     Note that all parameters used to create this instance are saved as instance
@@ -35,7 +34,6 @@ class LogsIngestionClientConfiguration(Configuration):  # pylint: disable=too-ma
     """
 
     def __init__(self, endpoint: str, credential: "AsyncTokenCredential", **kwargs: Any) -> None:
-        super(LogsIngestionClientConfiguration, self).__init__(**kwargs)
         api_version: str = kwargs.pop("api_version", "2023-01-01")
 
         if endpoint is None:
@@ -48,6 +46,7 @@ class LogsIngestionClientConfiguration(Configuration):  # pylint: disable=too-ma
         self.api_version = api_version
         self.credential_scopes = kwargs.pop("credential_scopes", ["https://monitor.azure.com//.default"])
         kwargs.setdefault("sdk_moniker", "monitor-ingestion/{}".format(VERSION))
+        self.polling_interval = kwargs.get("polling_interval", 30)
         self._configure(**kwargs)
 
     def _configure(self, **kwargs: Any) -> None:
@@ -56,9 +55,9 @@ class LogsIngestionClientConfiguration(Configuration):  # pylint: disable=too-ma
         self.proxy_policy = kwargs.get("proxy_policy") or policies.ProxyPolicy(**kwargs)
         self.logging_policy = kwargs.get("logging_policy") or policies.NetworkTraceLoggingPolicy(**kwargs)
         self.http_logging_policy = kwargs.get("http_logging_policy") or policies.HttpLoggingPolicy(**kwargs)
-        self.retry_policy = kwargs.get("retry_policy") or policies.AsyncRetryPolicy(**kwargs)
         self.custom_hook_policy = kwargs.get("custom_hook_policy") or policies.CustomHookPolicy(**kwargs)
         self.redirect_policy = kwargs.get("redirect_policy") or policies.AsyncRedirectPolicy(**kwargs)
+        self.retry_policy = kwargs.get("retry_policy") or policies.AsyncRetryPolicy(**kwargs)
         self.authentication_policy = kwargs.get("authentication_policy")
         if self.credential and not self.authentication_policy:
             self.authentication_policy = policies.AsyncBearerTokenCredentialPolicy(

--- a/sdk/monitor/azure-monitor-ingestion/azure/monitor/ingestion/aio/_operations/_operations.py
+++ b/sdk/monitor/azure-monitor-ingestion/azure/monitor/ingestion/aio/_operations/_operations.py
@@ -1,4 +1,4 @@
-# pylint: disable=too-many-lines
+# pylint: disable=too-many-lines,too-many-statements
 # coding=utf-8
 # --------------------------------------------------------------------------
 # Copyright (c) Microsoft Corporation. All rights reserved.
@@ -54,7 +54,7 @@ class LogsIngestionClientOperationsMixin(LogsIngestionClientMixinABC):
         self,
         rule_id: str,
         stream: str,
-        body: IO,
+        body: IO[bytes],
         *,
         content_encoding: Optional[str] = None,
         content_type: str = "application/json",
@@ -67,7 +67,7 @@ class LogsIngestionClientOperationsMixin(LogsIngestionClientMixinABC):
         self,
         rule_id: str,
         stream: str,
-        body: Union[List[JSON], IO],
+        body: Union[List[JSON], IO[bytes]],
         *,
         content_encoding: Optional[str] = None,
         **kwargs: Any
@@ -81,8 +81,8 @@ class LogsIngestionClientOperationsMixin(LogsIngestionClientMixinABC):
         :param stream: The streamDeclaration name as defined in the Data Collection Rule. Required.
         :type stream: str
         :param body: An array of objects matching the schema defined by the provided stream. Is either
-         a [JSON] type or a IO type. Required.
-        :type body: list[JSON] or IO
+         a [JSON] type or a IO[bytes] type. Required.
+        :type body: list[JSON] or IO[bytes]
         :keyword content_encoding: gzip. Default value is None.
         :paramtype content_encoding: str
         :keyword content_type: Body Parameter content-type. Known values are: 'application/json'.
@@ -114,7 +114,7 @@ class LogsIngestionClientOperationsMixin(LogsIngestionClientMixinABC):
         else:
             _json = body
 
-        request = build_logs_ingestion_upload_request(
+        _request = build_logs_ingestion_upload_request(
             rule_id=rule_id,
             stream=stream,
             content_encoding=content_encoding,
@@ -128,11 +128,11 @@ class LogsIngestionClientOperationsMixin(LogsIngestionClientMixinABC):
         path_format_arguments = {
             "endpoint": self._serialize.url("self._config.endpoint", self._config.endpoint, "str", skip_quote=True),
         }
-        request.url = self._client.format_url(request.url, **path_format_arguments)
+        _request.url = self._client.format_url(_request.url, **path_format_arguments)
 
         _stream = False
         pipeline_response: PipelineResponse = await self._client._pipeline.run(  # type: ignore # pylint: disable=protected-access
-            request, stream=_stream, **kwargs
+            _request, stream=_stream, **kwargs
         )
 
         response = pipeline_response.http_response
@@ -144,4 +144,4 @@ class LogsIngestionClientOperationsMixin(LogsIngestionClientMixinABC):
             raise HttpResponseError(response=response)
 
         if cls:
-            return cls(pipeline_response, None, {})
+            return cls(pipeline_response, None, {})  # type: ignore

--- a/sdk/monitor/azure-monitor-ingestion/setup.py
+++ b/sdk/monitor/azure-monitor-ingestion/setup.py
@@ -83,7 +83,7 @@ setup(
     ]),
     include_package_data=True,
     install_requires=[
-        'azure-core<2.0.0,>=1.24.0',
+        'azure-core<2.0.0,>=1.28.0',
         'isodate>=0.6.0',
         "typing-extensions>=4.0.1"
     ]

--- a/sdk/monitor/azure-monitor-query/azure/monitor/query/_generated/_serialization.py
+++ b/sdk/monitor/azure-monitor-query/azure/monitor/query/_generated/_serialization.py
@@ -745,7 +745,7 @@ class Serializer(object):
         :param str data_type: The type to be serialized from.
         :keyword bool skip_quote: Whether to skip quote the serialized result.
         Defaults to False.
-        :rtype: str
+        :rtype: str, list
         :raises: TypeError if serialization fails.
         :raises: ValueError if data is None
         """
@@ -1860,7 +1860,7 @@ class Deserializer(object):
         if isinstance(attr, ET.Element):
             attr = attr.text
         try:
-            return decimal.Decimal(attr)  # type: ignore
+            return decimal.Decimal(str(attr))  # type: ignore
         except decimal.DecimalException as err:
             msg = "Invalid decimal {}".format(attr)
             raise DeserializationError(msg) from err
@@ -1996,6 +1996,7 @@ class Deserializer(object):
         if isinstance(attr, ET.Element):
             attr = int(attr.text)  # type: ignore
         try:
+            attr = int(attr)
             date_obj = datetime.datetime.fromtimestamp(attr, TZ_UTC)
         except ValueError as err:
             msg = "Cannot deserialize to unix datetime object."

--- a/sdk/monitor/azure-monitor-query/azure/monitor/query/_generated/aio/operations/_operations.py
+++ b/sdk/monitor/azure-monitor-query/azure/monitor/query/_generated/aio/operations/_operations.py
@@ -1,4 +1,4 @@
-# pylint: disable=too-many-lines
+# pylint: disable=too-many-lines,too-many-statements
 # coding=utf-8
 # --------------------------------------------------------------------------
 # Copyright (c) Microsoft Corporation. All rights reserved.
@@ -66,6 +66,7 @@ class QueryOperations:
     async def get(
         self, workspace_id: str, *, query: str, timespan: Optional[datetime.timedelta] = None, **kwargs: Any
     ) -> JSON:
+        # pylint: disable=line-too-long
         """Execute an Analytics query.
 
         Executes an Analytics query for data.
@@ -190,6 +191,7 @@ class QueryOperations:
         content_type: str = "application/json",
         **kwargs: Any
     ) -> JSON:
+        # pylint: disable=line-too-long
         """Execute an Analytics query.
 
         Executes an Analytics query for data. `Here
@@ -280,12 +282,13 @@ class QueryOperations:
     async def execute(
         self,
         workspace_id: str,
-        body: IO,
+        body: IO[bytes],
         *,
         prefer: Optional[str] = None,
         content_type: str = "application/json",
         **kwargs: Any
     ) -> JSON:
+        # pylint: disable=line-too-long
         """Execute an Analytics query.
 
         Executes an Analytics query for data. `Here
@@ -298,7 +301,7 @@ class QueryOperations:
         :param body: The Analytics query. Learn more about the `Analytics query syntax
          <https://azure.microsoft.com/documentation/articles/app-insights-analytics-reference/>`_.
          Required.
-        :type body: IO
+        :type body: IO[bytes]
         :keyword prefer: Optional. The prefer header to set server timeout, query statistics and
          visualization information. Default value is None.
         :paramtype prefer: str
@@ -362,8 +365,9 @@ class QueryOperations:
 
     @distributed_trace_async
     async def execute(
-        self, workspace_id: str, body: Union[JSON, IO], *, prefer: Optional[str] = None, **kwargs: Any
+        self, workspace_id: str, body: Union[JSON, IO[bytes]], *, prefer: Optional[str] = None, **kwargs: Any
     ) -> JSON:
+        # pylint: disable=line-too-long
         """Execute an Analytics query.
 
         Executes an Analytics query for data. `Here
@@ -375,8 +379,8 @@ class QueryOperations:
         :type workspace_id: str
         :param body: The Analytics query. Learn more about the `Analytics query syntax
          <https://azure.microsoft.com/documentation/articles/app-insights-analytics-reference/>`_. Is
-         either a JSON type or a IO type. Required.
-        :type body: JSON or IO
+         either a JSON type or a IO[bytes] type. Required.
+        :type body: JSON or IO[bytes]
         :keyword prefer: Optional. The prefer header to set server timeout, query statistics and
          visualization information. Default value is None.
         :paramtype prefer: str
@@ -509,6 +513,7 @@ class QueryOperations:
     async def resource_get(
         self, resource_id: str, *, query: str, timespan: Optional[datetime.timedelta] = None, **kwargs: Any
     ) -> JSON:
+        # pylint: disable=line-too-long
         """Execute an Analytics query using resource URI.
 
         Executes an Analytics query for data in the context of a resource. `Here
@@ -634,6 +639,7 @@ class QueryOperations:
         content_type: str = "application/json",
         **kwargs: Any
     ) -> JSON:
+        # pylint: disable=line-too-long
         """Execute an Analytics query using resource ID.
 
         Executes an Analytics query for data in the context of a resource. `Here
@@ -723,12 +729,13 @@ class QueryOperations:
     async def resource_execute(
         self,
         resource_id: str,
-        body: IO,
+        body: IO[bytes],
         *,
         prefer: Optional[str] = None,
         content_type: str = "application/json",
         **kwargs: Any
     ) -> JSON:
+        # pylint: disable=line-too-long
         """Execute an Analytics query using resource ID.
 
         Executes an Analytics query for data in the context of a resource. `Here
@@ -740,7 +747,7 @@ class QueryOperations:
         :param body: The Analytics query. Learn more about the `Analytics query syntax
          <https://azure.microsoft.com/documentation/articles/app-insights-analytics-reference/>`_.
          Required.
-        :type body: IO
+        :type body: IO[bytes]
         :keyword prefer: Optional. The prefer header to set server timeout, query statistics and
          visualization information. Default value is None.
         :paramtype prefer: str
@@ -804,8 +811,9 @@ class QueryOperations:
 
     @distributed_trace_async
     async def resource_execute(
-        self, resource_id: str, body: Union[JSON, IO], *, prefer: Optional[str] = None, **kwargs: Any
+        self, resource_id: str, body: Union[JSON, IO[bytes]], *, prefer: Optional[str] = None, **kwargs: Any
     ) -> JSON:
+        # pylint: disable=line-too-long
         """Execute an Analytics query using resource ID.
 
         Executes an Analytics query for data in the context of a resource. `Here
@@ -816,8 +824,8 @@ class QueryOperations:
         :type resource_id: str
         :param body: The Analytics query. Learn more about the `Analytics query syntax
          <https://azure.microsoft.com/documentation/articles/app-insights-analytics-reference/>`_. Is
-         either a JSON type or a IO type. Required.
-        :type body: JSON or IO
+         either a JSON type or a IO[bytes] type. Required.
+        :type body: JSON or IO[bytes]
         :keyword prefer: Optional. The prefer header to set server timeout, query statistics and
          visualization information. Default value is None.
         :paramtype prefer: str
@@ -948,6 +956,7 @@ class QueryOperations:
 
     @overload
     async def batch(self, body: JSON, *, content_type: str = "application/json", **kwargs: Any) -> JSON:
+        # pylint: disable=line-too-long
         """Execute a batch of Analytics queries.
 
         Executes a batch of Analytics queries for data. `Here
@@ -1071,7 +1080,8 @@ class QueryOperations:
         """
 
     @overload
-    async def batch(self, body: IO, *, content_type: str = "application/json", **kwargs: Any) -> JSON:
+    async def batch(self, body: IO[bytes], *, content_type: str = "application/json", **kwargs: Any) -> JSON:
+        # pylint: disable=line-too-long
         """Execute a batch of Analytics queries.
 
         Executes a batch of Analytics queries for data. `Here
@@ -1079,7 +1089,7 @@ class QueryOperations:
         using POST with an Analytics query.
 
         :param body: The batch request body. Required.
-        :type body: IO
+        :type body: IO[bytes]
         :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
          Default value is "application/json".
         :paramtype content_type: str
@@ -1162,15 +1172,16 @@ class QueryOperations:
         """
 
     @distributed_trace_async
-    async def batch(self, body: Union[JSON, IO], **kwargs: Any) -> JSON:
+    async def batch(self, body: Union[JSON, IO[bytes]], **kwargs: Any) -> JSON:
+        # pylint: disable=line-too-long
         """Execute a batch of Analytics queries.
 
         Executes a batch of Analytics queries for data. `Here
         <https://learn.microsoft.com/azure/azure-monitor/logs/api/batch-queries>`_ is an example for
         using POST with an Analytics query.
 
-        :param body: The batch request body. Is either a JSON type or a IO type. Required.
-        :type body: JSON or IO
+        :param body: The batch request body. Is either a JSON type or a IO[bytes] type. Required.
+        :type body: JSON or IO[bytes]
         :keyword content_type: Body Parameter content-type. Known values are: 'application/json'.
          Default value is None.
         :paramtype content_type: str
@@ -1342,6 +1353,7 @@ class QueryOperations:
     async def resource_get_xms(
         self, resource_id: str, *, query: str, timespan: Optional[datetime.timedelta] = None, **kwargs: Any
     ) -> JSON:
+        # pylint: disable=line-too-long
         """Execute an Analytics query using resource URI.
 
         Executes an Analytics query for data in the context of a resource. `Here
@@ -1467,6 +1479,7 @@ class QueryOperations:
         content_type: str = "application/json",
         **kwargs: Any
     ) -> JSON:
+        # pylint: disable=line-too-long
         """Execute an Analytics query using resource ID.
 
         Executes an Analytics query for data in the context of a resource. `Here
@@ -1556,12 +1569,13 @@ class QueryOperations:
     async def resource_execute_xms(
         self,
         resource_id: str,
-        body: IO,
+        body: IO[bytes],
         *,
         prefer: Optional[str] = None,
         content_type: str = "application/json",
         **kwargs: Any
     ) -> JSON:
+        # pylint: disable=line-too-long
         """Execute an Analytics query using resource ID.
 
         Executes an Analytics query for data in the context of a resource. `Here
@@ -1573,7 +1587,7 @@ class QueryOperations:
         :param body: The Analytics query. Learn more about the `Analytics query syntax
          <https://azure.microsoft.com/documentation/articles/app-insights-analytics-reference/>`_.
          Required.
-        :type body: IO
+        :type body: IO[bytes]
         :keyword prefer: Optional. The prefer header to set server timeout, query statistics and
          visualization information. Default value is None.
         :paramtype prefer: str
@@ -1637,8 +1651,9 @@ class QueryOperations:
 
     @distributed_trace_async
     async def resource_execute_xms(
-        self, resource_id: str, body: Union[JSON, IO], *, prefer: Optional[str] = None, **kwargs: Any
+        self, resource_id: str, body: Union[JSON, IO[bytes]], *, prefer: Optional[str] = None, **kwargs: Any
     ) -> JSON:
+        # pylint: disable=line-too-long
         """Execute an Analytics query using resource ID.
 
         Executes an Analytics query for data in the context of a resource. `Here
@@ -1649,8 +1664,8 @@ class QueryOperations:
         :type resource_id: str
         :param body: The Analytics query. Learn more about the `Analytics query syntax
          <https://azure.microsoft.com/documentation/articles/app-insights-analytics-reference/>`_. Is
-         either a JSON type or a IO type. Required.
-        :type body: JSON or IO
+         either a JSON type or a IO[bytes] type. Required.
+        :type body: JSON or IO[bytes]
         :keyword prefer: Optional. The prefer header to set server timeout, query statistics and
          visualization information. Default value is None.
         :paramtype prefer: str
@@ -1799,6 +1814,7 @@ class MetadataOperations:
 
     @distributed_trace_async
     async def get(self, workspace_id: str, **kwargs: Any) -> JSON:
+        # pylint: disable=line-too-long
         """Gets metadata information.
 
         Retrieve the metadata information for the workspace, including its schema, functions, workspace
@@ -2200,6 +2216,7 @@ class MetadataOperations:
 
     @distributed_trace_async
     async def post(self, workspace_id: str, **kwargs: Any) -> JSON:
+        # pylint: disable=line-too-long
         """Gets metadata information.
 
         Retrieve the metadata information for the workspace, including its schema, functions, workspace

--- a/sdk/monitor/azure-monitor-query/azure/monitor/query/_generated/metrics/_serialization.py
+++ b/sdk/monitor/azure-monitor-query/azure/monitor/query/_generated/metrics/_serialization.py
@@ -745,7 +745,7 @@ class Serializer(object):
         :param str data_type: The type to be serialized from.
         :keyword bool skip_quote: Whether to skip quote the serialized result.
         Defaults to False.
-        :rtype: str
+        :rtype: str, list
         :raises: TypeError if serialization fails.
         :raises: ValueError if data is None
         """
@@ -1860,7 +1860,7 @@ class Deserializer(object):
         if isinstance(attr, ET.Element):
             attr = attr.text
         try:
-            return decimal.Decimal(attr)  # type: ignore
+            return decimal.Decimal(str(attr))  # type: ignore
         except decimal.DecimalException as err:
             msg = "Invalid decimal {}".format(attr)
             raise DeserializationError(msg) from err
@@ -1996,6 +1996,7 @@ class Deserializer(object):
         if isinstance(attr, ET.Element):
             attr = int(attr.text)  # type: ignore
         try:
+            attr = int(attr)
             date_obj = datetime.datetime.fromtimestamp(attr, TZ_UTC)
         except ValueError as err:
             msg = "Cannot deserialize to unix datetime object."

--- a/sdk/monitor/azure-monitor-query/azure/monitor/query/_generated/metrics/aio/operations/_operations.py
+++ b/sdk/monitor/azure-monitor-query/azure/monitor/query/_generated/metrics/aio/operations/_operations.py
@@ -1,4 +1,4 @@
-# pylint: disable=too-many-lines
+# pylint: disable=too-many-lines,too-many-statements
 # coding=utf-8
 # --------------------------------------------------------------------------
 # Copyright (c) Microsoft Corporation. All rights reserved.
@@ -59,6 +59,7 @@ class MetricDefinitionsOperations:
 
     @distributed_trace
     def list(self, resource_uri: str, *, metricnamespace: Optional[str] = None, **kwargs: Any) -> AsyncIterable[JSON]:
+        # pylint: disable=line-too-long
         """Lists the metric definitions for the resource.
 
         :param resource_uri: The identifier of the resource. Required.
@@ -211,6 +212,7 @@ class MetricsOperations:
         metricnamespace: Optional[str] = None,
         **kwargs: Any
     ) -> JSON:
+        # pylint: disable=line-too-long
         """**Lists the metric values for a resource**.
 
         :param resource_uri: The identifier of the resource. Required.

--- a/sdk/monitor/azure-monitor-query/azure/monitor/query/_generated/metrics/batch/_serialization.py
+++ b/sdk/monitor/azure-monitor-query/azure/monitor/query/_generated/metrics/batch/_serialization.py
@@ -745,7 +745,7 @@ class Serializer(object):
         :param str data_type: The type to be serialized from.
         :keyword bool skip_quote: Whether to skip quote the serialized result.
         Defaults to False.
-        :rtype: str
+        :rtype: str, list
         :raises: TypeError if serialization fails.
         :raises: ValueError if data is None
         """
@@ -1860,7 +1860,7 @@ class Deserializer(object):
         if isinstance(attr, ET.Element):
             attr = attr.text
         try:
-            return decimal.Decimal(attr)  # type: ignore
+            return decimal.Decimal(str(attr))  # type: ignore
         except decimal.DecimalException as err:
             msg = "Invalid decimal {}".format(attr)
             raise DeserializationError(msg) from err
@@ -1996,6 +1996,7 @@ class Deserializer(object):
         if isinstance(attr, ET.Element):
             attr = int(attr.text)  # type: ignore
         try:
+            attr = int(attr)
             date_obj = datetime.datetime.fromtimestamp(attr, TZ_UTC)
         except ValueError as err:
             msg = "Cannot deserialize to unix datetime object."

--- a/sdk/monitor/azure-monitor-query/azure/monitor/query/_generated/metrics/batch/aio/operations/_operations.py
+++ b/sdk/monitor/azure-monitor-query/azure/monitor/query/_generated/metrics/batch/aio/operations/_operations.py
@@ -1,4 +1,4 @@
-# pylint: disable=too-many-lines
+# pylint: disable=too-many-lines,too-many-statements
 # coding=utf-8
 # --------------------------------------------------------------------------
 # Copyright (c) Microsoft Corporation. All rights reserved.
@@ -70,6 +70,7 @@ class MetricsBatchOperations:
         content_type: str = "application/json",
         **kwargs: Any
     ) -> JSON:
+        # pylint: disable=line-too-long
         """Lists the metric values for multiple resources.
 
         :param subscription_id: The subscription identifier for the resources in this batch. Required.
@@ -221,7 +222,7 @@ class MetricsBatchOperations:
     async def batch(
         self,
         subscription_id: str,
-        resource_ids: IO,
+        resource_ids: IO[bytes],
         *,
         metricnamespace: str,
         metricnames: List[str],
@@ -235,12 +236,13 @@ class MetricsBatchOperations:
         content_type: str = "application/json",
         **kwargs: Any
     ) -> JSON:
+        # pylint: disable=line-too-long
         """Lists the metric values for multiple resources.
 
         :param subscription_id: The subscription identifier for the resources in this batch. Required.
         :type subscription_id: str
         :param resource_ids: The comma separated list of resource IDs to query metrics for. Required.
-        :type resource_ids: IO
+        :type resource_ids: IO[bytes]
         :keyword metricnamespace: Metric namespace that contains the requested metric names. Required.
         :paramtype metricnamespace: str
         :keyword metricnames: The names of the metrics (comma separated) to retrieve. Required.
@@ -379,7 +381,7 @@ class MetricsBatchOperations:
     async def batch(
         self,
         subscription_id: str,
-        resource_ids: Union[JSON, IO],
+        resource_ids: Union[JSON, IO[bytes]],
         *,
         metricnamespace: str,
         metricnames: List[str],
@@ -392,13 +394,14 @@ class MetricsBatchOperations:
         filter: Optional[str] = None,
         **kwargs: Any
     ) -> JSON:
+        # pylint: disable=line-too-long
         """Lists the metric values for multiple resources.
 
         :param subscription_id: The subscription identifier for the resources in this batch. Required.
         :type subscription_id: str
         :param resource_ids: The comma separated list of resource IDs to query metrics for. Is either a
-         JSON type or a IO type. Required.
-        :type resource_ids: JSON or IO
+         JSON type or a IO[bytes] type. Required.
+        :type resource_ids: JSON or IO[bytes]
         :keyword metricnamespace: Metric namespace that contains the requested metric names. Required.
         :paramtype metricnamespace: str
         :keyword metricnames: The names of the metrics (comma separated) to retrieve. Required.

--- a/sdk/monitor/azure-monitor-query/azure/monitor/query/_generated/metrics/batch/operations/_operations.py
+++ b/sdk/monitor/azure-monitor-query/azure/monitor/query/_generated/metrics/batch/operations/_operations.py
@@ -1,4 +1,4 @@
-# pylint: disable=too-many-lines
+# pylint: disable=too-many-lines,too-many-statements
 # coding=utf-8
 # --------------------------------------------------------------------------
 # Copyright (c) Microsoft Corporation. All rights reserved.
@@ -129,6 +129,7 @@ class MetricsBatchOperations:
         content_type: str = "application/json",
         **kwargs: Any
     ) -> JSON:
+        # pylint: disable=line-too-long
         """Lists the metric values for multiple resources.
 
         :param subscription_id: The subscription identifier for the resources in this batch. Required.
@@ -280,7 +281,7 @@ class MetricsBatchOperations:
     def batch(
         self,
         subscription_id: str,
-        resource_ids: IO,
+        resource_ids: IO[bytes],
         *,
         metricnamespace: str,
         metricnames: List[str],
@@ -294,12 +295,13 @@ class MetricsBatchOperations:
         content_type: str = "application/json",
         **kwargs: Any
     ) -> JSON:
+        # pylint: disable=line-too-long
         """Lists the metric values for multiple resources.
 
         :param subscription_id: The subscription identifier for the resources in this batch. Required.
         :type subscription_id: str
         :param resource_ids: The comma separated list of resource IDs to query metrics for. Required.
-        :type resource_ids: IO
+        :type resource_ids: IO[bytes]
         :keyword metricnamespace: Metric namespace that contains the requested metric names. Required.
         :paramtype metricnamespace: str
         :keyword metricnames: The names of the metrics (comma separated) to retrieve. Required.
@@ -438,7 +440,7 @@ class MetricsBatchOperations:
     def batch(
         self,
         subscription_id: str,
-        resource_ids: Union[JSON, IO],
+        resource_ids: Union[JSON, IO[bytes]],
         *,
         metricnamespace: str,
         metricnames: List[str],
@@ -451,13 +453,14 @@ class MetricsBatchOperations:
         filter: Optional[str] = None,
         **kwargs: Any
     ) -> JSON:
+        # pylint: disable=line-too-long
         """Lists the metric values for multiple resources.
 
         :param subscription_id: The subscription identifier for the resources in this batch. Required.
         :type subscription_id: str
         :param resource_ids: The comma separated list of resource IDs to query metrics for. Is either a
-         JSON type or a IO type. Required.
-        :type resource_ids: JSON or IO
+         JSON type or a IO[bytes] type. Required.
+        :type resource_ids: JSON or IO[bytes]
         :keyword metricnamespace: Metric namespace that contains the requested metric names. Required.
         :paramtype metricnamespace: str
         :keyword metricnames: The names of the metrics (comma separated) to retrieve. Required.

--- a/sdk/monitor/azure-monitor-query/azure/monitor/query/_generated/metrics/operations/_operations.py
+++ b/sdk/monitor/azure-monitor-query/azure/monitor/query/_generated/metrics/operations/_operations.py
@@ -1,4 +1,4 @@
-# pylint: disable=too-many-lines
+# pylint: disable=too-many-lines,too-many-statements
 # coding=utf-8
 # --------------------------------------------------------------------------
 # Copyright (c) Microsoft Corporation. All rights reserved.
@@ -168,6 +168,7 @@ class MetricDefinitionsOperations:
 
     @distributed_trace
     def list(self, resource_uri: str, *, metricnamespace: Optional[str] = None, **kwargs: Any) -> Iterable[JSON]:
+        # pylint: disable=line-too-long
         """Lists the metric definitions for the resource.
 
         :param resource_uri: The identifier of the resource. Required.
@@ -320,6 +321,7 @@ class MetricsOperations:
         metricnamespace: Optional[str] = None,
         **kwargs: Any
     ) -> JSON:
+        # pylint: disable=line-too-long
         """**Lists the metric values for a resource**.
 
         :param resource_uri: The identifier of the resource. Required.

--- a/sdk/monitor/azure-monitor-query/azure/monitor/query/_generated/operations/_operations.py
+++ b/sdk/monitor/azure-monitor-query/azure/monitor/query/_generated/operations/_operations.py
@@ -1,4 +1,4 @@
-# pylint: disable=too-many-lines
+# pylint: disable=too-many-lines,too-many-statements
 # coding=utf-8
 # --------------------------------------------------------------------------
 # Copyright (c) Microsoft Corporation. All rights reserved.
@@ -271,6 +271,7 @@ class QueryOperations:
     def get(
         self, workspace_id: str, *, query: str, timespan: Optional[datetime.timedelta] = None, **kwargs: Any
     ) -> JSON:
+        # pylint: disable=line-too-long
         """Execute an Analytics query.
 
         Executes an Analytics query for data.
@@ -395,6 +396,7 @@ class QueryOperations:
         content_type: str = "application/json",
         **kwargs: Any
     ) -> JSON:
+        # pylint: disable=line-too-long
         """Execute an Analytics query.
 
         Executes an Analytics query for data. `Here
@@ -485,12 +487,13 @@ class QueryOperations:
     def execute(
         self,
         workspace_id: str,
-        body: IO,
+        body: IO[bytes],
         *,
         prefer: Optional[str] = None,
         content_type: str = "application/json",
         **kwargs: Any
     ) -> JSON:
+        # pylint: disable=line-too-long
         """Execute an Analytics query.
 
         Executes an Analytics query for data. `Here
@@ -503,7 +506,7 @@ class QueryOperations:
         :param body: The Analytics query. Learn more about the `Analytics query syntax
          <https://azure.microsoft.com/documentation/articles/app-insights-analytics-reference/>`_.
          Required.
-        :type body: IO
+        :type body: IO[bytes]
         :keyword prefer: Optional. The prefer header to set server timeout, query statistics and
          visualization information. Default value is None.
         :paramtype prefer: str
@@ -566,7 +569,10 @@ class QueryOperations:
         """
 
     @distributed_trace
-    def execute(self, workspace_id: str, body: Union[JSON, IO], *, prefer: Optional[str] = None, **kwargs: Any) -> JSON:
+    def execute(
+        self, workspace_id: str, body: Union[JSON, IO[bytes]], *, prefer: Optional[str] = None, **kwargs: Any
+    ) -> JSON:
+        # pylint: disable=line-too-long
         """Execute an Analytics query.
 
         Executes an Analytics query for data. `Here
@@ -578,8 +584,8 @@ class QueryOperations:
         :type workspace_id: str
         :param body: The Analytics query. Learn more about the `Analytics query syntax
          <https://azure.microsoft.com/documentation/articles/app-insights-analytics-reference/>`_. Is
-         either a JSON type or a IO type. Required.
-        :type body: JSON or IO
+         either a JSON type or a IO[bytes] type. Required.
+        :type body: JSON or IO[bytes]
         :keyword prefer: Optional. The prefer header to set server timeout, query statistics and
          visualization information. Default value is None.
         :paramtype prefer: str
@@ -712,6 +718,7 @@ class QueryOperations:
     def resource_get(
         self, resource_id: str, *, query: str, timespan: Optional[datetime.timedelta] = None, **kwargs: Any
     ) -> JSON:
+        # pylint: disable=line-too-long
         """Execute an Analytics query using resource URI.
 
         Executes an Analytics query for data in the context of a resource. `Here
@@ -837,6 +844,7 @@ class QueryOperations:
         content_type: str = "application/json",
         **kwargs: Any
     ) -> JSON:
+        # pylint: disable=line-too-long
         """Execute an Analytics query using resource ID.
 
         Executes an Analytics query for data in the context of a resource. `Here
@@ -926,12 +934,13 @@ class QueryOperations:
     def resource_execute(
         self,
         resource_id: str,
-        body: IO,
+        body: IO[bytes],
         *,
         prefer: Optional[str] = None,
         content_type: str = "application/json",
         **kwargs: Any
     ) -> JSON:
+        # pylint: disable=line-too-long
         """Execute an Analytics query using resource ID.
 
         Executes an Analytics query for data in the context of a resource. `Here
@@ -943,7 +952,7 @@ class QueryOperations:
         :param body: The Analytics query. Learn more about the `Analytics query syntax
          <https://azure.microsoft.com/documentation/articles/app-insights-analytics-reference/>`_.
          Required.
-        :type body: IO
+        :type body: IO[bytes]
         :keyword prefer: Optional. The prefer header to set server timeout, query statistics and
          visualization information. Default value is None.
         :paramtype prefer: str
@@ -1007,8 +1016,9 @@ class QueryOperations:
 
     @distributed_trace
     def resource_execute(
-        self, resource_id: str, body: Union[JSON, IO], *, prefer: Optional[str] = None, **kwargs: Any
+        self, resource_id: str, body: Union[JSON, IO[bytes]], *, prefer: Optional[str] = None, **kwargs: Any
     ) -> JSON:
+        # pylint: disable=line-too-long
         """Execute an Analytics query using resource ID.
 
         Executes an Analytics query for data in the context of a resource. `Here
@@ -1019,8 +1029,8 @@ class QueryOperations:
         :type resource_id: str
         :param body: The Analytics query. Learn more about the `Analytics query syntax
          <https://azure.microsoft.com/documentation/articles/app-insights-analytics-reference/>`_. Is
-         either a JSON type or a IO type. Required.
-        :type body: JSON or IO
+         either a JSON type or a IO[bytes] type. Required.
+        :type body: JSON or IO[bytes]
         :keyword prefer: Optional. The prefer header to set server timeout, query statistics and
          visualization information. Default value is None.
         :paramtype prefer: str
@@ -1151,6 +1161,7 @@ class QueryOperations:
 
     @overload
     def batch(self, body: JSON, *, content_type: str = "application/json", **kwargs: Any) -> JSON:
+        # pylint: disable=line-too-long
         """Execute a batch of Analytics queries.
 
         Executes a batch of Analytics queries for data. `Here
@@ -1274,7 +1285,8 @@ class QueryOperations:
         """
 
     @overload
-    def batch(self, body: IO, *, content_type: str = "application/json", **kwargs: Any) -> JSON:
+    def batch(self, body: IO[bytes], *, content_type: str = "application/json", **kwargs: Any) -> JSON:
+        # pylint: disable=line-too-long
         """Execute a batch of Analytics queries.
 
         Executes a batch of Analytics queries for data. `Here
@@ -1282,7 +1294,7 @@ class QueryOperations:
         using POST with an Analytics query.
 
         :param body: The batch request body. Required.
-        :type body: IO
+        :type body: IO[bytes]
         :keyword content_type: Body Parameter content-type. Content type parameter for binary body.
          Default value is "application/json".
         :paramtype content_type: str
@@ -1365,15 +1377,16 @@ class QueryOperations:
         """
 
     @distributed_trace
-    def batch(self, body: Union[JSON, IO], **kwargs: Any) -> JSON:
+    def batch(self, body: Union[JSON, IO[bytes]], **kwargs: Any) -> JSON:
+        # pylint: disable=line-too-long
         """Execute a batch of Analytics queries.
 
         Executes a batch of Analytics queries for data. `Here
         <https://learn.microsoft.com/azure/azure-monitor/logs/api/batch-queries>`_ is an example for
         using POST with an Analytics query.
 
-        :param body: The batch request body. Is either a JSON type or a IO type. Required.
-        :type body: JSON or IO
+        :param body: The batch request body. Is either a JSON type or a IO[bytes] type. Required.
+        :type body: JSON or IO[bytes]
         :keyword content_type: Body Parameter content-type. Known values are: 'application/json'.
          Default value is None.
         :paramtype content_type: str
@@ -1545,6 +1558,7 @@ class QueryOperations:
     def resource_get_xms(
         self, resource_id: str, *, query: str, timespan: Optional[datetime.timedelta] = None, **kwargs: Any
     ) -> JSON:
+        # pylint: disable=line-too-long
         """Execute an Analytics query using resource URI.
 
         Executes an Analytics query for data in the context of a resource. `Here
@@ -1670,6 +1684,7 @@ class QueryOperations:
         content_type: str = "application/json",
         **kwargs: Any
     ) -> JSON:
+        # pylint: disable=line-too-long
         """Execute an Analytics query using resource ID.
 
         Executes an Analytics query for data in the context of a resource. `Here
@@ -1759,12 +1774,13 @@ class QueryOperations:
     def resource_execute_xms(
         self,
         resource_id: str,
-        body: IO,
+        body: IO[bytes],
         *,
         prefer: Optional[str] = None,
         content_type: str = "application/json",
         **kwargs: Any
     ) -> JSON:
+        # pylint: disable=line-too-long
         """Execute an Analytics query using resource ID.
 
         Executes an Analytics query for data in the context of a resource. `Here
@@ -1776,7 +1792,7 @@ class QueryOperations:
         :param body: The Analytics query. Learn more about the `Analytics query syntax
          <https://azure.microsoft.com/documentation/articles/app-insights-analytics-reference/>`_.
          Required.
-        :type body: IO
+        :type body: IO[bytes]
         :keyword prefer: Optional. The prefer header to set server timeout, query statistics and
          visualization information. Default value is None.
         :paramtype prefer: str
@@ -1840,8 +1856,9 @@ class QueryOperations:
 
     @distributed_trace
     def resource_execute_xms(
-        self, resource_id: str, body: Union[JSON, IO], *, prefer: Optional[str] = None, **kwargs: Any
+        self, resource_id: str, body: Union[JSON, IO[bytes]], *, prefer: Optional[str] = None, **kwargs: Any
     ) -> JSON:
+        # pylint: disable=line-too-long
         """Execute an Analytics query using resource ID.
 
         Executes an Analytics query for data in the context of a resource. `Here
@@ -1852,8 +1869,8 @@ class QueryOperations:
         :type resource_id: str
         :param body: The Analytics query. Learn more about the `Analytics query syntax
          <https://azure.microsoft.com/documentation/articles/app-insights-analytics-reference/>`_. Is
-         either a JSON type or a IO type. Required.
-        :type body: JSON or IO
+         either a JSON type or a IO[bytes] type. Required.
+        :type body: JSON or IO[bytes]
         :keyword prefer: Optional. The prefer header to set server timeout, query statistics and
          visualization information. Default value is None.
         :paramtype prefer: str
@@ -2002,6 +2019,7 @@ class MetadataOperations:
 
     @distributed_trace
     def get(self, workspace_id: str, **kwargs: Any) -> JSON:
+        # pylint: disable=line-too-long
         """Gets metadata information.
 
         Retrieve the metadata information for the workspace, including its schema, functions, workspace
@@ -2403,6 +2421,7 @@ class MetadataOperations:
 
     @distributed_trace
     def post(self, workspace_id: str, **kwargs: Any) -> JSON:
+        # pylint: disable=line-too-long
         """Gets metadata information.
 
         Retrieve the metadata information for the workspace, including its schema, functions, workspace


### PR DESCRIPTION
Regenerated `azure-monitor-query` and `azure-monitor-ingestion` with the latest autorest. This should resolve some `next-pylint` issues.

Closes: #32612