### PR TITLE
Fix broken import in opentelemetry readme examples 

### DIFF
--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
@@ -14,6 +14,8 @@
     ([#33432](https://github.com/Azure/azure-sdk-for-python/pull/33432))
 - Shutdown statsbeat on customer getting 400 error code
     ([#33489](https://github.com/Azure/azure-sdk-for-python/pull/33489))
+- Readme examples are updated with correct imports
+    ([#33691](https://github.com/Azure/azure-sdk-for-python/pull/33691))
 
 ## 1.0.0b19 (2023-11-20)
 

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/README.md
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/README.md
@@ -162,10 +162,10 @@ logging library are tracked and telemetry is exported to application insights wi
 import os
 import logging
 
+from opentelemetry._logs import set_logger_provider
 from opentelemetry.sdk._logs import (
     LoggerProvider,
     LoggingHandler,
-    set_logger_provider,
 )
 from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
 
@@ -204,10 +204,10 @@ import os
 import logging
 
 from opentelemetry import trace
+from opentelemetry._logs import set_logger_provider
 from opentelemetry.sdk._logs import (
     LoggerProvider,
     LoggingHandler,
-    set_logger_provider,
 )
 from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
 from opentelemetry.sdk.trace import TracerProvider
@@ -247,10 +247,10 @@ An example showing how to add custom properties to logging telemetry.
 import os
 import logging
 
+from opentelemetry._logs import set_logger_provider
 from opentelemetry.sdk._logs import (
     LoggerProvider,
     LoggingHandler,
-    set_logger_provider,
 )
 from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
 

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/README.md
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/README.md
@@ -646,7 +646,7 @@ For detailed overview of OpenTelemetry, visit their [overview](https://github.co
 
 For the official OpenTelemetry Python documentation and how to enable other telemetry scenarios, visit the official OpenTelemetry [website](https://opentelemetry.io/docs/instrumentation/python/).
 
-For more information on the Azure Monitor OpenTelemetry Distro, which is a bundle of useful, pre-assembled components (one of them being this current package) that enable telemetry scenarios with Azure Monitor, visit the [README](https://github.com/microsoft/ApplicationInsights-Python/tree/main/azure-monitor-opentelemetry).
+For more information on the Azure Monitor OpenTelemetry Distro, which is a bundle of useful, pre-assembled components (one of them being this current package) that enable telemetry scenarios with Azure Monitor, visit the [README](https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/monitor/azure-monitor-opentelemetry).
 
 ## Contributing
 

--- a/sdk/monitor/azure-monitor-opentelemetry/setup.py
+++ b/sdk/monitor/azure-monitor-opentelemetry/setup.py
@@ -56,7 +56,7 @@ setup(
     license="MIT License",
     author="Microsoft Corporation",
     author_email="ascl@microsoft.com",
-    url="https://github.com/microsoft/ApplicationInsights-Python/tree/main/azure-monitor-opentelemetry",
+    url="https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/monitor/azure-monitor-opentelemetry",
     keywords="azure, azure sdk",
     classifiers=[
         "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
# Description

Since Opentelemetry 1.15.0 `set_logger_provider` has been moved from `opentelemetry.sdk._logs` to `opentelemetry._logs`.

When testing with `azure-monitor-opentelemetry-exporter==1.0.0b19`, this change also applies. In this PR I updated the readme examples on how to use azure-monitor-opentelemetry-exporter to this new place to import `set_logger_provider`.

In the code all `set_logger_provider` occurences have already been already fixed, so this only needs a fix in the readme.

See also: [https://github.com/open-telemetry/opentelemetry-python/issues/3088](https://github.com/open-telemetry/opentelemetry-python/issues/3088)

Edit: The CI's were failing on a broken linkto the opentelemetry repo which are outside of my changes, changed it at 2 places to the correct current location: `https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/monitor/azure-monitor-opentelemetry`


# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
