### PR TITLE
Update precached python version

### DIFF
--- a/eng/pipelines/templates/stages/platform-matrix-excluding-pypy.json
+++ b/eng/pipelines/templates/stages/platform-matrix-excluding-pypy.json
@@ -31,7 +31,7 @@
         "Ubuntu2004_3120": {
           "OSVmImage": "MMSUbuntu20.04",
           "Pool": "azsdk-pool-mms-ubuntu-2004-general",
-          "PythonVersion": "3.12.0",
+          "PythonVersion": "3.12",
           "CoverageArg": "--disablecov",
           "TestSamples": "false"
         }

--- a/eng/pipelines/templates/stages/platform-matrix.json
+++ b/eng/pipelines/templates/stages/platform-matrix.json
@@ -28,10 +28,10 @@
     },
     {
       "Config": {
-        "Ubuntu2004_3120": {
+        "Ubuntu2004_312": {
           "OSVmImage": "MMSUbuntu20.04",
           "Pool": "azsdk-pool-mms-ubuntu-2004-general",
-          "PythonVersion": "3.12.0",
+          "PythonVersion": "3.12",
           "CoverageArg": "--disablecov",
           "TestSamples": "false"
         }

--- a/scripts/devops_tasks/install_python_version.py
+++ b/scripts/devops_tasks/install_python_version.py
@@ -19,7 +19,7 @@ MANIFEST_LOCATION = "https://raw.githubusercontent.com/actions/python-versions/m
 MAX_INSTALLER_RETRY = 3
 CURRENT_UBUNTU_VERSION = "20.04"  # full title is ubuntu-20.04
 MAX_PRECACHED_VERSION = (
-    "3.12.1"  # reference: https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2004-Readme.md#python
+    "3.12.1"  # reference: https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2004-Readme.md#python
 )
 
 UNIX_INSTALL_ARRAY = ["sh", "setup.sh"]

--- a/scripts/devops_tasks/install_python_version.py
+++ b/scripts/devops_tasks/install_python_version.py
@@ -19,7 +19,7 @@ MANIFEST_LOCATION = "https://raw.githubusercontent.com/actions/python-versions/m
 MAX_INSTALLER_RETRY = 3
 CURRENT_UBUNTU_VERSION = "20.04"  # full title is ubuntu-20.04
 MAX_PRECACHED_VERSION = (
-    "3.11.1"  # reference: https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2004-Readme.md#python
+    "3.12.1"  # reference: https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2004-Readme.md#python
 )
 
 UNIX_INSTALL_ARRAY = ["sh", "setup.sh"]

--- a/sdk/communication/azure-communication-phonenumbers/phonenumbers-livetest-matrix.json
+++ b/sdk/communication/azure-communication-phonenumbers/phonenumbers-livetest-matrix.json
@@ -47,7 +47,7 @@
         "Ubuntu2004_3120": {
           "OSVmImage": "MMSUbuntu20.04",
           "Pool": "azsdk-pool-mms-ubuntu-2004-general",
-          "PythonVersion": "3.12.0",
+          "PythonVersion": "3.12",
           "CoverageArg": "--disablecov",
           "TestSamples": "false",
           "COMMUNICATION_SKIP_CAPABILITIES_LIVE_TEST": "true"


### PR DESCRIPTION
Update

- [x] Targeted version of python 3.12
- [x] Reflect reality of what is precached on the agents. 

This is in response to another issue that Kushagra is seeing over in #33363 , who is running into troubles when attempting to install python 3.12 on windows from their installer.