### PR TITLE
[Test Proxy] Sanitize OAuth requests/responses throughout SDK by default

### DIFF
--- a/tools/azure-sdk-tools/devtools_testutils/proxy_startup.py
+++ b/tools/azure-sdk-tools/devtools_testutils/proxy_startup.py
@@ -25,7 +25,7 @@ from ci_tools.variables import in_ci
 
 from .config import PROXY_URL
 from .helpers import get_http_client, is_live_and_not_recording
-from .sanitizers import add_remove_header_sanitizer, set_custom_default_matcher
+from .sanitizers import add_oauth_response_sanitizer, add_remove_header_sanitizer, set_custom_default_matcher
 
 
 load_dotenv(find_dotenv())
@@ -339,6 +339,7 @@ def start_test_proxy(request) -> None:
     headers_to_ignore = "Authorization, x-ms-client-request-id, x-ms-request-id"
     add_remove_header_sanitizer(headers=headers_to_ignore)
     set_custom_default_matcher(excluded_headers=headers_to_ignore)
+    add_oauth_response_sanitizer()
 
 
 def stop_test_proxy() -> None:


### PR DESCRIPTION
# Description

OAuth interactions are a major potential source of test principal secret leakage if client data isn't correctly sanitized elsewhere. Since these interactions aren't necessary for any tests that I'm aware of, and sanitizing them won't break any existing functionality, this updates the test proxy's startup code to automatically register the OAuth response sanitizer, thereby opting everyone in to sanitizing them.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
