### PR TITLE
[Key Vault] Prepare for `strict-sphinx`

### DIFF
--- a/sdk/keyvault/azure-keyvault-administration/README.md
+++ b/sdk/keyvault/azure-keyvault-administration/README.md
@@ -124,7 +124,7 @@ A `KeyVaultSettingsClient` manages Managed HSM account settings.
 This section contains code snippets covering common tasks:
 * Access control
     * [List all role definitions](#list-all-role-definitions)
-    * [Set, get, and delete a role definition](#set-get-and-delete-a-role-defintion)
+    * [Set, get, and delete a role definition](#set-get-and-delete-a-role-definition)
     * [List all role assignments](#list-all-role-assignments)
     * [Create, get, and delete a role assignment](#create-get-and-delete-a-role-assignment)
 * Backup and restore
@@ -149,7 +149,6 @@ for definition in role_definitions:
 <!-- END SNIPPET -->
 
 ### Set, get, and delete a role definition
-
 `set_role_definition` can be used by a `KeyVaultAccessControlClient` to either create a custom role definition or update
 an existing definition with the specified unique `name` (a UUID).
 

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_models.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_models.py
@@ -236,11 +236,10 @@ class KeyVaultRSAPublicKey(RSAPublicKey):
 
         Normally you should use the `verify()` function to validate the signature. But for some non-standard signature
         formats you may need to explicitly recover and validate the signed data. The following are some examples:
-            * Some old Thawte and Verisign timestamp certificates without `DigestInfo`.
-            * Signed MD5/SHA1 hashes in TLS 1.1 or earlier
-              (`RFC 4346 <https://datatracker.ietf.org/doc/html/rfc4346.html>`_, section 4.7).
-            * IKE version 1 signatures without `DigestInfo`
-              (`RFC 2409 <https://datatracker.ietf.org/doc/html/rfc2409.html>`_, section 5.1).
+
+        * Some old Thawte and Verisign timestamp certificates without `DigestInfo`.
+        * Signed MD5/SHA1 hashes in TLS 1.1 or earlier (`RFC 4346 <https://datatracker.ietf.org/doc/html/rfc4346.html>`_, section 4.7).
+        * IKE version 1 signatures without `DigestInfo` (`RFC 2409 <https://datatracker.ietf.org/doc/html/rfc2409.html>`_, section 5.1).
 
         :param bytes signature: The signature.
         :param padding: An instance of `AsymmetricPadding`. Recovery is only supported with some of the padding types.
@@ -254,7 +253,7 @@ class KeyVaultRSAPublicKey(RSAPublicKey):
             NotImplementedError if the local version of `cryptography` doesn't support this method.
             :class:`~cryptography.exceptions.InvalidSignature` if the signature is invalid.
             :class:`~cryptography.exceptions.UnsupportedAlgorithm` if the signature data recovery is not supported with
-                the provided `padding` type.
+            the provided `padding` type.
         """
         public_key = self.public_numbers().public_key()
         try:

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_models.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_models.py
@@ -222,6 +222,7 @@ class KeyVaultRSAPublicKey(RSAPublicKey):
     def recover_data_from_signature(
         self, signature: bytes, padding: AsymmetricPadding, algorithm: Optional[HashAlgorithm]
     ) -> bytes:
+        # pylint: disable=line-too-long
         """Recovers the signed data from the signature. Only supported with `cryptography` version 3.3 and above.
 
         This function uses the `cryptography` library's implementation.

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/aio/__init__.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/aio/__init__.py
@@ -2,16 +2,49 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
+from typing import Any, List, Optional
+
 from ._client import CryptographyClient
-from .. import EncryptionAlgorithm, KeyWrapAlgorithm, SignatureAlgorithm
-from .. import EncryptResult, SignResult, WrapResult
+
 
 __all__ = [
     "CryptographyClient",
-    "EncryptionAlgorithm",
-    "EncryptResult",
-    "KeyWrapAlgorithm",
-    "SignatureAlgorithm",
-    "SignResult",
-    "WrapResult",
 ]
+
+
+def __dir__() -> List[str]:
+    return __all__
+
+
+# Allow importing these types for backwards compatibility, but exclude indexing types that shouldn't be in aio namespace
+
+
+def __getattr__(name: str):
+    requested: Optional[Any] = None
+    if name == "EncryptionAlgorithm":
+        from .. import EncryptionAlgorithm
+
+        requested = EncryptionAlgorithm
+    if name == "KeyWrapAlgorithm":
+        from .. import KeyWrapAlgorithm
+
+        requested = KeyWrapAlgorithm
+    if name == "SignatureAlgorithm":
+        from .. import SignatureAlgorithm
+
+        requested = SignatureAlgorithm
+    if name == "EncryptResult":
+        from .. import EncryptResult
+
+        requested = EncryptResult
+    if name == "SignResult":
+        from .. import SignResult
+
+        requested = SignResult
+    if name == "WrapResult":
+        from .. import WrapResult
+
+        requested = WrapResult
+    if requested:
+        return requested
+    raise AttributeError(f"module 'azure.keyvault.keys.crypto.aio' has no attribute {name}")

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client_async.py
@@ -17,7 +17,7 @@ from azure.keyvault.keys import ApiVersion, JsonWebKey, KeyCurveName, KeyOperati
 from azure.keyvault.keys.crypto._providers import NoLocalCryptography, get_local_cryptography_provider
 from azure.keyvault.keys.crypto.aio import (
     CryptographyClient,
-    EncryptionAlgorithm,
+    EncryptionAlgorithm,  # Shouldn't be imported from aio namespace, but do so to test backwards compatibility
     KeyWrapAlgorithm,
     SignatureAlgorithm,
 )


### PR DESCRIPTION
# Description

Resolves https://github.com/Azure/azure-sdk-for-python/issues/33553 and https://github.com/Azure/azure-sdk-for-python/issues/33555.

One error was that synchronous types are exposed from the `azure.keyvault.keys.crypto.aio` namespace. These were exported via `__all__` but also already exposed through the non-`aio` namespace, which sphinx was unhappy with.

We still need the types to be importable from there to preserve existing behavior, so this PR removes these types from `__all__` and supports imports dynamically with `__getattr__`. Tests verify that imports from `aio` still work while also satisfying sphinx checks.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
