### PR TITLE
Allow ml_client to be initialized with ws reference and registry name

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_workspace_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_workspace_operations.py
@@ -57,8 +57,8 @@ class WorkspaceOperations(WorkspaceOperationsBase):
         credentials: Optional[TokenCredential] = None,
         **kwargs: Dict,
     ):
-        self.dataplane_workspace_operations = kwargs.pop("dataplane_client").workspaces
-        self._requests_pipeline: HttpPipeline = kwargs.pop("requests_pipeline")
+        self.dataplane_workspace_operations = kwargs.pop("dataplane_client").workspaces if kwargs.get("dataplane_client") else None
+        self._requests_pipeline: HttpPipeline = kwargs.pop("requests_pipeline", None)
         ops_logger.update_info(kwargs)
         self._provision_network_operation = service_client.managed_network_provisions
         super().__init__(

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_workspace_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_workspace_operations.py
@@ -57,7 +57,9 @@ class WorkspaceOperations(WorkspaceOperationsBase):
         credentials: Optional[TokenCredential] = None,
         **kwargs: Dict,
     ):
-        self.dataplane_workspace_operations = kwargs.pop("dataplane_client").workspaces if kwargs.get("dataplane_client") else None
+        self.dataplane_workspace_operations = (
+            kwargs.pop("dataplane_client").workspaces if kwargs.get("dataplane_client") else None
+        )
         self._requests_pipeline: HttpPipeline = kwargs.pop("requests_pipeline", None)
         ops_logger.update_info(kwargs)
         self._provision_network_operation = service_client.managed_network_provisions


### PR DESCRIPTION
# Description

Model packaging in the sdk allows users to include a registry name and workspace reference in the ml_client initialization. When creating a model package, if there is an environment only available in a workspace, the workspace reference should allow them to access it to set up the model package. AI SDK changes to workspace operations introduced an issue where if a workspace reference is included it fails to pop "dataplane_client" from kwargs and ml_client fails to initialize for model packaging. 

If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
