### PR TITLE
Update authorization_code.py: solve AADSTS7000218 issue

### DIFF
--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/authorization_code.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/authorization_code.py
@@ -100,7 +100,7 @@ class AuthorizationCodeCredential(AsyncContextManager, GetTokenMixin):
     async def _request_token(self, *scopes: str, **kwargs: Any) -> AccessToken:
         if self._authorization_code:
             token = await self._client.obtain_token_by_authorization_code(
-                scopes=scopes, code=self._authorization_code, redirect_uri=self._redirect_uri, **kwargs
+                scopes=scopes, code=self._authorization_code, redirect_uri=self._redirect_uri, client_secret=self._client_secret, **kwargs
             )
             self._authorization_code = None  # auth codes are single-use
             return token


### PR DESCRIPTION
When using AuthorizationCodeCredentials, there is an error: "AADSTS7000218: The request body must contain the following parameter: 'client_assertion' or 'client_secret'" Solved by adding self._client_secret when _request_token calls obtain_token_by_authorization_code
