### PR TITLE
add configargparse to azure-sdk-tools dependencies for perf

### DIFF
--- a/tools/azure-sdk-tools/setup.py
+++ b/tools/azure-sdk-tools/setup.py
@@ -20,6 +20,8 @@ DEPENDENCIES = [
     "PyYAML",
     "urllib3",
     "tomli-w==1.0.0",
+    # Perf/Build
+    "ConfigArgParse>=0.12.0",
 ]
 
 setup(
@@ -56,7 +58,7 @@ setup(
     extras_require={
         ":python_version>='3.5'": ["pytest-asyncio>=0.9.0"],
         ":python_version<'3.11'": ["tomli==2.0.1"],
-        "build": ["six", "setuptools", "pyparsing", "certifi", "cibuildwheel", "ConfigArgParse>=0.12.0"],
+        "build": ["six", "setuptools", "pyparsing", "certifi", "cibuildwheel"],
         "conda": ["beautifulsoup4"],
         "systemperf": ["aiohttp>=3.0", "requests>=2.0", "tornado==6.0.3", "httpx>=0.21", "azure-core"],
         "ghtools": ["GitPython", "PyGithub>=1.59.0", "requests>=2.0"],


### PR DESCRIPTION
Previously, azure-devtools was installing configargparse and was used by perf tests. Since that was deleted, perf tests are failing. Adding `configargparse` to the basic dependencies, moving it out of just the build extra, to be used by perf and since everyone was already installing it via `azure-devtools`.