### PR TITLE
fix broken link

### DIFF
--- a/sdk/cognitiveservices/azure-cognitiveservices-vision-computervision/README.md
+++ b/sdk/cognitiveservices/azure-cognitiveservices-vision-computervision/README.md
@@ -300,7 +300,7 @@ For more extensive documentation on the Computer Vision service, see the [Azure 
 
 [ref_computervision_sdk]: https://docs.microsoft.com/python/api/azure-cognitiveservices-vision-computervision/azure.cognitiveservices.vision.computervision?view=azure-python
 [ref_computervision_computervisionerrorexception]:https://docs.microsoft.com/python/api/azure-cognitiveservices-vision-computervision/azure.cognitiveservices.vision.computervision.models.computervisionerrorresponseexception?view=azure-python
-[ref_httpfailure]: https://docs.microsoft.com/python/api/msrest/msrest.exceptions.httpoperationerror?view=azure-python
+[ref_httpfailure]: https://github.com/Azure/msrest-for-python/blob/master/msrest/exceptions.py#L133
 
 
 [computervision_resource]: https://docs.microsoft.com/azure/cognitive-services/computer-vision/vision-api-how-to-topics/howtosubscribe


### PR DESCRIPTION
Pipeline is reporting a broken link: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3433140&view=logs&j=b70e5e73-bbb6-5567-0939-8415943fadb9&t=72c41882-9d21-5580-4869-7f3ea1bd9c0a&l=59

Re-pointing to the best substitution I could find.