### PR TITLE
[ServiceBus] update ValueError to AMQPConnectionError for closed connection

### DIFF
--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/_connection.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/_connection.py
@@ -667,7 +667,10 @@ class Connection:  # pylint:disable=too-many-instance-attributes
             ConnectionState.OPEN_SENT,
             ConnectionState.OPENED,
         ]:
-            raise ValueError("Connection not open.")
+            raise AMQPConnectionError(
+                ErrorCondition.SocketError,
+                description="Connection not open."
+            )
         now = time.time()
         if get_local_timeout(
             now,

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/_transport.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/_transport.py
@@ -648,7 +648,11 @@ class SSLTransport(_AbstractTransport):
         """Write a string out to the SSL socket fully.
         :param str s: The string to write.
         """
-        write = self.sock.send
+        try:
+            write = self.sock.send
+        except AttributeError:
+            raise IOError("Socket has already been closed.") from None
+
         while s:
             try:
                 n = write(s)
@@ -659,7 +663,7 @@ class SSLTransport(_AbstractTransport):
                 # None.
                 n = 0
             if not n:
-                raise IOError("Socket closed")
+                raise IOError("Socket has already been closed.")
             s = s[n:]
 
     def negotiate(self):

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/_transport.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/_transport.py
@@ -663,7 +663,7 @@ class SSLTransport(_AbstractTransport):
                 # None.
                 n = 0
             if not n:
-                raise IOError("Socket has already been closed.")
+                raise IOError("Socket closed.")
             s = s[n:]
 
     def negotiate(self):

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_connection_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_connection_async.py
@@ -682,7 +682,10 @@ class Connection:  # pylint:disable=too-many-instance-attributes
             ConnectionState.OPEN_SENT,
             ConnectionState.OPENED,
         ]:
-            raise ValueError("Connection not open.")
+            raise AMQPConnectionError(
+                ErrorCondition.SocketError,
+                description="Connection not open."
+            )
         now = time.time()
         if get_local_timeout(
             now,


### PR DESCRIPTION
Currently, when a connection is disconnected during send, it will not retry since the underlying error being raised is a `ValueError` then wrapped with ServiceBusError, which is not retryable. Updating this to an AMQPConnectionError with SocketError as the condition, since we want this to be caught and raised as a ServiceBusConnectionError, then retried.

Did not add tests, since this was reproduced by turning off the connection (wifi) when sending, which cannot be done in our current test environment.

Stress was run over the weekend against this patch with no errors + sending/receiving equal number of messages.