### PR TITLE
[Identity] Integration test adjustments

### DIFF
--- a/sdk/identity/azure-identity/tests/integration/azure-vms/app.py
+++ b/sdk/identity/azure-identity/tests/integration/azure-vms/app.py
@@ -1,0 +1,76 @@
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+import os
+import asyncio
+
+from azure.identity import ManagedIdentityCredential
+from azure.identity.aio import ManagedIdentityCredential as AsyncManagedIdentityCredential
+from azure.storage.blob import BlobServiceClient
+from azure.storage.blob.aio import BlobServiceClient as AsyncBlobServiceClient
+
+
+def run_sync():
+    credential = ManagedIdentityCredential()
+    credential_user_assigned = ManagedIdentityCredential(
+        client_id=os.environ.get("IDENTITY_USER_DEFINED_IDENTITY_CLIENT_ID")
+    )
+
+    client = BlobServiceClient(
+        account_url=f"https://{os.environ['IDENTITY_STORAGE_NAME_1']}.blob.core.windows.net",
+        credential=credential,
+    )
+
+    client2 = BlobServiceClient(
+        account_url=f"https://{os.environ['IDENTITY_STORAGE_NAME_2']}.blob.core.windows.net",
+        credential=credential_user_assigned,
+    )
+
+    for container in client.list_containers():
+        print(container["name"])
+
+    print(f"Successfully acquired token with system-assigned ManagedIdentityCredential")
+
+    for container in client2.list_containers():
+        print(container["name"])
+
+    print(f"Successfully acquired token with user-assigned ManagedIdentityCredential")
+
+
+async def run_async():
+    credential = AsyncManagedIdentityCredential()
+    credential_user_assigned = AsyncManagedIdentityCredential(
+        client_id=os.environ.get("IDENTITY_USER_DEFINED_IDENTITY_CLIENT_ID")
+    )
+
+    client = AsyncBlobServiceClient(
+        account_url=f"https://{os.environ['IDENTITY_STORAGE_NAME_1']}.blob.core.windows.net",
+        credential=credential,
+    )
+    client2 = AsyncBlobServiceClient(
+        account_url=f"https://{os.environ['IDENTITY_STORAGE_NAME_2']}.blob.core.windows.net",
+        credential=credential_user_assigned,
+    )
+
+    async for container in client.list_containers():
+        print(container["name"])
+
+    print(f"Successfully acquired token with system-assigned async ManagedIdentityCredential")
+
+    async for container in client2.list_containers():
+        print(container["name"])
+
+    print(f"Successfully acquired token with user-assigned async ManagedIdentityCredential")
+
+    await client.close()
+    await credential.close()
+    await client2.close()
+    await credential_user_assigned.close()
+
+
+if __name__ == "__main__":
+    run_sync()
+    asyncio.run(run_async())
+
+    print("Passed!")

--- a/sdk/identity/azure-identity/tests/integration/azure-vms/requirements.txt
+++ b/sdk/identity/azure-identity/tests/integration/azure-vms/requirements.txt
@@ -1,0 +1,4 @@
+../../../../../identity/azure-identity
+../../../../../core/azure-core
+azure-storage-blob
+aiohttp

--- a/sdk/identity/azure-identity/tests/integration/azure-web-apps/requirements.txt
+++ b/sdk/identity/azure-identity/tests/integration/azure-web-apps/requirements.txt
@@ -1,5 +1,5 @@
 azure-core @ git+https://git@github.com/Azure/azure-sdk-for-python.git@main#subdirectory=sdk/core/azure-core
 azure-identity @ git+https://git@github.com/Azure/azure-sdk-for-python.git@main#subdirectory=sdk/identity/azure-identity
-aiohttp>-3.0
+aiohttp>=3.0
 flask[async]
 azure-storage-blob

--- a/sdk/identity/azure-identity/tests/integration/test_azure_functions.py
+++ b/sdk/identity/azure-identity/tests/integration/test_azure_functions.py
@@ -3,7 +3,6 @@
 # Licensed under the MIT License.
 # ------------------------------------
 import os
-import sys
 import pytest
 
 from azure.core import PipelineClient
@@ -20,7 +19,9 @@ def base_url():
 
 class TestAzureFunctionsIntegration:
     @pytest.mark.live_test_only
-    @pytest.mark.skipif(not sys.platform.startswith("linux"), reason="Test resource deployment only works on Linux.")
+    @pytest.mark.skipif(
+        not os.environ.get("IDENTITY_LIVE_RESOURCES_PROVISIONED"), reason="Integration resources not provisioned."
+    )
     def test_azure_functions_integration_sync(self, base_url):
         """Test the Azure Functions endpoint where the sync MI credential is used."""
         client = PipelineClient(base_url)
@@ -29,7 +30,9 @@ class TestAzureFunctionsIntegration:
         assert response.status_code == 200
 
     @pytest.mark.live_test_only
-    @pytest.mark.skipif(not sys.platform.startswith("linux"), reason="Test resource deployment only works on Linux.")
+    @pytest.mark.skipif(
+        not os.environ.get("IDENTITY_LIVE_RESOURCES_PROVISIONED"), reason="Integration resources not provisioned."
+    )
     def test_azure_functions_integration_async(self, base_url):
         """Test the Azure Functions endpoint where the async MI credential is used."""
         client = PipelineClient(base_url)

--- a/sdk/identity/azure-identity/tests/integration/test_azure_web_apps.py
+++ b/sdk/identity/azure-identity/tests/integration/test_azure_web_apps.py
@@ -3,7 +3,6 @@
 # Licensed under the MIT License.
 # ------------------------------------
 import os
-import sys
 import pytest
 
 from azure.core import PipelineClient
@@ -20,7 +19,9 @@ def base_url():
 
 class TestAzureWebAppsIntegration:
     @pytest.mark.live_test_only
-    @pytest.mark.skipif(not sys.platform.startswith("linux"), reason="Test resource deployment only works on Linux.")
+    @pytest.mark.skipif(
+        not os.environ.get("IDENTITY_LIVE_RESOURCES_PROVISIONED"), reason="Integration resources not provisioned."
+    )
     def test_azure_web_app_integration_sync(self, base_url):
         """Test the Azure Web App endpoint where the sync MI credential is used."""
         client = PipelineClient(base_url)
@@ -29,7 +30,9 @@ class TestAzureWebAppsIntegration:
         assert response.status_code == 200
 
     @pytest.mark.live_test_only
-    @pytest.mark.skipif(not sys.platform.startswith("linux"), reason="Test resource deployment only works on Linux.")
+    @pytest.mark.skipif(
+        not os.environ.get("IDENTITY_LIVE_RESOURCES_PROVISIONED"), reason="Integration resources not provisioned."
+    )
     def test_azure_web_app_integration_async(self, base_url):
         """Test the Azure Web App endpoint where the async MI credential is used."""
         client = PipelineClient(base_url)

--- a/sdk/identity/platform-matrix-integration.json
+++ b/sdk/identity/platform-matrix-integration.json
@@ -1,0 +1,15 @@
+{
+  "include": [
+    {
+      "Agent": {
+        "identity-integration": {
+          "OSVmImage": "MMSUbuntu20.04",
+          "Pool": "azsdk-pool-mms-ubuntu-2004-general",
+          "ArmTemplateParameters": "@{ ProvisionLiveResources = $true }"
+        }
+      },
+      "PythonVersion": "3.11",
+      "CoverageArg": ""
+    }
+  ]
+}

--- a/sdk/identity/test-resources-post.ps1
+++ b/sdk/identity/test-resources-post.ps1
@@ -4,13 +4,21 @@
 # IMPORTANT: Do not invoke this file directly. Please instead run eng/New-TestResources.ps1 from the repository root.
 
 param (
-  [hashtable] $DeploymentOutputs
+  [Parameter(ValueFromRemainingArguments = $true)]
+  $RemainingArguments,
+
+  [Parameter()]
+  [hashtable] $DeploymentOutputs,
+
+  [Parameter()]
+  [hashtable] $AdditionalParameters = @{}
 )
 
-# If not Linux, skip this script.
-if ($isLinux -ne "Linux") {
-  Write-Host "Skipping post-deployment because not running on Linux."
-  return
+$ProvisionLiveResources = $AdditionalParameters['ProvisionLiveResources']
+Write-Host "ProvisionLiveResources: $ProvisionLiveResources"
+if ($CI -and !$ProvisionLiveResources) {
+    Write-Host "Skipping test resource post-provisioning."
+    return
 }
 
 $ErrorActionPreference = 'Stop'
@@ -110,4 +118,13 @@ Write-Host $kubeConfig
 # Apply the config
 kubectl apply -f "$workingFolder/kubeconfig.yaml" --overwrite=true
 Write-Host "Applied kubeconfig.yaml"
+
+# Virtual machine setup
+$vmScript = @"
+sudo apt update && sudo apt install python3-pip -y --no-install-recommends &&
+git clone https://github.com/pvaneck/azure-sdk-for-python.git --depth 1 --single-branch --branch identity-vm-bicep /sdk &&
+cd /sdk/sdk/identity/azure-identity/tests/integration/azure-vms &&
+pip install -r requirements.txt
+"@
+az vm run-command invoke -n $DeploymentOutputs['IDENTITY_VM_NAME'] -g $DeploymentOutputs['IDENTITY_RESOURCE_GROUP'] --command-id RunShellScript --scripts "$vmScript"
 az logout

--- a/sdk/identity/test-resources-pre.ps1
+++ b/sdk/identity/test-resources-pre.ps1
@@ -22,10 +22,21 @@ param (
     [ValidatePattern('^[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}$')]
     [string] $SubscriptionId,
 
+    [Parameter()]
+    [hashtable] $AdditionalParameters = @{},
+
     [Parameter(ParameterSetName = 'Provisioner', Mandatory = $true)]
     [ValidateNotNullOrEmpty()]
     [string] $TenantId
 )
+
+$ProvisionLiveResources = $AdditionalParameters['ProvisionLiveResources']
+Write-Host "ProvisionLiveResources: $ProvisionLiveResources"
+if ($CI -and !$ProvisionLiveResources) {
+    Write-Host "Skipping test resource pre-provisioning."
+    return
+}
+$templateFileParameters['provisionLiveResources'] = $true
 
 Import-Module -Name $PSScriptRoot/../../eng/common/scripts/X509Certificate2 -Verbose
 

--- a/sdk/identity/tests.yml
+++ b/sdk/identity/tests.yml
@@ -19,5 +19,10 @@ stages:
         Public:
           SubscriptionConfigurations:
             - $(sub-config-azure-cloud-test-resources)
-            # Contains alternate tenant, AAD app and cert info for testing
-            - $(sub-config-identity-test-resources)
+      ${{ if contains(variables['Build.DefinitionName'], 'tests-weekly') }}:
+          # Test Managed Identity integrations tests on weekly tests pipeline.
+          AdditionalMatrixConfigs:
+            - Name: managed_identity_matrix
+              Path: sdk/identity/platform-matrix-integration.json
+              Selection: sparse
+              GenerateVMJobs: true


### PR DESCRIPTION
- Ensure integration testing and resource deployments only occurs the weekly pipeline only and only on one agent. This should dramatically cut down on cloud resource usage and agent usage time.
- Added VM deployment to the bicep configuration. Opted to have VMs be a part of the bicep deployment in order to maintain local testability.

Sample weekly pipeline run that shows deployment of resources and integration testing only occurring on one agent:
- https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3454243&view=logs&jobId=973900cd-9c1c-5719-af81-029a30869d0f

Integration test resources aren't deployed on nightly test runs.