### PR TITLE
[Monitor Query] Update `filter` docstrings

### DIFF
--- a/sdk/monitor/azure-monitor-query/azure/monitor/query/_metrics_client.py
+++ b/sdk/monitor/azure-monitor-query/azure/monitor/query/_metrics_client.py
@@ -84,23 +84,39 @@ class MetricsClient:  # pylint: disable=client-accepts-api-version-keyword
         :keyword order_by: The aggregation to use for sorting results and the direction of the sort.
             Only one order can be specified. Examples: 'sum asc', 'maximum desc'.
         :paramtype order_by: Optional[str]
-        :keyword filter: The **filter** is used to reduce the set of metric data returned. Example:
-            Metric contains metadata A, B and C. - Return all time series of C where A = a1 and B = b1 or
-            b2: **filter="A eq 'a1' and B eq 'b1' or B eq 'b2' and C eq '*'"** - Invalid variant: **filter="A
-            eq 'a1' and B eq 'b1' and C eq '*' or B = 'b2'"**. This is invalid because the logical or
-            operator cannot separate two different metadata names. - Return all time series where A = a1,
-            B = b1 and C = c1: **filter="A eq 'a1' and B eq 'b1' and C eq 'c1'"** - Return all time series
-            where A = a1: **filter="A eq 'a1' and B eq '*' and C eq '*'"**. Special case: When dimension
-            name or dimension value uses round brackets. Eg: When dimension name is **dim (test) 1**,
-            instead of using **filter="dim (test) 1 eq '*'"** use **filter="dim %2528test%2529 1 eq '*'"**.
-            When dimension name is **dim (test) 3** and dimension value is **dim3 (test) val**, instead of using
-            **filter="dim (test) 3 eq 'dim3 (test) val'"**, use **filter="dim
-            %2528test%2529 3 eq 'dim3 %2528test%2529 val'"**. Default value is None.
+        :keyword filter: The **filter** is used to reduce the set of metric data returned. Default value is None.
+
+            Example: Metric contains metadata A, B and C.
+
+            - Return all time series of C where A = a1 and B = b1 or b2:
+
+              **filter="A eq 'a1' and B eq 'b1' or B eq 'b2' and C eq '*'"**
+
+            - Invalid variant:
+
+              **filter="A eq 'a1' and B eq 'b1' and C eq '*' or B = 'b2'"**. This is invalid because the
+              logical 'or' operator cannot separate two different metadata names.
+
+            - Return all time series where A = a1, B = b1 and C = c1:
+
+              **filter="A eq 'a1' and B eq 'b1' and C eq 'c1'"**
+
+            - Return all time series where A = a1:
+
+              **filter="A eq 'a1' and B eq '*' and C eq '*'"**
+
+            - Special case: When dimension name or dimension value uses round brackets. Example: When dimension name
+              is **dim (test) 1**, instead of using **filter="dim (test) 1 eq '*'"** use
+              **filter="dim %2528test%2529 1 eq '*'"**.
+
+              When dimension name is **dim (test) 3** and dimension value is
+              **dim3 (test) val**, instead of using **filter="dim (test) 3 eq 'dim3 (test) val'"**, use **filter="dim
+              %2528test%2529 3 eq 'dim3 %2528test%2529 val'"**.
         :paramtype filter: str
         :keyword roll_up_by: Dimension name(s) to rollup results by. For example if you only want to see
             metric values with a filter like 'City eq Seattle or City eq Tacoma' but don't want to see
             separate values for each city, you can specify 'City' to see the results for Seattle
-            and Tacoma rolled up into one timeseries. Default value is None.
+            and Tacoma rolled up into one timeseries.
         :paramtype roll_up_by: str
         :return: A list of MetricsQueryResult objects.
         :rtype: list[~azure.monitor.query.MetricsQueryResult]

--- a/sdk/monitor/azure-monitor-query/azure/monitor/query/_metrics_client.py
+++ b/sdk/monitor/azure-monitor-query/azure/monitor/query/_metrics_client.py
@@ -84,17 +84,17 @@ class MetricsClient:  # pylint: disable=client-accepts-api-version-keyword
         :keyword order_by: The aggregation to use for sorting results and the direction of the sort.
             Only one order can be specified. Examples: 'sum asc', 'maximum desc'.
         :paramtype order_by: Optional[str]
-        :keyword filter: The **$filter** is used to reduce the set of metric data returned. Example:
+        :keyword filter: The **filter** is used to reduce the set of metric data returned. Example:
             Metric contains metadata A, B and C. - Return all time series of C where A = a1 and B = b1 or
-            b2 **$filter=A eq 'a1' and B eq 'b1' or B eq 'b2' and C eq '*'** - Invalid variant: **$filter=A
-            eq 'a1' and B eq 'b1' and C eq '*' or B = 'b2'** This is invalid because the logical or
+            b2: **filter="A eq 'a1' and B eq 'b1' or B eq 'b2' and C eq '*'"** - Invalid variant: **filter="A
+            eq 'a1' and B eq 'b1' and C eq '*' or B = 'b2'"**. This is invalid because the logical or
             operator cannot separate two different metadata names. - Return all time series where A = a1,
-            B = b1 and C = c1: **$filter=A eq 'a1' and B eq 'b1' and C eq 'c1'** - Return all time series
-            where A = a1 **$filter=A eq 'a1' and B eq '*' and C eq '*'**. Special case: When dimension
-            name or dimension value uses round brackets. Eg: When dimension name is **dim (test) 1**
-            Instead of using **$filter= "dim (test) 1 eq '*'"** use **$filter= "dim %2528test%2529 1 eq '*'"**.
+            B = b1 and C = c1: **filter="A eq 'a1' and B eq 'b1' and C eq 'c1'"** - Return all time series
+            where A = a1: **filter="A eq 'a1' and B eq '*' and C eq '*'"**. Special case: When dimension
+            name or dimension value uses round brackets. Eg: When dimension name is **dim (test) 1**,
+            instead of using **filter="dim (test) 1 eq '*'"** use **filter="dim %2528test%2529 1 eq '*'"**.
             When dimension name is **dim (test) 3** and dimension value is **dim3 (test) val**, instead of using
-            **$filter= "dim (test) 3 eq 'dim3 (test) val'"** use **$filter= "dim
+            **filter="dim (test) 3 eq 'dim3 (test) val'"**, use **filter="dim
             %2528test%2529 3 eq 'dim3 %2528test%2529 val'"**. Default value is None.
         :paramtype filter: str
         :keyword roll_up_by: Dimension name(s) to rollup results by. For example if you only want to see

--- a/sdk/monitor/azure-monitor-query/azure/monitor/query/_metrics_query_client.py
+++ b/sdk/monitor/azure-monitor-query/azure/monitor/query/_metrics_query_client.py
@@ -98,24 +98,24 @@ class MetricsQueryClient(object):  # pylint: disable=client-accepts-api-version-
          `azure.monitor.query.MetricAggregationType` enum to get each aggregation type.
         :paramtype aggregations: Optional[list[str]]
         :keyword max_results: The maximum number of records to retrieve.
-         Valid only if $filter is specified.
+         Valid only if 'filter' is specified.
          Defaults to 10.
         :paramtype max_results: Optional[int]
         :keyword order_by: The aggregation to use for sorting results and the direction of the sort.
          Only one order can be specified.
          Examples: sum asc.
         :paramtype order_by: Optional[str]
-        :keyword filter: The **$filter** is used to reduce the set of metric data returned. Example:
+        :keyword filter: The **filter** is used to reduce the set of metric data returned. Example:
          Metric contains metadata A, B and C. - Return all time series of C where A = a1 and B = b1 or
-         b2 **$filter=A eq 'a1' and B eq 'b1' or B eq 'b2' and C eq '*'** - Invalid variant: **$filter=A
-         eq 'a1' and B eq 'b1' and C eq '*' or B = 'b2'** This is invalid because the logical or
-         operator cannot separate two different metadata names. - Return all time series where A = a1, B
-         = b1 and C = c1: **$filter=A eq 'a1' and B eq 'b1' and C eq 'c1'** - Return all time series
-         where A = a1 **$filter=A eq 'a1' and B eq '*' and C eq '*'**. Special case: When dimension
-         name or dimension value uses round brackets. Eg: When dimension name is **dim (test) 1**
-         Instead of using **$filter= "dim (test) 1 eq '*'"** use **$filter= "dim %2528test%2529 1 eq '*'"**.
+         b2: **filter="A eq 'a1' and B eq 'b1' or B eq 'b2' and C eq '*'"** - Invalid variant: **filter="A
+         eq 'a1' and B eq 'b1' and C eq '*' or B = 'b2'"**. This is invalid because the logical or
+         operator cannot separate two different metadata names. - Return all time series where A = a1,
+         B = b1 and C = c1: **filter="A eq 'a1' and B eq 'b1' and C eq 'c1'"** - Return all time series
+         where A = a1: **filter="A eq 'a1' and B eq '*' and C eq '*'"**. Special case: When dimension
+         name or dimension value uses round brackets. Eg: When dimension name is **dim (test) 1**,
+         instead of using **filter="dim (test) 1 eq '*'"** use **filter="dim %2528test%2529 1 eq '*'"**.
          When dimension name is **dim (test) 3** and dimension value is **dim3 (test) val**, instead of using
-         **$filter= "dim (test) 3 eq 'dim3 (test) val'"** use **$filter= "dim
+         **filter="dim (test) 3 eq 'dim3 (test) val'"**, use **filter="dim
          %2528test%2529 3 eq 'dim3 %2528test%2529 val'"**. Default value is None.
         :paramtype filter: Optional[str]
         :keyword metric_namespace: Metric namespace to query metric definitions for.

--- a/sdk/monitor/azure-monitor-query/azure/monitor/query/_metrics_query_client.py
+++ b/sdk/monitor/azure-monitor-query/azure/monitor/query/_metrics_query_client.py
@@ -105,18 +105,34 @@ class MetricsQueryClient(object):  # pylint: disable=client-accepts-api-version-
          Only one order can be specified.
          Examples: sum asc.
         :paramtype order_by: Optional[str]
-        :keyword filter: The **filter** is used to reduce the set of metric data returned. Example:
-         Metric contains metadata A, B and C. - Return all time series of C where A = a1 and B = b1 or
-         b2: **filter="A eq 'a1' and B eq 'b1' or B eq 'b2' and C eq '*'"** - Invalid variant: **filter="A
-         eq 'a1' and B eq 'b1' and C eq '*' or B = 'b2'"**. This is invalid because the logical or
-         operator cannot separate two different metadata names. - Return all time series where A = a1,
-         B = b1 and C = c1: **filter="A eq 'a1' and B eq 'b1' and C eq 'c1'"** - Return all time series
-         where A = a1: **filter="A eq 'a1' and B eq '*' and C eq '*'"**. Special case: When dimension
-         name or dimension value uses round brackets. Eg: When dimension name is **dim (test) 1**,
-         instead of using **filter="dim (test) 1 eq '*'"** use **filter="dim %2528test%2529 1 eq '*'"**.
-         When dimension name is **dim (test) 3** and dimension value is **dim3 (test) val**, instead of using
-         **filter="dim (test) 3 eq 'dim3 (test) val'"**, use **filter="dim
-         %2528test%2529 3 eq 'dim3 %2528test%2529 val'"**. Default value is None.
+        :keyword filter: The **filter** is used to reduce the set of metric data returned. Default value is None.
+
+            Example: Metric contains metadata A, B and C.
+
+            - Return all time series of C where A = a1 and B = b1 or b2:
+
+              **filter="A eq 'a1' and B eq 'b1' or B eq 'b2' and C eq '*'"**
+
+            - Invalid variant:
+
+              **filter="A eq 'a1' and B eq 'b1' and C eq '*' or B = 'b2'"**. This is invalid because the
+              logical 'or' operator cannot separate two different metadata names.
+
+            - Return all time series where A = a1, B = b1 and C = c1:
+
+              **filter="A eq 'a1' and B eq 'b1' and C eq 'c1'"**
+
+            - Return all time series where A = a1:
+
+              **filter="A eq 'a1' and B eq '*' and C eq '*'"**
+
+            - Special case: When dimension name or dimension value uses round brackets. Example: When dimension name
+              is **dim (test) 1**, instead of using **filter="dim (test) 1 eq '*'"** use
+              **filter="dim %2528test%2529 1 eq '*'"**.
+
+              When dimension name is **dim (test) 3** and dimension value is
+              **dim3 (test) val**, instead of using **filter="dim (test) 3 eq 'dim3 (test) val'"**, use **filter="dim
+              %2528test%2529 3 eq 'dim3 %2528test%2529 val'"**.
         :paramtype filter: Optional[str]
         :keyword metric_namespace: Metric namespace to query metric definitions for.
         :paramtype metric_namespace: Optional[str]

--- a/sdk/monitor/azure-monitor-query/azure/monitor/query/aio/_metrics_client_async.py
+++ b/sdk/monitor/azure-monitor-query/azure/monitor/query/aio/_metrics_client_async.py
@@ -85,17 +85,17 @@ class MetricsClient:  # pylint: disable=client-accepts-api-version-keyword
         :keyword order_by: The aggregation to use for sorting results and the direction of the sort.
             Only one order can be specified. Examples: 'sum asc', 'maximum desc'.
         :paramtype order_by: Optional[str]
-        :keyword filter: The **$filter** is used to reduce the set of metric data returned. Example:
+        :keyword filter: The **filter** is used to reduce the set of metric data returned. Example:
             Metric contains metadata A, B and C. - Return all time series of C where A = a1 and B = b1 or
-            b2 **$filter=A eq 'a1' and B eq 'b1' or B eq 'b2' and C eq '*'** - Invalid variant: **$filter=A
-            eq 'a1' and B eq 'b1' and C eq '*' or B = 'b2'** This is invalid because the logical or
+            b2: **filter="A eq 'a1' and B eq 'b1' or B eq 'b2' and C eq '*'"** - Invalid variant: **filter="A
+            eq 'a1' and B eq 'b1' and C eq '*' or B = 'b2'"**. This is invalid because the logical or
             operator cannot separate two different metadata names. - Return all time series where A = a1,
-            B = b1 and C = c1: **$filter=A eq 'a1' and B eq 'b1' and C eq 'c1'** - Return all time series
-            where A = a1 **$filter=A eq 'a1' and B eq '*' and C eq '*'**. Special case: When dimension
-            name or dimension value uses round brackets. Eg: When dimension name is **dim (test) 1**
-            Instead of using **$filter= "dim (test) 1 eq '*'"** use **$filter= "dim %2528test%2529 1 eq '*'"**.
+            B = b1 and C = c1: **filter="A eq 'a1' and B eq 'b1' and C eq 'c1'"** - Return all time series
+            where A = a1: **filter="A eq 'a1' and B eq '*' and C eq '*'"**. Special case: When dimension
+            name or dimension value uses round brackets. Eg: When dimension name is **dim (test) 1**,
+            instead of using **filter="dim (test) 1 eq '*'"** use **filter="dim %2528test%2529 1 eq '*'"**.
             When dimension name is **dim (test) 3** and dimension value is **dim3 (test) val**, instead of using
-            **$filter= "dim (test) 3 eq 'dim3 (test) val'"** use **$filter= "dim
+            **filter="dim (test) 3 eq 'dim3 (test) val'"**, use **filter="dim
             %2528test%2529 3 eq 'dim3 %2528test%2529 val'"**. Default value is None.
         :paramtype filter: str
         :keyword roll_up_by: Dimension name(s) to rollup results by. For example if you only want to see

--- a/sdk/monitor/azure-monitor-query/azure/monitor/query/aio/_metrics_client_async.py
+++ b/sdk/monitor/azure-monitor-query/azure/monitor/query/aio/_metrics_client_async.py
@@ -85,23 +85,39 @@ class MetricsClient:  # pylint: disable=client-accepts-api-version-keyword
         :keyword order_by: The aggregation to use for sorting results and the direction of the sort.
             Only one order can be specified. Examples: 'sum asc', 'maximum desc'.
         :paramtype order_by: Optional[str]
-        :keyword filter: The **filter** is used to reduce the set of metric data returned. Example:
-            Metric contains metadata A, B and C. - Return all time series of C where A = a1 and B = b1 or
-            b2: **filter="A eq 'a1' and B eq 'b1' or B eq 'b2' and C eq '*'"** - Invalid variant: **filter="A
-            eq 'a1' and B eq 'b1' and C eq '*' or B = 'b2'"**. This is invalid because the logical or
-            operator cannot separate two different metadata names. - Return all time series where A = a1,
-            B = b1 and C = c1: **filter="A eq 'a1' and B eq 'b1' and C eq 'c1'"** - Return all time series
-            where A = a1: **filter="A eq 'a1' and B eq '*' and C eq '*'"**. Special case: When dimension
-            name or dimension value uses round brackets. Eg: When dimension name is **dim (test) 1**,
-            instead of using **filter="dim (test) 1 eq '*'"** use **filter="dim %2528test%2529 1 eq '*'"**.
-            When dimension name is **dim (test) 3** and dimension value is **dim3 (test) val**, instead of using
-            **filter="dim (test) 3 eq 'dim3 (test) val'"**, use **filter="dim
-            %2528test%2529 3 eq 'dim3 %2528test%2529 val'"**. Default value is None.
+        :keyword filter: The **filter** is used to reduce the set of metric data returned. Default value is None.
+
+            Example: Metric contains metadata A, B and C.
+
+            - Return all time series of C where A = a1 and B = b1 or b2:
+
+              **filter="A eq 'a1' and B eq 'b1' or B eq 'b2' and C eq '*'"**
+
+            - Invalid variant:
+
+              **filter="A eq 'a1' and B eq 'b1' and C eq '*' or B = 'b2'"**. This is invalid because the
+              logical 'or' operator cannot separate two different metadata names.
+
+            - Return all time series where A = a1, B = b1 and C = c1:
+
+              **filter="A eq 'a1' and B eq 'b1' and C eq 'c1'"**
+
+            - Return all time series where A = a1:
+
+              **filter="A eq 'a1' and B eq '*' and C eq '*'"**
+
+            - Special case: When dimension name or dimension value uses round brackets. Example: When dimension name
+              is **dim (test) 1**, instead of using **filter="dim (test) 1 eq '*'"** use
+              **filter="dim %2528test%2529 1 eq '*'"**.
+
+              When dimension name is **dim (test) 3** and dimension value is
+              **dim3 (test) val**, instead of using **filter="dim (test) 3 eq 'dim3 (test) val'"**, use **filter="dim
+              %2528test%2529 3 eq 'dim3 %2528test%2529 val'"**.
         :paramtype filter: str
         :keyword roll_up_by: Dimension name(s) to rollup results by. For example if you only want to see
             metric values with a filter like 'City eq Seattle or City eq Tacoma' but don't want to see
             separate values for each city, you can specify 'City' to see the results for Seattle
-            and Tacoma rolled up into one timeseries. Default value is None.
+            and Tacoma rolled up into one timeseries.
         :paramtype roll_up_by: str
         :return: A list of MetricsQueryResult objects.
         :rtype: list[~azure.monitor.query.MetricsQueryResult]

--- a/sdk/monitor/azure-monitor-query/azure/monitor/query/aio/_metrics_query_client_async.py
+++ b/sdk/monitor/azure-monitor-query/azure/monitor/query/aio/_metrics_query_client_async.py
@@ -106,18 +106,34 @@ class MetricsQueryClient(object):  # pylint: disable=client-accepts-api-version-
          Only one order can be specified.
          Examples: sum asc.
         :paramtype order_by: Optional[str]
-        :keyword filter: The **filter** is used to reduce the set of metric data returned. Example:
-         Metric contains metadata A, B and C. - Return all time series of C where A = a1 and B = b1 or
-         b2: **filter="A eq 'a1' and B eq 'b1' or B eq 'b2' and C eq '*'"** - Invalid variant: **filter="A
-         eq 'a1' and B eq 'b1' and C eq '*' or B = 'b2'"**. This is invalid because the logical or
-         operator cannot separate two different metadata names. - Return all time series where A = a1,
-         B = b1 and C = c1: **filter="A eq 'a1' and B eq 'b1' and C eq 'c1'"** - Return all time series
-         where A = a1: **filter="A eq 'a1' and B eq '*' and C eq '*'"**. Special case: When dimension
-         name or dimension value uses round brackets. Eg: When dimension name is **dim (test) 1**,
-         instead of using **filter="dim (test) 1 eq '*'"** use **filter="dim %2528test%2529 1 eq '*'"**.
-         When dimension name is **dim (test) 3** and dimension value is **dim3 (test) val**, instead of using
-         **filter="dim (test) 3 eq 'dim3 (test) val'"**, use **filter="dim
-         %2528test%2529 3 eq 'dim3 %2528test%2529 val'"**. Default value is None.
+        :keyword filter: The **filter** is used to reduce the set of metric data returned. Default value is None.
+
+            Example: Metric contains metadata A, B and C.
+
+            - Return all time series of C where A = a1 and B = b1 or b2:
+
+              **filter="A eq 'a1' and B eq 'b1' or B eq 'b2' and C eq '*'"**
+
+            - Invalid variant:
+
+              **filter="A eq 'a1' and B eq 'b1' and C eq '*' or B = 'b2'"**. This is invalid because the
+              logical 'or' operator cannot separate two different metadata names.
+
+            - Return all time series where A = a1, B = b1 and C = c1:
+
+              **filter="A eq 'a1' and B eq 'b1' and C eq 'c1'"**
+
+            - Return all time series where A = a1:
+
+              **filter="A eq 'a1' and B eq '*' and C eq '*'"**
+
+            - Special case: When dimension name or dimension value uses round brackets. Example: When dimension name
+              is **dim (test) 1**, instead of using **filter="dim (test) 1 eq '*'"** use
+              **filter="dim %2528test%2529 1 eq '*'"**.
+
+              When dimension name is **dim (test) 3** and dimension value is
+              **dim3 (test) val**, instead of using **filter="dim (test) 3 eq 'dim3 (test) val'"**, use **filter="dim
+              %2528test%2529 3 eq 'dim3 %2528test%2529 val'"**.
         :paramtype filter: Optional[str]
         :keyword metric_namespace: Metric namespace to query metric definitions for.
         :paramtype metric_namespace: Optional[str]

--- a/sdk/monitor/azure-monitor-query/azure/monitor/query/aio/_metrics_query_client_async.py
+++ b/sdk/monitor/azure-monitor-query/azure/monitor/query/aio/_metrics_query_client_async.py
@@ -99,24 +99,24 @@ class MetricsQueryClient(object):  # pylint: disable=client-accepts-api-version-
          Use `azure.monitor.query.MetricAggregationType` enum to get each aggregation type.
         :paramtype aggregations: Optional[list[str]]
         :keyword max_results: The maximum number of records to retrieve.
-         Valid only if $filter is specified.
+         Valid only if 'filter' is specified.
          Defaults to 10.
         :paramtype max_results: Optional[int]
         :keyword order_by: The aggregation to use for sorting results and the direction of the sort.
          Only one order can be specified.
          Examples: sum asc.
         :paramtype order_by: Optional[str]
-        :keyword filter: The **$filter** is used to reduce the set of metric data returned. Example:
+        :keyword filter: The **filter** is used to reduce the set of metric data returned. Example:
          Metric contains metadata A, B and C. - Return all time series of C where A = a1 and B = b1 or
-         b2 **$filter=A eq 'a1' and B eq 'b1' or B eq 'b2' and C eq '*'** - Invalid variant: **$filter=A
-         eq 'a1' and B eq 'b1' and C eq '*' or B = 'b2'** This is invalid because the logical or
-         operator cannot separate two different metadata names. - Return all time series where A = a1, B
-         = b1 and C = c1: **$filter=A eq 'a1' and B eq 'b1' and C eq 'c1'** - Return all time series
-         where A = a1 **$filter=A eq 'a1' and B eq '*' and C eq '*'**. Special case: When dimension
-         name or dimension value uses round brackets. Eg: When dimension name is **dim (test) 1**
-         Instead of using **$filter= "dim (test) 1 eq '*'"** use **$filter= "dim %2528test%2529 1 eq '*'"**.
+         b2: **filter="A eq 'a1' and B eq 'b1' or B eq 'b2' and C eq '*'"** - Invalid variant: **filter="A
+         eq 'a1' and B eq 'b1' and C eq '*' or B = 'b2'"**. This is invalid because the logical or
+         operator cannot separate two different metadata names. - Return all time series where A = a1,
+         B = b1 and C = c1: **filter="A eq 'a1' and B eq 'b1' and C eq 'c1'"** - Return all time series
+         where A = a1: **filter="A eq 'a1' and B eq '*' and C eq '*'"**. Special case: When dimension
+         name or dimension value uses round brackets. Eg: When dimension name is **dim (test) 1**,
+         instead of using **filter="dim (test) 1 eq '*'"** use **filter="dim %2528test%2529 1 eq '*'"**.
          When dimension name is **dim (test) 3** and dimension value is **dim3 (test) val**, instead of using
-         **$filter= "dim (test) 3 eq 'dim3 (test) val'"** use **$filter= "dim
+         **filter="dim (test) 3 eq 'dim3 (test) val'"**, use **filter="dim
          %2528test%2529 3 eq 'dim3 %2528test%2529 val'"**. Default value is None.
         :paramtype filter: Optional[str]
         :keyword metric_namespace: Metric namespace to query metric definitions for.


### PR DESCRIPTION
These were using `$filter`, but this is misleading. Updated to reflect more accurate usage.
