### PR TITLE
[Identity] Add multi-tenant live testing

### DIFF
--- a/sdk/identity/azure-identity/assets.json
+++ b/sdk/identity/azure-identity/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "python",
   "TagPrefix": "python/identity/azure-identity",
-  "Tag": "python/identity/azure-identity_ef8f51ecfd"
+  "Tag": "python/identity/azure-identity_cb8dd6f319"
 }

--- a/sdk/identity/azure-identity/tests/test_environment_credential.py
+++ b/sdk/identity/azure-identity/tests/test_environment_credential.py
@@ -34,19 +34,19 @@ def test_incomplete_configuration():
 
 
 @pytest.mark.parametrize(
-    "credential_name,environment_variables",
+    "credential_name,envvars",
     (
         ("ClientSecretCredential", EnvironmentVariables.CLIENT_SECRET_VARS),
         ("CertificateCredential", EnvironmentVariables.CERT_VARS),
         ("UsernamePasswordCredential", EnvironmentVariables.USERNAME_PASSWORD_VARS),
     ),
 )
-def test_passes_authority_argument(credential_name, environment_variables):
+def test_passes_authority_argument(credential_name, envvars):
     """the credential pass the 'authority' keyword argument to its inner credential"""
 
     authority = "authority"
 
-    with mock.patch.dict("os.environ", {variable: "foo" for variable in environment_variables}, clear=True):
+    with mock.patch.dict("os.environ", {variable: "foo" for variable in envvars}, clear=True):
         with mock.patch(EnvironmentCredential.__module__ + "." + credential_name) as mock_credential:
             EnvironmentCredential(authority=authority)
 

--- a/sdk/identity/azure-identity/tests/test_environment_credential_async.py
+++ b/sdk/identity/azure-identity/tests/test_environment_credential_async.py
@@ -70,18 +70,18 @@ async def test_incomplete_configuration():
 
 
 @pytest.mark.parametrize(
-    "credential_name,environment_variables",
+    "credential_name,envvars",
     (
         ("ClientSecretCredential", EnvironmentVariables.CLIENT_SECRET_VARS),
         ("CertificateCredential", EnvironmentVariables.CERT_VARS),
     ),
 )
-def test_passes_authority_argument(credential_name, environment_variables):
+def test_passes_authority_argument(credential_name, envvars):
     """the credential pass the 'authority' keyword argument to its inner credential"""
 
     authority = "authority"
 
-    with mock.patch.dict(ENVIRON, {variable: "foo" for variable in environment_variables}, clear=True):
+    with mock.patch.dict(ENVIRON, {variable: "foo" for variable in envvars}, clear=True):
         with mock.patch(EnvironmentCredential.__module__ + "." + credential_name) as mock_credential:
             EnvironmentCredential(authority=authority)
 

--- a/sdk/identity/azure-identity/tests/test_multi_tenant_auth.py
+++ b/sdk/identity/azure-identity/tests/test_multi_tenant_auth.py
@@ -1,0 +1,35 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE.txt in the project root for
+# license information.
+# -------------------------------------------------------------------------
+import os
+
+import pytest
+from devtools_testutils import AzureRecordedTestCase, is_live
+from azure.core import PipelineClient
+from azure.core.rest import HttpRequest, HttpResponse
+from azure.identity import ClientSecretCredential
+
+
+class TestMultiTenantAuth(AzureRecordedTestCase):
+    def _send_request(self, credential: ClientSecretCredential) -> HttpResponse:
+        client = PipelineClient(base_url="https://graph.microsoft.com")
+        token = credential.get_token("https://graph.microsoft.com/.default")
+        headers = {"Authorization": "Bearer " + token.token, "ConsistencyLevel": "eventual"}
+        request = HttpRequest("GET", "https://graph.microsoft.com/v1.0/applications/$count", headers=headers)
+        response = client.send_request(request)
+        return response
+
+    @pytest.mark.skipif(
+        is_live() and not os.environ.get("AZURE_IDENTITY_MULTI_TENANT_CLIENT_ID"),
+        reason="Multi-tenant envvars not configured.",
+    )
+    def test_multi_tenant_client_secret_graph_call(self, recorded_test, environment_variables):
+        client_id = environment_variables.get("AZURE_IDENTITY_MULTI_TENANT_CLIENT_ID")
+        tenant_id = environment_variables.get("AZURE_IDENTITY_MULTI_TENANT_TENANT_ID")
+        client_secret = environment_variables.get("AZURE_IDENTITY_MULTI_TENANT_CLIENT_SECRET")
+        credential = ClientSecretCredential(tenant_id, client_id, client_secret)
+        response = self._send_request(credential)
+        assert response.status_code == 200
+        assert int(response.text()) > 0

--- a/sdk/identity/azure-identity/tests/test_multi_tenant_auth_async.py
+++ b/sdk/identity/azure-identity/tests/test_multi_tenant_auth_async.py
@@ -1,0 +1,37 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE.txt in the project root for
+# license information.
+# -------------------------------------------------------------------------
+import os
+
+import pytest
+from devtools_testutils import AzureRecordedTestCase, is_live
+from azure.core import AsyncPipelineClient
+from azure.core.rest import HttpRequest, HttpResponse
+from azure.identity.aio import ClientSecretCredential
+
+
+class TestMultiTenantAuthAsync(AzureRecordedTestCase):
+    async def _send_request(self, credential: ClientSecretCredential) -> HttpResponse:
+        client = AsyncPipelineClient(base_url="https://graph.microsoft.com")
+        token = await credential.get_token("https://graph.microsoft.com/.default")
+        headers = {"Authorization": "Bearer " + token.token, "ConsistencyLevel": "eventual"}
+        request = HttpRequest("GET", "https://graph.microsoft.com/v1.0/applications/$count", headers=headers)
+        response = await client.send_request(request, stream=False)
+        return response
+
+    @pytest.mark.asyncio
+    @pytest.mark.skipif(
+        is_live() and not os.environ.get("AZURE_IDENTITY_MULTI_TENANT_CLIENT_ID"),
+        reason="Multi-tenant envvars not configured.",
+    )
+    async def test_multi_tenant_client_secret_graph_call(self, recorded_test, environment_variables):
+        client_id = environment_variables.get("AZURE_IDENTITY_MULTI_TENANT_CLIENT_ID")
+        tenant_id = environment_variables.get("AZURE_IDENTITY_MULTI_TENANT_TENANT_ID")
+        client_secret = environment_variables.get("AZURE_IDENTITY_MULTI_TENANT_CLIENT_SECRET")
+        credential = ClientSecretCredential(tenant_id, client_id, client_secret)
+        async with credential:
+            response = await self._send_request(credential)
+            assert response.status_code == 200
+            assert int(response.text()) > 0


### PR DESCRIPTION
In the CI, there are credential envvars that correspond to a multi-tenant enabled application. Here, live testing is provided for that along with corresponding recordings.

Follows similar pattern to the .NET multi-tenant authentication test: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/identity/Azure.Identity/tests/MultiTenantLiveTests.cs

Ref: https://github.com/Azure/azure-sdk-for-python/issues/31037
