### PR TITLE
[Cosmos] changelog for release and readme async client updates

### DIFF
--- a/sdk/cosmos/azure-cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos/CHANGELOG.md
@@ -1,21 +1,19 @@
 ## Release History
 
-### 4.5.2b4 (Unreleased)
+### 4.5.2b4 (2024-02-02)
 This version and all future versions will require Python 3.8+.
 
 #### Features Added
 * Added **preview** support for Computed Properties on Python SDK (Must be enabled on the account level before it can be used). See [PR 33626](https://github.com/Azure/azure-sdk-for-python/pull/33626).
 
-#### Breaking Changes
-
 #### Bugs Fixed
-
-#### Other Changes
+* Made use of `response_hook` thread-safe in the sync client. See [PR 33790](https://github.com/Azure/azure-sdk-for-python/pull/33790).
+* Fixed bug with the session container not being properly maintained. See [33738](https://github.com/Azure/azure-sdk-for-python/pull/33738).
 
 ### 4.5.2b3 (2023-11-10)
 
 #### Features Added
-* Added support for capturing Index Metrics in query operations. See [PR 33034](https://github.com/Azure/azure-sdk-for-python/pull/33034)
+* Added support for capturing Index Metrics in query operations. See [PR 33034](https://github.com/Azure/azure-sdk-for-python/pull/33034).
 
 ### 4.5.2b2 (2023-10-31)
 

--- a/sdk/cosmos/azure-cosmos/README.md
+++ b/sdk/cosmos/azure-cosmos/README.md
@@ -475,7 +475,7 @@ For more information on TTL, see [Time to Live for Azure Cosmos DB data][cosmos_
 ### Using the asynchronous client
 
 The asynchronous cosmos client is a separate client that looks and works in a similar fashion to the existing synchronous client. However, the async client needs to be imported separately and its methods need to be used with the async/await keywords.
-The Async client needs to be initialized and closed after usage, which can be done manually or with the use of a context manager. The example below shows how to do so manually.
+The Async client needs to be initialized and closed after usage, which can be done manually or with the use of a context manager. The example below shows how to do so manually. We don't recommend doing it this way, since it requires that you manually call __aenter__() before using the client.
 
 ```python
 from azure.cosmos.aio import CosmosClient
@@ -488,6 +488,7 @@ CONTAINER_NAME = 'products'
 
 async def create_products():
     client = CosmosClient(URL, credential=KEY)
+    await client.__aenter__() # this piece is important for the SDK to cache account information
     database = client.get_database_client(DATABASE_NAME)
     container = database.get_container_client(CONTAINER_NAME)
     for i in range(10):
@@ -500,7 +501,7 @@ async def create_products():
     await client.close() # the async client must be closed manually if it's not initialized in a with statement
 ```
 
-Instead of manually opening and closing the client, it is highly recommended to use the `async with` keywords. This creates a context manager that will initialize and later close the client once you're out of the statement. The example below shows how to do so.
+Instead of manually opening and closing the client, it is highly recommended to use the `async with` keywords. This creates a context manager that will initialize and later close the client once you're out of the statement, as well as cache important information the SDK needs. The example below shows how to do so.
 
 ```python
 from azure.cosmos.aio import CosmosClient


### PR DESCRIPTION
title, trying to run a release today

only thing I have questions with is the readme update - should we just remove the first bit entirely and explain the need for the context manager using `async with`? customers shouldn't be initializing their client manually as it is, but it seems like some of our customers already are doing that...