### PR TITLE
[CI] Fix parsing of dev_requirements.txt

### DIFF
--- a/tools/azure-sdk-tools/ci_tools/scenario/generation.py
+++ b/tools/azure-sdk-tools/ci_tools/scenario/generation.py
@@ -240,6 +240,11 @@ def build_and_install_dev_reqs(file: str, pkg_root: str) -> None:
 
     with open(file, "r") as f:
         for line in f:
+            # Remove inline comments which are denoted by a "#".
+            line = line.split("#")[0].strip()
+            if not line:
+                continue
+
             args = [part.strip() for part in line.split() if part and not part.strip() == "-e"]
             amended_line = " ".join(args)
 
@@ -262,7 +267,7 @@ def build_and_install_dev_reqs(file: str, pkg_root: str) -> None:
     shutil.rmtree(os.path.join(pkg_root, ".tmp_whl_dir"))
 
 
-def is_relative_install_path(req: str, package_path: str) -> str:
+def is_relative_install_path(req: str, package_path: str) -> bool:
     possible_setup_path = os.path.join(package_path, req, "setup.py")
 
     # blank lines are _allowed_ in a dev requirements. they should not resolve to the package_path erroneously


### PR DESCRIPTION
Encountered some issues with the `generation.py` script when comments or blank lines are in the `dev_requirements.txt` file.

For example, in the `azure-core` dev requirements, we have a [comment](https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/core/azure-core/dev_requirements.txt#L3) on its own line.

When running something like:

```
tox run -e pyright -c ../../../eng/tox/tox.ini --root .
```

The following error is encountered:

```
ERROR: Invalid requirement: '# Aiohttp 3.8.6 triggers https://github.com/aio-libs/aiohttp/issues/4581 on pypy for some reasons'
```

Similarly, a blank line will produce:

```
ERROR: Invalid requirement: ''
```

This change correctly parses them.