### PR TITLE
33602: Enforce strict checking during the Sphinx documentation build process for azure-maps-render

### DIFF
--- a/sdk/maps/azure-maps-render/pyproject.toml
+++ b/sdk/maps/azure-maps-render/pyproject.toml
@@ -3,3 +3,4 @@ pyright = false
 type_check_samples = false
 verifytypes = false
 ci_enabled = false
+strict_sphinx = true

--- a/sdk/maps/azure-maps-render/samples/async_samples/sample_get_copyright_from_bounding_box_async.py
+++ b/sdk/maps/azure-maps-render/samples/async_samples/sample_get_copyright_from_bounding_box_async.py
@@ -44,7 +44,7 @@ async def get_copyright_from_bounding_box_async():
     print(result.general_copyrights[0])
     print("Result country code:")
     print(result.regions[0].country.iso3)
-    # [END get_copyright_from_bounding_box]
+    # [END get_copyright_from_bounding_box_async]
 
 if __name__ == '__main__':
     asyncio.run(get_copyright_from_bounding_box_async())

--- a/sdk/maps/azure-maps-render/samples/async_samples/sample_get_map_tileset_async.py
+++ b/sdk/maps/azure-maps-render/samples/async_samples/sample_get_map_tileset_async.py
@@ -21,7 +21,7 @@ import os
 subscription_key = os.getenv("AZURE_SUBSCRIPTION_KEY")
 
 async def get_map_tileset_async():
-    # [START get_map_tile_async]
+    # [START get_map_tileset_async]
     from azure.core.credentials import AzureKeyCredential
     from azure.maps.render.aio import MapsRenderClient
     from azure.maps.render.models import TilesetID
@@ -35,7 +35,7 @@ async def get_map_tileset_async():
     print(result.map_attribution)
     print(result.bounds)
     print(result.version)
-    # [END get_map_tile_async]
+    # [END get_map_tileset_async]
 
 if __name__ == '__main__':
     asyncio.run(get_map_tileset_async())


### PR DESCRIPTION
# Description

Fix Sphinx errors related to formatting, styling and adopting anonymous links in docstrings. After introducing these changes, we are able to set strict_sphinx to true in pyproject.tom - which enforces strict checking during the Sphinx documentation build process.

Fixes: https://github.com/Azure/azure-sdk-for-python/issues/33602

# How to verify?

`../azure-maps-render>pip install "tox<5"

../azure-maps-render>tox run -e strict-sphinx -c ../../../eng/tox/tox.ini --root .`
