### PR TITLE
[OTel Distro] Reenable CI

### DIFF
--- a/sdk/monitor/azure-monitor-opentelemetry/pyproject.toml
+++ b/sdk/monitor/azure-monitor-opentelemetry/pyproject.toml
@@ -5,4 +5,3 @@ pyright = false
 pylint = true
 bandit = true
 strict_sphinx = true
-ci_enabled = false


### PR DESCRIPTION
The `ci_enabled = False` flag was added here in https://github.com/Azure/azure-sdk-for-python/commit/2219c7dc57b5fee6dccd2a78e5b505156886c3a1. 

After https://github.com/Azure/azure-sdk-for-python/commit/1f60f54bc4cd54b39a860a8fcdd15af16ecbd142, mypy now passes so re-enabling CI for this package to allow releases.
