### PR TITLE
setting pytest logging level at queue time

### DIFF
--- a/doc/eng_sys_checks.md
+++ b/doc/eng_sys_checks.md
@@ -7,6 +7,7 @@
   - [The pyproject.toml](#the-pyprojecttoml)
   - [Environment variables important to CI](#environment-variables-important-to-ci)
     - [Atomic Overrides](#atomic-overrides)
+    - [Enable test logging in CI pipelines](#enable-test-logging-in-ci-pipelines)
   - [Analyze Checks](#analyze-checks)
     - [MyPy](#mypy)
     - [Pyright](#pyright)
@@ -166,6 +167,16 @@ The name that you should use is visible based on what the `tox environment` that
 
 - `AZURE_SERVICEBUS_PYRIGHT=true` <-- enable a check that normally is disabled in `pyproject.toml`
 - `AZURE_CORE_PYLINT=false` <-- disable a check that normally runs
+
+### Enable test logging in CI pipelines
+
+You can enable test logging in a pipeline by setting the queue time variable `PYTEST_LOG_LEVEL` to the desired logging [level](https://docs.python.org/3/library/logging.html#logging-levels). For example,
+
+`PYTEST_LOG_LEVEL=INFO`
+
+This also works locally with tox by setting the `PYTEST_LOG_LEVEL` environment variable. 
+
+Note that if you want DEBUG level logging with sensitive information unredacted in the test logs, then you still must pass `logging_enable=True` into the client(s) being used in tests.
 
 ## Analyze Checks
 

--- a/eng/tox/tox.ini
+++ b/eng/tox/tox.ini
@@ -48,7 +48,7 @@ pkgs =
 
 [pytest]
 ignore_args=--ignore=.tox --ignore=build --ignore=.eggs
-default_args = -rsfE --junitxml={tox_root}/test-junit-{envname}.xml --verbose --cov-branch --durations=10 --ignore=azure {[pytest]ignore_args}
+default_args = -rsfE --junitxml={tox_root}/test-junit-{envname}.xml --verbose --cov-branch --durations=10 --ignore=azure {[pytest]ignore_args} --log-cli-level={pytest_log_level}
 
 [testenv]
 parallel_show_output =True

--- a/eng/tox/toxfile.py
+++ b/eng/tox/toxfile.py
@@ -1,3 +1,4 @@
+import os
 from logging import getLogger
 from pathlib import Path
 
@@ -17,3 +18,8 @@ def tox_add_core_config(core_conf: CoreConfigSet, state: State):
         next(p for p in Path(core_conf["config_file_path"]).resolve().parents if (p / ".git").exists()),
     )
 
+    core_conf.add_constant(
+        "pytest_log_level",
+        "The log level to use for pytest, supplied as environment or queue time variable PYTEST_LOG_LEVEL",
+        os.getenv("PYTEST_LOG_LEVEL", "51")  # Defaults to no logging
+    )


### PR DESCRIPTION
In our productivity brainstorm meeting, it was brought up that it would be nice to have an easy way to enable logging on test pipelines, especially for issues that only seem to repro in CI. AFAIK (but correct me if I'm wrong!), currently you have to create a logger and open a draft PR to get pytest logging going, so this PR adds a way to set a queue time variable which indicates which level of logging you want: 

`PYTEST_LOG_LEVEL=<log-level>` 

This defaults to no logging. Note that if a library owner wants DEBUG logging and sensitive information unredacted, then they still must explicitly pass the `logging_enable` keyword argument into the client they use for tests.

Testing: 

PYTEST_LOG_LEVEL=INFO: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3389008&view=logs&j=00d488d8-0928-537b-2837-a217e71ffc55&t=153f2ede-6903-56e0-bdbf-df96f42992de&l=179

Did not set queue time variable: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3391461&view=logs&j=00d488d8-0928-537b-2837-a217e71ffc55&t=153f2ede-6903-56e0-bdbf-df96f42992de&l=177