### PR TITLE
Fix az cli error when closing a handle by id

### DIFF
--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_directory_client.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_directory_client.py
@@ -622,10 +622,10 @@ class ShareDirectoryClient(StorageAccountHostsMixin):
         if handle_id == '*':
             raise ValueError("Handle ID '*' is not supported. Use 'close_all_handles' instead.")
         try:
+            kwargs.update({'recursive': None})
             response = self._client.directory.force_close_handles(
                 handle_id,
                 marker=None,
-                recursive=None,
                 sharesnapshot=self.snapshot,
                 cls=return_response_headers,
                 **kwargs


### PR DESCRIPTION
# Description

Trying to close a handle by id on an Azure File share produces an exception (https://github.com/Azure/azure-cli/issues/27671). This fixes the exception by making sure only a single definition of the `recursive` argument is passed.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
