### PR TITLE
33603: Enforce strict checking during the Sphinx documentation build process for azure-maps-route

### DIFF
--- a/sdk/maps/azure-maps-route/README.md
+++ b/sdk/maps/azure-maps-route/README.md
@@ -103,7 +103,7 @@ objects are async context managers and define async `close` methods.
 The following sections provide several code snippets covering some of the most common Azure Maps Route tasks, including:
 
 - [Request and Get Route Directions](#request-and-get-route-directions)
-- [Request and Get Route Range](#reqest-and-get-route-range)
+- [Request and Get Route Range](#request-and-get-route-range)
 - [Get Route Matrix](#get-route-matrix)
 - [Get Route Directions Batch](#get-route-directions-batch)
 

--- a/sdk/maps/azure-maps-route/azure/maps/route/_route_client.py
+++ b/sdk/maps/azure-maps-route/azure/maps/route/_route_client.py
@@ -153,7 +153,9 @@ class MapsRouteClient(MapsRouteClientBase):
          parameter was not specified by the caller. "effectiveSettings" Default value is None.
         :paramtype report: str or ~azure.maps.route.models.Report
         :keyword filter_section_type: Specifies which of the section types is reported in the route
-         response. :code:`<br>`:code:`<br>`For example if sectionType = pedestrian the sections which
+         response.
+
+         For example if sectionType = pedestrian the sections which
          are suited for pedestrians only are returned. Multiple types can be used. The default
          sectionType refers to the travelMode input. By default travelMode is set to car. Known values
          are: "carTrain", "country", "ferry", "motorway", "pedestrian", "tollRoad", "tollVignette",
@@ -191,7 +193,7 @@ class MapsRouteClient(MapsRouteClientBase):
          vehicles may not be allowed to drive on some roads. Default value is False.
         :paramtype is_commercial_vehicle: bool
         :keyword windingness: Level of turns for thrilling route. This parameter can only be used in
-         conjunction with ``routeType``=thrilling. Known values are: "low", "normal", and "high".
+         conjunction with ``routeType=thrilling``. Known values are: "low", "normal", and "high".
          Default value is None.
         :paramtype windingness: str or ~azure.maps.route.models.WindingnessLevel
         :keyword incline_level: Degree of hilliness for thrilling route. This parameter can only be
@@ -600,7 +602,9 @@ class MapsRouteClient(MapsRouteClientBase):
          best-estimate travel time. Known values are: "none" and "all". Default value is None.
         :paramtype compute_travel_time: str or ~azure.maps.route.models.ComputeTravelTime
         :keyword filter_section_type: Specifies which of the section types is reported in the route
-         response. :code:`<br>`:code:`<br>`For example if sectionType = pedestrian the sections which
+         response.
+
+         For example if sectionType = pedestrian the sections which
          are suited for pedestrians only are returned. Multiple types can be used. The default
          sectionType refers to the travelMode input. By default travelMode is set to car. Known values
          are: "carTrain", "country", "ferry", "motorway", "pedestrian", "tollRoad", "tollVignette",
@@ -733,7 +737,9 @@ class MapsRouteClient(MapsRouteClientBase):
          best-estimate travel time. Known values are: "none" and "all". Default value is None.
         :paramtype compute_travel_time: str or ~azure.maps.route.models.ComputeTravelTime
         :keyword filter_section_type: Specifies which of the section types is reported in the route
-         response. :code:`<br>`:code:`<br>`For example if sectionType = pedestrian the sections which
+         response.
+
+         For example if sectionType = pedestrian the sections which
          are suited for pedestrians only are returned. Multiple types can be used. The default
          sectionType refers to the travelMode input. By default travelMode is set to car. Known values
          are: "carTrain", "country", "ferry", "motorway", "pedestrian", "tollRoad", "tollVignette",

--- a/sdk/maps/azure-maps-route/azure/maps/route/aio/_route_client_async.py
+++ b/sdk/maps/azure-maps-route/azure/maps/route/aio/_route_client_async.py
@@ -34,6 +34,7 @@ def get_batch_id_from_poller(polling_method):
 # By default, use the latest supported API version
 class MapsRouteClient(AsyncMapsRouteClientBase):
     """Azure Maps Route REST APIs.
+
     :param credential:
         Credential needed for the client to connect to Azure.
     :type credential:
@@ -153,7 +154,9 @@ class MapsRouteClient(AsyncMapsRouteClientBase):
          parameter was not specified by the caller. "effectiveSettings" Default value is None.
         :paramtype report: str or ~azure.maps.route.models.Report
         :keyword filter_section_type: Specifies which of the section types is reported in the route
-         response. :code:`<br>`:code:`<br>`For example if sectionType = pedestrian the sections which
+         response.
+
+         For example if sectionType = pedestrian the sections which
          are suited for pedestrians only are returned. Multiple types can be used. The default
          sectionType refers to the travelMode input. By default travelMode is set to car. Known values
          are: "carTrain", "country", "ferry", "motorway", "pedestrian", "tollRoad", "tollVignette",
@@ -191,11 +194,11 @@ class MapsRouteClient(AsyncMapsRouteClientBase):
          vehicles may not be allowed to drive on some roads. Default value is False.
         :paramtype is_commercial_vehicle: bool
         :keyword windingness: Level of turns for thrilling route. This parameter can only be used in
-         conjunction with ``routeType``=thrilling. Known values are: "low", "normal", and "high".
+         conjunction with ``routeType=thrilling``. Known values are: "low", "normal", and "high".
          Default value is None.
         :paramtype windingness: str or ~azure.maps.route.models.WindingnessLevel
         :keyword incline_level: Degree of hilliness for thrilling route. This parameter can only be
-         used in conjunction with ``routeType``=thrilling. Known values are: "low", "normal", and
+         used in conjunction with ``routeType=thrilling``. Known values are: "low", "normal", and
          "high". Default value is None.
         :paramtype incline_level: str or ~azure.maps.route.models.InclineLevel
         :keyword travel_mode: The mode of travel for the requested route. If not defined, default is
@@ -377,11 +380,11 @@ class MapsRouteClient(AsyncMapsRouteClientBase):
          Default value is None.
         :paramtype travel_mode: str or ~azure.maps.route.models.TravelMode
         :keyword incline_level: Degree of hilliness for thrilling route. This parameter can only be
-         used in conjunction with ``routeType``=thrilling. Known values are: "low", "normal", and
+         used in conjunction with ``routeType=thrilling``. Known values are: "low", "normal", and
          "high". Default value is None.
         :paramtype incline_level: str or ~azure.maps.route.models.InclineLevel
         :keyword windingness: Level of turns for thrilling route. This parameter can only be used in
-         conjunction with ``routeType``=thrilling. Known values are: "low", "normal", and "high".
+         conjunction with ``routeType=thrilling``. Known values are: "low", "normal", and "high".
          Default value is None.
         :paramtype windingness: str or ~azure.maps.route.models.WindingnessLevel
         :keyword vehicle_axle_weight: Weight per axle of the vehicle in kg. A value of 0 means that
@@ -600,7 +603,9 @@ class MapsRouteClient(AsyncMapsRouteClientBase):
          best-estimate travel time. Known values are: "none" and "all". Default value is None.
         :paramtype compute_travel_time: str or ~azure.maps.route.models.ComputeTravelTime
         :keyword filter_section_type: Specifies which of the section types is reported in the route
-         response. :code:`<br>`:code:`<br>`For example if sectionType = pedestrian the sections which
+         response.
+
+         For example if sectionType = pedestrian the sections which
          are suited for pedestrians only are returned. Multiple types can be used. The default
          sectionType refers to the travelMode input. By default travelMode is set to car. Known values
          are: "carTrain", "country", "ferry", "motorway", "pedestrian", "tollRoad", "tollVignette",
@@ -634,11 +639,11 @@ class MapsRouteClient(AsyncMapsRouteClientBase):
         :keyword vehicle_weight: Weight of the vehicle in kilograms. Default value is 0.
         :paramtype vehicle_weight: int
         :keyword windingness: Level of turns for thrilling route. This parameter can only be used in
-         conjunction with ``routeType``=thrilling. Known values are: "low", "normal", and "high".
+         conjunction with ``routeType=thrilling``. Known values are: "low", "normal", and "high".
          Default value is None.
         :paramtype windingness: str or ~azure.maps.route.models.WindingnessLevel
         :keyword incline_level: Degree of hilliness for thrilling route. This parameter can only be
-         used in conjunction with ``routeType``=thrilling. Known values are: "low", "normal", and
+         used in conjunction with ``routeType=thrilling``. Known values are: "low", "normal", and
          "high". Default value is None.
         :paramtype incline_level: str or ~azure.maps.route.models.InclineLevel
         :keyword travel_mode: The mode of travel for the requested route. If not defined, default is
@@ -733,7 +738,9 @@ class MapsRouteClient(AsyncMapsRouteClientBase):
          best-estimate travel time. Known values are: "none" and "all". Default value is None.
         :paramtype compute_travel_time: str or ~azure.maps.route.models.ComputeTravelTime
         :keyword filter_section_type: Specifies which of the section types is reported in the route
-         response. :code:`<br>`:code:`<br>`For example if sectionType = pedestrian the sections which
+         response.
+
+         For example if sectionType = pedestrian the sections which
          are suited for pedestrians only are returned. Multiple types can be used. The default
          sectionType refers to the travelMode input. By default travelMode is set to car. Known values
          are: "carTrain", "country", "ferry", "motorway", "pedestrian", "tollRoad", "tollVignette",
@@ -767,11 +774,11 @@ class MapsRouteClient(AsyncMapsRouteClientBase):
         :keyword vehicle_weight: Weight of the vehicle in kilograms. Default value is 0.
         :paramtype vehicle_weight: int
         :keyword windingness: Level of turns for thrilling route. This parameter can only be used in
-         conjunction with ``routeType``=thrilling. Known values are: "low", "normal", and "high".
+         conjunction with ``routeType=thrilling``. Known values are: "low", "normal", and "high".
          Default value is None.
         :paramtype windingness: str or ~azure.maps.route.models.WindingnessLevel
         :keyword incline_level: Degree of hilliness for thrilling route. This parameter can only be
-         used in conjunction with ``routeType``=thrilling. Known values are: "low", "normal", and
+         used in conjunction with ``routeType=thrilling``. Known values are: "low", "normal", and
          "high". Default value is None.
         :paramtype incline_level: str or ~azure.maps.route.models.InclineLevel
         :keyword travel_mode: The mode of travel for the requested route. If not defined, default is

--- a/sdk/maps/azure-maps-route/azure/maps/route/models/_models.py
+++ b/sdk/maps/azure-maps-route/azure/maps/route/models/_models.py
@@ -265,12 +265,12 @@ class GeoJsonObjectType(str, Enum, metaclass=CaseInsensitiveEnumMeta):
 
 class GeoJsonObject(msrest.serialization.Model):
     """A valid ``GeoJSON`` object.
-    Please refer to `RFC 7946 <https://tools.ietf.org/html/rfc7946#section-3>`_ for details.
+    Please refer to `RFC 7946 <https://tools.ietf.org/html/rfc7946#section-3>`__ for details.
 
     You probably want to use the sub-classes and not this class directly. Known
     sub-classes are: GeoJsonFeature, GeoJsonFeatureCollection, GeoJsonGeometry,
-     GeoJsonGeometryCollection, GeoJsonLineString, GeoJsonMultiLineString,
-     GeoJsonMultiPoint, GeoJsonMultiPolygon, GeoJsonPoint, GeoJsonPolygon.
+    GeoJsonGeometryCollection, GeoJsonLineString, GeoJsonMultiLineString,
+    GeoJsonMultiPoint, GeoJsonMultiPolygon, GeoJsonPoint, GeoJsonPolygon.
 
     All required parameters must be populated in order to send to Azure.
 
@@ -313,7 +313,7 @@ class GeoJsonFeatureData(msrest.serialization.Model):
     All required parameters must be populated in order to send to Azure.
 
     :param geometry: Required. A valid ``GeoJSON`` object. Please refer to `RFC 7946
-     <https://tools.ietf.org/html/rfc7946#section-3>`_ for details.
+     <https://tools.ietf.org/html/rfc7946#section-3>`__ for details.
     :type geometry: ~azure.maps.route.models.GeoJsonObject
     :param properties: Properties can contain any additional metadata about the ``Feature``. Value
      can be any JSON object or a JSON null value.
@@ -348,12 +348,12 @@ class GeoJsonFeatureData(msrest.serialization.Model):
 
 class GeoJsonFeature(GeoJsonObject, GeoJsonFeatureData):
     """A valid ``GeoJSON Feature`` object type.
-    Please refer to `RFC 7946 <https://tools.ietf.org/html/rfc7946#section-3.2>`_ for details.
+    Please refer to `RFC 7946 <https://tools.ietf.org/html/rfc7946#section-3.2>`__ for details.
 
     All required parameters must be populated in order to send to Azure.
 
     :param geometry: Required. A valid ``GeoJSON`` object. Please refer to `RFC 7946
-     <https://tools.ietf.org/html/rfc7946#section-3>`_ for details.
+     <https://tools.ietf.org/html/rfc7946#section-3>`__ for details.
     :type geometry: ~azure.maps.route.models.GeoJsonObject
     :param properties: Properties can contain any additional metadata about the ``Feature``. Value
      can be any JSON object or a JSON null value.
@@ -427,7 +427,7 @@ class GeoJsonFeatureCollectionData(msrest.serialization.Model):
 
 class GeoJsonFeatureCollection(GeoJsonObject, GeoJsonFeatureCollectionData):
     """A valid ``GeoJSON FeatureCollection`` object type.
-    Please refer to `RFC 7946 <https://tools.ietf.org/html/rfc7946#section-3.3>`_ for details.
+    Please refer to `RFC 7946 <https://tools.ietf.org/html/rfc7946#section-3.3>`__ for details.
 
     All required parameters must be populated in order to send to Azure.
 
@@ -466,7 +466,7 @@ class GeoJsonGeometry(GeoJsonObject):
     """A valid ``GeoJSON`` geometry object.
     The type must be one of the seven valid GeoJSON geometry types -
     Point, MultiPoint, LineString, MultiLineString, Polygon, MultiPolygon and GeometryCollection.
-    Please refer to `RFC 7946 <https://tools.ietf.org/html/rfc7946#section-3.1>`_ for details.
+    Please refer to `RFC 7946 <https://tools.ietf.org/html/rfc7946#section-3.1>`__ for details.
 
     All required parameters must be populated in order to send to Azure.
 
@@ -524,7 +524,7 @@ class GeoJsonGeometryCollectionData(msrest.serialization.Model):
 
 class GeoJsonGeometryCollection(GeoJsonObject, GeoJsonGeometryCollectionData):
     """A valid ``GeoJSON GeometryCollection`` object type.
-    Please refer to `RFC 7946 <https://tools.ietf.org/html/rfc7946#section-3.1.8>`_ for details.
+    Please refer to `RFC 7946 <https://tools.ietf.org/html/rfc7946#section-3.1.8>`__ for details.
 
     All required parameters must be populated in order to send to Azure.
 
@@ -588,7 +588,7 @@ class GeoJsonLineStringData(msrest.serialization.Model):
 
 class GeoJsonLineString(GeoJsonObject, GeoJsonLineStringData):
     """A valid ``GeoJSON LineString`` geometry type.
-    Please refer to `RFC 7946 <https://tools.ietf.org/html/rfc7946#section-3.1.4>`_ for details.
+    Please refer to `RFC 7946 <https://tools.ietf.org/html/rfc7946#section-3.1.4>`__ for details.
 
     All required parameters must be populated in order to send to Azure.
 
@@ -674,7 +674,7 @@ class GeoJsonMultiPolygonData(object):
 
 class GeoJsonMultiLineString(GeoJsonObject, GeoJsonMultiLineStringData):
     """A valid ``GeoJSON MultiLineString`` geometry type.
-    Please refer to `RFC 7946 <https://tools.ietf.org/html/rfc7946#section-3.1.5>`_ for details.
+    Please refer to `RFC 7946 <https://tools.ietf.org/html/rfc7946#section-3.1.5>`__ for details.
 
     All required parameters must be populated in order to send to Azure.
 
@@ -700,7 +700,7 @@ class GeoJsonMultiLineString(GeoJsonObject, GeoJsonMultiLineStringData):
 
 class GeoJsonMultiPoint(GeoJsonObject, GeoJsonMultiPointData):
     """A valid ``GeoJSON MultiPoint`` geometry type.
-    Please refer to `RFC 7946 <https://tools.ietf.org/html/rfc7946#section-3.1.3>`_ for details.
+    Please refer to `RFC 7946 <https://tools.ietf.org/html/rfc7946#section-3.1.3>`__ for details.
 
     All required parameters must be populated in order to send to Azure.
 
@@ -726,7 +726,7 @@ class GeoJsonMultiPoint(GeoJsonObject, GeoJsonMultiPointData):
 
 class GeoJsonMultiPolygon(GeoJsonObject, GeoJsonMultiPolygonData):
     """A valid ``GeoJSON MultiPolygon`` object type.
-    Please refer to `RFC 7946 <https://tools.ietf.org/html/rfc7946#section-3.1.7>`_ for details.
+    Please refer to `RFC 7946 <https://tools.ietf.org/html/rfc7946#section-3.1.7>`__ for details.
 
     All required parameters must be populated in order to send to Azure.
 
@@ -771,7 +771,7 @@ class GeoJsonPointData(msrest.serialization.Model):
     :param coordinates: Required. A ``Position`` is an array of numbers with two or more elements.
      The first two elements are *longitude* and *latitude*, precisely in that order.
      *Altitude/Elevation* is an optional third element. Please refer to `RFC 7946
-     <https://tools.ietf.org/html/rfc7946#section-3.1.1>`_ for details.
+     <https://tools.ietf.org/html/rfc7946#section-3.1.1>`__ for details.
     :type coordinates: LatLon
     """
 
@@ -795,14 +795,14 @@ class GeoJsonPointData(msrest.serialization.Model):
 
 class GeoJsonPoint(GeoJsonObject, GeoJsonPointData):
     """A valid ``GeoJSON Point`` geometry type.
-    Please refer to `RFC 7946 <https://tools.ietf.org/html/rfc7946#section-3.1.2>`_ for details.
+    Please refer to `RFC 7946 <https://tools.ietf.org/html/rfc7946#section-3.1.2>`__ for details.
 
     All required parameters must be populated in order to send to Azure.
 
     :param coordinates: Required. A ``Position`` is an array of numbers with two or more elements.
      The first two elements are *longitude* and *latitude*, precisely in that order.
      *Altitude/Elevation* is an optional third element. Please refer to `RFC 7946
-     <https://tools.ietf.org/html/rfc7946#section-3.1.1>`_ for details.
+     <https://tools.ietf.org/html/rfc7946#section-3.1.1>`__ for details.
     :type coordinates: LatLon
     :param type: Required. Specifies the ``GeoJSON`` type. Must be one of the nine valid GeoJSON
      object types - Point, MultiPoint, LineString, MultiLineString, Polygon, MultiPolygon,
@@ -862,7 +862,7 @@ class GeoJsonPolygonData(msrest.serialization.Model):
 
 class GeoJsonPolygon(GeoJsonObject, GeoJsonPolygonData):
     """A valid ``GeoJSON Polygon`` geometry type.
-    Please refer to `RFC 7946 <https://tools.ietf.org/html/rfc7946#section-3.1.6>`_ for details.
+    Please refer to `RFC 7946 <https://tools.ietf.org/html/rfc7946#section-3.1.6>`__ for details.
 
     All required parameters must be populated in order to send to Azure.
 

--- a/sdk/maps/azure-maps-route/pyproject.toml
+++ b/sdk/maps/azure-maps-route/pyproject.toml
@@ -3,3 +3,4 @@ pyright = false
 type_check_samples = false
 verifytypes = false
 ci_enabled = false
+strict_sphinx = true


### PR DESCRIPTION
# Description

Fix Sphinx errors related to formatting, styling and adopting anonymous links in docstrings. After introducing these changes, we are able to set strict_sphinx to true in pyproject.tom - which enforces strict checking during the Sphinx documentation build process.

Fixes: https://github.com/Azure/azure-sdk-for-python/issues/33603

`../azure-maps-route>pip install "tox<5"

../azure-maps-route>tox run -e strict-sphinx -c ../../../eng/tox/tox.ini --root .`
