### PR TITLE
[Identity Broker] Minimum Python bump

### DIFF
--- a/sdk/identity/azure-identity-broker/CHANGELOG.md
+++ b/sdk/identity/azure-identity-broker/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.1 (Unreleased)
+## 1.1.0 (Unreleased)
 
 ### Features Added
 
@@ -9,6 +9,8 @@
 ### Bugs Fixed
 
 ### Other Changes
+
+- Python 3.7 is no longer supported. Please use Python version 3.8 or later.
 
 ## 1.0.0 (2023-11-07)
 

--- a/sdk/identity/azure-identity-broker/README.md
+++ b/sdk/identity/azure-identity-broker/README.md
@@ -53,7 +53,7 @@ from azure.storage.blob import BlobServiceClient
 current_window_handle = win32gui.GetForegroundWindow()
 
 credential = InteractiveBrowserBrokerCredential(parent_window_handle=current_window_handle)
-client = BlobServiceClient(account_url, credential=default_credential)
+client = BlobServiceClient(account_url, credential=credential)
 ```
 
 ## Troubleshooting

--- a/sdk/identity/azure-identity-broker/azure/identity/broker/_browser.py
+++ b/sdk/identity/azure-identity-broker/azure/identity/broker/_browser.py
@@ -35,9 +35,8 @@ class InteractiveBrowserBrokerCredential(_InteractiveBrowserCredential):
         may still log in with a different username.
     :paramtype cache_persistence_options: ~azure.identity.TokenCachePersistenceOptions
     :keyword int timeout: seconds to wait for the user to complete authentication. Defaults to 300 (5 minutes).
-    :keyword int parent_window_handle: If your app is a GUI app running on a modern Windows system,
-        and your app opts in to use broker via `allow_broker`, you are required to also provide its window handle,
-        so that the sign in UI window will properly pop up on top of your window.
+    :keyword int parent_window_handle: If your app is a GUI app running on a modern Windows system, you are required to
+        also provide its window handle so that the sign in UI window will properly pop up on top of your window.
     :keyword bool enable_msa_passthrough: Determines whether Microsoft Account (MSA) passthrough is enabled. Note, this
         is only needed for select legacy first-party applications. Defaults to False.
     :keyword bool disable_instance_discovery: Determines whether or not instance discovery is performed when attempting

--- a/sdk/identity/azure-identity-broker/azure/identity/broker/_version.py
+++ b/sdk/identity/azure-identity-broker/azure/identity/broker/_version.py
@@ -2,4 +2,4 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
-VERSION = "1.0.1"
+VERSION = "1.1.0"

--- a/sdk/identity/azure-identity-broker/setup.py
+++ b/sdk/identity/azure-identity-broker/setup.py
@@ -45,7 +45,6 @@ setup(
         "Programming Language :: Python",
         "Programming Language :: Python :: 3 :: Only",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
@@ -61,7 +60,7 @@ setup(
     package_data={
         "pytyped": ["py.typed"],
     },
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     install_requires=[
         "azure-identity<2.0.0,>=1.14.0",
         "msal[broker]>=1.25,<2",


### PR DESCRIPTION
- Bumped minimum Python version
- Removed reference to `allow_broker` kwarg we no longer use
- Fixed variable in README code snippet
