### PR TITLE
[Key Vault] Correctly handle token refreshes in AD FS

### DIFF
--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_internal/challenge_auth_policy.py
@@ -66,7 +66,7 @@ class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
     def __init__(self, credential: TokenCredential, *scopes: str, **kwargs: Any) -> None:
         super(ChallengeAuthPolicy, self).__init__(credential, *scopes, **kwargs)
         self._credential = credential
-        self._token: "Optional[AccessToken]" = None
+        self._token: Optional[AccessToken] = None
         self._verify_challenge_resource = kwargs.pop("verify_challenge_resource", True)
 
     def on_request(self, request: PipelineRequest) -> None:
@@ -77,7 +77,11 @@ class ChallengeAuthPolicy(BearerTokenCredentialPolicy):
             if self._need_new_token:
                 # azure-identity credentials require an AADv2 scope but the challenge may specify an AADv1 resource
                 scope = challenge.get_scope() or challenge.get_resource() + "/.default"
-                self._token = self._credential.get_token(scope, tenant_id=challenge.tenant_id)
+                # Exclude tenant for AD FS authentication
+                if challenge.tenant_id and challenge.tenant_id.lower().endswith("adfs"):
+                    self._token = self._credential.get_token(scope)
+                else:
+                    self._token = self._credential.get_token(scope, tenant_id=challenge.tenant_id)
 
             # ignore mypy's warning -- although self._token is Optional, get_token raises when it fails to get a token
             request.http_request.headers["Authorization"] = f"Bearer {self._token.token}"  # type: ignore

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/async_challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_shared/async_challenge_auth_policy.py
@@ -48,7 +48,11 @@ class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
             if self._need_new_token():
                 # azure-identity credentials require an AADv2 scope but the challenge may specify an AADv1 resource
                 scope = challenge.get_scope() or challenge.get_resource() + "/.default"
-                self._token = await self._credential.get_token(scope, tenant_id=challenge.tenant_id)
+                # Exclude tenant for AD FS authentication
+                if challenge.tenant_id and challenge.tenant_id.lower().endswith("adfs"):
+                    self._token = await self._credential.get_token(scope)
+                else:
+                    self._token = await self._credential.get_token(scope, tenant_id=challenge.tenant_id)
 
             # ignore mypy's warning -- although self._token is Optional, get_token raises when it fails to get a token
             request.http_request.headers["Authorization"] = f"Bearer {self._token.token}"  # type: ignore

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/async_challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_shared/async_challenge_auth_policy.py
@@ -48,7 +48,11 @@ class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
             if self._need_new_token():
                 # azure-identity credentials require an AADv2 scope but the challenge may specify an AADv1 resource
                 scope = challenge.get_scope() or challenge.get_resource() + "/.default"
-                self._token = await self._credential.get_token(scope, tenant_id=challenge.tenant_id)
+                # Exclude tenant for AD FS authentication
+                if challenge.tenant_id and challenge.tenant_id.lower().endswith("adfs"):
+                    self._token = await self._credential.get_token(scope)
+                else:
+                    self._token = await self._credential.get_token(scope, tenant_id=challenge.tenant_id)
 
             # ignore mypy's warning -- although self._token is Optional, get_token raises when it fails to get a token
             request.http_request.headers["Authorization"] = f"Bearer {self._token.token}"  # type: ignore

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_challenge_auth.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_challenge_auth.py
@@ -262,7 +262,7 @@ def test_adfs():
                 assert not request.body
                 assert request.headers["Content-Length"] == "0"
                 return challenge
-            elif Requests.count == 2:
+            elif Requests.count in (2, 3):
                 # second request should be authorized according to challenge and have the expected content
                 assert request.headers["Content-Length"]
                 assert request.body == expected_content
@@ -276,12 +276,16 @@ def test_adfs():
             return AccessToken(expected_token, 0)
 
         credential = Mock(get_token=Mock(wraps=get_token))
-        pipeline = Pipeline(policies=[ChallengeAuthPolicy(credential=credential)], transport=Mock(send=send))
+        policy = ChallengeAuthPolicy(credential=credential)
+        pipeline = Pipeline(policies=[policy], transport=Mock(send=send))
         request = HttpRequest("POST", get_random_url())
         request.set_bytes_body(expected_content)
         pipeline.run(request)
-
         assert credential.get_token.call_count == 1
+
+        # Regression test: https://github.com/Azure/azure-sdk-for-python/issues/33621
+        policy._token = None
+        pipeline.run(request)
 
     tenant = "tenant-id"
     # AD FS challenges have an unusual authority format; see https://github.com/Azure/azure-sdk-for-python/issues/28648

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/async_challenge_auth_policy.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_shared/async_challenge_auth_policy.py
@@ -48,7 +48,11 @@ class AsyncChallengeAuthPolicy(AsyncBearerTokenCredentialPolicy):
             if self._need_new_token():
                 # azure-identity credentials require an AADv2 scope but the challenge may specify an AADv1 resource
                 scope = challenge.get_scope() or challenge.get_resource() + "/.default"
-                self._token = await self._credential.get_token(scope, tenant_id=challenge.tenant_id)
+                # Exclude tenant for AD FS authentication
+                if challenge.tenant_id and challenge.tenant_id.lower().endswith("adfs"):
+                    self._token = await self._credential.get_token(scope)
+                else:
+                    self._token = await self._credential.get_token(scope, tenant_id=challenge.tenant_id)
 
             # ignore mypy's warning -- although self._token is Optional, get_token raises when it fails to get a token
             request.http_request.headers["Authorization"] = f"Bearer {self._token.token}"  # type: ignore


### PR DESCRIPTION
# Description

Resolves https://github.com/Azure/azure-sdk-for-python/issues/33621. https://github.com/Azure/azure-sdk-for-python/pull/30195 partially fixed authentication with KV in AD FS, but the issue crops back up when tokens are refreshed -- the refresh interaction wasn't updated to exclude a tenant ID from token requests in AD FS.

This updates tests to test the refresh scenario, and I verified that the updated tests failed before the code changes in this PR.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
