### PR TITLE
Add `application.ver` to Part A fields for exporter

### DIFF
--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Add device.* to part A fields
     ([#34229](https://github.com/Azure/azure-sdk-for-python/pull/34229))
+- Add application.ver to part A fields
+    ([#34229](https://github.com/Azure/azure-sdk-for-python/pull/34229))
 
 ### Breaking Changes
 

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Add device.* to part A fields
     ([#34229](https://github.com/Azure/azure-sdk-for-python/pull/34229))
 - Add application.ver to part A fields
-    ([#34229](https://github.com/Azure/azure-sdk-for-python/pull/34229))
+    ([#34401](https://github.com/Azure/azure-sdk-for-python/pull/34401))
 
 ### Breaking Changes
 

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_utils.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_utils.py
@@ -182,6 +182,7 @@ def _populate_part_a_fields(resource: Resource):
         device_id = resource.attributes.get(ResourceAttributes.DEVICE_ID)
         device_model = resource.attributes.get(ResourceAttributes.DEVICE_MODEL_NAME)
         device_make = resource.attributes.get(ResourceAttributes.DEVICE_MANUFACTURER)
+        app_version = resource.attributes.get(ResourceAttributes.SERVICE_VERSION)
         if service_name:
             if service_namespace:
                 tags[ContextTagKeys.AI_CLOUD_ROLE] = str(service_namespace) + \
@@ -199,6 +200,9 @@ def _populate_part_a_fields(resource: Resource):
             tags[ContextTagKeys.AI_DEVICE_MODEL] = device_model # type: ignore
         if device_make:
             tags[ContextTagKeys.AI_DEVICE_OEM_NAME] = device_make # type: ignore
+        if app_version:
+            tags[ContextTagKeys.AI_APPLICATION_VER] = app_version # type: ignore
+        
     return tags
 
 # pylint: disable=W0622

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_utils.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_utils.py
@@ -202,7 +202,7 @@ def _populate_part_a_fields(resource: Resource):
             tags[ContextTagKeys.AI_DEVICE_OEM_NAME] = device_make # type: ignore
         if app_version:
             tags[ContextTagKeys.AI_APPLICATION_VER] = app_version # type: ignore
-        
+
     return tags
 
 # pylint: disable=W0622

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/test_utils.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/test_utils.py
@@ -51,7 +51,10 @@ class TestUtils(unittest.TestCase):
              "service.instance.id": "testServiceInstanceId",
              "device.id": "testDeviceId",
              "device.model.name": "testDeviceModel",
-             "device.manufacturer": "testDeviceMake"})
+             "device.manufacturer": "testDeviceMake",
+             "service.version": "testApplicationVer",
+            }
+        )
         tags = _utils._populate_part_a_fields(resource)
         self.assertIsNotNone(tags)
         self.assertEqual(tags.get("ai.cloud.role"), "testServiceNamespace.testServiceName")
@@ -60,6 +63,7 @@ class TestUtils(unittest.TestCase):
         self.assertEqual(tags.get("ai.device.id"), "testDeviceId")
         self.assertEqual(tags.get("ai.device.model"), "testDeviceModel")
         self.assertEqual(tags.get("ai.device.oemName"), "testDeviceMake")
+        self.assertEqual(tags.get("ai.application.ver"), "testApplicationVer")
 
     def test_populate_part_a_fields_default(self):
         resource = Resource(


### PR DESCRIPTION
From [spec](https://github.com/microsoft/common-schema/pull/428), add `ai.application.ver` to Part A. Populated by `Resource`'s `service.version`.