### PR TITLE
[Core] Drop hard dependency on `anyio`

### DIFF
--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 1.29.7 (unreleased)
+
+### Other changes
+
+- Dropped hard dependency on `anyio`
+
 ## 1.29.6 (2023-12-14)
 
 ### Bugs Fixed

--- a/sdk/core/azure-core/azure/core/pipeline/policies/_authentication_async.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/_authentication_async.py
@@ -6,7 +6,6 @@
 import time
 from typing import TYPE_CHECKING, Any, Awaitable, Optional, cast, TypeVar
 
-from anyio import Lock
 from azure.core.credentials import AccessToken
 from azure.core.pipeline import PipelineRequest, PipelineResponse
 from azure.core.pipeline.policies import AsyncHTTPPolicy
@@ -20,6 +19,11 @@ from .._tools_async import await_result
 
 if TYPE_CHECKING:
     from azure.core.credentials_async import AsyncTokenCredential
+
+try:
+    from anyio import Lock
+except ImportError:
+    from asyncio import Lock
 
 AsyncHTTPResponseType = TypeVar("AsyncHTTPResponseType", AsyncHttpResponse, LegacyAsyncHttpResponse)
 HTTPRequestType = TypeVar("HTTPRequestType", HttpRequest, LegacyHttpRequest)

--- a/sdk/core/azure-core/setup.py
+++ b/sdk/core/azure-core/setup.py
@@ -69,7 +69,6 @@ setup(
     },
     python_requires=">=3.7",
     install_requires=[
-        "anyio>=3.0,<5.0",
         "requests>=2.21.0",
         "six>=1.11.0",
         "typing-extensions>=4.6.0",


### PR DESCRIPTION
# Description

Follows up on #33307.

This PR removes the hard dependency on `anyio` that was introduced by #33307 in favor of attempting to use it if possible, and falling back to the previous `asyncio.Lock` import otherwise.

Having a hard dependency on `anyio` requires pulling in a number of transitive dependencies that are of no use unless using `trio` in any case.

cc @pvaneck as the author of #33307.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
  - The test introduced in #33307 covers this.