### PR TITLE
Remove manual test proxy setup instructions

### DIFF
--- a/doc/dev/dev_setup.md
+++ b/doc/dev/dev_setup.md
@@ -7,7 +7,7 @@ or execute the various commands available in the toolbox.
 
 1.  If you don't already have it, install Python:
 
-    - Windows: [Python website][python_website] or from the [Windows store][python_39]
+    - Windows: [Python website][python_website] or from the [Windows store][python_312]
     - Ubuntu/Debian `sudo apt-get install python3`
     - RHEL/CentOS `sudo yum install python3`
 
@@ -46,17 +46,14 @@ or execute the various commands available in the toolbox.
     The recommended place to store your .env file is one directory higher than the `azure-sdk-for-python` location.
     This ensures the secrets will be loaded by the interpreter and most importantly not be committed to Git history.
 
-## Set up the SDK's test-running tool
+## Follow test-running guidance
 
-SDK tests use an in-house tool called the test proxy, which runs in a container and enables recording and playing back HTTP interactions.
-
-Follow the instructions in the [Perform one-time test proxy setup][proxy_setup] section of [tests.md][tests] to set up the test proxy on your machine.
+After following the steps above, you'll be able to run recorded SDK tests with `pytest`. For more information about tests -- how to run live tests, write new tests, etc. -- refer to the documentation in [tests.md][tests].
 
 
 <!-- LINKS -->
 [python_website]: https://www.python.org/downloads/
-[python_39]: https://www.microsoft.com/p/python-39/9p7qfqmjrfp7
-[proxy_setup]: https://github.com/Azure/azure-sdk-for-python/blob/main/doc/dev/tests.md#perform-one-time-test-proxy-setup
+[python_312]: https://apps.microsoft.com/detail/9ncvdn91xzqp
 [tests]: https://github.com/Azure/azure-sdk-for-python/blob/main/doc/dev/tests.md
 [tox]: https://tox.wiki/en/latest/
 [virtual_environment]: https://docs.python.org/3/tutorial/venv.html


### PR DESCRIPTION
# Description

This removes a link to the manual setup section of our test documentation, since the test proxy no longer needs it and the section was removed. This also updates the suggested version of Python from 3.9 to 3.12.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
