### PR TITLE
[Key Vault] Handle `cryptography` RSA keys without local key material

### DIFF
--- a/sdk/keyvault/azure-keyvault-keys/assets.json
+++ b/sdk/keyvault/azure-keyvault-keys/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "python",
   "TagPrefix": "python/keyvault/azure-keyvault-keys",
-  "Tag": "python/keyvault/azure-keyvault-keys_bba04d2efa"
+  "Tag": "python/keyvault/azure-keyvault-keys_6a80b2f740"
 }

--- a/sdk/keyvault/azure-keyvault-keys/assets.json
+++ b/sdk/keyvault/azure-keyvault-keys/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "python",
   "TagPrefix": "python/keyvault/azure-keyvault-keys",
-  "Tag": "python/keyvault/azure-keyvault-keys_d3b8eaba1a"
+  "Tag": "python/keyvault/azure-keyvault-keys_bba04d2efa"
 }

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_models.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_models.py
@@ -64,10 +64,10 @@ class KeyProperties(object):
 
     :keyword bool managed: Whether the key's lifetime is managed by Key Vault.
     :keyword tags: Application specific metadata in the form of key-value pairs.
-    :paramtype tags: dict[str, str]
+    :paramtype tags: dict[str, str] or None
     :keyword release_policy: The azure.keyvault.keys.KeyReleasePolicy specifying the rules under which the key
         can be exported.
-    :paramtype release_policy: ~azure.keyvault.keys.KeyReleasePolicy
+    :paramtype release_policy: ~azure.keyvault.keys.KeyReleasePolicy or None
     """
 
     def __init__(self, key_id: str, attributes: "Optional[_models.KeyAttributes]" = None, **kwargs: Any) -> None:
@@ -287,6 +287,8 @@ class KeyReleasePolicy(object):
 
 class ReleaseKeyResult(object):
     """The result of a key release operation.
+
+    :ivar str value: A signed token containing the released key.
 
     :param str value: A signed token containing the released key.
     """

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_models.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_models.py
@@ -299,8 +299,6 @@ class KeyVaultRSAPublicKey(RSAPublicKey):
         :returns: True if the objects are equal; False if the objects are unequal or if key material can't be obtained
             from Key Vault for comparison.
         :rtype: bool
-
-        :raises ValueError: if the client is unable to obtain the key material from Key Vault.
         """
         if self._key is None:
             return False

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_models.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_models.py
@@ -269,12 +269,11 @@ class KeyVaultRSAPublicKey(RSAPublicKey):
 
         :returns: The signed data.
         :rtype: bytes
-        :raises:
-            NotImplementedError if the local version of `cryptography` doesn't support this method.
-            :class:`~cryptography.exceptions.InvalidSignature` if the signature is invalid.
-            :class:`~cryptography.exceptions.UnsupportedAlgorithm` if the signature data recovery is not supported with
+        :raises NotImplementedError: if the local version of `cryptography` doesn't support this method.
+        :raises ~cryptography.exceptions.InvalidSignature: if the signature is invalid.
+        :raises ~cryptography.exceptions.UnsupportedAlgorithm: if the signature data recovery is not supported with
             the provided `padding` type.
-            ValueError if the client is unable to obtain the key material from Key Vault.
+        :raises ValueError: if the client is unable to obtain the key material from Key Vault.
         """
         if self._key is None:
             raise ValueError(

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_models.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_models.py
@@ -296,16 +296,14 @@ class KeyVaultRSAPublicKey(RSAPublicKey):
         :param object other: Another object to compare with this instance. Currently, only comparisons with
             `KeyVaultRSAPrivateKey` or `JsonWebKey` instances are supported.
 
-        :returns: True if the objects are equal; False otherwise.
+        :returns: True if the objects are equal; False if the objects are unequal or if key material can't be obtained
+            from Key Vault for comparison.
         :rtype: bool
 
         :raises ValueError: if the client is unable to obtain the key material from Key Vault.
         """
         if self._key is None:
-            raise ValueError(
-                "Key material could not be obtained from Key Vault. Only remote cryptographic operations "
-                "(encrypt, verify) can be performed."
-            )
+            return False
 
         if isinstance(other, KeyVaultRSAPublicKey):
             return all(getattr(self._key, field) == getattr(other._key, field) for field in self._key._FIELDS)

--- a/sdk/keyvault/azure-keyvault-keys/tests/_async_test_case.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/_async_test_case.py
@@ -9,7 +9,6 @@ import pytest
 from azure.core.pipeline import AsyncPipeline
 from azure.core.pipeline.transport import AioHttpTransport, HttpRequest
 from azure.keyvault.keys import KeyReleasePolicy
-from azure.keyvault.keys._shared.client_base import DEFAULT_VERSION, ApiVersion
 from devtools_testutils import AzureRecordedTestCase
 from _test_case import HSM_SUPPORTED_VERSIONS
 
@@ -42,7 +41,7 @@ def get_release_policy(attestation_uri, **kwargs):
 def get_test_parameters(only_hsm=False, only_vault=False, api_versions=None):
     """generates a list of parameter pairs for test case parameterization, where [x, y] = [api_version, is_hsm]"""
     combinations = []
-    versions = api_versions or ApiVersion
+    versions = api_versions or pytest.api_version  # pytest.api_version -> [DEFAULT_VERSION] if live, ApiVersion if not
 
     for api_version in versions:
         if not only_vault and api_version in HSM_SUPPORTED_VERSIONS:
@@ -74,7 +73,7 @@ class AsyncKeysClientPreparer(AzureRecordedTestCase):
     def __call__(self, fn):
         async def _preparer(test_class, api_version, is_hsm, **kwargs):
 
-            self._skip_if_not_configured(api_version, is_hsm)
+            self._skip_if_not_configured(is_hsm)
             if not self.is_logging_enabled:
                 kwargs.update({"logging_enable": False})
             endpoint_url = self.managed_hsm_url if is_hsm else self.vault_url
@@ -98,10 +97,8 @@ class AsyncKeysClientPreparer(AzureRecordedTestCase):
         if self.is_live:
             os.environ["AZURE_TENANT_ID"] = os.environ["KEYVAULT_TENANT_ID"]
             os.environ["AZURE_CLIENT_ID"] = os.environ["KEYVAULT_CLIENT_ID"]
-            os.environ["AZURE_CLIENT_SECRET"] = os.environ["KEYVAULT_CLIENT_SECRET"]
+            os.environ["AZURE_CLIENT_SECRET"] = os.environ.get("KEYVAULT_CLIENT_SECRET", "")  # Empty for user auth
 
-    def _skip_if_not_configured(self, api_version, is_hsm):
-        if self.is_live and api_version != DEFAULT_VERSION:
-            pytest.skip("This test only uses the default API version for live tests")
+    def _skip_if_not_configured(self, is_hsm):
         if self.is_live and is_hsm and self.managed_hsm_url is None:
             pytest.skip("No HSM endpoint for live testing")

--- a/sdk/keyvault/azure-keyvault-keys/tests/_test_case.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/_test_case.py
@@ -9,7 +9,7 @@ import pytest
 from azure.core.pipeline import Pipeline
 from azure.core.pipeline.transport import HttpRequest, RequestsTransport
 from azure.keyvault.keys import KeyReleasePolicy
-from azure.keyvault.keys._shared.client_base import DEFAULT_VERSION, ApiVersion
+from azure.keyvault.keys._shared.client_base import ApiVersion
 from devtools_testutils import AzureRecordedTestCase
 
 
@@ -44,7 +44,7 @@ def get_release_policy(attestation_uri, **kwargs):
 def get_test_parameters(only_hsm=False, only_vault=False, api_versions=None):
     """generates a list of parameter pairs for test case parameterization, where [x, y] = [api_version, is_hsm]"""
     combinations = []
-    versions = api_versions or pytest.api_version
+    versions = api_versions or pytest.api_version  # pytest.api_version -> [DEFAULT_VERSION] if live, ApiVersion if not
 
     for api_version in versions:
         if not only_vault and api_version in HSM_SUPPORTED_VERSIONS:
@@ -79,7 +79,7 @@ class KeysClientPreparer(AzureRecordedTestCase):
     def __call__(self, fn):
         def _preparer(test_class, api_version, is_hsm, **kwargs):
 
-            self._skip_if_not_configured(api_version, is_hsm)
+            self._skip_if_not_configured(is_hsm)
             if not self.is_logging_enabled:
                 kwargs.update({"logging_enable": False})
             endpoint_url = self.managed_hsm_url if is_hsm else self.vault_url
@@ -104,9 +104,6 @@ class KeysClientPreparer(AzureRecordedTestCase):
             os.environ["AZURE_CLIENT_ID"] = os.environ["KEYVAULT_CLIENT_ID"]
             os.environ["AZURE_CLIENT_SECRET"] = os.environ.get("KEYVAULT_CLIENT_SECRET", "")  # Empty for user auth
 
-    def _skip_if_not_configured(self, api_version, is_hsm):
-
-        if self.is_live and api_version != DEFAULT_VERSION:
-            pytest.skip("This test only uses the default API version for live tests")
+    def _skip_if_not_configured(self, is_hsm):
         if self.is_live and is_hsm and self.managed_hsm_url is None:
             pytest.skip("No HSM endpoint for live testing")

--- a/sdk/keyvault/azure-keyvault-keys/tests/_test_case.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/_test_case.py
@@ -102,7 +102,7 @@ class KeysClientPreparer(AzureRecordedTestCase):
         if self.is_live:
             os.environ["AZURE_TENANT_ID"] = os.environ["KEYVAULT_TENANT_ID"]
             os.environ["AZURE_CLIENT_ID"] = os.environ["KEYVAULT_CLIENT_ID"]
-            os.environ["AZURE_CLIENT_SECRET"] = os.environ["KEYVAULT_CLIENT_SECRET"]
+            os.environ["AZURE_CLIENT_SECRET"] = os.environ.get("KEYVAULT_CLIENT_SECRET", "")  # Empty for user auth
 
     def _skip_if_not_configured(self, api_version, is_hsm):
 

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_crypto_client_async.py
@@ -23,7 +23,6 @@ from azure.keyvault.keys.crypto.aio import (
 )
 from azure.keyvault.keys._generated._serialization import Deserializer, Serializer
 from azure.keyvault.keys._generated.models import KeySignParameters
-from azure.mgmt.keyvault.models import KeyPermissions, Permissions
 from devtools_testutils import set_bodiless_matcher
 from devtools_testutils.aio import recorded_by_proxy_async
 
@@ -32,13 +31,10 @@ from _shared.helpers_async import get_completed_future
 from _shared.test_case_async import KeyVaultTestCase
 from _keys_test_case import KeysTestCase
 
-# without keys/get, a CryptographyClient created with a key ID performs all ops remotely
-NO_GET = Permissions(keys=[p.value for p in KeyPermissions if p.value != "get"])
 
 all_api_versions = get_decorator(is_async=True)
 only_hsm = get_decorator(only_hsm=True, is_async=True)
 only_vault_7_4_plus = get_decorator(only_vault=True, is_async=True, api_versions=[ApiVersion.V7_4, ApiVersion.V7_5])
-no_get = get_decorator(is_async=True, permissions=NO_GET)
 
 
 class TestCryptoClient(KeyVaultTestCase, KeysTestCase):
@@ -173,7 +169,7 @@ class TestCryptoClient(KeyVaultTestCase, KeysTestCase):
         await crypto_client.wrap_key(KeyWrapAlgorithm.rsa_oaep, self.plaintext)
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("api_version,is_hsm",no_get)
+    @pytest.mark.parametrize("api_version,is_hsm",all_api_versions)
     @AsyncKeysClientPreparer()
     @recorded_by_proxy_async
     async def test_encrypt_and_decrypt(self, key_client, is_hsm, **kwargs):
@@ -182,6 +178,7 @@ class TestCryptoClient(KeyVaultTestCase, KeysTestCase):
 
         imported_key = await self._import_test_key(key_client, key_name, hardware_protected=is_hsm)
         crypto_client = self.create_crypto_client(imported_key.id, is_async=True, api_version=key_client.api_version)
+        crypto_client._keys_get_forbidden = True  # Prevent caching key material locally, to force remote ops
 
         result = await crypto_client.encrypt(EncryptionAlgorithm.rsa_oaep, self.plaintext)
         assert result.key_id == imported_key.id
@@ -192,7 +189,7 @@ class TestCryptoClient(KeyVaultTestCase, KeysTestCase):
         assert self.plaintext == result.plaintext
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("api_version,is_hsm",no_get)
+    @pytest.mark.parametrize("api_version,is_hsm",all_api_versions)
     @AsyncKeysClientPreparer()
     @recorded_by_proxy_async
     async def test_sign_and_verify(self, key_client, is_hsm, **kwargs):
@@ -204,6 +201,7 @@ class TestCryptoClient(KeyVaultTestCase, KeysTestCase):
 
         imported_key = await self._import_test_key(key_client, key_name, hardware_protected=is_hsm)
         crypto_client = self.create_crypto_client(imported_key.id, is_async=True, api_version=key_client.api_version)
+        crypto_client._keys_get_forbidden = True  # Prevent caching key material locally, to force remote ops
 
         result = await crypto_client.sign(SignatureAlgorithm.rs256, digest)
         assert result.key_id == imported_key.id
@@ -214,7 +212,7 @@ class TestCryptoClient(KeyVaultTestCase, KeysTestCase):
         assert verified.is_valid
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("api_version,is_hsm",no_get)
+    @pytest.mark.parametrize("api_version,is_hsm",all_api_versions)
     @AsyncKeysClientPreparer()
     @recorded_by_proxy_async
     async def test_wrap_and_unwrap(self, key_client, is_hsm, **kwargs):
@@ -224,6 +222,7 @@ class TestCryptoClient(KeyVaultTestCase, KeysTestCase):
         created_key = await self._create_rsa_key(key_client, key_name, hardware_protected=is_hsm)
         assert created_key is not None
         crypto_client = self.create_crypto_client(created_key.id, is_async=True, api_version=key_client.api_version)
+        crypto_client._keys_get_forbidden = True  # Prevent caching key material locally, to force remote ops
 
         # Wrap a key with the created key, then unwrap it. The wrapped key's bytes should round-trip.
         key_bytes = self.plaintext
@@ -543,13 +542,14 @@ class TestCryptoClient(KeyVaultTestCase, KeysTestCase):
             assert result.is_valid
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("api_version,is_hsm",no_get)
+    @pytest.mark.parametrize("api_version,is_hsm",all_api_versions)
     @AsyncKeysClientPreparer()
     @recorded_by_proxy_async
     async def test_local_validity_period_enforcement(self, key_client, is_hsm, **kwargs):
         """Local crypto operations should respect a key's nbf and exp properties"""
         async def test_operations(key, expected_error_substrings, encrypt_algorithms, wrap_algorithms):
             crypto_client = self.create_crypto_client(key, is_async=True, api_version=key_client.api_version)
+            crypto_client._keys_get_forbidden = True  # Prevent caching key material locally, to force remote ops
             for algorithm in encrypt_algorithms:
                 with pytest.raises(ValueError) as ex:
                     await crypto_client.encrypt(algorithm, self.plaintext)

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_models.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_models.py
@@ -24,7 +24,7 @@ class SecretProperties(object):
     :keyword bool managed: True if the secret's lifetime is managed by Key Vault. If this secret is backing a
         certificate, this will be True.
     :keyword tags: Application specific metadata in the form of key-value pairs.
-    :paramtype tags: dict[str, str]
+    :paramtype tags: dict[str, str] or None
     """
 
     def __init__(


### PR DESCRIPTION
# Description

A `KeyVaultRSAPublicKey` or `KeyVaultRSAPrivateKey` can be created with a cryptography client that's not permitted to fetch key material from Key Vault. In this scenario we can still perform crypto operations, and this is likely to be a real use case since these keys were requested for the purpose of offloading key material management to Key Vault.

When these keys don't have local key material, we now raise a `ValueError` for methods that aren't supported; e.g. `private_numbers` or `public_bytes`. Instead of raising on `__eq__`, which could be problematic, we document that equality comparisons will always yield `False` when we don't have key material to compare with.

This also adds docstring documentation that discourages users from creating these key types directly, as they should be initialized with CryptographyClient methods.

To properly test this scenario, I made some fixes to our testing setup to correctly prevent clients from getting key material from KV. Our previous setup was ineffective after we migrated away from management-plane resource preparers.

One final change was to fix type hints for `tags` in KeyProperties and SecretProperties; these should be Optional.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
