### PR TITLE
Remove prebuilt linux packages from `test_tools`, no longer necessary

### DIFF
--- a/eng/test_tools.txt
+++ b/eng/test_tools.txt
@@ -20,7 +20,3 @@ pyyaml==6.0.1
 urllib3==1.26.9
 ConfigArgParse==1.2.3
 six==1.16.0
-
-# 312 compatibility
-https://docsupport.blob.core.windows.net/repackaged/cffi-1.15.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl; python_version >= '3.12'
-https://docsupport.blob.core.windows.net/repackaged/aiohttp-4.0.0a2.dev0-cp312-cp312-linux_x86_64.whl; python_version >= '3.12'


### PR DESCRIPTION
`aiohttp` and `cffi` have released wheels for all platforms.