### PR TITLE
[Tracing] Add error.type attribute to spans

### DIFF
--- a/sdk/core/azure-core-tracing-opentelemetry/CHANGELOG.md
+++ b/sdk/core/azure-core-tracing-opentelemetry/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+- If a span exits with an exception, the exception name is now recorded in the `error.type` attribute. ([#34619](https://github.com/Azure/azure-sdk-for-python/pull/34619))
+
 ### Breaking Changes
 
 - Remapped certain attributes to converge with OpenTelemetry semantic conventions version `1.23.1` ([#34089](https://github.com/Azure/azure-sdk-for-python/pull/34089)):

--- a/sdk/core/azure-core-tracing-opentelemetry/azure/core/tracing/ext/opentelemetry_span/__init__.py
+++ b/sdk/core/azure-core-tracing-opentelemetry/azure/core/tracing/ext/opentelemetry_span/__init__.py
@@ -45,6 +45,7 @@ __version__ = VERSION
 
 _SUPPRESSED_SPAN_FLAG = "SUPPRESSED_SPAN_FLAG"
 _LAST_UNSUPPRESSED_SPAN = "LAST_UNSUPPRESSED_SPAN"
+_ERROR_SPAN_ATTRIBUTE = "error.type"
 
 
 class OpenTelemetrySpan(HttpSpanMixin, object):
@@ -226,6 +227,8 @@ class OpenTelemetrySpan(HttpSpanMixin, object):
 
     def __exit__(self, exception_type, exception_value, traceback) -> None:
         # Finish the span.
+        if exception_type:
+            self.add_attribute(_ERROR_SPAN_ATTRIBUTE, str(exception_type.__name__))
         if self._current_ctxt_manager:
             self._current_ctxt_manager.__exit__(exception_type, exception_value, traceback)  # pylint: disable=no-member
             self._current_ctxt_manager = None

--- a/sdk/core/azure-core-tracing-opentelemetry/azure/core/tracing/ext/opentelemetry_span/__init__.py
+++ b/sdk/core/azure-core-tracing-opentelemetry/azure/core/tracing/ext/opentelemetry_span/__init__.py
@@ -228,7 +228,9 @@ class OpenTelemetrySpan(HttpSpanMixin, object):
     def __exit__(self, exception_type, exception_value, traceback) -> None:
         # Finish the span.
         if exception_type:
-            self.add_attribute(_ERROR_SPAN_ATTRIBUTE, str(exception_type.__name__))
+            module = exception_type.__module__ if exception_type.__module__ != "builtins" else ""
+            error_type = f"{module}.{exception_type.__qualname__}" if module else exception_type.__qualname__
+            self.add_attribute(_ERROR_SPAN_ATTRIBUTE, error_type)
         if self._current_ctxt_manager:
             self._current_ctxt_manager.__exit__(exception_type, exception_value, traceback)  # pylint: disable=no-member
             self._current_ctxt_manager = None

--- a/sdk/core/azure-core-tracing-opentelemetry/tests/test_tracing_implementations.py
+++ b/sdk/core/azure-core-tracing-opentelemetry/tests/test_tracing_implementations.py
@@ -369,3 +369,10 @@ class TestOpentelemetryWrapper:
 
             with pytest.raises(ValueError):
                 wrapped_class.kind = "somethingstuid"
+
+    def test_error_type_attribute(self, tracer):
+        with tracer.start_as_current_span("Root") as parent:
+            with pytest.raises(ValueError):
+                with OpenTelemetrySpan() as wrapped_class:
+                    raise ValueError("This is a test error")
+            assert wrapped_class.span_instance.attributes.get("error.type") == "ValueError"

--- a/sdk/core/azure-core-tracing-opentelemetry/tests/test_tracing_implementations.py
+++ b/sdk/core/azure-core-tracing-opentelemetry/tests/test_tracing_implementations.py
@@ -12,6 +12,7 @@ import pytest
 import requests
 
 
+from azure.core.exceptions import ClientAuthenticationError
 from azure.core.tracing.ext.opentelemetry_span import OpenTelemetrySpan
 from azure.core.tracing import SpanKind, AbstractSpan
 from azure.core import __version__ as core_version
@@ -370,9 +371,19 @@ class TestOpentelemetryWrapper:
             with pytest.raises(ValueError):
                 wrapped_class.kind = "somethingstuid"
 
-    def test_error_type_attribute(self, tracer):
-        with tracer.start_as_current_span("Root") as parent:
+    def test_error_type_attribute_builtin_error(self, tracing_helper):
+        with tracing_helper.tracer.start_as_current_span("Root") as parent:
             with pytest.raises(ValueError):
                 with OpenTelemetrySpan() as wrapped_class:
                     raise ValueError("This is a test error")
             assert wrapped_class.span_instance.attributes.get("error.type") == "ValueError"
+
+    def test_error_type_attribute_azure_error(self, tracing_helper):
+        with tracing_helper.tracer.start_as_current_span("Root") as parent:
+            with pytest.raises(ClientAuthenticationError):
+                with OpenTelemetrySpan() as wrapped_class:
+                    raise ClientAuthenticationError("This is a test error")
+            assert (
+                wrapped_class.span_instance.attributes.get("error.type")
+                == "azure.core.exceptions.ClientAuthenticationError"
+            )

--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+- HTTP tracing spans will now include an `error.type` attribute if an error status code is returned.  #34619
+
 ## 1.30.1 (2024-02-29)
 
 ### Other Changes

--- a/sdk/core/azure-core/azure/core/tracing/_abstract_span.py
+++ b/sdk/core/azure-core/azure/core/tracing/_abstract_span.py
@@ -260,6 +260,7 @@ class HttpSpanMixin:
     _HTTP_STATUS_CODE = "http.status_code"
     _NET_PEER_NAME = "net.peer.name"
     _NET_PEER_PORT = "net.peer.port"
+    _ERROR_TYPE = "error.type"
 
     def set_http_attributes(
         self: AbstractSpan, request: HttpRequestType, response: Optional[HttpResponseType] = None
@@ -289,8 +290,11 @@ class HttpSpanMixin:
             self.add_attribute(HttpSpanMixin._HTTP_USER_AGENT, user_agent)
         if response and response.status_code:
             self.add_attribute(HttpSpanMixin._HTTP_STATUS_CODE, response.status_code)
+            if response.status_code >= 400:
+                self.add_attribute(HttpSpanMixin._ERROR_TYPE, str(response.status_code))
         else:
             self.add_attribute(HttpSpanMixin._HTTP_STATUS_CODE, 504)
+            self.add_attribute(HttpSpanMixin._ERROR_TYPE, "504")
 
 
 class Link:


### PR DESCRIPTION
OpenTelemetry defines an `error.type` attribute, and the guidance is to set it to the string http status code if a non-success status code is returned or just the name of the exception that was raised. 

Closes: #32804
Part-of: #32803 