### PR TITLE
[EH} Remove await from create_producer in async

### DIFF
--- a/sdk/eventhub/azure-eventhub/tests/conftest.py
+++ b/sdk/eventhub/azure-eventhub/tests/conftest.py
@@ -122,7 +122,7 @@ def resource_group():
     resource_client = ResourceManagementClient(EnvironmentCredential(), SUBSCRIPTION_ID, base_url=base_url, credential_scopes=credential_scopes)
     resource_group_name = RES_GROUP_PREFIX + str(uuid.uuid4())
     parameters = {"location": LOCATION}
-    expiry = datetime.datetime.utcnow() + datetime.timedelta(days=1)
+    expiry = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=1)
     parameters['tags'] = {'DeleteAfter': expiry.replace(microsecond=0).isoformat()}
     try:
         rg = resource_client.resource_groups.create_or_update(

--- a/sdk/eventhub/azure-eventhub/tests/livetest/asynctests/test_send_async.py
+++ b/sdk/eventhub/azure-eventhub/tests/livetest/asynctests/test_send_async.py
@@ -543,7 +543,7 @@ async def test_send_with_callback_async(connstr_receivers, uamqp_transport):
 @pytest.mark.parametrize("keep_alive", [None, 30, 60])
 @pytest.mark.liveTest
 @pytest.mark.asyncio
-def test_send_with_keep_alive_async(connstr_receivers, keep_alive, uamqp_transport):
+async def test_send_with_keep_alive_async(connstr_receivers, keep_alive, uamqp_transport):
     connection_str, receivers = connstr_receivers
     client = EventHubProducerClient.from_connection_string(connection_str, keep_alive=keep_alive, uamqp_transport=uamqp_transport)
     assert client._producers["all-partitions"]._keep_alive == keep_alive

--- a/sdk/eventhub/azure-eventhub/tests/livetest/asynctests/test_send_async.py
+++ b/sdk/eventhub/azure-eventhub/tests/livetest/asynctests/test_send_async.py
@@ -561,7 +561,7 @@ async def test_send_long_wait_idle_timeout(connstr_receivers, keep_alive, uamqp_
         retry_total = 0
     connection_str, receivers = connstr_receivers
     client = EventHubProducerClient.from_connection_string(connection_str, keep_alive=keep_alive, idle_timeout=10, retry_total=retry_total, uamqp_transport=uamqp_transport)
-    sender = await client._create_producer(partition_id="0")
+    sender = client._create_producer(partition_id="0")
     async with sender:
         await sender._open_with_retry()
         ed = EventData('data')


### PR DESCRIPTION
Few small fixes to EH tests

* remove await from `create_producer`
* add async to async test
* update from `datetime.datetime.utcnow()` to timezone aware version