### PR TITLE
[Identity Broker] Propagate enable support logging

### DIFF
--- a/sdk/identity/azure-identity-broker/CHANGELOG.md
+++ b/sdk/identity/azure-identity-broker/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features Added
 
 - `InteractiveBrowserBrokerCredential` now supports a `use_operating_system_account` property to enable the use of the currently logged in operating system account for authentication rather than prompting for a credential.
+- Added `enable_support_logging` as a keyword argument to `InteractiveBrowserBrokerCredential`. This allows additional support logging which may contain PII.
 
 ### Breaking Changes
 
@@ -13,6 +14,7 @@
 ### Other Changes
 
 - Python 3.7 is no longer supported. Please use Python version 3.8 or later.
+- Bumped minimum dependency on `azure-identity` to `1.15.0`.
 
 ## 1.0.0 (2023-11-07)
 

--- a/sdk/identity/azure-identity-broker/azure/identity/broker/_browser.py
+++ b/sdk/identity/azure-identity-broker/azure/identity/broker/_browser.py
@@ -48,6 +48,9 @@ class InteractiveBrowserBrokerCredential(_InteractiveBrowserCredential):
         https://login.microsoft.com/ to validate the authority. By setting this to **True**, the validation of the
         authority is disabled. As a result, it is crucial to ensure that the configured authority host is valid and
         trustworthy.
+    :keyword bool enable_support_logging: Enables additional support logging in the underlying MSAL library.
+        This logging potentially contains personally identifiable information and is intended to be used only for
+        troubleshooting purposes.
     :raises ValueError: invalid **redirect_uri**
     """
 
@@ -135,6 +138,7 @@ class InteractiveBrowserBrokerCredential(_InteractiveBrowserCredential):
                 http_client=self._client,
                 instance_discovery=self._instance_discovery,
                 enable_broker_on_windows=True,
+                enable_pii_log=self._enable_support_logging,
             )
 
         return client_applications_map[tenant_id]

--- a/sdk/identity/azure-identity-broker/setup.py
+++ b/sdk/identity/azure-identity-broker/setup.py
@@ -62,7 +62,7 @@ setup(
     },
     python_requires=">=3.8",
     install_requires=[
-        "azure-identity<2.0.0,>=1.14.0",
+        "azure-identity<2.0.0,>=1.15.0",
         "msal[broker]>=1.25,<2",
     ],
 )


### PR DESCRIPTION
The msal `enable_pii_log` flag is propagated to the broker runtime in msal, so we should ensure that users can use the
`enable_support_logging` flag with the broker credential.
