### PR TITLE
Add imports for test_proxy and environment_variables

### DIFF
--- a/sdk/remoterendering/azure-mixedreality-remoterendering/tests/conftest.py
+++ b/sdk/remoterendering/azure-mixedreality-remoterendering/tests/conftest.py
@@ -15,6 +15,7 @@ from devtools_testutils.sanitizers import (
     add_remove_header_sanitizer,
     is_live
 )
+from devtools_testutils import environment_variables, test_proxy
 
 # Environment variable keys
 ENV_ARR_SERVICE_ENDPOINT = "REMOTERENDERING_ARR_SERVICE_ENDPOINT"


### PR DESCRIPTION
# Description

The remoterendering tests started failing. I found a similar pattern of failure in this commit, so the same fix should also fix remoterendering as well: https://github.com/Azure/azure-sdk-for-python/pull/34033

It simply adds some imports to one test case.