### PR TITLE
Upgrade exporter to OTel 1.21

### DIFF
--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
@@ -10,6 +10,9 @@
 
 ### Other Changes
 
+- Update to OTel SKD/API 1.21
+    ([#XXXXX](https://github.com/Azure/azure-sdk-for-python/pull/XXXXX))
+
 ## 1.0.0b20 (2024-01-04)
 
 ### Other Changes

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### Other Changes
 
 - Update to OTel SKD/API 1.21
-    ([#XXXXX](https://github.com/Azure/azure-sdk-for-python/pull/XXXXX))
+    ([#33864](https://github.com/Azure/azure-sdk-for-python/pull/33864))
 
 ## 1.0.0b20 (2024-01-04)
 

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/setup.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/setup.py
@@ -85,8 +85,8 @@ setup(
         "azure-core<2.0.0,>=1.23.0",
         "fixedint==0.1.6",
         "msrest>=0.6.10",
-        "opentelemetry-api~=1.20",
-        "opentelemetry-sdk~=1.20",
+        "opentelemetry-api~=1.21",
+        "opentelemetry-sdk~=1.21",
     ],
     entry_points={
         "opentelemetry_traces_exporter": [


### PR DESCRIPTION
# Description

Upgrade exporter to OTel 1.21 to prepare for distro with updated VMResourceDetector dependency.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
