### PR TITLE
33601: Fix Sphinx error for azure-maps-geolocation

### DIFF
--- a/sdk/maps/azure-maps-geolocation/azure/maps/geolocation/aio/_geolocation_client_async.py
+++ b/sdk/maps/azure-maps-geolocation/azure/maps/geolocation/aio/_geolocation_client_async.py
@@ -29,6 +29,7 @@ class MapsGeolocationClient(AsyncMapsGeolocationClientBase):
         The API version of the service to use for requests. It defaults to the latest service version.
         Setting to an older version may result in reduced feature compatibility.
     :paramtype api_version: str
+
     .. admonition:: Example:
 
         .. literalinclude:: ../samples/async_samples/sample_authentication_async.py

--- a/sdk/maps/azure-maps-geolocation/pyproject.toml
+++ b/sdk/maps/azure-maps-geolocation/pyproject.toml
@@ -3,3 +3,4 @@ pyright = false
 type_check_samples = false
 verifytypes = false
 ci_enabled = false
+strict_sphinx = true


### PR DESCRIPTION
# Description

Fix Sphinx errors related to formatting, styling and adopting anonymous links in docstrings. After introducing these changes, we are able to set strict_sphinx to true in pyproject.tom - which enforces strict checking during the Sphinx documentation build process.

Fixes: https://github.com/Azure/azure-sdk-for-python/issues/33601


### [Testing Guidelines]
`../azure-maps-geolocation>pip install "tox<5"

../azure-maps-geolocation>tox run -e strict-sphinx -c ../../../eng/tox/tox.ini --root .`
