### PR TITLE
[Tables] fix list entities perf test

### DIFF
--- a/sdk/tables/azure-data-tables/tests/perfstress_tests/list_entities.py
+++ b/sdk/tables/azure-data-tables/tests/perfstress_tests/list_entities.py
@@ -6,20 +6,20 @@ import uuid
 
 from ._base import _TableTest, get_base_entity
 
-
 class ListEntitiesTest(_TableTest):
     def __init__(self, arguments):
         super().__init__(arguments)
-        self.base_entity = get_base_entity(self.args.full_edm)
-        self.base_entity["PartitionKey"] = str(uuid.uuid4())
+        self.partition_key = str(uuid.uuid4())
 
     async def global_setup(self):
         await super().global_setup()
         batch_size = 0
         batch = []
         for row in range(self.args.count):
-            self.base_entity["RowKey"] = str(row)
-            batch.append(("create", self.base_entity))
+            base_entity = get_base_entity(self.args.full_edm)
+            base_entity["PartitionKey"] = self.partition_key
+            base_entity["RowKey"] = str(row)
+            batch.append(("create", base_entity))
             batch_size += 1
             if batch_size >= 100:
                 await self.async_table_client.submit_transaction(batch)


### PR DESCRIPTION
Currently, the list entities perf test aborts with the following error:
```
Test processes failed - aborting. Error: 1:The batch request contains multiple changes with same row key. An entity can appear only once in a batch request.
RequestId:3ff4b9ef-6002-004c-71cf-45bdcb000000
Time:2024-01-13T03:17:12.7835197Z
ErrorCode:InvalidDuplicateRow
Content: {"odata.error":{"code":"InvalidDuplicateRow","message":{"lang":"en-US","value":"1:The batch request contains multiple changes with same row key. An entity can appear only once in a batch request.\nRequestId:3ff4b9ef-6002-004c-71cf-45bdcb000000\nTime:2024-01-13T03:17:12.7835197Z"}}}
Exception: One or more test processes failed and exited.
```

The row key value was being set to the same value in every entity. Updating the test to create new entity objects so that a mutable entity is not used.