### PR TITLE
Remove `PyGitHub` from default test setup env

### DIFF
--- a/eng/ci_tools.txt
+++ b/eng/ci_tools.txt
@@ -31,7 +31,6 @@ python-dotenv==0.21.1; python_version <= '3.7'
 python-dotenv==1.0.0; python_version > '3.7'
 pyyaml==6.0.1
 urllib3==1.26.9
-PyGithub==1.59.1
 ConfigArgParse==1.2.3
 six==1.16.0
 

--- a/eng/pipelines/templates/jobs/update_pr.yml
+++ b/eng/pipelines/templates/jobs/update_pr.yml
@@ -14,13 +14,13 @@ pool:
 
 steps:
 - task: UsePythonVersion@0
-  displayName: 'Use Python 3.7'
+  displayName: 'Use Python 3.8'
   inputs:
-    versionSpec: 3.7
+    versionSpec: 3.8
 
 - script: |
     python3 -m pip install azure-devtools[ci_tools]>=1.1.0
-    python3 -m pip install -e "git+https://github.com/Azure/azure-sdk-for-python#subdirectory=tools/azure-sdk-tools&egg=azure-sdk-tools"
+    python3 -m pip install -e $(Build.SourcesDirectory)/tools/azure-sdk-tools[ghtools]
   displayName: 'Install Azure SDK tools'
 
 - script: python3 -m packaging_tools.update_pr -v --pr-number $(System.PullRequest.PullRequestNumber) --repo $(Build.Repository.Name)

--- a/eng/test_tools.txt
+++ b/eng/test_tools.txt
@@ -20,7 +20,6 @@ python-dotenv==0.21.1; python_version <= '3.7'
 python-dotenv==1.0.0; python_version > '3.7'
 pyyaml==6.0.1
 urllib3==1.26.9
-PyGithub==1.59.1
 ConfigArgParse==1.2.3
 six==1.16.0
 

--- a/eng/tox/run_mypy.py
+++ b/eng/tox/run_mypy.py
@@ -18,7 +18,6 @@ from ci_tools.environment_exclusions import (
 )
 from ci_tools.parsing import ParsedSetup
 from ci_tools.variables import in_ci
-from gh_tools.vnext_issue_creator import create_vnext_issue
 
 
 logging.getLogger().setLevel(logging.INFO)
@@ -103,6 +102,7 @@ if __name__ == "__main__":
 
     if args.next and in_ci() and not is_typing_ignored(package_name):
         if src_code_error or sample_code_error:
+            from gh_tools.vnext_issue_creator import create_vnext_issue
             create_vnext_issue(package_name, "mypy")
 
     if src_code_error and sample_code_error:

--- a/eng/tox/run_pylint.py
+++ b/eng/tox/run_pylint.py
@@ -17,7 +17,6 @@ import sys
 from ci_tools.environment_exclusions import is_check_enabled
 from ci_tools.parsing import ParsedSetup
 from ci_tools.variables import in_ci
-from gh_tools.vnext_issue_creator import create_vnext_issue
 
 logging.getLogger().setLevel(logging.INFO)
 
@@ -74,6 +73,7 @@ if __name__ == "__main__":
             "{} exited with linting error {}. Please see this link for more information https://aka.ms/azsdk/python/pylint-guide".format(pkg_details.name, e.returncode)
         )
         if args.next and in_ci() and is_check_enabled(args.target_package, "pylint"):
+            from gh_tools.vnext_issue_creator import create_vnext_issue
             create_vnext_issue(pkg_details.name, "pylint")
 
         exit(1)

--- a/eng/tox/run_pyright.py
+++ b/eng/tox/run_pyright.py
@@ -19,7 +19,6 @@ from ci_tools.environment_exclusions import (
 )
 from ci_tools.parsing import ParsedSetup
 from ci_tools.variables import in_ci
-from gh_tools.vnext_issue_creator import create_vnext_issue
 
 logging.getLogger().setLevel(logging.INFO)
 
@@ -116,6 +115,7 @@ if __name__ == "__main__":
         check_call(commands)
     except CalledProcessError as error:
         if args.next and in_ci() and is_check_enabled(args.target_package, "pyright") and not is_typing_ignored(package_name):
+            from gh_tools.vnext_issue_creator import create_vnext_issue
             create_vnext_issue(package_name, "pyright")
 
         print("See https://aka.ms/python/typing-guide for information.\n\n")

--- a/eng/tox/run_sphinx_build.py
+++ b/eng/tox/run_sphinx_build.py
@@ -23,7 +23,6 @@ import shutil
 
 from ci_tools.parsing import ParsedSetup
 from ci_tools.functions import get_config_setting
-from gh_tools.vnext_issue_creator import create_vnext_issue
 
 logging.getLogger().setLevel(logging.INFO)
 
@@ -69,6 +68,7 @@ def sphinx_build(target_dir, output_dir, fail_on_warning=False, package_name=Non
             )
         )
         if args.strict and in_ci():
+            from gh_tools.vnext_issue_creator import create_vnext_issue
             create_vnext_issue(package_name, "sphinx")
         exit(1)
 

--- a/eng/tox/tox.ini
+++ b/eng/tox/tox.ini
@@ -115,6 +115,7 @@ setenv =
   PROXY_URL=http://localhost:5002
 deps =
   -rdev_requirements.txt
+  PyGitHub>=1.59.0
 commands =
     python -m pip install pylint=={[testenv:next-pylint]pylint_version}
     python -m pip install azure-pylint-guidelines-checker==0.2.0 --index-url="https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-python/pypi/simple/"
@@ -184,6 +185,7 @@ deps =
   types-requests==2.31.0.6
   types-six==1.16.21.9
   types-redis==4.6.0.7
+  PyGitHub>=1.59.0
 commands =
     python {repository_root}/eng/tox/create_package_and_install.py \
       -d {envtmpdir}/dist \
@@ -227,6 +229,7 @@ setenv =
 deps =
   {[base]deps}
   pyright=={[testenv:next-pyright]pyright_version}
+  PyGitHub>=1.59.0
 commands =
     python {repository_root}/eng/tox/create_package_and_install.py \
       -d {envtmpdir}/dist \
@@ -353,6 +356,7 @@ deps =
   sphinx_rtd_theme==1.3.0
   myst_parser==2.0.0
   sphinxcontrib-jquery==4.1
+  PyGitHub>=1.59.0
 commands =
   python {repository_root}/eng/tox/create_package_and_install.py \
     -d {envtmpdir}/dist \
@@ -574,6 +578,7 @@ skip_install=true
 deps =
   {[base]deps}
   tomli==2.0.1
+  PyGitHub>=1.59.0
 commands=
   python -m packaging_tools.generate_client
 

--- a/tools/azure-sdk-tools/setup.py
+++ b/tools/azure-sdk-tools/setup.py
@@ -59,6 +59,6 @@ setup(
         "build": ["six", "setuptools", "pyparsing", "certifi", "cibuildwheel"],
         "conda": ["beautifulsoup4"],
         "systemperf": ["aiohttp>=3.0", "requests>=2.0", "tornado==6.0.3", "httpx>=0.21", "azure-core"],
-         "ghtools": ["PyGithub>=1.59.0"],
+        "ghtools": ["PyGithub>=1.59.0"],
     },
 )

--- a/tools/azure-sdk-tools/setup.py
+++ b/tools/azure-sdk-tools/setup.py
@@ -20,8 +20,6 @@ DEPENDENCIES = [
     "PyYAML",
     "urllib3",
     "tomli-w==1.0.0",
-    # gh tools
-    "PyGithub>=1.59.0",
 ]
 
 setup(
@@ -60,6 +58,7 @@ setup(
         ":python_version<'3.11'": ["tomli==2.0.1"],
         "build": ["six", "setuptools", "pyparsing", "certifi", "cibuildwheel"],
         "conda": ["beautifulsoup4"],
-        "systemperf": ["aiohttp>=3.0", "requests>=2.0", "tornado==6.0.3", "httpx>=0.21", "azure-core"]
+        "systemperf": ["aiohttp>=3.0", "requests>=2.0", "tornado==6.0.3", "httpx>=0.21", "azure-core"],
+         "ghtools": ["PyGithub>=1.59.0"],
     },
 )


### PR DESCRIPTION
While resolving #33722 , I am realizing that building `pynacl` for a windows wheel is a nightmare and a half. Given that we don't actually use `pygithub` except for creating issues or generating a packaging update for mgmt packages, we don't need it always present.

I am moving `pygithub` to a extras dep in azure-sdk-tools. In addition, I am updating `update_pr.yml` to use the local version of azure-sdk-tools, versus recloning a repo we are **already in**.

This should allow me to bypass this install issue that is present on `pypy39` in #33722 

@msyyc sir can you please tell me if this update of update_pr (to install local azure-sdk-tools) breaks anything? It's currently set so that it reclones the repo we are already on, just from `main`. Given that your autogenerated branches are based off of latest `main`, I'm not certain this is actually necessary.

Let me know please!



