### PR TITLE
Fix azure-ai-ml docstring error of literalinclude directive indent

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_workspace_outbound_rule_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_workspace_outbound_rule_operations.py
@@ -88,7 +88,7 @@ class WorkspaceOutboundRuleOperations:
                 :language: python
                 :dedent: 8
                 :caption: Create an FQDN outbound rule for a workspace with the given name,
-                similar can be done for PrivateEndpointDestination or ServiceTagDestination.
+                    similar can be done for PrivateEndpointDestination or ServiceTagDestination.
         """
 
         workspace_name = self._check_workspace_name(workspace_name)
@@ -132,7 +132,7 @@ class WorkspaceOutboundRuleOperations:
                 :language: python
                 :dedent: 8
                 :caption: Update an FQDN outbound rule for a workspace with the given name,
-                similar can be done for PrivateEndpointDestination or ServiceTagDestination.
+                    similar can be done for PrivateEndpointDestination or ServiceTagDestination.
         """
 
         workspace_name = self._check_workspace_name(workspace_name)


### PR DESCRIPTION
# Description

Docstrings in azure-ai-ml causes warnings when build documents by Sphinx.
According to https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#directives and https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#field-lists,
Directive options are field lists which the field body should be indented relative to the field marker.

![image](https://github.com/Azure/azure-sdk-for-python/assets/40595015/d94dedd3-5e48-4bd8-8723-1281762a5180)
![image](https://github.com/Azure/azure-sdk-for-python/assets/40595015/26fcb630-c0c4-48dc-a95d-09e743c8b297)


# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
