### PR TITLE
Support user-based authentication in live tests

### DIFF
--- a/tools/azure-sdk-tools/devtools_testutils/azure_recorded_testcase.py
+++ b/tools/azure-sdk-tools/devtools_testutils/azure_recorded_testcase.py
@@ -91,8 +91,8 @@ class AzureRecordedTestCase(object):
         client_id = os.environ.get("AZURE_CLIENT_ID", getattr(os.environ, "CLIENT_ID", None))
         secret = os.environ.get("AZURE_CLIENT_SECRET", getattr(os.environ, "CLIENT_SECRET", None))
 
-        use_pwsh = os.environ.get("AZURE_TEST_USE_PWSH_AUTH")
-        use_cli = os.environ.get("AZURE_TEST_USE_CLI_AUTH")
+        use_pwsh = os.environ.get("AZURE_TEST_USE_PWSH_AUTH", "false")
+        use_cli = os.environ.get("AZURE_TEST_USE_CLI_AUTH", "false")
         is_async = kwargs.pop("is_async", False)
 
         # User-based authentication through Azure PowerShell, if requested

--- a/tools/azure-sdk-tools/devtools_testutils/azure_recorded_testcase.py
+++ b/tools/azure-sdk-tools/devtools_testutils/azure_recorded_testcase.py
@@ -95,45 +95,49 @@ class AzureRecordedTestCase(object):
         use_cli = os.environ.get("AZURE_TEST_USE_CLI_AUTH", "false")
         is_async = kwargs.pop("is_async", False)
 
-        # User-based authentication through Azure PowerShell, if requested
-        if use_pwsh.lower() == "true" and self.is_live:
-            _LOGGER.info(
-                "Environment variable AZURE_TEST_USE_PWSH_AUTH set to 'true'. Using AzurePowerShellCredential."
-            )
-            from azure.identity import AzurePowerShellCredential
-
-            if is_async:
-                from azure.identity.aio import AzurePowerShellCredential
-            return AzurePowerShellCredential()
-        # User-based authentication through Azure CLI, if requested
-        if use_cli.lower() == "true" and self.is_live:
-            _LOGGER.info("Environment variable AZURE_TEST_USE_CLI_AUTH set to 'true'. Using AzureCliCredential.")
-            from azure.identity import AzureCliCredential
-
-            if is_async:
-                from azure.identity.aio import AzureCliCredential
-            return AzureCliCredential()
-
-        # Service principal authentication
-        if tenant_id and client_id and secret and self.is_live:
-            if _is_autorest_v3(client_class):
+        # Return live credentials only in live mode
+        if self.is_live:
+            # User-based authentication through Azure PowerShell, if requested
+            if use_pwsh.lower() == "true":
                 _LOGGER.info(
-                    "Service principal client ID, secret, and tenant ID detected. Using ClientSecretCredential.\n"
-                    "For user-based authentication, set AZURE_TEST_USE_PWSH_AUTH or AZURE_TEST_USE_CLI_AUTH to 'true'."
+                    "Environment variable AZURE_TEST_USE_PWSH_AUTH set to 'true'. Using AzurePowerShellCredential."
                 )
-                # Create azure-identity class
-                from azure.identity import ClientSecretCredential
+                from azure.identity import AzurePowerShellCredential
 
                 if is_async:
-                    from azure.identity.aio import ClientSecretCredential
-                return ClientSecretCredential(tenant_id=tenant_id, client_id=client_id, client_secret=secret)
-            else:
-                # Create msrestazure class
-                from msrestazure.azure_active_directory import (
-                    ServicePrincipalCredentials,
-                )
+                    from azure.identity.aio import AzurePowerShellCredential
+                return AzurePowerShellCredential()
+            # User-based authentication through Azure CLI, if requested
+            if use_cli.lower() == "true":
+                _LOGGER.info("Environment variable AZURE_TEST_USE_CLI_AUTH set to 'true'. Using AzureCliCredential.")
+                from azure.identity import AzureCliCredential
 
-                return ServicePrincipalCredentials(tenant=tenant_id, client_id=client_id, secret=secret)
+                if is_async:
+                    from azure.identity.aio import AzureCliCredential
+                return AzureCliCredential()
+
+            # Service principal authentication
+            if tenant_id and client_id and secret:
+                # Check for track 2 client
+                if _is_autorest_v3(client_class):
+                    _LOGGER.info(
+                        "Service principal client ID, secret, and tenant ID detected. Using ClientSecretCredential.\n"
+                        "For user-based auth, set AZURE_TEST_USE_PWSH_AUTH or AZURE_TEST_USE_CLI_AUTH to 'true'."
+                    )
+                    from azure.identity import ClientSecretCredential
+
+                    if is_async:
+                        from azure.identity.aio import ClientSecretCredential
+                    return ClientSecretCredential(tenant_id=tenant_id, client_id=client_id, client_secret=secret)
+                else:
+                    # Create msrestazure class
+                    from msrestazure.azure_active_directory import (
+                        ServicePrincipalCredentials,
+                    )
+
+                    return ServicePrincipalCredentials(tenant=tenant_id, client_id=client_id, secret=secret)
+
+        # For playback tests, return credentials that will accept playback `get_token` calls
         else:
             if _is_autorest_v3(client_class):
                 if is_async:


### PR DESCRIPTION
# Description

Adds support for Azure PowerShell and CLI authentication, building on new support for user authentication with live test resources -- see https://github.com/Azure/azure-sdk-tools/pull/7580.

Since most users deploy test resources with PowerShell via `New-TestResources.ps1`, I gave `AZURE_TEST_USE_PWSH_AUTH` preference over `AZURE_TEST_USE_CLI_AUTH` when both are set to "true".

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
