### PR TITLE
[Core] update azure-core auth envvars

### DIFF
--- a/sdk/core/azure-core/tests/perf_tests/_test_base.py
+++ b/sdk/core/azure-core/tests/perf_tests/_test_base.py
@@ -59,9 +59,9 @@ class _ServiceTest(PerfStressTest):
         self.account_key = self.get_from_env("AZURE_STORAGE_ACCOUNT_KEY")
         async_transport_types = {"aiohttp": AioHttpTransport, "requests": AsyncioRequestsTransport}
         sync_transport_types = {"requests": RequestsTransport}
-        self.tenant_id = os.environ["CORE_TENANT_ID"]
-        self.client_id = os.environ["CORE_CLIENT_ID"]
-        self.client_secret = os.environ["CORE_CLIENT_SECRET"]
+        self.tenant_id = os.environ["AZURE-CORE_TENANT_ID"]
+        self.client_id = os.environ["AZURE-CORE_CLIENT_ID"]
+        self.client_secret = os.environ["AZURE-CORE_CLIENT_SECRET"]
         self.storage_scope = "https://storage.azure.com/.default"
 
         # defaults transports


### PR DESCRIPTION
Updating perf test base to use AZURE-CORE* specific environment variables, since perf-resources.bicep has been moved to the azure-core folder from core.