### PR TITLE
ML online endpoint invoke implement optional inputs

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_online_endpoint_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_online_endpoint_operations.py
@@ -297,11 +297,9 @@ class OnlineEndpointOperations(_ScopeDependentOperations):
         *,
         request_file: Any = None,
         deployment_name: Optional[str] = None,
-        # pylint: disable=unused-argument
         input_data: Optional[Union[str, Data]] = None,
         params_override: Any = None,
         local: bool = False,
-        # pylint: disable=unused-argument
         **kwargs: Any,
     ) -> str:
         """Invokes the endpoint with the provided payload.
@@ -329,8 +327,15 @@ class OnlineEndpointOperations(_ScopeDependentOperations):
         if deployment_name:
             self._validate_deployment_name(endpoint_name, deployment_name)
 
-        with open(request_file, "rb") as f:
-            data = json.loads(f.read())
+        if request_file != None:
+            with open(request_file, "rb") as f:
+                data = json.loads(f.read())
+        elif input_data != None:
+            data = input_data
+        elif kwargs != None:
+            data = kwargs
+        else:
+            data = {}
         if local:
             return self._local_endpoint_helper.invoke(
                 endpoint_name=endpoint_name, data=data, deployment_name=deployment_name

--- a/sdk/ml/azure-ai-ml/tests/online_services/unittests/test_online_endpoints.py
+++ b/sdk/ml/azure-ai-ml/tests/online_services/unittests/test_online_endpoints.py
@@ -375,7 +375,7 @@ class TestOnlineEndpointsOperations:
         with pytest.raises(Exception):
             mock_online_endpoint_operations.begin_create(endpoint=online_endpoint)
 
-    def test_online_invoke(
+    def test_online_invoke_with_file(
         self,
         mock_online_endpoint_operations: OnlineEndpointOperations,
         request_file: str,
@@ -397,6 +397,49 @@ class TestOnlineEndpointsOperations:
         mock_online_endpoint_operations._online_operation.get.assert_called_once()
         mock_online_endpoint_operations._online_operation.list_keys.assert_called_once()
 
+    def test_online_invoke_with_input(
+        self,
+        mock_online_endpoint_operations: OnlineEndpointOperations,
+        mocker: MockFixture,
+        mock_aml_services_2022_02_01_preview: Mock,
+    ) -> None:
+        random_name = "random_name"
+        mock_aml_services_2022_02_01_preview.online_endpoints.get.return_value = OnlineEndpointData(
+            name=random_name,
+            location="eastus",
+            properties=RestOnlineEndpoint(auth_mode="Key", scoring_uri="xxx"),
+        )
+        mockresponse = Mock()
+        mockresponse.text = lambda: '{"key": "value"}'
+        mockresponse.status_code = 200
+
+        mocker.patch.object(mock_online_endpoint_operations._requests_pipeline, "post", return_value=mockresponse)
+        assert mock_online_endpoint_operations.invoke(endpoint_name=random_name, input_data={"key": "value"})
+        mock_online_endpoint_operations._online_operation.get.assert_called_once()
+        mock_online_endpoint_operations._online_operation.list_keys.assert_called_once()
+
+    def test_online_invoke_with_kwargs(
+        self,
+        mock_online_endpoint_operations: OnlineEndpointOperations,
+        mocker: MockFixture,
+        mock_aml_services_2022_02_01_preview: Mock,
+    ) -> None:
+        random_name = "random_name"
+        mock_aml_services_2022_02_01_preview.online_endpoints.get.return_value = OnlineEndpointData(
+            name=random_name,
+            location="eastus",
+            properties=RestOnlineEndpoint(auth_mode="Key", scoring_uri="xxx"),
+        )
+        mockresponse = Mock()
+        mockresponse.text = lambda: '{"key": "value"}'
+        mockresponse.status_code = 200
+
+        mocker.patch.object(mock_online_endpoint_operations._requests_pipeline, "post", return_value=mockresponse)
+        assert mock_online_endpoint_operations.invoke(endpoint_name=random_name, key="value")
+        mock_online_endpoint_operations._online_operation.get.assert_called_once()
+        mock_online_endpoint_operations._online_operation.list_keys.assert_called_once()
+
+    
     def test_create_no_file_throw_exception(self, mock_online_endpoint_operations: OnlineEndpointOperations) -> None:
         with pytest.raises(Exception):
             mock_online_endpoint_operations.begin_create(name="random_name", file=None)


### PR DESCRIPTION
# Description

`request_file` is optional in the method but mandatory in code. Additional paramerers `input_data` and `kwargs` are ignored in code even if they are present in the method signature. These changes include these optional inputs and actually makes all of them optional

If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
