### PR TITLE
Re-generate Image Analysis SDK with: tox run -e generate -c ..\..\..\eng\tox\tox.ini --root .

### DIFF
--- a/sdk/vision/azure-ai-vision-imageanalysis/README.md
+++ b/sdk/vision/azure-ai-vision-imageanalysis/README.md
@@ -53,7 +53,7 @@ from azure.ai.vision.imageanalysis import ImageAnalysisClient
 from azure.ai.vision.imageanalysis.models import VisualFeatures
 from azure.core.credentials import AzureKeyCredential
 
-# Set the values of your computer vision endpoint and computer vision key 
+# Set the values of your computer vision endpoint and computer vision key
 # as environment variables:
 try:
     endpoint = os.environ["VISION_ENDPOINT"]
@@ -64,10 +64,7 @@ except KeyError:
     exit()
 
 # Create an Image Analysis client for synchronous operations
-client = ImageAnalysisClient(
-    endpoint = endpoint,
-    credential = AzureKeyCredential(key)
-)
+client = ImageAnalysisClient(endpoint=endpoint, credential=AzureKeyCredential(key))
 ```
 
 <!-- END SNIPPET -->
@@ -135,14 +132,14 @@ Notes:
 
 ```python
 # Load image to analyze into a 'bytes' object
-with open("sample.jpg", 'rb') as f:
+with open("sample.jpg", "rb") as f:
     image_data = f.read()
 
 # Get a caption for the image. This will be a synchronously (blocking) call.
 result = client.analyze(
-    image_data = image_data,
-    visual_features = [ VisualFeatures.CAPTION ],
-    gender_neutral_caption = True # Optional (default is False)
+    image_data=image_data,
+    visual_features=[VisualFeatures.CAPTION],
+    gender_neutral_caption=True,  # Optional (default is False)
 )
 
 # Print caption results to the console
@@ -165,9 +162,9 @@ This example is similar to the above, expect it calls the `analyze` method and p
 ```python
 # Get a caption for the image. This will be a synchronously (blocking) call.
 result = client.analyze(
-    image_url = "https://aka.ms/azsdk/image-analysis/sample.jpg",
-    visual_features = [ VisualFeatures.CAPTION ],
-    gender_neutral_caption = True # Optional (default is False)
+    image_url="https://aka.ms/azsdk/image-analysis/sample.jpg",
+    visual_features=[VisualFeatures.CAPTION],
+    gender_neutral_caption=True,  # Optional (default is False)
 )
 
 # Print caption results to the console
@@ -187,14 +184,11 @@ This example demonstrates how to extract printed or hand-written text for the im
 
 ```python
 # Load image to analyze into a 'bytes' object
-with open("sample.jpg", 'rb') as f:
+with open("sample.jpg", "rb") as f:
     image_data = f.read()
 
 # Extract text (OCR) from an image stream. This will be a synchronously (blocking) call.
-result = client.analyze(
-    image_data = image_data,
-    visual_features = [ VisualFeatures.READ ]
-)
+result = client.analyze(image_data=image_data, visual_features=[VisualFeatures.READ])
 
 # Print text (OCR) analysis results to the console
 print("Image analysis results:")
@@ -203,7 +197,9 @@ if result.read is not None:
     for line in result.read.blocks[0].lines:
         print(f"   Line: '{line.text}', Bounding box {line.bounding_polygon}")
         for word in line.words:
-            print(f"     Word: '{word.text}', Bounding polygon {word.bounding_polygon}, Confidence {word.confidence:.4f}")
+            print(
+                f"     Word: '{word.text}', Bounding polygon {word.bounding_polygon}, Confidence {word.confidence:.4f}"
+            )
 ```
 
 <!-- END SNIPPET -->
@@ -221,8 +217,7 @@ This example is similar to the above, expect it calls the `analyze` method and p
 ```python
 # Extract text (OCR) from an image stream. This will be a synchronously (blocking) call.
 result = client.analyze(
-    image_url = "https://aka.ms/azsdk/image-analysis/sample.jpg",
-    visual_features = [ VisualFeatures.READ ]
+    image_url="https://aka.ms/azsdk/image-analysis/sample.jpg", visual_features=[VisualFeatures.READ]
 )
 
 # Print text (OCR) analysis results to the console
@@ -232,7 +227,9 @@ if result.read is not None:
     for line in result.read.blocks[0].lines:
         print(f"   Line: '{line.text}', Bounding box {line.bounding_polygon}")
         for word in line.words:
-            print(f"     Word: '{word.text}', Bounding polygon {word.bounding_polygon}, Confidence {word.confidence:.4f}")
+            print(
+                f"     Word: '{word.text}', Bounding polygon {word.bounding_polygon}, Confidence {word.confidence:.4f}"
+            )
 ```
 
 <!-- END SNIPPET -->
@@ -277,21 +274,21 @@ The client uses the standard [Python logging library](https://docs.python.org/3/
 import sys
 import logging
 
-# Acquire the logger for this client library. Use 'azure' to affect both 
+# Acquire the logger for this client library. Use 'azure' to affect both
 # 'azure.core` and `azure.ai.vision.imageanalysis' libraries.
-logger = logging.getLogger('azure')
+logger = logging.getLogger("azure")
 
 # Set the desired logging level. logging.INFO or logging.DEBUG are good options.
 logger.setLevel(logging.INFO)
 
 # Direct logging output to stdout (the default):
-handler = logging.StreamHandler(stream = sys.stdout)
+handler = logging.StreamHandler(stream=sys.stdout)
 # Or direct logging output to a file:
 # handler = logging.FileHandler(filename = 'sample.log')
 logger.addHandler(handler)
 
 # Optional: change the default logging format. Here we add a timestamp.
-formatter = logging.Formatter('%(asctime)s:%(levelname)s:%(name)s:%(message)s')
+formatter = logging.Formatter("%(asctime)s:%(levelname)s:%(name)s:%(message)s")
 handler.setFormatter(formatter)
 ```
 
@@ -303,11 +300,7 @@ By default logs redact the values of URL query strings, the values of some HTTP 
 
 ```python
 # Create an Image Analysis client with none redacted log
-client = ImageAnalysisClient(
-    endpoint = endpoint,
-    credential = AzureKeyCredential(key),
-    logging_enable = True
-)
+client = ImageAnalysisClient(endpoint=endpoint, credential=AzureKeyCredential(key), logging_enable=True)
 ```
 
 <!-- END SNIPPET -->

--- a/sdk/vision/azure-ai-vision-imageanalysis/README.md
+++ b/sdk/vision/azure-ai-vision-imageanalysis/README.md
@@ -203,9 +203,7 @@ if result.read is not None:
     for line in result.read.blocks[0].lines:
         print(f"   Line: '{line.text}', Bounding box {line.bounding_polygon}")
         for word in line.words:
-            print(
-                f"     Word: '{word.text}', Bounding polygon {word.bounding_polygon}, Confidence {word.confidence:.4f}"
-            )
+            print(f"     Word: '{word.text}', Bounding polygon {word.bounding_polygon}, Confidence {word.confidence:.4f}")
 ```
 
 <!-- END SNIPPET -->
@@ -234,9 +232,7 @@ if result.read is not None:
     for line in result.read.blocks[0].lines:
         print(f"   Line: '{line.text}', Bounding box {line.bounding_polygon}")
         for word in line.words:
-            print(
-                f"     Word: '{word.text}', Bounding polygon {word.bounding_polygon}, Confidence {word.confidence:.4f}"
-            )
+            print(f"     Word: '{word.text}', Bounding polygon {word.bounding_polygon}, Confidence {word.confidence:.4f}")
 ```
 
 <!-- END SNIPPET -->

--- a/sdk/vision/azure-ai-vision-imageanalysis/README.md
+++ b/sdk/vision/azure-ai-vision-imageanalysis/README.md
@@ -64,7 +64,10 @@ except KeyError:
     exit()
 
 # Create an Image Analysis client for synchronous operations
-client = ImageAnalysisClient(endpoint=endpoint, credential=AzureKeyCredential(key))
+client = ImageAnalysisClient(
+    endpoint=endpoint,
+    credential=AzureKeyCredential(key)
+)
 ```
 
 <!-- END SNIPPET -->
@@ -188,7 +191,10 @@ with open("sample.jpg", "rb") as f:
     image_data = f.read()
 
 # Extract text (OCR) from an image stream. This will be a synchronously (blocking) call.
-result = client.analyze(image_data=image_data, visual_features=[VisualFeatures.READ])
+result = client.analyze(
+    image_data=image_data,
+    visual_features=[VisualFeatures.READ]
+)
 
 # Print text (OCR) analysis results to the console
 print("Image analysis results:")
@@ -217,7 +223,8 @@ This example is similar to the above, expect it calls the `analyze` method and p
 ```python
 # Extract text (OCR) from an image stream. This will be a synchronously (blocking) call.
 result = client.analyze(
-    image_url="https://aka.ms/azsdk/image-analysis/sample.jpg", visual_features=[VisualFeatures.READ]
+    image_url="https://aka.ms/azsdk/image-analysis/sample.jpg",
+    visual_features=[VisualFeatures.READ]
 )
 
 # Print text (OCR) analysis results to the console
@@ -300,7 +307,11 @@ By default logs redact the values of URL query strings, the values of some HTTP 
 
 ```python
 # Create an Image Analysis client with none redacted log
-client = ImageAnalysisClient(endpoint=endpoint, credential=AzureKeyCredential(key), logging_enable=True)
+client = ImageAnalysisClient(
+    endpoint=endpoint,
+    credential=AzureKeyCredential(key),
+    logging_enable=True
+)
 ```
 
 <!-- END SNIPPET -->

--- a/sdk/vision/azure-ai-vision-imageanalysis/azure/ai/vision/imageanalysis/__init__.py
+++ b/sdk/vision/azure-ai-vision-imageanalysis/azure/ai/vision/imageanalysis/__init__.py
@@ -6,21 +6,17 @@
 # Changes may cause incorrect behavior and will be lost if the code is regenerated.
 # --------------------------------------------------------------------------
 
-from ._client import ImageAnalysisClient
+from ._patch import ImageAnalysisClient
 from ._version import VERSION
 
 __version__ = VERSION
 
-try:
-    from ._patch import __all__ as _patch_all
-    from ._patch import *  # pylint: disable=unused-wildcard-import
-except ImportError:
-    _patch_all = []
+
 from ._patch import patch_sdk as _patch_sdk
 
 __all__ = [
     "ImageAnalysisClient",
 ]
-__all__.extend([p for p in _patch_all if p not in __all__])
+
 
 _patch_sdk()

--- a/sdk/vision/azure-ai-vision-imageanalysis/azure/ai/vision/imageanalysis/_operations/_operations.py
+++ b/sdk/vision/azure-ai-vision-imageanalysis/azure/ai/vision/imageanalysis/_operations/_operations.py
@@ -147,8 +147,7 @@ class ImageAnalysisClientOperationsMixin(ImageAnalysisClientMixinABC):
         :paramtype visual_features: list[str or ~azure.ai.vision.imageanalysis.models.VisualFeatures]
         :keyword language: The desired language for result generation (a two-letter language code).
          If this option is not specified, the default value 'en' is used (English).
-         See https://aka.ms/cv-languages for a list of supported languages.
-         At the moment, only tags can be generated in non-English languages. Default value is None.
+         See https://aka.ms/cv-languages for a list of supported languages. Default value is None.
         :paramtype language: str
         :keyword gender_neutral_caption: Boolean flag for enabling gender-neutral captioning for
          Caption and Dense Captions features.
@@ -468,8 +467,7 @@ class ImageAnalysisClientOperationsMixin(ImageAnalysisClientMixinABC):
         :paramtype visual_features: list[str or ~azure.ai.vision.imageanalysis.models.VisualFeatures]
         :keyword language: The desired language for result generation (a two-letter language code).
          If this option is not specified, the default value 'en' is used (English).
-         See https://aka.ms/cv-languages for a list of supported languages.
-         At the moment, only tags can be generated in non-English languages. Default value is None.
+         See https://aka.ms/cv-languages for a list of supported languages. Default value is None.
         :paramtype language: str
         :keyword gender_neutral_caption: Boolean flag for enabling gender-neutral captioning for
          Caption and Dense Captions features.

--- a/sdk/vision/azure-ai-vision-imageanalysis/azure/ai/vision/imageanalysis/_operations/_patch.py
+++ b/sdk/vision/azure-ai-vision-imageanalysis/azure/ai/vision/imageanalysis/_operations/_patch.py
@@ -5,7 +5,8 @@
 # --------------------------------------------------------------------------
 from typing import List
 
-__all__: List[str] = [] # Add all objects you want publicly available to users at this package level
+__all__: List[str] = []  # Add all objects you want publicly available to users at this package level
+
 
 def patch_sdk():
     """Do not remove from this file.

--- a/sdk/vision/azure-ai-vision-imageanalysis/azure/ai/vision/imageanalysis/_patch.py
+++ b/sdk/vision/azure-ai-vision-imageanalysis/azure/ai/vision/imageanalysis/_patch.py
@@ -21,6 +21,7 @@ from . import models as _models
 from ._operations._operations import ImageAnalysisClientOperationsMixin
 from ._client import ImageAnalysisClient as ImageAnalysisClientGenerated
 
+
 class ImageAnalysisClient(ImageAnalysisClientGenerated):
     """ImageAnalysisClient.
 
@@ -115,28 +116,31 @@ class ImageAnalysisClient(ImageAnalysisClientGenerated):
         visual_features_impl: List[Union[str, _models.VisualFeatures]] = list(visual_features)
 
         if image_url is not None:
-            return ImageAnalysisClientOperationsMixin._analyze_from_url( # pylint: disable=protected-access
+            return ImageAnalysisClientOperationsMixin._analyze_from_url(  # pylint: disable=protected-access
                 self,
-                image_content = _models._models.ImageUrl(url = image_url), # pylint: disable=protected-access
-                visual_features = visual_features_impl,
-                language = language,
-                gender_neutral_caption = gender_neutral_caption,
-                smart_crops_aspect_ratios = smart_crops_aspect_ratios,
-                model_version = model_version,
-                **kwargs)
+                image_content=_models._models.ImageUrl(url=image_url),  # pylint: disable=protected-access
+                visual_features=visual_features_impl,
+                language=language,
+                gender_neutral_caption=gender_neutral_caption,
+                smart_crops_aspect_ratios=smart_crops_aspect_ratios,
+                model_version=model_version,
+                **kwargs
+            )
 
         if image_data is not None:
-            return ImageAnalysisClientOperationsMixin._analyze_from_buffer( # pylint: disable=protected-access
+            return ImageAnalysisClientOperationsMixin._analyze_from_buffer(  # pylint: disable=protected-access
                 self,
-                image_content = image_data,
-                visual_features = visual_features_impl,
-                language = language,
-                gender_neutral_caption = gender_neutral_caption,
-                smart_crops_aspect_ratios = smart_crops_aspect_ratios,
-                model_version = model_version,
-                **kwargs)
+                image_content=image_data,
+                visual_features=visual_features_impl,
+                language=language,
+                gender_neutral_caption=gender_neutral_caption,
+                smart_crops_aspect_ratios=smart_crops_aspect_ratios,
+                model_version=model_version,
+                **kwargs
+            )
 
         raise ValueError("Either image_data or image_url must be specified.")
+
 
 __all__: List[str] = [
     "ImageAnalysisClient"

--- a/sdk/vision/azure-ai-vision-imageanalysis/azure/ai/vision/imageanalysis/aio/__init__.py
+++ b/sdk/vision/azure-ai-vision-imageanalysis/azure/ai/vision/imageanalysis/aio/__init__.py
@@ -6,18 +6,14 @@
 # Changes may cause incorrect behavior and will be lost if the code is regenerated.
 # --------------------------------------------------------------------------
 
-from ._client import ImageAnalysisClient
+from ._patch import ImageAnalysisClient
 
-try:
-    from ._patch import __all__ as _patch_all
-    from ._patch import *  # pylint: disable=unused-wildcard-import
-except ImportError:
-    _patch_all = []
+
 from ._patch import patch_sdk as _patch_sdk
 
 __all__ = [
     "ImageAnalysisClient",
 ]
-__all__.extend([p for p in _patch_all if p not in __all__])
+
 
 _patch_sdk()

--- a/sdk/vision/azure-ai-vision-imageanalysis/azure/ai/vision/imageanalysis/aio/_operations/_patch.py
+++ b/sdk/vision/azure-ai-vision-imageanalysis/azure/ai/vision/imageanalysis/aio/_operations/_patch.py
@@ -5,7 +5,8 @@
 # --------------------------------------------------------------------------
 from typing import List
 
-__all__: List[str] = [] # Add all objects you want publicly available to users at this package level
+__all__: List[str] = []  # Add all objects you want publicly available to users at this package level
+
 
 def patch_sdk():
     """Do not remove from this file.

--- a/sdk/vision/azure-ai-vision-imageanalysis/azure/ai/vision/imageanalysis/aio/_patch.py
+++ b/sdk/vision/azure-ai-vision-imageanalysis/azure/ai/vision/imageanalysis/aio/_patch.py
@@ -21,6 +21,7 @@ from .. import models as _models
 from ._operations._operations import ImageAnalysisClientOperationsMixin
 from ._client import ImageAnalysisClient as ImageAnalysisClientGenerated
 
+
 class ImageAnalysisClient(ImageAnalysisClientGenerated):
     """ImageAnalysisClient.
 
@@ -115,28 +116,31 @@ class ImageAnalysisClient(ImageAnalysisClientGenerated):
         visual_features_impl: List[Union[str, _models.VisualFeatures]] = list(visual_features)
 
         if image_url is not None:
-            return await ImageAnalysisClientOperationsMixin._analyze_from_url( # pylint: disable=protected-access
+            return await ImageAnalysisClientOperationsMixin._analyze_from_url(  # pylint: disable=protected-access
                 self,
-                image_content = _models._models.ImageUrl(url = image_url), # pylint: disable=protected-access
-                visual_features = visual_features_impl,
-                language = language,
-                gender_neutral_caption = gender_neutral_caption,
-                smart_crops_aspect_ratios = smart_crops_aspect_ratios,
-                model_version = model_version,
-                **kwargs)
+                image_content=_models._models.ImageUrl(url=image_url),  # pylint: disable=protected-access
+                visual_features=visual_features_impl,
+                language=language,
+                gender_neutral_caption=gender_neutral_caption,
+                smart_crops_aspect_ratios=smart_crops_aspect_ratios,
+                model_version=model_version,
+                **kwargs
+            )
 
         if image_data is not None:
-            return await ImageAnalysisClientOperationsMixin._analyze_from_buffer( # pylint: disable=protected-access
+            return await ImageAnalysisClientOperationsMixin._analyze_from_buffer(  # pylint: disable=protected-access
                 self,
-                image_content = image_data,
-                visual_features = visual_features_impl,
-                language = language,
-                gender_neutral_caption = gender_neutral_caption,
-                smart_crops_aspect_ratios = smart_crops_aspect_ratios,
-                model_version = model_version,
-                **kwargs)
+                image_content=image_data,
+                visual_features=visual_features_impl,
+                language=language,
+                gender_neutral_caption=gender_neutral_caption,
+                smart_crops_aspect_ratios=smart_crops_aspect_ratios,
+                model_version=model_version,
+                **kwargs
+            )
 
         raise ValueError("Either image_data or image_url must be specified.")
+
 
 __all__: List[str] = [
     "ImageAnalysisClient"

--- a/sdk/vision/azure-ai-vision-imageanalysis/azure/ai/vision/imageanalysis/models/_enums.py
+++ b/sdk/vision/azure-ai-vision-imageanalysis/azure/ai/vision/imageanalysis/models/_enums.py
@@ -15,20 +15,20 @@ class VisualFeatures(str, Enum, metaclass=CaseInsensitiveEnumMeta):
 
     TAGS = "tags"
     """Extract content tags for thousands of recognizable objects, living beings, scenery, and actions
-    that appear in the image."""
+    #: that appear in the image."""
     CAPTION = "caption"
     """Generate a human-readable caption sentence that describes the content of the image."""
     DENSE_CAPTIONS = "denseCaptions"
     """Generate human-readable caption sentences for up to 10 different regions in the image,
-    including one for the whole image."""
+    #: including one for the whole image."""
     OBJECTS = "objects"
     """Object detection. This is similar to tags, but focused on detecting physical objects in the
-    image and returning their location."""
+    #: image and returning their location."""
     READ = "read"
     """Extract printed or handwritten text from the image. Also known as Optical Character Recognition
-    (OCR)."""
+    #: (OCR)."""
     SMART_CROPS = "smartCrops"
     """Find representative sub-regions of the image for thumbnail generation, at desired aspect
-    ratios, with priority given to detected faces."""
+    #: ratios, with priority given to detected faces."""
     PEOPLE = "people"
     """Detect people in the image and return their location."""

--- a/sdk/vision/azure-ai-vision-imageanalysis/azure/ai/vision/imageanalysis/models/_enums.py
+++ b/sdk/vision/azure-ai-vision-imageanalysis/azure/ai/vision/imageanalysis/models/_enums.py
@@ -14,16 +14,21 @@ class VisualFeatures(str, Enum, metaclass=CaseInsensitiveEnumMeta):
     """The visual features supported by the Image Analysis service."""
 
     TAGS = "tags"
-    """Extract content tags for thousands of recognizable objects, living beings, scenery, and actions that appear in the image."""
+    """Extract content tags for thousands of recognizable objects, living beings, scenery, and actions
+    that appear in the image."""
     CAPTION = "caption"
     """Generate a human-readable caption sentence that describes the content of the image."""
     DENSE_CAPTIONS = "denseCaptions"
-    """Generate human-readable caption sentences for up to 10 different regions in the image, including one for the whole image."""
+    """Generate human-readable caption sentences for up to 10 different regions in the image,
+    including one for the whole image."""
     OBJECTS = "objects"
-    """Object detection. This is similar to tags, but focused on detecting physical objects in the image and returning their location."""
+    """Object detection. This is similar to tags, but focused on detecting physical objects in the
+    image and returning their location."""
     READ = "read"
-    """Extract printed or handwritten text from the image. Also known as Optical Character Recognition (OCR)."""
+    """Extract printed or handwritten text from the image. Also known as Optical Character Recognition
+    (OCR)."""
     SMART_CROPS = "smartCrops"
-    """Find representative sub-regions of the image for thumbnail generation, at desired aspect ratios, with priority given to detected faces."""
+    """Find representative sub-regions of the image for thumbnail generation, at desired aspect
+    ratios, with priority given to detected faces."""
     PEOPLE = "people"
     """Detect people in the image and return their location."""

--- a/sdk/vision/azure-ai-vision-imageanalysis/azure/ai/vision/imageanalysis/models/_enums.py
+++ b/sdk/vision/azure-ai-vision-imageanalysis/azure/ai/vision/imageanalysis/models/_enums.py
@@ -14,21 +14,16 @@ class VisualFeatures(str, Enum, metaclass=CaseInsensitiveEnumMeta):
     """The visual features supported by the Image Analysis service."""
 
     TAGS = "tags"
-    """Extract content tags for thousands of recognizable objects, living beings, scenery, and actions
-    #: that appear in the image."""
+    """Extract content tags for thousands of recognizable objects, living beings, scenery, and actions that appear in the image."""
     CAPTION = "caption"
     """Generate a human-readable caption sentence that describes the content of the image."""
     DENSE_CAPTIONS = "denseCaptions"
-    """Generate human-readable caption sentences for up to 10 different regions in the image,
-    #: including one for the whole image."""
+    """Generate human-readable caption sentences for up to 10 different regions in the image, including one for the whole image."""
     OBJECTS = "objects"
-    """Object detection. This is similar to tags, but focused on detecting physical objects in the
-    #: image and returning their location."""
+    """Object detection. This is similar to tags, but focused on detecting physical objects in the image and returning their location."""
     READ = "read"
-    """Extract printed or handwritten text from the image. Also known as Optical Character Recognition
-    #: (OCR)."""
+    """Extract printed or handwritten text from the image. Also known as Optical Character Recognition (OCR)."""
     SMART_CROPS = "smartCrops"
-    """Find representative sub-regions of the image for thumbnail generation, at desired aspect
-    #: ratios, with priority given to detected faces."""
+    """Find representative sub-regions of the image for thumbnail generation, at desired aspect ratios, with priority given to detected faces."""
     PEOPLE = "people"
     """Detect people in the image and return their location."""

--- a/sdk/vision/azure-ai-vision-imageanalysis/azure/ai/vision/imageanalysis/models/_models.py
+++ b/sdk/vision/azure-ai-vision-imageanalysis/azure/ai/vision/imageanalysis/models/_models.py
@@ -157,18 +157,18 @@ class DenseCaptionsResult(_model_base.Model):
 
     All required parameters must be populated in order to send to server.
 
-    :ivar values_property: The list of image captions. Required.
-    :vartype values_property: list[~azure.ai.vision.imageanalysis.models.DenseCaption]
+    :ivar list: The list of image captions. Required.
+    :vartype list: list[~azure.ai.vision.imageanalysis.models.DenseCaption]
     """
 
-    values_property: List["_models.DenseCaption"] = rest_field(name="values")
+    list: List["_models.DenseCaption"] = rest_field(name="values")
     """The list of image captions. Required."""
 
     @overload
     def __init__(
         self,
         *,
-        values_property: List["_models.DenseCaption"],
+        list: List["_models.DenseCaption"],
     ):
         ...
 
@@ -627,19 +627,18 @@ class ObjectsResult(_model_base.Model):
 
     All required parameters must be populated in order to send to server.
 
-    :ivar values_property: A list of physical object detected in an image and their location.
-     Required.
-    :vartype values_property: list[~azure.ai.vision.imageanalysis.models.DetectedObject]
+    :ivar list: A list of physical object detected in an image and their location. Required.
+    :vartype list: list[~azure.ai.vision.imageanalysis.models.DetectedObject]
     """
 
-    values_property: List["_models.DetectedObject"] = rest_field(name="values")
+    list: List["_models.DetectedObject"] = rest_field(name="values")
     """A list of physical object detected in an image and their location. Required."""
 
     @overload
     def __init__(
         self,
         *,
-        values_property: List["_models.DetectedObject"],
+        list: List["_models.DetectedObject"],
     ):
         ...
 
@@ -659,18 +658,18 @@ class PeopleResult(_model_base.Model):
 
     All required parameters must be populated in order to send to server.
 
-    :ivar values_property: A list of people detected in an image and their location. Required.
-    :vartype values_property: list[~azure.ai.vision.imageanalysis.models.DetectedPerson]
+    :ivar list: A list of people detected in an image and their location. Required.
+    :vartype list: list[~azure.ai.vision.imageanalysis.models.DetectedPerson]
     """
 
-    values_property: List["_models.DetectedPerson"] = rest_field(name="values")
+    list: List["_models.DetectedPerson"] = rest_field(name="values")
     """A list of people detected in an image and their location. Required."""
 
     @overload
     def __init__(
         self,
         *,
-        values_property: List["_models.DetectedPerson"],
+        list: List["_models.DetectedPerson"],
     ):
         ...
 
@@ -726,18 +725,18 @@ class SmartCropsResult(_model_base.Model):
 
     All required parameters must be populated in order to send to server.
 
-    :ivar values_property: A list of crop regions. Required.
-    :vartype values_property: list[~azure.ai.vision.imageanalysis.models.CropRegion]
+    :ivar list: A list of crop regions. Required.
+    :vartype list: list[~azure.ai.vision.imageanalysis.models.CropRegion]
     """
 
-    values_property: List["_models.CropRegion"] = rest_field(name="values")
+    list: List["_models.CropRegion"] = rest_field(name="values")
     """A list of crop regions. Required."""
 
     @overload
     def __init__(
         self,
         *,
-        values_property: List["_models.CropRegion"],
+        list: List["_models.CropRegion"],
     ):
         ...
 
@@ -759,18 +758,18 @@ class TagsResult(_model_base.Model):
 
     All required parameters must be populated in order to send to server.
 
-    :ivar values_property: A list of tags. Required.
-    :vartype values_property: list[~azure.ai.vision.imageanalysis.models.DetectedTag]
+    :ivar list: A list of tags. Required.
+    :vartype list: list[~azure.ai.vision.imageanalysis.models.DetectedTag]
     """
 
-    values_property: List["_models.DetectedTag"] = rest_field(name="values")
+    list: List["_models.DetectedTag"] = rest_field(name="values")
     """A list of tags. Required."""
 
     @overload
     def __init__(
         self,
         *,
-        values_property: List["_models.DetectedTag"],
+        list: List["_models.DetectedTag"],
     ):
         ...
 

--- a/sdk/vision/azure-ai-vision-imageanalysis/azure/ai/vision/imageanalysis/models/_models.py
+++ b/sdk/vision/azure-ai-vision-imageanalysis/azure/ai/vision/imageanalysis/models/_models.py
@@ -157,18 +157,18 @@ class DenseCaptionsResult(_model_base.Model):
 
     All required parameters must be populated in order to send to server.
 
-    :ivar values: The list of image captions. Required.
-    :vartype values: list[~azure.ai.vision.imageanalysis.models.DenseCaption]
+    :ivar values_property: The list of image captions. Required.
+    :vartype values_property: list[~azure.ai.vision.imageanalysis.models.DenseCaption]
     """
 
-    values: List["_models.DenseCaption"] = rest_field()
+    values_property: List["_models.DenseCaption"] = rest_field(name="values")
     """The list of image captions. Required."""
 
     @overload
     def __init__(
         self,
         *,
-        values: List["_models.DenseCaption"],
+        values_property: List["_models.DenseCaption"],
     ):
         ...
 
@@ -627,18 +627,19 @@ class ObjectsResult(_model_base.Model):
 
     All required parameters must be populated in order to send to server.
 
-    :ivar values: A list of physical object detected in an image and their location. Required.
-    :vartype values: list[~azure.ai.vision.imageanalysis.models.DetectedObject]
+    :ivar values_property: A list of physical object detected in an image and their location.
+     Required.
+    :vartype values_property: list[~azure.ai.vision.imageanalysis.models.DetectedObject]
     """
 
-    values: List["_models.DetectedObject"] = rest_field()
+    values_property: List["_models.DetectedObject"] = rest_field(name="values")
     """A list of physical object detected in an image and their location. Required."""
 
     @overload
     def __init__(
         self,
         *,
-        values: List["_models.DetectedObject"],
+        values_property: List["_models.DetectedObject"],
     ):
         ...
 
@@ -658,18 +659,18 @@ class PeopleResult(_model_base.Model):
 
     All required parameters must be populated in order to send to server.
 
-    :ivar values: A list of people detected in an image and their location. Required.
-    :vartype values: list[~azure.ai.vision.imageanalysis.models.DetectedPerson]
+    :ivar values_property: A list of people detected in an image and their location. Required.
+    :vartype values_property: list[~azure.ai.vision.imageanalysis.models.DetectedPerson]
     """
 
-    values: List["_models.DetectedPerson"] = rest_field()
+    values_property: List["_models.DetectedPerson"] = rest_field(name="values")
     """A list of people detected in an image and their location. Required."""
 
     @overload
     def __init__(
         self,
         *,
-        values: List["_models.DetectedPerson"],
+        values_property: List["_models.DetectedPerson"],
     ):
         ...
 
@@ -725,18 +726,18 @@ class SmartCropsResult(_model_base.Model):
 
     All required parameters must be populated in order to send to server.
 
-    :ivar values: A list of crop regions. Required.
-    :vartype values: list[~azure.ai.vision.imageanalysis.models.CropRegion]
+    :ivar values_property: A list of crop regions. Required.
+    :vartype values_property: list[~azure.ai.vision.imageanalysis.models.CropRegion]
     """
 
-    values: List["_models.CropRegion"] = rest_field()
+    values_property: List["_models.CropRegion"] = rest_field(name="values")
     """A list of crop regions. Required."""
 
     @overload
     def __init__(
         self,
         *,
-        values: List["_models.CropRegion"],
+        values_property: List["_models.CropRegion"],
     ):
         ...
 
@@ -758,18 +759,18 @@ class TagsResult(_model_base.Model):
 
     All required parameters must be populated in order to send to server.
 
-    :ivar values: A list of tags. Required.
-    :vartype values: list[~azure.ai.vision.imageanalysis.models.DetectedTag]
+    :ivar values_property: A list of tags. Required.
+    :vartype values_property: list[~azure.ai.vision.imageanalysis.models.DetectedTag]
     """
 
-    values: List["_models.DetectedTag"] = rest_field()
+    values_property: List["_models.DetectedTag"] = rest_field(name="values")
     """A list of tags. Required."""
 
     @overload
     def __init__(
         self,
         *,
-        values: List["_models.DetectedTag"],
+        values_property: List["_models.DetectedTag"],
     ):
         ...
 

--- a/sdk/vision/azure-ai-vision-imageanalysis/mypy.ini
+++ b/sdk/vision/azure-ai-vision-imageanalysis/mypy.ini
@@ -7,7 +7,3 @@
 # See GitHub issue: https://github.com/Azure/autorest.python/issues/2317
 [mypy-azure.ai.vision.imageanalysis.models._models]
 disable_error_code = assignment
-
-# Note that we also have the line `# mypy: disable-error-code="attr-defined"` at the top of every sample code file
-# under the "samples" folder. This is to suppress the MyPy error "ImageAnalysisClient has no attribute analyze  [attr-defined]".
-# See GitHub issue: https://github.com/Azure/autorest.python/issues/2321

--- a/sdk/vision/azure-ai-vision-imageanalysis/mypy.ini
+++ b/sdk/vision/azure-ai-vision-imageanalysis/mypy.ini
@@ -1,9 +1,0 @@
-# Per advice from Azure SDK team, suppress the assignment error in _models.py. This file was auto-generated from TypeSpec files, and produces these MyPy errors:
-#   azure\ai\vision\imageanalysis\models\_models.py:164: error: Incompatible types in assignment (expression has type "List[DenseCaption]", base class "_MyMutableMapping" defined the type as "Callable[[_MyMutableMapping], ValuesView[Any]]")  [assignment]
-#   azure\ai\vision\imageanalysis\models\_models.py:634: error: Incompatible types in assignment (expression has type "List[DetectedObject]", base class "_MyMutableMapping" defined the type as "Callable[[_MyMutableMapping], ValuesView[Any]]")  [assignment]
-#   azure\ai\vision\imageanalysis\models\_models.py:665: error: Incompatible types in assignment (expression has type "List[DetectedPerson]", base class "_MyMutableMapping" defined the type as "Callable[[_MyMutableMapping], ValuesView[Any]]")  [assignment]
-#   azure\ai\vision\imageanalysis\models\_models.py:732: error: Incompatible types in assignment (expression has type "List[CropRegion]", base class "_MyMutableMapping" defined the type as "Callable[[_MyMutableMapping], ValuesView[Any]]")  [assignment]
-#   azure\ai\vision\imageanalysis\models\_models.py:765: error: Incompatible types in assignment (expression has type "List[DetectedTag]", base class "_MyMutableMapping" defined the type as "Callable[[_MyMutableMapping], ValuesView[Any]]")  [assignment]
-# See GitHub issue: https://github.com/Azure/autorest.python/issues/2317
-[mypy-azure.ai.vision.imageanalysis.models._models]
-disable_error_code = assignment

--- a/sdk/vision/azure-ai-vision-imageanalysis/pyproject.toml
+++ b/sdk/vision/azure-ai-vision-imageanalysis/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.generate]
+autorest-post-process = true

--- a/sdk/vision/azure-ai-vision-imageanalysis/samples/async_samples/sample_caption_image_file_async.py
+++ b/sdk/vision/azure-ai-vision-imageanalysis/samples/async_samples/sample_caption_image_file_async.py
@@ -2,7 +2,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
-# mypy: disable-error-code="attr-defined"
 """
 DESCRIPTION:
     This sample demonstrates how to generate a human-readable sentence that describes the content

--- a/sdk/vision/azure-ai-vision-imageanalysis/samples/async_samples/sample_caption_image_file_async.py
+++ b/sdk/vision/azure-ai-vision-imageanalysis/samples/async_samples/sample_caption_image_file_async.py
@@ -28,6 +28,7 @@ USAGE:
 """
 import asyncio
 
+
 async def sample_caption_image_file_async():
     import os
     from azure.ai.vision.imageanalysis.aio import ImageAnalysisClient
@@ -44,20 +45,14 @@ async def sample_caption_image_file_async():
         exit()
 
     # Load image to analyze into a 'bytes' object
-    with open("sample.jpg", 'rb') as f:
+    with open("sample.jpg", "rb") as f:
         image_data = f.read()
 
     # Create an asynchronous Image Analysis client
-    client = ImageAnalysisClient(
-        endpoint = endpoint,
-        credential = AzureKeyCredential(key)
-    )
+    client = ImageAnalysisClient(endpoint=endpoint, credential=AzureKeyCredential(key))
 
     # Get a caption for the image, asynchronously.
-    result = await client.analyze(
-        image_data = image_data,
-        visual_features = [ VisualFeatures.CAPTION ]
-    )
+    result = await client.analyze(image_data=image_data, visual_features=[VisualFeatures.CAPTION])
 
     await client.close()
 
@@ -74,5 +69,6 @@ async def sample_caption_image_file_async():
 async def main():
     await sample_caption_image_file_async()
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     asyncio.run(main())

--- a/sdk/vision/azure-ai-vision-imageanalysis/samples/async_samples/sample_caption_image_file_async.py
+++ b/sdk/vision/azure-ai-vision-imageanalysis/samples/async_samples/sample_caption_image_file_async.py
@@ -48,10 +48,16 @@ async def sample_caption_image_file_async():
         image_data = f.read()
 
     # Create an asynchronous Image Analysis client
-    client = ImageAnalysisClient(endpoint=endpoint, credential=AzureKeyCredential(key))
+    client = ImageAnalysisClient(
+        endpoint=endpoint,
+        credential=AzureKeyCredential(key)
+    )
 
     # Get a caption for the image, asynchronously.
-    result = await client.analyze(image_data=image_data, visual_features=[VisualFeatures.CAPTION])
+    result = await client.analyze(
+        image_data=image_data,
+        visual_features=[VisualFeatures.CAPTION]
+    )
 
     await client.close()
 

--- a/sdk/vision/azure-ai-vision-imageanalysis/samples/async_samples/sample_ocr_image_url_async.py
+++ b/sdk/vision/azure-ai-vision-imageanalysis/samples/async_samples/sample_ocr_image_url_async.py
@@ -47,11 +47,15 @@ async def sample_ocr_image_file_async():
         exit()
 
     # Create an asynchronous Image Analysis client
-    client = ImageAnalysisClient(endpoint=endpoint, credential=AzureKeyCredential(key))
+    client = ImageAnalysisClient(
+        endpoint=endpoint,
+        credential=AzureKeyCredential(key)
+    )
 
     # Extract text (OCR) from an image URL, asynchronously.
     result = await client.analyze(
-        image_url="https://aka.ms/azsdk/image-analysis/sample.jpg", visual_features=[VisualFeatures.READ]
+        image_url="https://aka.ms/azsdk/image-analysis/sample.jpg",
+        visual_features=[VisualFeatures.READ]
     )
 
     await client.close()

--- a/sdk/vision/azure-ai-vision-imageanalysis/samples/async_samples/sample_ocr_image_url_async.py
+++ b/sdk/vision/azure-ai-vision-imageanalysis/samples/async_samples/sample_ocr_image_url_async.py
@@ -2,7 +2,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
-# mypy: disable-error-code="attr-defined"
 """
 DESCRIPTION:
     This sample demonstrates how to extract printed or hand-written text from a

--- a/sdk/vision/azure-ai-vision-imageanalysis/samples/async_samples/sample_ocr_image_url_async.py
+++ b/sdk/vision/azure-ai-vision-imageanalysis/samples/async_samples/sample_ocr_image_url_async.py
@@ -67,9 +67,7 @@ async def sample_ocr_image_file_async():
         for line in result.read.blocks[0].lines:
             print(f"   Line: '{line.text}', Bounding box {line.bounding_polygon}")
             for word in line.words:
-                print(
-                    f"     Word: '{word.text}', Bounding polygon {word.bounding_polygon}, Confidence {word.confidence:.4f}"
-                )
+                print(f"     Word: '{word.text}', Bounding polygon {word.bounding_polygon}, Confidence {word.confidence:.4f}")
     print(f" Image height: {result.metadata.height}")
     print(f" Image width: {result.metadata.width}")
     print(f" Model version: {result.model_version}")

--- a/sdk/vision/azure-ai-vision-imageanalysis/samples/async_samples/sample_ocr_image_url_async.py
+++ b/sdk/vision/azure-ai-vision-imageanalysis/samples/async_samples/sample_ocr_image_url_async.py
@@ -31,6 +31,7 @@ USAGE:
 """
 import asyncio
 
+
 async def sample_ocr_image_file_async():
     import os
     from azure.ai.vision.imageanalysis.aio import ImageAnalysisClient
@@ -47,15 +48,11 @@ async def sample_ocr_image_file_async():
         exit()
 
     # Create an asynchronous Image Analysis client
-    client = ImageAnalysisClient(
-        endpoint = endpoint,
-        credential = AzureKeyCredential(key)
-    )
+    client = ImageAnalysisClient(endpoint=endpoint, credential=AzureKeyCredential(key))
 
     # Extract text (OCR) from an image URL, asynchronously.
     result = await client.analyze(
-        image_url = "https://aka.ms/azsdk/image-analysis/sample.jpg",
-        visual_features = [ VisualFeatures.READ ]
+        image_url="https://aka.ms/azsdk/image-analysis/sample.jpg", visual_features=[VisualFeatures.READ]
     )
 
     await client.close()
@@ -67,7 +64,9 @@ async def sample_ocr_image_file_async():
         for line in result.read.blocks[0].lines:
             print(f"   Line: '{line.text}', Bounding box {line.bounding_polygon}")
             for word in line.words:
-                print(f"     Word: '{word.text}', Bounding polygon {word.bounding_polygon}, Confidence {word.confidence:.4f}")
+                print(
+                    f"     Word: '{word.text}', Bounding polygon {word.bounding_polygon}, Confidence {word.confidence:.4f}"
+                )
     print(f" Image height: {result.metadata.height}")
     print(f" Image width: {result.metadata.width}")
     print(f" Model version: {result.model_version}")
@@ -76,5 +75,6 @@ async def sample_ocr_image_file_async():
 async def main():
     await sample_ocr_image_file_async()
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     asyncio.run(main())

--- a/sdk/vision/azure-ai-vision-imageanalysis/samples/sample_analyze_all_image_file.py
+++ b/sdk/vision/azure-ai-vision-imageanalysis/samples/sample_analyze_all_image_file.py
@@ -112,9 +112,7 @@ def sample_analyze_all_image_file():
         for line in result.read.blocks[0].lines:
             print(f"   Line: '{line.text}', Bounding box {line.bounding_polygon}")
             for word in line.words:
-                print(
-                    f"     Word: '{word.text}', Bounding polygon {word.bounding_polygon}, Confidence {word.confidence:.4f}"
-                )
+                print(f"     Word: '{word.text}', Bounding polygon {word.bounding_polygon}, Confidence {word.confidence:.4f}")
 
     if result.tags is not None:
         print(" Tags:")

--- a/sdk/vision/azure-ai-vision-imageanalysis/samples/sample_analyze_all_image_file.py
+++ b/sdk/vision/azure-ai-vision-imageanalysis/samples/sample_analyze_all_image_file.py
@@ -70,7 +70,11 @@ def sample_analyze_all_image_file():
 
     # [START create_client_with_logging]
     # Create an Image Analysis client with none redacted log
-    client = ImageAnalysisClient(endpoint=endpoint, credential=AzureKeyCredential(key), logging_enable=True)
+    client = ImageAnalysisClient(
+        endpoint=endpoint,
+        credential=AzureKeyCredential(key),
+        logging_enable=True
+    )
     # [END create_client_with_logging]
 
     # Analyze all visual features from an image stream. This will be a synchronously (blocking) call.

--- a/sdk/vision/azure-ai-vision-imageanalysis/samples/sample_analyze_all_image_file.py
+++ b/sdk/vision/azure-ai-vision-imageanalysis/samples/sample_analyze_all_image_file.py
@@ -2,7 +2,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
-# mypy: disable-error-code="attr-defined"
 """
 DESCRIPTION:
     This sample demonstrates how to analyze all supported visual features from the image file sample.jpg,

--- a/sdk/vision/azure-ai-vision-imageanalysis/samples/sample_analyze_all_image_file.py
+++ b/sdk/vision/azure-ai-vision-imageanalysis/samples/sample_analyze_all_image_file.py
@@ -101,7 +101,7 @@ def sample_analyze_all_image_file():
 
     if result.dense_captions is not None:
         print(" Dense Captions:")
-        for caption in result.dense_captions.values:
+        for caption in result.dense_captions.list:
             print(f"   '{caption.text}', {caption.bounding_box}, Confidence: {caption.confidence:.4f}")
 
     if result.read is not None:
@@ -115,22 +115,22 @@ def sample_analyze_all_image_file():
 
     if result.tags is not None:
         print(" Tags:")
-        for tag in result.tags.values:
+        for tag in result.tags.list:
             print(f"   '{tag.name}', Confidence {tag.confidence:.4f}")
 
     if result.objects is not None:
         print(" Objects:")
-        for object in result.objects.values:
+        for object in result.objects.list:
             print(f"   '{object.tags[0].name}', {object.bounding_box}, Confidence: {object.tags[0].confidence:.4f}")
 
     if result.people is not None:
         print(" People:")
-        for person in result.people.values:
+        for person in result.people.list:
             print(f"   {person.bounding_box}, Confidence {person.confidence:.4f}")
 
     if result.smart_crops is not None:
         print(" Smart Cropping:")
-        for smart_crop in result.smart_crops.values:
+        for smart_crop in result.smart_crops.list:
             print(f"   Aspect ratio {smart_crop.aspect_ratio}: Smart crop {smart_crop.bounding_box}")
 
     print(f" Image height: {result.metadata.height}")

--- a/sdk/vision/azure-ai-vision-imageanalysis/samples/sample_analyze_all_image_file.py
+++ b/sdk/vision/azure-ai-vision-imageanalysis/samples/sample_analyze_all_image_file.py
@@ -26,6 +26,8 @@ USAGE:
                          where `your-resource-name` is your unique Azure Computer Vision resource name.
     2) VISION_KEY - Your Computer Vision key (a 32-character Hexadecimal number)
 """
+
+
 def sample_analyze_all_image_file():
     import os
     from azure.ai.vision.imageanalysis import ImageAnalysisClient
@@ -36,21 +38,21 @@ def sample_analyze_all_image_file():
     import sys
     import logging
 
-    # Acquire the logger for this client library. Use 'azure' to affect both 
+    # Acquire the logger for this client library. Use 'azure' to affect both
     # 'azure.core` and `azure.ai.vision.imageanalysis' libraries.
-    logger = logging.getLogger('azure')
+    logger = logging.getLogger("azure")
 
     # Set the desired logging level. logging.INFO or logging.DEBUG are good options.
     logger.setLevel(logging.INFO)
 
     # Direct logging output to stdout (the default):
-    handler = logging.StreamHandler(stream = sys.stdout)
+    handler = logging.StreamHandler(stream=sys.stdout)
     # Or direct logging output to a file:
     # handler = logging.FileHandler(filename = 'sample.log')
     logger.addHandler(handler)
 
     # Optional: change the default logging format. Here we add a timestamp.
-    formatter = logging.Formatter('%(asctime)s:%(levelname)s:%(name)s:%(message)s')
+    formatter = logging.Formatter("%(asctime)s:%(levelname)s:%(name)s:%(message)s")
     handler.setFormatter(formatter)
     # [END logging]
 
@@ -64,34 +66,30 @@ def sample_analyze_all_image_file():
         exit()
 
     # Load image to analyze into a 'bytes' object
-    with open("sample.jpg", 'rb') as f:
+    with open("sample.jpg", "rb") as f:
         image_data = f.read()
 
     # [START create_client_with_logging]
     # Create an Image Analysis client with none redacted log
-    client = ImageAnalysisClient(
-        endpoint = endpoint,
-        credential = AzureKeyCredential(key),
-        logging_enable = True
-    )
+    client = ImageAnalysisClient(endpoint=endpoint, credential=AzureKeyCredential(key), logging_enable=True)
     # [END create_client_with_logging]
 
     # Analyze all visual features from an image stream. This will be a synchronously (blocking) call.
     result = client.analyze(
-        image_data = image_data,
-        visual_features = [
+        image_data=image_data,
+        visual_features=[
             VisualFeatures.TAGS,
             VisualFeatures.OBJECTS,
             VisualFeatures.CAPTION,
             VisualFeatures.DENSE_CAPTIONS,
             VisualFeatures.READ,
             VisualFeatures.SMART_CROPS,
-            VisualFeatures.PEOPLE
-        ], # Mandatory. Select one or more visual features to analyze.
-        smart_crops_aspect_ratios = [0.9, 1.33], # Optional. Relevant only if SMART_CROPS was specified above.
-        gender_neutral_caption = True, # Optional. Relevant only if CAPTION or DENSE_CAPTIONS were specified above.
-        language = "en", # Optional. Relevant only if TAGS is specified above. See https://aka.ms/cv-languages for supported languages.
-        model_version = "latest" # Optional. Analysis model version to use. Defaults to "latest".
+            VisualFeatures.PEOPLE,
+        ],  # Mandatory. Select one or more visual features to analyze.
+        smart_crops_aspect_ratios=[0.9, 1.33],  # Optional. Relevant only if SMART_CROPS was specified above.
+        gender_neutral_caption=True,  # Optional. Relevant only if CAPTION or DENSE_CAPTIONS were specified above.
+        language="en",  # Optional. Relevant only if TAGS is specified above. See https://aka.ms/cv-languages for supported languages.
+        model_version="latest",  # Optional. Analysis model version to use. Defaults to "latest".
     )
 
     # Print all analysis results to the console
@@ -111,7 +109,9 @@ def sample_analyze_all_image_file():
         for line in result.read.blocks[0].lines:
             print(f"   Line: '{line.text}', Bounding box {line.bounding_polygon}")
             for word in line.words:
-                print(f"     Word: '{word.text}', Bounding polygon {word.bounding_polygon}, Confidence {word.confidence:.4f}")
+                print(
+                    f"     Word: '{word.text}', Bounding polygon {word.bounding_polygon}, Confidence {word.confidence:.4f}"
+                )
 
     if result.tags is not None:
         print(" Tags:")
@@ -138,5 +138,5 @@ def sample_analyze_all_image_file():
     print(f" Model version: {result.model_version}")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sample_analyze_all_image_file()

--- a/sdk/vision/azure-ai-vision-imageanalysis/samples/sample_caption_image_file.py
+++ b/sdk/vision/azure-ai-vision-imageanalysis/samples/sample_caption_image_file.py
@@ -2,7 +2,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
-# mypy: disable-error-code="attr-defined"
 """
 DESCRIPTION:
     This sample demonstrates how to generate a human-readable sentence that describes the content

--- a/sdk/vision/azure-ai-vision-imageanalysis/samples/sample_caption_image_file.py
+++ b/sdk/vision/azure-ai-vision-imageanalysis/samples/sample_caption_image_file.py
@@ -45,7 +45,10 @@ def sample_caption_image_file():
         exit()
 
     # Create an Image Analysis client for synchronous operations
-    client = ImageAnalysisClient(endpoint=endpoint, credential=AzureKeyCredential(key))
+    client = ImageAnalysisClient(
+        endpoint=endpoint,
+        credential=AzureKeyCredential(key)
+    )
     # [END create_client]
 
     # [START caption]

--- a/sdk/vision/azure-ai-vision-imageanalysis/samples/sample_caption_image_file.py
+++ b/sdk/vision/azure-ai-vision-imageanalysis/samples/sample_caption_image_file.py
@@ -26,6 +26,8 @@ USAGE:
                          where `your-resource-name` is your unique Azure Computer Vision resource name.
     2) VISION_KEY - Your Computer Vision key (a 32-character Hexadecimal number)
 """
+
+
 def sample_caption_image_file():
     # [START create_client]
     import os
@@ -33,7 +35,7 @@ def sample_caption_image_file():
     from azure.ai.vision.imageanalysis.models import VisualFeatures
     from azure.core.credentials import AzureKeyCredential
 
-    # Set the values of your computer vision endpoint and computer vision key 
+    # Set the values of your computer vision endpoint and computer vision key
     # as environment variables:
     try:
         endpoint = os.environ["VISION_ENDPOINT"]
@@ -44,22 +46,19 @@ def sample_caption_image_file():
         exit()
 
     # Create an Image Analysis client for synchronous operations
-    client = ImageAnalysisClient(
-        endpoint = endpoint,
-        credential = AzureKeyCredential(key)
-    )
+    client = ImageAnalysisClient(endpoint=endpoint, credential=AzureKeyCredential(key))
     # [END create_client]
 
     # [START caption]
     # Load image to analyze into a 'bytes' object
-    with open("sample.jpg", 'rb') as f:
+    with open("sample.jpg", "rb") as f:
         image_data = f.read()
 
     # Get a caption for the image. This will be a synchronously (blocking) call.
     result = client.analyze(
-        image_data = image_data,
-        visual_features = [ VisualFeatures.CAPTION ],
-        gender_neutral_caption = True # Optional (default is False)
+        image_data=image_data,
+        visual_features=[VisualFeatures.CAPTION],
+        gender_neutral_caption=True,  # Optional (default is False)
     )
 
     # Print caption results to the console
@@ -73,5 +72,5 @@ def sample_caption_image_file():
     print(f" Model version: {result.model_version}")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sample_caption_image_file()

--- a/sdk/vision/azure-ai-vision-imageanalysis/samples/sample_caption_image_url.py
+++ b/sdk/vision/azure-ai-vision-imageanalysis/samples/sample_caption_image_url.py
@@ -2,7 +2,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
-# mypy: disable-error-code="attr-defined"
 """
 DESCRIPTION:
     This sample demonstrates how to generate a human-readable sentence that describes the content

--- a/sdk/vision/azure-ai-vision-imageanalysis/samples/sample_caption_image_url.py
+++ b/sdk/vision/azure-ai-vision-imageanalysis/samples/sample_caption_image_url.py
@@ -26,13 +26,15 @@ USAGE:
                          where `your-resource-name` is your unique Azure Computer Vision resource name.
     2) VISION_KEY - Your Computer Vision key (a 32-character Hexadecimal number)
 """
+
+
 def sample_caption_image_url():
     import os
     from azure.ai.vision.imageanalysis import ImageAnalysisClient
     from azure.ai.vision.imageanalysis.models import VisualFeatures
     from azure.core.credentials import AzureKeyCredential
 
-    # Set the values of your computer vision endpoint and computer vision key 
+    # Set the values of your computer vision endpoint and computer vision key
     # as environment variables:
     try:
         endpoint = os.environ["VISION_ENDPOINT"]
@@ -43,17 +45,14 @@ def sample_caption_image_url():
         exit()
 
     # Create an Image Analysis client
-    client = ImageAnalysisClient(
-        endpoint = endpoint,
-        credential = AzureKeyCredential(key)
-    )
+    client = ImageAnalysisClient(endpoint=endpoint, credential=AzureKeyCredential(key))
 
     # [START caption]
     # Get a caption for the image. This will be a synchronously (blocking) call.
     result = client.analyze(
-        image_url = "https://aka.ms/azsdk/image-analysis/sample.jpg",
-        visual_features = [ VisualFeatures.CAPTION ],
-        gender_neutral_caption = True # Optional (default is False)
+        image_url="https://aka.ms/azsdk/image-analysis/sample.jpg",
+        visual_features=[VisualFeatures.CAPTION],
+        gender_neutral_caption=True,  # Optional (default is False)
     )
 
     # Print caption results to the console
@@ -67,5 +66,5 @@ def sample_caption_image_url():
     print(f" Model version: {result.model_version}")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sample_caption_image_url()

--- a/sdk/vision/azure-ai-vision-imageanalysis/samples/sample_caption_image_url.py
+++ b/sdk/vision/azure-ai-vision-imageanalysis/samples/sample_caption_image_url.py
@@ -44,7 +44,10 @@ def sample_caption_image_url():
         exit()
 
     # Create an Image Analysis client
-    client = ImageAnalysisClient(endpoint=endpoint, credential=AzureKeyCredential(key))
+    client = ImageAnalysisClient(
+        endpoint=endpoint,
+        credential=AzureKeyCredential(key)
+    )
 
     # [START caption]
     # Get a caption for the image. This will be a synchronously (blocking) call.

--- a/sdk/vision/azure-ai-vision-imageanalysis/samples/sample_dense_captions_image_file.py
+++ b/sdk/vision/azure-ai-vision-imageanalysis/samples/sample_dense_captions_image_file.py
@@ -48,7 +48,10 @@ def sample_dense_captions_image_file():
         exit()
 
     # Create an Image Analysis client.
-    client = ImageAnalysisClient(endpoint=endpoint, credential=AzureKeyCredential(key))
+    client = ImageAnalysisClient(
+        endpoint=endpoint,
+        credential=AzureKeyCredential(key)
+    )
 
     # Load image to analyze into a 'bytes' object.
     with open("sample.jpg", "rb") as f:

--- a/sdk/vision/azure-ai-vision-imageanalysis/samples/sample_dense_captions_image_file.py
+++ b/sdk/vision/azure-ai-vision-imageanalysis/samples/sample_dense_captions_image_file.py
@@ -2,7 +2,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
-# mypy: disable-error-code="attr-defined"
 """
 DESCRIPTION:
     This sample demonstrates how to generate up to 10 human-readable sentences (captions) that describe

--- a/sdk/vision/azure-ai-vision-imageanalysis/samples/sample_dense_captions_image_file.py
+++ b/sdk/vision/azure-ai-vision-imageanalysis/samples/sample_dense_captions_image_file.py
@@ -30,13 +30,15 @@ USAGE:
                          where `your-resource-name` is your unique Azure Computer Vision resource name.
     2) VISION_KEY - Your Computer Vision key (a 32-character Hexadecimal number)
 """
+
+
 def sample_dense_captions_image_file():
     import os
     from azure.ai.vision.imageanalysis import ImageAnalysisClient
     from azure.ai.vision.imageanalysis.models import VisualFeatures
     from azure.core.credentials import AzureKeyCredential
 
-    # Set the values of your computer vision endpoint and computer vision key 
+    # Set the values of your computer vision endpoint and computer vision key
     # as environment variables:
     try:
         endpoint = os.environ["VISION_ENDPOINT"]
@@ -47,21 +49,18 @@ def sample_dense_captions_image_file():
         exit()
 
     # Create an Image Analysis client.
-    client = ImageAnalysisClient(
-        endpoint = endpoint,
-        credential = AzureKeyCredential(key)
-    )
+    client = ImageAnalysisClient(endpoint=endpoint, credential=AzureKeyCredential(key))
 
     # Load image to analyze into a 'bytes' object.
-    with open("sample.jpg", 'rb') as f:
+    with open("sample.jpg", "rb") as f:
         image_data = f.read()
 
     # Extract multiple captions, each for a different area of the image.
     # This will be a synchronously (blocking) call.
     result = client.analyze(
-        image_data = image_data,
-        visual_features = [ VisualFeatures.DENSE_CAPTIONS ],
-        gender_neutral_caption = True # Optional (default is False)
+        image_data=image_data,
+        visual_features=[VisualFeatures.DENSE_CAPTIONS],
+        gender_neutral_caption=True,  # Optional (default is False)
     )
 
     # Print dense caption results to the console. The first caption always
@@ -76,5 +75,5 @@ def sample_dense_captions_image_file():
     print(f" Model version: {result.model_version}")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sample_dense_captions_image_file()

--- a/sdk/vision/azure-ai-vision-imageanalysis/samples/sample_dense_captions_image_file.py
+++ b/sdk/vision/azure-ai-vision-imageanalysis/samples/sample_dense_captions_image_file.py
@@ -68,7 +68,7 @@ def sample_dense_captions_image_file():
     print("Image analysis results:")
     print(" Dense Captions:")
     if result.dense_captions is not None:
-        for caption in result.dense_captions.values:
+        for caption in result.dense_captions.list:
             print(f"   '{caption.text}', {caption.bounding_box}, Confidence: {caption.confidence:.4f}")
     print(f" Image height: {result.metadata.height}")
     print(f" Image width: {result.metadata.width}")

--- a/sdk/vision/azure-ai-vision-imageanalysis/samples/sample_objects_image_file.py
+++ b/sdk/vision/azure-ai-vision-imageanalysis/samples/sample_objects_image_file.py
@@ -55,7 +55,7 @@ def sample_objects_image_file():
     print("Image analysis results:")
     print(" Objects:")
     if result.objects is not None:
-        for object in result.objects.values:
+        for object in result.objects.list:
             print(f"   '{object.tags[0].name}', {object.bounding_box}, Confidence: {object.tags[0].confidence:.4f}")
     print(f" Image height: {result.metadata.height}")
     print(f" Image width: {result.metadata.width}")

--- a/sdk/vision/azure-ai-vision-imageanalysis/samples/sample_objects_image_file.py
+++ b/sdk/vision/azure-ai-vision-imageanalysis/samples/sample_objects_image_file.py
@@ -41,14 +41,20 @@ def sample_objects_image_file():
         exit()
 
     # Create an Image Analysis client
-    client = ImageAnalysisClient(endpoint=endpoint, credential=AzureKeyCredential(key))
+    client = ImageAnalysisClient(
+        endpoint=endpoint,
+        credential=AzureKeyCredential(key)
+    )
 
     # Load image to analyze into a 'bytes' object
     with open("sample.jpg", "rb") as f:
         image_data = f.read()
 
     # Detect objects in an image stream. This will be a synchronously (blocking) call.
-    result = client.analyze(image_data=image_data, visual_features=[VisualFeatures.OBJECTS])
+    result = client.analyze(
+        image_data=image_data,
+        visual_features=[VisualFeatures.OBJECTS]
+    )
 
     # Print Objects analysis results to the console
     print("Image analysis results:")

--- a/sdk/vision/azure-ai-vision-imageanalysis/samples/sample_objects_image_file.py
+++ b/sdk/vision/azure-ai-vision-imageanalysis/samples/sample_objects_image_file.py
@@ -2,7 +2,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
-# mypy: disable-error-code="attr-defined"
 """
 DESCRIPTION:
     This sample demonstrates how to detect physical objects in an image file sample.jpg, using a synchronous client.

--- a/sdk/vision/azure-ai-vision-imageanalysis/samples/sample_objects_image_file.py
+++ b/sdk/vision/azure-ai-vision-imageanalysis/samples/sample_objects_image_file.py
@@ -23,13 +23,15 @@ USAGE:
                          where `your-resource-name` is your unique Azure Computer Vision resource name.
     2) VISION_KEY - Your Computer Vision key (a 32-character Hexadecimal number)
 """
+
+
 def sample_objects_image_file():
     import os
     from azure.ai.vision.imageanalysis import ImageAnalysisClient
     from azure.ai.vision.imageanalysis.models import VisualFeatures
     from azure.core.credentials import AzureKeyCredential
 
-    # Set the values of your computer vision endpoint and computer vision key 
+    # Set the values of your computer vision endpoint and computer vision key
     # as environment variables:
     try:
         endpoint = os.environ["VISION_ENDPOINT"]
@@ -40,20 +42,14 @@ def sample_objects_image_file():
         exit()
 
     # Create an Image Analysis client
-    client = ImageAnalysisClient(
-        endpoint = endpoint,
-        credential = AzureKeyCredential(key)
-    )
+    client = ImageAnalysisClient(endpoint=endpoint, credential=AzureKeyCredential(key))
 
     # Load image to analyze into a 'bytes' object
-    with open("sample.jpg", 'rb') as f:
+    with open("sample.jpg", "rb") as f:
         image_data = f.read()
 
     # Detect objects in an image stream. This will be a synchronously (blocking) call.
-    result = client.analyze(
-        image_data = image_data,
-        visual_features = [ VisualFeatures.OBJECTS ]
-    )
+    result = client.analyze(image_data=image_data, visual_features=[VisualFeatures.OBJECTS])
 
     # Print Objects analysis results to the console
     print("Image analysis results:")
@@ -66,5 +62,5 @@ def sample_objects_image_file():
     print(f" Model version: {result.model_version}")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sample_objects_image_file()

--- a/sdk/vision/azure-ai-vision-imageanalysis/samples/sample_ocr_image_file.py
+++ b/sdk/vision/azure-ai-vision-imageanalysis/samples/sample_ocr_image_file.py
@@ -2,7 +2,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
-# mypy: disable-error-code="attr-defined"
 """
 DESCRIPTION:
     This sample demonstrates how to extract printed or hand-written text for the image file sample.jpg

--- a/sdk/vision/azure-ai-vision-imageanalysis/samples/sample_ocr_image_file.py
+++ b/sdk/vision/azure-ai-vision-imageanalysis/samples/sample_ocr_image_file.py
@@ -29,13 +29,15 @@ USAGE:
                          where `your-resource-name` is your unique Azure Computer Vision resource name.
     2) VISION_KEY - Your Computer Vision key (a 32-character Hexadecimal number)
 """
+
+
 def sample_ocr_image_file():
     import os
     from azure.ai.vision.imageanalysis import ImageAnalysisClient
     from azure.ai.vision.imageanalysis.models import VisualFeatures
     from azure.core.credentials import AzureKeyCredential
 
-    # Set the values of your computer vision endpoint and computer vision key 
+    # Set the values of your computer vision endpoint and computer vision key
     # as environment variables:
     try:
         endpoint = os.environ["VISION_ENDPOINT"]
@@ -46,21 +48,15 @@ def sample_ocr_image_file():
         exit()
 
     # Create an Image Analysis client
-    client = ImageAnalysisClient(
-        endpoint = endpoint,
-        credential = AzureKeyCredential(key)
-    )
+    client = ImageAnalysisClient(endpoint=endpoint, credential=AzureKeyCredential(key))
 
     # [START read]
     # Load image to analyze into a 'bytes' object
-    with open("sample.jpg", 'rb') as f:
+    with open("sample.jpg", "rb") as f:
         image_data = f.read()
 
     # Extract text (OCR) from an image stream. This will be a synchronously (blocking) call.
-    result = client.analyze(
-        image_data = image_data,
-        visual_features = [ VisualFeatures.READ ]
-    )
+    result = client.analyze(image_data=image_data, visual_features=[VisualFeatures.READ])
 
     # Print text (OCR) analysis results to the console
     print("Image analysis results:")
@@ -69,12 +65,14 @@ def sample_ocr_image_file():
         for line in result.read.blocks[0].lines:
             print(f"   Line: '{line.text}', Bounding box {line.bounding_polygon}")
             for word in line.words:
-                print(f"     Word: '{word.text}', Bounding polygon {word.bounding_polygon}, Confidence {word.confidence:.4f}")
+                print(
+                    f"     Word: '{word.text}', Bounding polygon {word.bounding_polygon}, Confidence {word.confidence:.4f}"
+                )
     # [END read]
     print(f" Image height: {result.metadata.height}")
     print(f" Image width: {result.metadata.width}")
     print(f" Model version: {result.model_version}")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sample_ocr_image_file()

--- a/sdk/vision/azure-ai-vision-imageanalysis/samples/sample_ocr_image_file.py
+++ b/sdk/vision/azure-ai-vision-imageanalysis/samples/sample_ocr_image_file.py
@@ -70,9 +70,7 @@ def sample_ocr_image_file():
         for line in result.read.blocks[0].lines:
             print(f"   Line: '{line.text}', Bounding box {line.bounding_polygon}")
             for word in line.words:
-                print(
-                    f"     Word: '{word.text}', Bounding polygon {word.bounding_polygon}, Confidence {word.confidence:.4f}"
-                )
+                print(f"     Word: '{word.text}', Bounding polygon {word.bounding_polygon}, Confidence {word.confidence:.4f}")
     # [END read]
     print(f" Image height: {result.metadata.height}")
     print(f" Image width: {result.metadata.width}")

--- a/sdk/vision/azure-ai-vision-imageanalysis/samples/sample_ocr_image_file.py
+++ b/sdk/vision/azure-ai-vision-imageanalysis/samples/sample_ocr_image_file.py
@@ -47,7 +47,10 @@ def sample_ocr_image_file():
         exit()
 
     # Create an Image Analysis client
-    client = ImageAnalysisClient(endpoint=endpoint, credential=AzureKeyCredential(key))
+    client = ImageAnalysisClient(
+        endpoint=endpoint,
+        credential=AzureKeyCredential(key)
+    )
 
     # [START read]
     # Load image to analyze into a 'bytes' object
@@ -55,7 +58,10 @@ def sample_ocr_image_file():
         image_data = f.read()
 
     # Extract text (OCR) from an image stream. This will be a synchronously (blocking) call.
-    result = client.analyze(image_data=image_data, visual_features=[VisualFeatures.READ])
+    result = client.analyze(
+        image_data=image_data,
+        visual_features=[VisualFeatures.READ]
+    )
 
     # Print text (OCR) analysis results to the console
     print("Image analysis results:")

--- a/sdk/vision/azure-ai-vision-imageanalysis/samples/sample_ocr_image_url.py
+++ b/sdk/vision/azure-ai-vision-imageanalysis/samples/sample_ocr_image_url.py
@@ -29,13 +29,15 @@ USAGE:
                          where `your-resource-name` is your unique Azure Computer Vision resource name.
     2) VISION_KEY - Your Computer Vision key (a 32-character Hexadecimal number)
 """
+
+
 def sample_ocr_image_url():
     import os
     from azure.ai.vision.imageanalysis import ImageAnalysisClient
     from azure.ai.vision.imageanalysis.models import VisualFeatures
     from azure.core.credentials import AzureKeyCredential
 
-    # Set the values of your computer vision endpoint and computer vision key 
+    # Set the values of your computer vision endpoint and computer vision key
     # as environment variables:
     try:
         endpoint = os.environ["VISION_ENDPOINT"]
@@ -46,16 +48,12 @@ def sample_ocr_image_url():
         exit()
 
     # Create an Image Analysis client
-    client = ImageAnalysisClient(
-        endpoint = endpoint,
-        credential = AzureKeyCredential(key)
-    )
+    client = ImageAnalysisClient(endpoint=endpoint, credential=AzureKeyCredential(key))
 
     # [START read]
     # Extract text (OCR) from an image stream. This will be a synchronously (blocking) call.
     result = client.analyze(
-        image_url = "https://aka.ms/azsdk/image-analysis/sample.jpg",
-        visual_features = [ VisualFeatures.READ ]
+        image_url="https://aka.ms/azsdk/image-analysis/sample.jpg", visual_features=[VisualFeatures.READ]
     )
 
     # Print text (OCR) analysis results to the console
@@ -65,12 +63,14 @@ def sample_ocr_image_url():
         for line in result.read.blocks[0].lines:
             print(f"   Line: '{line.text}', Bounding box {line.bounding_polygon}")
             for word in line.words:
-                print(f"     Word: '{word.text}', Bounding polygon {word.bounding_polygon}, Confidence {word.confidence:.4f}")
+                print(
+                    f"     Word: '{word.text}', Bounding polygon {word.bounding_polygon}, Confidence {word.confidence:.4f}"
+                )
     # [END read]
     print(f" Image height: {result.metadata.height}")
     print(f" Image width: {result.metadata.width}")
     print(f" Model version: {result.model_version}")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sample_ocr_image_url()

--- a/sdk/vision/azure-ai-vision-imageanalysis/samples/sample_ocr_image_url.py
+++ b/sdk/vision/azure-ai-vision-imageanalysis/samples/sample_ocr_image_url.py
@@ -47,12 +47,16 @@ def sample_ocr_image_url():
         exit()
 
     # Create an Image Analysis client
-    client = ImageAnalysisClient(endpoint=endpoint, credential=AzureKeyCredential(key))
+    client = ImageAnalysisClient(
+        endpoint=endpoint,
+        credential=AzureKeyCredential(key)
+    )
 
     # [START read]
     # Extract text (OCR) from an image stream. This will be a synchronously (blocking) call.
     result = client.analyze(
-        image_url="https://aka.ms/azsdk/image-analysis/sample.jpg", visual_features=[VisualFeatures.READ]
+        image_url="https://aka.ms/azsdk/image-analysis/sample.jpg",
+        visual_features=[VisualFeatures.READ]
     )
 
     # Print text (OCR) analysis results to the console

--- a/sdk/vision/azure-ai-vision-imageanalysis/samples/sample_ocr_image_url.py
+++ b/sdk/vision/azure-ai-vision-imageanalysis/samples/sample_ocr_image_url.py
@@ -2,7 +2,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
-# mypy: disable-error-code="attr-defined"
 """
 DESCRIPTION:
     This sample demonstrates how to extract printed or hand-written text from a 

--- a/sdk/vision/azure-ai-vision-imageanalysis/samples/sample_ocr_image_url.py
+++ b/sdk/vision/azure-ai-vision-imageanalysis/samples/sample_ocr_image_url.py
@@ -66,9 +66,7 @@ def sample_ocr_image_url():
         for line in result.read.blocks[0].lines:
             print(f"   Line: '{line.text}', Bounding box {line.bounding_polygon}")
             for word in line.words:
-                print(
-                    f"     Word: '{word.text}', Bounding polygon {word.bounding_polygon}, Confidence {word.confidence:.4f}"
-                )
+                print(f"     Word: '{word.text}', Bounding polygon {word.bounding_polygon}, Confidence {word.confidence:.4f}")
     # [END read]
     print(f" Image height: {result.metadata.height}")
     print(f" Image width: {result.metadata.width}")

--- a/sdk/vision/azure-ai-vision-imageanalysis/samples/sample_people_image_file.py
+++ b/sdk/vision/azure-ai-vision-imageanalysis/samples/sample_people_image_file.py
@@ -2,7 +2,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
-# mypy: disable-error-code="attr-defined"
 """
 DESCRIPTION:
     This sample demonstrates how to detect people in the image file sample.jpg using a synchronous client.

--- a/sdk/vision/azure-ai-vision-imageanalysis/samples/sample_people_image_file.py
+++ b/sdk/vision/azure-ai-vision-imageanalysis/samples/sample_people_image_file.py
@@ -54,7 +54,7 @@ def sample_people_image_file():
     print("Image analysis results:")
     print(" People:")
     if result.people is not None:
-        for person in result.people.values:
+        for person in result.people.list:
             print(f"   {person.bounding_box}, Confidence {person.confidence:.4f}")
     print(f" Image height: {result.metadata.height}")
     print(f" Image width: {result.metadata.width}")

--- a/sdk/vision/azure-ai-vision-imageanalysis/samples/sample_people_image_file.py
+++ b/sdk/vision/azure-ai-vision-imageanalysis/samples/sample_people_image_file.py
@@ -40,14 +40,20 @@ def sample_people_image_file():
         exit()
 
     # Create an Image Analysis client
-    client = ImageAnalysisClient(endpoint=endpoint, credential=AzureKeyCredential(key))
+    client = ImageAnalysisClient(
+        endpoint=endpoint,
+        credential=AzureKeyCredential(key)
+    )
 
     # Load image to analyze into a 'bytes' object
     with open("sample.jpg", "rb") as f:
         image_data = f.read()
 
     # Find people in an image stream. This will be a synchronously (blocking) call.
-    result = client.analyze(image_data=image_data, visual_features=[VisualFeatures.PEOPLE])
+    result = client.analyze(
+        image_data=image_data,
+        visual_features=[VisualFeatures.PEOPLE]
+    )
 
     # Print People analysis results to the console
     print("Image analysis results:")

--- a/sdk/vision/azure-ai-vision-imageanalysis/samples/sample_people_image_file.py
+++ b/sdk/vision/azure-ai-vision-imageanalysis/samples/sample_people_image_file.py
@@ -22,13 +22,15 @@ USAGE:
                          where `your-resource-name` is your unique Azure Computer Vision resource name.
     2) VISION_KEY - Your Computer Vision key (a 32-character Hexadecimal number)
 """
+
+
 def sample_people_image_file():
     import os
     from azure.ai.vision.imageanalysis import ImageAnalysisClient
     from azure.ai.vision.imageanalysis.models import VisualFeatures
     from azure.core.credentials import AzureKeyCredential
 
-    # Set the values of your computer vision endpoint and computer vision key 
+    # Set the values of your computer vision endpoint and computer vision key
     # as environment variables:
     try:
         endpoint = os.environ["VISION_ENDPOINT"]
@@ -39,20 +41,14 @@ def sample_people_image_file():
         exit()
 
     # Create an Image Analysis client
-    client = ImageAnalysisClient(
-        endpoint = endpoint,
-        credential = AzureKeyCredential(key)
-    )
+    client = ImageAnalysisClient(endpoint=endpoint, credential=AzureKeyCredential(key))
 
     # Load image to analyze into a 'bytes' object
-    with open("sample.jpg", 'rb') as f:
+    with open("sample.jpg", "rb") as f:
         image_data = f.read()
 
     # Find people in an image stream. This will be a synchronously (blocking) call.
-    result = client.analyze(
-        image_data = image_data,
-        visual_features = [ VisualFeatures.PEOPLE ]
-    )
+    result = client.analyze(image_data=image_data, visual_features=[VisualFeatures.PEOPLE])
 
     # Print People analysis results to the console
     print("Image analysis results:")
@@ -65,6 +61,5 @@ def sample_people_image_file():
     print(f" Model version: {result.model_version}")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sample_people_image_file()
-

--- a/sdk/vision/azure-ai-vision-imageanalysis/samples/sample_smart_crops_image_file.py
+++ b/sdk/vision/azure-ai-vision-imageanalysis/samples/sample_smart_crops_image_file.py
@@ -2,7 +2,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
-# mypy: disable-error-code="attr-defined"
 """
 DESCRIPTION:
     This sample demonstrates how to find representatives sub-regions of the image file sample.jpg,

--- a/sdk/vision/azure-ai-vision-imageanalysis/samples/sample_smart_crops_image_file.py
+++ b/sdk/vision/azure-ai-vision-imageanalysis/samples/sample_smart_crops_image_file.py
@@ -31,13 +31,15 @@ USAGE:
                          where `your-resource-name` is your unique Azure Computer Vision resource name.
     2) VISION_KEY - Your Computer Vision key (a 32-character Hexadecimal number)
 """
+
+
 def sample_smart_crops_image_file():
     import os
     from azure.ai.vision.imageanalysis import ImageAnalysisClient
     from azure.ai.vision.imageanalysis.models import VisualFeatures
     from azure.core.credentials import AzureKeyCredential
 
-    # Set the values of your computer vision endpoint and computer vision key 
+    # Set the values of your computer vision endpoint and computer vision key
     # as environment variables:
     try:
         endpoint = os.environ["VISION_ENDPOINT"]
@@ -48,20 +50,17 @@ def sample_smart_crops_image_file():
         exit()
 
     # Create an Image Analysis client
-    client = ImageAnalysisClient(
-        endpoint = endpoint,
-        credential = AzureKeyCredential(key)
-    )
+    client = ImageAnalysisClient(endpoint=endpoint, credential=AzureKeyCredential(key))
 
     # Load image to analyze into a 'bytes' object
-    with open("sample.jpg", 'rb') as f:
+    with open("sample.jpg", "rb") as f:
         image_data = f.read()
 
     # Do Smart Cropping analysis on an image stream. This will be a synchronously (blocking) call.
     result = client.analyze(
-        image_data = image_data,
-        visual_features = [ VisualFeatures.SMART_CROPS ],
-        smart_crops_aspect_ratios = [0.9, 1.33] # Optional. Specify one more desired aspect ratios
+        image_data=image_data,
+        visual_features=[VisualFeatures.SMART_CROPS],
+        smart_crops_aspect_ratios=[0.9, 1.33],  # Optional. Specify one more desired aspect ratios
     )
 
     # Print smart crop analysis results to the console
@@ -75,5 +74,5 @@ def sample_smart_crops_image_file():
     print(f" Model version: {result.model_version}")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sample_smart_crops_image_file()

--- a/sdk/vision/azure-ai-vision-imageanalysis/samples/sample_smart_crops_image_file.py
+++ b/sdk/vision/azure-ai-vision-imageanalysis/samples/sample_smart_crops_image_file.py
@@ -67,7 +67,7 @@ def sample_smart_crops_image_file():
     print("Image analysis results:")
     print(" Smart Cropping:")
     if result.smart_crops is not None:
-        for smart_crop in result.smart_crops.values:
+        for smart_crop in result.smart_crops.list:
             print(f"   Aspect ratio {smart_crop.aspect_ratio}: Smart crop {smart_crop.bounding_box}")
     print(f" Image height: {result.metadata.height}")
     print(f" Image width: {result.metadata.width}")

--- a/sdk/vision/azure-ai-vision-imageanalysis/samples/sample_smart_crops_image_file.py
+++ b/sdk/vision/azure-ai-vision-imageanalysis/samples/sample_smart_crops_image_file.py
@@ -49,7 +49,10 @@ def sample_smart_crops_image_file():
         exit()
 
     # Create an Image Analysis client
-    client = ImageAnalysisClient(endpoint=endpoint, credential=AzureKeyCredential(key))
+    client = ImageAnalysisClient(
+        endpoint=endpoint,
+        credential=AzureKeyCredential(key)
+    )
 
     # Load image to analyze into a 'bytes' object
     with open("sample.jpg", "rb") as f:

--- a/sdk/vision/azure-ai-vision-imageanalysis/samples/sample_tags_image_file.py
+++ b/sdk/vision/azure-ai-vision-imageanalysis/samples/sample_tags_image_file.py
@@ -24,13 +24,15 @@ USAGE:
                          where `your-resource-name` is your unique Azure Computer Vision resource name.
     2) VISION_KEY - Your Computer Vision key (a 32-character Hexadecimal number)
 """
+
+
 def sample_tags_image_file():
     import os
     from azure.ai.vision.imageanalysis import ImageAnalysisClient
     from azure.ai.vision.imageanalysis.models import VisualFeatures
     from azure.core.credentials import AzureKeyCredential
 
-    # Set the values of your computer vision endpoint and computer vision key 
+    # Set the values of your computer vision endpoint and computer vision key
     # as environment variables:
     try:
         endpoint = os.environ["VISION_ENDPOINT"]
@@ -41,20 +43,17 @@ def sample_tags_image_file():
         exit()
 
     # Create an Image Analysis client
-    client = ImageAnalysisClient(
-        endpoint = endpoint,
-        credential = AzureKeyCredential(key)
-    )
+    client = ImageAnalysisClient(endpoint=endpoint, credential=AzureKeyCredential(key))
 
     # Load image to analyze into a 'bytes' object
-    with open("sample.jpg", 'rb') as f:
+    with open("sample.jpg", "rb") as f:
         image_data = f.read()
 
     # Do 'Tags' analysis on an image stream. This will be a synchronously (blocking) call.
     result = client.analyze(
-        image_data = image_data,
-        visual_features = [ VisualFeatures.TAGS ],
-        language = "en" # Optional. See https://aka.ms/cv-languages for supported languages.
+        image_data=image_data,
+        visual_features=[VisualFeatures.TAGS],
+        language="en",  # Optional. See https://aka.ms/cv-languages for supported languages.
     )
 
     # Print Tags analysis results to the console
@@ -68,5 +67,5 @@ def sample_tags_image_file():
     print(f" Model version: {result.model_version}")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sample_tags_image_file()

--- a/sdk/vision/azure-ai-vision-imageanalysis/samples/sample_tags_image_file.py
+++ b/sdk/vision/azure-ai-vision-imageanalysis/samples/sample_tags_image_file.py
@@ -42,7 +42,10 @@ def sample_tags_image_file():
         exit()
 
     # Create an Image Analysis client
-    client = ImageAnalysisClient(endpoint=endpoint, credential=AzureKeyCredential(key))
+    client = ImageAnalysisClient(
+        endpoint=endpoint,
+        credential=AzureKeyCredential(key)
+    )
 
     # Load image to analyze into a 'bytes' object
     with open("sample.jpg", "rb") as f:

--- a/sdk/vision/azure-ai-vision-imageanalysis/samples/sample_tags_image_file.py
+++ b/sdk/vision/azure-ai-vision-imageanalysis/samples/sample_tags_image_file.py
@@ -2,7 +2,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
-# mypy: disable-error-code="attr-defined"
 """
 DESCRIPTION:
     This sample demonstrates how to extract content tags in an image file sample.jpg, using a synchronous client.

--- a/sdk/vision/azure-ai-vision-imageanalysis/samples/sample_tags_image_file.py
+++ b/sdk/vision/azure-ai-vision-imageanalysis/samples/sample_tags_image_file.py
@@ -60,7 +60,7 @@ def sample_tags_image_file():
     print("Image analysis results:")
     print(" Tags:")
     if result.tags is not None:
-        for tag in result.tags.values:
+        for tag in result.tags.list:
             print(f"   '{tag.name}', Confidence {tag.confidence:.4f}")
     print(f" Image height: {result.metadata.height}")
     print(f" Image width: {result.metadata.width}")

--- a/sdk/vision/azure-ai-vision-imageanalysis/setup.py
+++ b/sdk/vision/azure-ai-vision-imageanalysis/setup.py
@@ -42,7 +42,6 @@ setup(
         "Programming Language :: Python",
         "Programming Language :: Python :: 3 :: Only",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
@@ -66,8 +65,8 @@ setup(
     },
     install_requires=[
         "isodate<1.0.0,>=0.6.1",
-        "azure-core<2.0.0,>=1.28.0",
+        "azure-core<2.0.0,>=1.29.5",
         "typing-extensions>=4.3.0; python_version<'3.8.0'",
     ],
-    python_requires=">=3.7",
+    python_requires=">=3.8",
 )

--- a/sdk/vision/azure-ai-vision-imageanalysis/tests/image_analysis_test_base.py
+++ b/sdk/vision/azure-ai-vision-imageanalysis/tests/image_analysis_test_base.py
@@ -21,7 +21,7 @@ LOGGING_ENABLED = True
 if LOGGING_ENABLED:
     # Create a logger for the 'azure' SDK
     # See https://docs.python.org/3/library/logging.html
-    logger = logging.getLogger('azure')
+    logger = logging.getLogger("azure")
     logger.setLevel(logging.INFO)  # INFO or DEBUG
 
     # Configure a console output
@@ -31,8 +31,8 @@ if LOGGING_ENABLED:
 ServicePreparer = functools.partial(
     EnvironmentVariableLoader,
     "vision",
-    vision_endpoint = "https://fake-resource-name.cognitiveservices.azure.com",
-    vision_key = "00000000000000000000000000000000",
+    vision_endpoint="https://fake-resource-name.cognitiveservices.azure.com",
+    vision_key="00000000000000000000000000000000",
 )
 
 
@@ -55,214 +55,212 @@ class ImageAnalysisTestBase(AzureRecordedTestCase):
         key = kwargs.pop("vision_key")
         self._create_client(endpoint, key, sync, get_connection_url)
 
-
     def _create_client_for_authentication_failure(self, sync: bool, **kwargs):
         endpoint = kwargs.pop("vision_endpoint")
         key = "00000000000000000000000000000000"
         self._create_client(endpoint, key, sync, False)
 
-
     def _create_client(self, endpoint: str, key: str, sync: bool, get_connection_url: bool):
         credential = AzureKeyCredential(key)
         if sync:
             self.client = sdk.ImageAnalysisClient(
-                endpoint = endpoint,
-                credential = credential,
-                logging_enable = LOGGING_ENABLED,
-                raw_request_hook = self._raw_request_check if get_connection_url else None)
+                endpoint=endpoint,
+                credential=credential,
+                logging_enable=LOGGING_ENABLED,
+                raw_request_hook=self._raw_request_check if get_connection_url else None,
+            )
             assert self.client is not None
         else:
             self.async_client = async_sdk.ImageAnalysisClient(
-                endpoint = endpoint,
-                credential = credential,
-                logging_enable = LOGGING_ENABLED,
-                raw_request_hook = self._raw_request_check if get_connection_url else None)
+                endpoint=endpoint,
+                credential=credential,
+                logging_enable=LOGGING_ENABLED,
+                raw_request_hook=self._raw_request_check if get_connection_url else None,
+            )
             assert self.async_client is not None
-
 
     def _raw_request_check(self, request: PipelineRequest):
         self.connection_url = request.http_request.url
         print(f"Connection URL: {request.http_request.url}")
 
-
     def _do_analysis(
-            self,
-            image_source: str,
-            visual_features: List[sdk.models.VisualFeatures],
-            language: Optional[str] = None,
-            gender_neutral_caption: Optional[bool] = None,
-            smart_crops_aspect_ratios: Optional[List[float]] = None,
-            model_version: Optional[str] = None,
-            query_params: Optional[dict] = None,
-            **kwargs):
+        self,
+        image_source: str,
+        visual_features: List[sdk.models.VisualFeatures],
+        language: Optional[str] = None,
+        gender_neutral_caption: Optional[bool] = None,
+        smart_crops_aspect_ratios: Optional[List[float]] = None,
+        model_version: Optional[str] = None,
+        query_params: Optional[dict] = None,
+        **kwargs,
+    ):
 
         image_content: Union[str, bytes]
 
         if "http" in image_source:
             result = self.client.analyze(
-                image_url = image_source,
-                visual_features = visual_features,
-                language = language,
-                gender_neutral_caption = gender_neutral_caption,
-                smart_crops_aspect_ratios = smart_crops_aspect_ratios,
-                model_version = model_version,
-                params = query_params)
+                image_url=image_source,
+                visual_features=visual_features,
+                language=language,
+                gender_neutral_caption=gender_neutral_caption,
+                smart_crops_aspect_ratios=smart_crops_aspect_ratios,
+                model_version=model_version,
+                params=query_params,
+            )
         else:
             # Load image to analyze into a 'bytes' object
-            with open(image_source, 'rb') as f:
+            with open(image_source, "rb") as f:
                 image_data = bytes(f.read())
 
             result = self.client.analyze(
-                image_data = image_data,
-                visual_features = visual_features,
-                language = language,
-                gender_neutral_caption = gender_neutral_caption,
-                smart_crops_aspect_ratios = smart_crops_aspect_ratios,
-                model_version = model_version,
-                params = query_params)
+                image_data=image_data,
+                visual_features=visual_features,
+                language=language,
+                gender_neutral_caption=gender_neutral_caption,
+                smart_crops_aspect_ratios=smart_crops_aspect_ratios,
+                model_version=model_version,
+                params=query_params,
+            )
 
         # Optional: console printout of all results
         if ImageAnalysisTestBase.PRINT_ANALYSIS_RESULTS:
             ImageAnalysisTestBase._print_analysis_results(result)
 
         # Validate all results
-        ImageAnalysisTestBase._validate_result(result, visual_features, gender_neutral_caption, smart_crops_aspect_ratios)
+        ImageAnalysisTestBase._validate_result(
+            result, visual_features, gender_neutral_caption, smart_crops_aspect_ratios
+        )
 
         # Validate that additional query parameters exists in the connection URL, if specify
         if query_params is not None:
             ImageAnalysisTestBase._validate_query_parameters(query_params, self.connection_url)
-
 
     async def _do_async_analysis(
-            self,
-            image_source: str,
-            visual_features: List[sdk.models.VisualFeatures],
-            language: Optional[str] = None,
-            gender_neutral_caption: Optional[bool] = None,
-            smart_crops_aspect_ratios: Optional[List[float]] = None,
-            model_version: Optional[str] = None,
-            query_params: Optional[dict] = None,
-            **kwargs):
+        self,
+        image_source: str,
+        visual_features: List[sdk.models.VisualFeatures],
+        language: Optional[str] = None,
+        gender_neutral_caption: Optional[bool] = None,
+        smart_crops_aspect_ratios: Optional[List[float]] = None,
+        model_version: Optional[str] = None,
+        query_params: Optional[dict] = None,
+        **kwargs,
+    ):
 
         image_content: Union[str, bytes]
 
         if "http" in image_source:
             result = await self.async_client.analyze(
-                image_url = image_source,
-                visual_features = visual_features,
-                language = language,
-                gender_neutral_caption = gender_neutral_caption,
-                smart_crops_aspect_ratios = smart_crops_aspect_ratios,
-                model_version = model_version,
-                params = query_params)
+                image_url=image_source,
+                visual_features=visual_features,
+                language=language,
+                gender_neutral_caption=gender_neutral_caption,
+                smart_crops_aspect_ratios=smart_crops_aspect_ratios,
+                model_version=model_version,
+                params=query_params,
+            )
 
         else:
             # Load image to analyze into a 'bytes' object
-            with open(image_source, 'rb') as f:
+            with open(image_source, "rb") as f:
                 image_data = bytes(f.read())
 
             result = await self.async_client.analyze(
-                image_data = image_data,
-                visual_features = visual_features,
-                language = language,
-                gender_neutral_caption = gender_neutral_caption,
-                smart_crops_aspect_ratios = smart_crops_aspect_ratios,
-                model_version = model_version,
-                params = query_params)
+                image_data=image_data,
+                visual_features=visual_features,
+                language=language,
+                gender_neutral_caption=gender_neutral_caption,
+                smart_crops_aspect_ratios=smart_crops_aspect_ratios,
+                model_version=model_version,
+                params=query_params,
+            )
 
         # Optional: console printout of all results
         if ImageAnalysisTestBase.PRINT_ANALYSIS_RESULTS:
             ImageAnalysisTestBase._print_analysis_results(result)
 
         # Validate all results
-        ImageAnalysisTestBase._validate_result(result, visual_features, gender_neutral_caption, smart_crops_aspect_ratios)
+        ImageAnalysisTestBase._validate_result(
+            result, visual_features, gender_neutral_caption, smart_crops_aspect_ratios
+        )
 
         # Validate that additional query parameters exists in the connection URL, if specify
         if query_params is not None:
             ImageAnalysisTestBase._validate_query_parameters(query_params, self.connection_url)
 
-
     def _do_analysis_with_error(
-            self,
-            image_source: str,
-            visual_features: List[sdk.models.VisualFeatures],
-            expected_status_code: int,
-            expected_message_contains: str,
-            **kwargs):
+        self,
+        image_source: str,
+        visual_features: List[sdk.models.VisualFeatures],
+        expected_status_code: int,
+        expected_message_contains: str,
+        **kwargs,
+    ):
 
         image_content: Union[str, bytes]
         try:
             if "http" in image_source:
-                result = self.client.analyze(
-                    image_url = image_source,
-                    visual_features = visual_features)
+                result = self.client.analyze(image_url=image_source, visual_features=visual_features)
             else:
                 # Load image to analyze into a 'bytes' object
-                with open(image_source, 'rb') as f:
+                with open(image_source, "rb") as f:
                     image_data = bytes(f.read())
 
-                result = self.client.analyze(
-                    image_data = image_data,
-                    visual_features = visual_features)
+                result = self.client.analyze(image_data=image_data, visual_features=visual_features)
 
         except AzureError as e:
             print(e)
-            assert hasattr(e, 'status_code')
+            assert hasattr(e, "status_code")
             assert e.status_code == expected_status_code
             assert expected_message_contains in e.message
             return
-        assert False # We should not get here
-
+        assert False  # We should not get here
 
     async def _do_async_analysis_with_error(
-                self,
-                image_source: str,
-                visual_features: List[sdk.models.VisualFeatures],
-                expected_status_code: int,
-                expected_message_contains: str,
-                **kwargs):
+        self,
+        image_source: str,
+        visual_features: List[sdk.models.VisualFeatures],
+        expected_status_code: int,
+        expected_message_contains: str,
+        **kwargs,
+    ):
 
         image_content: Union[str, bytes]
 
         try:
             if "http" in image_source:
-                result = await self.async_client.analyze(
-                    image_url = image_source,
-                    visual_features = visual_features)
+                result = await self.async_client.analyze(image_url=image_source, visual_features=visual_features)
             else:
                 # Load image to analyze into a 'bytes' object
-                with open(image_source, 'rb') as f:
+                with open(image_source, "rb") as f:
                     image_data = bytes(f.read())
 
-                result = await self.async_client.analyze(
-                    image_data = image_data,
-                    visual_features = visual_features)
+                result = await self.async_client.analyze(image_data=image_data, visual_features=visual_features)
 
         except AzureError as e:
             print(e)
-            assert hasattr(e, 'status_code')
+            assert hasattr(e, "status_code")
             assert e.status_code == expected_status_code
             assert expected_message_contains in e.message
             return
-        assert False # We should not get here
-
+        assert False  # We should not get here
 
     @staticmethod
     def _validate_query_parameters(query_params: dict, connection_url: str):
         assert len(query_params) > 0
-        query_string = ''
+        query_string = ""
         for key, value in query_params.items():
-            query_string += '&' + key + '=' + value
-        query_string = '?' + query_string[1:]
+            query_string += "&" + key + "=" + value
+        query_string = "?" + query_string[1:]
         assert query_string in connection_url
-
 
     @staticmethod
     def _validate_result(
-            result: sdk.models.ImageAnalysisResult,
-            expected_features: List[sdk.models.VisualFeatures],
-            gender_neutral_caption: Optional[bool] = None,
-            smart_crops_aspect_ratios: Optional[List[float]] = None):
+        result: sdk.models.ImageAnalysisResult,
+        expected_features: List[sdk.models.VisualFeatures],
+        gender_neutral_caption: Optional[bool] = None,
+        smart_crops_aspect_ratios: Optional[List[float]] = None,
+    ):
         ImageAnalysisTestBase._validate_metadata(result)
         ImageAnalysisTestBase._validate_model_version(result)
 
@@ -301,19 +299,16 @@ class ImageAnalysisTestBase(AzureRecordedTestCase):
         else:
             assert result.read is None
 
-
     @staticmethod
     def _validate_metadata(result: sdk.models.ImageAnalysisResult):
         assert result.metadata is not None
         assert result.metadata.height == 576
         assert result.metadata.width == 864
 
-
     @staticmethod
     def _validate_model_version(result: sdk.models.ImageAnalysisResult):
         assert result.model_version is not None
         assert result.model_version == "2023-10-01"
-
 
     @staticmethod
     def _validate_caption(result: sdk.models.ImageAnalysisResult, gender_neutral_caption: Optional[bool] = None):
@@ -326,7 +321,6 @@ class ImageAnalysisTestBase(AzureRecordedTestCase):
         assert "table" in result.caption.text.lower()
         assert "laptop" in result.caption.text.lower()
         assert 0.0 < result.caption.confidence < 1.0
-
 
     @staticmethod
     def _validate_dense_captions(result: sdk.models.ImageAnalysisResult):
@@ -363,14 +357,15 @@ class ImageAnalysisTestBase(AzureRecordedTestCase):
 
         # Make sure each dense caption is unique
         for i, dense_caption in enumerate(result.dense_captions.values):
-            for other_dense_caption in result.dense_captions.values[i + 1:]:
+            for other_dense_caption in result.dense_captions.values[i + 1 :]:
                 # Do not include the check below. It's okay to have two identical dense captions since they have different bounding boxes.
-                #assert other_dense_caption.text != dense_caption.text
-                assert  not (other_dense_caption.bounding_box.x == dense_caption.bounding_box.x 
+                # assert other_dense_caption.text != dense_caption.text
+                assert not (
+                    other_dense_caption.bounding_box.x == dense_caption.bounding_box.x
                     and other_dense_caption.bounding_box.y == dense_caption.bounding_box.y
                     and other_dense_caption.bounding_box.height == dense_caption.bounding_box.height
-                    and other_dense_caption.bounding_box.width == dense_caption.bounding_box.width)
-
+                    and other_dense_caption.bounding_box.width == dense_caption.bounding_box.width
+                )
 
     @staticmethod
     def _validate_objects(result: sdk.models.ImageAnalysisResult):
@@ -397,12 +392,13 @@ class ImageAnalysisTestBase(AzureRecordedTestCase):
         for i in range(len(objects.values)):
             for j in range(i + 1, len(objects.values)):
                 box_i = objects.values[i].bounding_box
-                box_j= objects.values[j].bounding_box
-                assert not (box_i.x ==box_j.x
+                box_j = objects.values[j].bounding_box
+                assert not (
+                    box_i.x == box_j.x
                     and box_i.y == box_j.y
                     and box_i.height == box_j.height
-                    and box_i.width == box_j.width)
-
+                    and box_i.width == box_j.width
+                )
 
     @staticmethod
     def _validate_tags(result: sdk.models.ImageAnalysisResult):
@@ -429,7 +425,6 @@ class ImageAnalysisTestBase(AzureRecordedTestCase):
             for j in range(i + 1, len(tags.values)):
                 assert tags.values[j].name != tags.values[i].name
 
-
     @staticmethod
     def _validate_people(result: sdk.models.ImageAnalysisResult):
         assert result.people is not None
@@ -444,31 +439,30 @@ class ImageAnalysisTestBase(AzureRecordedTestCase):
 
         # Make sure each person is unique
         for i, person in enumerate(result.people.values):
-            for other_person in result.people.values[i + 1:]:
+            for other_person in result.people.values[i + 1 :]:
                 assert not (
                     other_person.bounding_box.x == person.bounding_box.x
                     and other_person.bounding_box.y == person.bounding_box.y
                     and other_person.bounding_box.height == person.bounding_box.height
-                    and other_person.bounding_box.width == person.bounding_box.width)
-
+                    and other_person.bounding_box.width == person.bounding_box.width
+                )
 
     @staticmethod
     def _validate_smart_crops(
-        result: sdk.models.ImageAnalysisResult,
-        smart_crops_aspect_ratios: Optional[List[float]] =  None):
+        result: sdk.models.ImageAnalysisResult, smart_crops_aspect_ratios: Optional[List[float]] = None
+    ):
 
         assert result.smart_crops is not None
         crop_regions = result.smart_crops.values
 
         if smart_crops_aspect_ratios is None:
-            assert(len(crop_regions) == 1)
-            assert(crop_regions[0].aspect_ratio >= 0.5 and crop_regions[0].aspect_ratio <= 2.0)
+            assert len(crop_regions) == 1
+            assert crop_regions[0].aspect_ratio >= 0.5 and crop_regions[0].aspect_ratio <= 2.0
         else:
             assert len(crop_regions) == len(smart_crops_aspect_ratios)
             for i, region in enumerate(crop_regions):
                 assert region.aspect_ratio == smart_crops_aspect_ratios[i]
-                assert(region.aspect_ratio >= 0.75 and region.aspect_ratio <= 1.8)
-
+                assert region.aspect_ratio >= 0.75 and region.aspect_ratio <= 1.8
 
         for region in crop_regions:
             assert region.bounding_box.x >= 0
@@ -478,13 +472,13 @@ class ImageAnalysisTestBase(AzureRecordedTestCase):
 
         # Make sure each bounding box is unique
         for i, region in enumerate(crop_regions):
-            for other_region in crop_regions[i+1:]:
+            for other_region in crop_regions[i + 1 :]:
                 assert not (
                     other_region.bounding_box.x == region.bounding_box.x
                     and other_region.bounding_box.y == region.bounding_box.y
                     and other_region.bounding_box.height == region.bounding_box.height
-                    and other_region.bounding_box.width == region.bounding_box.width)
-
+                    and other_region.bounding_box.width == region.bounding_box.width
+                )
 
     @staticmethod
     def _validate_read(result: sdk.models.ImageAnalysisResult):
@@ -541,7 +535,6 @@ class ImageAnalysisTestBase(AzureRecordedTestCase):
             assert polygon[i].x > 0.0
             assert polygon[i].y > 0.0
 
-
     @staticmethod
     def _print_analysis_results(result: sdk.models.ImageAnalysisResult):
 
@@ -561,7 +554,11 @@ class ImageAnalysisTestBase(AzureRecordedTestCase):
         if result.objects is not None:
             print(" Objects:")
             for object in result.objects.values:
-                print("   '{}', {}, Confidence: {:.4f}".format(object.tags[0].name, object.bounding_box, object.tags[0].confidence))
+                print(
+                    "   '{}', {}, Confidence: {:.4f}".format(
+                        object.tags[0].name, object.bounding_box, object.tags[0].confidence
+                    )
+                )
 
         if result.tags is not None:
             print(" Tags:")
@@ -576,12 +573,13 @@ class ImageAnalysisTestBase(AzureRecordedTestCase):
         if result.smart_crops is not None:
             print(" Smart Cropping:")
             for smart_crop in result.smart_crops.values:
-                print("   Aspect ratio {}: Smart crop {}" .format(smart_crop.aspect_ratio, smart_crop.bounding_box))
+                print("   Aspect ratio {}: Smart crop {}".format(smart_crop.aspect_ratio, smart_crop.bounding_box))
 
         if result.read is not None:
             print(" Read:")
             for line in result.read.blocks[0].lines:
                 print(f"   Line: '{line.text}', Bounding box {line.bounding_polygon}")
                 for word in line.words:
-                    print(f"     Word: '{word.text}', Bounding polygon {word.bounding_polygon}, Confidence {word.confidence:.4f}")
-
+                    print(
+                        f"     Word: '{word.text}', Bounding polygon {word.bounding_polygon}, Confidence {word.confidence:.4f}"
+                    )

--- a/sdk/vision/azure-ai-vision-imageanalysis/tests/image_analysis_test_base.py
+++ b/sdk/vision/azure-ai-vision-imageanalysis/tests/image_analysis_test_base.py
@@ -325,10 +325,10 @@ class ImageAnalysisTestBase(AzureRecordedTestCase):
     @staticmethod
     def _validate_dense_captions(result: sdk.models.ImageAnalysisResult):
         assert result.dense_captions is not None
-        assert len(result.dense_captions.values) > 1
+        assert len(result.dense_captions.list) > 1
 
         # First dense caption should apply to the whole image, and be identical to the caption found in CaptionResult
-        first_dense_caption = result.dense_captions.values[0]
+        first_dense_caption = result.dense_captions.list[0]
         assert first_dense_caption is not None
         assert first_dense_caption.text is not None
         if result.caption is not None:
@@ -343,7 +343,7 @@ class ImageAnalysisTestBase(AzureRecordedTestCase):
         assert first_dense_caption.bounding_box.width == result.metadata.width
 
         # Sanity checks on all dense captions
-        for dense_caption in result.dense_captions.values:
+        for dense_caption in result.dense_captions.list:
             assert dense_caption is not None
             assert dense_caption.text is not None
             assert len(dense_caption.text) > 0
@@ -356,8 +356,8 @@ class ImageAnalysisTestBase(AzureRecordedTestCase):
             assert dense_caption.bounding_box.width <= result.metadata.width - dense_caption.bounding_box.x
 
         # Make sure each dense caption is unique
-        for i, dense_caption in enumerate(result.dense_captions.values):
-            for other_dense_caption in result.dense_captions.values[i + 1 :]:
+        for i, dense_caption in enumerate(result.dense_captions.list):
+            for other_dense_caption in result.dense_captions.list[i + 1 :]:
                 # Do not include the check below. It's okay to have two identical dense captions since they have different bounding boxes.
                 # assert other_dense_caption.text != dense_caption.text
                 assert not (
@@ -371,10 +371,10 @@ class ImageAnalysisTestBase(AzureRecordedTestCase):
     def _validate_objects(result: sdk.models.ImageAnalysisResult):
         objects = result.objects
         assert objects is not None
-        assert len(objects.values) > 1
+        assert len(objects.list) > 1
 
         found1 = False
-        for object in objects.values:
+        for object in objects.list:
             assert object is not None
             assert object.tags is not None
             assert len(object.tags) == 1
@@ -389,10 +389,10 @@ class ImageAnalysisTestBase(AzureRecordedTestCase):
         assert found1
 
         # Make sure each object box is unique
-        for i in range(len(objects.values)):
-            for j in range(i + 1, len(objects.values)):
-                box_i = objects.values[i].bounding_box
-                box_j = objects.values[j].bounding_box
+        for i in range(len(objects.list)):
+            for j in range(i + 1, len(objects.list)):
+                box_i = objects.list[i].bounding_box
+                box_j = objects.list[j].bounding_box
                 assert not (
                     box_i.x == box_j.x
                     and box_i.y == box_j.y
@@ -404,11 +404,11 @@ class ImageAnalysisTestBase(AzureRecordedTestCase):
     def _validate_tags(result: sdk.models.ImageAnalysisResult):
         tags = result.tags
         assert tags is not None
-        assert tags.values is not None
-        assert len(tags.values) > 1
+        assert tags.list is not None
+        assert len(tags.list) > 1
 
         found1, found2 = False, False
-        for tag in tags.values:
+        for tag in tags.list:
             assert tag.name is not None
             assert len(tag.name) > 0
             assert 0.0 < tag.confidence < 1.0
@@ -421,16 +421,16 @@ class ImageAnalysisTestBase(AzureRecordedTestCase):
         assert found2
 
         # Make sure each tag is unique
-        for i in range(len(tags.values)):
-            for j in range(i + 1, len(tags.values)):
-                assert tags.values[j].name != tags.values[i].name
+        for i in range(len(tags.list)):
+            for j in range(i + 1, len(tags.list)):
+                assert tags.list[j].name != tags.list[i].name
 
     @staticmethod
     def _validate_people(result: sdk.models.ImageAnalysisResult):
         assert result.people is not None
-        assert len(result.people.values) > 0
+        assert len(result.people.list) > 0
 
-        for person in result.people.values:
+        for person in result.people.list:
             assert 0.0 < person.confidence < 1.0
             assert person.bounding_box.x >= 0
             assert person.bounding_box.y >= 0
@@ -438,8 +438,8 @@ class ImageAnalysisTestBase(AzureRecordedTestCase):
             assert person.bounding_box.width <= result.metadata.width - person.bounding_box.x
 
         # Make sure each person is unique
-        for i, person in enumerate(result.people.values):
-            for other_person in result.people.values[i + 1 :]:
+        for i, person in enumerate(result.people.list):
+            for other_person in result.people.list[i + 1 :]:
                 assert not (
                     other_person.bounding_box.x == person.bounding_box.x
                     and other_person.bounding_box.y == person.bounding_box.y
@@ -453,7 +453,7 @@ class ImageAnalysisTestBase(AzureRecordedTestCase):
     ):
 
         assert result.smart_crops is not None
-        crop_regions = result.smart_crops.values
+        crop_regions = result.smart_crops.list
 
         if smart_crops_aspect_ratios is None:
             assert len(crop_regions) == 1
@@ -548,12 +548,12 @@ class ImageAnalysisTestBase(AzureRecordedTestCase):
 
         if result.dense_captions is not None:
             print(" Dense Captions:")
-            for caption in result.dense_captions.values:
+            for caption in result.dense_captions.list:
                 print("   '{}', {}, Confidence: {:.4f}".format(caption.text, caption.bounding_box, caption.confidence))
 
         if result.objects is not None:
             print(" Objects:")
-            for object in result.objects.values:
+            for object in result.objects.list:
                 print(
                     "   '{}', {}, Confidence: {:.4f}".format(
                         object.tags[0].name, object.bounding_box, object.tags[0].confidence
@@ -562,17 +562,17 @@ class ImageAnalysisTestBase(AzureRecordedTestCase):
 
         if result.tags is not None:
             print(" Tags:")
-            for tag in result.tags.values:
+            for tag in result.tags.list:
                 print("   '{}', Confidence {:.4f}".format(tag.name, tag.confidence))
 
         if result.people is not None:
             print(" People:")
-            for person in result.people.values:
+            for person in result.people.list:
                 print("   {}, Confidence {:.4f}".format(person.bounding_box, person.confidence))
 
         if result.smart_crops is not None:
             print(" Smart Cropping:")
-            for smart_crop in result.smart_crops.values:
+            for smart_crop in result.smart_crops.list:
                 print("   Aspect ratio {}: Smart crop {}".format(smart_crop.aspect_ratio, smart_crop.bounding_box))
 
         if result.read is not None:

--- a/sdk/vision/azure-ai-vision-imageanalysis/tests/test_image_analysis_async_client.py
+++ b/sdk/vision/azure-ai-vision-imageanalysis/tests/test_image_analysis_async_client.py
@@ -11,31 +11,32 @@ from devtools_testutils.aio import recorded_by_proxy_async
 # The test class name needs to start with "Test" to get collected by pytest
 class TestImageAnalysisAsyncClient(ImageAnalysisTestBase):
 
-    #**********************************************************************************
+    # **********************************************************************************
     #
     #                            HAPPY PATH TESTS
     #
-    #**********************************************************************************
+    # **********************************************************************************
 
     # Test all visual features from a local image, using default settings
     @ServicePreparer()
     @recorded_by_proxy_async
     async def test_analyze_async_all_features_from_file(self, **kwargs):
 
-        self._create_client_for_standard_analysis(sync = False, **kwargs)
+        self._create_client_for_standard_analysis(sync=False, **kwargs)
 
         await self._do_async_analysis(
-            image_source = self.IMAGE_FILE,
-            visual_features = [
+            image_source=self.IMAGE_FILE,
+            visual_features=[
                 sdk.models.VisualFeatures.TAGS,
                 sdk.models.VisualFeatures.OBJECTS,
                 sdk.models.VisualFeatures.CAPTION,
                 sdk.models.VisualFeatures.DENSE_CAPTIONS,
                 sdk.models.VisualFeatures.READ,
                 sdk.models.VisualFeatures.SMART_CROPS,
-                sdk.models.VisualFeatures.PEOPLE
+                sdk.models.VisualFeatures.PEOPLE,
             ],
-            **kwargs)
+            **kwargs
+        )
 
         await self.async_client.close()
 
@@ -44,50 +45,50 @@ class TestImageAnalysisAsyncClient(ImageAnalysisTestBase):
     @recorded_by_proxy_async
     async def test_analyze_async_single_feature_from_url(self, **kwargs):
 
-        self._create_client_for_standard_analysis(sync = False, **kwargs)
+        self._create_client_for_standard_analysis(sync=False, **kwargs)
 
         await self._do_async_analysis(
-            image_source = self.IMAGE_URL,
-            visual_features = [ sdk.models.VisualFeatures.DENSE_CAPTIONS ],
-            gender_neutral_caption = True,
-            **kwargs)
+            image_source=self.IMAGE_URL,
+            visual_features=[sdk.models.VisualFeatures.DENSE_CAPTIONS],
+            gender_neutral_caption=True,
+            **kwargs
+        )
 
         await self._do_async_analysis(
-            image_source = self.IMAGE_URL,
-            visual_features = [ sdk.models.VisualFeatures.SMART_CROPS ],
-            smart_crops_aspect_ratios = [0.9, 1.33],
-            **kwargs)
+            image_source=self.IMAGE_URL,
+            visual_features=[sdk.models.VisualFeatures.SMART_CROPS],
+            smart_crops_aspect_ratios=[0.9, 1.33],
+            **kwargs
+        )
 
         await self._do_async_analysis(
-            image_source = self.IMAGE_URL,
-            visual_features = [ sdk.models.VisualFeatures.TAGS ],
-            language = "en",
-            **kwargs)
+            image_source=self.IMAGE_URL, visual_features=[sdk.models.VisualFeatures.TAGS], language="en", **kwargs
+        )
 
         await self._do_async_analysis(
-            image_source = self.IMAGE_URL,
-            visual_features = [ sdk.models.VisualFeatures.PEOPLE ],
-            **kwargs)
+            image_source=self.IMAGE_URL, visual_features=[sdk.models.VisualFeatures.PEOPLE], **kwargs
+        )
 
         await self.async_client.close()
 
-    #**********************************************************************************
+    # **********************************************************************************
     #
     #                            ERROR TESTS
     #
-    #**********************************************************************************
+    # **********************************************************************************
 
     @ServicePreparer()
     @recorded_by_proxy_async
     async def test_analyze_async_authentication_failure(self, **kwargs):
 
-        self._create_client_for_authentication_failure(sync = False, **kwargs)
+        self._create_client_for_authentication_failure(sync=False, **kwargs)
 
         await self._do_async_analysis_with_error(
-            image_source = self.IMAGE_URL,
-            visual_features = [ sdk.models.VisualFeatures.TAGS ],
-            expected_status_code = 401,
-            expected_message_contains = "Access denied",
-            **kwargs)
+            image_source=self.IMAGE_URL,
+            visual_features=[sdk.models.VisualFeatures.TAGS],
+            expected_status_code=401,
+            expected_message_contains="Access denied",
+            **kwargs
+        )
 
         await self.async_client.close()

--- a/sdk/vision/azure-ai-vision-imageanalysis/tests/test_image_analysis_client.py
+++ b/sdk/vision/azure-ai-vision-imageanalysis/tests/test_image_analysis_client.py
@@ -12,81 +12,77 @@ from devtools_testutils import recorded_by_proxy
 # The test class name needs to start with "Test" to get collected by pytest
 class TestImageAnalysisClient(ImageAnalysisTestBase):
 
-    #**********************************************************************************
+    # **********************************************************************************
     #
     #                            HAPPY PATH TESTS
     #
-    #**********************************************************************************
+    # **********************************************************************************
 
     # Test all visual features from an image URL, which settings specified
     @ServicePreparer()
     @recorded_by_proxy
     def test_analyze_sync_all_features_from_url(self, **kwargs):
 
-        self._create_client_for_standard_analysis(sync = True, **kwargs)
+        self._create_client_for_standard_analysis(sync=True, **kwargs)
 
         self._do_analysis(
-            image_source = self.IMAGE_URL,
-            visual_features = [
+            image_source=self.IMAGE_URL,
+            visual_features=[
                 sdk.models.VisualFeatures.TAGS,
                 sdk.models.VisualFeatures.OBJECTS,
                 sdk.models.VisualFeatures.CAPTION,
                 sdk.models.VisualFeatures.DENSE_CAPTIONS,
                 sdk.models.VisualFeatures.READ,
                 sdk.models.VisualFeatures.SMART_CROPS,
-                sdk.models.VisualFeatures.PEOPLE
+                sdk.models.VisualFeatures.PEOPLE,
             ],
-            language = "en",
-            gender_neutral_caption = True,
-            smart_crops_aspect_ratios = [0.9, 1.33],
-            model_version = "latest",
-            **kwargs)
+            language="en",
+            gender_neutral_caption=True,
+            smart_crops_aspect_ratios=[0.9, 1.33],
+            model_version="latest",
+            **kwargs
+        )
 
         self.client.close()
-
 
     # Test some visual features, one after the other, from file, using default settings
     @ServicePreparer()
     @recorded_by_proxy
     def test_analyze_sync_single_feature_from_file(self, **kwargs):
 
-        self._create_client_for_standard_analysis(sync = True, get_connection_url =  True, **kwargs)
+        self._create_client_for_standard_analysis(sync=True, get_connection_url=True, **kwargs)
 
         self._do_analysis(
-            image_source = self.IMAGE_FILE,
-            visual_features = [ sdk.models.VisualFeatures.CAPTION ],
-            query_params = {'key1': 'value1', 'key2': 'value2'},
-            **kwargs)
+            image_source=self.IMAGE_FILE,
+            visual_features=[sdk.models.VisualFeatures.CAPTION],
+            query_params={"key1": "value1", "key2": "value2"},
+            **kwargs
+        )
 
-        self._do_analysis(
-            image_source = self.IMAGE_FILE,
-            visual_features = [ sdk.models.VisualFeatures.READ ],
-            **kwargs)
+        self._do_analysis(image_source=self.IMAGE_FILE, visual_features=[sdk.models.VisualFeatures.READ], **kwargs)
 
-        self._do_analysis(
-            image_source = self.IMAGE_FILE,
-            visual_features = [ sdk.models.VisualFeatures.TAGS ],
-            **kwargs)
+        self._do_analysis(image_source=self.IMAGE_FILE, visual_features=[sdk.models.VisualFeatures.TAGS], **kwargs)
 
         self.client.close()
 
-    #**********************************************************************************
+    # **********************************************************************************
     #
     #                            ERROR TESTS
     #
-    #**********************************************************************************
+    # **********************************************************************************
 
     @ServicePreparer()
     @recorded_by_proxy
     def test_analyze_sync_image_url_does_not_exist(self, **kwargs):
 
-        self._create_client_for_standard_analysis(sync = True, **kwargs)
+        self._create_client_for_standard_analysis(sync=True, **kwargs)
 
         self._do_analysis_with_error(
-            image_source = "https://www.this.is.a.bad.url.com/for/sure.jpg",
-            visual_features = [ sdk.models.VisualFeatures.CAPTION ],
-            expected_status_code = 400,
-            expected_message_contains = "image url is not accessible",
-            **kwargs)
-        
+            image_source="https://www.this.is.a.bad.url.com/for/sure.jpg",
+            visual_features=[sdk.models.VisualFeatures.CAPTION],
+            expected_status_code=400,
+            expected_message_contains="image url is not accessible",
+            **kwargs
+        )
+
         self.client.close()

--- a/sdk/vision/azure-ai-vision-imageanalysis/tsp-location.yaml
+++ b/sdk/vision/azure-ai-vision-imageanalysis/tsp-location.yaml
@@ -1,5 +1,6 @@
 additionalDirectories: []
 repo: Azure/azure-rest-api-specs
 directory: specification/ai/ImageAnalysis
-commit: 49a78b92e9ef42da134e833e36123ca9bb20994f
+commit: f2d0e7863a591e538366b251cfd85cc725153384
+
 


### PR DESCRIPTION
- Re-generate the SDK using the [steps shown here](https://github.com/Azure/azure-sdk-for-python/wiki/Dataplane-Codegen-Quick-Start#2-run-cmd-to-generate-the-sdk),  including `tox run -e generate -c ..\..\..\eng\tox\tox.ini --root .`, and applying post-processing per new file `pyproject.toml`. This means:
  - mypy error suppression is no longer needed in the sample code.
  - Remove mypy.ini
  - We get some code style fixes
- Also pull in a minor TypeSpec change, to rename model class property `values` to `list`, since `values` is already a method name in the base model's base class
- Hit what looks like an emitter bug and opened a GitHub issue on it ["tox run -e generate" messes up _enums.py -- it puts #: at the start of every new ref-doc comment line](https://github.com/Azure/autorest.python/issues/2355). I fixed it manually.

Big thanks go to @kristapratico for making the above possible! 