### PR TITLE
[OTel plugin] Add new schema version

### DIFF
--- a/sdk/core/azure-core-tracing-opentelemetry/CHANGELOG.md
+++ b/sdk/core/azure-core-tracing-opentelemetry/CHANGELOG.md
@@ -6,6 +6,13 @@
 
 ### Breaking Changes
 
+- Remapped certain attributes to converge with OpenTelemetry semantic conventions version `1.23.1` ([#34089](https://github.com/Azure/azure-sdk-for-python/pull/34089)):
+    - `http.method` -> `http.request.method`
+    - `http.status_code` -> `http.response.status_code`
+    - `net.peer.name` -> `server.address`
+    - `net.peer.port` -> `server.port`
+    - `http.url` -> `url.full`
+
 ### Bugs Fixed
 
 ### Other Changes

--- a/sdk/core/azure-core-tracing-opentelemetry/azure/core/tracing/ext/opentelemetry_span/_schema.py
+++ b/sdk/core/azure-core-tracing-opentelemetry/azure/core/tracing/ext/opentelemetry_span/_schema.py
@@ -13,11 +13,15 @@ class OpenTelemetrySchemaVersion(
 ):  # pylint: disable=enum-must-inherit-case-insensitive-enum-meta
 
     V1_19_0 = "1.19.0"
+    V1_23_1 = "1.23.1"
 
 
 class OpenTelemetrySchema:
 
-    SUPPORTED_VERSIONS = (OpenTelemetrySchemaVersion.V1_19_0,)
+    SUPPORTED_VERSIONS = (
+        OpenTelemetrySchemaVersion.V1_19_0,
+        OpenTelemetrySchemaVersion.V1_23_1,
+    )
 
     # Mappings of attributes potentially reported by Azure SDKs to corresponding ones that follow
     # OpenTelemetry semantic conventions.
@@ -28,7 +32,19 @@ class OpenTelemetrySchema:
             "http.user_agent": "user_agent.original",
             "message_bus.destination": "messaging.destination.name",
             "peer.address": "net.peer.name",
-        }
+        },
+        OpenTelemetrySchemaVersion.V1_23_1: {
+            "x-ms-client-request-id": "az.client_request_id",
+            "x-ms-request-id": "az.service_request_id",
+            "http.user_agent": "user_agent.original",
+            "message_bus.destination": "messaging.destination.name",
+            "peer.address": "server.address",
+            "http.method": "http.request.method",
+            "http.status_code": "http.response.status_code",
+            "net.peer.name": "server.address",
+            "net.peer.port": "server.port",
+            "http.url": "url.full",
+        },
     }
 
     @classmethod

--- a/sdk/core/azure-core-tracing-opentelemetry/samples/sample_custom_span_processor.py
+++ b/sdk/core/azure-core-tracing-opentelemetry/samples/sample_custom_span_processor.py
@@ -57,6 +57,11 @@ class CustomSpanProcessor(BatchSpanProcessor):
         for regex in self.EXCLUDED_SPAN_NAMES:
             if re.match(regex, span.name):
                 return
+        if "url.full" in span.attributes:
+            for regex in self.EXCLUDED_SPAN_URLS:
+                if re.match(regex, span.attributes["url.full"]):
+                    return
+        # Check for the older attribute name as well.
         if "http.url" in span.attributes:
             for regex in self.EXCLUDED_SPAN_URLS:
                 if re.match(regex, span.attributes["http.url"]):

--- a/sdk/core/azure-core-tracing-opentelemetry/tests/test_tracing_implementations.py
+++ b/sdk/core/azure-core-tracing-opentelemetry/tests/test_tracing_implementations.py
@@ -321,23 +321,23 @@ class TestOpentelemetryWrapper:
             setattr(response, "status_code", 200)
             wrapped_class.set_http_attributes(request)
             assert wrapped_class.span_instance.kind == OpenTelemetrySpanKind.CLIENT
-            assert wrapped_class.span_instance.attributes.get("http.method") == request.method
+            assert wrapped_class.span_instance.attributes.get("http.request.method") == request.method
             assert wrapped_class.span_instance.attributes.get("component") == "http"
-            assert wrapped_class.span_instance.attributes.get("http.url") == request.url
-            assert wrapped_class.span_instance.attributes.get("http.status_code") == 504
+            assert wrapped_class.span_instance.attributes.get("url.full") == request.url
+            assert wrapped_class.span_instance.attributes.get("http.response.status_code") == 504
             assert wrapped_class.span_instance.attributes.get("user_agent.original") is None
 
             request.headers["User-Agent"] = "some user agent"
             request.url = "http://foo.bar:8080/path"
             wrapped_class.set_http_attributes(request, response)
-            assert wrapped_class.span_instance.attributes.get("http.status_code") == response.status_code
+            assert wrapped_class.span_instance.attributes.get("http.response.status_code") == response.status_code
             assert wrapped_class.span_instance.attributes.get("user_agent.original") == request.headers.get(
                 "User-Agent"
             )
 
             if wrapped_class.span_instance.attributes.get("net.peer.name"):
-                assert wrapped_class.span_instance.attributes.get("net.peer.name") == "foo.bar"
-                assert wrapped_class.span_instance.attributes.get("net.peer.port") == 8080
+                assert wrapped_class.span_instance.attributes.get("server.address") == "foo.bar"
+                assert wrapped_class.span_instance.attributes.get("server.port") == 8080
 
     def test_span_kind(self, tracer):
         with tracer.start_as_current_span("Root") as parent:


### PR DESCRIPTION
Using the stable 1.23.1 semantic conventions version. Attribute names are also remapped.

Ref: https://github.com/Azure/azure-sdk-for-python/issues/32803