### PR TITLE
Resolve CI Conflict within `ai` builds

### DIFF
--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -31,6 +31,10 @@ steps:
     parameters:
       versionSpec: '${{ parameters.PythonVersion }}'
 
+  - template: set-dev-build.yml
+    parameters:
+      ServiceDirectory: ${{ parameters.ServiceDirectory }}
+
   - pwsh: |
       $ErrorActionPreference = 'Stop'
       $PSNativeCommandUseErrorActionPreference = $true

--- a/eng/tox/tox.ini
+++ b/eng/tox/tox.ini
@@ -380,7 +380,6 @@ deps =
   {[packaging]pkgs}
 commands =
     python -m pip install {repository_root}/tools/azure-sdk-tools --no-deps
-    python {repository_root}/eng/tox/sanitize_setup.py -t {tox_root}
     python {repository_root}/eng/tox/create_package_and_install.py \
       -d {envtmpdir} \
       -p {tox_root} \

--- a/tools/azure-sdk-tools/ci_tools/scenario/generation.py
+++ b/tools/azure-sdk-tools/ci_tools/scenario/generation.py
@@ -143,6 +143,7 @@ def create_package_and_install(
                         non_present_reqs = []
                         for addition in installation_additions:
                             try:
+                                logging.info(f"Download command {download_command + [addition] + commands_options}")
                                 subprocess.check_call(
                                     download_command + [addition] + commands_options,
                                     env=dict(os.environ, PIP_EXTRA_INDEX_URL=""),
@@ -151,9 +152,12 @@ def create_package_and_install(
                                 req_name, req_specifier = parse_require(addition)
                                 non_present_reqs.append(req_name)
 
-                        additional_downloaded_reqs = [
+                        pre_downloaded_reqs = [
                             os.path.abspath(os.path.join(tmp_dl_folder, pth)) for pth in os.listdir(tmp_dl_folder)
-                        ] + [
+                        ] 
+
+                        logging.info(f"pre downloaded wheels are: {pre_downloaded_reqs}")
+                        additional_downloaded_reqs = pre_downloaded_reqs + [
                             get_package_from_repo_or_folder(
                                 package_name, os.path.join(target_package.folder, ".tmp_whl_dir")
                             )

--- a/tools/azure-sdk-tools/ci_tools/scenario/generation.py
+++ b/tools/azure-sdk-tools/ci_tools/scenario/generation.py
@@ -143,7 +143,6 @@ def create_package_and_install(
                         non_present_reqs = []
                         for addition in installation_additions:
                             try:
-                                logging.info(f"Download command {download_command + [addition] + commands_options}")
                                 subprocess.check_call(
                                     download_command + [addition] + commands_options,
                                     env=dict(os.environ, PIP_EXTRA_INDEX_URL=""),
@@ -152,12 +151,9 @@ def create_package_and_install(
                                 req_name, req_specifier = parse_require(addition)
                                 non_present_reqs.append(req_name)
 
-                        pre_downloaded_reqs = [
+                        additional_downloaded_reqs = [
                             os.path.abspath(os.path.join(tmp_dl_folder, pth)) for pth in os.listdir(tmp_dl_folder)
-                        ] 
-
-                        logging.info(f"pre downloaded wheels are: {pre_downloaded_reqs}")
-                        additional_downloaded_reqs = pre_downloaded_reqs + [
+                        ] + [
                             get_package_from_repo_or_folder(
                                 package_name, os.path.join(target_package.folder, ".tmp_whl_dir")
                             )


### PR DESCRIPTION
We've been seeing failures on the _non-dev_ internal CI builds for `azure-ai` packages.

[These are the failures](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3435310&view=logs&j=69247760-d00b-59ba-802c-4e283c193199&t=f20575ad-23dc-5da2-643e-2edfc62d6048&l=4043)

This is caused by the fact that the `depends` check is updating a package req on the fly when it is unable to locate the version on pypi. Because _all_ of the tox environments actually utilize the requirements from the `setup.py` to resolve their `azure` requirements to either a pip-downloaded wheel or a cached prebuilt wheel, this causes crashes in some non-deterministic set of the tox environments that run _after_ the `depends` check.

During a `dev` build, all the requirements are coherent, and alpha versions are able to be installed. During a **non-dev** build, the `depends` package is unable to locate a package that matches the necessary version, causing it to update on the fly to the `alpha` dependency. While this works for the `depends` environment, the _other_ environments are attempting to install the prebuilt wheel from the `build` phase. THESE packages _do not_ have the on-the-fly updated dev specifiers, and as such are attempting to satisfy `azure-ai-ml>=1.13.0b1` with `azure-ai-ml1.13.0aXXXX`. This obviously conflicts, and cannot be resolved.

This PR resolves this problem by making it consistent in either direction. During a dev build, the packages at rest have their requirements updated to alpha version if necessary. Otherwise, they are _left alone_ and the prebuilt wheel dir should have everything they need.

[`python - ai` Dev Build](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3436067&view=results)
[`python - ai` Non-Dev Build](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3436068&view=results)

[`python - storage` Dev Build](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3436239&view=results)
[`python - storage` Non-Dev Build](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3436240&view=results)



This PR is only acceptable if both of these pass.

