### PR TITLE
[EventHubs/ServiceBus] update network trace params to use empty strings not None

### DIFF
--- a/sdk/eventhub/azure-eventhub/CHANGELOG.md
+++ b/sdk/eventhub/azure-eventhub/CHANGELOG.md
@@ -10,14 +10,18 @@
 
 ### Other Changes
 
+- Updated network trace logging to replace `None` values in AMQP connection info with empty strings as per the OpenTelemetry specification.
+
 ## 5.11.6 (2024-02-12)
 
 This version and all future versions will require Python 3.8+. Python 3.7 is no longer supported.
 
 ### Features Added
+
 - Added `keep_alive` functionality on EventHubProducerClient to allow for long-living producers. [#33726](https://github.com/Azure/azure-sdk-for-python/issues/33726)
 
 ### Other Changes
+
 - Added support for Python 3.12.
 
 ## 5.11.5 (2023-11-13)

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/_connection.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/_connection.py
@@ -135,7 +135,7 @@ class Connection:  # pylint:disable=too-many-instance-attributes
             custom_endpoint = f"{custom_parsed_url.hostname}:{custom_port}{custom_parsed_url.path}"
         self._container_id = container_id or str(uuid.uuid4())
         self._network_trace = network_trace
-        self._network_trace_params = {"amqpConnection": self._container_id, "amqpSession": None, "amqpLink": None}
+        self._network_trace_params = {"amqpConnection": self._container_id, "amqpSession": "", "amqpLink": ""}
 
         transport = kwargs.get("transport")
         self._transport_type = transport_type

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_cbs_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_cbs_async.py
@@ -63,7 +63,7 @@ class CBSAuthenticator:  # pylint:disable=too-many-instance-attributes, disable=
         self._network_trace_params = {
             "amqpConnection": self._session._connection._container_id,
             "amqpSession": self._session.name,
-            "amqpLink": None
+            "amqpLink": ""
         }
 
         self._token_status_code: Optional[int] = None

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_client_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_client_async.py
@@ -304,8 +304,8 @@ class AMQPClientAsync(AMQPClientSync):
         if self._keep_alive_thread:
             await self._keep_alive_thread
             self._keep_alive_thread = None
-        self._network_trace_params["amqpConnection"] = None
-        self._network_trace_params["amqpSession"] = None
+        self._network_trace_params["amqpConnection"] = ""
+        self._network_trace_params["amqpSession"] = ""
 
     async def auth_complete_async(self):
         """Whether the authentication handshake is complete during

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_connection_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_connection_async.py
@@ -116,7 +116,7 @@ class Connection:  # pylint:disable=too-many-instance-attributes
             custom_endpoint = f"{custom_parsed_url.hostname}:{custom_port}{custom_parsed_url.path}"
         self._container_id: str = container_id or str(uuid.uuid4())
         self._network_trace = network_trace
-        self._network_trace_params = {"amqpConnection": self._container_id, "amqpSession": None, "amqpLink": None}
+        self._network_trace_params = {"amqpConnection": self._container_id, "amqpSession": "", "amqpLink": ""}
 
         transport = kwargs.get("transport")
         self._transport_type = transport_type

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_management_operation_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_management_operation_async.py
@@ -31,7 +31,7 @@ class ManagementOperation(object):
         self._network_trace_params = {
             "amqpConnection": self._session._connection._container_id,
             "amqpSession": self._session.name,
-            "amqpLink": None
+            "amqpLink": ""
         }
         self._mgmt_link: ManagementLink = self._session.create_request_response_link_pair(
             endpoint=endpoint,

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/cbs.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/cbs.py
@@ -81,7 +81,7 @@ class CBSAuthenticator:  # pylint:disable=too-many-instance-attributes, disable=
         self._network_trace_params = {
             "amqpConnection": self._session._connection._container_id,
             "amqpSession": self._session.name,
-            "amqpLink": None
+            "amqpLink": ""
         }
 
         self._token_status_code: Optional[int] = None

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/client.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/client.py
@@ -181,7 +181,7 @@ class AMQPClient(
             "remote_idle_timeout_empty_frame_send_ratio", None
         )
         self._network_trace = kwargs.pop("network_trace", False)
-        self._network_trace_params = {"amqpConnection": None, "amqpSession": None, "amqpLink": None}
+        self._network_trace_params = {"amqpConnection": "", "amqpSession": "", "amqpLink": ""}
 
         # Session settings
         self._outgoing_window = kwargs.pop("outgoing_window", OUTGOING_WINDOW)
@@ -377,8 +377,8 @@ class AMQPClient(
             except RuntimeError:  # Probably thread failed to start in .open()
                 logging.debug("Keep alive thread failed to join.", exc_info=True)
             self._keep_alive_thread = None
-        self._network_trace_params["amqpConnection"] = None
-        self._network_trace_params["amqpSession"] = None
+        self._network_trace_params["amqpConnection"] = ""
+        self._network_trace_params["amqpSession"] = ""
 
     def auth_complete(self):
         """Whether the authentication handshake is complete during

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/management_operation.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/management_operation.py
@@ -31,7 +31,7 @@ class ManagementOperation(object):
         self._network_trace_params = {
             "amqpConnection": self._session._connection._container_id,
             "amqpSession": self._session.name,
-            "amqpLink": None
+            "amqpLink": ""
         }
         self._mgmt_link: ManagementLink = self._session.create_request_response_link_pair(
             endpoint=endpoint,

--- a/sdk/servicebus/azure-servicebus/CHANGELOG.md
+++ b/sdk/servicebus/azure-servicebus/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Other Changes
 
 - Updated minimum `azure-core` version to 1.28.0.
+- Updated network trace logging to replace `None` values in AMQP connection info with empty strings as per the OpenTelemetry specification ([#32190](https://github.com/Azure/azure-sdk-for-python/issues/32190)).
 
 ## 7.11.4 (2023-11-13)
 

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/_connection.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/_connection.py
@@ -135,7 +135,7 @@ class Connection:  # pylint:disable=too-many-instance-attributes
             custom_endpoint = f"{custom_parsed_url.hostname}:{custom_port}{custom_parsed_url.path}"
         self._container_id = container_id or str(uuid.uuid4())
         self._network_trace = network_trace
-        self._network_trace_params = {"amqpConnection": self._container_id, "amqpSession": None, "amqpLink": None}
+        self._network_trace_params = {"amqpConnection": self._container_id, "amqpSession": "", "amqpLink": ""}
 
         transport = kwargs.get("transport")
         self._transport_type = transport_type

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_cbs_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_cbs_async.py
@@ -63,7 +63,7 @@ class CBSAuthenticator:  # pylint:disable=too-many-instance-attributes, disable=
         self._network_trace_params = {
             "amqpConnection": self._session._connection._container_id,
             "amqpSession": self._session.name,
-            "amqpLink": None
+            "amqpLink": ""
         }
 
         self._token_status_code: Optional[int] = None

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_client_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_client_async.py
@@ -304,8 +304,8 @@ class AMQPClientAsync(AMQPClientSync):
         if self._keep_alive_thread:
             await self._keep_alive_thread
             self._keep_alive_thread = None
-        self._network_trace_params["amqpConnection"] = None
-        self._network_trace_params["amqpSession"] = None
+        self._network_trace_params["amqpConnection"] = ""
+        self._network_trace_params["amqpSession"] = ""
 
     async def auth_complete_async(self):
         """Whether the authentication handshake is complete during

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_connection_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_connection_async.py
@@ -116,7 +116,7 @@ class Connection:  # pylint:disable=too-many-instance-attributes
             custom_endpoint = f"{custom_parsed_url.hostname}:{custom_port}{custom_parsed_url.path}"
         self._container_id: str = container_id or str(uuid.uuid4())
         self._network_trace = network_trace
-        self._network_trace_params = {"amqpConnection": self._container_id, "amqpSession": None, "amqpLink": None}
+        self._network_trace_params = {"amqpConnection": self._container_id, "amqpSession": "", "amqpLink": ""}
 
         transport = kwargs.get("transport")
         self._transport_type = transport_type

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_management_operation_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_management_operation_async.py
@@ -31,7 +31,7 @@ class ManagementOperation(object):
         self._network_trace_params = {
             "amqpConnection": self._session._connection._container_id,
             "amqpSession": self._session.name,
-            "amqpLink": None
+            "amqpLink": ""
         }
         self._mgmt_link: ManagementLink = self._session.create_request_response_link_pair(
             endpoint=endpoint,

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/cbs.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/cbs.py
@@ -81,7 +81,7 @@ class CBSAuthenticator:  # pylint:disable=too-many-instance-attributes, disable=
         self._network_trace_params = {
             "amqpConnection": self._session._connection._container_id,
             "amqpSession": self._session.name,
-            "amqpLink": None
+            "amqpLink": ""
         }
 
         self._token_status_code: Optional[int] = None

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/client.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/client.py
@@ -181,7 +181,7 @@ class AMQPClient(
             "remote_idle_timeout_empty_frame_send_ratio", None
         )
         self._network_trace = kwargs.pop("network_trace", False)
-        self._network_trace_params = {"amqpConnection": None, "amqpSession": None, "amqpLink": None}
+        self._network_trace_params = {"amqpConnection": "", "amqpSession": "", "amqpLink": ""}
 
         # Session settings
         self._outgoing_window = kwargs.pop("outgoing_window", OUTGOING_WINDOW)
@@ -377,8 +377,8 @@ class AMQPClient(
             except RuntimeError:  # Probably thread failed to start in .open()
                 logging.debug("Keep alive thread failed to join.", exc_info=True)
             self._keep_alive_thread = None
-        self._network_trace_params["amqpConnection"] = None
-        self._network_trace_params["amqpSession"] = None
+        self._network_trace_params["amqpConnection"] = ""
+        self._network_trace_params["amqpSession"] = ""
 
     def auth_complete(self):
         """Whether the authentication handshake is complete during

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/management_operation.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/management_operation.py
@@ -31,7 +31,7 @@ class ManagementOperation(object):
         self._network_trace_params = {
             "amqpConnection": self._session._connection._container_id,
             "amqpSession": self._session.name,
-            "amqpLink": None
+            "amqpLink": ""
         }
         self._mgmt_link: ManagementLink = self._session.create_request_response_link_pair(
             endpoint=endpoint,


### PR DESCRIPTION
fixes #32190
following #32215

As per the OpenTelemetry spec Attribute Validation, attribute values [cannot be None but can be empty strings](https://github.com/open-telemetry/opentelemetry-specification/tree/main/specification/common#attribute).