### PR TITLE
Fix incorrect repo source link

### DIFF
--- a/sdk/ai/azure-ai-generative/setup.py
+++ b/sdk/ai/azure-ai-generative/setup.py
@@ -135,6 +135,6 @@ setup(
     },
     project_urls={
         "Bug Reports": "https://github.com/Azure/azure-sdk-for-python/issues",
-        "Source": "https://github.com/Azure/azure-sdk-python",
+        "Source": "https://github.com/Azure/azure-sdk-for-python",
     },
 )

--- a/sdk/ai/azure-ai-resources/setup.py
+++ b/sdk/ai/azure-ai-resources/setup.py
@@ -74,7 +74,7 @@ setup(
     ],
     project_urls={
         "Bug Reports": "https://github.com/Azure/azure-sdk-for-python/issues",
-        "Source": "https://github.com/Azure/azure-sdk-python",
+        "Source": "https://github.com/Azure/azure-sdk-for-python",
     },
     package_data={
         'azure.ai.resources': ['py.typed', 'azure/ai/resources/_index/_utils/encodings/*'],

--- a/sdk/cognitivelanguage/azure-ai-language-conversations/setup.py
+++ b/sdk/cognitivelanguage/azure-ai-language-conversations/setup.py
@@ -81,6 +81,6 @@ setup(
     ],
     project_urls={
         'Bug Reports': 'https://github.com/Azure/azure-sdk-for-python/issues',
-        'Source': 'https://github.com/Azure/azure-sdk-python',
+        'Source': 'https://github.com/Azure/azure-sdk-for-python',
     }
 )

--- a/sdk/cognitivelanguage/azure-ai-language-questionanswering/setup.py
+++ b/sdk/cognitivelanguage/azure-ai-language-questionanswering/setup.py
@@ -72,6 +72,6 @@ setup(
     ],
     project_urls={
         'Bug Reports': 'https://github.com/Azure/azure-sdk-for-python/issues',
-        'Source': 'https://github.com/Azure/azure-sdk-python',
+        'Source': 'https://github.com/Azure/azure-sdk-for-python',
     }
 )

--- a/sdk/confidentialledger/azure-confidentialledger/setup.py
+++ b/sdk/confidentialledger/azure-confidentialledger/setup.py
@@ -82,6 +82,6 @@ setup(
     ],
     project_urls={
         'Bug Reports': 'https://github.com/Azure/azure-sdk-for-python/issues',
-        'Source': 'https://github.com/Azure/azure-sdk-python',
+        'Source': 'https://github.com/Azure/azure-sdk-for-python',
     }
 )

--- a/sdk/containerregistry/azure-containerregistry/setup.py
+++ b/sdk/containerregistry/azure-containerregistry/setup.py
@@ -61,6 +61,6 @@ setup(
     ],
     project_urls={
         "Bug Reports": "https://github.com/Azure/azure-sdk-for-python/issues",
-        "Source": "https://github.com/Azure/azure-sdk-python",
+        "Source": "https://github.com/Azure/azure-sdk-for-python",
     },
 )

--- a/sdk/eventhub/azure-eventhub-checkpointstoretable/setup.py
+++ b/sdk/eventhub/azure-eventhub-checkpointstoretable/setup.py
@@ -86,6 +86,6 @@ setup(
     },
     project_urls={
         "Bug Reports": "https://github.com/Azure/azure-sdk-for-python/issues",
-        "Source": "https://github.com/Azure/azure-sdk-python",
+        "Source": "https://github.com/Azure/azure-sdk-for-python",
     },
 )

--- a/sdk/mixedreality/azure-mixedreality-authentication/setup.py
+++ b/sdk/mixedreality/azure-mixedreality-authentication/setup.py
@@ -71,6 +71,6 @@ setup(
     ],
     project_urls={
         'Bug Reports': 'https://github.com/Azure/azure-sdk-for-python/issues',
-        'Source': 'https://github.com/Azure/azure-sdk-python',
+        'Source': 'https://github.com/Azure/azure-sdk-for-python',
     }
 )

--- a/sdk/ml/azure-ai-ml/setup.py
+++ b/sdk/ml/azure-ai-ml/setup.py
@@ -103,6 +103,6 @@ setup(
     },
     project_urls={
         "Bug Reports": "https://github.com/Azure/azure-sdk-for-python/issues",
-        "Source": "https://github.com/Azure/azure-sdk-python",
+        "Source": "https://github.com/Azure/azure-sdk-for-python",
     },
 )

--- a/sdk/openai/azure-openai/setup.py
+++ b/sdk/openai/azure-openai/setup.py
@@ -67,6 +67,6 @@ setup(
     python_requires=">=3.7",
     project_urls={
         "Bug Reports": "https://github.com/Azure/azure-sdk-for-python/issues",
-        "Source": "https://github.com/Azure/azure-sdk-python",
+        "Source": "https://github.com/Azure/azure-sdk-for-python",
     },
 )

--- a/sdk/personalizer/azure-ai-personalizer/setup.py
+++ b/sdk/personalizer/azure-ai-personalizer/setup.py
@@ -75,6 +75,6 @@ setup(
     python_requires=">=3.7",
     project_urls={
         "Bug Reports": "https://github.com/Azure/azure-sdk-for-python/issues",
-        "Source": "https://github.com/Azure/azure-sdk-python",
+        "Source": "https://github.com/Azure/azure-sdk-for-python",
     },
 )

--- a/sdk/remoterendering/azure-mixedreality-remoterendering/setup.py
+++ b/sdk/remoterendering/azure-mixedreality-remoterendering/setup.py
@@ -69,6 +69,6 @@ setup(
     ],
     project_urls={
         'Bug Reports': 'https://github.com/Azure/azure-sdk-for-python/issues',
-        'Source': 'https://github.com/Azure/azure-sdk-python',
+        'Source': 'https://github.com/Azure/azure-sdk-for-python',
     }
 )

--- a/sdk/template/azure-template/setup.py
+++ b/sdk/template/azure-template/setup.py
@@ -80,6 +80,6 @@ setup(
     python_requires=">=3.7",
     project_urls={
         "Bug Reports": "https://github.com/Azure/azure-sdk-for-python/issues",
-        "Source": "https://github.com/Azure/azure-sdk-python",
+        "Source": "https://github.com/Azure/azure-sdk-for-python",
     },
 )

--- a/sdk/translation/azure-ai-translation-document/setup.py
+++ b/sdk/translation/azure-ai-translation-document/setup.py
@@ -61,6 +61,6 @@ setup(
     ],
     project_urls={
         'Bug Reports': 'https://github.com/Azure/azure-sdk-for-python/issues',
-        'Source': 'https://github.com/Azure/azure-sdk-python',
+        'Source': 'https://github.com/Azure/azure-sdk-for-python',
     }
 )

--- a/tools/azure-sdk-tools/tests/integration/scenarios/optional_environment_two_options/setup.py
+++ b/tools/azure-sdk-tools/tests/integration/scenarios/optional_environment_two_options/setup.py
@@ -73,6 +73,6 @@ setup(
     python_requires=">=3.7",
     project_urls={
         "Bug Reports": "https://github.com/Azure/azure-sdk-for-python/issues",
-        "Source": "https://github.com/Azure/azure-sdk-python",
+        "Source": "https://github.com/Azure/azure-sdk-for-python",
     },
 )

--- a/tools/azure-sdk-tools/tests/integration/scenarios/optional_environment_zero_options/setup.py
+++ b/tools/azure-sdk-tools/tests/integration/scenarios/optional_environment_zero_options/setup.py
@@ -73,6 +73,6 @@ setup(
     python_requires=">=3.7",
     project_urls={
         "Bug Reports": "https://github.com/Azure/azure-sdk-for-python/issues",
-        "Source": "https://github.com/Azure/azure-sdk-python",
+        "Source": "https://github.com/Azure/azure-sdk-for-python",
     },
 )


### PR DESCRIPTION
# Description

Resolves https://github.com/Azure/azure-sdk-for-python/issues/34174. Our package template's `setup.py` incorrectly links to https://github.com/Azure/azure-sdk-python as the source repo instead of https://github.com/Azure/azure-sdk-for-python, which led to a number of packages including the mistake.

The CI failures in Mixed Reality are pre-existing and unrelated.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
