### PR TITLE
fix user logs encoding in azure-ai-generative package causing UnicodeEncodeError

### DIFF
--- a/sdk/ai/azure-ai-generative/azure/ai/generative/evaluate/_mlflow_log_collector.py
+++ b/sdk/ai/azure-ai-generative/azure/ai/generative/evaluate/_mlflow_log_collector.py
@@ -30,7 +30,7 @@ class RedirectUserOutputStreams(object):
     def __enter__(self):
         self.logger.debug("Redirecting user output to {0}".format(self.user_log_path))
 
-        self.user_log_fp = open(self.user_log_path, "at+")
+        self.user_log_fp = open(self.user_log_path, "at+", encoding="utf-8")
         self.original_stdout = sys.stdout
         self.original_stderr = sys.stderr
         sys.stdout = OutputCollector(sys.stdout, self.user_log_fp.write)


### PR DESCRIPTION
# Description

This PR was made due to errors when calling the evaluate API in the azure-ai-generative package:

```
| 0/13 [00:00<?, ?it/s]Computing gpt based metrics failed with the exception : 'charmap' codec can't encode characters in position 6-30: character maps to <undefined>
Computation of GPT Evaluation metrics failed with the following exception :
 'charmap' codec can't encode characters in position 6-30: character maps to <undefined>
Scoring failed for QA metric gpt_coherence
Class: UnicodeEncodeError
Message: 'charmap' codec can't encode characters in position 6-30: character maps to <undefined>
```

When adding stack trace in debug code, it was found that this exception was being generated when calling the open method in RedirectUserOutputStreams class with default encoding, which can't handle many characters.

Copilot summary:
This pull request includes a change to the `__init__` method in the `sdk/ai/azure-ai-generative/azure/ai/generative/evaluate/_mlflow_log_collector.py` file. The change modifies the way the `user_log_fp` file is opened by adding the `utf-8` encoding. This ensures that the file is opened in a way that supports a wider range of characters.

* [`sdk/ai/azure-ai-generative/azure/ai/generative/evaluate/_mlflow_log_collector.py`](diffhunk://#diff-df6965ac8714a99eff61788b05d2eb05c27ce0bae46811ee0e672c27f50e3ebeL33-R33): Modified the `open` function in the `__init__` method to include `utf-8` encoding when opening the `user_log_fp` file. This change helps to avoid potential issues with character encoding.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
