### PR TITLE
[Cosmos] fixing bug with not passing kwargs/ response_hook in `create_container_if_not_exists`

### DIFF
--- a/sdk/cosmos/azure-cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos/CHANGELOG.md
@@ -7,7 +7,7 @@
 #### Breaking Changes
 
 #### Bugs Fixed
-* Keyword arguments were not being passed down for `create_container_if_not_exists()` methods. See [PR]().
+* Keyword arguments were not being passed down for `create_container_if_not_exists()` methods. See [PR 34286](https://github.com/Azure/azure-sdk-for-python/pull/34286).
 
 #### Other Changes
 * Marked `computed_properties` keyword as provisional, un-marked `continuation_token_limit` as provisional. See [PR 34207](https://github.com/Azure/azure-sdk-for-python/pull/34207).

--- a/sdk/cosmos/azure-cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos/CHANGELOG.md
@@ -7,6 +7,7 @@
 #### Breaking Changes
 
 #### Bugs Fixed
+* Keyword arguments were not being passed down for `create_container_if_not_exists()` methods. See [PR]().
 
 #### Other Changes
 * Marked `computed_properties` keyword as provisional, un-marked `continuation_token_limit` as provisional. See [PR 34207](https://github.com/Azure/azure-sdk-for-python/pull/34207).

--- a/sdk/cosmos/azure-cosmos/README.md
+++ b/sdk/cosmos/azure-cosmos/README.md
@@ -153,15 +153,12 @@ Currently, the features below are **not supported**. For alternatives options, c
 
 * Group By queries
 * Queries with COUNT from a DISTINCT subquery: SELECT COUNT (1) FROM (SELECT DISTINCT C.ID FROM C)
-* Transactional batch processing
 * Direct TCP Mode access
 * Continuation token support for aggregate cross-partition queries like sorting, counting, and distinct.
 Streamable queries like `SELECT * FROM WHERE` *do* support continuation tokens.
 * Change Feed: Processor
 * Change Feed: Read multiple partitions key values
 * Change Feed: Read specific time
-* Change Feed: Read from the beginning
-* Change Feed: Pull model
 * Cross-partition ORDER BY for mixed types
 * Enabling diagnostics for async query-type methods
 

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_database.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_database.py
@@ -324,7 +324,8 @@ class DatabaseProxy(object):
                 unique_key_policy=unique_key_policy,
                 conflict_resolution_policy=conflict_resolution_policy,
                 analytical_storage_ttl=analytical_storage_ttl,
-                computed_properties=computed_properties
+                computed_properties=computed_properties,
+                **kwargs
             )
 
     def get_container_client(self, container: Union[str, ContainerProxy, Dict[str, Any]]) -> ContainerProxy:

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_database.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_database.py
@@ -310,6 +310,8 @@ class DatabaseProxy(object):
         analytical_storage_ttl = kwargs.pop("analytical_storage_ttl", None)
         offer_throughput = kwargs.pop('offer_throughput', None)
         computed_properties = kwargs.pop("computed_properties", None)
+        etag = kwargs.pop("etag", None)
+        match_condition = kwargs.pop("match_condition", None)
         try:
             container_proxy = self.get_container_client(id)
             await container_proxy.read(**kwargs)
@@ -325,6 +327,8 @@ class DatabaseProxy(object):
                 conflict_resolution_policy=conflict_resolution_policy,
                 analytical_storage_ttl=analytical_storage_ttl,
                 computed_properties=computed_properties,
+                etag=etag,
+                match_condition=match_condition,
                 **kwargs
             )
 

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/database.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/database.py
@@ -309,6 +309,8 @@ class DatabaseProxy(object):
         """
         analytical_storage_ttl = kwargs.pop("analytical_storage_ttl", None)
         computed_properties = kwargs.pop("computed_properties", None)
+        etag = kwargs.pop("etag", None)
+        match_condition = kwargs.pop("match_condition", None)
         try:
             container_proxy = self.get_container_client(id)
             container_proxy.read(
@@ -328,6 +330,8 @@ class DatabaseProxy(object):
                 conflict_resolution_policy=conflict_resolution_policy,
                 analytical_storage_ttl=analytical_storage_ttl,
                 computed_properties=computed_properties,
+                etag=etag,
+                match_condition=match_condition,
                 **kwargs
             )
 

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/database.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/database.py
@@ -327,7 +327,8 @@ class DatabaseProxy(object):
                 unique_key_policy=unique_key_policy,
                 conflict_resolution_policy=conflict_resolution_policy,
                 analytical_storage_ttl=analytical_storage_ttl,
-                computed_properties=computed_properties
+                computed_properties=computed_properties,
+                **kwargs
             )
 
     @distributed_trace


### PR DESCRIPTION
Addressing this [issue](https://github.com/Azure/azure-sdk-for-python/issues/34281) pointing out a gap in our SDK's response_hook behavior for certain methods.