### PR TITLE
[ServiceBus] Fix typing in tracing method

### DIFF
--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/message.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/message.py
@@ -62,7 +62,7 @@ if _CAN_ADD_DOCSTRING:
         This field contains the relative Message priority. Higher numbers indicate higher priority Messages.
         Messages with higher priorities MAY be delivered before those with lower priorities. An AMQP intermediary
         implementing distinct priority levels MUST do so in the following manner:
-        
+
             - If n distince priorities are implemented and n is less than 10 - priorities 0 to (5 - ceiling(n/2))
               MUST be treated equivalently and MUST be the lowest effective priority. The priorities (4 + fioor(n/2))
               and above MUST be treated equivalently and MUST be the highest effective priority. The priorities
@@ -184,7 +184,7 @@ class Message(NamedTuple):
     delivery_annotations: Optional[Dict[Union[str, bytes], Any]] = None
     message_annotations: Optional[Dict[Union[str, bytes], Any]] = None
     properties: Optional[Properties] = None
-    application_properties: Optional[Dict[Union[str, bytes], Any]] = None   # TODO: make not read-only
+    application_properties: Optional[Dict[Union[str, bytes], Any]] = None
     data: Optional[bytes] = None
     sequence: Optional[List[Any]] = None
     value: Optional[Any] = None

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_transport/_pyamqp_transport.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_transport/_pyamqp_transport.py
@@ -361,13 +361,7 @@ class PyamqpTransport(AmqpTransport):   # pylint: disable=too-many-public-method
         """
         if not message.application_properties:
             message = message._replace(application_properties={})
-        # TODO: fix error when typing pyamqp: `Property "application_properties" defined in "Message" is read-only `
-        # may be able to add @property.setter to app props in pyamqp.Message to fix this
-        message.application_properties = cast(  # type: ignore[misc]
-            Dict[Union[str, bytes], Any], message.application_properties
-        )
-        # casting from Optional to Dict above for use with setdefault
-        message.application_properties.setdefault(key, value)
+        cast(Dict[Union[str, bytes], Any], message.application_properties).setdefault(key, value)
         return message
 
     @staticmethod


### PR DESCRIPTION
This fixes an issue when we try to set a read-only property. In use, this would yield a "can't set attribute" error.

Move the cast down to not have it be an assignment to `message.application_properties`.
