### PR TITLE
Remove non-offline tests for azure core streaming

### DIFF
--- a/sdk/core/azure-core/tests/async_tests/test_streaming_async.py
+++ b/sdk/core/azure-core/tests/async_tests/test_streaming_async.py
@@ -31,6 +31,7 @@ from azure.core.exceptions import DecodeError
 from utils import HTTP_REQUESTS
 
 
+@pytest.mark.live_test_only
 @pytest.mark.asyncio
 @pytest.mark.parametrize("http_request", HTTP_REQUESTS)
 async def test_decompress_plain_no_header(http_request):
@@ -51,6 +52,7 @@ async def test_decompress_plain_no_header(http_request):
         assert decoded == "test"
 
 
+@pytest.mark.live_test_only
 @pytest.mark.asyncio
 @pytest.mark.parametrize("http_request", HTTP_REQUESTS)
 async def test_compress_plain_no_header(http_request):
@@ -71,6 +73,7 @@ async def test_compress_plain_no_header(http_request):
         assert decoded == "test"
 
 
+@pytest.mark.live_test_only
 @pytest.mark.asyncio
 @pytest.mark.parametrize("http_request", HTTP_REQUESTS)
 async def test_decompress_compressed_no_header(http_request):
@@ -94,6 +97,7 @@ async def test_decompress_compressed_no_header(http_request):
             pass
 
 
+@pytest.mark.live_test_only
 @pytest.mark.asyncio
 @pytest.mark.parametrize("http_request", HTTP_REQUESTS)
 async def test_compress_compressed_no_header(http_request):
@@ -141,6 +145,7 @@ async def test_decompress_plain_header(http_request):
             pass
 
 
+@pytest.mark.live_test_only
 @pytest.mark.asyncio
 @pytest.mark.parametrize("http_request", HTTP_REQUESTS)
 async def test_compress_plain_header(http_request):
@@ -161,6 +166,7 @@ async def test_compress_plain_header(http_request):
         assert decoded == "test"
 
 
+@pytest.mark.live_test_only
 @pytest.mark.asyncio
 @pytest.mark.parametrize("http_request", HTTP_REQUESTS)
 async def test_decompress_compressed_header(http_request):

--- a/sdk/core/azure-core/tests/test_streaming.py
+++ b/sdk/core/azure-core/tests/test_streaming.py
@@ -31,6 +31,7 @@ from azure.core.pipeline.transport import RequestsTransport
 from utils import HTTP_REQUESTS
 
 
+@pytest.mark.live_test_only
 @pytest.mark.parametrize("http_request", HTTP_REQUESTS)
 def test_decompress_plain_no_header(http_request):
     # expect plain text
@@ -79,6 +80,7 @@ def test_compress_plain_no_header(http_request):
     assert decoded == "test"
 
 
+@pytest.mark.live_test_only
 @pytest.mark.parametrize("http_request", HTTP_REQUESTS)
 def test_decompress_compressed_no_header(http_request):
     # expect compressed text
@@ -158,6 +160,7 @@ def test_decompress_plain_header_offline(port, http_request):
             list(data)
 
 
+@pytest.mark.live_test_only
 @pytest.mark.parametrize("http_request", HTTP_REQUESTS)
 def test_compress_plain_header(http_request):
     # expect plain text
@@ -204,6 +207,7 @@ def test_decompress_compressed_header_offline(port, http_request):
         assert decoded == "test"
 
 
+@pytest.mark.live_test_only
 @pytest.mark.parametrize("http_request", HTTP_REQUESTS)
 def test_compress_compressed_header(http_request):
     # expect compressed text


### PR DESCRIPTION
# Description

Removed live tests from azure core streaming services as offline tests have been written for the same.

This pull request is in reference of issue https://github.com/Azure/azure-sdk-for-python/issues/9324 .
Related PR : https://github.com/Azure/azure-sdk-for-python/pull/33800


