### PR TITLE
[SB] Internal Detach

### DIFF
--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_link_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_link_async.py
@@ -254,7 +254,7 @@ class Link:  # pylint: disable=too-many-instance-attributes
                 # We should detach as per the spec but then retry connecting
                 self._error = AMQPLinkError(condition=ErrorCondition.UnknownError,
                                             description="Link detached unexpectedly.", retryable=True)
-            self._set_state(LinkState.DETACHED)
+            await self._set_state(LinkState.DETACHED)
 
     async def attach(self) -> None:
         if self._is_closed:

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_link_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_link_async.py
@@ -244,12 +244,17 @@ class Link:  # pylint: disable=too-many-instance-attributes
             self._error = error_cls(condition=frame[2][0], description=frame[2][1], info=frame[2][2])
             await self._set_state(LinkState.ERROR)
         else:
-            if self.state != LinkState.DETACH_SENT:
+            if self.state == LinkState.DETACH_SENT:
+                # If we have triggered the detach, don't retry.
+                self._error = AMQPLinkError(condition=ErrorCondition.UnknownError,
+                                            description="Link detach sent.", retryable=False)
+              
+            else:
                 # Handle the case of when the remote side detaches without sending an error.
                 # We should detach as per the spec but then retry connecting
                 self._error = AMQPLinkError(condition=ErrorCondition.UnknownError,
-                                          description="Link detached unexpectedly.", retryable=True)
-            await self._set_state(LinkState.DETACHED)
+                                            description="Link detached unexpectedly.", retryable=True)
+            self._set_state(LinkState.DETACHED)
 
     async def attach(self) -> None:
         if self._is_closed:

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/link.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/link.py
@@ -239,11 +239,17 @@ class Link:  # pylint: disable=too-many-instance-attributes
             self._error = error_cls(condition=frame[2][0], description=frame[2][1], info=frame[2][2])
             self._set_state(LinkState.ERROR)
         else:
-            # if self.state != LinkState.DETACH_SENT:
+            if self.state == LinkState.DETACH_SENT:
+                # If we have triggered the detach, don't retry.
+                self._error = AMQPLinkError(condition=ErrorCondition.UnknownError,
+                                            description="Link detach sent.", retryable=False)
+              
+            else:
                 # Handle the case of when the remote side detaches without sending an error.
                 # We should detach as per the spec but then retry connecting
-            self._error = AMQPLinkError(condition=ErrorCondition.UnknownError,
-                                        description="Link detached unexpectedly.", retryable=True)
+                self._error = AMQPLinkError(condition=ErrorCondition.UnknownError,
+                                            description="Link detached unexpectedly.", retryable=True)
+            self._set_state(LinkState.DETACHED)
             self._set_state(LinkState.DETACHED)
 
     def attach(self) -> None:

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/link.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/link.py
@@ -239,11 +239,11 @@ class Link:  # pylint: disable=too-many-instance-attributes
             self._error = error_cls(condition=frame[2][0], description=frame[2][1], info=frame[2][2])
             self._set_state(LinkState.ERROR)
         else:
-            if self.state != LinkState.DETACH_SENT:
+            # if self.state != LinkState.DETACH_SENT:
                 # Handle the case of when the remote side detaches without sending an error.
                 # We should detach as per the spec but then retry connecting
-                self._error = AMQPLinkError(condition=ErrorCondition.UnknownError,
-                                          description="Link detached unexpectedly.", retryable=True)
+            self._error = AMQPLinkError(condition=ErrorCondition.UnknownError,
+                                        description="Link detached unexpectedly.", retryable=True)
             self._set_state(LinkState.DETACHED)
 
     def attach(self) -> None:


### PR DESCRIPTION
If we do trigger a LinkDetach with close=False, the service may send back a DetachFrame with no error code. 
In this case, we must set self._error as well in order to signal that our Link has been closed for future operations.


** need to handle non-closing detaches