### PR TITLE
[EH] Keep alive fixes on producer

### DIFF
--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_client_base.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_client_base.py
@@ -311,7 +311,6 @@ class ClientBase:  # pylint:disable=too-many-instance-attributes
             self._credential = EventhubAzureNamedKeyTokenCredential(credential)  # type: ignore
         else:
             self._credential = credential  # type: ignore
-        self._keep_alive = kwargs.get("keep_alive", 30)
         self._auto_reconnect = kwargs.get("auto_reconnect", True)
         self._auth_uri = f"sb://{self._address.hostname}{self._address.path}"
         self._config = Configuration(

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_consumer.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_consumer.py
@@ -83,7 +83,7 @@ class EventHubConsumer(
         event_position = kwargs.get("event_position", None)
         prefetch = kwargs.get("prefetch", 300)
         owner_level = kwargs.get("owner_level", None)
-        keep_alive = kwargs.get("keep_alive", None)
+        keep_alive = kwargs.get("keep_alive", 30)
         auto_reconnect = kwargs.get("auto_reconnect", True)
         track_last_enqueued_event_properties = kwargs.get(
             "track_last_enqueued_event_properties", False

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_producer_client.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_producer_client.py
@@ -197,6 +197,9 @@ class EventHubProducerClient(
             network_tracing=kwargs.get("logging_enable"),
             **kwargs
         )
+
+        self._keep_alive = kwargs.get("keep_alive", None)
+
         self._producers: Dict[str, Optional[EventHubProducer]] = {
             ALL_PARTITIONS: self._create_producer()
         }
@@ -210,7 +213,6 @@ class EventHubProducerClient(
         self._max_wait_time = max_wait_time
         self._max_buffer_length = max_buffer_length
         self._executor = kwargs.get("buffer_concurrency")
-        self._keep_alive = kwargs.get("keep_alive", None)
 
         if self._buffered_mode:
             setattr(self, "send_batch", self._buffered_send_batch)

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_producer_client.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_producer_client.py
@@ -210,6 +210,7 @@ class EventHubProducerClient(
         self._max_wait_time = max_wait_time
         self._max_buffer_length = max_buffer_length
         self._executor = kwargs.get("buffer_concurrency")
+        self._keep_alive = kwargs.get("keep_alive", None)
 
         if self._buffered_mode:
             setattr(self, "send_batch", self._buffered_send_batch)
@@ -380,6 +381,7 @@ class EventHubProducerClient(
             send_timeout=send_timeout,
             idle_timeout=self._idle_timeout,
             amqp_transport=self._amqp_transport,
+            keep_alive=self._keep_alive,
         )
         return handler
 

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_consumer_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_consumer_async.py
@@ -82,7 +82,7 @@ class EventHubConsumer(
         event_position = kwargs.get("event_position", None)
         prefetch = kwargs.get("prefetch", 300)
         owner_level = kwargs.get("owner_level", None)
-        keep_alive = kwargs.get("keep_alive", None)
+        keep_alive = kwargs.get("keep_alive", 30)
         auto_reconnect = kwargs.get("auto_reconnect", True)
         track_last_enqueued_event_properties = kwargs.get(
             "track_last_enqueued_event_properties", False

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_producer_client_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_producer_client_async.py
@@ -184,6 +184,7 @@ class EventHubProducerClient(
             network_tracing=kwargs.pop("logging_enable", False),
             **kwargs
         )
+        self._keep_alive = kwargs.get("keep_alive", None)
         self._producers: Dict[str, Optional[EventHubProducer]] = {
             ALL_PARTITIONS: self._create_producer()
         }
@@ -365,6 +366,7 @@ class EventHubProducerClient(
             send_timeout=send_timeout,
             idle_timeout=self._idle_timeout,
             amqp_transport = self._amqp_transport,
+            keep_alive = self._keep_alive,
             **self._internal_kwargs
         )
         return handler

--- a/sdk/eventhub/azure-eventhub/tests/livetest/asynctests/test_send_async.py
+++ b/sdk/eventhub/azure-eventhub/tests/livetest/asynctests/test_send_async.py
@@ -38,12 +38,12 @@ from azure.eventhub._utils import transform_outbound_single_message
 try:
     import uamqp
     from uamqp import compat
-    from azure.eventhub._transport._uamqp_transport import UamqpTransport
+    from azure.eventhub.aio._transport._uamqp_transport_async import UamqpTransportAsync as UamqpTransport
 except (ModuleNotFoundError, ImportError):
     uamqp = None
     UamqpTransport = None
 
-from azure.eventhub._transport._pyamqp_transport import PyamqpTransport
+from azure.eventhub.aio._transport._pyamqp_transport_async import PyamqpTransportAsync as PyamqpTransport
 
 
 @pytest.mark.liveTest

--- a/sdk/eventhub/azure-eventhub/tests/livetest/asynctests/test_send_async.py
+++ b/sdk/eventhub/azure-eventhub/tests/livetest/asynctests/test_send_async.py
@@ -548,7 +548,7 @@ async def test_send_long_wait_async(connstr_receivers, keep_alive, uamqp_transpo
     async with client:
         await client.send_event(EventData("Single Message"))
 
-        asyncio.sleep(200)
+        asyncio.sleep(300)
 
         
         assert client._producers["all-partitions"].closed == False
@@ -557,13 +557,13 @@ async def test_send_long_wait_async(connstr_receivers, keep_alive, uamqp_transpo
 @pytest.mark.parametrize("keep_alive", [5, 30])
 @pytest.mark.liveTest
 @pytest.mark.asyncio
-async def test_send_long_wait_async(connstr_receivers, keep_alive, uamqp_transport):
+async def test_send_long_wait_idle_timeout_async(connstr_receivers, keep_alive, uamqp_transport):
     connection_str, receivers = connstr_receivers
     client = EventHubProducerClient.from_connection_string(connection_str, keep_alive=keep_alive, idle_timeout=10, uamqp_transport=uamqp_transport)
     async with client:
         await client.send_event(EventData("Single Message"))
 
-        asyncio.sleep(200)
+        asyncio.sleep(300)
 
         
         assert client._producers["all-partitions"].closed == False

--- a/sdk/eventhub/azure-eventhub/tests/livetest/asynctests/test_send_async.py
+++ b/sdk/eventhub/azure-eventhub/tests/livetest/asynctests/test_send_async.py
@@ -529,3 +529,11 @@ async def test_send_with_callback_async(connstr_receivers, uamqp_transport):
         assert sent_events[-1][1] == "0"
 
         assert not on_error.err
+
+@pytest.mark.parametrize("keep_alive", [None, 30, 60])
+@pytest.mark.liveTest
+@pytest.mark.asyncio
+def test_send_with_keep_alive(connstr_receivers, keep_alive, uamqp_transport):
+    connection_str, receivers = connstr_receivers
+    client = EventHubProducerClient.from_connection_string(connection_str, keep_alive=keep_alive, uamqp_transport=uamqp_transport)
+    assert client._producers["all_partitions"]._keep_alive == keep_alive

--- a/sdk/eventhub/azure-eventhub/tests/livetest/asynctests/test_send_async.py
+++ b/sdk/eventhub/azure-eventhub/tests/livetest/asynctests/test_send_async.py
@@ -34,6 +34,16 @@ from azure.eventhub._pyamqp.message import Properties
 from azure.eventhub._pyamqp.authentication import SASTokenAuth
 from azure.eventhub._pyamqp.client import ReceiveClient
 from azure.eventhub._pyamqp.error import AMQPConnectionError
+from azure.eventhub._utils import transform_outbound_single_message
+try:
+    import uamqp
+    from uamqp import compat
+    from azure.eventhub._transport._uamqp_transport import UamqpTransport
+except (ModuleNotFoundError, ImportError):
+    uamqp = None
+    UamqpTransport = None
+
+from azure.eventhub._transport._pyamqp_transport import PyamqpTransport
 
 
 @pytest.mark.liveTest
@@ -539,32 +549,39 @@ def test_send_with_keep_alive_async(connstr_receivers, keep_alive, uamqp_transpo
     assert client._producers["all-partitions"]._keep_alive == keep_alive
 
 
-@pytest.mark.parametrize("keep_alive", [30, 60])
+@pytest.mark.parametrize("keep_alive", [None, 5, 30])
 @pytest.mark.liveTest
 @pytest.mark.asyncio
-async def test_send_long_wait_async(connstr_receivers, keep_alive, uamqp_transport):
+async def test_send_long_wait_idle_timeout(connstr_receivers, keep_alive, uamqp_transport):
+    if uamqp_transport:
+        amqp_transport = UamqpTransport
+        retry_total = 3
+    else:
+        amqp_transport = PyamqpTransport
+        retry_total = 0
     connection_str, receivers = connstr_receivers
-    client = EventHubProducerClient.from_connection_string(connection_str, keep_alive=keep_alive, uamqp_transport=uamqp_transport)
-    async with client:
-        await client.send_event(EventData("Single Message"))
+    client = EventHubProducerClient.from_connection_string(connection_str, keep_alive=keep_alive, idle_timeout=10, retry_total=retry_total, uamqp_transport=uamqp_transport)
+    sender = await client._create_producer(partition_id="0")
+    async with sender:
+        await sender._open_with_retry()
+        ed = EventData('data')
+        ed = transform_outbound_single_message(ed, EventData, amqp_transport.to_outgoing_amqp_message)
+        sender._unsent_events = [ed._message]
+        # hit idle timeout error
+        await asyncio.sleep(11)
 
-        asyncio.sleep(300)
+        if uamqp_transport:
+            sender._unsent_events[0].on_send_complete = sender._on_outcome
+            if keep_alive !=5:
+                with pytest.raises((uamqp.errors.ConnectionClose,
+                                        uamqp.errors.MessageHandlerError, OperationTimeoutError)):
+                    await sender._send_event_data()
+            else:
+                await sender._send_event_data()
 
-        
-        assert client._producers["all-partitions"].closed == False
-        await client.send_event(EventData("Single Event"))
-
-@pytest.mark.parametrize("keep_alive", [5, 30])
-@pytest.mark.liveTest
-@pytest.mark.asyncio
-async def test_send_long_wait_idle_timeout_async(connstr_receivers, keep_alive, uamqp_transport):
-    connection_str, receivers = connstr_receivers
-    client = EventHubProducerClient.from_connection_string(connection_str, keep_alive=keep_alive, idle_timeout=10, uamqp_transport=uamqp_transport)
-    async with client:
-        await client.send_event(EventData("Single Message"))
-
-        asyncio.sleep(300)
-
-        
-        assert client._producers["all-partitions"].closed == False
-        await client.send_event(EventData("Single Event"))
+        if not uamqp_transport:
+            if keep_alive == 5:
+                await sender._send_event_data()
+            else:
+                with pytest.raises(AMQPConnectionError):
+                    await sender._send_event_data()

--- a/sdk/eventhub/azure-eventhub/tests/livetest/asynctests/test_send_async.py
+++ b/sdk/eventhub/azure-eventhub/tests/livetest/asynctests/test_send_async.py
@@ -536,5 +536,4 @@ async def test_send_with_callback_async(connstr_receivers, uamqp_transport):
 def test_send_with_keep_alive(connstr_receivers, keep_alive, uamqp_transport):
     connection_str, receivers = connstr_receivers
     client = EventHubProducerClient.from_connection_string(connection_str, keep_alive=keep_alive, uamqp_transport=uamqp_transport)
-    for producer in client._producers:
-        assert producer._keep_alive == keep_alive
+    assert client._producers["all-partitions"]._keep_alive == keep_alive

--- a/sdk/eventhub/azure-eventhub/tests/livetest/asynctests/test_send_async.py
+++ b/sdk/eventhub/azure-eventhub/tests/livetest/asynctests/test_send_async.py
@@ -536,4 +536,5 @@ async def test_send_with_callback_async(connstr_receivers, uamqp_transport):
 def test_send_with_keep_alive(connstr_receivers, keep_alive, uamqp_transport):
     connection_str, receivers = connstr_receivers
     client = EventHubProducerClient.from_connection_string(connection_str, keep_alive=keep_alive, uamqp_transport=uamqp_transport)
-    assert client._producers["all_partitions"]._keep_alive == keep_alive
+    for producer in client._producers:
+        assert producer._keep_alive == keep_alive

--- a/sdk/eventhub/azure-eventhub/tests/livetest/asynctests/test_send_async.py
+++ b/sdk/eventhub/azure-eventhub/tests/livetest/asynctests/test_send_async.py
@@ -550,6 +550,21 @@ async def test_send_long_wait_async(connstr_receivers, keep_alive, uamqp_transpo
 
         asyncio.sleep(200)
 
-        for producer in client._producers["all-partitions"]:
-            assert producer.closed == False
+        
+        assert client._producers["all-partitions"].closed == False
+        await client.send_event(EventData("Single Event"))
+
+@pytest.mark.parametrize("keep_alive", [5, 30])
+@pytest.mark.liveTest
+@pytest.mark.asyncio
+async def test_send_long_wait_async(connstr_receivers, keep_alive, uamqp_transport):
+    connection_str, receivers = connstr_receivers
+    client = EventHubProducerClient.from_connection_string(connection_str, keep_alive=keep_alive, idle_timeout=10, uamqp_transport=uamqp_transport)
+    async with client:
+        await client.send_event(EventData("Single Message"))
+
+        asyncio.sleep(200)
+
+        
+        assert client._producers["all-partitions"].closed == False
         await client.send_event(EventData("Single Event"))

--- a/sdk/eventhub/azure-eventhub/tests/livetest/synctests/test_send.py
+++ b/sdk/eventhub/azure-eventhub/tests/livetest/synctests/test_send.py
@@ -557,3 +557,10 @@ def test_send_with_callback(connstr_receivers, uamqp_transport):
         assert sent_events[-1][1] == "0"
 
         assert not on_error.err
+
+@pytest.mark.parametrize("keep_alive", [None, 30, 60])
+@pytest.mark.liveTest
+def test_send_with_keep_alive(connstr_receivers, keep_alive, uamqp_transport):
+    connection_str, receivers = connstr_receivers
+    client = EventHubProducerClient.from_connection_string(connection_str, keep_alive=keep_alive, uamqp_transport=uamqp_transport)
+    assert client._producers["all_partitions"]._keep_alive == keep_alive

--- a/sdk/eventhub/azure-eventhub/tests/livetest/synctests/test_send.py
+++ b/sdk/eventhub/azure-eventhub/tests/livetest/synctests/test_send.py
@@ -563,4 +563,5 @@ def test_send_with_callback(connstr_receivers, uamqp_transport):
 def test_send_with_keep_alive(connstr_receivers, keep_alive, uamqp_transport):
     connection_str, receivers = connstr_receivers
     client = EventHubProducerClient.from_connection_string(connection_str, keep_alive=keep_alive, uamqp_transport=uamqp_transport)
-    assert client._producers["all_partitions"]._keep_alive == keep_alive
+    for producer in client._producers:
+        assert producer._keep_alive == keep_alive

--- a/sdk/eventhub/azure-eventhub/tests/livetest/synctests/test_send.py
+++ b/sdk/eventhub/azure-eventhub/tests/livetest/synctests/test_send.py
@@ -563,5 +563,4 @@ def test_send_with_callback(connstr_receivers, uamqp_transport):
 def test_send_with_keep_alive(connstr_receivers, keep_alive, uamqp_transport):
     connection_str, receivers = connstr_receivers
     client = EventHubProducerClient.from_connection_string(connection_str, keep_alive=keep_alive, uamqp_transport=uamqp_transport)
-    for producer in client._producers:
-        assert producer._keep_alive == keep_alive
+    assert client._producers["all-partitions"]._keep_alive == keep_alive

--- a/sdk/eventhub/azure-eventhub/tests/livetest/synctests/test_send.py
+++ b/sdk/eventhub/azure-eventhub/tests/livetest/synctests/test_send.py
@@ -575,6 +575,18 @@ def test_send_long_wait(connstr_receivers, keep_alive, uamqp_transport):
 
         time.sleep(200)
 
-        for producer in client._producers["all-partitions"]:
-            assert producer.closed == False
+        assert client._producers["all-partitions"].closed == False
+        client.send_event(EventData("Single Event"))
+
+@pytest.mark.parametrize("keep_alive", [5, 30])
+@pytest.mark.liveTest
+def test_send_long_wait_idle_timeout(connstr_receivers, keep_alive, uamqp_transport):
+    connection_str, receivers = connstr_receivers
+    client = EventHubProducerClient.from_connection_string(connection_str, keep_alive=keep_alive, idle_timeout=10, uamqp_transport=uamqp_transport)
+    with client:
+        client.send_event(EventData("Single Message"))
+
+        time.sleep(200)
+
+        assert client._producers["all-partitions"].closed == False
         client.send_event(EventData("Single Event"))

--- a/sdk/eventhub/azure-eventhub/tests/livetest/synctests/test_send.py
+++ b/sdk/eventhub/azure-eventhub/tests/livetest/synctests/test_send.py
@@ -564,3 +564,17 @@ def test_send_with_keep_alive(connstr_receivers, keep_alive, uamqp_transport):
     connection_str, receivers = connstr_receivers
     client = EventHubProducerClient.from_connection_string(connection_str, keep_alive=keep_alive, uamqp_transport=uamqp_transport)
     assert client._producers["all-partitions"]._keep_alive == keep_alive
+
+@pytest.mark.parametrize("keep_alive", [30, 60])
+@pytest.mark.liveTest
+def test_send_long_wait(connstr_receivers, keep_alive, uamqp_transport):
+    connection_str, receivers = connstr_receivers
+    client = EventHubProducerClient.from_connection_string(connection_str, keep_alive=keep_alive, uamqp_transport=uamqp_transport)
+    with client:
+        client.send_event(EventData("Single Message"))
+
+        time.sleep(200)
+
+        for producer in client._producers["all-partitions"]:
+            assert producer.closed == False
+        client.send_event(EventData("Single Event"))

--- a/sdk/eventhub/azure-eventhub/tests/livetest/synctests/test_send.py
+++ b/sdk/eventhub/azure-eventhub/tests/livetest/synctests/test_send.py
@@ -573,7 +573,7 @@ def test_send_long_wait(connstr_receivers, keep_alive, uamqp_transport):
     with client:
         client.send_event(EventData("Single Message"))
 
-        time.sleep(200)
+        time.sleep(300)
 
         assert client._producers["all-partitions"].closed == False
         client.send_event(EventData("Single Event"))
@@ -586,7 +586,7 @@ def test_send_long_wait_idle_timeout(connstr_receivers, keep_alive, uamqp_transp
     with client:
         client.send_event(EventData("Single Message"))
 
-        time.sleep(200)
+        time.sleep(300)
 
         assert client._producers["all-partitions"].closed == False
         client.send_event(EventData("Single Event"))

--- a/sdk/eventhub/azure-eventhub/tests/livetest/synctests/test_send.py
+++ b/sdk/eventhub/azure-eventhub/tests/livetest/synctests/test_send.py
@@ -34,6 +34,16 @@ from azure.eventhub._pyamqp.message import Properties
 from azure.eventhub._pyamqp.authentication import SASTokenAuth
 from azure.eventhub._pyamqp import ReceiveClient
 from azure.eventhub._pyamqp.error import AMQPConnectionError
+from azure.eventhub._utils import transform_outbound_single_message
+try:
+    import uamqp
+    from uamqp import compat
+    from azure.eventhub._transport._uamqp_transport import UamqpTransport
+except (ModuleNotFoundError, ImportError):
+    uamqp = None
+    UamqpTransport = None
+
+from azure.eventhub._transport._pyamqp_transport import PyamqpTransport
 
 
 @pytest.mark.liveTest
@@ -565,28 +575,38 @@ def test_send_with_keep_alive(connstr_receivers, keep_alive, uamqp_transport):
     client = EventHubProducerClient.from_connection_string(connection_str, keep_alive=keep_alive, uamqp_transport=uamqp_transport)
     assert client._producers["all-partitions"]._keep_alive == keep_alive
 
-@pytest.mark.parametrize("keep_alive", [30, 60])
-@pytest.mark.liveTest
-def test_send_long_wait(connstr_receivers, keep_alive, uamqp_transport):
-    connection_str, receivers = connstr_receivers
-    client = EventHubProducerClient.from_connection_string(connection_str, keep_alive=keep_alive, uamqp_transport=uamqp_transport)
-    with client:
-        client.send_event(EventData("Single Message"))
-
-        time.sleep(300)
-
-        assert client._producers["all-partitions"].closed == False
-        client.send_event(EventData("Single Event"))
-
-@pytest.mark.parametrize("keep_alive", [5, 30])
+@pytest.mark.parametrize("keep_alive", [None, 5, 30])
 @pytest.mark.liveTest
 def test_send_long_wait_idle_timeout(connstr_receivers, keep_alive, uamqp_transport):
+    if uamqp_transport:
+        amqp_transport = UamqpTransport
+        retry_total = 3
+    else:
+        amqp_transport = PyamqpTransport
+        retry_total = 0
     connection_str, receivers = connstr_receivers
-    client = EventHubProducerClient.from_connection_string(connection_str, keep_alive=keep_alive, idle_timeout=10, uamqp_transport=uamqp_transport)
-    with client:
-        client.send_event(EventData("Single Message"))
+    client = EventHubProducerClient.from_connection_string(connection_str, keep_alive=keep_alive, idle_timeout=10, retry_total=retry_total, uamqp_transport=uamqp_transport)
+    sender = client._create_producer(partition_id="0")
+    with sender:
+        sender._open_with_retry()
+        ed = EventData('data')
+        ed = transform_outbound_single_message(ed, EventData, amqp_transport.to_outgoing_amqp_message)
+        sender._unsent_events = [ed._message]
+        # hit idle timeout error
+        time.sleep(11)
 
-        time.sleep(300)
+        if uamqp_transport:
+            sender._unsent_events[0].on_send_complete = sender._on_outcome
+            if keep_alive !=5:
+                with pytest.raises((uamqp.errors.ConnectionClose,
+                                        uamqp.errors.MessageHandlerError, OperationTimeoutError)):
+                    sender._send_event_data()
+            else:
+                sender._send_event_data()
 
-        assert client._producers["all-partitions"].closed == False
-        client.send_event(EventData("Single Event"))
+        if not uamqp_transport:
+            if keep_alive == 5:
+                sender._send_event_data()
+            else:
+                with pytest.raises(AMQPConnectionError):
+                    sender._send_event_data()


### PR DESCRIPTION
Pass through keep_alive option on producer side sync/async

Remove 30 second keep alive constant from client_base that was being used for consumer -- and set that on the consumer itself sync/async