### PR TITLE
[Storage] Proper datetime conversion to UTC timezone

### DIFF
--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/parser.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/parser.py
@@ -22,7 +22,7 @@ else:
 
 
 def _to_utc_datetime(value: datetime) -> str:
-    return value.strftime('%Y-%m-%dT%H:%M:%SZ')
+    return value.astimezone(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')
 
 def _rfc_1123_to_datetime(rfc_1123: str) -> Optional[datetime]:
     """Converts an RFC 1123 date string to a UTC datetime.


### PR DESCRIPTION
As title states. Here is my findings from a local toy implementation:
```
now = datetime.now()
in_utc = now.astimezone(timezone.utc)
formatted_str = in_utc.strftime('%Y-%m-%dT%H:%M:%SZ')

print("now", now)
print("in_utc", in_utc)
print("formatted_str", formatted_str)
```
Output:
```
now 2024-03-22 15:20:26.223027
in_utc 2024-03-22 22:20:26.223027+00:00
formatted_str 2024-03-22T22:20:26Z
```

Which would make sense in my case as PST -> UTC is a +7 offset

Hanging questions:

1. Should this be propagated to the other packages `parser.py` (probably yes)
2. Would this be breaking or be filed under bugfix since technically users who had previously been inputting their datetimes were getting their pure datetime objects being passed rather than their datetime translated to UTC if _not_ originally UTC