### PR TITLE
Fix translation config

### DIFF
--- a/sdk/translation/azure-ai-translation-text/README.md
+++ b/sdk/translation/azure-ai-translation-text/README.md
@@ -64,7 +64,7 @@ With the value of the `endpoint`, `credential` and a `region`, you can create th
 
 ```python
 credential = TranslatorCredential(apikey, region)
-text_translator = TextTranslationClient(credential, endpoint)
+text_translator = TextTranslationClient(credential, endpoint=endpoint)
 ```
 
 <!-- END SNIPPET -->

--- a/sdk/translation/azure-ai-translation-text/azure/ai/translation/text/__init__.py
+++ b/sdk/translation/azure-ai-translation-text/azure/ai/translation/text/__init__.py
@@ -6,21 +6,19 @@
 # Changes may cause incorrect behavior and will be lost if the code is regenerated.
 # --------------------------------------------------------------------------
 
-from ._client import TextTranslationClient
+from ._patch import TextTranslationClient
 from ._version import VERSION
 
 __version__ = VERSION
 
-try:
-    from ._patch import __all__ as _patch_all
-    from ._patch import *  # pylint: disable=unused-wildcard-import
-except ImportError:
-    _patch_all = []
+
+from ._patch import TranslatorCredential
 from ._patch import patch_sdk as _patch_sdk
 
 __all__ = [
+    "TranslatorCredential",
     "TextTranslationClient",
 ]
-__all__.extend([p for p in _patch_all if p not in __all__])
+
 
 _patch_sdk()

--- a/sdk/translation/azure-ai-translation-text/azure/ai/translation/text/aio/__init__.py
+++ b/sdk/translation/azure-ai-translation-text/azure/ai/translation/text/aio/__init__.py
@@ -6,18 +6,14 @@
 # Changes may cause incorrect behavior and will be lost if the code is regenerated.
 # --------------------------------------------------------------------------
 
-from ._client import TextTranslationClient
+from ._patch import TextTranslationClient
 
-try:
-    from ._patch import __all__ as _patch_all
-    from ._patch import *  # pylint: disable=unused-wildcard-import
-except ImportError:
-    _patch_all = []
+
 from ._patch import patch_sdk as _patch_sdk
 
 __all__ = [
     "TextTranslationClient",
 ]
-__all__.extend([p for p in _patch_all if p not in __all__])
+
 
 _patch_sdk()

--- a/sdk/translation/azure-ai-translation-text/pyproject.toml
+++ b/sdk/translation/azure-ai-translation-text/pyproject.toml
@@ -1,5 +1,4 @@
 [tool.azure-sdk-build]
-mypy = false
 pylint = false
 type_check_samples = false
 verifytypes = false

--- a/sdk/translation/azure-ai-translation-text/samples/README.md
+++ b/sdk/translation/azure-ai-translation-text/samples/README.md
@@ -49,7 +49,7 @@ The appropriate constructor is invoked in each sample to create a `TextTranslati
 
 ```python
 credential = TranslatorCredential(apikey, region)
-text_translator = TextTranslationClient(credential, endpoint)
+text_translator = TextTranslationClient(credential, endpoint=endpoint)
 ```
 
 <!-- END SNIPPET -->

--- a/sdk/translation/azure-ai-translation-text/samples/sample_text_translation_client.py
+++ b/sdk/translation/azure-ai-translation-text/samples/sample_text_translation_client.py
@@ -47,6 +47,6 @@ def create_text_translation_client_with_credential():
     region = os.environ["AZURE_TEXT_TRANSLATION_REGION"]
     # [START create_text_translation_client_with_credential]
     credential = TranslatorCredential(apikey, region)
-    text_translator = TextTranslationClient(credential, endpoint)
+    text_translator = TextTranslationClient(credential, endpoint=endpoint)
     # [END create_text_translation_client_with_credential]
     return text_translator

--- a/sdk/translation/tests.yml
+++ b/sdk/translation/tests.yml
@@ -3,7 +3,6 @@ trigger: none
 stages:
   - template: /eng/pipelines/templates/stages/archetype-sdk-tests.yml
     parameters:
-      BuildTargetingString: azure-ai-translation-document
       ServiceDirectory: translation
       Clouds: Public # Skipping INT, re-enable when environment fixed
       CloudConfig:


### PR DESCRIPTION
Resolves https://github.com/Azure/azure-sdk-for-python/issues/33861

This PR does 2 things:

1. The specified BuildTargetingString was excluding translation-text from running in the live tests pipeline. This removes the targeting string so translation-text will run live and weekly live tests
2. This runs the post-processing script to fix init imports to use the patched clients, and as a result, fixes the mypy errors. translation is part of the core PR build so want to fix this now as we flip over to mypy required to avoid blocked builds.