### PR TITLE
[Storage] [STG93] Missing docstring for `upn`

### DIFF
--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_path_client.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_path_client.py
@@ -918,6 +918,15 @@ class PathClient(StorageAccountHostsMixin):
             Decrypts the data on the service-side with the given key.
             Use of customer-provided keys must be done over HTTPS.
             Required if the file/directory was created with a customer-provided key.
+        :keyword bool upn:
+            Optional. Valid only when Hierarchical Namespace is
+            enabled for the account. If "True", the user identity values returned
+            in the x-ms-owner, x-ms-group, and x-ms-acl response headers will be
+            transformed from Azure Active Directory Object IDs to User Principal
+            Names. If "False", the values will be returned as Azure Active
+            Directory Object IDs. The default value is false. Note that group and
+            application Object IDs are not translated because they do not have
+            unique friendly names.
         :keyword int timeout:
             Sets the server-side timeout for the operation in seconds. For more details see
             https://learn.microsoft.com/rest/api/storageservices/setting-timeouts-for-blob-service-operations.

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/aio/_path_client_async.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/aio/_path_client_async.py
@@ -707,6 +707,15 @@ class PathClient(AsyncStorageAccountHostsMixin, PathClientBase):
             Decrypts the data on the service-side with the given key.
             Use of customer-provided keys must be done over HTTPS.
             Required if the file/directory was created with a customer-provided key.
+        :keyword bool upn:
+            Optional. Valid only when Hierarchical Namespace is
+            enabled for the account. If "True", the user identity values returned
+            in the x-ms-owner, x-ms-group, and x-ms-acl response headers will be
+            transformed from Azure Active Directory Object IDs to User Principal
+            Names. If "False", the values will be returned as Azure Active
+            Directory Object IDs. The default value is false. Note that group and
+            application Object IDs are not translated because they do not have
+            unique friendly names.
         :keyword int timeout:
             Sets the server-side timeout for the operation in seconds. For more details see
             https://learn.microsoft.com/rest/api/storageservices/setting-timeouts-for-blob-service-operations.


### PR DESCRIPTION
When we moved it to `_get_path_properties` for 1000IQ code re-use, I 0IQ forgot to add the docstring (and forced merge since it was only a docstring change between last change 😄 )