### PR TITLE
Fix low performance of async download routines

### DIFF
--- a/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_download_async.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_download_async.py
@@ -527,11 +527,11 @@ class StorageStreamDownloader(Generic[T]):  # pylint: disable=too-many-instance-
                 except HttpResponseError as error:
                     process_storage_error(error)
                 try:
-                    next_chunk = next(dl_tasks)
+                    for _ in range(0, len(done)):
+                        next_chunk = next(dl_tasks)
+                        running_futures.add(asyncio.ensure_future(downloader.process_chunk(next_chunk)))
                 except StopIteration:
                     break
-                else:
-                    running_futures.add(asyncio.ensure_future(downloader.process_chunk(next_chunk)))
 
             if running_futures:
                 # Wait for the remaining downloads to finish
@@ -683,11 +683,11 @@ class StorageStreamDownloader(Generic[T]):  # pylint: disable=too-many-instance-
             except HttpResponseError as error:
                 process_storage_error(error)
             try:
-                next_chunk = next(dl_tasks)
+                for _ in range(0, len(done)):
+                    next_chunk = next(dl_tasks)
+                    running_futures.add(asyncio.ensure_future(downloader.process_chunk(next_chunk)))
             except StopIteration:
                 break
-            else:
-                running_futures.add(asyncio.ensure_future(downloader.process_chunk(next_chunk)))
 
         if running_futures:
             # Wait for the remaining downloads to finish


### PR DESCRIPTION
# Description

This PR fixes the performance of download routines when max_concurrency is bigger than 1. On large files (5-10GB+) with a max_concurrency set to a big enough value, like 20 the performance drops sharply, leading to increased download times. The download starts at about 100MB/s while the average for the whole duration drops to about 20MB/s.

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
