### PR TITLE
generate docs with py3.11 to match doc team's build

### DIFF
--- a/eng/pipelines/generate-all-docs.yml
+++ b/eng/pipelines/generate-all-docs.yml
@@ -1,7 +1,7 @@
 trigger: none
 
 variables:
-  PythonVersion: '3.6'
+  PythonVersion: '3.11'
 
 jobs:
   - job: 'Generate_Individual_Package_Documentation'

--- a/eng/pipelines/templates/stages/python-analyze-weekly.yml
+++ b/eng/pipelines/templates/stages/python-analyze-weekly.yml
@@ -87,6 +87,11 @@ stages:
             env:
               GH_TOKEN: $(azuresdk-github-pat)
 
+          - task: UsePythonVersion@0
+            displayName: 'Use Python 3.11 for docs generation'
+            inputs:
+              versionSpec: '3.11'
+
           - task: PythonScript@0
             displayName: 'Generate Docs'
             continueOnError: true

--- a/eng/pipelines/templates/stages/python-analyze-weekly.yml
+++ b/eng/pipelines/templates/stages/python-analyze-weekly.yml
@@ -92,6 +92,11 @@ stages:
             inputs:
               versionSpec: '3.11'
 
+          - script: |
+              python -m pip install setuptools==58.3.0
+              python -m pip install -r eng/ci_tools.txt
+            displayName: 'Prep Environment'
+
           - task: PythonScript@0
             displayName: 'Generate Docs'
             continueOnError: true

--- a/eng/pipelines/templates/steps/build-extended-artifacts.yml
+++ b/eng/pipelines/templates/steps/build-extended-artifacts.yml
@@ -61,6 +61,11 @@ steps:
       parameters:
         DevFeedName: ${{ parameters.DevFeedName }}
 
+  - task: UsePythonVersion@0
+    displayName: 'Use Python 3.11 for docs generation'
+    inputs:
+      versionSpec: '3.11'
+
   - task: PythonScript@0
     displayName: 'Generate Docs'
     condition: and(succeededOrFailed(), ${{parameters.BuildDocs}})

--- a/eng/pipelines/templates/steps/build-extended-artifacts.yml
+++ b/eng/pipelines/templates/steps/build-extended-artifacts.yml
@@ -43,9 +43,9 @@ steps:
     condition: and(eq(variables['Build.SourceBranchName'], variables['DefaultBranch']), eq(variables['Build.Reason'],'Schedule'))
 
   - task: UsePythonVersion@0
-    displayName: 'Use Python $(PythonVersion)'
+    displayName: 'Use Python 3.11'
     inputs:
-      versionSpec: $(PythonVersion)
+      versionSpec: '3.11'
 
   - script: |
       python -m pip install setuptools==58.3.0
@@ -60,16 +60,6 @@ steps:
     - template: auth-dev-feed.yml
       parameters:
         DevFeedName: ${{ parameters.DevFeedName }}
-
-  - task: UsePythonVersion@0
-    displayName: 'Use Python 3.11 for docs generation'
-    inputs:
-      versionSpec: '3.11'
-
-  - script: |
-      python -m pip install setuptools==58.3.0
-      python -m pip install -r eng/ci_tools.txt
-    displayName: 'Prep Environment'
 
   - task: PythonScript@0
     displayName: 'Generate Docs'

--- a/eng/pipelines/templates/steps/build-extended-artifacts.yml
+++ b/eng/pipelines/templates/steps/build-extended-artifacts.yml
@@ -66,6 +66,11 @@ steps:
     inputs:
       versionSpec: '3.11'
 
+  - script: |
+      python -m pip install setuptools==58.3.0
+      python -m pip install -r eng/ci_tools.txt
+    displayName: 'Prep Environment'
+
   - task: PythonScript@0
     displayName: 'Generate Docs'
     condition: and(succeededOrFailed(), ${{parameters.BuildDocs}})


### PR DESCRIPTION
Resolves https://github.com/Azure/azure-sdk-for-python/issues/34023

Sphinx errors/warnings seem to depend on the Python version used. In this PR we update to Python 3.11 to match what the Doc Team uses to run their builds. 

Testing:

[python - core](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3444021&view=results)
[python - core - ci](https://dev.azure.com/azure-sdk/public/_build/results?buildId=3444040&view=results)
[python - core - tests-weekly](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3443780&view=logs&j=e5b925a9-9650-5321-24fd-5d9499fe02b8&t=0d206e13-b346-5d3f-79e6-d5bfba9e089e)
