### PR TITLE
[CI] Shift additional platform matrix

### DIFF
--- a/eng/pipelines/templates/stages/platform-matrix-excluding-pypy.json
+++ b/eng/pipelines/templates/stages/platform-matrix-excluding-pypy.json
@@ -10,7 +10,7 @@
       "ubuntu-20.04": { "OSVmImage": "MMSUbuntu20.04", "Pool": "azsdk-pool-mms-ubuntu-2004-general" },
       "macos-11": { "OSVmImage": "macos-11", "Pool": "Azure Pipelines" }
     },
-    "PythonVersion": [ "3.9", "3.8", "3.10", "3.11" ],
+    "PythonVersion": [ "3.9", "3.8", "3.11", "3.10" ],
     "CoverageArg": "--disablecov",
     "TestSamples": "false"
   },


### PR DESCRIPTION
Some issues with the storage CI Job for Python 3.11 on Windows. This order adjustment should prevent CI failures.

This follows the change made here: https://github.com/Azure/azure-sdk-for-python/pull/33806

Sample failure: https://dev.azure.com/azure-sdk/public/_build/results?buildId=3400912&view=logs&j=f050e386-8c65-559c-10ff-6436bafe6323&t=6242d9bb-5486-5cb2-aa74-12dc40d75f41&l=6566