### PR TITLE
[Monitor Query] Remove audience docstring

### DIFF
--- a/sdk/monitor/azure-monitor-query/azure/monitor/query/_metrics_client.py
+++ b/sdk/monitor/azure-monitor-query/azure/monitor/query/_metrics_client.py
@@ -27,8 +27,6 @@ class MetricsClient:  # pylint: disable=client-accepts-api-version-keyword
         resources. For global resources, the region should be 'global'. Required.
     :param credential: The credential to authenticate the client.
     :type credential: ~azure.core.credentials.TokenCredential
-    :keyword str audience: The audience to use when requesting a token. If not provided, the public cloud audience
-        will be assumed. Defaults to 'https://metrics.monitor.azure.com'.
     """
 
     def __init__(self, endpoint: str, credential: TokenCredential, **kwargs: Any) -> None:

--- a/sdk/monitor/azure-monitor-query/azure/monitor/query/aio/_metrics_client_async.py
+++ b/sdk/monitor/azure-monitor-query/azure/monitor/query/aio/_metrics_client_async.py
@@ -28,8 +28,6 @@ class MetricsClient:  # pylint: disable=client-accepts-api-version-keyword
         resources. For global resources, the region should be 'global'. Required.
     :param credential: The credential to authenticate the client.
     :type credential: ~azure.core.credentials_async.AsyncTokenCredential
-    :keyword str audience: The audience to use when requesting a token. If not provided, the public cloud audience
-        will be assumed. Defaults to 'https://metrics.monitor.azure.com'.
     """
 
     def __init__(self, endpoint: str, credential: AsyncTokenCredential, **kwargs: Any) -> None:


### PR DESCRIPTION
This removes the audience docstring for now until support for other clouds (i.e. non-public clouds) is in-place and validated.
