### PR TITLE
[Cosmos] Bugfix for race condition on async lock

### DIFF
--- a/sdk/cosmos/azure-cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos/CHANGELOG.md
@@ -7,6 +7,7 @@
 #### Breaking Changes
 
 #### Bugs Fixed
+* Fixed bug with async lock not properly releasing on async global endpoint manager.
 
 #### Other Changes
 * Marked `computed_properties` keyword as provisional, un-marked `continuation_token_limit` as provisional. See [PR 34207](https://github.com/Azure/azure-sdk-for-python/pull/34207).

--- a/sdk/cosmos/azure-cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos/CHANGELOG.md
@@ -7,7 +7,7 @@
 #### Breaking Changes
 
 #### Bugs Fixed
-* Fixed bug with async lock not properly releasing on async global endpoint manager.
+* Fixed bug with async lock not properly releasing on async global endpoint manager. see [PR 34579](https://github.com/Azure/azure-sdk-for-python/pull/34579).
 
 #### Other Changes
 * Marked `computed_properties` keyword as provisional, un-marked `continuation_token_limit` as provisional. See [PR 34207](https://github.com/Azure/azure-sdk-for-python/pull/34207).

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_global_endpoint_manager_async.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_global_endpoint_manager_async.py
@@ -83,29 +83,29 @@ class _GlobalEndpointManager(object):
         await self.refresh_endpoint_list(database_account)
 
     async def refresh_endpoint_list(self, database_account, **kwargs):
-        async with self.refresh_lock:
-            # if refresh is not needed or refresh is already taking place, return
-            if not self.refresh_needed:
-                return
-            try:
-                await self._refresh_endpoint_list_private(database_account, **kwargs)
-            except Exception as e:
-                raise e
+        if self.refresh_needed:
+            async with self.refresh_lock:
+                # if refresh is not needed or refresh is already taking place, return
+                if not self.refresh_needed:
+                    return
+                try:
+                    await self._refresh_endpoint_list_private(database_account, **kwargs)
+                except Exception as e:
+                    raise e
 
     async def _refresh_endpoint_list_private(self, database_account=None, **kwargs):
         if database_account:
             self.location_cache.perform_on_database_account_read(database_account)
-            self.refresh_needed = False
-
-        if (
-            self.location_cache.should_refresh_endpoints()
-            and self.location_cache.current_time_millis() - self.last_refresh_time > self.refresh_time_interval_in_ms
-        ):
-            if not database_account:
+        else:
+            if (
+                self.location_cache.should_refresh_endpoints()
+                and
+                self.location_cache.current_time_millis() - self.last_refresh_time > self.refresh_time_interval_in_ms
+            ):
                 database_account = await self._GetDatabaseAccount(**kwargs)
                 self.location_cache.perform_on_database_account_read(database_account)
                 self.last_refresh_time = self.location_cache.current_time_millis()
-                self.refresh_needed = False
+        self.refresh_needed = False
 
     async def _GetDatabaseAccount(self, **kwargs):
         """Gets the database account.

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_global_endpoint_manager_async.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_global_endpoint_manager_async.py
@@ -94,6 +94,7 @@ class _GlobalEndpointManager(object):
                     raise e
 
     async def _refresh_endpoint_list_private(self, database_account=None, **kwargs):
+        self.refresh_needed = False
         if database_account:
             self.location_cache.perform_on_database_account_read(database_account)
         else:
@@ -105,7 +106,6 @@ class _GlobalEndpointManager(object):
                 database_account = await self._GetDatabaseAccount(**kwargs)
                 self.location_cache.perform_on_database_account_read(database_account)
                 self.last_refresh_time = self.location_cache.current_time_millis()
-        self.refresh_needed = False
 
     async def _GetDatabaseAccount(self, **kwargs):
         """Gets the database account.


### PR DESCRIPTION
Seems like a race condition on the async lock used here can be reached with customers with enough load, causing their applications to come to a stop on all requests:
![image](https://github.com/Azure/azure-sdk-for-python/assets/30335873/0c9dd974-1a38-4eec-be57-c59c155e9e44)

making these changes to ensure we can more quickly skip the acquiring of the lock by other processes.