### PR TITLE
fix SDK generation pipeline

### DIFF
--- a/scripts/sdk_init.sh
+++ b/scripts/sdk_init.sh
@@ -18,6 +18,8 @@ echo "$PATH"
 python3.10 -m venv $TMPDIR/venv-sdk
 python -m pip install -U pip
 python scripts/dev_setup.py -p azure-core
+python -m pip install PyGithub
+python -m pip install GitPython
 
 if [ x"$1" = x ]; then
         echo "[Generate] init success!!!"


### PR DESCRIPTION
Before https://github.com/Azure/azure-sdk-for-python/commit/0527e86ada9c20d9680d5782f7628a1ca05367fc#diff-5cd3072371963f58614f1e0b362614b83b94113f52d0ea156ceebb05a4a588fc, it works well. Now we meet the following error:
![image](https://github.com/Azure/azure-sdk-for-python/assets/70930885/e1b060e4-5be8-4954-badc-a8494459556d)
