### PR TITLE
Update default broker account sample

### DIFF
--- a/sdk/identity/azure-identity-broker/README.md
+++ b/sdk/identity/azure-identity-broker/README.md
@@ -59,7 +59,7 @@ client = BlobServiceClient(account_url, credential=credential)
 To bypass the account selection dialog and use the account currently signed into the operating system, set the `use_default_broker_account` argument to `True`. The credential will attempt to silently use the default broker account. If using the default account fails, the credential will fall back to interactive authentication.
 
 ```python
-cred = new InteractiveBrowserBrokerCredential(
+credential = new InteractiveBrowserBrokerCredential(
     parent_window_handle=current_window_handle,
     use_default_broker_account=True
 )

--- a/sdk/identity/azure-identity-broker/README.md
+++ b/sdk/identity/azure-identity-broker/README.md
@@ -38,14 +38,6 @@ Microsoft Entra applications rely on redirect URIs to determine where to send th
 ms-appx-web://Microsoft.AAD.BrokerPlugin/{client_id}
 ```
 
-## Use the default account for sign-in
-
-When the `use_default_broker_account` argument is set to `True`, the credential will attempt to silently use the default broker account. If using the default account fails, the credential will fall back to interactive authentication.
-
-```
-cred = new InteractiveBrowserBrokerCredential(use_default_broker_account=True)
-```
-
 ## Examples
 
 ### Authenticate with `InteractiveBrowserBrokerCredential`
@@ -62,6 +54,15 @@ current_window_handle = win32gui.GetForegroundWindow()
 
 credential = InteractiveBrowserBrokerCredential(parent_window_handle=current_window_handle)
 client = BlobServiceClient(account_url, credential=credential)
+```
+
+To bypass the account selection dialog and use the account currently signed into the operating system, set the `use_default_broker_account` argument to `True`. The credential will attempt to silently use the default broker account. If using the default account fails, the credential will fall back to interactive authentication.
+
+```python
+cred = new InteractiveBrowserBrokerCredential(
+    parent_window_handle=current_window_handle,
+    use_default_broker_account=True
+)
 ```
 
 ## Troubleshooting


### PR DESCRIPTION
In the event that token acquisition fails when using the default account, a window handle will be needed to properly position the account picker. Update the README section accordingly so that it matches this test code: https://github.com/Azure/azure-sdk-for-python/blob/4ed19c330e9df93955d532fcb88c3fbd60226654/sdk/identity/azure-identity-broker/tests/test_broker.py#L23-L25