### PR TITLE
[FR] Fix failing live pipeline

### DIFF
--- a/sdk/formrecognizer/azure-ai-formrecognizer/assets.json
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "python",
   "TagPrefix": "python/formrecognizer/azure-ai-formrecognizer",
-  "Tag": "python/formrecognizer/azure-ai-formrecognizer_9918a968ae"
+  "Tag": "python/formrecognizer/azure-ai-formrecognizer_b624efa337"
 }

--- a/sdk/formrecognizer/azure-ai-formrecognizer/samples/v3.2_and_later/async_samples/sample_analyze_addon_barcodes_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/samples/v3.2_and_later/async_samples/sample_analyze_addon_barcodes_async.py
@@ -84,7 +84,7 @@ async def analyze_barcodes():
         # Specify which add-on capabilities to enable.
         with open(path_to_sample_documents, "rb") as f:
             poller = await document_analysis_client.begin_analyze_document(
-                "prebuilt-layout", document=f, features=[AnalysisFeature.barcode/QR code]
+                "prebuilt-layout", document=f, features=[AnalysisFeature.BARCODES]
             )
         result = await poller.result()
 

--- a/sdk/formrecognizer/azure-ai-formrecognizer/samples/v3.2_and_later/async_samples/sample_send_request_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/samples/v3.2_and_later/async_samples/sample_send_request_async.py
@@ -45,28 +45,42 @@ async def sample_send_request():
         response = await client.send_request(request)
         response.raise_for_status()
         response_body = response.json()
-        print(response_body)
+        print(
+            f"Our resource has {response_body['customDocumentModels']['count']} custom models, "
+            f"and we can have at most {response_body['customDocumentModels']['limit']} custom models."
+            f"The quota limit for custom neural document models is {response_body['customNeuralDocumentModelBuilds']['quota']} and the resource has"
+            f"used {response_body['customNeuralDocumentModelBuilds']['used']}. The resource quota will reset on {response_body['customNeuralDocumentModelBuilds']['quotaResetDateTime']}"
+        )
     
         # pass with absolute url and override the API version
         request = HttpRequest(method="GET", url=f"{endpoint}/formrecognizer/info?api-version=2022-08-31")
         response = await client.send_request(request)
         response.raise_for_status()
         response_body = response.json()
-        print(response_body)
+        print(
+            f"Our resource has {response_body['customDocumentModels']['count']} custom models, "
+            f"and we can have at most {response_body['customDocumentModels']['limit']} custom models."
+        )
     
         # override the API version to v2.1
         request = HttpRequest(method="GET", url="v2.1/custom/models?op=summary")
         response = await client.send_request(request)
         response.raise_for_status()
         response_body = response.json()
-        print(response_body)
+        print(
+            f"Our account has {response_body['summary']['count']} custom models, "
+            f"and we can have at most {response_body['summary']['limit']} custom models."
+        )
     
         # pass with absolute url and override the API version to v2.1
         request = HttpRequest(method="GET", url=f"{endpoint}/formrecognizer/v2.1/custom/models?op=summary")
         response = await client.send_request(request)
         response.raise_for_status()
         response_body = response.json()
-        print(response_body)
+        print(
+            f"Our account has {response_body['summary']['count']} custom models, "
+            f"and we can have at most {response_body['summary']['limit']} custom models."
+        )
 
 
 async def sample_send_request_v2():
@@ -88,14 +102,20 @@ async def sample_send_request_v2():
         response = await client.send_request(request)
         response.raise_for_status()
         response_body = response.json()
-        print(response_body)
+        print(
+            f"Our account has {response_body['summary']['count']} custom models, "
+            f"and we can have at most {response_body['summary']['limit']} custom models."
+        )
     
         # pass with absolute  url and override the API version
         request = HttpRequest(method="GET", url=f"{endpoint}/formrecognizer/v2.0/custom/models?op=summary")
         response = await client.send_request(request)
         response.raise_for_status()
         response_body = response.json()
-        print(response_body)
+        print(
+            f"Our account has {response_body['summary']['count']} custom models, "
+            f"and we can have at most {response_body['summary']['limit']} custom models."
+        )
     
         # override the API version to 2023-07-31
         # can only override the API version to 2022-08-31 or later with absolute url
@@ -103,7 +123,12 @@ async def sample_send_request_v2():
         response = await client.send_request(request)
         response.raise_for_status()
         response_body = response.json()
-        print(response_body)
+        print(
+            f"Our resource has {response_body['customDocumentModels']['count']} custom models, "
+            f"and we can have at most {response_body['customDocumentModels']['limit']} custom models."
+            f"The quota limit for custom neural document models is {response_body['customNeuralDocumentModelBuilds']['quota']} and the resource has"
+            f"used {response_body['customNeuralDocumentModelBuilds']['used']}. The resource quota will reset on {response_body['customNeuralDocumentModelBuilds']['quotaResetDateTime']}"
+        )
 
 
 async def main():

--- a/sdk/formrecognizer/azure-ai-formrecognizer/samples/v3.2_and_later/async_samples/sample_send_request_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/samples/v3.2_and_later/async_samples/sample_send_request_async.py
@@ -35,53 +35,38 @@ async def sample_send_request():
         endpoint=endpoint, credential=AzureKeyCredential(key)
     )
     
-    # The `send_request` method can send custom HTTP requests that share the client's existing pipeline,
-    # while adding convenience for endpoint construction and service API versioning.
-    # Now let's use the `send_request` method to make a resource details fetching request.
-    # The URL of the request can be relative (your endpoint is the default base URL),
-    # and the API version of your client will automatically be used for the request.
-    request = HttpRequest(method="GET", url="info")
     async with client:
+        # The `send_request` method can send custom HTTP requests that share the client's existing pipeline,
+        # while adding convenience for endpoint construction and service API versioning.
+        # Now let's use the `send_request` method to make a resource details fetching request.
+        # The URL of the request can be relative (your endpoint is the default base URL),
+        # and the API version of your client will automatically be used for the request.
+        request = HttpRequest(method="GET", url="info")
         response = await client.send_request(request)
-    response.raise_for_status()
-    response_body = response.json()
-    print(
-        f"Our resource has {response_body['customDocumentModels']['count']} custom models, "
-        f"and we can have at most {response_body['customDocumentModels']['limit']} custom models."
-        f"The quota limit for custom neural document models is {response_body['customNeuralDocumentModelBuilds']['quota']} and the resource has"
-        f"used {response_body['customNeuralDocumentModelBuilds']['used']}. The resource quota will reset on {response_body['customNeuralDocumentModelBuilds']['quotaResetDateTime']}"
-    )
+        response.raise_for_status()
+        response_body = response.json()
+        print(response_body)
     
-    # pass with absolute url and override the API version
-    request = HttpRequest(method="GET", url=f"{endpoint}/formrecognizer/info?api-version=2022-08-31")
-    async with client:
+        # pass with absolute url and override the API version
+        request = HttpRequest(method="GET", url=f"{endpoint}/formrecognizer/info?api-version=2022-08-31")
         response = await client.send_request(request)
-    response.raise_for_status()
-    response_body = response.json()
-    print(
-        f"Our resource has {response_body['customDocumentModels']['count']} custom models, "
-        f"and we can have at most {response_body['customDocumentModels']['limit']} custom models."
-        f"The quota limit for custom neural document models is {response_body['customNeuralDocumentModelBuilds']['quota']} and the resource has"
-        f"used {response_body['customNeuralDocumentModelBuilds']['used']}. The resource quota will reset on {response_body['customNeuralDocumentModelBuilds']['quotaResetDateTime']}"
-    )
+        response.raise_for_status()
+        response_body = response.json()
+        print(response_body)
     
-    # override the API version to v2.1
-    request = HttpRequest(method="GET", url="v2.1/custom/models?op=summary")
-    async with client:
+        # override the API version to v2.1
+        request = HttpRequest(method="GET", url="v2.1/custom/models?op=summary")
         response = await client.send_request(request)
-    response.raise_for_status()
-    response_body = response.json()
-    print(f"Our account has {response_body['summary']['count']} custom models, "
-          f"and we can have at most {response_body['summary']['limit']} custom models.")
+        response.raise_for_status()
+        response_body = response.json()
+        print(response_body)
     
-    # pass with absolute url and override the API version to v2.1
-    request = HttpRequest(method="GET", url=f"{endpoint}/formrecognizer/v2.1/custom/models?op=summary")
-    async with client:
+        # pass with absolute url and override the API version to v2.1
+        request = HttpRequest(method="GET", url=f"{endpoint}/formrecognizer/v2.1/custom/models?op=summary")
         response = await client.send_request(request)
-    response.raise_for_status()
-    response_body = response.json()
-    print(f"Our account has {response_body['summary']['count']} custom models, "
-          f"and we can have at most {response_body['summary']['limit']} custom models.")
+        response.raise_for_status()
+        response_body = response.json()
+        print(response_body)
 
 
 async def sample_send_request_v2():
@@ -92,42 +77,33 @@ async def sample_send_request_v2():
     client = FormTrainingClient(
         endpoint=endpoint, credential=AzureKeyCredential(key)
     )
-    
-    # The `send_request` method can send custom HTTP requests that share the client's existing pipeline,
-    # while adding convenience for endpoint construction and service API versioning.
-    # Now let's use the `send_request` method to make a resource details fetching request.
-    # The URL of the request can be relative (your endpoint is the default base URL),
-    # and the API version of your client will automatically be used for the request.
-    request = HttpRequest(method="GET", url="custom/models?op=summary")
+
     async with client:
+        # The `send_request` method can send custom HTTP requests that share the client's existing pipeline,
+        # while adding convenience for endpoint construction and service API versioning.
+        # Now let's use the `send_request` method to make a resource details fetching request.
+        # The URL of the request can be relative (your endpoint is the default base URL),
+        # and the API version of your client will automatically be used for the request.
+        request = HttpRequest(method="GET", url="custom/models?op=summary")
         response = await client.send_request(request)
-    response.raise_for_status()
-    response_body = response.json()
-    print(f"Our account has {response_body['summary']['count']} custom models, "
-          f"and we can have at most {response_body['summary']['limit']} custom models.")
+        response.raise_for_status()
+        response_body = response.json()
+        print(response_body)
     
-    # pass with absolute  url and override the API version
-    request = HttpRequest(method="GET", url=f"{endpoint}/formrecognizer/v2.0/custom/models?op=summary")
-    async with client:
+        # pass with absolute  url and override the API version
+        request = HttpRequest(method="GET", url=f"{endpoint}/formrecognizer/v2.0/custom/models?op=summary")
         response = await client.send_request(request)
-    response.raise_for_status()
-    response_body = response.json()
-    print(f"Our account has {response_body['summary']['count']} custom models, "
-          f"and we can have at most {response_body['summary']['limit']} custom models.")
+        response.raise_for_status()
+        response_body = response.json()
+        print(response_body)
     
-    # override the API version to 2023-07-31
-    # can only override the API version to 2022-08-31 or later with absolute url
-    request = HttpRequest(method="GET", url=f"{endpoint}/formrecognizer/info?api-version=2023-07-31")
-    async with client:
+        # override the API version to 2023-07-31
+        # can only override the API version to 2022-08-31 or later with absolute url
+        request = HttpRequest(method="GET", url=f"{endpoint}/formrecognizer/info?api-version=2023-07-31")
         response = await client.send_request(request)
-    response.raise_for_status()
-    response_body = response.json()
-    print(
-        f"Our resource has {response_body['customDocumentModels']['count']} custom models, "
-        f"and we can have at most {response_body['customDocumentModels']['limit']} custom models."
-        f"The quota limit for custom neural document models is {response_body['customNeuralDocumentModelBuilds']['quota']} and the resource has"
-        f"used {response_body['customNeuralDocumentModelBuilds']['used']}. The resource quota will reset on {response_body['customNeuralDocumentModelBuilds']['quotaResetDateTime']}"
-    )
+        response.raise_for_status()
+        response_body = response.json()
+        print(response_body)
 
 
 async def main():

--- a/sdk/formrecognizer/azure-ai-formrecognizer/samples/v3.2_and_later/sample_send_request.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/samples/v3.2_and_later/sample_send_request.py
@@ -43,40 +43,28 @@ def sample_send_request():
     response = client.send_request(request)
     response.raise_for_status()
     response_body = response.json()
-    print(
-        f"Our resource has {response_body['customDocumentModels']['count']} custom models, "
-        f"and we can have at most {response_body['customDocumentModels']['limit']} custom models."
-        f"The quota limit for custom neural document models is {response_body['customNeuralDocumentModelBuilds']['quota']} and the resource has"
-        f"used {response_body['customNeuralDocumentModelBuilds']['used']}. The resource quota will reset on {response_body['customNeuralDocumentModelBuilds']['quotaResetDateTime']}"
-    )
+    print(response_body)
     
     # pass with absolute url and override the API version
     request = HttpRequest(method="GET", url=f"{endpoint}/formrecognizer/info?api-version=2022-08-31")
     response = client.send_request(request)
     response.raise_for_status()
     response_body = response.json()
-    print(
-        f"Our resource has {response_body['customDocumentModels']['count']} custom models, "
-        f"and we can have at most {response_body['customDocumentModels']['limit']} custom models."
-        f"The quota limit for custom neural document models is {response_body['customNeuralDocumentModelBuilds']['quota']} and the resource has"
-        f"used {response_body['customNeuralDocumentModelBuilds']['used']}. The resource quota will reset on {response_body['customNeuralDocumentModelBuilds']['quotaResetDateTime']}"
-    )
+    print(response_body)
     
     # override the API version to v2.1
     request = HttpRequest(method="GET", url="v2.1/custom/models?op=summary")
     response = client.send_request(request)
     response.raise_for_status()
     response_body = response.json()
-    print(f"Our account has {response_body['summary']['count']} custom models, "
-          f"and we can have at most {response_body['summary']['limit']} custom models.")
+    print(response_body)
     
     # pass with absolute url and override the API version to v2.1
     request = HttpRequest(method="GET", url=f"{endpoint}/formrecognizer/v2.1/custom/models?op=summary")
     response = client.send_request(request)
     response.raise_for_status()
     response_body = response.json()
-    print(f"Our account has {response_body['summary']['count']} custom models, "
-          f"and we can have at most {response_body['summary']['limit']} custom models.")
+    print(response_body)
 
 
 def sample_send_request_v2():
@@ -97,28 +85,21 @@ def sample_send_request_v2():
     response = client.send_request(request)
     response.raise_for_status()
     response_body = response.json()
-    print(f"Our account has {response_body['summary']['count']} custom models, "
-          f"and we can have at most {response_body['summary']['limit']} custom models.")
+    print(response_body)
     
     # pass with absolute url and override the API version
     request = HttpRequest(method="GET", url=f"{endpoint}/formrecognizer/v2.0/custom/models?op=summary")
     response = client.send_request(request)
     response.raise_for_status()
     response_body = response.json()
-    print(f"Our account has {response_body['summary']['count']} custom models, "
-          f"and we can have at most {response_body['summary']['limit']} custom models.")
+    print(response_body)
     
     # override the API version to 2023-07-31
     request = HttpRequest(method="GET", url=f"{endpoint}/formrecognizer/info?api-version=2023-07-31")
     response = client.send_request(request)
     response.raise_for_status()
     response_body = response.json()
-    print(
-        f"Our resource has {response_body['customDocumentModels']['count']} custom models, "
-        f"and we can have at most {response_body['customDocumentModels']['limit']} custom models."
-        f"The quota limit for custom neural document models is {response_body['customNeuralDocumentModelBuilds']['quota']} and the resource has"
-        f"used {response_body['customNeuralDocumentModelBuilds']['used']}. The resource quota will reset on {response_body['customNeuralDocumentModelBuilds']['quotaResetDateTime']}"
-    )
+    print(response_body)
 
 
 if __name__ == "__main__":

--- a/sdk/formrecognizer/azure-ai-formrecognizer/samples/v3.2_and_later/sample_send_request.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/samples/v3.2_and_later/sample_send_request.py
@@ -43,28 +43,42 @@ def sample_send_request():
     response = client.send_request(request)
     response.raise_for_status()
     response_body = response.json()
-    print(response_body)
+    print(
+        f"Our resource has {response_body['customDocumentModels']['count']} custom models, "
+        f"and we can have at most {response_body['customDocumentModels']['limit']} custom models."
+        f"The quota limit for custom neural document models is {response_body['customNeuralDocumentModelBuilds']['quota']} and the resource has"
+        f"used {response_body['customNeuralDocumentModelBuilds']['used']}. The resource quota will reset on {response_body['customNeuralDocumentModelBuilds']['quotaResetDateTime']}"
+    )
     
     # pass with absolute url and override the API version
     request = HttpRequest(method="GET", url=f"{endpoint}/formrecognizer/info?api-version=2022-08-31")
     response = client.send_request(request)
     response.raise_for_status()
     response_body = response.json()
-    print(response_body)
+    print(
+        f"Our resource has {response_body['customDocumentModels']['count']} custom models, "
+        f"and we can have at most {response_body['customDocumentModels']['limit']} custom models."
+    )
     
     # override the API version to v2.1
     request = HttpRequest(method="GET", url="v2.1/custom/models?op=summary")
     response = client.send_request(request)
     response.raise_for_status()
     response_body = response.json()
-    print(response_body)
+    print(
+        f"Our account has {response_body['summary']['count']} custom models, "
+        f"and we can have at most {response_body['summary']['limit']} custom models."
+    )
     
     # pass with absolute url and override the API version to v2.1
     request = HttpRequest(method="GET", url=f"{endpoint}/formrecognizer/v2.1/custom/models?op=summary")
     response = client.send_request(request)
     response.raise_for_status()
     response_body = response.json()
-    print(response_body)
+    print(
+        f"Our account has {response_body['summary']['count']} custom models, "
+        f"and we can have at most {response_body['summary']['limit']} custom models."
+    )
 
 
 def sample_send_request_v2():
@@ -85,21 +99,32 @@ def sample_send_request_v2():
     response = client.send_request(request)
     response.raise_for_status()
     response_body = response.json()
-    print(response_body)
+    print(
+        f"Our account has {response_body['summary']['count']} custom models, "
+        f"and we can have at most {response_body['summary']['limit']} custom models."
+    )
     
     # pass with absolute url and override the API version
     request = HttpRequest(method="GET", url=f"{endpoint}/formrecognizer/v2.0/custom/models?op=summary")
     response = client.send_request(request)
     response.raise_for_status()
     response_body = response.json()
-    print(response_body)
+    print(
+        f"Our account has {response_body['summary']['count']} custom models, "
+        f"and we can have at most {response_body['summary']['limit']} custom models."
+    )
     
     # override the API version to 2023-07-31
     request = HttpRequest(method="GET", url=f"{endpoint}/formrecognizer/info?api-version=2023-07-31")
     response = client.send_request(request)
     response.raise_for_status()
     response_body = response.json()
-    print(response_body)
+    print(
+        f"Our resource has {response_body['customDocumentModels']['count']} custom models, "
+        f"and we can have at most {response_body['customDocumentModels']['limit']} custom models."
+        f"The quota limit for custom neural document models is {response_body['customNeuralDocumentModelBuilds']['quota']} and the resource has"
+        f"used {response_body['customNeuralDocumentModelBuilds']['used']}. The resource quota will reset on {response_body['customNeuralDocumentModelBuilds']['quotaResetDateTime']}"
+    )
 
 
 if __name__ == "__main__":

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_send_request.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_send_request.py
@@ -22,6 +22,8 @@ class TestSendRequest(FormRecognizerTest):
     @recorded_by_proxy
     def test_get_resource_details(self, client, **kwargs):
         set_bodiless_matcher()
+        resource_details = client.get_resource_details()
+
         request = HttpRequest(
             method="GET",
             url="info",
@@ -31,8 +33,8 @@ class TestSendRequest(FormRecognizerTest):
         received_info1 = result.json()
         assert received_info1
         assert received_info1["customDocumentModels"]
-        assert received_info1["customDocumentModels"]["count"]
-        assert received_info1["customDocumentModels"]["limit"] == 250
+        assert received_info1["customDocumentModels"]["count"] == resource_details.custom_document_models.count
+        assert received_info1["customDocumentModels"]["limit"] == resource_details.custom_document_models.limit
 
         request = HttpRequest(
             method="GET",
@@ -43,7 +45,7 @@ class TestSendRequest(FormRecognizerTest):
         received_info2 = result.json()
         assert received_info2["customDocumentModels"]["count"] == received_info1["customDocumentModels"]["count"]
         assert received_info2["customDocumentModels"]["limit"] == received_info1["customDocumentModels"]["limit"]
-        
+
         # test with absolute url
         request = HttpRequest(
             method="GET",
@@ -54,7 +56,7 @@ class TestSendRequest(FormRecognizerTest):
         received_info3 = result.json()
         assert received_info3["customDocumentModels"]["count"] == received_info1["customDocumentModels"]["count"]
         assert received_info3["customDocumentModels"]["limit"] == received_info1["customDocumentModels"]["limit"]
-        
+
         # test with v2 API version
         request = HttpRequest(
             method="GET",
@@ -64,9 +66,9 @@ class TestSendRequest(FormRecognizerTest):
         result = client.send_request(request)
         received_info4 = result.json()
         assert received_info4
-        assert received_info4["summary"]["count"]
-        assert received_info4["summary"]["limit"] == 250
-        
+        assert received_info4["summary"]["count"] == resource_details.custom_document_models.count
+        assert received_info4["summary"]["limit"] == resource_details.custom_document_models.limit
+
         # test with v2 API version with absolute url
         request = HttpRequest(
             method="GET",
@@ -83,6 +85,8 @@ class TestSendRequest(FormRecognizerTest):
     @recorded_by_proxy
     def test_get_account_properties_v2(self, client):
         set_bodiless_matcher()
+        account_properties = client.get_account_properties()
+
         request = HttpRequest(
             method="GET",
             url="custom/models?op=summary",
@@ -92,9 +96,9 @@ class TestSendRequest(FormRecognizerTest):
         received_info1 = result.json()
         assert received_info1
         assert received_info1["summary"]
-        assert received_info1["summary"]["count"]
-        assert received_info1["summary"]["limit"] == 250
-        
+        assert received_info1["summary"]["count"] == account_properties.custom_model_count
+        assert received_info1["summary"]["limit"] == account_properties.custom_model_limit
+
         # test with absolute url
         request = HttpRequest(
             method="GET",
@@ -105,7 +109,7 @@ class TestSendRequest(FormRecognizerTest):
         received_info3 = result.json()
         assert received_info3["summary"]["count"] == received_info1["summary"]["count"]
         assert received_info3["summary"]["limit"] == received_info1["summary"]["limit"]
-        
+
         # relative URLs can't override the API version on 2.x clients
         request = HttpRequest(
             method="GET",
@@ -116,7 +120,7 @@ class TestSendRequest(FormRecognizerTest):
         received_info4 = result.json()
         assert received_info4["error"]["code"] == "404"
         assert received_info4["error"]["message"] == "Resource not found"
-        
+
         # test with v2 API version with absolute url
         request = HttpRequest(
             method="GET",
@@ -126,5 +130,5 @@ class TestSendRequest(FormRecognizerTest):
         result = client.send_request(request)
         received_info5 = result.json()
         assert received_info5
-        assert received_info5["customDocumentModels"]["count"]
-        assert received_info5["customDocumentModels"]["limit"] == 250
+        assert received_info5["customDocumentModels"]["count"] == account_properties.custom_model_count
+        assert received_info5["customDocumentModels"]["limit"] == account_properties.custom_model_limit

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_send_request.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_send_request.py
@@ -31,7 +31,7 @@ class TestSendRequest(FormRecognizerTest):
         received_info1 = result.json()
         assert received_info1
         assert received_info1["customDocumentModels"]
-        assert received_info1["customDocumentModels"]["count"] == 0
+        assert received_info1["customDocumentModels"]["count"]
         assert received_info1["customDocumentModels"]["limit"] == 250
 
         request = HttpRequest(
@@ -64,8 +64,8 @@ class TestSendRequest(FormRecognizerTest):
         result = client.send_request(request)
         received_info4 = result.json()
         assert received_info4
-        assert received_info4["summary"]["count"] == 0
-        assert received_info4["summary"]["limit"]
+        assert received_info4["summary"]["count"]
+        assert received_info4["summary"]["limit"] == 250
         
         # test with v2 API version with absolute url
         request = HttpRequest(
@@ -92,7 +92,7 @@ class TestSendRequest(FormRecognizerTest):
         received_info1 = result.json()
         assert received_info1
         assert received_info1["summary"]
-        assert received_info1["summary"]["count"] == 0
+        assert received_info1["summary"]["count"]
         assert received_info1["summary"]["limit"] == 250
         
         # test with absolute url
@@ -126,5 +126,5 @@ class TestSendRequest(FormRecognizerTest):
         result = client.send_request(request)
         received_info5 = result.json()
         assert received_info5
-        assert received_info5["customDocumentModels"]["count"] == 0
+        assert received_info5["customDocumentModels"]["count"]
         assert received_info5["customDocumentModels"]["limit"] == 250

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_send_request_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_send_request_async.py
@@ -33,7 +33,7 @@ class TestSendRequestAsync(AsyncFormRecognizerTest):
             received_info1 = result.json()
             assert received_info1
             assert received_info1["customDocumentModels"]
-            assert received_info1["customDocumentModels"]["count"] == 0
+            assert received_info1["customDocumentModels"]["count"]
             assert received_info1["customDocumentModels"]["limit"] == 250
 
             request = HttpRequest(
@@ -66,7 +66,7 @@ class TestSendRequestAsync(AsyncFormRecognizerTest):
             result = await client.send_request(request)
             received_info4 = result.json()
             assert received_info4
-            assert received_info4["summary"]["count"] == 0
+            assert received_info4["summary"]["count"]
             assert received_info4["summary"]["limit"] == 250
             
             # test with v2 API version with absolute url
@@ -95,7 +95,7 @@ class TestSendRequestAsync(AsyncFormRecognizerTest):
             received_info1 = result.json()
             assert received_info1
             assert received_info1["summary"]
-            assert received_info1["summary"]["count"] == 0
+            assert received_info1["summary"]["count"]
             assert received_info1["summary"]["limit"] == 250
             
             # test with absolute url
@@ -129,5 +129,5 @@ class TestSendRequestAsync(AsyncFormRecognizerTest):
             result = await client.send_request(request)
             received_info5 = result.json()
             assert received_info5
-            assert received_info5["customDocumentModels"]["count"] == 0
+            assert received_info5["customDocumentModels"]["count"]
             assert received_info5["customDocumentModels"]["limit"] == 250

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_send_request_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_send_request_async.py
@@ -17,13 +17,14 @@ FormTrainingClientPreparer = functools.partial(_GlobalClientPreparer, FormTraini
 
 
 class TestSendRequestAsync(AsyncFormRecognizerTest):
-
     @FormRecognizerPreparer()
     @DocumentModelAdministrationClientPreparer()
     @recorded_by_proxy_async
     async def test_get_resource_details(self, client, **kwargs):
         set_bodiless_matcher()
         async with client:
+            resource_details = await client.get_resource_details()
+
             request = HttpRequest(
                 method="GET",
                 url="info",
@@ -33,8 +34,8 @@ class TestSendRequestAsync(AsyncFormRecognizerTest):
             received_info1 = result.json()
             assert received_info1
             assert received_info1["customDocumentModels"]
-            assert received_info1["customDocumentModels"]["count"]
-            assert received_info1["customDocumentModels"]["limit"] == 250
+            assert received_info1["customDocumentModels"]["count"] == resource_details.custom_document_models.count
+            assert received_info1["customDocumentModels"]["limit"] == resource_details.custom_document_models.limit
 
             request = HttpRequest(
                 method="GET",
@@ -66,9 +67,9 @@ class TestSendRequestAsync(AsyncFormRecognizerTest):
             result = await client.send_request(request)
             received_info4 = result.json()
             assert received_info4
-            assert received_info4["summary"]["count"]
-            assert received_info4["summary"]["limit"] == 250
-            
+            assert received_info4["summary"]["count"] == resource_details.custom_document_models.count
+            assert received_info4["summary"]["limit"] == resource_details.custom_document_models.limit
+
             # test with v2 API version with absolute url
             request = HttpRequest(
                 method="GET",
@@ -86,6 +87,8 @@ class TestSendRequestAsync(AsyncFormRecognizerTest):
     async def test_get_account_properties_v2(self, client):
         set_bodiless_matcher()
         async with client:
+            account_properties = await client.get_account_properties()
+
             request = HttpRequest(
                 method="GET",
                 url="custom/models?op=summary",
@@ -95,9 +98,9 @@ class TestSendRequestAsync(AsyncFormRecognizerTest):
             received_info1 = result.json()
             assert received_info1
             assert received_info1["summary"]
-            assert received_info1["summary"]["count"]
-            assert received_info1["summary"]["limit"] == 250
-            
+            assert received_info1["summary"]["count"] == account_properties.custom_model_count
+            assert received_info1["summary"]["limit"] == account_properties.custom_model_limit
+
             # test with absolute url
             request = HttpRequest(
                 method="GET",
@@ -108,7 +111,7 @@ class TestSendRequestAsync(AsyncFormRecognizerTest):
             received_info3 = result.json()
             assert received_info3["summary"]["count"] == received_info1["summary"]["count"]
             assert received_info3["summary"]["limit"] == received_info1["summary"]["limit"]
-            
+
             # relative URLs can't override the API version on 2.x clients
             request = HttpRequest(
                 method="GET",
@@ -119,7 +122,7 @@ class TestSendRequestAsync(AsyncFormRecognizerTest):
             received_info4 = result.json()
             assert received_info4["error"]["code"] == "404"
             assert received_info4["error"]["message"] == "Resource not found"
-            
+
             # test with v2 API version with absolute url
             request = HttpRequest(
                 method="GET",
@@ -129,5 +132,5 @@ class TestSendRequestAsync(AsyncFormRecognizerTest):
             result = await client.send_request(request)
             received_info5 = result.json()
             assert received_info5
-            assert received_info5["customDocumentModels"]["count"]
-            assert received_info5["customDocumentModels"]["limit"] == 250
+            assert received_info5["customDocumentModels"]["count"] == account_properties.custom_model_count
+            assert received_info5["customDocumentModels"]["limit"] == account_properties.custom_model_limit


### PR DESCRIPTION
Resolves https://github.com/Azure/azure-sdk-for-python/issues/34873

This PR fixed:
* Failing tests as "count" is not a fixed value in each response, changed to not asserting its exact value.
* Failing sample as the enum "barcode" value is incorrect in use.
* Failing send request sample as the JSON output is different between two API versions: the quota info was introduced since API `2023-02-28-preview`.