### PR TITLE
[Storage] [STG93] Update changelogs to prep for beta release

### DIFF
--- a/sdk/storage/azure-storage-blob-changefeed/CHANGELOG.md
+++ b/sdk/storage/azure-storage-blob-changefeed/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Release History
 
-## 12.0.0b5 (Unreleased)
+## 12.0.0b5 (2024-03-05)
 
 This version and all future versions will require Python 3.8+. Python 3.6 and 3.7 are no longer supported.
 

--- a/sdk/storage/azure-storage-blob/CHANGELOG.md
+++ b/sdk/storage/azure-storage-blob/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 12.20.0b1 (Unreleased)
+## 12.20.0b1 (2024-03-05)
 
 This version and all future versions will require Python 3.8+. Python 3.7 is no longer supported.
 
@@ -207,7 +207,7 @@ This version and all future versions will require Python 3.6+. Python 2.7 is no 
     - `set_immutability_policy`
 - Encryption Scope is now supported for Sync Blob Copy (`copy_from_url()`).
 - Encryption Scope is now supported as a SAS permission.
-- Added support for blob names containing invalid XML characters. 
+- Added support for blob names containing invalid XML characters.
   Previously \uFFFE and \uFFFF would fail if present in blob name.
 - Added support for listing system containers with get_blob_containers().
 - Added support for `find_blobs_by_tags()` on a container.
@@ -258,7 +258,7 @@ This version and all future versions will require Python 3.6+. Python 2.7 is no 
 
 **Fixes**
 - Blob Client Typing annotation issues have been resolved, specifically `invalid type inference` issues (#19906)
-- Duplicate type signature issue has been resolved (#19739) 
+- Duplicate type signature issue has been resolved (#19739)
 
 ## 12.9.0 (2021-09-15)
 **Stable release of preview features**

--- a/sdk/storage/azure-storage-file-datalake/CHANGELOG.md
+++ b/sdk/storage/azure-storage-file-datalake/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 12.15.0b1 (Unreleased)
+## 12.15.0b1 (2024-03-05)
 
 This version and all future versions will require Python 3.8+. Python 3.7 is no longer supported.
 
@@ -191,7 +191,7 @@ in a future release.
     - `permanent_delete`
     - `set_immutability_policy`
 **Fixes**
-- `FileSystemProperties` was not subscriptable. Now it is both subscriptable and attributes can also be accessed directly (#20772) 
+- `FileSystemProperties` was not subscriptable. Now it is both subscriptable and attributes can also be accessed directly (#20772)
 - Datalake Client Typing annotation issues have been resolved (#19906)
 
 ## 12.5.0 (2021-09-15)

--- a/sdk/storage/azure-storage-file-share/CHANGELOG.md
+++ b/sdk/storage/azure-storage-file-share/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 12.16.0b1 (Unreleased)
+## 12.16.0b1 (2024-03-05)
 
 This version and all future versions will require Python 3.8+. Python 3.7 is no longer supported.
 
@@ -250,7 +250,7 @@ was not generating the proper SAS signature.
 - Preview feature `get_ranges` on ShareFileClient
 
 **New features**
-- Added `set_share_properties` which allows setting share tier. 
+- Added `set_share_properties` which allows setting share tier.
 
 **Notes**
 - Updated dependency `azure-core` from  azure-core<2.0.0,>=1.2.2 to azure-core<2.0.0,>=1.9.0 to get continuation_token attr on AzureError.
@@ -270,7 +270,7 @@ was not generating the proper SAS signature.
 **New features**
 - Added `undelete_share` on FileShareServiceClient so that users can restore deleted share on share soft delete enabled account. Users can also list deleted shares when `list_shares` by specifying `include_deleted=True`.
 
-## 12.1.2 
+## 12.1.2
 **Fixes**
 - Improve the performance of upload when using max_concurrency
 
@@ -279,7 +279,7 @@ was not generating the proper SAS signature.
 **Notes**
 - The `StorageUserAgentPolicy` is now replaced with the `UserAgentPolicy` from azure-core. With this, the custom user agents are now added as a prefix instead of being appended.
 
-## 12.1.0 
+## 12.1.0
 
 **New features**
 - Added support for the 2019-07-07 service version, and added `api_version` parameter to clients.
@@ -294,7 +294,7 @@ was not generating the proper SAS signature.
 **Fixes**
 - Responses are always decoded as UTF8
 
-## 12.0.0 
+## 12.0.0
 
 **New features**
 - Added `delete_directory` method to the `share_client`.
@@ -306,7 +306,7 @@ was not generating the proper SAS signature.
 **Breaking changes**
 - `close_handle(handle)` and `close_all_handles()` no longer return int. These functions return a dictionary which has the number of handles closed and number of handles failed to be closed.
 
-## 12.0.0b5 
+## 12.0.0b5
 
 **Important: This package was previously named azure-storage-file**
 
@@ -361,7 +361,7 @@ the following APIs:
 - `ResourceTypes`, `NTFSAttributes`, and `Services` now have method `from_string` which takes parameters as a string.
 
 
-## 12.0.0b4 
+## 12.0.0b4
 
 **Breaking changes**
 
@@ -377,7 +377,7 @@ the following APIs:
 - `AccountSasPermissions`, `FileSasPermissions`, `ShareSasPermissions` now have method `from_string` which
 takes parameters as a string.
 
-## 12.0.0b3 
+## 12.0.0b3
 
 **New features**
 - Added upload_range_from_url API to write the bytes from one Azure File endpoint into the specified range of another Azure File endpoint.
@@ -397,7 +397,7 @@ takes parameters as a string.
 - Fix where content-type was being added in the request when not mentioned explicitly.
 
 
-## 12.0.0b2 
+## 12.0.0b2
 
 **Breaking changes**
 - Renamed `copy_file_from_url` to `start_copy_from_url` and changed behaviour to return a dictionary of copy properties rather than a polling object. Status of the copy operation can be retrieved with the `get_file_properties` operation.
@@ -426,7 +426,7 @@ takes parameters as a string.
 - General refactor of duplicate and shared code.
 
 
-## 12.0.0b1 
+## 12.0.0b1
 
 Version 12.0.0b1 is the first preview of our efforts to create a user-friendly and Pythonic client library for Azure Storage Files. For more information about this, and preview releases of other Azure SDK libraries, please visit
 https://aka.ms/azure-sdk-preview1-python.
@@ -467,36 +467,36 @@ https://aka.ms/azure-sdk-preview1-python.
 - No longer have specific operations for `exists` - use `get_properties` instead.
 - Operation `update_range` has been renamed to `upload_range`.
 
-## 2.0.1 
+## 2.0.1
 - Updated dependency on azure-storage-common.
 
-## 2.0.0 
+## 2.0.0
 - Support for 2018-11-09 REST version. Please see our REST API documentation and blogs for information about the related added features.
 - Added an option to get share stats in bytes.
 - Added support for listing and closing file handles.
 
-## 1.4.0 
+## 1.4.0
 
 - azure-storage-nspkg is not installed anymore on Python 3 (PEP420-based namespace package)
 
-## 1.3.1 
+## 1.3.1
 
 - Fixed design flaw where get_file_to_* methods buffer entire file when max_connections is set to 1.
 
-## 1.3.0 
+## 1.3.0
 
 - Support for 2018-03-28 REST version. Please see our REST API documentation and blog for information about the related added features.
 
-## 1.2.0rc1 
+## 1.2.0rc1
 
 - Support for 2017-11-09 REST version. Please see our REST API documentation and blog for information about the related added features.
 
-## 1.1.0 
+## 1.1.0
 
 - Support for 2017-07-29 REST version. Please see our REST API documentation and blogs for information about the related added features.
 - Error message now contains the ErrorCode from the x-ms-error-code header value.
 
-## 1.0.0 
+## 1.0.0
 
 - The package has switched from Apache 2.0 to the MIT license.
 - Fixed bug where get_file_to_* cannot get a single byte when start_range and end_range are both equal to 0.

--- a/sdk/storage/azure-storage-queue/CHANGELOG.md
+++ b/sdk/storage/azure-storage-queue/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 12.10.0b1 (Unreleased)
+## 12.10.0b1 (2024-03-05)
 
 This version and all future versions will require Python 3.8+. Python 3.7 is no longer supported.
 
@@ -117,7 +117,7 @@ an Account SAS with certain service level operations.
 also included a change to how account SAS is generated to reflect a change made to the service in SAS generation for
 service version 2020-12-06.
 - Updated documentation for `receive_messages()` to explain iterator behavior and life-cycle.
-- Added a sample to `queue_samples_message.py` (and async-equivalent) showcasing the use of `max_messages` in `receive_messages()`. 
+- Added a sample to `queue_samples_message.py` (and async-equivalent) showcasing the use of `max_messages` in `receive_messages()`.
 
 ## 12.2.0 (2022-03-08)
 

--- a/sdk/storage/azure-storage-queue/CHANGELOG.md
+++ b/sdk/storage/azure-storage-queue/CHANGELOG.md
@@ -4,8 +4,6 @@
 
 This version and all future versions will require Python 3.8+. Python 3.7 is no longer supported.
 
-### Features Added
-
 ### Bugs Fixed
 - Bumped dependency of `typing-extensions` to `>=4.6.0` to avoid potential `TypeError` with `typing.TypeVar` on
 Python 3.12.


### PR DESCRIPTION
As title states -- followup will be running CI against `feature/storage-stg93` & livetests then merging to `main`