### PR TITLE
[ServiceBus] remove inaccurate keep alive logging

### DIFF
--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/_connection.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/_connection.py
@@ -337,13 +337,13 @@ class Connection:  # pylint:disable=too-many-instance-attributes
 
     def _outgoing_empty(self) -> None:
         """Send an empty frame to prevent the connection from reaching an idle timeout."""
-        if self._network_trace:
-            _LOGGER.debug("-> EmptyFrame()", extra=self._network_trace_params)
         if self._error:
             raise self._error
 
         try:
             if self._can_write():
+                if self._network_trace:
+                    _LOGGER.debug("-> EmptyFrame()", extra=self._network_trace_params)
                 self._transport.write(EMPTY_FRAME)
                 self._last_frame_sent_time = time.time()
         except (OSError, IOError, SSLError, socket.error) as exc:

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_client_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_client_async.py
@@ -150,11 +150,6 @@ class AMQPClientAsync(AMQPClientSync):
                 current_time = time.time()
                 elapsed_time = current_time - start_time
                 if elapsed_time >= self._keep_alive_interval:
-                    _logger.debug(
-                        "Keeping %r connection alive.",
-                        self.__class__.__name__,
-                        extra=self._network_trace_params
-                    )
                     await asyncio.shield(self._connection.listen(wait=self._socket_timeout,
                         batch=self._link.current_link_credit))
                     start_time = current_time

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_connection_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_connection_async.py
@@ -345,14 +345,13 @@ class Connection:  # pylint:disable=too-many-instance-attributes
 
     async def _outgoing_empty(self) -> None:
         """Send an empty frame to prevent the connection from reaching an idle timeout."""
-        if self._network_trace:
-            _LOGGER.debug("-> EmptyFrame()", extra=self._network_trace_params)
-
         if self._error:
             raise self._error
 
         try:
             if self._can_write():
+                if self._network_trace:
+                    _LOGGER.debug("-> EmptyFrame()", extra=self._network_trace_params)
                 await self._transport.write(EMPTY_FRAME)
                 self._last_frame_sent_time = time.time()
         except (OSError, IOError, SSLError, socket.error) as exc:

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/client.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/client.py
@@ -236,7 +236,6 @@ class AMQPClient(
                 current_time = time.time()
                 elapsed_time = current_time - start_time
                 if elapsed_time >= self._keep_alive_interval:
-                    _logger.debug("Keeping %r connection alive.", self.__class__.__name__)
                     self._connection.listen(wait=self._socket_timeout, batch=self._link.current_link_credit)
                     start_time = current_time
                 time.sleep(1)


### PR DESCRIPTION
Removing the `Keeping connection alive` debug logs that log _before_ we send the empty frame to "keep alive" on the client side, since we only want them printed if/once the empty frame can been sent.