### PR TITLE
Update the logging level as this is supposed to be a warning

### DIFF
--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/_connection.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/_connection.py
@@ -516,7 +516,7 @@ class Connection:  # pylint:disable=too-many-instance-attributes
             self._error = AMQPConnectionError(
                 condition=frame[0][0], description=frame[0][1], info=frame[0][2]
             )
-            _LOGGER.error(
+            _LOGGER.warning(
                 "Connection closed with error: %r", frame[0],
                 extra=self._network_trace_params
             )

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_connection_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_connection_async.py
@@ -533,7 +533,7 @@ class Connection:  # pylint:disable=too-many-instance-attributes
             self._error = AMQPConnectionError(
                 condition=frame[0][0], description=frame[0][1], info=frame[0][2]
             )
-            _LOGGER.error(
+            _LOGGER.warning(
                 "Connection closed with error: %r", frame[0],
                 extra=self._network_trace_params
             )


### PR DESCRIPTION
# Description

According to [this](https://github.com/Azure/azure-service-bus-java/issues/408), an inactive connection should only raise a warning, not an error level log message. This seems to have been fixed in the Java SDK, but not in the Python SDK.

This PR changes the log level in the corresponding `_connection.py` file to warning.

# All SDK Contribution checklist:
- [X] **The pull request does not introduce [breaking changes]**
- [N/A] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [X] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [X] Title of the pull request is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [N/A] Pull request includes test coverage for the included changes.
