### PR TITLE
[Tracing] Add EventHubs live tracing tests

### DIFF
--- a/sdk/core/azure-core-tracing-opentelemetry/dev_requirements.txt
+++ b/sdk/core/azure-core-tracing-opentelemetry/dev_requirements.txt
@@ -6,3 +6,4 @@ opentelemetry-instrumentation-requests>=0.32b0
 requests
 azure-storage-blob
 -e ../../servicebus/azure-servicebus
+-e ../../eventhub/azure-eventhub

--- a/sdk/core/azure-core-tracing-opentelemetry/dev_requirements.txt
+++ b/sdk/core/azure-core-tracing-opentelemetry/dev_requirements.txt
@@ -5,5 +5,5 @@ opentelemetry-sdk<2.0.0,>=1.12.0
 opentelemetry-instrumentation-requests>=0.32b0
 requests
 azure-storage-blob
--e ../../servicebus/azure-servicebus
--e ../../eventhub/azure-eventhub
+../../servicebus/azure-servicebus
+../../eventhub/azure-eventhub

--- a/sdk/core/azure-core-tracing-opentelemetry/tests/conftest.py
+++ b/sdk/core/azure-core-tracing-opentelemetry/tests/conftest.py
@@ -41,4 +41,6 @@ def config():
         "servicebus_queue_name": os.environ.get("AZURE_SERVICEBUS_QUEUE_NAME"),
         "servicebus_topic_name": os.environ.get("AZURE_SERVICEBUS_TOPIC_NAME"),
         "servicebus_subscription_name": os.environ.get("AZURE_SERVICEBUS_SUBSCRIPTION_NAME"),
+        "eventhub_connection_string": os.environ.get("AZURE_EVENTHUB_CONNECTION_STRING"),
+        "eventhub_name": os.environ.get("AZURE_EVENTHUB_NAME"),
     }

--- a/sdk/core/azure-core-tracing-opentelemetry/tests/test_eventhubs_live.py
+++ b/sdk/core/azure-core-tracing-opentelemetry/tests/test_eventhubs_live.py
@@ -1,0 +1,150 @@
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+from datetime import datetime
+import threading
+
+import pytest
+from azure.core.tracing.common import with_current_context
+from azure.eventhub import EventHubConsumerClient, EventHubProducerClient, EventData
+from opentelemetry.trace import SpanKind
+
+
+class TestEventHubsTracing:
+    def _verify_span_attributes(self, *, span):
+        # Ensure all attributes are set and have a value.
+        for attr in span.attributes:
+            assert span.attributes[attr] is not None and span.attributes[attr] != ""
+
+    def _verify_message(self, *, span, dest, server_address):
+        assert span.name == "EventHubs.message"
+        assert span.kind == SpanKind.PRODUCER
+        self._verify_span_attributes(span=span)
+        assert span.attributes["az.namespace"] == "Microsoft.EventHub"
+        assert span.attributes["messaging.system"] == "eventhubs"
+        assert span.attributes["messaging.destination.name"] == dest
+        assert span.attributes["server.address"] == server_address
+
+    def _verify_send(self, *, span, dest, server_address, message_count):
+        assert span.name == "EventHubs.send"
+        assert span.kind == SpanKind.CLIENT
+        self._verify_span_attributes(span=span)
+        assert span.attributes["az.namespace"] == "Microsoft.EventHub"
+        assert span.attributes["messaging.system"] == "eventhubs"
+        assert span.attributes["messaging.destination.name"] == dest
+        assert span.attributes["messaging.operation"] == "publish"
+        assert span.attributes["server.address"] == server_address
+        if message_count > 1:
+            assert span.attributes["messaging.batch.message_count"] == message_count
+
+    def _verify_receive(self, *, span, dest, server_address, message_count):
+        assert span.name == "EventHubs.receive"
+        assert span.kind == SpanKind.CLIENT
+        self._verify_span_attributes(span=span)
+        assert span.attributes["az.namespace"] == "Microsoft.EventHub"
+        assert span.attributes["messaging.system"] == "eventhubs"
+        assert span.attributes["messaging.destination.name"] == dest
+        assert span.attributes["messaging.operation"] == "receive"
+        assert span.attributes["server.address"] == server_address
+        for link in span.links:
+            assert "enqueuedTime" in link.attributes
+        if message_count > 1:
+            assert span.attributes["messaging.batch.message_count"] == message_count
+
+    def _verify_process(self, *, span, dest, server_address, message_count):
+        assert span.name == "EventHubs.process"
+        assert span.kind == SpanKind.CONSUMER
+        self._verify_span_attributes(span=span)
+        assert span.attributes["az.namespace"] == "Microsoft.EventHub"
+        assert span.attributes["messaging.system"] == "eventhubs"
+        assert span.attributes["messaging.destination.name"] == dest
+        assert span.attributes["messaging.operation"] == "process"
+        assert span.attributes["server.address"] == server_address
+        if message_count > 1:
+            assert span.attributes["messaging.batch.message_count"] == message_count
+
+    @pytest.mark.live_test_only
+    def test_eventhubs_client_tracing(self, config, exporter, tracer):
+
+        connection_string = config["eventhub_connection_string"]
+        eventhub_name = config["eventhub_name"]
+
+        producer_client = EventHubProducerClient.from_connection_string(
+            conn_str=connection_string,
+            eventhub_name=eventhub_name,
+        )
+
+        consumer_client = EventHubConsumerClient.from_connection_string(
+            conn_str=connection_string,
+            consumer_group="$Default",
+            eventhub_name=eventhub_name,
+        )
+
+        with tracer.start_as_current_span(name="root"):
+
+            current_date = datetime.now()
+
+            with producer_client:
+
+                # Send batch of events
+                event_data_batch = producer_client.create_batch()
+                event_data_batch.add(EventData("First message inside an EventDataBatch"))
+                event_data_batch.add(EventData("Second message inside an EventDataBatch"))
+                producer_client.send_batch(event_data_batch)
+
+            send_spans = exporter.get_finished_spans()
+
+            # We expect 3 spans to have finished: 1 send spans, and 2 message spans.
+            assert len(send_spans) == 3
+
+            server_address = producer_client._address.hostname
+            dest_name = producer_client._address.path
+
+            # Verify the spans from the batch send.
+            self._verify_message(span=send_spans[0], dest=dest_name, server_address=server_address)
+            self._verify_message(span=send_spans[1], dest=dest_name, server_address=server_address)
+            self._verify_send(span=send_spans[2], dest=dest_name, server_address=server_address, message_count=2)
+
+            # Verify span links from batch send.
+            assert len(send_spans[2].links) == 2
+            link = send_spans[2].links[0]
+            assert link.context.span_id == send_spans[0].context.span_id
+            assert link.context.trace_id == send_spans[0].context.trace_id
+
+            link = send_spans[2].links[1]
+            assert link.context.span_id == send_spans[1].context.span_id
+            assert link.context.trace_id == send_spans[1].context.trace_id
+
+            exporter.clear()
+
+            def on_event_batch(partition_context, event_batch):
+                pass
+
+            # Receive batch of events.
+            worker = threading.Thread(
+                target=with_current_context(consumer_client.receive_batch),
+                args=(on_event_batch,),
+                kwargs={"starting_position": current_date},
+            )
+            worker.daemon = True
+            worker.start()
+            worker.join(timeout=3)
+
+            receive_spans = exporter.get_finished_spans()
+
+            # We expect 2 spans to have finished: 1 receive span and 1 process span.
+            assert len(receive_spans) == 2
+
+            self._verify_receive(span=receive_spans[0], dest=dest_name, server_address=server_address, message_count=2)
+            self._verify_process(span=receive_spans[1], dest=dest_name, server_address=server_address, message_count=2)
+
+            # Verify receive span links.
+            assert len(receive_spans[0].links) == 2
+            assert receive_spans[0].links[0].context.span_id == send_spans[0].context.span_id
+            assert receive_spans[0].links[1].context.span_id == send_spans[1].context.span_id
+
+            # Verify process span links.
+            assert len(receive_spans[1].links) == 2
+            assert receive_spans[1].links[0].context.span_id == send_spans[0].context.span_id
+            assert receive_spans[1].links[1].context.span_id == send_spans[1].context.span_id

--- a/sdk/core/azure-core-tracing-opentelemetry/tests/test_schema.py
+++ b/sdk/core/azure-core-tracing-opentelemetry/tests/test_schema.py
@@ -11,8 +11,8 @@ from azure.core.tracing.ext.opentelemetry_span._schema import OpenTelemetrySchem
 
 
 class TestOpenTelemetrySchema:
-    def test_latest_schema_attributes_renamed(self, tracer):
-        with tracer.start_as_current_span("Root", kind=OpenTelemetrySpanKind.CLIENT) as parent:
+    def test_latest_schema_attributes_renamed(self, tracing_helper):
+        with tracing_helper.tracer.start_as_current_span("Root", kind=OpenTelemetrySpanKind.CLIENT) as parent:
             wrapped_class = OpenTelemetrySpan(span=parent)
             schema_version = OpenTelemetrySchema.get_latest_version()
             attribute_mappings = OpenTelemetrySchema.get_attribute_mappings(schema_version)
@@ -30,8 +30,8 @@ class TestOpenTelemetrySchema:
                 # Check that original attribute is not present.
                 assert wrapped_class.span_instance.attributes.get(key) is None
 
-    def test_latest_schema_attributes_not_renamed(self, tracer):
-        with tracer.start_as_current_span("Root", kind=OpenTelemetrySpanKind.CLIENT) as parent:
+    def test_latest_schema_attributes_not_renamed(self, tracing_helper):
+        with tracing_helper.tracer.start_as_current_span("Root", kind=OpenTelemetrySpanKind.CLIENT) as parent:
             wrapped_class = OpenTelemetrySpan(span=parent)
 
             wrapped_class.add_attribute("foo", "bar")

--- a/sdk/core/azure-core-tracing-opentelemetry/tests/test_storage_live.py
+++ b/sdk/core/azure-core-tracing-opentelemetry/tests/test_storage_live.py
@@ -11,14 +11,14 @@ from opentelemetry.sdk.trace import ReadableSpan
 
 class TestStorageTracing:
     @pytest.mark.live_test_only
-    def test_blob_service_client_tracing(self, config, exporter, tracer):
+    def test_blob_service_client_tracing(self, config, tracing_helper):
         connection_string = config["storage_connection_string"]
         client = BlobServiceClient.from_connection_string(connection_string)
 
-        with tracer.start_as_current_span(name="root") as parent:
+        with tracing_helper.tracer.start_as_current_span(name="root") as parent:
             client.get_service_properties()
 
-        spans = exporter.get_finished_spans()
+        spans = tracing_helper.exporter.get_finished_spans()
 
         # We expect 3 spans, one for the root span, one for the method call, and one for the HTTP request.
         assert len(spans) == 3

--- a/sdk/core/azure-core-tracing-opentelemetry/tests/test_tracing_implementations.py
+++ b/sdk/core/azure-core-tracing-opentelemetry/tests/test_tracing_implementations.py
@@ -24,8 +24,8 @@ def test_structural_subtyping():
 
 
 class TestOpentelemetryWrapper:
-    def test_span_passed_in(self, tracer):
-        with tracer.start_as_current_span(name="parent") as parent:
+    def test_span_passed_in(self, tracing_helper):
+        with tracing_helper.tracer.start_as_current_span(name="parent") as parent:
             wrapped_span = OpenTelemetrySpan(parent)
 
             assert wrapped_span.span_instance.name == "parent"
@@ -34,8 +34,8 @@ class TestOpentelemetryWrapper:
 
             assert parent is trace.get_current_span()
 
-    def test_no_span_passed_in_with_no_environ(self, tracer):
-        with tracer.start_as_current_span("Root") as parent:
+    def test_no_span_passed_in_with_no_environ(self, tracing_helper):
+        with tracing_helper.tracer.start_as_current_span("Root") as parent:
             with OpenTelemetrySpan() as wrapped_span:
 
                 assert wrapped_span.span_instance.name == "span"
@@ -43,8 +43,8 @@ class TestOpentelemetryWrapper:
 
             assert parent is trace.get_current_span()
 
-    def test_span(self, tracer):
-        with tracer.start_as_current_span("Root") as parent:
+    def test_span(self, tracing_helper):
+        with tracing_helper.tracer.start_as_current_span("Root") as parent:
             with OpenTelemetrySpan() as wrapped_span:
                 assert wrapped_span.span_instance is trace.get_current_span()
 
@@ -53,8 +53,8 @@ class TestOpentelemetryWrapper:
                     assert child.span_instance is trace.get_current_span()
                     assert child.span_instance.parent is wrapped_span.span_instance.context
 
-    def test_nested_span_suppression(self, tracer, exporter):
-        with tracer.start_as_current_span("Root"):
+    def test_nested_span_suppression(self, tracing_helper):
+        with tracing_helper.tracer.start_as_current_span("Root"):
             with OpenTelemetrySpan(name="outer-span", kind=SpanKind.INTERNAL) as outer_span:
                 assert isinstance(outer_span.span_instance, trace.Span)
                 assert outer_span.span_instance.kind == OpenTelemetrySpanKind.INTERNAL
@@ -62,15 +62,15 @@ class TestOpentelemetryWrapper:
                 with outer_span.span(name="inner-span", kind=SpanKind.INTERNAL) as inner_span:
                     assert isinstance(inner_span.span_instance, NonRecordingSpan)
 
-                assert len(exporter.get_finished_spans()) == 0
-            assert len(exporter.get_finished_spans()) == 1
+                assert len(tracing_helper.exporter.get_finished_spans()) == 0
+            assert len(tracing_helper.exporter.get_finished_spans()) == 1
 
-        assert len(exporter.get_finished_spans()) == 2
-        spans_names_list = [span.name for span in exporter.get_finished_spans()]
+        assert len(tracing_helper.exporter.get_finished_spans()) == 2
+        spans_names_list = [span.name for span in tracing_helper.exporter.get_finished_spans()]
         assert spans_names_list == ["outer-span", "Root"]
 
-    def test_nested_span_suppression_with_multiple_outer_spans(self, tracer, exporter):
-        with tracer.start_as_current_span("Root"):
+    def test_nested_span_suppression_with_multiple_outer_spans(self, tracing_helper):
+        with tracing_helper.tracer.start_as_current_span("Root"):
             with OpenTelemetrySpan(name="outer-span-1", kind=SpanKind.INTERNAL) as outer_span_1:
                 assert isinstance(outer_span_1.span_instance, trace.Span)
                 assert outer_span_1.span_instance.kind == OpenTelemetrySpanKind.INTERNAL
@@ -78,7 +78,7 @@ class TestOpentelemetryWrapper:
                 with OpenTelemetrySpan(name="inner-span-1", kind=SpanKind.INTERNAL) as inner_span_1:
                     assert isinstance(inner_span_1.span_instance, NonRecordingSpan)
 
-            assert len(exporter.get_finished_spans()) == 1
+            assert len(tracing_helper.exporter.get_finished_spans()) == 1
 
             with OpenTelemetrySpan(name="outer-span-2", kind=SpanKind.INTERNAL) as outer_span_2:
                 assert isinstance(outer_span_2.span_instance, trace.Span)
@@ -87,14 +87,14 @@ class TestOpentelemetryWrapper:
                 with OpenTelemetrySpan(name="inner-span-2", kind=SpanKind.INTERNAL) as inner_span_2:
                     assert isinstance(inner_span_2.span_instance, NonRecordingSpan)
 
-            assert len(exporter.get_finished_spans()) == 2
+            assert len(tracing_helper.exporter.get_finished_spans()) == 2
 
-        assert len(exporter.get_finished_spans()) == 3
-        spans_names_list = [span.name for span in exporter.get_finished_spans()]
+        assert len(tracing_helper.exporter.get_finished_spans()) == 3
+        spans_names_list = [span.name for span in tracing_helper.exporter.get_finished_spans()]
         assert spans_names_list == ["outer-span-1", "outer-span-2", "Root"]
 
-    def test_nested_span_suppression_with_nested_client(self, tracer, exporter):
-        with tracer.start_as_current_span("Root"):
+    def test_nested_span_suppression_with_nested_client(self, tracing_helper):
+        with tracing_helper.tracer.start_as_current_span("Root"):
             with OpenTelemetrySpan(name="outer-span", kind=SpanKind.INTERNAL) as outer_span:
                 assert isinstance(outer_span.span_instance, trace.Span)
                 assert outer_span.span_instance.kind == OpenTelemetrySpanKind.INTERNAL
@@ -107,14 +107,14 @@ class TestOpentelemetryWrapper:
                         assert client_span.span_instance.kind == OpenTelemetrySpanKind.CLIENT
                         # Parent of this should be the unsuppressed outer span.
                         assert client_span.span_instance.parent is outer_span.span_instance.context
-                    assert len(exporter.get_finished_spans()) == 1
+                    assert len(tracing_helper.exporter.get_finished_spans()) == 1
 
-        assert len(exporter.get_finished_spans()) == 3
-        spans_names_list = [span.name for span in exporter.get_finished_spans()]
+        assert len(tracing_helper.exporter.get_finished_spans()) == 3
+        spans_names_list = [span.name for span in tracing_helper.exporter.get_finished_spans()]
         assert spans_names_list == ["client-span", "outer-span", "Root"]
 
-    def test_nested_span_suppression_with_attributes(self, tracer):
-        with tracer.start_as_current_span("Root"):
+    def test_nested_span_suppression_with_attributes(self, tracing_helper):
+        with tracing_helper.tracer.start_as_current_span("Root"):
             with OpenTelemetrySpan(name="outer-span", kind=SpanKind.INTERNAL) as outer_span:
 
                 with outer_span.span(name="inner-span", kind=SpanKind.INTERNAL) as inner_span:
@@ -132,8 +132,8 @@ class TestOpentelemetryWrapper:
                         assert "foo" in client_span.span_instance.attributes
                         assert client_span.span_instance.attributes["foo"] == "biz"
 
-    def test_nested_span_suppression_deep_nested(self, tracer, exporter):
-        with tracer.start_as_current_span("Root"):
+    def test_nested_span_suppression_deep_nested(self, tracing_helper):
+        with tracing_helper.tracer.start_as_current_span("Root"):
             with OpenTelemetrySpan(name="outer-span", kind=SpanKind.INTERNAL) as outer_span:
 
                 with OpenTelemetrySpan(name="inner-span-1", kind=SpanKind.INTERNAL):
@@ -144,12 +144,12 @@ class TestOpentelemetryWrapper:
                                 with OpenTelemetrySpan(name="client-span", kind=SpanKind.CLIENT) as client_span:
                                     assert client_span.span_instance.parent is producer_span.span_instance.context
 
-        assert len(exporter.get_finished_spans()) == 4
-        spans_names_list = [span.name for span in exporter.get_finished_spans()]
+        assert len(tracing_helper.exporter.get_finished_spans()) == 4
+        spans_names_list = [span.name for span in tracing_helper.exporter.get_finished_spans()]
         assert spans_names_list == ["client-span", "producer-span", "outer-span", "Root"]
 
-    def test_nested_get_current_span(self, tracer):
-        with tracer.start_as_current_span("Root"):
+    def test_nested_get_current_span(self, tracing_helper):
+        with tracing_helper.tracer.start_as_current_span("Root"):
             with OpenTelemetrySpan(name="outer-span", kind=SpanKind.INTERNAL) as outer_span:
                 with outer_span.span(name="inner-span", kind=SpanKind.INTERNAL) as inner_span:
                     assert isinstance(inner_span.span_instance, NonRecordingSpan)
@@ -178,7 +178,7 @@ class TestOpentelemetryWrapper:
             assert isinstance(span2.span_instance, trace.Span)
         span1.finish()
 
-    def test_suppress_http_auto_instrumentation(self, exporter):
+    def test_suppress_http_auto_instrumentation(self, tracing_helper):
         # Enable auto-instrumentation for requests.
         RequestsInstrumentor().instrument()
         from requests import Response
@@ -191,16 +191,16 @@ class TestOpentelemetryWrapper:
                 with OpenTelemetrySpan(name="client-span", kind=SpanKind.CLIENT):
                     # With CLIENT spans and automatic HTTP instrumentation is suppressed.
                     requests.get("https://www.foo.bar/first")
-                assert len(exporter.get_finished_spans()) == 1
+                assert len(tracing_helper.exporter.get_finished_spans()) == 1
                 # The following requests should still be auto-instrumented since it's not in the scope
                 # of a CLIENT span.
                 requests.post("https://www.foo.bar/second")
                 requests.get("https://www.foo.bar/third")
-                assert len(exporter.get_finished_spans()) == 3
-            assert len(exporter.get_finished_spans()) == 4
+                assert len(tracing_helper.exporter.get_finished_spans()) == 3
+            assert len(tracing_helper.exporter.get_finished_spans()) == 4
 
-    def test_start_finish(self, tracer):
-        with tracer.start_as_current_span("Root") as parent:
+    def test_start_finish(self, tracing_helper):
+        with tracing_helper.tracer.start_as_current_span("Root") as parent:
             wrapped_class = OpenTelemetrySpan()
             assert wrapped_class.span_instance.start_time is not None
             assert wrapped_class.span_instance.end_time is None
@@ -211,14 +211,14 @@ class TestOpentelemetryWrapper:
             assert wrapped_class.span_instance.start_time is not None
             assert wrapped_class.span_instance.end_time is not None
 
-    def test_change_context(self, tracer):
-        with tracer.start_as_current_span("Root") as parent:
+    def test_change_context(self, tracing_helper):
+        with tracing_helper.tracer.start_as_current_span("Root") as parent:
             with OpenTelemetrySpan() as wrapped_class:
                 with OpenTelemetrySpan.change_context(parent):
                     assert trace.get_current_span() is parent
 
-    def test_to_header(self, tracer):
-        with tracer.start_as_current_span("Root") as parent:
+    def test_to_header(self, tracing_helper):
+        with tracing_helper.tracer.start_as_current_span("Root") as parent:
             wrapped_class = OpenTelemetrySpan()
             headers = wrapped_class.to_header()
             assert "traceparent" in headers
@@ -229,8 +229,8 @@ class TestOpentelemetryWrapper:
 
             assert traceparent == headers["traceparent"]
 
-    def test_links(self, tracer):
-        with tracer.start_as_current_span("Root") as parent:
+    def test_links(self, tracing_helper):
+        with tracing_helper.tracer.start_as_current_span("Root") as parent:
             og_header = {"traceparent": "00-2578531519ed94423ceae67588eff2c9-231ebdc614cb9ddd-01"}
             with OpenTelemetrySpan() as wrapped_class:
                 OpenTelemetrySpan.link_from_headers(og_header)
@@ -250,8 +250,8 @@ class TestOpentelemetryWrapper:
                 assert link.context.trace_id == int("2578531519ed94423ceae67588eff2c9", 16)
                 assert link.context.span_id == int("231ebdc614cb9ddd", 16)
 
-    def test_links_with_attribute(self, tracer):
-        with tracer.start_as_current_span("Root") as parent:
+    def test_links_with_attribute(self, tracing_helper):
+        with tracing_helper.tracer.start_as_current_span("Root") as parent:
             attributes = {"attribute1": 1, "attribute2": 2}
             og_header = {"traceparent": "00-2578531519ed94423ceae67588eff2c9-231ebdc614cb9ddd-02"}
             with OpenTelemetrySpan() as wrapped_class:
@@ -278,15 +278,15 @@ class TestOpentelemetryWrapper:
                 assert "attribute2" in link.attributes
                 assert link.attributes == attributes
 
-    def test_parent_context(self, tracer):
-        with tracer.start_as_current_span("Root"):
+    def test_parent_context(self, tracing_helper):
+        with tracing_helper.tracer.start_as_current_span("Root"):
             parent_header = {"traceparent": "00-2578531519ed94423ceae67588eff2c9-231ebdc614cb9ddd-01"}
             span = OpenTelemetrySpan(name="test_span", context=parent_header)
             assert span.span_instance.context.trace_id == int("2578531519ed94423ceae67588eff2c9", 16)
             assert span.span_instance.parent.span_id == int("231ebdc614cb9ddd", 16)
 
-    def test_empty_parent_context(self, tracer):
-        with tracer.start_as_current_span("Root") as root:
+    def test_empty_parent_context(self, tracing_helper):
+        with tracing_helper.tracer.start_as_current_span("Root") as root:
             span = OpenTelemetrySpan(name="test_span", context={})
             # Parent of span should be current span context if context is empty.
             assert span.span_instance.parent is root.context
@@ -303,15 +303,15 @@ class TestOpentelemetryWrapper:
         # If no outer span and no context, parent should be None.
         assert span.span_instance.parent is None
 
-    def test_add_attribute(self, tracer):
-        with tracer.start_as_current_span("Root") as parent:
+    def test_add_attribute(self, tracing_helper):
+        with tracing_helper.tracer.start_as_current_span("Root") as parent:
             wrapped_class = OpenTelemetrySpan(span=parent)
             wrapped_class.add_attribute("test", "test2")
             assert wrapped_class.span_instance.attributes["test"] == "test2"
             assert parent.attributes["test"] == "test2"
 
-    def test_set_http_attributes(self, tracer):
-        with tracer.start_as_current_span("Root", kind=OpenTelemetrySpanKind.CLIENT) as parent:
+    def test_set_http_attributes(self, tracing_helper):
+        with tracing_helper.tracer.start_as_current_span("Root", kind=OpenTelemetrySpanKind.CLIENT) as parent:
             wrapped_class = OpenTelemetrySpan(span=parent)
             request = mock.Mock()
             setattr(request, "method", "GET")
@@ -339,8 +339,8 @@ class TestOpentelemetryWrapper:
                 assert wrapped_class.span_instance.attributes.get("server.address") == "foo.bar"
                 assert wrapped_class.span_instance.attributes.get("server.port") == 8080
 
-    def test_span_kind(self, tracer):
-        with tracer.start_as_current_span("Root") as parent:
+    def test_span_kind(self, tracing_helper):
+        with tracing_helper.tracer.start_as_current_span("Root") as parent:
             wrapped_class = OpenTelemetrySpan(span=parent)
 
             wrapped_class.kind = SpanKind.UNSPECIFIED


### PR DESCRIPTION
- This adds an EventHubs live test for validating tracing spans.
- Pytest fixtures were refactored so that the tracer and exporter are instantiated and accessible from the same fixture. 

