### PR TITLE
33604: Update docstring for sphinx for azure-maps-search

### DIFF
--- a/sdk/maps/azure-maps-search/azure/maps/search/_generated/models/_models_py3.py
+++ b/sdk/maps/azure-maps-search/azure/maps/search/_generated/models/_models_py3.py
@@ -574,7 +574,7 @@ class GeoJsonFeatureData(msrest.serialization.Model):
     All required parameters must be populated in order to send to Azure.
 
     :param geometry: Required. A valid ``GeoJSON`` object. Please refer to `RFC 7946
-     <https://tools.ietf.org/html/rfc7946#section-3>`_ for details.
+     <https://tools.ietf.org/html/rfc7946#section-3>`__ for details.
     :type geometry: ~azure.maps.search.models.GeoJsonObject
     :param properties: Properties can contain any additional metadata about the ``Feature``. Value
      can be any JSON object or a JSON null value.
@@ -614,7 +614,7 @@ class GeoJsonFeatureData(msrest.serialization.Model):
 
 
 class GeoJsonObject(msrest.serialization.Model):
-    """A valid ``GeoJSON`` object. Please refer to `RFC 7946 <https://tools.ietf.org/html/rfc7946#section-3>`_ for details.
+    """A valid ``GeoJSON`` object. Please refer to `RFC 7946 <https://tools.ietf.org/html/rfc7946#section-3>`__ for details.
 
     You probably want to use the sub-classes and not this class directly. Known
     sub-classes are: GeoJsonFeature, GeoJsonFeatureCollection, GeoJsonGeometry, GeoJsonGeometryCollection, GeoJsonLineString, GeoJsonMultiLineString, GeoJsonMultiPoint, GeoJsonMultiPolygon, GeoJsonPoint, GeoJsonPolygon.
@@ -650,12 +650,12 @@ class GeoJsonObject(msrest.serialization.Model):
 
 
 class GeoJsonFeature(GeoJsonObject, GeoJsonFeatureData):
-    """A valid ``GeoJSON Feature`` object type. Please refer to `RFC 7946 <https://tools.ietf.org/html/rfc7946#section-3.2>`_ for details.
+    """A valid ``GeoJSON Feature`` object type. Please refer to `RFC 7946 <https://tools.ietf.org/html/rfc7946#section-3.2>`__ for details.
 
     All required parameters must be populated in order to send to Azure.
 
     :param geometry: Required. A valid ``GeoJSON`` object. Please refer to `RFC 7946
-     <https://tools.ietf.org/html/rfc7946#section-3>`_ for details.
+     <https://tools.ietf.org/html/rfc7946#section-3>`__ for details.
     :type geometry: ~azure.maps.search.models.GeoJsonObject
     :param properties: Properties can contain any additional metadata about the ``Feature``. Value
      can be any JSON object or a JSON null value.
@@ -732,7 +732,7 @@ class GeoJsonFeatureCollectionData(msrest.serialization.Model):
 
 
 class GeoJsonFeatureCollection(GeoJsonObject, GeoJsonFeatureCollectionData):
-    """A valid ``GeoJSON FeatureCollection`` object type. Please refer to `RFC 7946 <https://tools.ietf.org/html/rfc7946#section-3.3>`_ for details.
+    """A valid ``GeoJSON FeatureCollection`` object type. Please refer to `RFC 7946 <https://tools.ietf.org/html/rfc7946#section-3.3>`__ for details.
 
     All required parameters must be populated in order to send to Azure.
 
@@ -769,7 +769,7 @@ class GeoJsonFeatureCollection(GeoJsonObject, GeoJsonFeatureCollectionData):
 
 
 class GeoJsonGeometry(GeoJsonObject):
-    """A valid ``GeoJSON`` geometry object. The type must be one of the seven valid GeoJSON geometry types - Point, MultiPoint, LineString, MultiLineString, Polygon, MultiPolygon and GeometryCollection. Please refer to `RFC 7946 <https://tools.ietf.org/html/rfc7946#section-3.1>`_ for details.
+    """A valid ``GeoJSON`` geometry object. The type must be one of the seven valid GeoJSON geometry types - Point, MultiPoint, LineString, MultiLineString, Polygon, MultiPolygon and GeometryCollection. Please refer to `RFC 7946 <https://tools.ietf.org/html/rfc7946#section-3.1>`__ for details.
 
     All required parameters must be populated in order to send to Azure.
 
@@ -826,7 +826,7 @@ class GeoJsonGeometryCollectionData(msrest.serialization.Model):
 
 
 class GeoJsonGeometryCollection(GeoJsonObject, GeoJsonGeometryCollectionData):
-    """A valid ``GeoJSON GeometryCollection`` object type. Please refer to `RFC 7946 <https://tools.ietf.org/html/rfc7946#section-3.1.8>`_ for details.
+    """A valid ``GeoJSON GeometryCollection`` object type. Please refer to `RFC 7946 <https://tools.ietf.org/html/rfc7946#section-3.1.8>`__ for details.
 
     All required parameters must be populated in order to send to Azure.
 
@@ -891,7 +891,7 @@ class GeoJsonLineStringData(msrest.serialization.Model):
 
 
 class GeoJsonLineString(GeoJsonObject, GeoJsonLineStringData):
-    """A valid ``GeoJSON LineString`` geometry type. Please refer to `RFC 7946 <https://tools.ietf.org/html/rfc7946#section-3.1.4>`_ for details.
+    """A valid ``GeoJSON LineString`` geometry type. Please refer to `RFC 7946 <https://tools.ietf.org/html/rfc7946#section-3.1.4>`__ for details.
 
     All required parameters must be populated in order to send to Azure.
 
@@ -955,7 +955,7 @@ class GeoJsonMultiLineStringData(msrest.serialization.Model):
 
 
 class GeoJsonMultiLineString(GeoJsonObject, GeoJsonMultiLineStringData):
-    """A valid ``GeoJSON MultiLineString`` geometry type. Please refer to `RFC 7946 <https://tools.ietf.org/html/rfc7946#section-3.1.5>`_ for details.
+    """A valid ``GeoJSON MultiLineString`` geometry type. Please refer to `RFC 7946 <https://tools.ietf.org/html/rfc7946#section-3.1.5>`__ for details.
 
     All required parameters must be populated in order to send to Azure.
 
@@ -1019,7 +1019,7 @@ class GeoJsonMultiPointData(msrest.serialization.Model):
 
 
 class GeoJsonMultiPoint(GeoJsonObject, GeoJsonMultiPointData):
-    """A valid ``GeoJSON MultiPoint`` geometry type. Please refer to `RFC 7946 <https://tools.ietf.org/html/rfc7946#section-3.1.3>`_ for details.
+    """A valid ``GeoJSON MultiPoint`` geometry type. Please refer to `RFC 7946 <https://tools.ietf.org/html/rfc7946#section-3.1.3>`__ for details.
 
     All required parameters must be populated in order to send to Azure.
 
@@ -1084,7 +1084,7 @@ class GeoJsonMultiPolygonData(msrest.serialization.Model):
 
 
 class GeoJsonMultiPolygon(GeoJsonObject, GeoJsonMultiPolygonData):
-    """A valid ``GeoJSON MultiPolygon`` object type. Please refer to `RFC 7946 <https://tools.ietf.org/html/rfc7946#section-3.1.7>`_ for details.
+    """A valid ``GeoJSON MultiPolygon`` object type. Please refer to `RFC 7946 <https://tools.ietf.org/html/rfc7946#section-3.1.7>`__ for details.
 
     All required parameters must be populated in order to send to Azure.
 
@@ -1129,7 +1129,7 @@ class GeoJsonPointData(msrest.serialization.Model):
     :param coordinates: Required. A ``Position`` is an array of numbers with two or more elements.
      The first two elements are *longitude* and *latitude*\ , precisely in that order.
      *Altitude/Elevation* is an optional third element. Please refer to `RFC 7946
-     <https://tools.ietf.org/html/rfc7946#section-3.1.1>`_ for details.
+     <https://tools.ietf.org/html/rfc7946#section-3.1.1>`__ for details.
     :type coordinates: list[float]
     """
 
@@ -1152,14 +1152,14 @@ class GeoJsonPointData(msrest.serialization.Model):
 
 
 class GeoJsonPoint(GeoJsonObject, GeoJsonPointData):
-    """A valid ``GeoJSON Point`` geometry type. Please refer to `RFC 7946 <https://tools.ietf.org/html/rfc7946#section-3.1.2>`_ for details.
+    """A valid ``GeoJSON Point`` geometry type. Please refer to `RFC 7946 <https://tools.ietf.org/html/rfc7946#section-3.1.2>`__ for details.
 
     All required parameters must be populated in order to send to Azure.
 
     :param coordinates: Required. A ``Position`` is an array of numbers with two or more elements.
      The first two elements are *longitude* and *latitude*\ , precisely in that order.
      *Altitude/Elevation* is an optional third element. Please refer to `RFC 7946
-     <https://tools.ietf.org/html/rfc7946#section-3.1.1>`_ for details.
+     <https://tools.ietf.org/html/rfc7946#section-3.1.1>`__ for details.
     :type coordinates: list[float]
     :param type: Required. Specifies the ``GeoJSON`` type. Must be one of the nine valid GeoJSON
      object types - Point, MultiPoint, LineString, MultiLineString, Polygon, MultiPolygon,
@@ -1219,7 +1219,7 @@ class GeoJsonPolygonData(msrest.serialization.Model):
 
 
 class GeoJsonPolygon(GeoJsonObject, GeoJsonPolygonData):
-    """A valid ``GeoJSON Polygon`` geometry type. Please refer to `RFC 7946 <https://tools.ietf.org/html/rfc7946#section-3.1.6>`_ for details.
+    """A valid ``GeoJSON Polygon`` geometry type. Please refer to `RFC 7946 <https://tools.ietf.org/html/rfc7946#section-3.1.6>`__ for details.
 
     All required parameters must be populated in order to send to Azure.
 
@@ -1558,7 +1558,7 @@ class Polygon(msrest.serialization.Model):
     :ivar provider_id: ID of the returned entity.
     :vartype provider_id: str
     :param geometry_data: Geometry data in GeoJSON format. Please refer to `RFC 7946
-     <https://tools.ietf.org/html/rfc7946>`_ for details. Present only if "error" is not present.
+     <https://tools.ietf.org/html/rfc7946>`__ for details. Present only if "error" is not present.
     :type geometry_data: ~azure.maps.search.models.GeoJsonObject
     """
 
@@ -2095,7 +2095,7 @@ class SearchAlongRouteRequest(msrest.serialization.Model):
     """This type represents the request body for the Search Along Route service.
 
     :param route: A valid ``GeoJSON LineString`` geometry type. Please refer to `RFC 7946
-     <https://tools.ietf.org/html/rfc7946#section-3.1.4>`_ for details.
+     <https://tools.ietf.org/html/rfc7946#section-3.1.4>`__ for details.
     :type route: ~azure.maps.search.models.GeoJsonLineString
     """
 
@@ -2117,7 +2117,7 @@ class SearchInsideGeometryRequest(msrest.serialization.Model):
     """This type represents the request body for the Search Inside Geometry service.
 
     :param geometry: A valid ``GeoJSON`` object. Please refer to `RFC 7946
-     <https://tools.ietf.org/html/rfc7946#section-3>`_ for details.
+     <https://tools.ietf.org/html/rfc7946#section-3>`__ for details.
     :type geometry: ~azure.maps.search.models.GeoJsonObject
     """
 

--- a/sdk/maps/azure-maps-search/azure/maps/search/_search_client.py
+++ b/sdk/maps/azure-maps-search/azure/maps/search/_search_client.py
@@ -401,8 +401,7 @@ class MapsSearchClient(MapsSearchClientBase):
         :type route:
             ~azure.maps.search.models.SearchAlongRouteOptions
         :keyword int top:
-            Maximum number of responses that will be returned. Default value is 10. Max value
-         is 20.
+            Maximum number of responses that will be returned. Default value is 10. Max value is 20.
         :keyword list[str] brand_filter:
             A comma-separated list of brand names which could be used to restrict the
             result to specific brands. Item order does not matter. When multiple brands are provided, only
@@ -622,9 +621,9 @@ class MapsSearchClient(MapsSearchClientBase):
         coordinates: LatLon,
         **kwargs: Any
     ) -> SearchAddressResult:
-        """**Search Nearby Point of Interest **
+        """**Search Nearby Point of Interest**
 
-         If you have a use case for only retrieving POI results around a specific location, the nearby
+        If you have a use case for only retrieving POI results around a specific location, the nearby
         search method may be the right choice. This endpoint will only return POI results, and does not
         take in a search query parameter.
 

--- a/sdk/maps/azure-maps-search/azure/maps/search/aio/_search_client_async.py
+++ b/sdk/maps/azure-maps-search/azure/maps/search/aio/_search_client_async.py
@@ -406,8 +406,7 @@ class MapsSearchClient(AsyncMapsSearchClientBase):
         :type route:
             ~azure.maps.search.models.SearchAlongRouteOptions
         :keyword int top:
-            Maximum number of responses that will be returned. Default value is 10. Max value
-         is 20.
+            Maximum number of responses that will be returned. Default value is 10. Max value is 20.
         :keyword list[str] brand_filter:
             A comma-separated list of brand names which could be used to restrict the
             result to specific brands. Item order does not matter. When multiple brands are provided, only
@@ -628,7 +627,7 @@ class MapsSearchClient(AsyncMapsSearchClientBase):
         coordinates: LatLon,
         **kwargs: Any
     ) -> SearchAddressResult:
-        """**Search Nearby Point of Interest **
+        """**Search Nearby Point of Interest**
 
         If you have a use case for only retrieving POI results around a specific location, the nearby
         search method may be the right choice. This endpoint will only return POI results, and does not

--- a/sdk/maps/azure-maps-search/azure/maps/search/models/_models.py
+++ b/sdk/maps/azure-maps-search/azure/maps/search/models/_models.py
@@ -509,12 +509,12 @@ class ReverseSearchAddressBatchProcessResult(object):
 
 class GeoJsonObject(msrest.serialization.Model):
     """A valid ``GeoJSON`` object.
-    Please refer to `RFC 7946 <https://tools.ietf.org/html/rfc7946#section-3>`_ for details.
+    Please refer to `RFC 7946 <https://tools.ietf.org/html/rfc7946#section-3>`__ for details.
 
     You probably want to use the sub-classes and not this class directly. Known
     sub-classes are: GeoJsonFeature, GeoJsonFeatureCollection, GeoJsonGeometry,
-     GeoJsonGeometryCollection, GeoJsonLineString, GeoJsonMultiLineString,
-     GeoJsonMultiPoint, GeoJsonMultiPolygon, GeoJsonPoint, GeoJsonPolygon.
+    GeoJsonGeometryCollection, GeoJsonLineString, GeoJsonMultiLineString,
+    GeoJsonMultiPoint, GeoJsonMultiPolygon, GeoJsonPoint, GeoJsonPolygon.
 
     All required parameters must be populated in order to send to Azure.
 
@@ -557,7 +557,7 @@ class GeoJsonFeatureData(msrest.serialization.Model):
     All required parameters must be populated in order to send to Azure.
 
     :param geometry: Required. A valid ``GeoJSON`` object. Please refer to `RFC 7946
-     <https://tools.ietf.org/html/rfc7946#section-3>`_ for details.
+     <https://tools.ietf.org/html/rfc7946#section-3>`__ for details.
     :type geometry: ~azure.maps.search.models.GeoJsonObject
     :param properties: Properties can contain any additional metadata about the ``Feature``. Value
      can be any JSON object or a JSON null value.
@@ -592,12 +592,12 @@ class GeoJsonFeatureData(msrest.serialization.Model):
 
 class GeoJsonFeature(GeoJsonObject, GeoJsonFeatureData):
     """A valid ``GeoJSON Feature`` object type.
-    Please refer to `RFC 7946 <https://tools.ietf.org/html/rfc7946#section-3.2>`_ for details.
+    Please refer to `RFC 7946 <https://tools.ietf.org/html/rfc7946#section-3.2>`__ for details.
 
     All required parameters must be populated in order to send to Azure.
 
     :param geometry: Required. A valid ``GeoJSON`` object. Please refer to `RFC 7946
-     <https://tools.ietf.org/html/rfc7946#section-3>`_ for details.
+     <https://tools.ietf.org/html/rfc7946#section-3>`__ for details.
     :type geometry: ~azure.maps.search.models.GeoJsonObject
     :param properties: Properties can contain any additional metadata about the ``Feature``. Value
      can be any JSON object or a JSON null value.
@@ -659,7 +659,7 @@ class GeoJsonFeatureCollectionData(msrest.serialization.Model):
 
 class GeoJsonFeatureCollection(GeoJsonObject, GeoJsonFeatureCollectionData):
     """A valid ``GeoJSON FeatureCollection`` object type.
-    Please refer to `RFC 7946 <https://tools.ietf.org/html/rfc7946#section-3.3>`_ for details.
+    Please refer to `RFC 7946 <https://tools.ietf.org/html/rfc7946#section-3.3>`__ for details.
 
     All required parameters must be populated in order to send to Azure.
 
@@ -699,7 +699,7 @@ class GeoJsonGeometry(GeoJsonObject):
     """A valid ``GeoJSON`` geometry object.
     The type must be one of the seven valid GeoJSON geometry types -
     Point, MultiPoint, LineString, MultiLineString, Polygon, MultiPolygon and GeometryCollection.
-    Please refer to `RFC 7946 <https://tools.ietf.org/html/rfc7946#section-3.1>`_ for details.
+    Please refer to `RFC 7946 <https://tools.ietf.org/html/rfc7946#section-3.1>`__ for details.
 
     All required parameters must be populated in order to send to Azure.
 
@@ -757,7 +757,7 @@ class GeoJsonGeometryCollectionData(msrest.serialization.Model):
 
 class GeoJsonGeometryCollection(GeoJsonObject, GeoJsonGeometryCollectionData):
     """A valid ``GeoJSON GeometryCollection`` object type.
-    Please refer to `RFC 7946 <https://tools.ietf.org/html/rfc7946#section-3.1.8>`_ for details.
+    Please refer to `RFC 7946 <https://tools.ietf.org/html/rfc7946#section-3.1.8>`__ for details.
 
     All required parameters must be populated in order to send to Azure.
 
@@ -822,7 +822,7 @@ class GeoJsonLineStringData(msrest.serialization.Model):
 
 class GeoJsonLineString(GeoJsonObject, GeoJsonLineStringData):
     """A valid ``GeoJSON LineString`` geometry type.
-    Please refer to `RFC 7946 <https://tools.ietf.org/html/rfc7946#section-3.1.4>`_ for details.
+    Please refer to `RFC 7946 <https://tools.ietf.org/html/rfc7946#section-3.1.4>`__ for details.
 
     All required parameters must be populated in order to send to Azure.
 
@@ -887,7 +887,7 @@ class GeoJsonMultiLineStringData(msrest.serialization.Model):
 
 class GeoJsonMultiLineString(GeoJsonObject, GeoJsonMultiLineStringData):
     """A valid ``GeoJSON MultiLineString`` geometry type.
-    Please refer to `RFC 7946 <https://tools.ietf.org/html/rfc7946#section-3.1.5>`_ for details.
+    Please refer to `RFC 7946 <https://tools.ietf.org/html/rfc7946#section-3.1.5>`__ for details.
 
     All required parameters must be populated in order to send to Azure.
 
@@ -952,7 +952,7 @@ class GeoJsonMultiPointData(msrest.serialization.Model):
 
 class GeoJsonMultiPoint(GeoJsonObject, GeoJsonMultiPointData):
     """A valid ``GeoJSON MultiPoint`` geometry type.
-    Please refer to `RFC 7946 <https://tools.ietf.org/html/rfc7946#section-3.1.3>`_ for details.
+    Please refer to `RFC 7946 <https://tools.ietf.org/html/rfc7946#section-3.1.3>`__ for details.
 
     All required parameters must be populated in order to send to Azure.
 
@@ -1018,7 +1018,7 @@ class GeoJsonMultiPolygonData(msrest.serialization.Model):
 
 class GeoJsonMultiPolygon(GeoJsonObject, GeoJsonMultiPolygonData):
     """A valid ``GeoJSON MultiPolygon`` object type.
-    Please refer to `RFC 7946 <https://tools.ietf.org/html/rfc7946#section-3.1.7>`_ for details.
+    Please refer to `RFC 7946 <https://tools.ietf.org/html/rfc7946#section-3.1.7>`__ for details.
 
     All required parameters must be populated in order to send to Azure.
 
@@ -1063,7 +1063,7 @@ class GeoJsonPointData(msrest.serialization.Model):
     :param coordinates: Required. A ``Position`` is an array of numbers with two or more elements.
      The first two elements are *longitude* and *latitude*, precisely in that order.
      *Altitude/Elevation* is an optional third element. Please refer to `RFC 7946
-     <https://tools.ietf.org/html/rfc7946#section-3.1.1>`_ for details.
+     <https://tools.ietf.org/html/rfc7946#section-3.1.1>`__ for details.
     :type coordinates: LatLon
     """
 
@@ -1087,14 +1087,14 @@ class GeoJsonPointData(msrest.serialization.Model):
 
 class GeoJsonPoint(GeoJsonObject, GeoJsonPointData):
     """A valid ``GeoJSON Point`` geometry type.
-    Please refer to `RFC 7946 <https://tools.ietf.org/html/rfc7946#section-3.1.2>`_ for details.
+    Please refer to `RFC 7946 <https://tools.ietf.org/html/rfc7946#section-3.1.2>`__ for details.
 
     All required parameters must be populated in order to send to Azure.
 
     :param coordinates: Required. A ``Position`` is an array of numbers with two or more elements.
      The first two elements are *longitude* and *latitude*, precisely in that order.
      *Altitude/Elevation* is an optional third element. Please refer to `RFC 7946
-     <https://tools.ietf.org/html/rfc7946#section-3.1.1>`_ for details.
+     <https://tools.ietf.org/html/rfc7946#section-3.1.1>`__ for details.
     :type coordinates: LatLon
     :param type: Required. Specifies the ``GeoJSON`` type. Must be one of the nine valid GeoJSON
      object types - Point, MultiPoint, LineString, MultiLineString, Polygon, MultiPolygon,
@@ -1153,7 +1153,7 @@ class GeoJsonPolygonData(msrest.serialization.Model):
 
 class GeoJsonPolygon(GeoJsonObject, GeoJsonPolygonData):
     """A valid ``GeoJSON Polygon`` geometry type.
-    Please refer to `RFC 7946 <https://tools.ietf.org/html/rfc7946#section-3.1.6>`_ for details.
+    Please refer to `RFC 7946 <https://tools.ietf.org/html/rfc7946#section-3.1.6>`__ for details.
 
     All required parameters must be populated in order to send to Azure.
 

--- a/sdk/maps/azure-maps-search/pyproject.toml
+++ b/sdk/maps/azure-maps-search/pyproject.toml
@@ -3,3 +3,4 @@ pyright = false
 type_check_samples = false
 verifytypes = false
 ci_enabled = false
+strict_sphinx = true


### PR DESCRIPTION
# Description

Fix Sphinx errors related to formatting, styling and adopting anonymous links in docstrings. After introducing these changes, we are able to set strict_sphinx to true in pyproject.tom - which enforces strict checking during the Sphinx documentation build process.

Fixes: https://github.com/Azure/azure-sdk-for-python/issues/33604


### [Testing Guidelines]
`../azure-maps-search>pip install "tox<5"

../azure-maps-search>tox run -e strict-sphinx -c ../../../eng/tox/tox.ini --root .`
