### PR TITLE
[ml][pipeline] Fix pipeline job outputs not load correctly when referring local component

### DIFF
--- a/sdk/ml/azure-ai-ml/CHANGELOG.md
+++ b/sdk/ml/azure-ai-ml/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Remove `experimental` tag for  `ml_client.jobs.validate`.
 
 ### Bugs Fixed
+- Fix pipeline job `outputs` not load correctly when `component: <local-file>` exists in pipeline job yaml.
 
 ### Breaking Changes
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/pipeline/pipeline_job.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/pipeline/pipeline_job.py
@@ -140,8 +140,8 @@ class PipelineJob(Job, YamlTranslatableMixin, PipelineJobIOMixin, PathAwareSchem
         ]:
             self._inputs = self._build_inputs_dict(inputs, input_definition_dict=component.inputs)
             # for pipeline component created pipeline jobs,
-            # it's output should have same value with the component outputs
-            self._outputs = self._build_pipeline_outputs_dict(component.outputs)
+            # it's output should have same value with the component outputs, then override it with given outputs
+            self._outputs = self._build_pipeline_outputs_dict({**component.outputs, **(outputs or {})})
         else:
             # Build inputs/outputs dict without meta when definition not available
             self._inputs = self._build_inputs_dict(inputs)
@@ -228,6 +228,11 @@ class PipelineJob(Job, YamlTranslatableMixin, PipelineJobIOMixin, PathAwareSchem
 
     @settings.setter
     def settings(self, value: Union[Dict, PipelineJobSettings]) -> None:
+        """Set the pipeline job settings.
+
+        :param value: The pipeline job settings.
+        :type value: Union[dict, ~azure.ai.ml.entities.PipelineJobSettings]
+        """
         if value is not None:
             if isinstance(value, PipelineJobSettings):
                 # since PipelineJobSettings inherit _AttrDict, we need add this branch to distinguish with dict

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/pipeline/pipeline_job.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/pipeline/pipeline_job.py
@@ -140,8 +140,10 @@ class PipelineJob(Job, YamlTranslatableMixin, PipelineJobIOMixin, PathAwareSchem
         ]:
             self._inputs = self._build_inputs_dict(inputs, input_definition_dict=component.inputs)
             # for pipeline component created pipeline jobs,
-            # it's output should have same value with the component outputs, then override it with given outputs
-            self._outputs = self._build_pipeline_outputs_dict({**component.outputs, **(outputs or {})})
+            # it's output should have same value with the component outputs,
+            # then override it with given outputs (filter out None value)
+            pipeline_outputs = {k: v for k, v in (outputs or {}).items() if v}
+            self._outputs = self._build_pipeline_outputs_dict({**component.outputs, **pipeline_outputs})
         else:
             # Build inputs/outputs dict without meta when definition not available
             self._inputs = self._build_inputs_dict(inputs)

--- a/sdk/ml/azure-ai-ml/tests/pipeline_job/unittests/test_pipeline_job_schema.py
+++ b/sdk/ml/azure-ai-ml/tests/pipeline_job/unittests/test_pipeline_job_schema.py
@@ -28,12 +28,12 @@ from azure.ai.ml.entities import CommandComponent, Component, Job, PipelineJob, 
 from azure.ai.ml.entities._assets import Code
 from azure.ai.ml.entities._component.datatransfer_component import DataTransferComponent
 from azure.ai.ml.entities._component.parallel_component import ParallelComponent
+from azure.ai.ml.entities._credentials import UserIdentityConfiguration
 from azure.ai.ml.entities._inputs_outputs import Input, Output
 from azure.ai.ml.entities._job._input_output_helpers import (
     INPUT_MOUNT_MAPPING_FROM_REST,
     validate_pipeline_input_key_characters,
 )
-from azure.ai.ml.entities._credentials import UserIdentityConfiguration
 from azure.ai.ml.entities._job.automl.search_space_utils import _convert_sweep_dist_dict_to_str_dict
 from azure.ai.ml.entities._job.job_service import (
     JobService,
@@ -1840,6 +1840,15 @@ class TestPipelineJobSchema:
         assert "component" not in job_dict
         assert "jobs" in job_dict
         assert "component_a_job" in job_dict["jobs"]
+
+        test_path = "./tests/test_configs/pipeline_jobs/pipeline_component_job_with_overrides.yml"
+        job: PipelineJob = load_job(source=test_path)
+        assert job._validate().passed
+        job_dict = job._to_dict()
+        assert job_dict["outputs"] == {
+            "not_exists": {"path": "azureml://datastores/mock/paths/not_exists.txt", "type": "uri_file"},
+            "output_path": {"path": "azureml://datastores/mock/paths/my_output_file.txt", "type": "uri_file"},
+        }
 
     def test_invalid_pipeline_component_job(self):
         test_path = "./tests/test_configs/pipeline_jobs/invalid/invalid_pipeline_component_job.yml"

--- a/sdk/ml/azure-ai-ml/tests/pipeline_job/unittests/test_pipeline_job_schema.py
+++ b/sdk/ml/azure-ai-ml/tests/pipeline_job/unittests/test_pipeline_job_schema.py
@@ -1850,6 +1850,16 @@ class TestPipelineJobSchema:
             "output_path": {"path": "azureml://datastores/mock/paths/my_output_file.txt", "type": "uri_file"},
         }
 
+        # Assert the output_path:None not override original component output value
+        test_path = "./tests/test_configs/pipeline_jobs/pipeline_component_job_with_overrides2.yml"
+        job: PipelineJob = load_job(source=test_path)
+        assert job._validate().passed
+        job_dict = job._to_dict()
+        assert job_dict["outputs"] == {
+            "not_exists": {"path": "azureml://datastores/mock/paths/not_exists.txt", "type": "uri_file"},
+            "output_path": {"type": "uri_folder"},  # uri_folder from component output
+        }
+
     def test_invalid_pipeline_component_job(self):
         test_path = "./tests/test_configs/pipeline_jobs/invalid/invalid_pipeline_component_job.yml"
         with pytest.raises(Exception) as e:

--- a/sdk/ml/azure-ai-ml/tests/test_configs/pipeline_jobs/pipeline_component_job_with_overrides.yml
+++ b/sdk/ml/azure-ai-ml/tests/test_configs/pipeline_jobs/pipeline_component_job_with_overrides.yml
@@ -1,0 +1,27 @@
+type: pipeline
+
+description: The hello world pipeline job
+tags:
+  tag: tagvalue
+  owner: sdkteam
+
+settings:
+  default_compute: azureml:cpu-cluster
+
+inputs:
+  # examples of inputs that take values such as int, string, etc.
+  component_in_number: 20
+  component_in_path:
+    path: https://dprepdata.blob.core.windows.net/demo/Titanic.csv
+    type: uri_file
+
+
+outputs:
+  output_path:
+    type: uri_file
+    path: azureml://datastores/mock/paths/my_output_file.txt
+  not_exists:
+    type: uri_file
+    path: azureml://datastores/mock/paths/not_exists.txt
+
+component: ../components/helloworld_pipeline_component.yml

--- a/sdk/ml/azure-ai-ml/tests/test_configs/pipeline_jobs/pipeline_component_job_with_overrides2.yml
+++ b/sdk/ml/azure-ai-ml/tests/test_configs/pipeline_jobs/pipeline_component_job_with_overrides2.yml
@@ -1,0 +1,25 @@
+type: pipeline
+
+description: The hello world pipeline job
+tags:
+  tag: tagvalue
+  owner: sdkteam
+
+settings:
+  default_compute: azureml:cpu-cluster
+
+inputs:
+  # examples of inputs that take values such as int, string, etc.
+  component_in_number: 20
+  component_in_path:
+    path: https://dprepdata.blob.core.windows.net/demo/Titanic.csv
+    type: uri_file
+
+
+outputs:
+  output_path:
+  not_exists:
+    type: uri_file
+    path: azureml://datastores/mock/paths/not_exists.txt
+
+component: ../components/helloworld_pipeline_component.yml


### PR DESCRIPTION

# Description

Please add an informative description that covers that changes made by the pull request and link all relevant issues.

Pipeline job outputs get lost when local component reference exists in pipeline job yaml.

If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
