### PR TITLE
[Opentelemetry] Fix link to renamed sample

### DIFF
--- a/sdk/monitor/azure-monitor-opentelemetry/samples/README.md
+++ b/sdk/monitor/azure-monitor-opentelemetry/samples/README.md
@@ -32,7 +32,7 @@ For guidance on the samples README, visit the [sample guide](https://github.com/
 |[tracing/http_urllib.py][http_urllib] | Instrument the URLLib library |
 |[tracing/http_urllib3.py][http_urllib3] | Instrument the URLLib library |
 |[tracing/instrumentation_options.py][instrumentation_options] | Enable and disable instrumentations |
-|[tracing/manual.py][manual] | Manually add instrumentation |
+|[tracing/manually_instrumented.py][manual] | Manually add instrumentation |
 |[tracing/sampling.py][sampling] | Sample distributed tracing telemetry |
 |[tracing/tracing_simple.py][tracing_simple] | Produce manual spans |
 
@@ -76,7 +76,7 @@ To learn more, see the [Azure Monitor OpenTelemetry Distro documentation][distro
 [http_urllib]: https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/monitor/azure-monitor-opentelemetry/samples/tracing/http_urllib.py
 [http_urllib3]: https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/monitor/azure-monitor-opentelemetry/samples/tracing/http_urllib3.py
 [instrumentation_options]: https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/monitor/azure-monitor-opentelemetry/samples/tracing/instrumentation_options.py
-[manual]: https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/monitor/azure-monitor-opentelemetry/samples/tracing/manual.py
+[manual]: https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/monitor/azure-monitor-opentelemetry/samples/tracing/manually_instrumented.py
 [sampling]: https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/monitor/azure-monitor-opentelemetry/samples/tracing/sampling.py
 [tracing_simple]: https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/monitor/azure-monitor-opentelemetry/samples/tracing/simple.py
 [pip]: https://pypi.org/project/pip/


### PR DESCRIPTION
# Description

Resolves nightly link check failures that appeared last night, after a sample file was renamed: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3501030&view=logs&j=09cf8b18-32ff-5ace-942c-480825d4e4bd&t=038ef773-2c87-526e-5636-46093602ba59

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
