### PR TITLE
install tool dependencies before verify ci step in release build

### DIFF
--- a/eng/pipelines/templates/stages/archetype-python-release.yml
+++ b/eng/pipelines/templates/stages/archetype-python-release.yml
@@ -53,6 +53,10 @@ stages:
                         ServiceDirectory: ${{parameters.ServiceDirectory}}
                         ArtifactLocation: $(Pipeline.Workspace)/${{parameters.ArtifactName}}
 
+                    - script: |
+                        python -m pip install "./tools/azure-sdk-tools"
+                      displayName: Install tool dependencies
+
                     - task: PythonScript@0
                       displayName: Verify CI enabled
                       condition: succeeded()

--- a/sdk/template/azure-template/pyproject.toml
+++ b/sdk/template/azure-template/pyproject.toml
@@ -6,3 +6,4 @@ pyright = true
 pylint = true
 black = true
 strict_sphinx = true
+ci_enabled = false

--- a/sdk/template/azure-template/pyproject.toml
+++ b/sdk/template/azure-template/pyproject.toml
@@ -6,4 +6,3 @@ pyright = true
 pylint = true
 black = true
 strict_sphinx = true
-ci_enabled = false


### PR DESCRIPTION
Context: [teams chat](https://teams.microsoft.com/l/message/19:59dbfadafb5e41c4890e2cd3d74cc7ba@thread.skype/1709339956618?tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&groupId=3e17dcb0-4257-4a30-b843-77f47f1d4121&parentMessageId=1709339956618&teamName=Azure%20SDK&channelName=Engineering%20System%20%F0%9F%9B%A0%EF%B8%8F&createdTime=1709339956618)

The verify CI step on the release build is suddenly failing for a particular package with `ModuleNotFoundError: No module named 'ci_tools'`. I'm not totally certain what changed, but in this PR we ensure we have azure-sdk-tools by installing it right before the verify CI step.

Test verify CI prevents package release when `ci_enabled=false`: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3554495&view=logs&j=7bb69cc7-6f52-585e-8b13-5bae7c4a9fa4&t=66ec37bc-d774-526e-7316-aa88863bcdc6

Test verify CI allows package release otherwise: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3554576&view=logs&j=7bb69cc7-6f52-585e-8b13-5bae7c4a9fa4&t=66ec37bc-d774-526e-7316-aa88863bcdc6