### PR TITLE
fix: Fix typing of include_spark parameter

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_feature_store_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_feature_store_operations.py
@@ -508,7 +508,7 @@ class FeatureStoreOperations(WorkspaceOperationsBase):
         self,
         *,
         feature_store_name: Optional[str] = None,
-        include_spark: Optional[bool] = False,
+        include_spark: bool = False,
         **kwargs: Any,
     ) -> LROPoller[ManagedNetworkProvisionStatus]:
         """Triggers the feature store to provision the managed network. Specifying spark enabled


### PR DESCRIPTION
# Description

This pull request addresses some feedback received in our ApiView review that correctly pointed out that the `include_spark` parameter should be type `bool` and not `Optional[bool]`

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
