### PR TITLE
[FR] Disable mypy and pylint check

### DIFF
--- a/sdk/formrecognizer/azure-ai-formrecognizer/pyproject.toml
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/pyproject.toml
@@ -1,3 +1,5 @@
 [tool.azure-sdk-build]
 pyright = false
 type_check_samples = false
+mypy = false
+pylint = false


### PR DESCRIPTION
FR has been rebranded to DI, so disable mypy and pylint check in this package to avoid ci failing from new mypy/pylint versions.