### PR TITLE
[EventHubs] fix failing test pipeline

### DIFF
--- a/eng/pipelines/templates/stages/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tests.yml
@@ -113,9 +113,9 @@ extends:
   ${{ else }}:
     template: v1/1ES.Unofficial.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
+    settings:
+      skipBuildTagsForGitHubPullRequests: true
     ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-      settings:
-        skipBuildTagsForGitHubPullRequests: true
       sdl:
         sourceAnalysisPool:
           name: azsdk-pool-mms-win-2022-general

--- a/eng/pipelines/templates/stages/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tests.yml
@@ -114,6 +114,8 @@ extends:
     template: v1/1ES.Unofficial.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
     ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+      settings:
+        skipBuildTagsForGitHubPullRequests: true
       sdl:
         sourceAnalysisPool:
           name: azsdk-pool-mms-win-2022-general

--- a/sdk/eventhub/tests.yml
+++ b/sdk/eventhub/tests.yml
@@ -1,6 +1,6 @@
 trigger: none
 
-extemds:
+extends:
     template: ../../eng/pipelines/templates/stages/archetype-sdk-tests.yml
     parameters:
       ServiceDirectory: eventhub


### PR DESCRIPTION
Updating tests.yml to fix test pipeline failure.
+ Adding the skipBuildTagsForGitHubPullRequests: true to archetype-sdk-tests.yml following #34677 for same failure.