### PR TITLE
[Storage] Fix error handling for AAD error responses

### DIFF
--- a/sdk/storage/azure-storage-blob/CHANGELOG.md
+++ b/sdk/storage/azure-storage-blob/CHANGELOG.md
@@ -7,6 +7,8 @@
 ### Bugs Fixed
 - Bumped dependency of `typing-extensions` to `>=4.6.0` to avoid potential `TypeError` with `typing.TypeVar` on
 Python 3.12.
+- Fixed an issue where authentication errors could raise `AttributeError` instead of `ClientAuthenticationError` when
+using async OAuth credentials.
 
 ## 12.19.0 (2023-11-07)
 

--- a/sdk/storage/azure-storage-blob/assets.json
+++ b/sdk/storage/azure-storage-blob/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "python",
   "TagPrefix": "python/storage/azure-storage-blob",
-  "Tag": "python/storage/azure-storage-blob_12c8154ae2"
+  "Tag": "python/storage/azure-storage-blob_ad4923b44f"
 }

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/response_handlers.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/response_handlers.py
@@ -116,7 +116,8 @@ def process_storage_error(storage_error) -> NoReturn: # type: ignore [misc] # py
             error_dict = {'message': str(error_body)}
 
         # If we extracted from a Json or XML response
-        if error_dict:
+        # There is a chance error_dict is just a string
+        if error_dict and isinstance(error_dict, dict):
             error_code = error_dict.get('code')
             error_message = error_dict.get('message')
             additional_data = {k: v for k, v in error_dict.items() if k not in {'code', 'message'}}

--- a/sdk/storage/azure-storage-blob/tests/test_common_blob.py
+++ b/sdk/storage/azure-storage-blob/tests/test_common_blob.py
@@ -3335,4 +3335,29 @@ class TestStorageCommonBlob(StorageRecordedTestCase):
         response = blob.exists()
         assert response is not None
 
+    @pytest.mark.live_test_only
+    @BlobPreparer()
+    def test_oauth_error_handling(self, **kwargs):
+        storage_account_name = kwargs.pop("storage_account_name")
+
+        # Arrange
+        if self.is_live:
+            from azure.identity import ClientSecretCredential
+
+            # Generate an invalid credential
+            creds = ClientSecretCredential(
+                self.get_settings_value("TENANT_ID"),
+                self.get_settings_value("CLIENT_ID"),
+                self.get_settings_value("CLIENT_SECRET") + 'a',
+            )
+        else:
+            creds = self.generate_fake_token()
+
+        bsc = BlobServiceClient(self.account_url(storage_account_name, "blob"), credential=creds, retry_total=0)
+        container = bsc.get_container_client('testing')
+
+        # Act
+        with pytest.raises(ClientAuthenticationError):
+            container.exists()
+
     # ------------------------------------------------------------------------------

--- a/sdk/storage/azure-storage-blob/tests/test_common_blob.py
+++ b/sdk/storage/azure-storage-blob/tests/test_common_blob.py
@@ -3341,17 +3341,14 @@ class TestStorageCommonBlob(StorageRecordedTestCase):
         storage_account_name = kwargs.pop("storage_account_name")
 
         # Arrange
-        if self.is_live:
-            from azure.identity import ClientSecretCredential
+        from azure.identity import ClientSecretCredential
 
-            # Generate an invalid credential
-            creds = ClientSecretCredential(
-                self.get_settings_value("TENANT_ID"),
-                self.get_settings_value("CLIENT_ID"),
-                self.get_settings_value("CLIENT_SECRET") + 'a',
-            )
-        else:
-            creds = self.generate_fake_token()
+        # Generate an invalid credential
+        creds = ClientSecretCredential(
+            self.get_settings_value("TENANT_ID"),
+            self.get_settings_value("CLIENT_ID"),
+            self.get_settings_value("CLIENT_SECRET") + 'a'
+        )
 
         bsc = BlobServiceClient(self.account_url(storage_account_name, "blob"), credential=creds, retry_total=0)
         container = bsc.get_container_client('testing')

--- a/sdk/storage/azure-storage-blob/tests/test_common_blob_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_common_blob_async.py
@@ -3260,4 +3260,28 @@ class TestStorageCommonBlobAsync(AsyncStorageRecordedTestCase):
         response = await blob.exists()
         assert response is not None
 
+    @pytest.mark.live_test_only
+    @BlobPreparer()
+    async def test_oauth_error_handling(self, **kwargs):
+        storage_account_name = kwargs.pop("storage_account_name")
+
+        # Arrange
+        if self.is_live:
+            from azure.identity.aio import ClientSecretCredential
+
+            # Generate an invalid credential
+            creds = ClientSecretCredential(
+                self.get_settings_value("TENANT_ID"),
+                self.get_settings_value("CLIENT_ID"),
+                self.get_settings_value("CLIENT_SECRET") + 'a',
+            )
+        else:
+            creds = self.generate_fake_token()
+
+        bsc = BlobServiceClient(self.account_url(storage_account_name, "blob"), credential=creds, retry_total=0)
+        container = bsc.get_container_client('testing')
+
+        # Act
+        with pytest.raises(ClientAuthenticationError):
+            await container.exists()
 # ------------------------------------------------------------------------------

--- a/sdk/storage/azure-storage-blob/tests/test_common_blob_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_common_blob_async.py
@@ -3266,17 +3266,14 @@ class TestStorageCommonBlobAsync(AsyncStorageRecordedTestCase):
         storage_account_name = kwargs.pop("storage_account_name")
 
         # Arrange
-        if self.is_live:
-            from azure.identity.aio import ClientSecretCredential
+        from azure.identity.aio import ClientSecretCredential
 
-            # Generate an invalid credential
-            creds = ClientSecretCredential(
-                self.get_settings_value("TENANT_ID"),
-                self.get_settings_value("CLIENT_ID"),
-                self.get_settings_value("CLIENT_SECRET") + 'a',
-            )
-        else:
-            creds = self.generate_fake_token()
+        # Generate an invalid credential
+        creds = ClientSecretCredential(
+            self.get_settings_value("TENANT_ID"),
+            self.get_settings_value("CLIENT_ID"),
+            self.get_settings_value("CLIENT_SECRET") + 'a'
+        )
 
         bsc = BlobServiceClient(self.account_url(storage_account_name, "blob"), credential=creds, retry_total=0)
         container = bsc.get_container_client('testing')

--- a/sdk/storage/azure-storage-file-datalake/CHANGELOG.md
+++ b/sdk/storage/azure-storage-file-datalake/CHANGELOG.md
@@ -7,6 +7,8 @@
 ### Bugs Fixed
 - Bumped dependency of `typing-extensions` to `>=4.6.0` to avoid potential `TypeError` with `typing.TypeVar` on
 Python 3.12.
+- Fixed an issue where authentication errors could raise `AttributeError` instead of `ClientAuthenticationError` when
+using async OAuth credentials.
 
 ## 12.14.0 (2023-11-07)
 

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/response_handlers.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/response_handlers.py
@@ -115,6 +115,7 @@ def process_storage_error(storage_error) -> NoReturn: # type: ignore [misc] # py
                 'Unexpected return type %s from ContentDecodePolicy.deserialize_from_http_generics.', type(error_body))
             error_dict = {'message': str(error_body)}
 
+        # If we extracted from a Json or XML response
         # There is a chance error_dict is just a string
         if error_dict and isinstance(error_dict, dict):
             error_code = error_dict.get('code')

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/response_handlers.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/response_handlers.py
@@ -115,8 +115,8 @@ def process_storage_error(storage_error) -> NoReturn: # type: ignore [misc] # py
                 'Unexpected return type %s from ContentDecodePolicy.deserialize_from_http_generics.', type(error_body))
             error_dict = {'message': str(error_body)}
 
-        # If we extracted from a Json or XML response
-        if error_dict:
+        # There is a chance error_dict is just a string
+        if error_dict and isinstance(error_dict, dict):
             error_code = error_dict.get('code')
             error_message = error_dict.get('message')
             additional_data = {k: v for k, v in error_dict.items() if k not in {'code', 'message'}}

--- a/sdk/storage/azure-storage-file-share/CHANGELOG.md
+++ b/sdk/storage/azure-storage-file-share/CHANGELOG.md
@@ -10,6 +10,8 @@
 pointing to the root of the file share would raise an `InvalidResourceName` on any operations.
 - Bumped dependency of `typing-extensions` to `>=4.6.0` to avoid potential `TypeError` with `typing.TypeVar` on
 Python 3.12.
+- Fixed an issue where authentication errors could raise `AttributeError` instead of `ClientAuthenticationError` when
+using async OAuth credentials.
 
 ## 12.15.0 (2023-11-07)
 

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/response_handlers.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/response_handlers.py
@@ -116,7 +116,8 @@ def process_storage_error(storage_error) -> NoReturn: # type: ignore [misc] # py
             error_dict = {'message': str(error_body)}
 
         # If we extracted from a Json or XML response
-        if error_dict:
+        # There is a chance error_dict is just a string
+        if error_dict and isinstance(error_dict, dict):
             error_code = error_dict.get('code')
             error_message = error_dict.get('message')
             additional_data = {k: v for k, v in error_dict.items() if k not in {'code', 'message'}}

--- a/sdk/storage/azure-storage-queue/CHANGELOG.md
+++ b/sdk/storage/azure-storage-queue/CHANGELOG.md
@@ -7,6 +7,8 @@
 ### Bugs Fixed
 - Bumped dependency of `typing-extensions` to `>=4.6.0` to avoid potential `TypeError` with `typing.TypeVar` on
 Python 3.12.
+- Fixed an issue where authentication errors could raise `AttributeError` instead of `ClientAuthenticationError` when
+using async OAuth credentials.
 
 ## 12.9.0 (2023-12-05)
 

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/response_handlers.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/response_handlers.py
@@ -116,7 +116,8 @@ def process_storage_error(storage_error) -> NoReturn: # type: ignore [misc] # py
             error_dict = {'message': str(error_body)}
 
         # If we extracted from a Json or XML response
-        if error_dict:
+        # There is a chance error_dict is just a string
+        if error_dict and isinstance(error_dict, dict):
             error_code = error_dict.get('code')
             error_message = error_dict.get('message')
             additional_data = {k: v for k, v in error_dict.items() if k not in {'code', 'message'}}


### PR DESCRIPTION
Resolves #33477.

Async credentials from `azure-identity` can raise a `ClientAuthenticationError` which contains the HTTP response from Entra Id. The Storage error handling pipeline had an issue parsing the error response from Entra Id as it is formed differently than a typical error response from the Storage service. This change adjusts the error response parsing a little to be more resilient.