### PR TITLE
[Cosmos] fix partition_key type in create container method

### DIFF
--- a/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_database.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_database.py
@@ -160,7 +160,7 @@ class DatabaseProxy(object):
     async def create_container(
         self,
         id: str,
-        partition_key: PartitionKey,
+        partition_key: Optional[PartitionKey],
         *,
         indexing_policy: Optional[Dict[str, str]] = None,
         default_ttl: Optional[int] = None,
@@ -266,7 +266,7 @@ class DatabaseProxy(object):
     async def create_container_if_not_exists(
         self,
         id: str,
-        partition_key: PartitionKey,
+        partition_key: Optional[PartitionKey],
         *,
         indexing_policy: Optional[Dict[str, str]] = None,
         default_ttl: Optional[int] = None,
@@ -461,7 +461,7 @@ class DatabaseProxy(object):
     async def replace_container(
         self,
         container: Union[str, ContainerProxy, Mapping[str, Any]],
-        partition_key: PartitionKey,
+        partition_key: Optional[PartitionKey],
         *,
         indexing_policy: Optional[Dict[str, str]] = None,
         default_ttl: Optional[int] = None,

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/database.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/database.py
@@ -160,7 +160,7 @@ class DatabaseProxy(object):
     def create_container(  # pylint:disable=docstring-missing-param
         self,
         id: str,
-        partition_key: PartitionKey,
+        partition_key: Optional[PartitionKey],
         indexing_policy: Optional[Dict[str, Any]] = None,
         default_ttl: Optional[int] = None,
         populate_query_metrics: Optional[bool] = None,
@@ -268,7 +268,7 @@ class DatabaseProxy(object):
     def create_container_if_not_exists(  # pylint:disable=docstring-missing-param
         self,
         id: str,
-        partition_key: PartitionKey,
+        partition_key: Optional[PartitionKey],
         indexing_policy: Optional[Dict[str, Any]] = None,
         default_ttl: Optional[int] = None,
         populate_query_metrics: Optional[bool] = None,
@@ -519,7 +519,7 @@ class DatabaseProxy(object):
     def replace_container(  # pylint:disable=docstring-missing-param
         self,
         container: Union[str, ContainerProxy, Mapping[str, Any]],
-        partition_key: PartitionKey,
+        partition_key: Optional[PartitionKey],
         indexing_policy: Optional[Dict[str, Any]] = None,
         default_ttl: Optional[int] = None,
         conflict_resolution_policy: Optional[Dict[str, Any]] = None,


### PR DESCRIPTION
# Description

This PR updates the type hint of `partition_key` param in the methods `create_container` and `replace_container` by making it optional, where `None` is an accepted value to create nonpartitioned containers.

related: https://github.com/apache/airflow/issues/38196
related: #33341

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
