### PR TITLE
Update API documentation link

### DIFF
--- a/doc/dev/docstring.md
+++ b/doc/dev/docstring.md
@@ -194,4 +194,4 @@ Positional parameters and keyword arguments are documented in the exact same way
 ## Additional references
 
 - [Official Sphinx documentation](https://www.sphinx-doc.org/en/master/usage/domains/python.html)
-- [Microsoft - How to document a Python API (internal)](https://github.com/MicrosoftDocs/docs-help-pr/blob/main/help-content/onboard/admin/reference/python/documenting-api.md)
+- [Microsoft - How to document a Python API (internal)](https://review.learn.microsoft.com/help/onboard/admin/reference/python/documenting-api)


### PR DESCRIPTION
# Description

Possibly because the link is to a private repo, the API documentation reference link is yielding a 401 in the `aggregate-reports` link checker: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3549713&view=logs&j=09cf8b18-32ff-5ace-942c-480825d4e4bd&t=038ef773-2c87-526e-5636-46093602ba59&l=86

This updates the link to point to the corresponding page preview on `learn.microsoft.com` instead.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
