### PR TITLE
fix: correctly initializes the completion time of the copy properties

### DIFF
--- a/sdk/storage/azure-storage-blob/CHANGELOG.md
+++ b/sdk/storage/azure-storage-blob/CHANGELOG.md
@@ -14,6 +14,7 @@ Python 3.12.
 - Fixed an issue where authentication errors could raise `AttributeError` instead of `ClientAuthenticationError` when
 using async OAuth credentials.
 - Fixed an typing issue which incorrectly typed the `readinto` API. The correct input type is `IO[bytes]`.
+- Fixed a typo in the initialization of `completion_time` for the `CopyProperties` model.
 
 ## 12.19.0 (2023-11-07)
 

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_models.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_models.py
@@ -651,7 +651,7 @@ class CopyProperties(DictMixin):
         self.source = kwargs.get('x-ms-copy-source')
         self.status = get_enum_value(kwargs.get('x-ms-copy-status'))
         self.progress = kwargs.get('x-ms-copy-progress')
-        self.completion_time = kwargs.get('x-ms-copy-completion_time')
+        self.completion_time = kwargs.get('x-ms-copy-completion-time')
         self.status_description = kwargs.get('x-ms-copy-status-description')
         self.incremental_copy = kwargs.get('x-ms-incremental-copy')
         self.destination_snapshot = kwargs.get('x-ms-copy-destination-snapshot')


### PR DESCRIPTION
# Description
Corrects initialization of the copy properties completion time attribute. In its current form, the completion time is set to None as the key is using the incorrect keyname.
Please add an informative description that covers that changes made by the pull request and link all relevant issues.

If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
