### PR TITLE
Fixed error message check in remote rendering tests

### DIFF
--- a/sdk/remoterendering/azure-mixedreality-remoterendering/assets.json
+++ b/sdk/remoterendering/azure-mixedreality-remoterendering/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "python",
   "TagPrefix": "python/remoterendering/azure-mixedreality-remoterendering",
-  "Tag": "python/remoterendering/azure-mixedreality-remoterendering_a55c315517"
+  "Tag": "python/remoterendering/azure-mixedreality-remoterendering_f4be00cf1c"
 }

--- a/sdk/remoterendering/azure-mixedreality-remoterendering/dev_requirements.txt
+++ b/sdk/remoterendering/azure-mixedreality-remoterendering/dev_requirements.txt
@@ -3,3 +3,4 @@
 ../../mixedreality/azure-mixedreality-authentication
 aiohttp>=3.0
 -e ../../identity/azure-identity
+configargparse

--- a/sdk/remoterendering/azure-mixedreality-remoterendering/tests/test_client.py
+++ b/sdk/remoterendering/azure-mixedreality-remoterendering/tests/test_client.py
@@ -216,7 +216,7 @@ class TestRemoteRenderingClient(AzureRecordedTestCase):
 
         assert "InputContainerError" == error_details.error.code
         # Message: "Could not find the asset file in the storage account. Please make sure all paths and names are correct and the file is uploaded to storage."
-        assert None != error_details.error.message
+        assert error_details.error.message is not None
         assert "Could not find the asset file in the storage account" in error_details.error.message
 
     def test_simple_session(self, recorded_test, account_info, arr_client):

--- a/sdk/remoterendering/azure-mixedreality-remoterendering/tests/test_client.py
+++ b/sdk/remoterendering/azure-mixedreality-remoterendering/tests/test_client.py
@@ -5,6 +5,7 @@
 # --------------------------------------------------------------------------
 import pytest
 import uuid
+import json
 
 from azure.core.credentials import AzureKeyCredential
 from azure.core.exceptions import HttpResponseError
@@ -69,6 +70,8 @@ class TestRemoteRenderingClient(AzureRecordedTestCase):
         conversion_id = account_info["id_placeholder"]
         if self.is_live:
             conversion_id += str(uuid.uuid4())
+            
+        print("Using conversion id: {}".format(conversion_id))
 
         storage_container_uri = "https://"+account_info["storage_account_name"] + \
             ".blob."+account_info["storage_endpoint_suffix"]+"/"+account_info["blob_container_name"]
@@ -120,6 +123,8 @@ class TestRemoteRenderingClient(AzureRecordedTestCase):
         conversion_id = account_info["id_placeholder"]
         if self.is_live:
             conversion_id += str(uuid.uuid4())
+            
+        print("Using conversion id: {}".format(conversion_id))
 
         storage_container_uri = "https://"+account_info["storage_account_name"] + \
             ".blob."+account_info["storage_endpoint_suffix"]+"/"+account_info["blob_container_name"]
@@ -182,6 +187,8 @@ class TestRemoteRenderingClient(AzureRecordedTestCase):
         if self.is_live:
             conversion_id += str(uuid.uuid4())
 
+        print("Using conversion id: {}".format(conversion_id))
+
         storage_container_uri = "https://"+account_info["storage_account_name"] + \
             ".blob."+account_info["storage_endpoint_suffix"]+"/"+account_info["blob_container_name"]
 
@@ -204,6 +211,9 @@ class TestRemoteRenderingClient(AzureRecordedTestCase):
             conversion_poller.result()
 
         error_details = excinfo.value
+
+        print(json.dumps(error_details.error.__dict__))
+
         assert "InputContainerError" == error_details.error.code
         # Message: "Could not find the asset file in the storage account. Please make sure all paths and names are correct and the file is uploaded to storage."
         assert None != error_details.error.message
@@ -213,6 +223,9 @@ class TestRemoteRenderingClient(AzureRecordedTestCase):
         session_id = account_info["id_placeholder"]
         if self.is_live:
             session_id += str(uuid.uuid4())
+
+        print("Using session id: {}".format(session_id))
+
         session_poller = arr_client.begin_rendering_session(
             session_id=session_id, size=RenderingSessionSize.STANDARD, lease_time_minutes=15)
 
@@ -254,6 +267,8 @@ class TestRemoteRenderingClient(AzureRecordedTestCase):
         session_id = account_info["id_placeholder"]
         if self.is_live:
             session_id += str(uuid.uuid4())
+            
+        print("Using session id: {}".format(session_id))
 
         with pytest.raises(HttpResponseError) as excinfo:
             # Make an invalid request (negative lease time).

--- a/sdk/remoterendering/azure-mixedreality-remoterendering/tests/test_client.py
+++ b/sdk/remoterendering/azure-mixedreality-remoterendering/tests/test_client.py
@@ -204,10 +204,10 @@ class TestRemoteRenderingClient(AzureRecordedTestCase):
             conversion_poller.result()
 
         error_details = excinfo.value
-        assert "InputContainerError" == error_details.code
+        assert "InputContainerError" == error_details.error.code
         # Message: "Could not find the asset file in the storage account. Please make sure all paths and names are correct and the file is uploaded to storage."
-        assert None != error_details.message
-        assert "could not find the asset file in the storage account" in error_details.message
+        assert None != error_details.error.message
+        assert "could not find the asset file in the storage account" in error_details.error.message
 
     def test_simple_session(self, recorded_test, account_info, arr_client):
         session_id = account_info["id_placeholder"]

--- a/sdk/remoterendering/azure-mixedreality-remoterendering/tests/test_client.py
+++ b/sdk/remoterendering/azure-mixedreality-remoterendering/tests/test_client.py
@@ -204,8 +204,10 @@ class TestRemoteRenderingClient(AzureRecordedTestCase):
             conversion_poller.result()
 
         error_details = excinfo.value
-        assert "invalid input" in error_details.error.message.lower()
-        assert "logs" in error_details.error.message.lower()
+        assert "InputContainerError" == error_details.code
+        # Message: "Could not find the asset file in the storage account. Please make sure all paths and names are correct and the file is uploaded to storage."
+        assert None != error_details.message
+        assert "could not find the asset file in the storage account" in error_details.message
 
     def test_simple_session(self, recorded_test, account_info, arr_client):
         session_id = account_info["id_placeholder"]

--- a/sdk/remoterendering/azure-mixedreality-remoterendering/tests/test_client.py
+++ b/sdk/remoterendering/azure-mixedreality-remoterendering/tests/test_client.py
@@ -217,7 +217,7 @@ class TestRemoteRenderingClient(AzureRecordedTestCase):
         assert "InputContainerError" == error_details.error.code
         # Message: "Could not find the asset file in the storage account. Please make sure all paths and names are correct and the file is uploaded to storage."
         assert None != error_details.error.message
-        assert "could not find the asset file in the storage account" in error_details.error.message
+        assert "Could not find the asset file in the storage account" in error_details.error.message
 
     def test_simple_session(self, recorded_test, account_info, arr_client):
         session_id = account_info["id_placeholder"]

--- a/sdk/remoterendering/azure-mixedreality-remoterendering/tests/test_client_async.py
+++ b/sdk/remoterendering/azure-mixedreality-remoterendering/tests/test_client_async.py
@@ -210,10 +210,10 @@ class TestRemoteRenderingClientAsync(AzureRecordedTestCase):
             await conversion_poller.result()
 
         error_details = excinfo.value
-        assert "InputContainerError" == error_details.code
+        assert "InputContainerError" == error_details.error.code
         # Message: "Could not find the asset file in the storage account. Please make sure all paths and names are correct and the file is uploaded to storage."
-        assert None != error_details.message
-        assert "could not find the asset file in the storage account" in error_details.message
+        assert None != error_details.error.message
+        assert "could not find the asset file in the storage account" in error_details.error.message
 
     @pytest.mark.asyncio
     async def test_simple_session(self, recorded_test, account_info, async_arr_client):

--- a/sdk/remoterendering/azure-mixedreality-remoterendering/tests/test_client_async.py
+++ b/sdk/remoterendering/azure-mixedreality-remoterendering/tests/test_client_async.py
@@ -213,7 +213,7 @@ class TestRemoteRenderingClientAsync(AzureRecordedTestCase):
         assert "InputContainerError" == error_details.error.code
         # Message: "Could not find the asset file in the storage account. Please make sure all paths and names are correct and the file is uploaded to storage."
         assert None != error_details.error.message
-        assert "could not find the asset file in the storage account" in error_details.error.message
+        assert "Could not find the asset file in the storage account" in error_details.error.message
 
     @pytest.mark.asyncio
     async def test_simple_session(self, recorded_test, account_info, async_arr_client):

--- a/sdk/remoterendering/azure-mixedreality-remoterendering/tests/test_client_async.py
+++ b/sdk/remoterendering/azure-mixedreality-remoterendering/tests/test_client_async.py
@@ -212,7 +212,7 @@ class TestRemoteRenderingClientAsync(AzureRecordedTestCase):
         error_details = excinfo.value
         assert "InputContainerError" == error_details.error.code
         # Message: "Could not find the asset file in the storage account. Please make sure all paths and names are correct and the file is uploaded to storage."
-        assert None != error_details.error.message
+        assert error_details.error.message is not None
         assert "Could not find the asset file in the storage account" in error_details.error.message
 
     @pytest.mark.asyncio

--- a/sdk/remoterendering/azure-mixedreality-remoterendering/tests/test_client_async.py
+++ b/sdk/remoterendering/azure-mixedreality-remoterendering/tests/test_client_async.py
@@ -210,8 +210,10 @@ class TestRemoteRenderingClientAsync(AzureRecordedTestCase):
             await conversion_poller.result()
 
         error_details = excinfo.value
-        assert "invalid input" in error_details.error.message.lower()
-        assert "logs" in error_details.error.message.lower()
+        assert "InputContainerError" == error_details.code
+        # Message: "Could not find the asset file in the storage account. Please make sure all paths and names are correct and the file is uploaded to storage."
+        assert None != error_details.message
+        assert "could not find the asset file in the storage account" in error_details.message
 
     @pytest.mark.asyncio
     async def test_simple_session(self, recorded_test, account_info, async_arr_client):


### PR DESCRIPTION
# Description

We changed some error message on the remote rendering service side, because the old messages were more confusing than helping. This broke the tests here, because it compared to the old messages still.

If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
