### PR TITLE
Update Authorization Code client_secret kwarg usage

### DIFF
--- a/sdk/identity/azure-identity/azure/identity/_credentials/authorization_code.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/authorization_code.py
@@ -86,11 +86,8 @@ class AuthorizationCodeCredential(GetTokenMixin):
           ``response`` attribute.
         """
         # pylint:disable=useless-super-delegation
-        client_secret = (
-            kwargs.pop("client_secret", None) or self._client_secret
-        )  # If secret not provided in method, use init secret
         return super(AuthorizationCodeCredential, self).get_token(
-            *scopes, claims=claims, tenant_id=tenant_id, client_secret=client_secret, **kwargs
+            *scopes, claims=claims, tenant_id=tenant_id, **kwargs
         )
 
     def _acquire_token_silently(self, *scopes: str, **kwargs) -> Optional[AccessToken]:

--- a/sdk/identity/azure-identity/azure/identity/_credentials/authorization_code.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/authorization_code.py
@@ -87,7 +87,7 @@ class AuthorizationCodeCredential(GetTokenMixin):
         """
         # pylint:disable=useless-super-delegation
         return super(AuthorizationCodeCredential, self).get_token(
-            *scopes, claims=claims, tenant_id=tenant_id, **kwargs
+            *scopes, claims=claims, tenant_id=tenant_id, client_secret=self._client_secret, **kwargs
         )
 
     def _acquire_token_silently(self, *scopes: str, **kwargs) -> Optional[AccessToken]:

--- a/sdk/identity/azure-identity/azure/identity/_credentials/authorization_code.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/authorization_code.py
@@ -86,8 +86,12 @@ class AuthorizationCodeCredential(GetTokenMixin):
           ``response`` attribute.
         """
         # pylint:disable=useless-super-delegation
-        client_secret =  kwargs.pop("client_secret", None) or self._client_secret # If secret not provided in method, use init secret
-        return super(AuthorizationCodeCredential, self).get_token(*scopes, claims=claims, tenant_id=tenant_id, client_secret=client_secret, **kwargs)
+        client_secret = (
+            kwargs.pop("client_secret", None) or self._client_secret
+        )  # If secret not provided in method, use init secret
+        return super(AuthorizationCodeCredential, self).get_token(
+            *scopes, claims=claims, tenant_id=tenant_id, client_secret=client_secret, **kwargs
+        )
 
     def _acquire_token_silently(self, *scopes: str, **kwargs) -> Optional[AccessToken]:
         return self._client.get_cached_access_token(scopes, **kwargs)

--- a/sdk/identity/azure-identity/azure/identity/_credentials/authorization_code.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/authorization_code.py
@@ -86,7 +86,8 @@ class AuthorizationCodeCredential(GetTokenMixin):
           ``response`` attribute.
         """
         # pylint:disable=useless-super-delegation
-        return super(AuthorizationCodeCredential, self).get_token(*scopes, claims=claims, tenant_id=tenant_id, **kwargs)
+        client_secret =  kwargs.pop("client_secret", None) or self._client_secret # If secret not provided in method, use init secret
+        return super(AuthorizationCodeCredential, self).get_token(*scopes, claims=claims, tenant_id=tenant_id, client_secret=client_secret, **kwargs)
 
     def _acquire_token_silently(self, *scopes: str, **kwargs) -> Optional[AccessToken]:
         return self._client.get_cached_access_token(scopes, **kwargs)

--- a/sdk/identity/azure-identity/azure/identity/_internal/aad_client_base.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/aad_client_base.py
@@ -302,6 +302,9 @@ class AadClientBase(abc.ABC):
             "client_id": self._client_id,
             "client_info": 1,  # request Microsoft Entra ID include home_account_id in its response
         }
+        client_secret = kwargs.pop('client_secret', None)
+        if client_secret:
+            data["client_secret"] = client_secret
 
         claims = _merge_claims_challenge_and_capabilities(
             ["CP1"] if kwargs.get("enable_cae") else [], kwargs.get("claims")

--- a/sdk/identity/azure-identity/azure/identity/_internal/aad_client_base.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/aad_client_base.py
@@ -302,7 +302,7 @@ class AadClientBase(abc.ABC):
             "client_id": self._client_id,
             "client_info": 1,  # request Microsoft Entra ID include home_account_id in its response
         }
-        client_secret = kwargs.pop('client_secret', None)
+        client_secret = kwargs.pop("client_secret", None)
         if client_secret:
             data["client_secret"] = client_secret
 

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/authorization_code.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/authorization_code.py
@@ -92,7 +92,8 @@ class AuthorizationCodeCredential(AsyncContextManager, GetTokenMixin):
           attribute gives a reason. Any error response from Microsoft Entra ID is available as the error's
           ``response`` attribute.
         """
-        return await super().get_token(*scopes, claims=claims, tenant_id=tenant_id, **kwargs)
+        client_secret =  kwargs.pop("client_secret", None) or self._client_secret # If secret not provided in method, use init secret
+        return await super(AuthorizationCodeCredential, self).get_token(*scopes, claims=claims, tenant_id=tenant_id, client_secret=client_secret, **kwargs)
 
     async def _acquire_token_silently(self, *scopes: str, **kwargs: Any) -> Optional[AccessToken]:
         return self._client.get_cached_access_token(scopes, **kwargs)

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/authorization_code.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/authorization_code.py
@@ -93,7 +93,7 @@ class AuthorizationCodeCredential(AsyncContextManager, GetTokenMixin):
           ``response`` attribute.
         """
         return await super(AuthorizationCodeCredential, self).get_token(
-            *scopes, claims=claims, tenant_id=tenant_id, client_secret=self._client_secret,  **kwargs
+            *scopes, claims=claims, tenant_id=tenant_id, client_secret=self._client_secret, **kwargs
         )
 
     async def _acquire_token_silently(self, *scopes: str, **kwargs: Any) -> Optional[AccessToken]:

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/authorization_code.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/authorization_code.py
@@ -92,8 +92,12 @@ class AuthorizationCodeCredential(AsyncContextManager, GetTokenMixin):
           attribute gives a reason. Any error response from Microsoft Entra ID is available as the error's
           ``response`` attribute.
         """
-        client_secret =  kwargs.pop("client_secret", None) or self._client_secret # If secret not provided in method, use init secret
-        return await super(AuthorizationCodeCredential, self).get_token(*scopes, claims=claims, tenant_id=tenant_id, client_secret=client_secret, **kwargs)
+        client_secret = (
+            kwargs.pop("client_secret", None) or self._client_secret
+        )  # If secret not provided in method, use init secret
+        return await super(AuthorizationCodeCredential, self).get_token(
+            *scopes, claims=claims, tenant_id=tenant_id, client_secret=client_secret, **kwargs
+        )
 
     async def _acquire_token_silently(self, *scopes: str, **kwargs: Any) -> Optional[AccessToken]:
         return self._client.get_cached_access_token(scopes, **kwargs)

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/authorization_code.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/authorization_code.py
@@ -93,7 +93,7 @@ class AuthorizationCodeCredential(AsyncContextManager, GetTokenMixin):
           ``response`` attribute.
         """
         return await super(AuthorizationCodeCredential, self).get_token(
-            *scopes, claims=claims, tenant_id=tenant_id, **kwargs
+            *scopes, claims=claims, tenant_id=tenant_id, client_secret=self._client_secret,  **kwargs
         )
 
     async def _acquire_token_silently(self, *scopes: str, **kwargs: Any) -> Optional[AccessToken]:

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/authorization_code.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/authorization_code.py
@@ -92,11 +92,8 @@ class AuthorizationCodeCredential(AsyncContextManager, GetTokenMixin):
           attribute gives a reason. Any error response from Microsoft Entra ID is available as the error's
           ``response`` attribute.
         """
-        client_secret = (
-            kwargs.pop("client_secret", None) or self._client_secret
-        )  # If secret not provided in method, use init secret
         return await super(AuthorizationCodeCredential, self).get_token(
-            *scopes, claims=claims, tenant_id=tenant_id, client_secret=client_secret, **kwargs
+            *scopes, claims=claims, tenant_id=tenant_id, **kwargs
         )
 
     async def _acquire_token_silently(self, *scopes: str, **kwargs: Any) -> Optional[AccessToken]:

--- a/sdk/identity/azure-identity/tests/test_auth_code.py
+++ b/sdk/identity/azure-identity/tests/test_auth_code.py
@@ -78,6 +78,7 @@ def test_tenant_id():
 
 def test_auth_code_credential():
     client_id = "client id"
+    secret = "fake-client-secret"
     tenant_id = "tenant"
     expected_code = "auth code"
     redirect_uri = "https://localhost"
@@ -92,6 +93,7 @@ def test_auth_code_credential():
                 url_substring=tenant_id,
                 required_data={
                     "client_id": client_id,
+                    "client_secret": secret,
                     "code": expected_code,
                     "grant_type": "authorization_code",
                     "redirect_uri": redirect_uri,
@@ -102,6 +104,7 @@ def test_auth_code_credential():
                 url_substring=tenant_id,
                 required_data={
                     "client_id": client_id,
+                    "client_secret": secret,
                     "grant_type": "refresh_token",
                     "refresh_token": expected_refresh_token,
                     "scope": expected_scope,
@@ -114,6 +117,7 @@ def test_auth_code_credential():
 
     credential = AuthorizationCodeCredential(
         client_id=client_id,
+        client_secret=secret,
         tenant_id=tenant_id,
         authorization_code=expected_code,
         redirect_uri=redirect_uri,

--- a/sdk/identity/azure-identity/tests/test_auth_code_async.py
+++ b/sdk/identity/azure-identity/tests/test_auth_code_async.py
@@ -102,6 +102,7 @@ async def test_tenant_id():
 
 async def test_auth_code_credential():
     client_id = "client id"
+    secret = "fake-client-secret"
     tenant_id = "tenant"
     expected_code = "auth code"
     redirect_uri = "https://localhost"
@@ -116,6 +117,7 @@ async def test_auth_code_credential():
                 url_substring=tenant_id,
                 required_data={
                     "client_id": client_id,
+                    "client_secret": secret,
                     "code": expected_code,
                     "grant_type": "authorization_code",
                     "redirect_uri": redirect_uri,
@@ -126,6 +128,7 @@ async def test_auth_code_credential():
                 url_substring=tenant_id,
                 required_data={
                     "client_id": client_id,
+                    "client_secret": secret,
                     "grant_type": "refresh_token",
                     "refresh_token": expected_refresh_token,
                     "scope": expected_scope,
@@ -138,6 +141,7 @@ async def test_auth_code_credential():
 
     credential = AuthorizationCodeCredential(
         client_id=client_id,
+        client_secret=secret,
         tenant_id=tenant_id,
         authorization_code=expected_code,
         redirect_uri=redirect_uri,


### PR DESCRIPTION
# Description

- Update the Authorization code Class to use the kwarg of `client_secret` as documented in issue 
  - https://github.com/Azure/azure-sdk-for-python/issues/8004.
- Resolve error where class successfully redeems an authorization code by passing `client_secret` into the AuthorizationCode.get_token() method breaks on a refresh call due to the kwarg getting passed into the request pipeline.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
