### PR TITLE
Repair `communication` livetests

### DIFF
--- a/sdk/communication/tests.yml
+++ b/sdk/communication/tests.yml
@@ -20,7 +20,6 @@ parameters:
 extends:
     template: /eng/pipelines/templates/stages/archetype-sdk-tests.yml
     parameters:
-      JobName: ${{ replace(service, '-', '_') }}
       # All 5 service stages run in parallel, and with no parallel limits the tests may get throttled.
       MaxParallel: 2
       ServiceDirectory: communication


### PR DESCRIPTION
We left parameter `jobName` referencing the old `service` value from when we iterated across `Services` _within_ the `tests.yml`.

Now we allow `archetype-sdk-tests` to do that for us via the `Packages` parameter, so we simply won't provide the `jobName` parameter anymore.