### PR TITLE
Update aka.ms link of JPEG test image used in Image Analysis SDK tests

### DIFF
--- a/sdk/vision/azure-ai-vision-imageanalysis/assets.json
+++ b/sdk/vision/azure-ai-vision-imageanalysis/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "python",
   "TagPrefix": "python/vision/azure-ai-vision-imageanalysis",
-  "Tag": "python/vision/azure-ai-vision-imageanalysis_a18b3495f0"
+  "Tag": "python/vision/azure-ai-vision-imageanalysis_c2497c4b3c"
 }

--- a/sdk/vision/azure-ai-vision-imageanalysis/tests/image_analysis_test_base.py
+++ b/sdk/vision/azure-ai-vision-imageanalysis/tests/image_analysis_test_base.py
@@ -47,7 +47,7 @@ class ImageAnalysisTestBase(AzureRecordedTestCase):
     PRINT_ANALYSIS_RESULTS = True
 
     # We use a single image (the same one) for all error-free tests, one hosted on the web and one local
-    IMAGE_URL = "https://aka.ms/azai/vision/image-analysis-sample.jpg"
+    IMAGE_URL = "https://aka.ms/azsdk/image-analysis/sample.jpg"
     IMAGE_FILE = path.abspath(path.join(path.abspath(__file__), "..", "./sample.jpg"))
 
     def _create_client_for_standard_analysis(self, sync: bool, get_connection_url: bool = False, **kwargs):


### PR DESCRIPTION
Update the aka.ms URL link that points to the JPEG image used in test, to better match the Azure SDK aka.ms links format. Both URL links resolve to the same JPEG image file in one of the public Azure SDK repos, so there is no actual change in test.

Sample code is already using the new aka.ms link. Looks like I forgot to update the test a while back when I did the change.

Update test recording assets to reflect the change.