### PR TITLE
[corehttp] Misc updates to sync with azure-core

### DIFF
--- a/sdk/core/corehttp/corehttp/credentials.py
+++ b/sdk/core/corehttp/corehttp/credentials.py
@@ -4,7 +4,6 @@
 # license information.
 # -------------------------------------------------------------------------
 from __future__ import annotations
-from collections import namedtuple
 from types import TracebackType
 from typing import Any, NamedTuple, Optional, AsyncContextManager, Type
 from typing_extensions import Protocol, runtime_checkable
@@ -40,7 +39,12 @@ class TokenCredential(Protocol):
         ...
 
 
-ServiceNamedKey = namedtuple("ServiceNamedKey", ["name", "key"])
+class ServiceNamedKey(NamedTuple):
+    """Represents a name and key pair."""
+
+    name: str
+    key: str
+
 
 __all__ = [
     "AccessToken",

--- a/sdk/core/corehttp/corehttp/runtime/_base.py
+++ b/sdk/core/corehttp/corehttp/runtime/_base.py
@@ -23,11 +23,11 @@
 # IN THE SOFTWARE.
 #
 # --------------------------------------------------------------------------
-from typing import Any
+from typing import Any, Dict
 from urllib.parse import urlparse
 
 
-def _format_url_section(template, **kwargs):
+def _format_url_section(template, **kwargs: Dict[str, str]) -> str:
     """String format the template with the kwargs, auto-skip sections of the template that are NOT in the kwargs.
 
     By default in Python, "format" will raise a KeyError if a template element is not found. Here the section between
@@ -53,6 +53,7 @@ def _format_url_section(template, **kwargs):
                     f"The value provided for the url part '{template}' was incorrect, and resulted in an invalid url"
                 ) from key
             last_template = template
+    return last_template
 
 
 def _urljoin(base_url: str, stub_url: str) -> str:
@@ -71,7 +72,7 @@ def _urljoin(base_url: str, stub_url: str) -> str:
     stub_url_path = split_url.pop(0)
     stub_url_query = split_url.pop() if split_url else None
 
-    # Note that _replace is a public API named that way to avoid to avoid conflicts in namedtuple
+    # Note that _replace is a public API named that way to avoid conflicts in namedtuple
     # https://docs.python.org/3/library/collections.html?highlight=namedtuple#collections.namedtuple
     parsed_base_url = parsed_base_url._replace(
         path=parsed_base_url.path.rstrip("/") + "/" + stub_url_path,

--- a/sdk/core/corehttp/corehttp/runtime/policies/_authentication_async.py
+++ b/sdk/core/corehttp/corehttp/runtime/policies/_authentication_async.py
@@ -4,7 +4,6 @@
 # license information.
 # -------------------------------------------------------------------------
 from __future__ import annotations
-import asyncio
 import time
 from typing import TYPE_CHECKING, Any, Awaitable, Optional, cast, TypeVar
 
@@ -14,6 +13,7 @@ from ..pipeline._tools_async import await_result
 from ._base_async import AsyncHTTPPolicy
 from ._authentication import _BearerTokenCredentialPolicyBase
 from ...rest import AsyncHttpResponse, HttpRequest
+from ...utils._utils import get_running_async_lock
 
 if TYPE_CHECKING:
     from ...credentials import AsyncTokenCredential
@@ -36,9 +36,15 @@ class AsyncBearerTokenCredentialPolicy(AsyncHTTPPolicy[HTTPRequestType, AsyncHTT
     ) -> None:
         super().__init__()
         self._credential = credential
-        self._lock = asyncio.Lock()
+        self._lock_instance = None
         self._scopes = scopes
         self._token: Optional["AccessToken"] = None
+
+    @property
+    def _lock(self):
+        if self._lock_instance is None:
+            self._lock_instance = get_running_async_lock()
+        return self._lock_instance
 
     async def on_request(self, request: PipelineRequest[HTTPRequestType]) -> None:
         """Adds a bearer token Authorization header to request and sends request to next policy.

--- a/sdk/core/corehttp/corehttp/runtime/policies/_universal.py
+++ b/sdk/core/corehttp/corehttp/runtime/policies/_universal.py
@@ -35,7 +35,7 @@ import platform
 import xml.etree.ElementTree as ET
 import types
 import re
-from typing import IO, cast, Union, Optional, AnyStr, Dict, Any, Mapping, TYPE_CHECKING
+from typing import IO, cast, Union, Optional, AnyStr, Dict, Any, MutableMapping, TYPE_CHECKING
 
 from ... import __version__ as core_version
 from ...exceptions import DecodeError
@@ -449,12 +449,12 @@ class ProxyPolicy(SansIOHTTPPolicy[HTTPRequestType, HTTPResponseType]):
     Dictionary mapping protocol or protocol and host to the URL of the proxy
     to be used on each Request.
 
-    :param dict proxies: Maps protocol or protocol and hostname to the URL
+    :param MutableMapping proxies: Maps protocol or protocol and hostname to the URL
      of the proxy.
     """
 
     def __init__(
-        self, proxies: Optional[Mapping[str, str]] = None, **kwargs: Any
+        self, proxies: Optional[MutableMapping[str, str]] = None, **kwargs: Any
     ):  # pylint: disable=unused-argument,super-init-not-called
         self.proxies = proxies
 

--- a/sdk/core/corehttp/corehttp/transport/requests/_bigger_block_size_http_adapters.py
+++ b/sdk/core/corehttp/corehttp/transport/requests/_bigger_block_size_http_adapters.py
@@ -25,18 +25,21 @@
 # --------------------------------------------------------------------------
 
 import sys
+from typing import MutableMapping, Optional
+
 from requests.adapters import HTTPAdapter  # pylint: disable=all
+from urllib3.connectionpool import ConnectionPool
 
 
 class BiggerBlockSizeHTTPAdapter(HTTPAdapter):
-    def get_connection(self, url, proxies=None):
+    def get_connection(self, url: str, proxies: Optional[MutableMapping[str, str]] = None) -> ConnectionPool:
         """Returns a urllib3 connection for the given URL. This should not be
         called from user code, and is only exposed for use when subclassing the
         :class:`HTTPAdapter <requests.adapters.HTTPAdapter>`.
 
         :param str url: The URL to connect to.
         :param dict proxies: (optional) A Requests-style dictionary of proxies used on this request.
-        :rtype: urllib3.ConnectionPool
+        :rtype: urllib3.connectionpool.ConnectionPool
         :returns: The urllib3 ConnectionPool for the given URL.
         """
         conn = super(BiggerBlockSizeHTTPAdapter, self).get_connection(url, proxies)

--- a/sdk/core/corehttp/corehttp/utils/_utils.py
+++ b/sdk/core/corehttp/corehttp/utils/_utils.py
@@ -7,6 +7,7 @@
 import datetime
 from typing import (
     Any,
+    AsyncContextManager,
     Iterable,
     Iterator,
     Mapping,
@@ -164,3 +165,21 @@ def get_file_items(files: "FilesType") -> Sequence[Tuple[str, "FileType"]]:
         # though realistically it is ordered python 3.7 and after
         return cast(Sequence[Tuple[str, "FileType"]], files.items())
     return files
+
+
+def get_running_async_lock() -> AsyncContextManager:
+    """Get a lock instance from the async library that the current context is running under.
+    :return: An instance of the running async library's Lock class.
+    :rtype: AsyncContextManager
+    :raises: RuntimeError if the current context is not running under an async library.
+    """
+
+    try:
+        import asyncio
+
+        # Check if we are running in an asyncio event loop.
+        asyncio.get_running_loop()
+        return asyncio.Lock()
+    except RuntimeError as err:
+        # Otherwise, assume we are running in a trio event loop, but this currently isn't supported.
+        raise RuntimeError("An asyncio event loop is required.") from err

--- a/sdk/core/corehttp/tests/async_tests/test_authentication_async.py
+++ b/sdk/core/corehttp/tests/async_tests/test_authentication_async.py
@@ -252,3 +252,14 @@ async def test_async_token_credential_inheritance():
 
     cred = TestTokenCredential()
     await cred.get_token("scope")
+
+
+@pytest.mark.asyncio
+async def test_async_token_credential_asyncio_lock():
+    auth_policy = AsyncBearerTokenCredentialPolicy(Mock(), "scope")
+    assert isinstance(auth_policy._lock, asyncio.Lock)
+
+
+def test_async_token_credential_sync():
+    """Verify that AsyncBearerTokenCredentialPolicy can be constructed in a synchronous context."""
+    AsyncBearerTokenCredentialPolicy(Mock(), "scope")

--- a/sdk/core/corehttp/tests/async_tests/test_streaming_async.py
+++ b/sdk/core/corehttp/tests/async_tests/test_streaming_async.py
@@ -3,8 +3,23 @@
 # Licensed under the MIT License. See LICENSE.txt in the project root for
 # license information.
 # -------------------------------------------------------------------------
-import pytest
+"""
+Asynchronous streaming tests.
 
+Test naming convention: test_{1}_{2}
+
+1:
+compress or decompress. Refers to the stream that is returned from the testserver / streams.py
+
+2:
+plain_header - text file with {Content-Type: text/plain} and {Content-Encoding: gzip}
+plain_no_header - text file with {Content-Type: text/plain}
+compressed_no_header - tar.gz file with {Content-Type: application/gzip}
+compressed_header - tar.gz file with {Content-Type: application/gzip} and {Content-Encoding: gzip}
+"""
+import zlib
+
+import pytest
 from corehttp.rest import HttpRequest
 from corehttp.runtime import AsyncPipelineClient
 from corehttp.exceptions import DecodeError
@@ -12,6 +27,7 @@ from corehttp.exceptions import DecodeError
 from utils import ASYNC_TRANSPORTS
 
 
+@pytest.mark.live_test_only
 @pytest.mark.asyncio
 @pytest.mark.parametrize("transport", ASYNC_TRANSPORTS)
 async def test_decompress_plain_no_header(transport):
@@ -25,13 +41,11 @@ async def test_decompress_plain_no_header(transport):
         pipeline_response = await client.pipeline.run(request, stream=True)
         response = pipeline_response.http_response
         data = response.iter_bytes()
-        content = b""
-        async for d in data:
-            content += d
-        decoded = content.decode("utf-8")
+        decoded = b"".join([d async for d in data]).decode("utf-8")
         assert decoded == "test"
 
 
+@pytest.mark.live_test_only
 @pytest.mark.asyncio
 @pytest.mark.parametrize("transport", ASYNC_TRANSPORTS)
 async def test_compress_plain_no_header(transport):
@@ -45,13 +59,11 @@ async def test_compress_plain_no_header(transport):
         pipeline_response = await client.pipeline.run(request, stream=True)
         response = pipeline_response.http_response
         data = response.iter_raw()
-        content = b""
-        async for d in data:
-            content += d
-        decoded = content.decode("utf-8")
+        decoded = b"".join([d async for d in data]).decode("utf-8")
         assert decoded == "test"
 
 
+@pytest.mark.live_test_only
 @pytest.mark.asyncio
 @pytest.mark.parametrize("transport", ASYNC_TRANSPORTS)
 async def test_decompress_compressed_no_header(transport):
@@ -65,16 +77,12 @@ async def test_decompress_compressed_no_header(transport):
         pipeline_response = await client.pipeline.run(request, stream=True)
         response = pipeline_response.http_response
         data = response.iter_bytes()
-        content = b""
-        async for d in data:
-            content += d
-        try:
+        content = b"".join([d async for d in data])
+        with pytest.raises(UnicodeDecodeError):
             content.decode("utf-8")
-            assert False
-        except UnicodeDecodeError:
-            pass
 
 
+@pytest.mark.live_test_only
 @pytest.mark.asyncio
 @pytest.mark.parametrize("transport", ASYNC_TRANSPORTS)
 async def test_compress_compressed_no_header(transport):
@@ -88,14 +96,25 @@ async def test_compress_compressed_no_header(transport):
         pipeline_response = await client.pipeline.run(request, stream=True)
         response = pipeline_response.http_response
         data = response.iter_raw()
-        content = b""
-        async for d in data:
-            content += d
-        try:
+        content = b"".join([d async for d in data])
+        with pytest.raises(UnicodeDecodeError):
             content.decode("utf-8")
-            assert False
-        except UnicodeDecodeError:
-            pass
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("transport", ASYNC_TRANSPORTS)
+async def test_compress_compressed_no_header_offline(port, transport):
+    # expect compressed text
+    url = "http://localhost:{}/streams/compressed_no_header".format(port)
+    client = AsyncPipelineClient(url, transport=transport())
+    async with client:
+        request = HttpRequest("GET", url)
+        pipeline_response = await client.pipeline.run(request, stream=True)
+        response = pipeline_response.http_response
+        data = response.iter_raw()
+        content = b"".join([d async for d in data])
+        with pytest.raises(UnicodeDecodeError):
+            content.decode("utf-8")
 
 
 @pytest.mark.live_test_only
@@ -103,8 +122,6 @@ async def test_compress_compressed_no_header(transport):
 @pytest.mark.parametrize("transport", ASYNC_TRANSPORTS)
 async def test_decompress_plain_header(transport):
     # expect error
-    import zlib
-
     account_name = "coretests"
     account_url = "https://{}.blob.core.windows.net".format(account_name)
     url = "https://{}.blob.core.windows.net/tests/test_with_header.txt".format(account_name)
@@ -114,15 +131,11 @@ async def test_decompress_plain_header(transport):
         pipeline_response = await client.pipeline.run(request, stream=True)
         response = pipeline_response.http_response
         data = response.iter_bytes()
-        try:
-            content = b""
-            async for d in data:
-                content += d
-            assert False
-        except (zlib.error, DecodeError):
-            pass
+        with pytest.raises((zlib.error, DecodeError)):
+            b"".join([d async for d in data])
 
 
+@pytest.mark.live_test_only
 @pytest.mark.asyncio
 @pytest.mark.parametrize("transport", ASYNC_TRANSPORTS)
 async def test_compress_plain_header(transport):
@@ -136,13 +149,11 @@ async def test_compress_plain_header(transport):
         pipeline_response = await client.pipeline.run(request, stream=True)
         response = pipeline_response.http_response
         data = response.iter_raw()
-        content = b""
-        async for d in data:
-            content += d
-        decoded = content.decode("utf-8")
+        decoded = b"".join([d async for d in data]).decode("utf-8")
         assert decoded == "test"
 
 
+@pytest.mark.live_test_only
 @pytest.mark.asyncio
 @pytest.mark.parametrize("transport", ASYNC_TRANSPORTS)
 async def test_decompress_compressed_header(transport):
@@ -156,10 +167,7 @@ async def test_decompress_compressed_header(transport):
         pipeline_response = await client.pipeline.run(request, stream=True)
         response = pipeline_response.http_response
         data = response.iter_bytes()
-        content = b""
-        async for d in data:
-            content += d
-        decoded = content.decode("utf-8")
+        decoded = b"".join([d async for d in data]).decode("utf-8")
         assert decoded == "test"
 
 
@@ -177,11 +185,112 @@ async def test_compress_compressed_header(transport):
         pipeline_response = await client.pipeline.run(request, stream=True)
         response = pipeline_response.http_response
         data = response.iter_raw()
-        content = b""
-        async for d in data:
-            content += d
-        try:
+        content = b"".join([d async for d in data])
+        with pytest.raises(UnicodeDecodeError):
             content.decode("utf-8")
-            assert False
-        except UnicodeDecodeError:
-            pass
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("transport", ASYNC_TRANSPORTS)
+async def test_decompress_plain_no_header_offline(port, transport):
+    # expect plain text
+    url = "http://localhost:{}/streams/string".format(port)
+    client = AsyncPipelineClient(url, transport=transport())
+    async with client:
+        request = HttpRequest("GET", url)
+        pipeline_response = await client.pipeline.run(request, stream=True)
+        response = pipeline_response.http_response
+        data = response.iter_bytes()
+        decoded = b"".join([d async for d in data]).decode("utf-8")
+        assert decoded == "test"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("transport", ASYNC_TRANSPORTS)
+async def test_compress_plain_header_offline(port, transport):
+    # expect plain text
+    url = "http://localhost:{}/streams/plain_header".format(port)
+    client = AsyncPipelineClient(url, transport=transport())
+    async with client:
+        request = HttpRequest("GET", url)
+        pipeline_response = await client.pipeline.run(request, stream=True)
+        response = pipeline_response.http_response
+        data = response.iter_raw()
+        decoded = b"".join([d async for d in data]).decode("utf-8")
+        assert decoded == "test"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("transport", ASYNC_TRANSPORTS)
+async def test_decompress_compressed_no_header_offline(port, transport):
+    # expect compressed text
+    url = "http://localhost:{}/streams/compressed_no_header".format(port)
+    client = AsyncPipelineClient(url, transport=transport())
+    async with client:
+        request = HttpRequest("GET", url)
+        pipeline_response = await client.pipeline.run(request, stream=True)
+        response = pipeline_response.http_response
+        data = response.iter_bytes()
+        content = b"".join([d async for d in data])
+        with pytest.raises(UnicodeDecodeError):
+            content.decode("utf-8")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("transport", ASYNC_TRANSPORTS)
+async def test_compress_compressed_header_offline(port, transport):
+    # expect compressed text
+    url = "http://localhost:{}/streams/compressed_header".format(port)
+    client = AsyncPipelineClient(url, transport=transport())
+    async with client:
+        request = HttpRequest("GET", url)
+        pipeline_response = await client.pipeline.run(request, stream=True)
+        response = pipeline_response.http_response
+        data = response.iter_raw()
+        content = b"".join([d async for d in data])
+        with pytest.raises(UnicodeDecodeError):
+            content.decode("utf-8")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("transport", ASYNC_TRANSPORTS)
+async def test_decompress_plain_header_offline(port, transport):
+    # expect error
+    url = "http://localhost:{}/streams/compressed".format(port)
+    client = AsyncPipelineClient(url, transport=transport())
+    async with client:
+        request = HttpRequest("GET", url)
+        pipeline_response = await client.pipeline.run(request, stream=True)
+        response = pipeline_response.http_response
+        data = response.iter_bytes()
+        with pytest.raises((zlib.error, DecodeError)):
+            b"".join([d async for d in data])
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("transport", ASYNC_TRANSPORTS)
+async def test_compress_plain_no_header_offline(port, transport):
+    url = "http://localhost:{}/streams/string".format(port)
+    client = AsyncPipelineClient(url, transport=transport())
+    async with client:
+        request = HttpRequest("GET", url)
+        pipeline_response = await client.pipeline.run(request, stream=True)
+        response = pipeline_response.http_response
+        data = response.iter_raw()
+        decoded = b"".join([d async for d in data]).decode("utf-8")
+        assert decoded == "test"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("transport", ASYNC_TRANSPORTS)
+async def test_decompress_compressed_header_offline(port, transport):
+    # expect compressed text
+    url = "http://localhost:{}/streams/decompress_header".format(port)
+    client = AsyncPipelineClient(url, transport=transport())
+    async with client:
+        request = HttpRequest("GET", url)
+        pipeline_response = await client.pipeline.run(request, stream=True)
+        response = pipeline_response.http_response
+        data = response.iter_bytes()
+        decoded = b"".join([d async for d in data]).decode("utf-8")
+        assert decoded == "test"

--- a/sdk/core/corehttp/tests/test_utils.py
+++ b/sdk/core/corehttp/tests/test_utils.py
@@ -2,8 +2,12 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
+import sys
+from unittest.mock import patch
+
 import pytest
 from corehttp.utils import case_insensitive_dict
+from corehttp.utils._utils import get_running_async_lock
 
 
 @pytest.fixture()
@@ -108,3 +112,15 @@ def test_case_iter():
 
     for key in my_dict:
         assert key in keys
+
+
+@pytest.mark.asyncio
+async def test_get_running_async_module_asyncio():
+    import asyncio
+
+    assert isinstance(get_running_async_lock(), asyncio.Lock)
+
+
+def test_get_running_async_module_sync():
+    with pytest.raises(RuntimeError):
+        get_running_async_lock()

--- a/sdk/core/corehttp/tests/testserver_tests/coretestserver/coretestserver/test_routes/streams.py
+++ b/sdk/core/corehttp/tests/testserver_tests/coretestserver/coretestserver/test_routes/streams.py
@@ -58,9 +58,19 @@ def string():
     return Response(streaming_test(), status=200, mimetype="text/plain")
 
 
+@streams_api.route("/plain_header", methods=["GET"])
+def plain_header():
+    return Response(streaming_test(), status=200, mimetype="text/plain", headers={"Content-Encoding": "gzip"})
+
+
 @streams_api.route("/compressed_no_header", methods=["GET"])
 def compressed_no_header():
     return Response(compressed_stream(), status=300)
+
+
+@streams_api.route("/compressed_header", methods=["GET"])
+def compressed_header():
+    return Response(compressed_stream(), status=200, headers={"Content-Encoding": "gzip"})
 
 
 @streams_api.route("/compressed", methods=["GET"])


### PR DESCRIPTION
These updates are similar updates that were made to azure-core previously.

- Changed `ServiceNamedKey` to be a class instead of a namedtuple to fix a verifytypes issue.
- Typing/linting updates.
- Async auth policy lock refactoring.
- Refactored streaming tests to remove requirement on external endpoint.