### PR TITLE
[Core][Corehttp] Add streaming request tests

### DIFF
--- a/sdk/core/azure-core/tests/testserver_tests/coretestserver/coretestserver/test_routes/streams.py
+++ b/sdk/core/azure-core/tests/testserver_tests/coretestserver/coretestserver/test_routes/streams.py
@@ -10,6 +10,7 @@ import tempfile
 from flask import (
     Response,
     Blueprint,
+    request,
 )
 
 streams_api = Blueprint("streams_api", __name__)
@@ -91,3 +92,15 @@ def compressed_stream():
 @streams_api.route("/decompress_header", methods=["GET"])
 def decompress_header():
     return Response(compressed_stream(), status=200, headers={"Content-Encoding": "gzip"})
+
+
+@streams_api.route("/upload", methods=["POST"])
+def upload():
+    chunk_size = 1024
+    byte_content = b""
+    while True:
+        chunk = request.stream.read(chunk_size)
+        if len(chunk) == 0:
+            break
+        byte_content += chunk
+    return Response(byte_content, status=200)

--- a/sdk/core/corehttp/tests/testserver_tests/coretestserver/coretestserver/test_routes/streams.py
+++ b/sdk/core/corehttp/tests/testserver_tests/coretestserver/coretestserver/test_routes/streams.py
@@ -9,6 +9,7 @@ import tempfile
 from flask import (
     Response,
     Blueprint,
+    request,
 )
 
 streams_api = Blueprint("streams_api", __name__)
@@ -90,3 +91,15 @@ def compressed_stream():
 @streams_api.route("/decompress_header", methods=["GET"])
 def decompress_header():
     return Response(compressed_stream(), status=200, headers={"Content-Encoding": "gzip"})
+
+
+@streams_api.route("/upload", methods=["POST"])
+def upload():
+    chunk_size = 1024
+    byte_content = b""
+    while True:
+        chunk = request.stream.read(chunk_size)
+        if len(chunk) == 0:
+            break
+        byte_content += chunk
+    return Response(byte_content, status=200)


### PR DESCRIPTION
We already have some tests that test creating HttpRequests with iterable/generator content, but none actually send the requests through our transports.

This adds some tests that will do so.
