### PR TITLE
[ServiceBus/EventHubs] change invalid link error to warning log

### DIFF
--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_session_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_session_async.py
@@ -204,7 +204,7 @@ class Session(object):  # pylint: disable=too-many-instance-attributes
             self._input_handles[frame[1]] = new_link
         except ValueError as e:
             # Reject Link
-            _LOGGER.warning(
+            _LOGGER.debug(
                     "Unable to attach new link: %r",
                     e,
                     extra=self.network_trace_params

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_session_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_session_async.py
@@ -204,7 +204,7 @@ class Session(object):  # pylint: disable=too-many-instance-attributes
             self._input_handles[frame[1]] = new_link
         except ValueError as e:
             # Reject Link
-            _LOGGER.error(
+            _LOGGER.warning(
                     "Unable to attach new link: %r",
                     e,
                     extra=self.network_trace_params

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/session.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/session.py
@@ -230,7 +230,7 @@ class Session(object):  # pylint: disable=too-many-instance-attributes
             self._input_handles[frame[1]] = new_link
         except ValueError as e:
             # Reject Link
-            _LOGGER.warning(
+            _LOGGER.debug(
                     "Unable to attach new link: %r",
                     e,
                     extra=self.network_trace_params

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/session.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/session.py
@@ -230,7 +230,7 @@ class Session(object):  # pylint: disable=too-many-instance-attributes
             self._input_handles[frame[1]] = new_link
         except ValueError as e:
             # Reject Link
-            _LOGGER.error(
+            _LOGGER.warning(
                     "Unable to attach new link: %r",
                     e,
                     extra=self.network_trace_params

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_session_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_session_async.py
@@ -204,7 +204,7 @@ class Session(object):  # pylint: disable=too-many-instance-attributes
             self._input_handles[frame[1]] = new_link
         except ValueError as e:
             # Reject Link
-            _LOGGER.warning(
+            _LOGGER.debug(
                     "Unable to attach new link: %r",
                     e,
                     extra=self.network_trace_params

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_session_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_session_async.py
@@ -204,7 +204,7 @@ class Session(object):  # pylint: disable=too-many-instance-attributes
             self._input_handles[frame[1]] = new_link
         except ValueError as e:
             # Reject Link
-            _LOGGER.error(
+            _LOGGER.warning(
                     "Unable to attach new link: %r",
                     e,
                     extra=self.network_trace_params

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/session.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/session.py
@@ -230,7 +230,7 @@ class Session(object):  # pylint: disable=too-many-instance-attributes
             self._input_handles[frame[1]] = new_link
         except ValueError as e:
             # Reject Link
-            _LOGGER.warning(
+            _LOGGER.debug(
                     "Unable to attach new link: %r",
                     e,
                     extra=self.network_trace_params

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/session.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/session.py
@@ -230,7 +230,7 @@ class Session(object):  # pylint: disable=too-many-instance-attributes
             self._input_handles[frame[1]] = new_link
         except ValueError as e:
             # Reject Link
-            _LOGGER.error(
+            _LOGGER.warning(
                     "Unable to attach new link: %r",
                     e,
                     extra=self.network_trace_params


### PR DESCRIPTION
Changing the noisy error log to warning, from various issues such as #34212 