### PR TITLE
[Cosmos] make response_hook thread safe for the async client

### DIFF
--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_base.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_base.py
@@ -766,8 +766,7 @@ def _replace_throughput(
             max_throughput = throughput.auto_scale_max_throughput
             increment_percent = throughput.auto_scale_increment_percent
             if max_throughput is not None:
-                new_throughput_properties['content']['offerAutopilotSettings'][
-                    'maxThroughput'] = max_throughput
+                new_throughput_properties['content']['offerAutopilotSettings']['maxThroughput'] = max_throughput
                 if increment_percent:
                     new_throughput_properties['content']['offerAutopilotSettings']['autoUpgradePolicy']['throughputPolicy']['incrementPercent'] = increment_percent  # pylint: disable=line-too-long
                 if throughput.offer_throughput:

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_container.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_container.py
@@ -156,7 +156,6 @@ class ContainerProxy:
         :returns: Dict representing the retrieved container.
         :rtype: Dict[str, Any]
         """
-        response_hook = kwargs.pop('response_hook', None)
         if session_token is not None:
             kwargs['session_token'] = session_token
         if priority_level is not None:
@@ -173,8 +172,6 @@ class ContainerProxy:
         self._properties = await self.client_connection.ReadContainer(
             collection_link, options=request_options, **kwargs
         )
-        if response_hook:
-            response_hook(self.client_connection.last_response_headers, self._properties)
         return self._properties
 
     @distributed_trace_async
@@ -220,7 +217,6 @@ class ContainerProxy:
         :returns: A dict representing the new item.
         :rtype: Dict[str, Any]
         """
-        response_hook = kwargs.pop('response_hook', None)
         if pre_trigger_include is not None:
             kwargs['pre_trigger_include'] = pre_trigger_include
         if post_trigger_include is not None:
@@ -243,8 +239,6 @@ class ContainerProxy:
         result = await self.client_connection.CreateItem(
             database_or_container_link=self.container_link, document=body, options=request_options, **kwargs
         )
-        if response_hook:
-            response_hook(self.client_connection.last_response_headers, result)
         return result
 
     @distributed_trace_async
@@ -291,7 +285,6 @@ class ContainerProxy:
                 :caption: Get an item from the database and update one of its properties:
                 :name: update_item
         """
-        response_hook = kwargs.pop('response_hook', None)
         doc_link = self._get_document_link(item)
         if post_trigger_include is not None:
             kwargs['post_trigger_include'] = post_trigger_include
@@ -309,10 +302,7 @@ class ContainerProxy:
             validate_cache_staleness_value(max_integrated_cache_staleness_in_ms)
             request_options["maxIntegratedCacheStaleness"] = max_integrated_cache_staleness_in_ms
 
-        result = await self.client_connection.ReadItem(document_link=doc_link, options=request_options, **kwargs)
-        if response_hook:
-            response_hook(self.client_connection.last_response_headers, result)
-        return result
+        return await self.client_connection.ReadItem(document_link=doc_link, options=request_options, **kwargs)
 
     @distributed_trace
     def read_all_items(
@@ -571,7 +561,6 @@ class ContainerProxy:
         :returns: A dict representing the upserted item.
         :rtype: Dict[str, Any]
         """
-        response_hook = kwargs.pop('response_hook', None)
         if pre_trigger_include is not None:
             kwargs['pre_trigger_include'] = pre_trigger_include
         if post_trigger_include is not None:
@@ -595,8 +584,6 @@ class ContainerProxy:
             options=request_options,
             **kwargs
         )
-        if response_hook:
-            response_hook(self.client_connection.last_response_headers, result)
         return result
 
     @distributed_trace_async
@@ -639,7 +626,6 @@ class ContainerProxy:
         :returns: A dict representing the item after replace went through.
         :rtype: Dict[str, Any]
         """
-        response_hook = kwargs.pop('response_hook', None)
         item_link = self._get_document_link(item)
         if pre_trigger_include is not None:
             kwargs['pre_trigger_include'] = pre_trigger_include
@@ -661,8 +647,6 @@ class ContainerProxy:
         result = await self.client_connection.ReplaceItem(
             document_link=item_link, new_document=body, options=request_options, **kwargs
         )
-        if response_hook:
-            response_hook(self.client_connection.last_response_headers, result)
         return result
 
     @distributed_trace_async
@@ -708,7 +692,6 @@ class ContainerProxy:
             given id does not exist.
         :rtype: dict[str, Any]
         """
-        response_hook = kwargs.pop('response_hook', None)
         if pre_trigger_include is not None:
             kwargs['pre_trigger_include'] = pre_trigger_include
         if post_trigger_include is not None:
@@ -728,11 +711,8 @@ class ContainerProxy:
             request_options["filterPredicate"] = filter_predicate
 
         item_link = self._get_document_link(item)
-        result = await self.client_connection.PatchItem(
+        return await self.client_connection.PatchItem(
             document_link=item_link, operations=patch_operations, options=request_options, **kwargs)
-        if response_hook:
-            response_hook(self.client_connection.last_response_headers, result)
-        return result
 
     @distributed_trace_async
     async def delete_item(
@@ -770,7 +750,6 @@ class ContainerProxy:
         :raises ~azure.cosmos.exceptions.CosmosResourceNotFoundError: The item does not exist in the container.
         :rtype: None
         """
-        response_hook = kwargs.pop('response_hook', None)
         if pre_trigger_include is not None:
             kwargs['pre_trigger_include'] = pre_trigger_include
         if post_trigger_include is not None:
@@ -788,8 +767,6 @@ class ContainerProxy:
 
         document_link = self._get_document_link(item)
         await self.client_connection.DeleteItem(document_link=document_link, options=request_options, **kwargs)
-        if response_hook:
-            response_hook(self.client_connection.last_response_headers, None)
 
     @distributed_trace_async
     async def get_throughput(self, **kwargs: Any) -> ThroughputProperties:
@@ -842,7 +819,6 @@ class ContainerProxy:
         :returns: ThroughputProperties for the container, updated with new throughput.
         :rtype: ~azure.cosmos.offer.ThroughputProperties
         """
-        response_hook = kwargs.pop('response_hook', None)
         properties = await self._get_properties()
         link = properties["_self"]
         query_spec = {
@@ -860,8 +836,6 @@ class ContainerProxy:
         _replace_throughput(throughput=throughput, new_throughput_properties=new_offer)
         data = await self.client_connection.ReplaceOffer(offer_link=throughput_properties[0]["_self"],
                                                          offer=throughput_properties[0], **kwargs)
-        if response_hook:
-            response_hook(self.client_connection.last_response_headers, data)
 
         return ThroughputProperties(offer_throughput=data["content"]["offerThroughput"], properties=data)
 
@@ -955,13 +929,10 @@ class ContainerProxy:
         :rtype: Dict[str, Any]
         """
         request_options = _build_options(kwargs)
-        response_hook = kwargs.pop('response_hook', None)
         request_options["partitionKey"] = await self._set_partition_key(partition_key)
         result = await self.client_connection.ReadConflict(
             conflict_link=self._get_conflict_link(conflict), options=request_options, **kwargs
         )
-        if response_hook:
-            response_hook(self.client_connection.last_response_headers, result)
         return result
 
     @distributed_trace_async
@@ -986,13 +957,11 @@ class ContainerProxy:
         :rtype: None
         """
         request_options = _build_options(kwargs)
-        response_hook = kwargs.pop('response_hook', None)
         request_options["partitionKey"] = await self._set_partition_key(partition_key)
+
         await self.client_connection.DeleteConflict(
             conflict_link=self._get_conflict_link(conflict), options=request_options, **kwargs
         )
-        if response_hook:
-            response_hook(self.client_connection.last_response_headers, None)
 
     @distributed_trace_async
     async def delete_all_items_by_partition_key(
@@ -1023,7 +992,6 @@ class ContainerProxy:
         :keyword Callable response_hook: A callable invoked with the response metadata.
         :rtype: None
         """
-        response_hook = kwargs.pop('response_hook', None)
         if pre_trigger_include is not None:
             kwargs['pre_trigger_include'] = pre_trigger_include
         if post_trigger_include is not None:
@@ -1040,8 +1008,6 @@ class ContainerProxy:
 
         await self.client_connection.DeleteAllItemsByPartitionKey(collection_link=self.container_link,
                                                                   options=request_options, **kwargs)
-        if response_hook:
-            response_hook(self.client_connection.last_response_headers, None)
 
     @distributed_trace_async
     async def execute_item_batch(
@@ -1074,7 +1040,6 @@ class ContainerProxy:
         :raises ~azure.cosmos.exceptions.CosmosBatchOperationError: A transactional batch operation failed in the batch.
         :rtype: List[Dict[str, Any]]
         """
-        response_hook = kwargs.pop('response_hook', None)
         if pre_trigger_include is not None:
             kwargs['pre_trigger_include'] = pre_trigger_include
         if post_trigger_include is not None:
@@ -1089,8 +1054,5 @@ class ContainerProxy:
         request_options["partitionKey"] = await self._set_partition_key(partition_key)
         request_options["disableAutomaticIdGeneration"] = True
 
-        result = await self.client_connection.Batch(
+        return await self.client_connection.Batch(
             collection_link=self.container_link, batch_operations=batch_operations, options=request_options, **kwargs)
-        if response_hook:
-            response_hook(self.client_connection.last_response_headers, result)
-        return result

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_cosmos_client.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_cosmos_client.py
@@ -271,7 +271,6 @@ class CosmosClient:  # pylint: disable=client-accepts-api-version-keyword
                 :caption: Create a database in the Cosmos DB account:
                 :name: create_database
         """
-        response_hook = kwargs.pop('response_hook', None)
         if session_token is not None:
             kwargs["session_token"] = session_token
         if initial_headers is not None:
@@ -284,8 +283,6 @@ class CosmosClient:  # pylint: disable=client-accepts-api-version-keyword
         _set_throughput_options(offer=offer_throughput, request_options=request_options)
 
         result = await self.client_connection.CreateDatabase(database=dict(id=id), options=request_options, **kwargs)
-        if response_hook:
-            response_hook(self.client_connection.last_response_headers, result)
         return DatabaseProxy(self.client_connection, id=result["id"], properties=result)
 
     @distributed_trace_async

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_cosmos_client_connection_async.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_cosmos_client_connection_async.py
@@ -697,6 +697,7 @@ class CosmosClientConnection:  # pylint: disable=too-many-public-methods,too-man
             dict
 
         """
+        response_hook = kwargs.pop("response_hook", None)
         if options is None:
             options = {}
 
@@ -705,10 +706,13 @@ class CosmosClientConnection:  # pylint: disable=too-many-public-methods,too-man
         # Create will use WriteEndpoint since it uses POST operation
 
         request_params = _request_object.RequestObject(typ, documents._OperationType.Create)
-        result, self.last_response_headers = await self.__Post(path, request_params, body, headers, **kwargs)
+        result, last_response_headers = await self.__Post(path, request_params, body, headers, **kwargs)
+        self.last_response_headers = last_response_headers
 
         # update session for write request
-        self._UpdateSessionIfRequired(headers, result, self.last_response_headers)
+        self._UpdateSessionIfRequired(headers, result, last_response_headers)
+        if response_hook:
+            response_hook(last_response_headers, result)
         return result
 
     async def UpsertUser(
@@ -829,6 +833,7 @@ class CosmosClientConnection:  # pylint: disable=too-many-public-methods,too-man
             dict
 
         """
+        response_hook = kwargs.pop("response_hook", None)
         if options is None:
             options = {}
 
@@ -839,9 +844,12 @@ class CosmosClientConnection:  # pylint: disable=too-many-public-methods,too-man
 
         # Upsert will use WriteEndpoint since it uses POST operation
         request_params = _request_object.RequestObject(typ, documents._OperationType.Upsert)
-        result, self.last_response_headers = await self.__Post(path, request_params, body, headers, **kwargs)
+        result, last_response_headers = await self.__Post(path, request_params, body, headers, **kwargs)
+        self.last_response_headers = last_response_headers
         # update session for write request
         self._UpdateSessionIfRequired(headers, result, self.last_response_headers)
+        if response_hook:
+            response_hook(last_response_headers, result)
         return result
 
     async def __Post(
@@ -1112,7 +1120,7 @@ class CosmosClientConnection:  # pylint: disable=too-many-public-methods,too-man
         options: Optional[Mapping[str, Any]] = None,
         **kwargs: Any
     ) -> Dict[str, Any]:
-        """Reads a Azure Cosmos resource and returns it.
+        """Reads an Azure Cosmos resource and returns it.
 
         :param str path:
         :param str typ:
@@ -1127,6 +1135,7 @@ class CosmosClientConnection:  # pylint: disable=too-many-public-methods,too-man
             dict
 
         """
+        response_hook = kwargs.pop("response_hook", None)
         if options is None:
             options = {}
 
@@ -1134,7 +1143,10 @@ class CosmosClientConnection:  # pylint: disable=too-many-public-methods,too-man
         headers = base.GetHeaders(self, initial_headers, "get", path, id, typ, options)
         # Read will use ReadEndpoint since it uses GET operation
         request_params = _request_object.RequestObject(typ, documents._OperationType.Read)
-        result, self.last_response_headers = await self.__Get(path, request_params, headers, **kwargs)
+        result, last_response_headers = await self.__Get(path, request_params, headers, **kwargs)
+        self.last_response_headers = last_response_headers
+        if response_hook:
+            response_hook(last_response_headers, result)
         return result
 
     async def __Get(
@@ -1375,6 +1387,7 @@ class CosmosClientConnection:  # pylint: disable=too-many-public-methods,too-man
             dict
 
         """
+        response_hook = kwargs.pop("response_hook", None)
         path = base.GetPathFromLink(document_link)
         document_id = base.GetResourceIdOrFullNameFromLink(document_link)
         typ = "docs"
@@ -1390,10 +1403,13 @@ class CosmosClientConnection:  # pylint: disable=too-many-public-methods,too-man
         if options.get("filterPredicate"):
             request_data["condition"] = options.get("filterPredicate")
         request_data["operations"] = operations
-        result, self.last_response_headers = await self.__Patch(path, request_params, request_data, headers, **kwargs)
+        result, last_response_headers = await self.__Patch(path, request_params, request_data, headers, **kwargs)
+        self.last_response_headers = last_response_headers
 
         # update session for request mutates data on server side
-        self._UpdateSessionIfRequired(headers, result, self.last_response_headers)
+        self._UpdateSessionIfRequired(headers, result, last_response_headers)
+        if response_hook:
+            response_hook(last_response_headers, result)
         return result
 
     async def ReplaceOffer(
@@ -1477,6 +1493,7 @@ class CosmosClientConnection:  # pylint: disable=too-many-public-methods,too-man
             dict
 
         """
+        response_hook = kwargs.pop("response_hook", None)
         if options is None:
             options = {}
 
@@ -1484,10 +1501,13 @@ class CosmosClientConnection:  # pylint: disable=too-many-public-methods,too-man
         headers = base.GetHeaders(self, initial_headers, "put", path, id, typ, options)
         # Replace will use WriteEndpoint since it uses PUT operation
         request_params = _request_object.RequestObject(typ, documents._OperationType.Replace)
-        result, self.last_response_headers = await self.__Put(path, request_params, resource, headers, **kwargs)
+        result, last_response_headers = await self.__Put(path, request_params, resource, headers, **kwargs)
+        self.last_response_headers = last_response_headers
 
         # update session for request mutates data on server side
         self._UpdateSessionIfRequired(headers, result, self.last_response_headers)
+        if response_hook:
+            response_hook(last_response_headers, result)
         return result
 
     async def __Put(
@@ -1670,7 +1690,7 @@ class CosmosClientConnection:  # pylint: disable=too-many-public-methods,too-man
 
         path = base.GetPathFromLink(document_link)
         document_id = base.GetResourceIdOrFullNameFromLink(document_link)
-        return await self.DeleteResource(path, "docs", document_id, None, options, **kwargs)
+        await self.DeleteResource(path, "docs", document_id, None, options, **kwargs)
 
     async def DeleteUserDefinedFunction(
         self,
@@ -1769,7 +1789,7 @@ class CosmosClientConnection:  # pylint: disable=too-many-public-methods,too-man
 
         path = base.GetPathFromLink(conflict_link)
         conflict_id = base.GetResourceIdOrFullNameFromLink(conflict_link)
-        return await self.DeleteResource(path, "conflicts", conflict_id, None, options, **kwargs)
+        await self.DeleteResource(path, "conflicts", conflict_id, None, options, **kwargs)
 
     async def DeleteResource(
         self,
@@ -1794,6 +1814,7 @@ class CosmosClientConnection:  # pylint: disable=too-many-public-methods,too-man
             dict
 
         """
+        response_hook = kwargs.pop("response_hook", None)
         if options is None:
             options = {}
 
@@ -1801,10 +1822,13 @@ class CosmosClientConnection:  # pylint: disable=too-many-public-methods,too-man
         headers = base.GetHeaders(self, initial_headers, "delete", path, id, typ, options)
         # Delete will use WriteEndpoint since it uses DELETE operation
         request_params = _request_object.RequestObject(typ, documents._OperationType.Delete)
-        result, self.last_response_headers = await self.__Delete(path, request_params, headers, **kwargs)
+        result, last_response_headers = await self.__Delete(path, request_params, headers, **kwargs)
+        self.last_response_headers = last_response_headers
 
         # update session for request mutates data on server side
-        self._UpdateSessionIfRequired(headers, result, self.last_response_headers)
+        self._UpdateSessionIfRequired(headers, result, last_response_headers)
+        if response_hook:
+            response_hook(last_response_headers, None)
 
     async def __Delete(
         self,
@@ -1852,6 +1876,7 @@ class CosmosClientConnection:  # pylint: disable=too-many-public-methods,too-man
             list
 
         """
+        response_hook = kwargs.pop("response_hook", None)
         if options is None:
             options = {}
 
@@ -1860,12 +1885,13 @@ class CosmosClientConnection:  # pylint: disable=too-many-public-methods,too-man
 
         formatted_operations = base._format_batch_operations(batch_operations)
 
-        results, self.last_response_headers = await self._Batch(
+        results, last_response_headers = await self._Batch(
             formatted_operations,
             path,
             collection_id,
             options,
             **kwargs)
+        self.last_response_headers = last_response_headers
 
         final_responses = []
         is_error = False
@@ -1891,6 +1917,8 @@ class CosmosClientConnection:  # pylint: disable=too-many-public-methods,too-man
                 ),
                 operation_responses=final_responses
             )
+        if response_hook:
+            response_hook(last_response_headers, final_responses)
         return final_responses
 
     async def _Batch(
@@ -3129,6 +3157,7 @@ class CosmosClientConnection:  # pylint: disable=too-many-public-methods,too-man
             None
 
         """
+        response_hook = kwargs.pop("response_hook", None)
         if options is None:
             options = {}
 
@@ -3139,5 +3168,8 @@ class CosmosClientConnection:  # pylint: disable=too-many-public-methods,too-man
         initial_headers = dict(self.default_headers)
         headers = base.GetHeaders(self, initial_headers, "post", path, collection_id, "partitionkey", options)
         request_params = _request_object.RequestObject("partitionkey", documents._OperationType.Delete)
-        _, self.last_response_headers = await self.__Post(path=path, request_params=request_params,
-                                                               req_headers=headers, body=None, **kwargs)
+        _, last_response_headers = await self.__Post(path=path, request_params=request_params,
+                                                        req_headers=headers, body=None, **kwargs)
+        self.last_response_headers = last_response_headers
+        if response_hook:
+            response_hook(last_response_headers, None)

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_user.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_user.py
@@ -83,15 +83,12 @@ class UserProxy:
         :rtype: Dict[str, Any]
         """
         request_options = build_options(kwargs)
-        response_hook = kwargs.pop('response_hook', None)
 
         self._properties = await self.client_connection.ReadUser(
             user_link=self.user_link,
             options=request_options,
             **kwargs
         )
-        if response_hook:
-            response_hook(self.client_connection.last_response_headers, self._properties)
         return self._properties
 
     @distributed_trace
@@ -176,13 +173,10 @@ class UserProxy:
         :rtype: ~azure.cosmos.Permission
         """
         request_options = build_options(kwargs)
-        response_hook = kwargs.pop('response_hook', None)
 
         permission_resp = await self.client_connection.ReadPermission(
             permission_link=self._get_permission_link(permission), options=request_options, **kwargs
         )
-        if response_hook:
-            response_hook(self.client_connection.last_response_headers, permission_resp)
         return Permission(
             id=permission_resp["id"],
             user_link=self.user_link,
@@ -206,14 +200,10 @@ class UserProxy:
         :rtype: ~azure.cosmos.Permission
         """
         request_options = build_options(kwargs)
-        response_hook = kwargs.pop('response_hook', None)
 
         permission = await self.client_connection.CreatePermission(
             user_link=self.user_link, permission=body, options=request_options, **kwargs
         )
-
-        if response_hook:
-            response_hook(self.client_connection.last_response_headers, permission)
 
         return Permission(
             id=permission["id"],
@@ -239,14 +229,10 @@ class UserProxy:
         :rtype: ~azure.cosmos.Permission
         """
         request_options = build_options(kwargs)
-        response_hook = kwargs.pop('response_hook', None)
 
         permission = await self.client_connection.UpsertPermission(
             user_link=self.user_link, permission=body, options=request_options, **kwargs
         )
-
-        if response_hook:
-            response_hook(self.client_connection.last_response_headers, permission)
 
         return Permission(
             id=permission["id"],
@@ -280,14 +266,10 @@ class UserProxy:
         :rtype: ~azure.cosmos.Permission
         """
         request_options = build_options(kwargs)
-        response_hook = kwargs.pop('response_hook', None)
 
         permission_resp = await self.client_connection.ReplacePermission(
             permission_link=self._get_permission_link(permission), permission=body, options=request_options, **kwargs
         )  # type: Dict[str, str]
-
-        if response_hook:
-            response_hook(self.client_connection.last_response_headers, permission_resp)
 
         return Permission(
             id=permission_resp["id"],
@@ -317,10 +299,7 @@ class UserProxy:
         :rtype: None
         """
         request_options = build_options(kwargs)
-        response_hook = kwargs.pop('response_hook', None)
 
         await self.client_connection.DeletePermission(
             permission_link=self._get_permission_link(permission), options=request_options, **kwargs
         )
-        if response_hook:
-            response_hook(self.client_connection.last_response_headers, None)


### PR DESCRIPTION
This PR ensures that the use of `response_hook` by users is utilizing thread-safe headers as opposed to `client_connection.last_response_headers` for the async client.