### PR TITLE
[Core] Update async auth policy lock logic

### DIFF
--- a/sdk/ai/azure-ai-resources/dev_requirements.txt
+++ b/sdk/ai/azure-ai-resources/dev_requirements.txt
@@ -5,3 +5,4 @@
 -e ../../ml/azure-ai-ml
 pytest
 pytest-xdist
+anyio>=3.6,<5.0

--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+- Removed dependency on `anyio`.  #33282
+
 ## 1.29.6 (2023-12-14)
 
 ### Bugs Fixed

--- a/sdk/core/azure-core/azure/core/pipeline/policies/_authentication_async.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/_authentication_async.py
@@ -6,7 +6,6 @@
 import time
 from typing import TYPE_CHECKING, Any, Awaitable, Optional, cast, TypeVar
 
-from anyio import Lock
 from azure.core.credentials import AccessToken
 from azure.core.pipeline import PipelineRequest, PipelineResponse
 from azure.core.pipeline.policies import AsyncHTTPPolicy
@@ -15,6 +14,7 @@ from azure.core.pipeline.policies._authentication import (
 )
 from azure.core.pipeline.transport import AsyncHttpResponse as LegacyAsyncHttpResponse, HttpRequest as LegacyHttpRequest
 from azure.core.rest import AsyncHttpResponse, HttpRequest
+from azure.core.utils._utils import get_running_async_lock
 
 from .._tools_async import await_result
 
@@ -38,10 +38,16 @@ class AsyncBearerTokenCredentialPolicy(AsyncHTTPPolicy[HTTPRequestType, AsyncHTT
     def __init__(self, credential: "AsyncTokenCredential", *scopes: str, **kwargs: Any) -> None:
         super().__init__()
         self._credential = credential
-        self._lock = Lock()
+        self._lock_instance = None
         self._scopes = scopes
         self._token: Optional["AccessToken"] = None
         self._enable_cae: bool = kwargs.get("enable_cae", False)
+
+    @property
+    def _lock(self):
+        if self._lock_instance is None:
+            self._lock_instance = get_running_async_lock()
+        return self._lock_instance
 
     async def on_request(self, request: PipelineRequest[HTTPRequestType]) -> None:
         """Adds a bearer token Authorization header to request and sends request to next policy.

--- a/sdk/core/azure-core/azure/core/utils/_utils.py
+++ b/sdk/core/azure-core/azure/core/utils/_utils.py
@@ -5,8 +5,10 @@
 # license information.
 # --------------------------------------------------------------------------
 import datetime
+import sys
 from typing import (
     Any,
+    AsyncContextManager,
     Iterable,
     Iterator,
     Mapping,
@@ -161,3 +163,25 @@ class CaseInsensitiveDict(MutableMapping[str, Any]):
 
     def __repr__(self) -> str:
         return str(dict(self.items()))
+
+
+def get_running_async_lock() -> AsyncContextManager:
+    """Get a lock instance from the async library that the current context is running under.
+    :return: An instance of the running async library's Lock class.
+    :rtype: AsyncContextManager
+    :raises: RuntimeError if the current context is not running under an async library.
+    """
+
+    try:
+        import asyncio
+
+        # Check if we are running in an asyncio event loop.
+        asyncio.get_running_loop()
+        return asyncio.Lock()
+    except RuntimeError as err:
+        # Otherwise, assume we are running in a trio event loop if it has already been imported.
+        if "trio" in sys.modules:
+            import trio  # pylint: disable=networking-import-outside-azure-core-transport
+
+            return trio.Lock()
+        raise RuntimeError("An asyncio or trio event loop is required.") from err

--- a/sdk/core/azure-core/setup.py
+++ b/sdk/core/azure-core/setup.py
@@ -69,7 +69,6 @@ setup(
     },
     python_requires=">=3.7",
     install_requires=[
-        "anyio>=3.0,<5.0",
         "requests>=2.21.0",
         "six>=1.11.0",
         "typing-extensions>=4.6.0",

--- a/sdk/core/azure-core/tests/test_utils.py
+++ b/sdk/core/azure-core/tests/test_utils.py
@@ -2,8 +2,12 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
+import sys
+from unittest.mock import patch
+
 import pytest
 from azure.core.utils import case_insensitive_dict
+from azure.core.utils._utils import get_running_async_lock
 
 
 @pytest.fixture()
@@ -108,3 +112,25 @@ def test_case_iter():
 
     for key in my_dict:
         assert key in keys
+
+
+@pytest.mark.asyncio
+async def test_get_running_async_module_asyncio():
+    import asyncio
+
+    assert isinstance(get_running_async_lock(), asyncio.Lock)
+
+
+@pytest.mark.trio
+async def test_get_running_async_module_trio():
+    import trio
+
+    assert isinstance(get_running_async_lock(), trio.Lock)
+
+
+def test_get_running_async_module_sync():
+    with patch.dict("sys.modules"):
+        # Ensure trio isn't in sys.modules (i.e. imported).
+        sys.modules.pop("trio", None)
+        with pytest.raises(RuntimeError):
+            get_running_async_lock()


### PR DESCRIPTION
Sometimes users might be using trio and its mechanisms for running tasks concurrently. This updates the lock initialization logic to check if the user is in an asyncio event loop and sets the lock accordingly.  If not, assume trio. We don't expect users to be in anything else other than asyncio or trio event loops.

A utility function was added that tries to determine the current async library being used.
