### PR TITLE
Image Analysis SDK: Mention dependency on `aiohttp` package when using the async client 

### DIFF
--- a/sdk/vision/azure-ai-vision-imageanalysis/README.md
+++ b/sdk/vision/azure-ai-vision-imageanalysis/README.md
@@ -71,11 +71,16 @@ client = ImageAnalysisClient(
 
 <!-- END SNIPPET -->
 
-A synchronous client supports synchronous analysis methods, meaning they will block until the service responds with analysis results. The code snippets below all use synchronous methods because it's easier for a getting-started guide. The SDK offers equivalent asynchronous APIs which are often preferred. To create an asynchronous client, simply update the above code to import `ImageAnalysisClient` from the `aio` namespace:
+A synchronous client supports synchronous analysis methods, meaning they will block until the service responds with analysis results. The code snippets below all use synchronous methods because it's easier for a getting-started guide. The SDK offers equivalent asynchronous APIs which are often preferred. To create an asynchronous client, do the following:
 
-```python
-from azure.ai.vision.imageanalysis.aio import ImageAnalysisClient
-```
+* Update the above code to import `ImageAnalysisClient` from the `aio` namespace:
+    ```python
+    from azure.ai.vision.imageanalysis.aio import ImageAnalysisClient
+    ```
+* Install the additional package [aiohttp](https://pypi.org/project/aiohttp/):
+    ```bash
+    pip install aiohttp
+    ```
 
 ## Key concepts
 

--- a/sdk/vision/azure-ai-vision-imageanalysis/samples/README.md
+++ b/sdk/vision/azure-ai-vision-imageanalysis/samples/README.md
@@ -37,13 +37,16 @@ See [Prerequisites](https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/
 
 ## Setup
 
-1. Clone or download this sample repository
-1. Open a command prompt / terminal window in this samples folder
-1. Install the Image Analysis client library for Python with pip:
-
-```bash
-pip install azure-ai-vision-imageanalysis
-```
+* Clone or download this sample repository
+* Open a command prompt / terminal window in this samples folder
+* Install the Image Analysis client library for Python with pip:
+  ```bash
+  pip install azure-ai-vision-imageanalysis
+  ```
+* If you plan to run the asynchronous client samples, insall the additional package [aiohttp](https://pypi.org/project/aiohttp/):
+  ```bash
+  pip install aiohttp
+  ```
 
 ## Set environment variables
 

--- a/sdk/vision/azure-ai-vision-imageanalysis/samples/run_all_samples.ps1
+++ b/sdk/vision/azure-ai-vision-imageanalysis/samples/run_all_samples.ps1
@@ -1,37 +1,38 @@
 # A PowerShell script to run all Python samples in the folder, one after the other.
+$python = if ($env:OS -eq "Windows_NT") { "python" } else { "python3" }
 
 Write-Host "===> sample_analyze_all_image_file.py"
-Start-Process -NoNewWindow -Wait python sample_analyze_all_image_file.py
+Start-Process -NoNewWindow -Wait $python sample_analyze_all_image_file.py
 
 Write-Host "===> sample_caption_image_file.py"
-Start-Process -NoNewWindow -Wait python sample_caption_image_file.py
+Start-Process -NoNewWindow -Wait $python sample_caption_image_file.py
 
 Write-Host "===> sample_caption_image_file_async.py"
-Start-Process -NoNewWindow -Wait python async_samples/sample_caption_image_file_async.py
+Start-Process -NoNewWindow -Wait $python async_samples/sample_caption_image_file_async.py
 
 Write-Host "===> sample_caption_image_url.py"
-Start-Process -NoNewWindow -Wait python sample_caption_image_url.py
+Start-Process -NoNewWindow -Wait $python sample_caption_image_url.py
 
 Write-Host "===> sample_dense_captions_image_file.py"
-Start-Process -NoNewWindow -Wait python sample_dense_captions_image_file.py
+Start-Process -NoNewWindow -Wait $python sample_dense_captions_image_file.py
 
 Write-Host "===> sample_objects_image_file.py"
-Start-Process -NoNewWindow -Wait python sample_objects_image_file.py
+Start-Process -NoNewWindow -Wait $python sample_objects_image_file.py
 
 Write-Host "===> sample_ocr_image_file.py"
-Start-Process -NoNewWindow -Wait python sample_ocr_image_file.py
+Start-Process -NoNewWindow -Wait $python sample_ocr_image_file.py
 
 Write-Host "===> sample_ocr_image_url.py"
-Start-Process -NoNewWindow -Wait python sample_ocr_image_url.py
+Start-Process -NoNewWindow -Wait $python sample_ocr_image_url.py
 
 Write-Host "===> sample_ocr_image_url_async.py"
-Start-Process -NoNewWindow -Wait python async_samples/sample_ocr_image_url_async.py
+Start-Process -NoNewWindow -Wait $python async_samples/sample_ocr_image_url_async.py
 
 Write-Host "===> sample_people_image_file.py"
-Start-Process -NoNewWindow -Wait python sample_people_image_file.py
+Start-Process -NoNewWindow -Wait $python sample_people_image_file.py
 
 Write-Host "===> sample_smart_crops_image_file.py"
-Start-Process -NoNewWindow -Wait python sample_smart_crops_image_file.py
+Start-Process -NoNewWindow -Wait $python sample_smart_crops_image_file.py
 
 Write-Host "===> sample_tags_image_file.py"
-Start-Process -NoNewWindow -Wait python sample_tags_image_file.py
+Start-Process -NoNewWindow -Wait $python sample_tags_image_file.py


### PR DESCRIPTION
When testing the Image Analysis on a clean Ubuntu VM, the asynchronous samples failed to run, with an error indicating a package is missing. Installing the `aiohttp` package and re-running the samples solved the problem.

This led me to investigate why, and find out that `aiohttp` is listed as an optional dependency in azure-core package, not a required dependency. See these lines in [/sdk/core/azure-core/setup.py](https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/core/azure-core/setup.py#L77)
```python
    extras_require={
        "aio": [
            "aiohttp>=3.0",
        ],
    },
```

The PR updates the package README and samples README to mention the need to install `aiohttp` if you use the async client.

Also update the `run_all_samples.ps1` script such that it works both on Windows and Linux.