### PR TITLE
[EventHubs] remove unused testApplicationSecret from test-resources.json

### DIFF
--- a/sdk/eventhub/test-resources.json
+++ b/sdk/eventhub/test-resources.json
@@ -42,12 +42,6 @@
         "description": "The application client ID used to run tests."
       }
     },
-    "testApplicationSecret": {
-      "type": "string",
-      "metadata": {
-        "description": "The application client secret used to run tests."
-      }
-    },
     "location": {
       "type": "string",
       "defaultValue": "[resourceGroup().location]",

--- a/sdk/servicebus/test-resources.json
+++ b/sdk/servicebus/test-resources.json
@@ -42,12 +42,6 @@
         "description": "The application client ID used to run tests."
       }
     },
-    "testApplicationSecret": {
-      "type": "string",
-      "metadata": {
-        "description": "The application client secret used to run tests."
-      }
-    },
     "location": {
       "type": "string",
       "defaultValue": "[resourceGroup().location]",


### PR DESCRIPTION
Removing the testApplicationSecret parameter from the test-resources.json, so that we are not prompted to pass one in when running the New-TestResources script with -UserAuth. Thanks @mccoyp for the fix!