### PR TITLE
Use prebuilt wheel dir to resolve necessary azure requirements before using repo version

### DIFF
--- a/tools/azure-sdk-tools/ci_tools/functions.py
+++ b/tools/azure-sdk-tools/ci_tools/functions.py
@@ -297,7 +297,7 @@ def get_package_from_repo_or_folder(req: str, prebuilt_wheel_dir: str = None) ->
             # return the first package found, there should only be a single one matching given that our prebuilt wheel directory
             # is populated by the replacement of dev_reqs.txt with the prebuilt wheels
             # ref tox_harness replace_dev_reqs() calls
-            return prebuilt_package[0]
+            return os.path.join(prebuilt_wheel_dir, prebuilt_package[0])
 
     return local_package.folder
 

--- a/tools/azure-sdk-tools/ci_tools/functions.py
+++ b/tools/azure-sdk-tools/ci_tools/functions.py
@@ -28,8 +28,7 @@ MANAGEMENT_PACKAGE_IDENTIFIERS = [
     "azure-ai-anomalydetector",
 ]
 
-NO_TESTS_ALLOWED = [
-]
+NO_TESTS_ALLOWED = []
 
 
 META_PACKAGES = ["azure", "azure-mgmt", "azure-keyvault"]
@@ -432,6 +431,7 @@ def pip_install(requirements: List[str], include_dependencies: bool = True, pyth
 
     return True
 
+
 def pip_uninstall(requirements: List[str], python_executable: str) -> bool:
     """
     Attempts to invoke an install operation using the invoking python's pip. Empty requirements are auto-success.
@@ -501,7 +501,7 @@ def pytest(args: [], cwd: str = None, python_executable: str = None) -> bool:
         result = subprocess.run(commands, cwd=cwd)
     else:
         result = subprocess.run(commands)
-    
+
     return result.returncode == 0
 
 

--- a/tools/azure-sdk-tools/ci_tools/functions.py
+++ b/tools/azure-sdk-tools/ci_tools/functions.py
@@ -268,7 +268,13 @@ def is_required_version_on_pypi(package_name, spec):
     return versions
 
 
-def get_package_from_repo(pkg_name: str, repo_root: str = None) -> ParsedSetup:
+def get_package_from_repo(pkg_name: str, repo_root: str = None, optional_wheel_dir: str = None) -> ParsedSetup:
+    if optional_wheel_dir:
+        # find the prebuilt wheel
+        pass
+
+        # if we do have it prebuilt, return it, otherwise, continue on to the repo find
+    
     root_dir = discover_repo_root(repo_root)
 
     glob_path = os.path.join(root_dir, "sdk", "*", pkg_name, "setup.py")

--- a/tools/azure-sdk-tools/ci_tools/scenario/generation.py
+++ b/tools/azure-sdk-tools/ci_tools/scenario/generation.py
@@ -116,6 +116,7 @@ def create_package_and_install(
                         addition_necessary = True
                         # get all installed packages
                         installed_pkgs = get_pip_list_output(python_exe)
+                        logging.info("Installed packages: {}".format(installed_pkgs))
 
                         # parse the specifier
                         req_name, req_specifier = parse_require(req)
@@ -343,7 +344,9 @@ def prepare_and_test_optional(mapped_args: argparse.Namespace) -> int:
 
         if mapped_args.optional:
             if env_name != mapped_args.optional:
-                logging.info(f"{env_name} does not match targeted environment {mapped_args.optional}, skipping this environment.")
+                logging.info(
+                    f"{env_name} does not match targeted environment {mapped_args.optional}, skipping this environment."
+                )
                 continue
 
         environment_exe = prepare_environment(mapped_args.target, mapped_args.temp_dir, env_name)

--- a/tools/azure-sdk-tools/ci_tools/scenario/generation.py
+++ b/tools/azure-sdk-tools/ci_tools/scenario/generation.py
@@ -153,7 +153,12 @@ def create_package_and_install(
 
                         additional_downloaded_reqs = [
                             os.path.abspath(os.path.join(tmp_dl_folder, pth)) for pth in os.listdir(tmp_dl_folder)
-                        ] + [get_package_from_repo_or_folder(package_name, os.path.join(target_package.folder, ".tmp_whl_dir")) for package_name in non_present_reqs]
+                        ] + [
+                            get_package_from_repo_or_folder(
+                                package_name, os.path.join(target_package.folder, ".tmp_whl_dir")
+                            )
+                            for package_name in non_present_reqs
+                        ]
 
             commands = [python_exe, "-m", "pip", "install", built_pkg_path]
             commands.extend(additional_downloaded_reqs)

--- a/tools/azure-sdk-tools/ci_tools/scenario/generation.py
+++ b/tools/azure-sdk-tools/ci_tools/scenario/generation.py
@@ -16,7 +16,7 @@ from ci_tools.functions import (
 )
 from ci_tools.build import cleanup_build_artifacts, create_package
 from ci_tools.parsing import ParsedSetup, parse_require
-from ci_tools.functions import get_package_from_repo, find_whl, get_pip_list_output, pytest
+from ci_tools.functions import get_package_from_repo_or_folder, find_whl, get_pip_list_output, pytest
 from .managed_virtual_env import ManagedVirtualEnv
 
 
@@ -70,6 +70,8 @@ def create_package_and_install(
     discovered_packages = discover_packages(
         setup_py_path, distribution_directory, target_setup, package_type, force_create
     )
+
+    target_package = ParsedSetup.from_path(setup_py_path)
 
     if skip_install:
         logging.info("Flag to skip install whl is passed. Skipping package installation")
@@ -151,7 +153,7 @@ def create_package_and_install(
 
                         additional_downloaded_reqs = [
                             os.path.abspath(os.path.join(tmp_dl_folder, pth)) for pth in os.listdir(tmp_dl_folder)
-                        ] + [get_package_from_repo(relative_req).folder for relative_req in non_present_reqs]
+                        ] + [get_package_from_repo_or_folder(package_name, os.path.join(target_package.folder, ".tmp_whl_dir")) for package_name in non_present_reqs]
 
             commands = [python_exe, "-m", "pip", "install", built_pkg_path]
             commands.extend(additional_downloaded_reqs)


### PR DESCRIPTION
Resolves #33886

## Before this change:

If we are running a non-dev build, and we're installing a package with a requirement not on pypi, we would resolve the package to one within the repo (as a relative path, EG `sdk/ml/azure-ai-ml/`)

This is the origin of the failures that look [like this](https://dev.azure.com/azure-sdk/public/_build/results?buildId=3419200&view=logs&j=b44a1dd8-76ee-573b-f41c-d189c4aff101&t=831b442b-6682-55ac-0767-72470a9002a0&l=5163).

If multiple parallel tox environments are attempting to install this relative req from path, non-deterministic errors will result. This is due to the fact that building a wheel generates artifacts on the drive in the folder path of the package, and having multiple processes attempt at the same time causes conflicts with these artifacts.

## After this change

As part of CI, we replace relative deps with prebuilt wheels to avoid _exactly these non-deterministic errors_. This pr will utilize this _same prebuilt dir_ to attempt to resolve a dep BEFORE falling back to the relative dep in the repo.

