### PR TITLE
Handle package-specific warning suppressions

### DIFF
--- a/eng/pipelines/templates/steps/build-package-artifacts.yml
+++ b/eng/pipelines/templates/steps/build-package-artifacts.yml
@@ -99,11 +99,6 @@ steps:
         ArtifactPath: '$(Build.ArtifactStagingDirectory)'
         ArtifactName: 'packages'
 
-    - template: /eng/common/pipelines/templates/steps/publish-artifact.yml
-      parameters:
-        ArtifactPath: '$(Build.SourcesDirectory)/.logs'
-        ArtifactName: 'build_logs'
-
     - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
       - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
         displayName: 'Generate BOM'
@@ -121,11 +116,6 @@ steps:
       parameters:
         ArtifactPath: '$(Build.ArtifactStagingDirectory)'
         ArtifactName: 'packages_${{ parameters.ArtifactSuffix }}'
-
-    - template: /eng/common/pipelines/templates/steps/publish-artifact.yml
-      parameters:
-        ArtifactPath: '$(Build.SourcesDirectory)/.logs'
-        ArtifactName: 'build_logs_${{ parameters.ArtifactSuffix }}'
 
     - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
       - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0

--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -114,11 +114,6 @@ steps:
 
   - template: /eng/common/pipelines/templates/steps/publish-artifact.yml
     parameters:
-      ArtifactPath: '$(Build.SourcesDirectory)/.logs'
-      ArtifactName: '$(System.StageName)_$(Agent.JobName)_logs'
-
-  - template: /eng/common/pipelines/templates/steps/publish-artifact.yml
-    parameters:
       ArtifactPath: '$(Build.SourcesDirectory)/_tox_logs'
       ArtifactName: '$(System.StageName)_$(Agent.JobName)_tox_logs'
       CustomCondition: failed()

--- a/scripts/devops_tasks/tox_harness.py
+++ b/scripts/devops_tasks/tox_harness.py
@@ -20,6 +20,7 @@ from ci_tools.environment_exclusions import filter_tox_environment_string
 from ci_tools.ci_interactions import output_ci_warning
 from ci_tools.scenario.generation import replace_dev_reqs
 from ci_tools.functions import cleanup_directory
+from ci_tools.parsing import ParsedSetup
 from pkg_resources import parse_requirements, RequirementParseError
 import logging
 
@@ -252,6 +253,7 @@ def prep_and_run_tox(targeted_packages: List[str], parsed_args: Namespace) -> No
     skipped_tox_checks = {}
 
     for index, package_dir in enumerate(targeted_packages):
+        parsed_package = ParsedSetup.from_path(package_dir)
         destination_tox_ini = os.path.join(package_dir, "tox.ini")
         destination_dev_req = os.path.join(package_dir, "dev_requirements.txt")
 
@@ -316,7 +318,7 @@ def prep_and_run_tox(targeted_packages: List[str], parsed_args: Namespace) -> No
                         if check not in skipped_tox_checks:
                             skipped_tox_checks[check] = []
 
-                    skipped_tox_checks[check].append(package_name)
+                    skipped_tox_checks[check].append(parsed_package)
 
             if not filtered_tox_environment_set:
                 logging.info(
@@ -342,7 +344,10 @@ def prep_and_run_tox(targeted_packages: List[str], parsed_args: Namespace) -> No
     if in_ci() and skipped_tox_checks:
         warning_content = ""
         for check in skipped_tox_checks:
-            warning_content += f"{check} is skipped by packages: {sorted(set(skipped_tox_checks[check]))}. \n"
+            packages_with_suppression = [pkg.name for pkg in skipped_tox_checks[check] if not pkg.is_reporting_suppressed(check)]
+
+            if packages_with_suppression:
+                warning_content += f"{check} is skipped by packages: {sorted(set(packages_with_suppression))}. \n"
 
         if warning_content:
             output_ci_warning(

--- a/sdk/storage/azure-storage-extensions/pyproject.toml
+++ b/sdk/storage/azure-storage-extensions/pyproject.toml
@@ -11,7 +11,7 @@ sdist = false
 breaking = false
 bandit = false
 # these can be any number of suppressions. note that * present means that ALL warnings will be suppressed for this package
-suppressed_build_warnings = ["*"]
+suppressed_skip_warnings = ["*"]
 
 [tool.cibuildwheel]
 build = ["cp38*", "cp39*", "cp310*", "cp311*", "cp312*", "pp38*", "pp39*", "pp310*"]

--- a/sdk/storage/azure-storage-extensions/pyproject.toml
+++ b/sdk/storage/azure-storage-extensions/pyproject.toml
@@ -10,6 +10,8 @@ verifywhl = false
 sdist = false
 breaking = false
 bandit = false
+# these can be any number of suppressions. note that * present means that ALL warnings will be suppressed for this package
+suppressed_build_warnings = ["*"]
 
 [tool.cibuildwheel]
 build = ["cp38*", "cp39*", "cp310*", "cp311*", "cp312*", "pp38*", "pp39*", "pp310*"]

--- a/tools/azure-sdk-tools/ci_tools/build.py
+++ b/tools/azure-sdk-tools/ci_tools/build.py
@@ -180,17 +180,9 @@ def create_package(
     setup_parsed = ParsedSetup.from_path(setup_directory_or_file)
 
     if setup_parsed.ext_modules:
-        run(
-            [sys.executable, "-m", "cibuildwheel", "--output-dir", dist], cwd=setup_parsed.folder
-        )
+        run([sys.executable, "-m", "cibuildwheel", "--output-dir", dist], cwd=setup_parsed.folder, check=True)
 
     if enable_wheel:
-        run_logged(
-            [sys.executable, "setup.py", "bdist_wheel", "-d", dist], prefix="create_wheel", cwd=setup_parsed.folder
-        )
+        run([sys.executable, "setup.py", "bdist_wheel", "-d", dist], cwd=setup_parsed.folder, check=True)
     if enable_sdist:
-        run_logged(
-            [sys.executable, "setup.py", "sdist", "-d", dist],
-            prefix="create_sdist",
-            cwd=setup_parsed.folder,
-        )
+        run([sys.executable, "setup.py", "sdist", "-d", dist], cwd=setup_parsed.folder, check=True)

--- a/tools/azure-sdk-tools/ci_tools/parsing/__init__.py
+++ b/tools/azure-sdk-tools/ci_tools/parsing/__init__.py
@@ -8,6 +8,7 @@ from .parse_functions import (
     get_build_config,
     get_config_setting,
     update_build_config,
+    compare_string_to_glob_array
 )
 
 __all__ = [
@@ -20,4 +21,5 @@ __all__ = [
     "get_build_config",
     "get_config_setting",
     "update_build_config",
+    "compare_string_to_glob_array"
 ]

--- a/tools/azure-sdk-tools/ci_tools/parsing/parse_functions.py
+++ b/tools/azure-sdk-tools/ci_tools/parsing/parse_functions.py
@@ -343,7 +343,4 @@ def compare_string_to_glob_array(string: str, glob_array: List[str]) -> bool:
     """
     This function is used to easily compare a string to a set of glob strings, if it matches any of them, returns True.
     """
-    for glob in glob_array:
-        if fnmatch.fnmatch(string, glob):
-            return True
-    return False
+    return any([fnmatch.fnmatch(string, glob) for glob in glob_array])

--- a/tools/azure-sdk-tools/ci_tools/parsing/parse_functions.py
+++ b/tools/azure-sdk-tools/ci_tools/parsing/parse_functions.py
@@ -2,6 +2,7 @@ import os
 import ast
 import textwrap
 import re
+import fnmatch
 
 try:
     # py 311 adds this library natively
@@ -102,6 +103,12 @@ class ParsedSetup:
 
     def get_build_config(self) -> Dict[str, Any]:
         return get_build_config(self.folder)
+
+    def get_config_setting(self, setting: str, default: Any = True) -> Any:
+        return get_config_setting(self.folder, setting, default)
+
+    def is_reporting_suppressed(self, setting: str) -> bool:
+        return compare_string_to_glob_array(setting, self.get_config_setting("suppressed_build_warnings", []))
 
 
 def update_build_config(package_path: str, new_build_config: Dict[str, Any]) -> Dict[str, Any]:
@@ -330,3 +337,13 @@ def get_name_from_specifier(version: str) -> str:
     "azure-core<2.0.0,>=1.11.0" -> azure-core
     """
     return re.split(r"[><=]", version)[0]
+
+
+def compare_string_to_glob_array(string: str, glob_array: List[str]) -> bool:
+    """
+    This function is used to easily compare a string to a set of glob strings, if it matches any of them, returns True.
+    """
+    for glob in glob_array:
+        if fnmatch.fnmatch(string, glob):
+            return True
+    return False

--- a/tools/azure-sdk-tools/ci_tools/parsing/parse_functions.py
+++ b/tools/azure-sdk-tools/ci_tools/parsing/parse_functions.py
@@ -108,7 +108,7 @@ class ParsedSetup:
         return get_config_setting(self.folder, setting, default)
 
     def is_reporting_suppressed(self, setting: str) -> bool:
-        return compare_string_to_glob_array(setting, self.get_config_setting("suppressed_build_warnings", []))
+        return compare_string_to_glob_array(setting, self.get_config_setting("suppressed_skip_warnings", []))
 
 
 def update_build_config(package_path: str, new_build_config: Dict[str, Any]) -> Dict[str, Any]:

--- a/tools/azure-sdk-tools/tests/test_individual_functions.py
+++ b/tools/azure-sdk-tools/tests/test_individual_functions.py
@@ -1,0 +1,24 @@
+# Used to test the individual functions in the `functions` module of azure-sdk-tools
+
+import os
+import pytest
+
+from ci_tools.parsing import ParsedSetup, compare_string_to_glob_array
+from typing import List
+
+@pytest.mark.parametrize(
+    "input_string, glob_array, expected_result",
+    [
+        ("sphinx", ["*"], True),
+        ("sphinx", ["a*"], False),
+        ("sphinx", [""], False),
+        ("sphinx", ["sphinx"], True),
+        ("sphinx", ["sphinx "], False),
+        ("azure-storage-blob", ["azure-*"], True),
+        ("azure-storage-blob", ["azure-storage*"], True),
+    ],
+)
+def test_compare_string_to_glob_array(input_string: str, glob_array: List[str], expected_result: bool):
+    result = compare_string_to_glob_array(input_string, glob_array)
+
+    assert result == expected_result

--- a/tools/azure-sdk-tools/tests/test_individual_functions.py
+++ b/tools/azure-sdk-tools/tests/test_individual_functions.py
@@ -12,6 +12,8 @@ from typing import List
         ("sphinx", ["*"], True),
         ("sphinx", ["a*"], False),
         ("sphinx", [""], False),
+        ("sphinx", ["sphinx2"], False),
+        ("sphinx", ["whl"], False),
         ("sphinx", ["sphinx"], True),
         ("sphinx", ["sphinx "], False),
         ("azure-storage-blob", ["azure-*"], True),


### PR DESCRIPTION
@jalauzon-msft this resolves #33972

- [x] Fixes the issue with crashed build stage not properly failing when `cibuildwheel` fails
- [x] Adds package-specific suppression via glob string array, see new test for example usage
   - This simply suppresses the _warning_ about the environment being skipped. This doesn't affect actual skip logic at all.
- [x] ~~Discovered issue, it's suppressing all warnings for some reason, need to figure out why.~~ All jobs need to complete before warnings are output.


