### PR TITLE
[Key Vault] Remove `x509_thumbprint_string` property

### DIFF
--- a/sdk/keyvault/azure-keyvault-certificates/CHANGELOG.md
+++ b/sdk/keyvault/azure-keyvault-certificates/CHANGELOG.md
@@ -6,6 +6,9 @@
 - Added support for service API version `7.5`
 
 ### Breaking Changes
+> These changes do not impact the API of stable versions such as 4.7.0. Only code written against a beta version such as 4.8.0b2 may be affected.
+- Removed `CertificateProperties.x509_thumbprint_string`. To get the certificate's thumbprint in hex, use
+  `CertificateProperties.x509_thumbprint.hex()` or print the `CertificateProperties` instance.
 
 ### Bugs Fixed
 

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_models.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_models.py
@@ -144,7 +144,7 @@ class CertificateProperties(object):
         self._tags = kwargs.pop("tags", None)
 
     def __repr__(self) -> str:
-        return f"<CertificateProperties [{self.id}]>"[:1024]
+        return f"<CertificateProperties [{self._x509_thumbprint.hex().upper()}]>"[:1024]
 
     @classmethod
     def _from_certificate_item(
@@ -254,21 +254,12 @@ class CertificateProperties(object):
     def x509_thumbprint(self) -> bytes:
         """The certificate's thumbprint, in bytes.
 
+        To get the thumbprint as a hexadecimal string, call ``.hex()`` on this property.
+
         :return: The certificate's thumbprint, in bytes.
         :rtype: bytes
         """
         return self._x509_thumbprint
-
-    @property
-    def x509_thumbprint_string(self) -> str:
-        """The certificate's thumbprint, as a hexadecimal string.
-
-        The thumbprint is formatted without colon delimiters; e.g. 76E1819FADF06A55EF4B126A2EF743C2BAE8A151.
-
-        :return: The certificate's thumbprint, as a hexadecimal string.
-        :rtype: str
-        """
-        return self._x509_thumbprint.hex().upper()
 
     @property
     def tags(self) -> Optional[Dict[str, str]]:

--- a/sdk/keyvault/azure-keyvault-certificates/tests/test_certificates_client.py
+++ b/sdk/keyvault/azure-keyvault-certificates/tests/test_certificates_client.py
@@ -774,9 +774,9 @@ def test_case_insensitive_key_type():
 
 
 def test_thumbprint_hex():
-    """Ensure the `CertificateProperties.x509_thumbprint_string` property correctly converts a thumbprint to hex."""
+    """Ensure `CertificateProperties.__repr__()` correctly displays the cert's thumbprint as hex."""
     properties = CertificateProperties(
         cert_id="https://vaultname.vault.azure.net/certificates/certname/version",
         x509_thumbprint=b"v\xe1\x81\x9f\xad\xf0jU\xefK\x12j.\xf7C\xc2\xba\xe8\xa1Q",
     )
-    assert properties.x509_thumbprint_string == "76E1819FADF06A55EF4B126A2EF743C2BAE8A151"
+    assert "76E1819FADF06A55EF4B126A2EF743C2BAE8A151" in str(properties)


### PR DESCRIPTION
# Description

Since the property was redundant (calling `.hex()` on `x509_thumbprint` is trivial), this PR removes the property and advises on how to manually produce the value using `x509_thumbprint`. It also adds the hex thumbprint to `CertificateProperties.__repr__` to make it easy to manually compare certificates.

The thumbprint replaces the certificate ID in `__repr__` since the ID is already included in `KeyVaultCertificate.__repr__`.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
