### PR TITLE
Add explicit requirement for azure-core in mgmt-compute

### DIFF
--- a/sdk/compute/azure-mgmt-compute/setup.py
+++ b/sdk/compute/azure-mgmt-compute/setup.py
@@ -76,6 +76,7 @@ setup(
     install_requires=[
         "isodate>=0.6.1",
         "azure-common>=1.1",
+        "azure-core>=1.28.0",
         "azure-mgmt-core>=1.3.2",
     ],
     python_requires=">=3.8",


### PR DESCRIPTION
https://github.com/Azure/azure-sdk-for-python/pull/34770 added a direct dependency for azure.core, and it actually requires this to be newer than 1.28. 
 Related to https://github.com/Azure/azure-sdk-for-python/issues/34091

# Description

Please add an informative description that covers that changes made by the pull request and link all relevant issues.

If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
