### PR TITLE
Update CHANGELOG.md

### DIFF
--- a/sdk/search/azure-search-documents/CHANGELOG.md
+++ b/sdk/search/azure-search-documents/CHANGELOG.md
@@ -75,6 +75,7 @@
 - `query_language` and `query_speller` are not available for `Search` method in this stable release.
 - `alias` operations are not available in this stable release.
 - `AzureOpenAIEmbeddingSkill`, `AzureOpenAIParameters` and `AzureOpenAIVectorizer` are not available in 11.4.0.
+- Renamed `vector_search_profile` to `vector_search_profile_name` in `SearchField`.
 
 ### Other Changes
 

--- a/sdk/search/azure-search-documents/CHANGELOG.md
+++ b/sdk/search/azure-search-documents/CHANGELOG.md
@@ -94,7 +94,7 @@
 
 > These changes do not impact the API of stable versions such as 11.3.0.
 > Only code written against a beta version such as 11.4.0b6 may be affected.
-- Renamed `vector_search_configuration` to `vector_search_profile_name` in `SearchField`.
+- Renamed `vector_search_configuration` to `vector_search_profile` in `SearchField`.
 - Renamed `vectors` to `vector_queries` in `Search` method.
 - Renamed `azure.search.documents.models.Vector` to `azure.search.documents.models.VectorQuery`.
 - Stopped supporting api version `V2023_07_01_PREVIEW` anymore.

--- a/sdk/search/azure-search-documents/CHANGELOG.md
+++ b/sdk/search/azure-search-documents/CHANGELOG.md
@@ -93,7 +93,7 @@
 
 > These changes do not impact the API of stable versions such as 11.3.0.
 > Only code written against a beta version such as 11.4.0b6 may be affected.
-- Renamed `vector_search_configuration` to `vector_search_profile` in `SearchField`.
+- Renamed `vector_search_configuration` to `vector_search_profile_name` in `SearchField`.
 - Renamed `vectors` to `vector_queries` in `Search` method.
 - Renamed `azure.search.documents.models.Vector` to `azure.search.documents.models.VectorQuery`.
 - Stopped supporting api version `V2023_07_01_PREVIEW` anymore.


### PR DESCRIPTION
It looks like this was renamed to vector_search_profile_name

 https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/search/azure-search-documents/azure/search/documents/indexes/models/_index.py#L154