### PR TITLE
[ServiceBus] fix sphinx

### DIFF
--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_common/constants.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_common/constants.py
@@ -155,10 +155,8 @@ class ServiceBusMessageState(int, Enum):
     DEFERRED = 1
     SCHEDULED = 2
 
-
 class ServiceBusSessionFilter(Enum):
     NEXT_AVAILABLE = 0
-
 
 class ServiceBusSubQueue(str, Enum, metaclass=CaseInsensitiveEnumMeta):
     DEAD_LETTER = "deadletter"
@@ -171,9 +169,9 @@ NEXT_AVAILABLE_SESSION = ServiceBusSessionFilter.NEXT_AVAILABLE
 class TransportType(Enum):
     """Transport type
     The underlying transport protocol type:
-     Amqp: AMQP over the default TCP transport protocol, it uses port 5671.
-     AmqpOverWebsocket: Amqp over the Web Sockets transport protocol, it uses
-     port 443.
+    - Amqp: AMQP over the default TCP transport protocol, it uses port 5671.
+    - AmqpOverWebsocket: Amqp over the Web Sockets transport protocol, it uses
+    port 443.
     """
     Amqp = 1
     AmqpOverWebsocket = 2

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_servicebus_client.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_servicebus_client.py
@@ -372,7 +372,7 @@ class ServiceBusClient(object): # pylint: disable=client-accepts-api-version-key
          The default value is 0, meaning messages will be received from the service and processed one at a time.
          In the case of prefetch_count being 0, `ServiceBusReceiver.receive_messages` would try to cache
          `max_message_count` (if provided) within its request to the service.
-         **WARNING: If prefetch_count > 0 and RECEIVE_AND_DELETE mode is used, all prefetched messages will stay in
+         WARNING: If prefetch_count > 0 and RECEIVE_AND_DELETE mode is used, all prefetched messages will stay in
          the in-memory prefetch buffer until they're received into the application. If the application ends before
          the messages are received into the application, those messages will be lost and unable to be recovered.
          Therefore, it's recommended that PEEK_LOCK mode be used with prefetch.
@@ -383,7 +383,6 @@ class ServiceBusClient(object): # pylint: disable=client-accepts-api-version-key
          wait when sending and receiving data before timing out. The default value is 0.2 for TransportType.Amqp
          and 1 for TransportType.AmqpOverWebsocket. If connection errors are occurring due to write timing out,
          a larger than default value may need to be passed in.
-
         :rtype: ~azure.servicebus.ServiceBusReceiver
 
         .. admonition:: Example:
@@ -394,7 +393,6 @@ class ServiceBusClient(object): # pylint: disable=client-accepts-api-version-key
                 :language: python
                 :dedent: 4
                 :caption: Create a new instance of the ServiceBusReceiver from ServiceBusClient.
-
 
         """
 
@@ -564,7 +562,7 @@ class ServiceBusClient(object): # pylint: disable=client-accepts-api-version-key
          The default value is 0, meaning messages will be received from the service and processed one at a time.
          In the case of prefetch_count being 0, `ServiceBusReceiver.receive_messages` would try to cache
          `max_message_count` (if provided) within its request to the service.
-         **WARNING: If prefetch_count > 0 and RECEIVE_AND_DELETE mode is used, all prefetched messages will stay in
+         WARNING: If prefetch_count > 0 and RECEIVE_AND_DELETE mode is used, all prefetched messages will stay in
          the in-memory prefetch buffer until they're received into the application. If the application ends before
          the messages are received into the application, those messages will be lost and unable to be recovered.
          Therefore, it's recommended that PEEK_LOCK mode be used with prefetch.
@@ -575,6 +573,7 @@ class ServiceBusClient(object): # pylint: disable=client-accepts-api-version-key
          wait when sending and receiving data before timing out. The default value is 0.2 for TransportType.Amqp
          and 1 for TransportType.AmqpOverWebsocket. If connection errors are occurring due to write timing out,
          a larger than default value may need to be passed in.
+        :returns: A subscription receiver.
         :rtype: ~azure.servicebus.ServiceBusReceiver
 
         .. admonition:: Example:

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_servicebus_receiver.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_servicebus_receiver.py
@@ -83,8 +83,8 @@ class ServiceBusReceiver(
     The two primary channels for message receipt are `receive()` to make a single request for messages,
     and `for message in receiver:` to continuously receive incoming messages in an ongoing fashion.
 
-    **Please use the `get_<queue/subscription>_receiver` method of ~azure.servicebus.ServiceBusClient to create a
-    ServiceBusReceiver instance.**
+    Please use the `get_<queue/subscription>_receiver` method of ~azure.servicebus.ServiceBusClient to create a
+    ServiceBusReceiver instance.
 
     :ivar fully_qualified_namespace: The fully qualified host name for the Service Bus namespace.
      The namespace format is: `<yournamespace>.servicebus.windows.net`.
@@ -136,7 +136,7 @@ class ServiceBusReceiver(
      The default value is 0, meaning messages will be received from the service and processed one at a time.
      In the case of prefetch_count being 0, `ServiceBusReceiver.receive_messages` would try to cache
      `max_message_count` (if provided) within its request to the service.
-     **WARNING: If prefetch_count > 0 and RECEIVE_AND_DELETE mode is used, all prefetched messages will stay in
+     WARNING: If prefetch_count > 0 and RECEIVE_AND_DELETE mode is used, all prefetched messages will stay in
      the in-memory prefetch buffer until they're received into the application. If the application ends before
      the messages are received into the application, those messages will be lost and unable to be recovered.
      Therefore, it's recommended that PEEK_LOCK mode be used with prefetch.
@@ -321,7 +321,7 @@ class ServiceBusReceiver(
          The default value is 0, meaning messages will be received from the service and processed one at a time.
          In the case of prefetch_count being 0, `ServiceBusReceiver.receive_messages` would try to cache
          `max_message_count` (if provided) within its request to the service.
-         **WARNING: If prefetch_count > 0 and RECEIVE_AND_DELETE mode is used, all prefetched messages will stay in
+         WARNING: If prefetch_count > 0 and RECEIVE_AND_DELETE mode is used, all prefetched messages will stay in
          the in-memory prefetch buffer until they're received into the application. If the application ends before
          the messages are received into the application, those messages will be lost and unable to be recovered.
          Therefore, it's recommended that PEEK_LOCK mode be used with prefetch.

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_servicebus_client_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_servicebus_client_async.py
@@ -357,7 +357,7 @@ class ServiceBusClient(object): # pylint: disable=client-accepts-api-version-key
          The default value is 0, meaning messages will be received from the service and processed one at a time.
          In the case of prefetch_count being 0, `ServiceBusReceiver.receive_messages` would try to cache
          `max_message_count` (if provided) within its request to the service.
-         **WARNING: If prefetch_count > 0 and RECEIVE_AND_DELETE mode is used, all prefetched messages will stay in
+         WARNING: If prefetch_count > 0 and RECEIVE_AND_DELETE mode is used, all prefetched messages will stay in
          the in-memory prefetch buffer until they're received into the application. If the application ends before
          the messages are received into the application, those messages will be lost and unable to be recovered.
          Therefore, it's recommended that PEEK_LOCK mode be used with prefetch.
@@ -538,7 +538,7 @@ class ServiceBusClient(object): # pylint: disable=client-accepts-api-version-key
          The default value is 0, meaning messages will be received from the service and processed one at a time.
          In the case of prefetch_count being 0, `ServiceBusReceiver.receive_messages` would try to cache
          `max_message_count` (if provided) within its request to the service.
-         **WARNING: If prefetch_count > 0 and RECEIVE_AND_DELETE mode is used, all prefetched messages will stay in
+         WARNING: If prefetch_count > 0 and RECEIVE_AND_DELETE mode is used, all prefetched messages will stay in
          the in-memory prefetch buffer until they're received into the application. If the application ends before
          the messages are received into the application, those messages will be lost and unable to be recovered.
          Therefore, it's recommended that PEEK_LOCK mode be used with prefetch.

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_servicebus_receiver_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_servicebus_receiver_async.py
@@ -88,8 +88,8 @@ class ServiceBusReceiver(AsyncIterator, BaseHandler, ReceiverMixin):
     The two primary channels for message receipt are `receive()` to make a single request for messages,
     and `async for message in receiver:` to continuously receive incoming messages in an ongoing fashion.
 
-    **Please use the `get_<queue/subscription>_receiver` method of ~azure.servicebus.aio.ServiceBusClient to create a
-    ServiceBusReceiver instance.**
+    Please use the `get_<queue/subscription>_receiver` method of ~azure.servicebus.aio.ServiceBusClient to create a
+    ServiceBusReceiver instance.
 
     :ivar fully_qualified_namespace: The fully qualified host name for the Service Bus namespace.
      The namespace format is: `<yournamespace>.servicebus.windows.net`.
@@ -141,7 +141,7 @@ class ServiceBusReceiver(AsyncIterator, BaseHandler, ReceiverMixin):
      The default value is 0, meaning messages will be received from the service and processed one at a time.
      In the case of prefetch_count being 0, `ServiceBusReceiver.receive_messages` would try to cache
      `max_message_count` (if provided) within its request to the service.
-     **WARNING: If prefetch_count > 0 and RECEIVE_AND_DELETE mode is used, all prefetched messages will stay in
+     WARNING: If prefetch_count > 0 and RECEIVE_AND_DELETE mode is used, all prefetched messages will stay in
      the in-memory prefetch buffer until they're received into the application. If the application ends before
      the messages are received into the application, those messages will be lost and unable to be recovered.
      Therefore, it's recommended that PEEK_LOCK mode be used with prefetch.
@@ -319,7 +319,7 @@ class ServiceBusReceiver(AsyncIterator, BaseHandler, ReceiverMixin):
          The default value is 0, meaning messages will be received from the service and processed one at a time.
          In the case of prefetch_count being 0, `ServiceBusReceiver.receive_messages` would try to cache
          `max_message_count` (if provided) within its request to the service.
-         **WARNING: If prefetch_count > 0 and RECEIVE_AND_DELETE mode is used, all prefetched messages will stay in
+         WARNING: If prefetch_count > 0 and RECEIVE_AND_DELETE mode is used, all prefetched messages will stay in
          the in-memory prefetch buffer until they're received into the application. If the application ends before
          the messages are received into the application, those messages will be lost and unable to be recovered.
          Therefore, it's recommended that PEEK_LOCK mode be used with prefetch.


### PR DESCRIPTION
fixes #34639

Did not add strict_sphinx=True to pyproject.toml as per Krista's recommendation, since we're hitting this error that's originating from cpython docs:
`azure-sdk-for-python/sdk/servicebus/azure-servicebus/.tox/strict-sphinx/lib/python3.11/site-packages/azure/servicebus/_common/constants.py:docstring of azure.servicebus.ServiceBusMessageState.from_bytes:9: WARNING: Inline interpreted text or phrase reference start-string without end-string.`

Otherwise, this will break our build. Fixed all other sphinx errors.