### PR TITLE
[Identity] Update get_token method signatures

### DIFF
--- a/sdk/identity/azure-identity/azure/identity/_credentials/application.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/application.py
@@ -64,7 +64,12 @@ class AzureApplicationCredential(ChainedTokenCredential):
         )
 
     def get_token(
-        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs: Any
+        self,
+        *scopes: str,
+        claims: Optional[str] = None,
+        tenant_id: Optional[str] = None,
+        enable_cae: bool = False,
+        **kwargs: Any
     ) -> AccessToken:
         """Request an access token for `scopes`.
 
@@ -76,6 +81,8 @@ class AzureApplicationCredential(ChainedTokenCredential):
         :keyword str claims: additional claims required in the token, such as those returned in a resource provider's
             claims challenge following an authorization failure.
         :keyword str tenant_id: optional tenant to include in the token request.
+        :keyword bool enable_cae: Indicates whether to enable Continuous Access Evaluation (CAE) for the requested
+            token if possible. Defaults to False.
 
         :return: An access token with the desired scopes.
         :rtype: ~azure.core.credentials.AccessToken
@@ -83,10 +90,14 @@ class AzureApplicationCredential(ChainedTokenCredential):
             `message` attribute listing each authentication attempt and its error message.
         """
         if self._successful_credential:
-            token = self._successful_credential.get_token(*scopes, claims=claims, tenant_id=tenant_id, **kwargs)
+            token = self._successful_credential.get_token(
+                *scopes, claims=claims, tenant_id=tenant_id, enable_cae=enable_cae, **kwargs
+            )
             _LOGGER.info(
                 "%s acquired a token from %s", self.__class__.__name__, self._successful_credential.__class__.__name__
             )
             return token
 
-        return super(AzureApplicationCredential, self).get_token(*scopes, claims=claims, tenant_id=tenant_id, **kwargs)
+        return super(AzureApplicationCredential, self).get_token(
+            *scopes, claims=claims, tenant_id=tenant_id, enable_cae=enable_cae, **kwargs
+        )

--- a/sdk/identity/azure-identity/azure/identity/_credentials/authorization_code.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/authorization_code.py
@@ -62,7 +62,12 @@ class AuthorizationCodeCredential(GetTokenMixin):
         self.__exit__()
 
     def get_token(
-        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs: Any
+        self,
+        *scopes: str,
+        claims: Optional[str] = None,
+        tenant_id: Optional[str] = None,
+        enable_cae: bool = False,
+        **kwargs: Any
     ) -> AccessToken:
         """Request an access token for `scopes`.
 
@@ -78,6 +83,8 @@ class AuthorizationCodeCredential(GetTokenMixin):
         :keyword str claims: additional claims required in the token, such as those returned in a resource provider's
             claims challenge following an authorization failure.
         :keyword str tenant_id: optional tenant to include in the token request.
+        :keyword bool enable_cae: Indicates whether to enable Continuous Access Evaluation (CAE) for the requested
+            token. Defaults to False.
 
         :return: An access token with the desired scopes.
         :rtype: ~azure.core.credentials.AccessToken
@@ -87,7 +94,12 @@ class AuthorizationCodeCredential(GetTokenMixin):
         """
         # pylint:disable=useless-super-delegation
         return super(AuthorizationCodeCredential, self).get_token(
-            *scopes, claims=claims, tenant_id=tenant_id, client_secret=self._client_secret, **kwargs
+            *scopes,
+            claims=claims,
+            tenant_id=tenant_id,
+            enable_cae=enable_cae,
+            client_secret=self._client_secret,
+            **kwargs
         )
 
     def _acquire_token_silently(self, *scopes: str, **kwargs) -> Optional[AccessToken]:

--- a/sdk/identity/azure-identity/azure/identity/_credentials/azd_cli.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/azd_cli.py
@@ -97,6 +97,7 @@ class AzureDeveloperCliCredential:
         *scopes: str,
         claims: Optional[str] = None,  # pylint:disable=unused-argument
         tenant_id: Optional[str] = None,
+        enable_cae: bool = False,  # pylint:disable=unused-argument
         **kwargs: Any,
     ) -> AccessToken:
         """Request an access token for `scopes`.
@@ -109,6 +110,8 @@ class AzureDeveloperCliCredential:
             https://learn.microsoft.com/entra/identity-platform/scopes-oidc.
         :keyword str claims: not used by this credential; any value provided will be ignored.
         :keyword str tenant_id: optional tenant to include in the token request.
+        :keyword bool enable_cae: Indicates whether to enable Continuous Access Evaluation (CAE) for the requested
+            token. Not supported by this credential.
 
         :return: An access token with the desired scopes.
         :rtype: ~azure.core.credentials.AccessToken

--- a/sdk/identity/azure-identity/azure/identity/_credentials/azure_cli.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/azure_cli.py
@@ -74,6 +74,7 @@ class AzureCliCredential:
         *scopes: str,
         claims: Optional[str] = None,  # pylint:disable=unused-argument
         tenant_id: Optional[str] = None,
+        enable_cae: bool = False,  # pylint:disable=unused-argument
         **kwargs: Any,
     ) -> AccessToken:
         """Request an access token for `scopes`.
@@ -86,6 +87,8 @@ class AzureCliCredential:
             https://learn.microsoft.com/entra/identity-platform/scopes-oidc.
         :keyword str claims: not used by this credential; any value provided will be ignored.
         :keyword str tenant_id: optional tenant to include in the token request.
+        :keyword bool enable_cae: Indicates whether to enable Continuous Access Evaluation (CAE) for the requested
+            token. Not supported by this credential.
 
         :return: An access token with the desired scopes.
         :rtype: ~azure.core.credentials.AccessToken

--- a/sdk/identity/azure-identity/azure/identity/_credentials/azure_powershell.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/azure_powershell.py
@@ -89,6 +89,7 @@ class AzurePowerShellCredential:
         *scopes: str,
         claims: Optional[str] = None,  # pylint:disable=unused-argument
         tenant_id: Optional[str] = None,
+        enable_cae: bool = False,  # pylint:disable=unused-argument
         **kwargs: Any,
     ) -> AccessToken:
         """Request an access token for `scopes`.
@@ -101,6 +102,8 @@ class AzurePowerShellCredential:
             https://learn.microsoft.com/entra/identity-platform/scopes-oidc.
         :keyword str claims: not used by this credential; any value provided will be ignored.
         :keyword str tenant_id: optional tenant to include in the token request.
+        :keyword bool enable_cae: Indicates whether to enable Continuous Access Evaluation (CAE) for the requested
+            token. Not supported by this credential.
 
         :return: An access token with the desired scopes.
         :rtype: ~azure.core.credentials.AccessToken

--- a/sdk/identity/azure-identity/azure/identity/_credentials/chained.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/chained.py
@@ -70,7 +70,12 @@ class ChainedTokenCredential:
         self.__exit__()
 
     def get_token(
-        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs: Any
+        self,
+        *scopes: str,
+        claims: Optional[str] = None,
+        tenant_id: Optional[str] = None,
+        enable_cae: bool = False,
+        **kwargs: Any
     ) -> AccessToken:
         """Request a token from each chained credential, in order, returning the first token received.
 
@@ -82,6 +87,8 @@ class ChainedTokenCredential:
         :keyword str claims: additional claims required in the token, such as those returned in a resource provider's
             claims challenge following an authorization failure.
         :keyword str tenant_id: optional tenant to include in the token request.
+        :keyword bool enable_cae: Indicates whether to enable Continuous Access Evaluation (CAE) for the requested
+            token if the underlying credential supports it. Defaults to False.
 
         :return: An access token with the desired scopes.
         :rtype: ~azure.core.credentials.AccessToken
@@ -91,7 +98,9 @@ class ChainedTokenCredential:
         history = []
         for credential in self.credentials:
             try:
-                token = credential.get_token(*scopes, claims=claims, tenant_id=tenant_id, **kwargs)
+                token = credential.get_token(
+                    *scopes, claims=claims, tenant_id=tenant_id, enable_cae=enable_cae, **kwargs
+                )
                 _LOGGER.info("%s acquired a token from %s", self.__class__.__name__, credential.__class__.__name__)
                 self._successful_credential = credential
                 within_credential_chain.set(False)

--- a/sdk/identity/azure-identity/azure/identity/_credentials/default.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/default.py
@@ -196,7 +196,12 @@ class DefaultAzureCredential(ChainedTokenCredential):
         super(DefaultAzureCredential, self).__init__(*credentials)
 
     def get_token(
-        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs: Any
+        self,
+        *scopes: str,
+        claims: Optional[str] = None,
+        tenant_id: Optional[str] = None,
+        enable_cae: bool = False,
+        **kwargs: Any
     ) -> AccessToken:
         """Request an access token for `scopes`.
 
@@ -208,6 +213,8 @@ class DefaultAzureCredential(ChainedTokenCredential):
         :keyword str claims: additional claims required in the token, such as those returned in a resource provider's
             claims challenge following an authorization failure.
         :keyword str tenant_id: optional tenant to include in the token request.
+        :keyword bool enable_cae: Indicates whether to enable Continuous Access Evaluation (CAE) for the requested
+            token if the underlying credential supports it. Defaults to False.
 
         :return: An access token with the desired scopes.
         :rtype: ~azure.core.credentials.AccessToken
@@ -216,12 +223,14 @@ class DefaultAzureCredential(ChainedTokenCredential):
           `message` attribute listing each authentication attempt and its error message.
         """
         if self._successful_credential:
-            token = self._successful_credential.get_token(*scopes, claims=claims, tenant_id=tenant_id, **kwargs)
+            token = self._successful_credential.get_token(
+                *scopes, claims=claims, tenant_id=tenant_id, enable_cae=enable_cae, **kwargs
+            )
             _LOGGER.info(
                 "%s acquired a token from %s", self.__class__.__name__, self._successful_credential.__class__.__name__
             )
             return token
         within_dac.set(True)
-        token = super().get_token(*scopes, claims=claims, tenant_id=tenant_id, **kwargs)
+        token = super().get_token(*scopes, claims=claims, tenant_id=tenant_id, enable_cae=enable_cae, **kwargs)
         within_dac.set(False)
         return token

--- a/sdk/identity/azure-identity/azure/identity/_credentials/environment.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/environment.py
@@ -123,7 +123,12 @@ class EnvironmentCredential:
 
     @log_get_token("EnvironmentCredential")
     def get_token(
-        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs: Any
+        self,
+        *scopes: str,
+        claims: Optional[str] = None,
+        tenant_id: Optional[str] = None,
+        enable_cae: bool = False,
+        **kwargs: Any
     ) -> AccessToken:
         """Request an access token for `scopes`.
 
@@ -135,6 +140,8 @@ class EnvironmentCredential:
         :keyword str claims: additional claims required in the token, such as those returned in a resource provider's
             claims challenge following an authorization failure.
         :keyword str tenant_id: optional tenant to include in the token request.
+        :keyword bool enable_cae: Indicates whether to enable Continuous Access Evaluation (CAE) for the requested
+            token. Defaults to False.
 
         :return: An access token with the desired scopes.
         :rtype: ~azure.core.credentials.AccessToken
@@ -148,4 +155,4 @@ class EnvironmentCredential:
                 "this issue."
             )
             raise CredentialUnavailableError(message=message)
-        return self._credential.get_token(*scopes, claims=claims, tenant_id=tenant_id, **kwargs)
+        return self._credential.get_token(*scopes, claims=claims, tenant_id=tenant_id, enable_cae=enable_cae, **kwargs)

--- a/sdk/identity/azure-identity/azure/identity/_credentials/managed_identity.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/managed_identity.py
@@ -111,7 +111,12 @@ class ManagedIdentityCredential:
 
     @log_get_token("ManagedIdentityCredential")
     def get_token(
-        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs: Any
+        self,
+        *scopes: str,
+        claims: Optional[str] = None,
+        tenant_id: Optional[str] = None,
+        enable_cae: bool = False,  # pylint:disable=unused-argument
+        **kwargs: Any
     ) -> AccessToken:
         """Request an access token for `scopes`.
 
@@ -123,6 +128,8 @@ class ManagedIdentityCredential:
 
         :keyword str claims: not used by this credential; any value provided will be ignored.
         :keyword str tenant_id: not used by this credential; any value provided will be ignored.
+        :keyword bool enable_cae: Indicates whether to enable Continuous Access Evaluation (CAE) for the requested
+            token. Not supported by this credential.
 
         :return: An access token with the desired scopes.
         :rtype: ~azure.core.credentials.AccessToken

--- a/sdk/identity/azure-identity/azure/identity/_credentials/silent.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/silent.py
@@ -55,16 +55,21 @@ class SilentAuthenticationCredential:
         self._client.__exit__(*args)
 
     def get_token(
-        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs: Any
+        self,
+        *scopes: str,
+        claims: Optional[str] = None,
+        tenant_id: Optional[str] = None,
+        enable_cae: bool = False,
+        **kwargs: Any
     ) -> AccessToken:
         if not scopes:
             raise ValueError('"get_token" requires at least one scope')
 
-        token_cache = self._cae_cache if kwargs.get("enable_cae") else self._cache
+        token_cache = self._cae_cache if enable_cae else self._cache
 
         # Try to load the cache if it is None.
         if not token_cache:
-            token_cache = self._initialize_cache(is_cae=bool(kwargs.get("enable_cae")))
+            token_cache = self._initialize_cache(is_cae=enable_cae)
 
             # If the cache is still None, raise an error.
             if not token_cache:
@@ -72,7 +77,7 @@ class SilentAuthenticationCredential:
                     raise CredentialUnavailableError(message="Shared token cache unavailable")
                 raise ClientAuthenticationError(message="Shared token cache unavailable")
 
-        return self._acquire_token_silent(*scopes, claims=claims, tenant_id=tenant_id, **kwargs)
+        return self._acquire_token_silent(*scopes, claims=claims, tenant_id=tenant_id, enable_cae=enable_cae, **kwargs)
 
     def _initialize_cache(self, is_cae: bool = False) -> Optional[TokenCache]:
 

--- a/sdk/identity/azure-identity/azure/identity/_credentials/vscode.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/vscode.py
@@ -141,7 +141,12 @@ class VisualStudioCodeCredential(_VSCodeCredentialBase, GetTokenMixin):
 
     @log_get_token("VSCodeCredential")
     def get_token(
-        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs: Any
+        self,
+        *scopes: str,
+        claims: Optional[str] = None,
+        tenant_id: Optional[str] = None,
+        enable_cae: bool = False,  # pylint:disable=unused-argument
+        **kwargs: Any
     ) -> AccessToken:
         """Request an access token for `scopes` as the user currently signed in to Visual Studio Code.
 
@@ -153,6 +158,8 @@ class VisualStudioCodeCredential(_VSCodeCredentialBase, GetTokenMixin):
         :keyword str claims: additional claims required in the token, such as those returned in a resource provider's
             claims challenge following an authorization failure.
         :keyword str tenant_id: optional tenant to include in the token request.
+        :keyword bool enable_cae: Indicates whether to enable Continuous Access Evaluation (CAE) for the requested
+            token. Not supported by this credential.
 
         :return: An access token with the desired scopes.
         :rtype: ~azure.core.credentials.AccessToken

--- a/sdk/identity/azure-identity/azure/identity/_internal/managed_identity_base.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/managed_identity_base.py
@@ -42,7 +42,12 @@ class ManagedIdentityBase(GetTokenMixin):
         self.__exit__()
 
     def get_token(
-        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs: Any
+        self,
+        *scopes: str,
+        claims: Optional[str] = None,
+        tenant_id: Optional[str] = None,
+        enable_cae: bool = False,  # pylint:disable=unused-argument
+        **kwargs: Any
     ) -> AccessToken:
         if not self._client:
             raise CredentialUnavailableError(message=self.get_unavailable_message())

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/application.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/application.py
@@ -63,7 +63,12 @@ class AzureApplicationCredential(ChainedTokenCredential):
         )
 
     async def get_token(
-        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs: Any
+        self,
+        *scopes: str,
+        claims: Optional[str] = None,
+        tenant_id: Optional[str] = None,
+        enable_cae: bool = False,
+        **kwargs: Any
     ) -> AccessToken:
         """Asynchronously request an access token for `scopes`.
 
@@ -75,6 +80,8 @@ class AzureApplicationCredential(ChainedTokenCredential):
         :keyword str claims: additional claims required in the token, such as those returned in a resource provider's
             claims challenge following an authorization failure.
         :keyword str tenant_id: optional tenant to include in the token request.
+        :keyword bool enable_cae: Indicates whether to enable Continuous Access Evaluation (CAE) for the requested
+            token if possible. Defaults to False.
 
         :return: An access token with the desired scopes.
         :rtype: ~azure.core.credentials.AccessToken
@@ -82,10 +89,12 @@ class AzureApplicationCredential(ChainedTokenCredential):
             `message` attribute listing each authentication attempt and its error message.
         """
         if self._successful_credential:
-            token = await self._successful_credential.get_token(*scopes, claims=claims, tenant_id=tenant_id, **kwargs)
+            token = await self._successful_credential.get_token(
+                *scopes, claims=claims, tenant_id=tenant_id, enable_cae=enable_cae, **kwargs
+            )
             _LOGGER.info(
                 "%s acquired a token from %s", self.__class__.__name__, self._successful_credential.__class__.__name__
             )
             return token
 
-        return await super().get_token(*scopes, claims=claims, tenant_id=tenant_id, **kwargs)
+        return await super().get_token(*scopes, claims=claims, tenant_id=tenant_id, enable_cae=enable_cae, **kwargs)

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/authorization_code.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/authorization_code.py
@@ -69,7 +69,12 @@ class AuthorizationCodeCredential(AsyncContextManager, GetTokenMixin):
         super().__init__()
 
     async def get_token(
-        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs: Any
+        self,
+        *scopes: str,
+        claims: Optional[str] = None,
+        tenant_id: Optional[str] = None,
+        enable_cae: bool = False,
+        **kwargs: Any
     ) -> AccessToken:
         """Request an access token for `scopes`.
 
@@ -85,6 +90,8 @@ class AuthorizationCodeCredential(AsyncContextManager, GetTokenMixin):
         :keyword str claims: additional claims required in the token, such as those returned in a resource provider's
             claims challenge following an authorization failure.
         :keyword str tenant_id: optional tenant to include in the token request.
+        :keyword bool enable_cae: Indicates whether to enable Continuous Access Evaluation (CAE) for the requested
+            token. Defaults to False.
 
         :return: An access token with the desired scopes.
         :rtype: ~azure.core.credentials.AccessToken
@@ -93,7 +100,12 @@ class AuthorizationCodeCredential(AsyncContextManager, GetTokenMixin):
           ``response`` attribute.
         """
         return await super(AuthorizationCodeCredential, self).get_token(
-            *scopes, claims=claims, tenant_id=tenant_id, client_secret=self._client_secret, **kwargs
+            *scopes,
+            claims=claims,
+            tenant_id=tenant_id,
+            enable_cae=enable_cae,
+            client_secret=self._client_secret,
+            **kwargs
         )
 
     async def _acquire_token_silently(self, *scopes: str, **kwargs: Any) -> Optional[AccessToken]:

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/azd_cli.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/azd_cli.py
@@ -85,6 +85,7 @@ class AzureDeveloperCliCredential(AsyncContextManager):
         *scopes: str,
         claims: Optional[str] = None,  # pylint:disable=unused-argument
         tenant_id: Optional[str] = None,
+        enable_cae: bool = False,  # pylint:disable=unused-argument
         **kwargs: Any,
     ) -> AccessToken:
         """Request an access token for `scopes`.
@@ -97,6 +98,8 @@ class AzureDeveloperCliCredential(AsyncContextManager):
             https://learn.microsoft.com/entra/identity-platform/scopes-oidc.
         :keyword str claims: not used by this credential; any value provided will be ignored.
         :keyword str tenant_id: optional tenant to include in the token request.
+        :keyword bool enable_cae: Indicates whether to enable Continuous Access Evaluation (CAE) for the requested
+            token. Not supported by this credential.
 
         :return: An access token with the desired scopes.
         :rtype: ~azure.core.credentials.AccessToken

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/azure_cli.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/azure_cli.py
@@ -66,6 +66,7 @@ class AzureCliCredential(AsyncContextManager):
         *scopes: str,
         claims: Optional[str] = None,  # pylint:disable=unused-argument
         tenant_id: Optional[str] = None,
+        enable_cae: bool = False,  # pylint:disable=unused-argument
         **kwargs: Any,
     ) -> AccessToken:
         """Request an access token for `scopes`.
@@ -78,6 +79,8 @@ class AzureCliCredential(AsyncContextManager):
             https://learn.microsoft.com/entra/identity-platform/scopes-oidc.
         :keyword str claims: not used by this credential; any value provided will be ignored.
         :keyword str tenant_id: optional tenant to include in the token request.
+        :keyword bool enable_cae: Indicates whether to enable Continuous Access Evaluation (CAE) for the requested
+            token. Not supported by this credential.
 
         :return: An access token with the desired scopes.
         :rtype: ~azure.core.credentials.AccessToken

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/azure_powershell.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/azure_powershell.py
@@ -60,6 +60,7 @@ class AzurePowerShellCredential(AsyncContextManager):
         *scopes: str,
         claims: Optional[str] = None,  # pylint:disable=unused-argument
         tenant_id: Optional[str] = None,
+        enable_cae: bool = False,  # pylint:disable=unused-argument
         **kwargs: Any,
     ) -> AccessToken:
         """Request an access token for `scopes`.
@@ -72,6 +73,8 @@ class AzurePowerShellCredential(AsyncContextManager):
             https://learn.microsoft.com/entra/identity-platform/scopes-oidc.
         :keyword str claims: not used by this credential; any value provided will be ignored.
         :keyword str tenant_id: optional tenant to include in the token request.
+        :keyword bool enable_cae: Indicates whether to enable Continuous Access Evaluation (CAE) for the requested
+            token. Not supported by this credential.
 
         :return: An access token with the desired scopes.
         :rtype: ~azure.core.credentials.AccessToken

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/default.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/default.py
@@ -177,7 +177,12 @@ class DefaultAzureCredential(ChainedTokenCredential):
         super().__init__(*credentials)
 
     async def get_token(
-        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs: Any
+        self,
+        *scopes: str,
+        claims: Optional[str] = None,
+        tenant_id: Optional[str] = None,
+        enable_cae: bool = False,
+        **kwargs: Any
     ) -> AccessToken:
         """Asynchronously request an access token for `scopes`.
 
@@ -189,6 +194,8 @@ class DefaultAzureCredential(ChainedTokenCredential):
         :keyword str claims: additional claims required in the token, such as those returned in a resource provider's
             claims challenge following an authorization failure.
         :keyword str tenant_id: optional tenant to include in the token request.
+        :keyword bool enable_cae: Indicates whether to enable Continuous Access Evaluation (CAE) for the requested
+            token if the underlying credential supports it. Defaults to False.
 
         :return: An access token with the desired scopes.
         :rtype: ~azure.core.credentials.AccessToken
@@ -196,8 +203,10 @@ class DefaultAzureCredential(ChainedTokenCredential):
           `message` attribute listing each authentication attempt and its error message.
         """
         if self._successful_credential:
-            return await self._successful_credential.get_token(*scopes, claims=claims, tenant_id=tenant_id, **kwargs)
+            return await self._successful_credential.get_token(
+                *scopes, claims=claims, tenant_id=tenant_id, enable_cae=enable_cae, **kwargs
+            )
         within_dac.set(True)
-        token = await super().get_token(*scopes, claims=claims, tenant_id=tenant_id, **kwargs)
+        token = await super().get_token(*scopes, claims=claims, tenant_id=tenant_id, enable_cae=enable_cae, **kwargs)
         within_dac.set(False)
         return token

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/environment.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/environment.py
@@ -96,7 +96,12 @@ class EnvironmentCredential(AsyncContextManager):
 
     @log_get_token_async
     async def get_token(
-        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs: Any
+        self,
+        *scopes: str,
+        claims: Optional[str] = None,
+        tenant_id: Optional[str] = None,
+        enable_cae: bool = False,
+        **kwargs: Any
     ) -> AccessToken:
         """Asynchronously request an access token for `scopes`.
 
@@ -108,6 +113,8 @@ class EnvironmentCredential(AsyncContextManager):
         :keyword str claims: additional claims required in the token, such as those returned in a resource provider's
             claims challenge following an authorization failure.
         :keyword str tenant_id: optional tenant to include in the token request.
+        :keyword bool enable_cae: Indicates whether to enable Continuous Access Evaluation (CAE) for the requested
+            token. Defaults to False.
 
         :return: An access token with the desired scopes.
         :rtype: ~azure.core.credentials.AccessToken
@@ -120,4 +127,6 @@ class EnvironmentCredential(AsyncContextManager):
                 "this issue."
             )
             raise CredentialUnavailableError(message=message)
-        return await self._credential.get_token(*scopes, claims=claims, tenant_id=tenant_id, **kwargs)
+        return await self._credential.get_token(
+            *scopes, claims=claims, tenant_id=tenant_id, enable_cae=enable_cae, **kwargs
+        )

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/managed_identity.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/managed_identity.py
@@ -115,7 +115,12 @@ class ManagedIdentityCredential(AsyncContextManager):
 
     @log_get_token_async
     async def get_token(
-        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs: Any
+        self,
+        *scopes: str,
+        claims: Optional[str] = None,
+        tenant_id: Optional[str] = None,
+        enable_cae: bool = False,  # pylint:disable=unused-argument
+        **kwargs: Any
     ) -> AccessToken:
         """Asynchronously request an access token for `scopes`.
 
@@ -126,6 +131,8 @@ class ManagedIdentityCredential(AsyncContextManager):
             https://learn.microsoft.com/entra/identity-platform/scopes-oidc.
         :keyword str claims: not used by this credential; any value provided will be ignored.
         :keyword str tenant_id: not used by this credential; any value provided will be ignored.
+        :keyword bool enable_cae: Indicates whether to enable Continuous Access Evaluation (CAE) for the requested
+            token. Not supported by this credential.
 
         :return: An access token with the desired scopes.
         :rtype: ~azure.core.credentials.AccessToken

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/vscode.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/vscode.py
@@ -48,7 +48,12 @@ class VisualStudioCodeCredential(_VSCodeCredentialBase, AsyncContextManager, Get
 
     @log_get_token_async
     async def get_token(
-        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs: Any
+        self,
+        *scopes: str,
+        claims: Optional[str] = None,
+        tenant_id: Optional[str] = None,
+        enable_cae: bool = False,  # pylint:disable=unused-argument
+        **kwargs: Any
     ) -> AccessToken:
         """Request an access token for `scopes` as the user currently signed in to Visual Studio Code.
 
@@ -60,6 +65,8 @@ class VisualStudioCodeCredential(_VSCodeCredentialBase, AsyncContextManager, Get
         :keyword str claims: additional claims required in the token, such as those returned in a resource provider's
             claims challenge following an authorization failure.
         :keyword str tenant_id: optional tenant to include in the token request.
+        :keyword bool enable_cae: Indicates whether to enable Continuous Access Evaluation (CAE) for the requested
+            token. Not supported by this credential.
 
         :return: An access token with the desired scopes.
         :rtype: ~azure.core.credentials.AccessToken

--- a/sdk/identity/azure-identity/azure/identity/aio/_internal/managed_identity_base.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_internal/managed_identity_base.py
@@ -42,7 +42,12 @@ class AsyncManagedIdentityBase(AsyncContextManager, GetTokenMixin):
         await self.__aexit__()
 
     async def get_token(
-        self, *scopes: str, claims: Optional[str] = None, tenant_id: Optional[str] = None, **kwargs: Any
+        self,
+        *scopes: str,
+        claims: Optional[str] = None,
+        tenant_id: Optional[str] = None,
+        enable_cae: bool = False,  # pylint:disable=unused-argument
+        **kwargs: Any
     ) -> AccessToken:
         if not self._client:
             raise CredentialUnavailableError(message=self.get_unavailable_message())


### PR DESCRIPTION
Several `get_token` method signatures were updated to _explicitly_ include the `enable_cae` keyword argument to match the [TokenCredential protocol method signature](https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/core/azure-core/azure/core/credentials.py#L25).

This is similar to the changes made previously in https://github.com/Azure/azure-sdk-for-python/pull/31047.
