### PR TITLE
Data Collector Data field string fix

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_deployment/online/deployment_collection_schema.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_deployment/online/deployment_collection_schema.py
@@ -18,8 +18,8 @@ class DeploymentCollectionSchema(metaclass=PatchedSchemaMeta):
     enabled = StringTransformedEnum(required=True, allowed_values=[Boolean.TRUE, Boolean.FALSE])
     data = UnionField(
         [
-            fields.Str(),
             NestedField(DataAssetSchema),
+            fields.Str(),
         ]
     )
     client_id = fields.Str()

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_deployment/deployment_collection.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_deployment/deployment_collection.py
@@ -4,11 +4,11 @@
 
 from typing import Any, Dict, Optional, Union
 
-from .data_asset import DataAsset
 from azure.ai.ml._restclient.v2023_04_01_preview.models import Collection as RestCollection
 from azure.ai.ml._schema._deployment.online.deployment_collection_schema import DeploymentCollectionSchema
 from azure.ai.ml._utils._experimental import experimental
 from azure.ai.ml.constants._common import BASE_PATH_CONTEXT_KEY
+from .data_asset import DataAsset
 
 
 @experimental

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_deployment/deployment_collection.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_deployment/deployment_collection.py
@@ -2,8 +2,9 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Union
 
+from .data_asset import DataAsset
 from azure.ai.ml._restclient.v2023_04_01_preview.models import Collection as RestCollection
 from azure.ai.ml._schema._deployment.online.deployment_collection_schema import DeploymentCollectionSchema
 from azure.ai.ml._utils._experimental import experimental
@@ -27,7 +28,7 @@ class DeploymentCollection:
         self,
         *,
         enabled: Optional[str] = None,
-        data: Optional[str] = None,
+        data: Optional[Union[str, DataAsset]] = None,
         client_id: Optional[str] = None,
         **kwargs: Any
     ):


### PR DESCRIPTION
# Description

Previously, custom blob storage collections on data collector were passing in a string of a reference to the data collector object. This has the update parameters for the data object in the collection return as a data object and then passed in the string reference to the registered data object to the back end call. 

![data collector data parameter](https://github.com/Azure/azure-sdk-for-python/assets/98433579/36c749f4-29f1-4499-b030-aeb98a3d30a2)
![data collector deployment data id](https://github.com/Azure/azure-sdk-for-python/assets/98433579/8745e941-ac2c-4090-a46f-2808c86b840f)

https://dev.azure.com/msdata/Vienna/_workitems/edit/2872030


If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**


## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
