### PR TITLE
add myst-parser header anchor option to sphinx conf to avoid warnings

### DIFF
--- a/doc/sphinx/conf.py
+++ b/doc/sphinx/conf.py
@@ -276,3 +276,8 @@ latex_documents = [
 
 # If false, no module index is generated.
 #latex_domain_indices = True
+
+# Used my myst-parser
+# https://myst-parser.readthedocs.io/en/latest/syntax/optional.html#syntax-header-anchors
+# Controls allowable header anchors in markdown files. Value allows header anchors for h1 - h6
+myst_heading_anchors = 6


### PR DESCRIPTION
A lot of our libraries fail running sphinx with warnings that look like this:

[Example pipeline](dev.azure.com/azure-sdk/internal/_build/results?buildId=3372594&view=logs&j=e5b925a9-9650-5321-24fd-5d9499fe02b8&t=0d206e13-b346-5d3f-79e6-d5bfba9e089e&l=617)

```
/mnt/vss/_work/1/s/sdk/maps/azure-maps-search/.tox/strict-sphinx/tmp/dist/unzipped/docgen/index.md:102: WARNING: 'myst' cross-reference target not found: 'request-latitude-and-longitude-coordinates-for-an-address' [myst.xref_missing]
```

These warnings occur on the README where we do anchor links to examples, e.g. `[How to upload a blob](#upload-a-blob)`

It seems a library we use, `myst-parser` requires you to specify the depth of header levels for which anchor links should work. Documentation here: https://myst-parser.readthedocs.io/en/latest/syntax/optional.html#syntax-header-anchors and https://github.com/executablebooks/MyST-Parser/issues/519

Since a lot of our libraries use anchor heading for examples in the README and use headers at level h3 or greater, we see the warnings. This adds configuration to specify the header depth we want to allow for links, i.e. h1 - h6

**Testing:**

Without conf option: https://dev.azure.com/azure-sdk/public/_build/results?buildId=3339909&view=logs&j=4259cd7e-6a4b-5ca5-581a-0ae020cd9d20&t=4d670c9c-5acd-5cc3-aede-d35282ac764a&l=693

With conf option: https://dev.azure.com/azure-sdk/public/_build/results?buildId=3378892&view=logs&j=4259cd7e-6a4b-5ca5-581a-0ae020cd9d20&t=4d670c9c-5acd-5cc3-aede-d35282ac764a&l=696