### PR TITLE
32850 Fix mypy typing errors for azure-maps-geolocation

### DIFF
--- a/sdk/maps/azure-maps-geolocation/azure/maps/geolocation/models/_models.py
+++ b/sdk/maps/azure-maps-geolocation/azure/maps/geolocation/models/_models.py
@@ -16,8 +16,8 @@ class CountryRegionResult(object):
     """
     def __init__(
         self,
-        ip_address: str = None,
-        iso_code: str = None
+        ip_address: str = "",
+        iso_code: str = ""
     ):
         self.ip_address = ip_address
         self.iso_code = iso_code

--- a/sdk/maps/azure-maps-geolocation/azure/maps/geolocation/models/_models.py
+++ b/sdk/maps/azure-maps-geolocation/azure/maps/geolocation/models/_models.py
@@ -3,21 +3,23 @@
 # Licensed under the MIT License.
 # ------------------------------------
 
+from typing import Optional
+
 class CountryRegionResult(object):
     """Represents coordinate latitude and longitude
 
     :keyword ip_address:
         The IP Address of the request.
-    :paramtype ip_address: str
+    :paramtype ip_address: Optional[str]
     :keyword iso_code: iso_code:
         The IP Address's 2-character code of the country or region.
         Please note, IP address in ranges reserved for special purpose will return Null for country/region.
-    :paramtype iso_code: str
+    :paramtype iso_code: Optional[str]
     """
     def __init__(
         self,
-        ip_address: str = "",
-        iso_code: str = ""
+        ip_address: Optional[str] = None,
+        iso_code: Optional[str] = None
     ):
         self.ip_address = ip_address
         self.iso_code = iso_code

--- a/sdk/maps/azure-maps-geolocation/pyproject.toml
+++ b/sdk/maps/azure-maps-geolocation/pyproject.toml
@@ -1,6 +1,5 @@
 [tool.azure-sdk-build]
 pyright = false
-type_check_samples = false
 verifytypes = false
 ci_enabled = false
 strict_sphinx = true

--- a/sdk/maps/azure-maps-geolocation/samples/async_samples/sample_authentication_async.py
+++ b/sdk/maps/azure-maps-geolocation/samples/async_samples/sample_authentication_async.py
@@ -31,7 +31,7 @@ async def authentication_maps_service_client_with_subscription_key_credential_as
     from azure.core.credentials import AzureKeyCredential
     from azure.maps.geolocation.aio import MapsGeolocationClient
 
-    subscription_key = os.getenv("AZURE_SUBSCRIPTION_KEY")
+    subscription_key = os.getenv("AZURE_SUBSCRIPTION_KEY") or "your subscription key"
 
     maps_geolocation_client = MapsGeolocationClient(credential=AzureKeyCredential(subscription_key))
     # [END create_maps_geolocation_service_client_with_key_async]

--- a/sdk/maps/azure-maps-geolocation/samples/async_samples/sample_get_country_code_async.py
+++ b/sdk/maps/azure-maps-geolocation/samples/async_samples/sample_get_country_code_async.py
@@ -19,7 +19,7 @@ USAGE:
 import asyncio
 import os
 
-subscription_key = os.getenv("AZURE_SUBSCRIPTION_KEY")
+subscription_key = os.getenv("AZURE_SUBSCRIPTION_KEY") or "your subscription key"
 
 async def get_country_code_async():
     # [START get_country_code_async]

--- a/sdk/maps/azure-maps-geolocation/samples/sample_authentication.py
+++ b/sdk/maps/azure-maps-geolocation/samples/sample_authentication.py
@@ -29,7 +29,7 @@ def authentication_maps_service_client_with_subscription_key_credential():
     from azure.core.credentials import AzureKeyCredential
     from azure.maps.geolocation import MapsGeolocationClient
 
-    subscription_key = os.getenv("AZURE_SUBSCRIPTION_KEY")
+    subscription_key = os.getenv("AZURE_SUBSCRIPTION_KEY") or "your subscription key"
 
     maps_geolocation_client = MapsGeolocationClient(credential=AzureKeyCredential(subscription_key))
     # [END create_maps_geolocation_service_client_with_key]

--- a/sdk/maps/azure-maps-geolocation/samples/sample_get_country_code.py
+++ b/sdk/maps/azure-maps-geolocation/samples/sample_get_country_code.py
@@ -19,7 +19,7 @@ USAGE:
 
 import os
 
-subscription_key = os.getenv("AZURE_SUBSCRIPTION_KEY")
+subscription_key = os.getenv("AZURE_SUBSCRIPTION_KEY") or "your subscription key"
 
 def get_country_code():
     # [START get_country_code]


### PR DESCRIPTION
# Description

This change will fix mypy typing errors for azure-maps-geolocation.

Current mypy version in tox.ini: `mypy_version=1.6.1`

Resolves: https://github.com/Azure/azure-sdk-for-python/issues/32850

# How it is tested?
`azure-sdk-for-python\sdk\maps\azure-maps-geolocation> tox run -e mypy -c ../../../eng/tox/tox.ini --root . `
