### PR TITLE
Implement StructredMessageDecodeStream

### DIFF
--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/streams.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/streams.py
@@ -1,0 +1,150 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+
+import sys
+from enum import IntFlag, auto
+from io import BytesIO
+from typing import IO
+
+from azure.storage.extensions import crc64
+
+
+class StructuredMessageConstants:
+    V1_HEADER_LENGTH = 13
+    V1_SEGMENT_HEADER_LENGTH = 10
+    CRC64_LENGTH = 8
+
+
+class StructuredMessageProperties(IntFlag):
+    NONE = 0
+    CRC64 = auto()
+
+
+def verify_crc64(data: bytes, expected_crc: bytes) -> None:
+    actual_crc = crc64.compute_crc64(data, 0).to_bytes(StructuredMessageConstants.CRC64_LENGTH, 'little')
+    if actual_crc != expected_crc:
+        raise ValueError("CRC64 mismatch detected.")
+
+
+class StructuredMessageDecodeStream:
+
+    message_version: int
+    """The version of the structured message."""
+    message_length: int
+    """The total length of the structured message."""
+    flags: StructuredMessageProperties
+    """The properties included in the structured message."""
+    num_segments: int
+    """The number of message segments."""
+
+    _inner_stream: IO[bytes]
+    _message_offset: int
+    _segment_number: int
+    _segment_content: bytes
+    _segment_content_length: int
+    _segment_content_offset: int
+
+    def __init__(self, inner_stream: IO[bytes], content_length: int) -> None:
+        self.message_length = content_length
+        # The stream should be at least long enough to hold minimum header length
+        if self.message_length < StructuredMessageConstants.V1_HEADER_LENGTH:
+            raise ValueError("Content not long enough to contain a valid message header.")
+
+        self._inner_stream = inner_stream
+        self._message_offset = 0
+
+        self._segment_number = 0
+        self._segment_content = b''
+        self._segment_content_length = 0
+        self._segment_content_offset = 0
+
+    @property
+    def _end_of_segment(self) -> bool:
+        return self._segment_content_offset == self._segment_content_length
+
+    @property
+    def _end_of_message(self) -> bool:
+        return self._message_offset == self.message_length
+
+    def read(self, size: int = -1) -> bytes:
+        if size == 0:
+            return b''
+        if size < 0:
+            size = sys.maxsize
+
+        # On the first read, read the header and first segment
+        if self._message_offset == 0:
+            self._read_message_header()
+            self._read_segment()
+
+        count = 0
+        content = BytesIO()
+        while count < size and not (self._end_of_segment and self._end_of_message):
+            if self._end_of_segment:
+                self._read_segment()
+
+            remaining_segment_size = self._segment_content_length - self._segment_content_offset
+            read_length = min((size - count), remaining_segment_size)
+
+            segment_content = self._segment_content[self._segment_content_offset:
+                                                    self._segment_content_offset + read_length]
+            self._segment_content_offset += read_length
+
+            content.write(segment_content)
+            count += read_length
+
+        return content.getvalue()
+
+    def _read_message_header(self) -> None:
+        # The first byte should always be the message version
+        self.message_version = int.from_bytes(self._inner_stream.read(1), 'little')
+
+        if self.message_version == 1:
+            message_length = int.from_bytes(self._inner_stream.read(8), 'little')
+            if message_length != self.message_length:
+                raise ValueError(f"Structured message length {message_length} "
+                                 f"did not match content length {self.message_length}")
+
+            self.flags = StructuredMessageProperties(int.from_bytes(self._inner_stream.read(2), 'little'))
+            self.num_segments = int.from_bytes(self._inner_stream.read(2), 'little')
+
+            self._message_offset += StructuredMessageConstants.V1_HEADER_LENGTH
+
+        else:
+            raise ValueError(f"The structured message version is not supported: {self.message_version}")
+
+    def _read_message_footer(self) -> None:
+        # V1 does not have a message footer
+        pass
+
+    def _read_segment(self) -> None:
+        self._read_segment_header()
+        self._read_segment_content()
+        self._read_segment_footer()
+
+    def _read_segment_header(self) -> None:
+        segment_number = int.from_bytes(self._inner_stream.read(2), 'little')
+        if segment_number != self._segment_number + 1:
+            raise ValueError(f"Structured message segment number invalid or out of order {segment_number}")
+        self._segment_number = segment_number
+        self._segment_content_length = int.from_bytes(self._inner_stream.read(8), 'little')
+        self._segment_content_offset = 0
+
+        self._message_offset += StructuredMessageConstants.V1_SEGMENT_HEADER_LENGTH
+
+    def _read_segment_content(self) -> None:
+        self._segment_content = self._inner_stream.read(self._segment_content_length)
+        self._message_offset += self._segment_content_length
+
+    def _read_segment_footer(self) -> None:
+        footer_length = 0
+        if StructuredMessageProperties.CRC64 in self.flags:
+            segment_crc = self._inner_stream.read(StructuredMessageConstants.CRC64_LENGTH)
+            footer_length += StructuredMessageConstants.CRC64_LENGTH
+
+            verify_crc64(self._segment_content, segment_crc)
+
+        self._message_offset += footer_length

--- a/sdk/storage/azure-storage-blob/dev_requirements.txt
+++ b/sdk/storage/azure-storage-blob/dev_requirements.txt
@@ -1,7 +1,7 @@
 -e ../../../tools/azure-devtools
 -e ../../../tools/azure-sdk-tools
 ../../core/azure-core
-../azure-storage-extensions
+azure-storage-extensions
 azure-identity
 azure-mgmt-storage==20.1.0
 aiohttp>=3.0

--- a/sdk/storage/azure-storage-blob/dev_requirements.txt
+++ b/sdk/storage/azure-storage-blob/dev_requirements.txt
@@ -1,6 +1,7 @@
 -e ../../../tools/azure-devtools
 -e ../../../tools/azure-sdk-tools
 ../../core/azure-core
+../azure-storage-extensions
 azure-identity
 azure-mgmt-storage==20.1.0
 aiohttp>=3.0

--- a/sdk/storage/azure-storage-blob/tests/test_streams.py
+++ b/sdk/storage/azure-storage-blob/tests/test_streams.py
@@ -1,0 +1,172 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+
+import math
+import os
+import random
+from io import BytesIO
+from typing import List, Tuple, Union
+
+import pytest
+from azure.storage.blob._shared.streams import (
+    StructuredMessageConstants,
+    StructuredMessageDecodeStream,
+    StructuredMessageProperties,
+)
+from azure.storage.extensions import crc64
+
+
+def _write_message_header(
+    message_length: int,
+    flags: StructuredMessageProperties,
+    segment_count: int,
+    stream: BytesIO
+) -> None:
+    stream.write(b'\x01')  # Version
+    stream.write(message_length.to_bytes(8, 'little'))  # Message length
+    stream.write(int(flags).to_bytes(2, 'little'))  # Flags
+    stream.write(segment_count.to_bytes(2, 'little'))  # Num segments
+
+
+def _write_segment(number: int, data: bytes, flags: StructuredMessageProperties, stream: BytesIO) -> None:
+    stream.write(number.to_bytes(2, 'little'))  # Segment number
+    stream.write(len(data).to_bytes(8, 'little'))  # Segment length
+    stream.write(data)  # Segment content
+    if StructuredMessageProperties.CRC64 in flags:
+        crc: int = crc64.compute_crc64(data, 0)
+        stream.write(crc.to_bytes(StructuredMessageConstants.CRC64_LENGTH, 'little'))
+
+
+def _build_structured_message(
+    data: bytes,
+    segment_size: Union[int, List[int]],
+    flags: StructuredMessageProperties,
+) -> Tuple[BytesIO, int]:
+    if isinstance(segment_size, list):
+        segment_count = len(segment_size)
+    else:
+        segment_count = 1 if segment_size == 0 else math.ceil(len(data) / segment_size)
+    segment_footer_length = StructuredMessageConstants.CRC64_LENGTH if StructuredMessageProperties.CRC64 in flags else 0
+
+    message_length = (
+        StructuredMessageConstants.V1_HEADER_LENGTH +
+        ((StructuredMessageConstants.V1_SEGMENT_HEADER_LENGTH + segment_footer_length) * segment_count) +
+        len(data))
+
+    message = BytesIO()
+
+    # Message Header
+    _write_message_header(message_length, flags, segment_count, message)
+
+    # Special case for 0 length content
+    if len(data) == 0:
+        _write_segment(1, data, flags, message)
+        message.seek(0, 0)
+        return message, message_length
+
+    # Segments
+    segment_sizes = segment_size if isinstance(segment_size, list) else [segment_size] * segment_count
+    offset = 0
+    for i in range(1, segment_count + 1):
+        size = segment_sizes[i - 1]
+        segment_data = data[offset: offset + size]
+        offset += size
+
+        _write_segment(i, segment_data, flags, message)
+
+    message.seek(0, 0)
+    return message, message_length
+
+
+class TestStructuredMessageDecodeStream:
+
+    def test_empty_inner_stream(self):
+        with pytest.raises(ValueError):
+            StructuredMessageDecodeStream(BytesIO(), 0)
+
+    def test_read_past_end(self):
+        data = os.urandom(10)
+        message_stream, length = _build_structured_message(data, len(data), StructuredMessageProperties.CRC64)
+
+        stream = StructuredMessageDecodeStream(message_stream, length)
+        result = stream.read(100)
+        assert result == data
+
+        result = stream.read(100)
+        assert result == b''
+
+    @pytest.mark.parametrize("size, segment_size, flags", [
+        (0, 0, StructuredMessageProperties.NONE),
+        (0, 0, StructuredMessageProperties.CRC64),
+        (10, 1, StructuredMessageProperties.NONE),
+        (10, 1, StructuredMessageProperties.CRC64),
+        (1024, 1024, StructuredMessageProperties.NONE),
+        (1024, 1024, StructuredMessageProperties.CRC64),
+        (1024, 512, StructuredMessageProperties.NONE),
+        (1024, 512, StructuredMessageProperties.CRC64),
+        (1024, 200, StructuredMessageProperties.NONE),
+        (1024, 200, StructuredMessageProperties.CRC64),
+        (123456, 1234, StructuredMessageProperties.NONE),
+        (123456, 1234, StructuredMessageProperties.CRC64),
+        (10 * 1024 * 1024, 4 * 1024 * 1024, StructuredMessageProperties.NONE),
+        (10 * 1024 * 1024, 4 * 1024 * 1024, StructuredMessageProperties.CRC64),
+    ])
+    def test_read_all(self, size, segment_size, flags):
+        data = os.urandom(size)
+        message_stream, length = _build_structured_message(data, segment_size, flags)
+
+        stream = StructuredMessageDecodeStream(message_stream, length)
+        content = stream.read()
+
+        assert content == data
+
+    @pytest.mark.parametrize("size, segment_size, chunk_size, flags", [
+        (10, 10, 1, StructuredMessageProperties.NONE),
+        (10, 10, 1, StructuredMessageProperties.CRC64),
+        (1024, 512, 512, StructuredMessageProperties.NONE),
+        (1024, 512, 512, StructuredMessageProperties.CRC64),
+        (1024, 512, 123, StructuredMessageProperties.NONE),
+        (1024, 512, 123, StructuredMessageProperties.CRC64),
+        (1024, 200, 512, StructuredMessageProperties.NONE),
+        (1024, 200, 512, StructuredMessageProperties.CRC64),
+        (10 * 1024 * 1024, 4 * 1024 * 1024, 1 * 1024 * 1024, StructuredMessageProperties.NONE),
+        (10 * 1024 * 1024, 4 * 1024 * 1024, 1 * 1024 * 1024, StructuredMessageProperties.CRC64),
+    ])
+    def test_read_chunks(self, size, segment_size, chunk_size, flags):
+        data = os.urandom(size)
+        message_stream, length = _build_structured_message(data, segment_size, flags)
+
+        stream = StructuredMessageDecodeStream(message_stream, length)
+        read = 0
+        content = b''
+        while read < len(data):
+            chunk = stream.read(chunk_size)
+            content += chunk
+            read += chunk_size
+
+        assert content == data
+
+    @pytest.mark.parametrize("data_size", [100, 1024, 10 * 1024, 100 * 1024])
+    def test_random_reads(self, data_size):
+        pass
+
+    @pytest.mark.parametrize("data_size", [100, 1024, 10 * 1024, 100 * 1024])
+    def test_random_segment_sizes(self, data_size):
+        segment_sizes = []
+        count = 0
+        while count < data_size:
+            size = random.randint(10, data_size // 3)
+            size = min(size, data_size - count)
+            segment_sizes.append(size)
+            count += size
+
+        data = os.urandom(data_size)
+        message_stream, length = _build_structured_message(data, segment_sizes, StructuredMessageProperties.CRC64)
+
+        stream = StructuredMessageDecodeStream(message_stream, length)
+        content = stream.read()
+
+        assert content == data


### PR DESCRIPTION
First PR for content validation. This change implements the new `StructuredMessageDecodeStream` which wraps a stream and can handle decoding the new Structured Message format from the service. Currently only including implementation of the stream itself along with unit tests. Integration will come later.