### PR TITLE
Bump typing-extensions dependency to >= 4.6.0 to fix import name issue in azure-servicebus

### DIFF
--- a/sdk/servicebus/azure-servicebus/CHANGELOG.md
+++ b/sdk/servicebus/azure-servicebus/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fixed incorrect dependency on typing-extensions ([34868]https://github.com/Azure/azure-sdk-for-python/issues/34868)
+
 ### Other Changes
 
 ## 7.12.1 (2024-03-20)

--- a/sdk/servicebus/azure-servicebus/CHANGELOG.md
+++ b/sdk/servicebus/azure-servicebus/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bugs Fixed
 
-- Fixed incorrect dependency on typing-extensions ([34868]https://github.com/Azure/azure-sdk-for-python/issues/34868)
+- Fixed incorrect dependency on typing-extensions ([34868](https://github.com/Azure/azure-sdk-for-python/issues/34868))
 
 ### Other Changes
 

--- a/sdk/servicebus/azure-servicebus/setup.py
+++ b/sdk/servicebus/azure-servicebus/setup.py
@@ -68,6 +68,6 @@ setup(
     install_requires=[
         "azure-core>=1.28.0",
         "isodate>=0.6.0",
-        "typing-extensions>=4.0.1",
+        "typing-extensions>=4.6.0",
     ]
 )


### PR DESCRIPTION
# Description

Fixes "ImportError: cannot import name 'Buffer' from 'typing_extensions'" as described in this issue https://github.com/Azure/azure-sdk-for-python/issues/34868

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
