### PR TITLE
Support all developer tools for user-based auth in tests

### DIFF
--- a/doc/dev/tests.md
+++ b/doc/dev/tests.md
@@ -183,9 +183,12 @@ Both pure ARM templates (`test-resources.json`) and BICEP files (`test-resources
 
 User-based authentication is preferred when using test resources. To enable this:
 - Use the [`-UserAuth` command flag][user_auth_flag] when running the `New-TestResources` script.
-- Set the environment variable `AZURE_TEST_USE_PWSH_AUTH` to "true" to authenticate with Azure PowerShell, or
-`AZURE_TEST_USE_CLI_AUTH` to "true" to authenticate with Azure CLI.
-  - Ensure you're logged into the tool you choose -- if
+- Choose a development tool to authenticate with by setting an `AZURE_TEST_USE_*_AUTH` environment variable to "true" (tests will authenticate as the tool's logged-in user). The following tools are supported, listed in the order that authentication will be attempted in if requested:
+  1. Azure PowerShell: set `AZURE_TEST_USE_PWSH_AUTH`.
+  2. Azure CLI (`az`): set `AZURE_TEST_USE_CLI_AUTH`.
+  3. Visual Studio Code: set `AZURE_TEST_USE_VSCODE_AUTH`.
+  4. Azure Developer CLI (`azd`): set `AZURE_TEST_USE_AZD_AUTH`.
+- Ensure you're logged into the tool you choose -- if
 you used `New-TestResources.ps1` to deploy resources, you'll already have logged in with Azure PowerShell.
 
 If you haven't yet set up a `test-resources` file for test resource deployment and/or want to use test resources of
@@ -216,13 +219,15 @@ environment variables necessary to run live tests for the service. After storing
 -- formatted as `VARIABLE=value` on separate lines -- your credentials and test configuration variables will be set in
 our environment when running tests.
 
-If you used the [`-UserAuth` command flag][user_auth_flag] to deploy test resources, set either
-`AZURE_TEST_USE_PWSH_AUTH` or `AZURE_TEST_USE_CLI_AUTH` to "true" to authenticate with Azure PowerShell or Azure CLI,
-respectively. If both are set to true, Azure PowerShell will be used.
+If you used the [`-UserAuth` command flag][user_auth_flag] to deploy test resources, choose a development tool to
+authenticate with by setting an `AZURE_TEST_USE_*_AUTH` environment variable to "true". The following tools are supported, listed in the order that authentication will be attempted in if requested:
+  1. Azure PowerShell: set `AZURE_TEST_USE_PWSH_AUTH`.
+  2. Azure CLI (`az`): set `AZURE_TEST_USE_CLI_AUTH`.
+  3. Visual Studio Code: set `AZURE_TEST_USE_VSCODE_AUTH`.
+  4. Azure Developer CLI (`azd`): set `AZURE_TEST_USE_AZD_AUTH`.
 
 If your service doesn't have a `test-resources` file for test deployment, you'll need to set environment variables
-for authentication at minimum. For user-based authentication, use `AZURE_TEST_USE_PWSH_AUTH` or
-`AZURE_TEST_USE_CLI_AUTH` as described above.
+for authentication at minimum. For user-based authentication, use `AZURE_TEST_USE_*_AUTH` as described above.
 
 For service principal authentication:
 1. Set the `AZURE_SUBSCRIPTION_ID` variable to your organization's subscription ID. You can find it in the "Overview"

--- a/tools/azure-sdk-tools/devtools_testutils/azure_recorded_testcase.py
+++ b/tools/azure-sdk-tools/devtools_testutils/azure_recorded_testcase.py
@@ -93,6 +93,8 @@ class AzureRecordedTestCase(object):
 
         use_pwsh = os.environ.get("AZURE_TEST_USE_PWSH_AUTH", "false")
         use_cli = os.environ.get("AZURE_TEST_USE_CLI_AUTH", "false")
+        use_vscode = os.environ.get("AZURE_TEST_USE_VSCODE_AUTH", "false")
+        use_azd = os.environ.get("AZURE_TEST_USE_AZD_AUTH", "false")
         is_async = kwargs.pop("is_async", False)
 
         # Return live credentials only in live mode
@@ -107,7 +109,7 @@ class AzureRecordedTestCase(object):
                 if is_async:
                     from azure.identity.aio import AzurePowerShellCredential
                 return AzurePowerShellCredential()
-            # User-based authentication through Azure CLI, if requested
+            # User-based authentication through Azure CLI (az), if requested
             if use_cli.lower() == "true":
                 _LOGGER.info("Environment variable AZURE_TEST_USE_CLI_AUTH set to 'true'. Using AzureCliCredential.")
                 from azure.identity import AzureCliCredential
@@ -115,6 +117,26 @@ class AzureRecordedTestCase(object):
                 if is_async:
                     from azure.identity.aio import AzureCliCredential
                 return AzureCliCredential()
+            # User-based authentication through Visual Studio Code, if requested
+            if use_vscode.lower() == "true":
+                _LOGGER.info(
+                    "Environment variable AZURE_TEST_USE_VSCODE_AUTH set to 'true'. Using VisualStudioCodeCredential."
+                )
+                from azure.identity import VisualStudioCodeCredential
+
+                if is_async:
+                    from azure.identity.aio import VisualStudioCodeCredential
+                return VisualStudioCodeCredential()
+            # User-based authentication through Azure Developer CLI (azd), if requested
+            if use_azd.lower() == "true":
+                _LOGGER.info(
+                    "Environment variable AZURE_TEST_USE_AZD_AUTH set to 'true'. Using AzureDeveloperCliCredential."
+                )
+                from azure.identity import AzureDeveloperCliCredential
+
+                if is_async:
+                    from azure.identity.aio import AzureDeveloperCliCredential
+                return AzureDeveloperCliCredential()
 
             # Service principal authentication
             if tenant_id and client_id and secret:


### PR DESCRIPTION
# Description

@mrm9084 pointed out that it would be great to support VS Code authentication in our tests, and there's no reason not to. This PR adds support for VS Code and Azure Developer CLI authentication, to round out support for all developer tools enabled through `azure-identity`.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
