### PR TITLE
[CODEOWNERS] Remove automation section

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,13 +14,6 @@
 # /scripts/
 # /tools/
 
-################
-# Automation
-################
-
-# Git Hub integration and bot rules
-/.github/                                                            @jsquire @ronniegeraghty
-
 ###########
 # SDK
 ###########


### PR DESCRIPTION
# Summary

The focus of these changes is to remove the automation section, as CODEOWNERS changes no longer require manual syncing.