### PR TITLE
Adjust conftest to allow graceful continuation in absence of azure-sdk-tools

### DIFF
--- a/sdk/conftest.py
+++ b/sdk/conftest.py
@@ -26,9 +26,8 @@
 import os
 import pytest
 
-# in instances where packages do not require azure-sdk-tools, need to work in a clean pytest instance,
-# we need to make sure that the following imports do not fail. This is because this conftest is always activated,
-# and we don't want to fail the pytest run if azure-sdk-tools is not installed.
+# In instances where packages do not require azure-sdk-tools we need to make sure that the following imports do not fail.
+# This is because this conftest is always activated, and we don't want to fail the pytest run if azure-sdk-tools is not installed.
 try:
     from devtools_testutils import environment_variables, recorded_test, test_proxy, variable_recorder
 except ImportError:

--- a/sdk/conftest.py
+++ b/sdk/conftest.py
@@ -26,7 +26,13 @@
 import os
 import pytest
 
-from devtools_testutils import environment_variables, recorded_test, test_proxy, variable_recorder
+# in instances where packages do not require azure-sdk-tools, need to work in a clean pytest instance,
+# we need to make sure that the following imports do not fail. This is because this conftest is always activated,
+# and we don't want to fail the pytest run if azure-sdk-tools is not installed.
+try:
+    from devtools_testutils import environment_variables, recorded_test, test_proxy, variable_recorder
+except ImportError:
+    print("Failed to import test-proxy fixtures from azure-sdk-tools. If these are necessary, install tools/azure-sdk-tools.")
 
 def pytest_configure(config):
     # register an additional marker


### PR DESCRIPTION
- Not having `azure-sdk-tools` installed means that `pytest` will fail, due to the fact that `sdk/conftest.py` is always imported
- `azure-storage-extensions` has pure unit tests, and has no need to install `azure-sdk-tools`
- We need to fail gracefully, as if you _do_ need them your actual pytest run will quickly reveal the missing fixtures

- [x] [storage ci run](https://dev.azure.com/azure-sdk/public/_build/results?buildId=3448920&view=results)
- [x] [core ci run](https://dev.azure.com/azure-sdk/public/_build/results?buildId=3448924&view=results)
