### PR TITLE
[EventHub] Fix race condition when buffered mode is enabled

### DIFF
--- a/sdk/eventhub/azure-eventhub/CHANGELOG.md
+++ b/sdk/eventhub/azure-eventhub/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fixed a bug where using `EventHubProducerClient` in buffered mode could potentially drop a buffered message without actually sending it. ([#34712](https://github.com/Azure/azure-sdk-for-python/pull/34712))
+
 ### Other Changes
 
 - Updated network trace logging to replace `None` values in AMQP connection info with empty strings as per the OpenTelemetry specification.

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_buffered_producer/_buffered_producer.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_buffered_producer/_buffered_producer.py
@@ -144,6 +144,7 @@ class BufferedProducer:
             _LOGGER.info("Partition: %r started flushing.", self.partition_id)
             if self._cur_batch:  # if there is batch, enqueue it to the buffer first
                 self._buffered_queue.put(self._cur_batch)
+                self._cur_batch = EventDataBatch(self._max_message_size_on_link, amqp_transport=self._amqp_transport)
             while self._buffered_queue.qsize() > 0:
                 remaining_time = timeout_time - time.time() if timeout_time else None
                 if (remaining_time and remaining_time > 0) or remaining_time is None:
@@ -195,9 +196,6 @@ class BufferedProducer:
                     break
             # after finishing flushing, reset cur batch and put it into the buffer
             self._last_send_time = time.time()
-            #reset buffered count
-            self._cur_buffered_len = 0
-            self._cur_batch = EventDataBatch(self._max_message_size_on_link, amqp_transport=self._amqp_transport)
             _LOGGER.info("Partition %r finished flushing.", self.partition_id)
 
     def check_max_wait_time_worker(self):

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_buffered_producer/_buffered_producer.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_buffered_producer/_buffered_producer.py
@@ -105,24 +105,22 @@ class BufferedProducer:
             raise OperationTimeoutError(
                 "Failed to enqueue events into buffer due to timeout."
             )
-        try:
-            # add single event into current batch
-            self._cur_batch.add(events)
-        except AttributeError:  # if the input events is a EventDataBatch, put the whole into the buffer
-            # if there are events in cur_batch, enqueue cur_batch to the buffer
-            with self._lock:
+        with self._lock:
+            try:
+                # add single event into current batch
+                self._cur_batch.add(events)
+            except AttributeError:  # if the input events is a EventDataBatch, put the whole into the buffer
+                # if there are events in cur_batch, enqueue cur_batch to the buffer
                 if self._cur_batch:
                     self._buffered_queue.put(self._cur_batch)
                 self._buffered_queue.put(events)
-            # create a new batch for incoming events
-            self._cur_batch = EventDataBatch(self._max_message_size_on_link, amqp_transport=self._amqp_transport)
-        except ValueError:
-            # add single event exceeds the cur batch size, create new batch
-            with self._lock:
+                # create a new batch for incoming events
+                self._cur_batch = EventDataBatch(self._max_message_size_on_link, amqp_transport=self._amqp_transport)
+            except ValueError:
+                # add single event exceeds the cur batch size, create new batch
                 self._buffered_queue.put(self._cur_batch)
-            self._cur_batch = EventDataBatch(self._max_message_size_on_link, amqp_transport=self._amqp_transport)
-            self._cur_batch.add(events)
-        with self._lock:
+                self._cur_batch = EventDataBatch(self._max_message_size_on_link, amqp_transport=self._amqp_transport)
+                self._cur_batch.add(events)
             self._cur_buffered_len += new_events_len
 
     def failsafe_callback(self, callback):

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_buffered_producer/_buffered_producer_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_buffered_producer/_buffered_producer_async.py
@@ -105,24 +105,22 @@ class BufferedProducer:
             raise OperationTimeoutError(
                 "Failed to enqueue events into buffer due to timeout."
             )
-        try:
-            # add single event into current batch
-            self._cur_batch.add(events)
-        except AttributeError:  # if the input events is a EventDataBatch, put the whole into the buffer
-            # if there are events in cur_batch, enqueue cur_batch to the buffer
-            async with self._lock:
+        async with self._lock:
+            try:
+                # add single event into current batch
+                self._cur_batch.add(events)
+            except AttributeError:  # if the input events is a EventDataBatch, put the whole into the buffer
+                # if there are events in cur_batch, enqueue cur_batch to the buffer
                 if self._cur_batch:
                     self._buffered_queue.put(self._cur_batch)
                 self._buffered_queue.put(events)
-            # create a new batch for incoming events
-            self._cur_batch = EventDataBatch(self._max_message_size_on_link, amqp_transport=self._amqp_transport)
-        except ValueError:
-            # add single event exceeds the cur batch size, create new batch
-            async with self._lock:
+                # create a new batch for incoming events
+                self._cur_batch = EventDataBatch(self._max_message_size_on_link, amqp_transport=self._amqp_transport)
+            except ValueError:
+                # add single event exceeds the cur batch size, create new batch
                 self._buffered_queue.put(self._cur_batch)
-            self._cur_batch = EventDataBatch(self._max_message_size_on_link, amqp_transport=self._amqp_transport)
-            self._cur_batch.add(events)
-        async with self._lock:
+                self._cur_batch = EventDataBatch(self._max_message_size_on_link, amqp_transport=self._amqp_transport)
+                self._cur_batch.add(events)
             self._cur_buffered_len += new_events_len
 
     def failsafe_callback(self, callback):

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_buffered_producer/_buffered_producer_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_buffered_producer/_buffered_producer_async.py
@@ -198,9 +198,6 @@ class BufferedProducer:
                 break
         # after finishing flushing, reset cur batch and put it into the buffer
         self._last_send_time = time.time()
-        #reset curr_buffered
-        self._cur_buffered_len = 0
-        self._cur_batch = EventDataBatch(self._max_message_size_on_link, amqp_transport=self._amqp_transport)
         _LOGGER.info("Partition %r finished flushing.", self.partition_id)
 
     async def check_max_wait_time_worker(self):


### PR DESCRIPTION
# Description

This PR implements a fix to the race condition described in #34711.

The approach here is twofold:
1. Require the `lock` while trying to add new events to internal EventBatch buffer
2. Remove unnecessary clean up code

Implementing either of these would be enough to fix the related issue, but I would argue that both are necessary to make thinks consistent:

- Change 1. helps preventing future race condition issues, since it properly protects the shared resource `self._cur_batch`. It is especially important to synchronous `BufferedProducer`, since it relies on multi-threading, which can be even more unpredictable than an event loop.
- Change 2. improves the consistency of `self._cur_batch` and `self._cur_buffered_len`:
    - `_cur_batch` is "reset" (i.e., assigned to a new `EventBatch` object) when and only when it gets enqueued to `self._buffered_queue`
    - `_cur_buffered_len` is decreased solely as a consequence of a `self._producer.send`. PR #25406 previously introduced a manual reset to this number, but it did not consider the timeout-based exit condition:
        https://github.com/Azure/azure-sdk-for-python/blob/23121a583108b6a09f2d45e3c7d1e99e70c365da/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_buffered_producer/_buffered_producer_async.py#L190-L200

A last note regarding Change 1.:
- it seems that the `azure-sdk-for-net` also updates the `self._cur_batch` with a synchronization tool, see [`RunPublishingAsync`](https://github.com/Azure/azure-sdk-for-net/blob/769f04a20fa288fbb58cc516ff7eeb0d6b048347/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubBufferedProducerClient.cs#L2262-L2273)

I also have another small set of changes that could make sync and async `BufferedProducer` codebase more consistent. Since they do not have an impact on functionality, I thought it would be better to submit them in follow up PR.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.

It would indeed be interesting to have some test code here, though I think it's hard to make determinist tests check this potential race condition. We would think something based on this test, though it is currently skipped:

https://github.com/Azure/azure-sdk-for-python/blob/23121a583108b6a09f2d45e3c7d1e99e70c365da/sdk/eventhub/azure-eventhub/tests/livetest/asynctests/test_buffered_producer_async.py#L529-L532