### PR TITLE
[ServiceBus] update canary test resource region

### DIFF
--- a/sdk/servicebus/tests.yml
+++ b/sdk/servicebus/tests.yml
@@ -22,7 +22,7 @@ extends:
           SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
         Canary:
           SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
-          Location: 'centraluseuap'
+          Location: 'eastus2euap'
         UsGov:
           SubscriptionConfiguration: $(sub-config-gov-test-resources)
           Location: 'usgovarizona'


### PR DESCRIPTION
Running into a capacity error with centraluseuap, so switching to eastus2euap to see if it helps.