### PR TITLE
Refactor statsbeat constants

### DIFF
--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
@@ -11,6 +11,9 @@
 
 ### Breaking Changes
 
+- Rename Statbeat environments variables to use `APPLICATIONINSIGHTS_*`
+    ([#34742](https://github.com/Azure/azure-sdk-for-python/pull/34742))
+
 ### Bugs Fixed
 
 ### Other Changes

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_constants.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_constants.py
@@ -82,6 +82,28 @@ _STATSBEAT_METRIC_NAME_MAPPINGS = dict(
         _REQ_THROTTLE_NAME,
     ]
 )
+_APPLICATIONINSIGHTS_STATS_CONNECTION_STRING_ENV_NAME = "APPLICATIONINSIGHTS_STATS_CONNECTION_STRING"
+_APPLICATIONINSIGHTS_STATS_SHORT_EXPORT_INTERVAL_ENV_NAME = "APPLICATIONINSIGHTS_STATS_SHORT_EXPORT_INTERVAL"
+_APPLICATIONINSIGHTS_STATS_LONG_EXPORT_INTERVAL_ENV_NAME = "APPLICATIONINSIGHTS_STATS_LONG_EXPORT_INTERVAL"
+# pylint: disable=line-too-long
+_DEFAULT_NON_EU_STATS_CONNECTION_STRING = "InstrumentationKey=c4a29126-a7cb-47e5-b348-11414998b11e;IngestionEndpoint=https://westus-0.in.applicationinsights.azure.com/"
+_DEFAULT_EU_STATS_CONNECTION_STRING = "InstrumentationKey=7dc56bab-3c0c-4e9f-9ebb-d1acadee8d0f;IngestionEndpoint=https://westeurope-5.in.applicationinsights.azure.com/"
+_DEFAULT_STATS_SHORT_EXPORT_INTERVAL = 900  # 15 minutes
+_DEFAULT_STATS_LONG_EXPORT_INTERVAL = 86400  # 24 hours
+_EU_ENDPOINTS = [
+    "westeurope",
+    "northeurope",
+    "francecentral",
+    "francesouth",
+    "germanywestcentral",
+    "norwayeast",
+    "norwaywest",
+    "swedencentral",
+    "switzerlandnorth",
+    "switzerlandwest",
+    "uksouth",
+    "ukwest",
+]
 
 # Instrumentations
 

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_quickpulse/_live_metrics.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_quickpulse/_live_metrics.py
@@ -52,7 +52,7 @@ from azure.monitor.opentelemetry.exporter._utils import (
 
 PROCESS = psutil.Process()
 
-def enable_live_metrics(**kwargs: Any) -> None:
+def enable_live_metrics(**kwargs: Any) -> None:  # pylint: disable=C4758
     """Live metrics entry point.
 
     :keyword str connection_string: The connection string used for your Application Insights resource.

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/statsbeat/_statsbeat.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/statsbeat/_statsbeat.py
@@ -7,6 +7,16 @@ from opentelemetry.sdk.metrics import MeterProvider
 from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
 from opentelemetry.sdk.resources import Resource
 
+from azure.monitor.opentelemetry.exporter._constants import (
+    _APPLICATIONINSIGHTS_STATS_CONNECTION_STRING_ENV_NAME,
+    _APPLICATIONINSIGHTS_STATS_LONG_EXPORT_INTERVAL_ENV_NAME,
+    _APPLICATIONINSIGHTS_STATS_SHORT_EXPORT_INTERVAL_ENV_NAME,
+    _DEFAULT_NON_EU_STATS_CONNECTION_STRING,
+    _DEFAULT_EU_STATS_CONNECTION_STRING,
+    _DEFAULT_STATS_SHORT_EXPORT_INTERVAL,
+    _DEFAULT_STATS_LONG_EXPORT_INTERVAL,
+    _EU_ENDPOINTS,
+)
 from azure.monitor.opentelemetry.exporter.statsbeat._exporter import _StatsBeatExporter
 from azure.monitor.opentelemetry.exporter.statsbeat._statsbeat_metrics import _StatsbeatMetrics
 from azure.monitor.opentelemetry.exporter.statsbeat._state import (
@@ -14,25 +24,6 @@ from azure.monitor.opentelemetry.exporter.statsbeat._state import (
     _STATSBEAT_STATE_LOCK,
 )
 
-# pylint: disable=line-too-long
-_DEFAULT_NON_EU_STATS_CONNECTION_STRING = "InstrumentationKey=c4a29126-a7cb-47e5-b348-11414998b11e;IngestionEndpoint=https://westus-0.in.applicationinsights.azure.com/"
-_DEFAULT_EU_STATS_CONNECTION_STRING = "InstrumentationKey=7dc56bab-3c0c-4e9f-9ebb-d1acadee8d0f;IngestionEndpoint=https://westeurope-5.in.applicationinsights.azure.com/"
-_DEFAULT_STATS_SHORT_EXPORT_INTERVAL = 900  # 15 minutes
-_DEFAULT_STATS_LONG_EXPORT_INTERVAL = 86400  # 24 hours
-_EU_ENDPOINTS = [
-    "westeurope",
-    "northeurope",
-    "francecentral",
-    "francesouth",
-    "germanywestcentral",
-    "norwayeast",
-    "norwaywest",
-    "swedencentral",
-    "switzerlandnorth",
-    "switzerlandwest",
-    "uksouth",
-    "ukwest",
-]
 
 _STATSBEAT_METRICS = None
 _STATSBEAT_LOCK = threading.Lock()
@@ -92,7 +83,7 @@ def shutdown_statsbeat_metrics() -> None:
 
 
 def _get_stats_connection_string(endpoint: str) -> str:
-    cs_env = os.environ.get("APPLICATION_INSIGHTS_STATS_CONNECTION_STRING")
+    cs_env = os.environ.get(_APPLICATIONINSIGHTS_STATS_CONNECTION_STRING_ENV_NAME)
     if cs_env:
         return cs_env
     for endpoint_location in _EU_ENDPOINTS:
@@ -104,7 +95,7 @@ def _get_stats_connection_string(endpoint: str) -> str:
 
 # seconds
 def _get_stats_short_export_interval() -> int:
-    ei_env = os.environ.get("APPLICATION_INSIGHTS_STATS_SHORT_EXPORT_INTERVAL")
+    ei_env = os.environ.get(_APPLICATIONINSIGHTS_STATS_SHORT_EXPORT_INTERVAL_ENV_NAME)
     if ei_env:
         try:
             return int(ei_env)
@@ -115,7 +106,7 @@ def _get_stats_short_export_interval() -> int:
 
 # seconds
 def _get_stats_long_export_interval() -> int:
-    ei_env = os.environ.get("APPLICATION_INSIGHTS_STATS_LONG_EXPORT_INTERVAL")
+    ei_env = os.environ.get(_APPLICATIONINSIGHTS_STATS_LONG_EXPORT_INTERVAL_ENV_NAME)
     if ei_env:
         try:
             return int(ei_env)

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/statsbeat/test_statsbeat.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/statsbeat/test_statsbeat.py
@@ -28,9 +28,12 @@ from azure.monitor.opentelemetry.exporter.statsbeat._state import (
     _REQUESTS_MAP,
     _STATSBEAT_STATE,
 )
-from azure.monitor.opentelemetry.exporter.statsbeat._statsbeat import (
+from azure.monitor.opentelemetry.exporter._constants import (
+    _APPLICATIONINSIGHTS_STATS_CONNECTION_STRING_ENV_NAME,
     _DEFAULT_STATS_LONG_EXPORT_INTERVAL,
     _DEFAULT_STATS_SHORT_EXPORT_INTERVAL,
+    _APPLICATIONINSIGHTS_STATS_SHORT_EXPORT_INTERVAL_ENV_NAME,
+    _APPLICATIONINSIGHTS_STATS_LONG_EXPORT_INTERVAL_ENV_NAME,
 )
 from azure.monitor.opentelemetry.exporter.statsbeat._statsbeat_metrics import (
     _shorten_host,
@@ -110,7 +113,7 @@ class TestStatsbeat(unittest.TestCase):
         self.assertIsNone(_statsbeat._STATSBEAT_METRICS)
         with mock.patch.dict(
             os.environ, {
-                "APPLICATION_INSIGHTS_STATS_CONNECTION_STRING": "",
+                _APPLICATIONINSIGHTS_STATS_CONNECTION_STRING_ENV_NAME: "",
             }):
             _statsbeat.collect_statsbeat_metrics(exporter)
         self.assertIsNotNone(_statsbeat._STATSBEAT_METRICS)
@@ -141,7 +144,7 @@ class TestStatsbeat(unittest.TestCase):
         self.assertIsNone(_statsbeat._STATSBEAT_METRICS)
         with mock.patch.dict(
             os.environ, {
-                "APPLICATION_INSIGHTS_STATS_CONNECTION_STRING": "",
+                _APPLICATIONINSIGHTS_STATS_CONNECTION_STRING_ENV_NAME: "",
             }):
             _statsbeat.collect_statsbeat_metrics(exporter)
         self.assertIsNotNone(_statsbeat._STATSBEAT_METRICS)
@@ -162,8 +165,8 @@ class TestStatsbeat(unittest.TestCase):
     @mock.patch.dict(
         "os.environ",
         {
-            "APPLICATION_INSIGHTS_STATS_SHORT_EXPORT_INTERVAL": "",
-            "APPLICATION_INSIGHTS_STATS_LONG_EXPORT_INTERVAL": "",
+            _APPLICATIONINSIGHTS_STATS_SHORT_EXPORT_INTERVAL_ENV_NAME: "",
+            _APPLICATIONINSIGHTS_STATS_LONG_EXPORT_INTERVAL_ENV_NAME: "",
         },
     )
     def test_collect_statsbeat_metrics_aad(
@@ -195,8 +198,8 @@ class TestStatsbeat(unittest.TestCase):
     @mock.patch.dict(
         "os.environ",
         {
-            "APPLICATION_INSIGHTS_STATS_SHORT_EXPORT_INTERVAL": "",
-            "APPLICATION_INSIGHTS_STATS_LONG_EXPORT_INTERVAL": "",
+            _APPLICATIONINSIGHTS_STATS_SHORT_EXPORT_INTERVAL_ENV_NAME: "",
+            _APPLICATIONINSIGHTS_STATS_LONG_EXPORT_INTERVAL_ENV_NAME: "",
         },
     )
     def test_collect_statsbeat_metrics_no_aad(
@@ -227,8 +230,8 @@ class TestStatsbeat(unittest.TestCase):
     @mock.patch.dict(
         "os.environ",
         {
-            "APPLICATION_INSIGHTS_STATS_SHORT_EXPORT_INTERVAL": "",
-            "APPLICATION_INSIGHTS_STATS_LONG_EXPORT_INTERVAL": "",
+            _APPLICATIONINSIGHTS_STATS_SHORT_EXPORT_INTERVAL_ENV_NAME: "",
+            _APPLICATIONINSIGHTS_STATS_LONG_EXPORT_INTERVAL_ENV_NAME: "",
         },
     )
     def test_collect_statsbeat_metrics_distro_version(


### PR DESCRIPTION
Move statsbeat constants to constants file.

Rename statsbeat env vars to use `APPLICATIONINSIGHTS` instead of `APPLICATION_INSIGHTS` to match the original breeze connection string.

Also fixes https://github.com/Azure/azure-sdk-for-python/issues/34583