### PR TITLE
Bring `azure-devtools`'s GH tool dependencies over to `azure-sdk-tools`

### DIFF
--- a/tools/azure-sdk-tools/dev_requirements.txt
+++ b/tools/azure-sdk-tools/dev_requirements.txt
@@ -1,0 +1,1 @@
+-e .[ghtools]

--- a/tools/azure-sdk-tools/setup.py
+++ b/tools/azure-sdk-tools/setup.py
@@ -59,6 +59,6 @@ setup(
         "build": ["six", "setuptools", "pyparsing", "certifi", "cibuildwheel", "ConfigArgParse>=0.12.0"],
         "conda": ["beautifulsoup4"],
         "systemperf": ["aiohttp>=3.0", "requests>=2.0", "tornado==6.0.3", "httpx>=0.21", "azure-core"],
-        "ghtools": ["PyGithub>=1.59.0"],
+        "ghtools": ["GitPython", "PyGithub>=1.59.0"],
     },
 )

--- a/tools/azure-sdk-tools/setup.py
+++ b/tools/azure-sdk-tools/setup.py
@@ -59,6 +59,6 @@ setup(
         "build": ["six", "setuptools", "pyparsing", "certifi", "cibuildwheel", "ConfigArgParse>=0.12.0"],
         "conda": ["beautifulsoup4"],
         "systemperf": ["aiohttp>=3.0", "requests>=2.0", "tornado==6.0.3", "httpx>=0.21", "azure-core"],
-        "ghtools": ["GitPython", "PyGithub>=1.59.0"],
+        "ghtools": ["GitPython", "PyGithub>=1.59.0", "requests>=2.0"],
     },
 )


### PR DESCRIPTION
# Description

After we fully removed `azure-devtools` from the SDK, @msyyc found that the SDK generation pipeline was now missing a `GitPython` dependency: https://github.com/Azure/azure-sdk-for-python/pull/34956.

`GitPython` and `PyGithub` were previously being installed via `azure-devtools/dev_requirements.txt` or [update-pr.yml](https://github.com/Azure/azure-sdk-for-python/commit/0527e86ada9c20d9680d5782f7628a1ca05367fc#diff-f05bef8030f6e616d2ca02f5bd75040497d4b70b31d13d5a9eaf7fc735dd1af5). To fetch them correctly again, we need to add the former `[ci_tools]` dependencies to `[ghtools]` in `azure-sdk-tools` and correctly target `[ghtools]` from `azure-sdk-tools/dev_requirements.txt`.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
