### PR TITLE
Stop requiring SP credentials when user-based auth is used

### DIFF
--- a/tools/azure-sdk-tools/devtools_testutils/envvariable_loader.py
+++ b/tools/azure-sdk-tools/devtools_testutils/envvariable_loader.py
@@ -13,6 +13,9 @@ from .exceptions import AzureTestError
 from .sanitizers import add_general_string_sanitizer
 
 
+_logger = logging.getLogger(__name__)
+
+
 class EnvironmentVariableLoader(AzureMgmtPreparer):
     def __init__(
         self,
@@ -53,9 +56,34 @@ class EnvironmentVariableLoader(AzureMgmtPreparer):
 
     def _set_mgmt_settings_real_values(self):
         if self.is_live:
-            os.environ["AZURE_TENANT_ID"] = os.environ["{}_TENANT_ID".format(self.directory.upper())]
-            os.environ["AZURE_CLIENT_ID"] = os.environ["{}_CLIENT_ID".format(self.directory.upper())]
-            os.environ["AZURE_CLIENT_SECRET"] = os.environ["{}_CLIENT_SECRET".format(self.directory.upper())]
+            tenant = os.environ.get(f"{self.directory.upper()}_TENANT_ID")
+            client = os.environ.get(f"{self.directory.upper()}_CLIENT_ID")
+            secret = os.environ.get(f"{self.directory.upper()}_CLIENT_SECRET")
+
+            # If the environment variables are not all set, check if user-based authentication is requested
+            if not all(x is not None for x in [tenant, client, secret]):
+                use_pwsh = os.environ.get("AZURE_TEST_USE_PWSH_AUTH", "false")
+                use_cli = os.environ.get("AZURE_TEST_USE_CLI_AUTH", "false")
+                user_auth = use_pwsh.lower() == "true" or use_cli.lower() == "true"
+                if not user_auth:
+                    # All variables are required for service principal authentication
+                    raise AzureTestError(
+                        f"Environment variables for service principal credentials are not all set. "
+                        "Please either set the variables or request user-based authentication by setting "
+                        "'AZURE_TEST_USE_PWSH_AUTH' or 'AZURE_TEST_USE_CLI_AUTH' to 'true'."
+                    )
+
+                _logger.info(
+                    "Environment variables for service principal credentials not set but user-based authentication "
+                    "requested. Setting fake value(s) for missing variable(s)."
+                )
+                tenant = "fake-tenant" if tenant is None else tenant
+                client = "fake-client" if client is None else client
+                secret = "fake-secret" if secret is None else secret
+
+            os.environ["AZURE_TENANT_ID"] = tenant
+            os.environ["AZURE_CLIENT_ID"] = client
+            os.environ["AZURE_CLIENT_SECRET"] = secret
 
     def create_resource(self, name, **kwargs):
         load_dotenv(find_dotenv())
@@ -82,17 +110,18 @@ class EnvironmentVariableLoader(AzureMgmtPreparer):
                                     target=self.real_values[key.lower()],
                                 )
                             except:
-                                logger = logging.getLogger()
-                                logger.info(
+                                _logger.info(
                                     "This test class instance has no scrubber and a sanitizer could not be registered "
-                                    "with the test proxy, so the EnvironmentVariableLoader will not scrub the value of {} in "
-                                    "recordings.".format(key)
+                                    "with the test proxy, so the EnvironmentVariableLoader will not scrub the value of "
+                                    f"{key} in recordings."
                                 )
                     else:
-                        template = 'To pass a live ID you must provide the scrubbed value for recordings to \
-                            prevent secrets from being written to files. {} was not given. For example: \
-                                @EnvironmentVariableLoader("schemaregistry", schemaregistry_endpoint="fake_endpoint.servicebus.windows.net")'
-                        raise AzureTestError(template.format(key))
+                        raise AzureTestError(
+                            'To pass a live ID you must provide the scrubbed value for recordings to prevent secrets '
+                            f'from being written to files. {key} was not given. For example: '
+                            '@EnvironmentVariableLoader("schemaregistry", '
+                            'schemaregistry_endpoint="fake_endpoint.servicebus.windows.net")'
+                        )
             except KeyError as key_error:
                 if not self._backup_preparers:
                     raise


### PR DESCRIPTION
# Description

The EnvironmentVariableLoader currently assumes there are always environment variables set for service principal authentication (a tenant ID, client ID, and client secret). User-based authentication doesn't use these variables, so there's no reason to continue requiring them.

This PR updates the preparer to handle unset variables when user auth is requested instead of failing with a KeyError, as well as unset corresponding `AZURE_*` variables accordingly. I debated whether we should unset missing variables or leave missing variables untouched, but settled on the former to make our behavior as consistent as possible.

When the EnvironmentVariableLoader is used, the intent is to only use environment variables that begin with the service directory's prefix. When running KV tests, `AZURE_CLIENT_ID`, etc. are always set to `KEYVAULT_CLIENT_ID`, etc. If we stopped changing the value of `AZURE_CLIENT_ID` when `KEYVAULT_CLIENT_ID` is unset, that would be inconsistent and cause confusion if tests were to inspect `AZURE_CLIENT_ID` and expect that it's set to a KV-specific value. Setting `AZURE_CLIENT_ID` to a placeholder value would also be inconsistent since we usually don't modify `KEYVAULT_CLIENT_ID` -- leaving the latter variable unset could be intentional, and we should reflect this in the former variable.

If any of these variables were unset in the past, the preparer would fail -- so any behavior updates are non-breaking in that sense.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
