### PR TITLE
Import pytest fixture in `sdk/conftest` to resolve missing `test_proxy` fixture

### DIFF
--- a/sdk/conftest.py
+++ b/sdk/conftest.py
@@ -26,6 +26,7 @@
 import os
 import pytest
 
+from devtools_testutils.proxy_startup import test_proxy
 
 def pytest_configure(config):
     # register an additional marker

--- a/sdk/conftest.py
+++ b/sdk/conftest.py
@@ -26,7 +26,7 @@
 import os
 import pytest
 
-from devtools_testutils.proxy_startup import test_proxy
+from devtools_testutils import environment_variables, recorded_test, test_proxy, variable_recorder
 
 def pytest_configure(config):
     # register an additional marker


### PR DESCRIPTION
Not certain why this randomly started happening, as our `pytest` versions are the same. This resolves the issue locally though.
@kristapratico please review when you have a second.