### PR TITLE
[Storage] Fix `datetime` parsing docstring

### DIFF
--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_models.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_models.py
@@ -792,8 +792,8 @@ class AccessPolicy(GenAccessPolicy):
     :param start:
         The time at which the shared access signature becomes valid. If
         omitted, start time for this call is assumed to be the time when the
-        storage service receives the request. Azure will always interpret all
-        dates specified to be UTC.
+        storage service receives the request. The provided datetime will always
+        be interpreted as UTC.
     :type start: ~datetime.datetime or str
     """
     def __init__(self, permission=None, expiry=None, start=None):

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_models.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_models.py
@@ -792,9 +792,8 @@ class AccessPolicy(GenAccessPolicy):
     :param start:
         The time at which the shared access signature becomes valid. If
         omitted, start time for this call is assumed to be the time when the
-        storage service receives the request. Azure will always convert values
-        to UTC. If a date is passed in without timezone info, it is assumed to
-        be UTC.
+        storage service receives the request. Azure will always interpret all
+        dates specified to be UTC.
     :type start: ~datetime.datetime or str
     """
     def __init__(self, permission=None, expiry=None, start=None):

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/shared_access_signature.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/shared_access_signature.py
@@ -136,8 +136,8 @@ class SharedAccessSignature(object):
         :param start:
             The time at which the shared access signature becomes valid. If
             omitted, start time for this call is assumed to be the time when the
-            storage service receives the request. Azure will always interpret all
-            dates specified to be UTC.
+            storage service receives the request. The provided datetime will always
+            be interpreted as UTC.
         :type start: datetime or str
         :param str ip:
             Specifies an IP address or a range of IP addresses from which to accept requests.

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/shared_access_signature.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/shared_access_signature.py
@@ -136,9 +136,8 @@ class SharedAccessSignature(object):
         :param start:
             The time at which the shared access signature becomes valid. If
             omitted, start time for this call is assumed to be the time when the
-            storage service receives the request. Azure will always convert values
-            to UTC. If a date is passed in without timezone info, it is assumed to
-            be UTC.
+            storage service receives the request. Azure will always interpret all
+            dates specified to be UTC.
         :type start: datetime or str
         :param str ip:
             Specifies an IP address or a range of IP addresses from which to accept requests.

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared_access_signature.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared_access_signature.py
@@ -91,9 +91,8 @@ class BlobSharedAccessSignature(SharedAccessSignature):
         :param start:
             The time at which the shared access signature becomes valid. If
             omitted, start time for this call is assumed to be the time when the
-            storage service receives the request. Azure will always convert values
-            to UTC. If a date is passed in without timezone info, it is assumed to
-            be UTC.
+            storage service receives the request. Azure will always interpret all
+            dates specified to be UTC.
         :type start: datetime or str
         :param str policy_id:
             A unique value up to 64 characters in length that correlates to a
@@ -178,9 +177,8 @@ class BlobSharedAccessSignature(SharedAccessSignature):
         :param start:
             The time at which the shared access signature becomes valid. If
             omitted, start time for this call is assumed to be the time when the
-            storage service receives the request. Azure will always convert values
-            to UTC. If a date is passed in without timezone info, it is assumed to
-            be UTC.
+            storage service receives the request. Azure will always interpret all
+            dates specified to be UTC.
         :type start: datetime or str
         :param str policy_id:
             A unique value up to 64 characters in length that correlates to a
@@ -337,15 +335,13 @@ def generate_account_sas(
     :type permission: str or ~azure.storage.blob.AccountSasPermissions
     :param expiry:
         The time at which the shared access signature becomes invalid.
-        Azure will always convert values to UTC. If a date is passed in
-        without timezone info, it is assumed to be UTC.
+        Azure will always interpret all dates specified to be UTC.
     :type expiry: ~datetime.datetime or str
     :param start:
         The time at which the shared access signature becomes valid. If
         omitted, start time for this call is assumed to be the time when the
-        storage service receives the request. Azure will always convert values
-        to UTC. If a date is passed in without timezone info, it is assumed to
-        be UTC.
+        storage service receives the request. Azure will always interpret all
+        dates specified to be UTC.
     :type start: ~datetime.datetime or str
     :param str ip:
         Specifies an IP address or a range of IP addresses from which to accept requests.
@@ -433,9 +429,8 @@ def generate_container_sas(
     :param start:
         The time at which the shared access signature becomes valid. If
         omitted, start time for this call is assumed to be the time when the
-        storage service receives the request. Azure will always convert values
-        to UTC. If a date is passed in without timezone info, it is assumed to
-        be UTC.
+        storage service receives the request. Azure will always interpret all
+        dates specified to be UTC.
     :type start: ~datetime.datetime or str
     :param str policy_id:
         A unique value up to 64 characters in length that correlates to a
@@ -560,9 +555,8 @@ def generate_blob_sas(
     :param start:
         The time at which the shared access signature becomes valid. If
         omitted, start time for this call is assumed to be the time when the
-        storage service receives the request. Azure will always convert values
-        to UTC. If a date is passed in without timezone info, it is assumed to
-        be UTC.
+        storage service receives the request. Azure will always interpret all
+        dates specified to be UTC.
     :type start: ~datetime.datetime or str
     :param str policy_id:
         A unique value up to 64 characters in length that correlates to a

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared_access_signature.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared_access_signature.py
@@ -91,8 +91,8 @@ class BlobSharedAccessSignature(SharedAccessSignature):
         :param start:
             The time at which the shared access signature becomes valid. If
             omitted, start time for this call is assumed to be the time when the
-            storage service receives the request. Azure will always interpret all
-            dates specified to be UTC.
+            storage service receives the request. The provided datetime will always
+            be interpreted as UTC.
         :type start: datetime or str
         :param str policy_id:
             A unique value up to 64 characters in length that correlates to a
@@ -177,8 +177,8 @@ class BlobSharedAccessSignature(SharedAccessSignature):
         :param start:
             The time at which the shared access signature becomes valid. If
             omitted, start time for this call is assumed to be the time when the
-            storage service receives the request. Azure will always interpret all
-            dates specified to be UTC.
+            storage service receives the request. The provided datetime will always
+            be interpreted as UTC.
         :type start: datetime or str
         :param str policy_id:
             A unique value up to 64 characters in length that correlates to a
@@ -335,13 +335,13 @@ def generate_account_sas(
     :type permission: str or ~azure.storage.blob.AccountSasPermissions
     :param expiry:
         The time at which the shared access signature becomes invalid.
-        Azure will always interpret all dates specified to be UTC.
+        The provided datetime will always be interpreted as UTC.
     :type expiry: ~datetime.datetime or str
     :param start:
         The time at which the shared access signature becomes valid. If
         omitted, start time for this call is assumed to be the time when the
-        storage service receives the request. Azure will always interpret all
-        dates specified to be UTC.
+        storage service receives the request. The provided datetime will always
+        be interpreted as UTC.
     :type start: ~datetime.datetime or str
     :param str ip:
         Specifies an IP address or a range of IP addresses from which to accept requests.
@@ -429,8 +429,8 @@ def generate_container_sas(
     :param start:
         The time at which the shared access signature becomes valid. If
         omitted, start time for this call is assumed to be the time when the
-        storage service receives the request. Azure will always interpret all
-        dates specified to be UTC.
+        storage service receives the request. The provided datetime will always
+        be interpreted as UTC.
     :type start: ~datetime.datetime or str
     :param str policy_id:
         A unique value up to 64 characters in length that correlates to a
@@ -555,8 +555,8 @@ def generate_blob_sas(
     :param start:
         The time at which the shared access signature becomes valid. If
         omitted, start time for this call is assumed to be the time when the
-        storage service receives the request. Azure will always interpret all
-        dates specified to be UTC.
+        storage service receives the request. The provided datetime will always
+        be interpreted as UTC.
     :type start: ~datetime.datetime or str
     :param str policy_id:
         A unique value up to 64 characters in length that correlates to a

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_models.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_models.py
@@ -656,9 +656,8 @@ class AccessPolicy(BlobAccessPolicy):
     :keyword start:
         The time at which the shared access signature becomes valid. If
         omitted, start time for this call is assumed to be the time when the
-        storage service receives the request. Azure will always convert values
-        to UTC. If a date is passed in without timezone info, it is assumed to
-        be UTC.
+        storage service receives the request. Azure will always interpret all
+        dates specified to be UTC.
     :paramtype start: ~datetime.datetime or str
     """
 

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_models.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_models.py
@@ -656,8 +656,8 @@ class AccessPolicy(BlobAccessPolicy):
     :keyword start:
         The time at which the shared access signature becomes valid. If
         omitted, start time for this call is assumed to be the time when the
-        storage service receives the request. Azure will always interpret all
-        dates specified to be UTC.
+        storage service receives the request. The provided datetime will always
+        be interpreted as UTC.
     :paramtype start: ~datetime.datetime or str
     """
 

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/shared_access_signature.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/shared_access_signature.py
@@ -136,8 +136,8 @@ class SharedAccessSignature(object):
         :param start:
             The time at which the shared access signature becomes valid. If
             omitted, start time for this call is assumed to be the time when the
-            storage service receives the request. Azure will always interpret all
-            dates specified to be UTC.
+            storage service receives the request. The provided datetime will always
+            be interpreted as UTC.
         :type start: datetime or str
         :param str ip:
             Specifies an IP address or a range of IP addresses from which to accept requests.

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/shared_access_signature.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/shared_access_signature.py
@@ -136,9 +136,8 @@ class SharedAccessSignature(object):
         :param start:
             The time at which the shared access signature becomes valid. If
             omitted, start time for this call is assumed to be the time when the
-            storage service receives the request. Azure will always convert values
-            to UTC. If a date is passed in without timezone info, it is assumed to
-            be UTC.
+            storage service receives the request. Azure will always interpret all
+            dates specified to be UTC.
         :type start: datetime or str
         :param str ip:
             Specifies an IP address or a range of IP addresses from which to accept requests.

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared_access_signature.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared_access_signature.py
@@ -54,13 +54,13 @@ def generate_account_sas(
     :type permission: str or ~azure.storage.filedatalake.AccountSasPermissions
     :param expiry:
         The time at which the shared access signature becomes invalid.
-        Azure will always interpret all dates specified to be UTC.
+        The provided datetime will always be interpreted as UTC.
     :type expiry: ~datetime.datetime or str
     :keyword start:
         The time at which the shared access signature becomes valid. If
         omitted, start time for this call is assumed to be the time when the
-        storage service receives the request. Azure will always interpret all
-        dates specified to be UTC.
+        storage service receives the request. The provided datetime will always
+        be interpreted as UTC.
     :paramtype start: ~datetime.datetime or str
     :keyword str ip:
         Specifies an IP address or a range of IP addresses from which to accept requests.
@@ -135,8 +135,8 @@ def generate_file_system_sas(
     :keyword start:
         The time at which the shared access signature becomes valid. If
         omitted, start time for this call is assumed to be the time when the
-        storage service receives the request. Azure will always interpret all
-        dates specified to be UTC.
+        storage service receives the request. The provided datetime will always
+        be interpreted as UTC.
     :paramtype start: datetime or str
     :keyword str policy_id:
         A unique value up to 64 characters in length that correlates to a
@@ -242,8 +242,8 @@ def generate_directory_sas(
     :keyword start:
         The time at which the shared access signature becomes valid. If
         omitted, start time for this call is assumed to be the time when the
-        storage service receives the request. Azure will always interpret all
-        dates specified to be UTC.
+        storage service receives the request. The provided datetime will always
+        be interpreted as UTC.
     :paramtype start: ~datetime.datetime or str
     :keyword str policy_id:
         A unique value up to 64 characters in length that correlates to a
@@ -356,8 +356,8 @@ def generate_file_sas(
     :keyword start:
         The time at which the shared access signature becomes valid. If
         omitted, start time for this call is assumed to be the time when the
-        storage service receives the request. Azure will always interpret all
-        dates specified to be UTC.
+        storage service receives the request. The provided datetime will always
+        be interpreted as UTC.
     :paramtype start: ~datetime.datetime or str
     :keyword str policy_id:
         A unique value up to 64 characters in length that correlates to a

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared_access_signature.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared_access_signature.py
@@ -54,15 +54,13 @@ def generate_account_sas(
     :type permission: str or ~azure.storage.filedatalake.AccountSasPermissions
     :param expiry:
         The time at which the shared access signature becomes invalid.
-        Azure will always convert values to UTC. If a date is passed in
-        without timezone info, it is assumed to be UTC.
+        Azure will always interpret all dates specified to be UTC.
     :type expiry: ~datetime.datetime or str
     :keyword start:
         The time at which the shared access signature becomes valid. If
         omitted, start time for this call is assumed to be the time when the
-        storage service receives the request. Azure will always convert values
-        to UTC. If a date is passed in without timezone info, it is assumed to
-        be UTC.
+        storage service receives the request. Azure will always interpret all
+        dates specified to be UTC.
     :paramtype start: ~datetime.datetime or str
     :keyword str ip:
         Specifies an IP address or a range of IP addresses from which to accept requests.
@@ -137,9 +135,8 @@ def generate_file_system_sas(
     :keyword start:
         The time at which the shared access signature becomes valid. If
         omitted, start time for this call is assumed to be the time when the
-        storage service receives the request. Azure will always convert values
-        to UTC. If a date is passed in without timezone info, it is assumed to
-        be UTC.
+        storage service receives the request. Azure will always interpret all
+        dates specified to be UTC.
     :paramtype start: datetime or str
     :keyword str policy_id:
         A unique value up to 64 characters in length that correlates to a
@@ -245,9 +242,8 @@ def generate_directory_sas(
     :keyword start:
         The time at which the shared access signature becomes valid. If
         omitted, start time for this call is assumed to be the time when the
-        storage service receives the request. Azure will always convert values
-        to UTC. If a date is passed in without timezone info, it is assumed to
-        be UTC.
+        storage service receives the request. Azure will always interpret all
+        dates specified to be UTC.
     :paramtype start: ~datetime.datetime or str
     :keyword str policy_id:
         A unique value up to 64 characters in length that correlates to a
@@ -360,9 +356,8 @@ def generate_file_sas(
     :keyword start:
         The time at which the shared access signature becomes valid. If
         omitted, start time for this call is assumed to be the time when the
-        storage service receives the request. Azure will always convert values
-        to UTC. If a date is passed in without timezone info, it is assumed to
-        be UTC.
+        storage service receives the request. Azure will always interpret all
+        dates specified to be UTC.
     :paramtype start: ~datetime.datetime or str
     :keyword str policy_id:
         A unique value up to 64 characters in length that correlates to a

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_models.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_models.py
@@ -220,8 +220,8 @@ class AccessPolicy(GenAccessPolicy):
     :param start:
         The time at which the shared access signature becomes valid. If
         omitted, start time for this call is assumed to be the time when the
-        storage service receives the request. Azure will always interpret all
-        dates specified to be UTC.
+        storage service receives the request. The provided datetime will always
+        be interpreted as UTC.
     :type start: ~datetime.datetime or str
     """
     def __init__(self, permission=None, expiry=None, start=None):

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_models.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_models.py
@@ -220,9 +220,8 @@ class AccessPolicy(GenAccessPolicy):
     :param start:
         The time at which the shared access signature becomes valid. If
         omitted, start time for this call is assumed to be the time when the
-        storage service receives the request. Azure will always convert values
-        to UTC. If a date is passed in without timezone info, it is assumed to
-        be UTC.
+        storage service receives the request. Azure will always interpret all
+        dates specified to be UTC.
     :type start: ~datetime.datetime or str
     """
     def __init__(self, permission=None, expiry=None, start=None):

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/shared_access_signature.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/shared_access_signature.py
@@ -136,8 +136,8 @@ class SharedAccessSignature(object):
         :param start:
             The time at which the shared access signature becomes valid. If
             omitted, start time for this call is assumed to be the time when the
-            storage service receives the request. Azure will always interpret all
-            dates specified to be UTC.
+            storage service receives the request. The provided datetime will always
+            be interpreted as UTC.
         :type start: datetime or str
         :param str ip:
             Specifies an IP address or a range of IP addresses from which to accept requests.

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/shared_access_signature.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/shared_access_signature.py
@@ -136,9 +136,8 @@ class SharedAccessSignature(object):
         :param start:
             The time at which the shared access signature becomes valid. If
             omitted, start time for this call is assumed to be the time when the
-            storage service receives the request. Azure will always convert values
-            to UTC. If a date is passed in without timezone info, it is assumed to
-            be UTC.
+            storage service receives the request. Azure will always interpret all
+            dates specified to be UTC.
         :type start: datetime or str
         :param str ip:
             Specifies an IP address or a range of IP addresses from which to accept requests.

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared_access_signature.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared_access_signature.py
@@ -76,9 +76,8 @@ class FileSharedAccessSignature(SharedAccessSignature):
         :param start:
             The time at which the shared access signature becomes valid. If
             omitted, start time for this call is assumed to be the time when the
-            storage service receives the request. Azure will always convert values
-            to UTC. If a date is passed in without timezone info, it is assumed to
-            be UTC.
+            storage service receives the request. Azure will always interpret all
+            dates specified to be UTC.
         :type start: datetime or str
         :param str policy_id:
             A unique value up to 64 characters in length that correlates to a
@@ -157,9 +156,8 @@ class FileSharedAccessSignature(SharedAccessSignature):
         :param start:
             The time at which the shared access signature becomes valid. If
             omitted, start time for this call is assumed to be the time when the
-            storage service receives the request. Azure will always convert values
-            to UTC. If a date is passed in without timezone info, it is assumed to
-            be UTC.
+            storage service receives the request. Azure will always interpret all
+            dates specified to be UTC.
         :type start: datetime or str
         :param str policy_id:
             A unique value up to 64 characters in length that correlates to a
@@ -269,15 +267,13 @@ def generate_account_sas(
         user is restricted to operations allowed by the permissions.
     :param expiry:
         The time at which the shared access signature becomes invalid.
-        Azure will always convert values to UTC. If a date is passed in without
-        timezone info, it is assumed to be UTC.
+        Azure will always interpret all dates specified to be UTC.
     :type expiry: ~datetime.datetime or str
     :param start:
         The time at which the shared access signature becomes valid. If
         omitted, start time for this call is assumed to be the time when the
-        storage service receives the request. Azure will always convert values
-        to UTC. If a date is passed in without timezone info, it is assumed to
-        be UTC.
+        storage service receives the request. Azure will always interpret all
+        dates specified to be UTC.
     :type start: ~datetime.datetime or str
     :param str ip:
         Specifies an IP address or a range of IP addresses from which to accept requests.
@@ -355,9 +351,8 @@ def generate_share_sas(
     :param start:
         The time at which the shared access signature becomes valid. If
         omitted, start time for this call is assumed to be the time when the
-        storage service receives the request. Azure will always convert values
-        to UTC. If a date is passed in without timezone info, it is assumed to
-        be UTC.
+        storage service receives the request. Azure will always interpret all
+        dates specified to be UTC.
     :type start: ~datetime.datetime or str
     :param str policy_id:
         A unique value up to 64 characters in length that correlates to a
@@ -452,9 +447,8 @@ def generate_file_sas(
     :param start:
         The time at which the shared access signature becomes valid. If
         omitted, start time for this call is assumed to be the time when the
-        storage service receives the request. Azure will always convert values
-        to UTC. If a date is passed in without timezone info, it is assumed to
-        be UTC.
+        storage service receives the request. Azure will always interpret all
+        dates specified to be UTC.
     :type start: ~datetime.datetime or str
     :param str policy_id:
         A unique value up to 64 characters in length that correlates to a

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared_access_signature.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared_access_signature.py
@@ -76,8 +76,8 @@ class FileSharedAccessSignature(SharedAccessSignature):
         :param start:
             The time at which the shared access signature becomes valid. If
             omitted, start time for this call is assumed to be the time when the
-            storage service receives the request. Azure will always interpret all
-            dates specified to be UTC.
+            storage service receives the request. The provided datetime will always
+            be interpreted as UTC.
         :type start: datetime or str
         :param str policy_id:
             A unique value up to 64 characters in length that correlates to a
@@ -156,8 +156,8 @@ class FileSharedAccessSignature(SharedAccessSignature):
         :param start:
             The time at which the shared access signature becomes valid. If
             omitted, start time for this call is assumed to be the time when the
-            storage service receives the request. Azure will always interpret all
-            dates specified to be UTC.
+            storage service receives the request. The provided datetime will always
+            be interpreted as UTC.
         :type start: datetime or str
         :param str policy_id:
             A unique value up to 64 characters in length that correlates to a
@@ -267,13 +267,13 @@ def generate_account_sas(
         user is restricted to operations allowed by the permissions.
     :param expiry:
         The time at which the shared access signature becomes invalid.
-        Azure will always interpret all dates specified to be UTC.
+        The provided datetime will always be interpreted as UTC.
     :type expiry: ~datetime.datetime or str
     :param start:
         The time at which the shared access signature becomes valid. If
         omitted, start time for this call is assumed to be the time when the
-        storage service receives the request. Azure will always interpret all
-        dates specified to be UTC.
+        storage service receives the request. The provided datetime will always
+        be interpreted as UTC.
     :type start: ~datetime.datetime or str
     :param str ip:
         Specifies an IP address or a range of IP addresses from which to accept requests.
@@ -351,8 +351,8 @@ def generate_share_sas(
     :param start:
         The time at which the shared access signature becomes valid. If
         omitted, start time for this call is assumed to be the time when the
-        storage service receives the request. Azure will always interpret all
-        dates specified to be UTC.
+        storage service receives the request. The provided datetime will always
+        be interpreted as UTC.
     :type start: ~datetime.datetime or str
     :param str policy_id:
         A unique value up to 64 characters in length that correlates to a
@@ -447,8 +447,8 @@ def generate_file_sas(
     :param start:
         The time at which the shared access signature becomes valid. If
         omitted, start time for this call is assumed to be the time when the
-        storage service receives the request. Azure will always interpret all
-        dates specified to be UTC.
+        storage service receives the request. The provided datetime will always
+        be interpreted as UTC.
     :type start: ~datetime.datetime or str
     :param str policy_id:
         A unique value up to 64 characters in length that correlates to a

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_models.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_models.py
@@ -325,9 +325,8 @@ class AccessPolicy(GenAccessPolicy):
     :param Optional[Union["datetime", str]] start:
         The time at which the shared access signature becomes valid. If
         omitted, start time for this call is assumed to be the time when the
-        storage service receives the request. Azure will always convert values
-        to UTC. If a date is passed in without timezone info, it is assumed to
-        be UTC.
+        storage service receives the request. Azure will always interpret all
+        dates specified to be UTC.
     """
 
     permission: Optional[Union[QueueSasPermissions, str]] #type: ignore [assignment]

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_models.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_models.py
@@ -325,8 +325,8 @@ class AccessPolicy(GenAccessPolicy):
     :param Optional[Union["datetime", str]] start:
         The time at which the shared access signature becomes valid. If
         omitted, start time for this call is assumed to be the time when the
-        storage service receives the request. Azure will always interpret all
-        dates specified to be UTC.
+        storage service receives the request. The provided datetime will always
+        be interpreted as UTC.
     """
 
     permission: Optional[Union[QueueSasPermissions, str]] #type: ignore [assignment]

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/shared_access_signature.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/shared_access_signature.py
@@ -136,8 +136,8 @@ class SharedAccessSignature(object):
         :param start:
             The time at which the shared access signature becomes valid. If
             omitted, start time for this call is assumed to be the time when the
-            storage service receives the request. Azure will always interpret all
-            dates specified to be UTC.
+            storage service receives the request. The provided datetime will always
+            be interpreted as UTC.
         :type start: datetime or str
         :param str ip:
             Specifies an IP address or a range of IP addresses from which to accept requests.

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/shared_access_signature.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/shared_access_signature.py
@@ -136,9 +136,8 @@ class SharedAccessSignature(object):
         :param start:
             The time at which the shared access signature becomes valid. If
             omitted, start time for this call is assumed to be the time when the
-            storage service receives the request. Azure will always convert values
-            to UTC. If a date is passed in without timezone info, it is assumed to
-            be UTC.
+            storage service receives the request. Azure will always interpret all
+            dates specified to be UTC.
         :type start: datetime or str
         :param str ip:
             Specifies an IP address or a range of IP addresses from which to accept requests.

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_shared_access_signature.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_shared_access_signature.py
@@ -74,9 +74,8 @@ class QueueSharedAccessSignature(SharedAccessSignature):
         :param start:
             The time at which the shared access signature becomes valid. If
             omitted, start time for this call is assumed to be the time when the
-            storage service receives the request. Azure will always convert values
-            to UTC. If a date is passed in without timezone info, it is assumed to
-            be UTC.
+            storage service receives the request. Azure will always interpret all
+            dates specified to be UTC.
         :type start: ~datetime.datetime or str
         :param str policy_id:
             A unique value up to 64 characters in length that correlates to a
@@ -161,15 +160,13 @@ def generate_account_sas(
     :type permission: ~azure.storage.queue.AccountSasPermissions or str
     :param expiry:
         The time at which the shared access signature becomes invalid.
-        Azure will always convert values to UTC. If a date is passed in
-        without timezone info, it is assumed to be UTC.
+        Azure will always interpret all dates specified to be UTC.
     :type expiry: ~datetime.datetime or str
     :param start:
         The time at which the shared access signature becomes valid. If
         omitted, start time for this call is assumed to be the time when the
-        storage service receives the request. Azure will always convert values
-        to UTC. If a date is passed in without timezone info, it is assumed to
-        be UTC.
+        storage service receives the request. Azure will always interpret all
+        dates specified to be UTC.
     :type start: ~datetime.datetime or str
     :param str ip:
         Specifies an IP address or a range of IP addresses from which to accept requests.
@@ -236,9 +233,8 @@ def generate_queue_sas(
     :param start:
         The time at which the shared access signature becomes valid. If
         omitted, start time for this call is assumed to be the time when the
-        storage service receives the request. Azure will always convert values
-        to UTC. If a date is passed in without timezone info, it is assumed to
-        be UTC.
+        storage service receives the request. Azure will always interpret all
+        dates specified to be UTC.
     :type start: ~datetime.datetime or str
     :param str policy_id:
         A unique value up to 64 characters in length that correlates to a

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_shared_access_signature.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_shared_access_signature.py
@@ -74,8 +74,8 @@ class QueueSharedAccessSignature(SharedAccessSignature):
         :param start:
             The time at which the shared access signature becomes valid. If
             omitted, start time for this call is assumed to be the time when the
-            storage service receives the request. Azure will always interpret all
-            dates specified to be UTC.
+            storage service receives the request. The provided datetime will always
+            be interpreted as UTC.
         :type start: ~datetime.datetime or str
         :param str policy_id:
             A unique value up to 64 characters in length that correlates to a
@@ -160,13 +160,13 @@ def generate_account_sas(
     :type permission: ~azure.storage.queue.AccountSasPermissions or str
     :param expiry:
         The time at which the shared access signature becomes invalid.
-        Azure will always interpret all dates specified to be UTC.
+        The provided datetime will always be interpreted as UTC.
     :type expiry: ~datetime.datetime or str
     :param start:
         The time at which the shared access signature becomes valid. If
         omitted, start time for this call is assumed to be the time when the
-        storage service receives the request. Azure will always interpret all
-        dates specified to be UTC.
+        storage service receives the request. The provided datetime will always
+        be interpreted as UTC.
     :type start: ~datetime.datetime or str
     :param str ip:
         Specifies an IP address or a range of IP addresses from which to accept requests.
@@ -233,8 +233,8 @@ def generate_queue_sas(
     :param start:
         The time at which the shared access signature becomes valid. If
         omitted, start time for this call is assumed to be the time when the
-        storage service receives the request. Azure will always interpret all
-        dates specified to be UTC.
+        storage service receives the request. The provided datetime will always
+        be interpreted as UTC.
     :type start: ~datetime.datetime or str
     :param str policy_id:
         A unique value up to 64 characters in length that correlates to a


### PR DESCRIPTION
As discussed, fixing the docstring to be more accurate to the behavior of the client and interaction with the service.