### PR TITLE
Rebalance build matrix

### DIFF
--- a/eng/pipelines/templates/stages/platform-matrix.json
+++ b/eng/pipelines/templates/stages/platform-matrix.json
@@ -10,7 +10,7 @@
       "ubuntu-20.04": { "OSVmImage": "MMSUbuntu20.04", "Pool": "azsdk-pool-mms-ubuntu-2004-general" },
       "macos-11": { "OSVmImage": "macos-11", "Pool": "Azure Pipelines" }
     },
-    "PythonVersion": [ "3.8", "pypy3.9", "3.10", "3.11" ],
+    "PythonVersion": [ "3.8", "pypy3.9", "3.11", "3.10" ],
     "CoverageArg": "--disablecov",
     "TestSamples": "false"
   },


### PR DESCRIPTION
# Description

Dropping 3.7 from our pipelines shifted the matrix such that we're running 3.11 on Windows again, which caused strange issues in the past: https://github.com/Azure/azure-sdk-for-python/issues/32409

The failures are limited to EH Checkpoint, Schema Registry, and Key Vault this time, but we should probably still shift the matrix a nudge to avoid the issue altogether since there's not much that can be gleaned from the pipeline output.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
