### PR TITLE
Fix env var check for `ClientSecretCredential`.

### DIFF
--- a/sdk/identity/azure-identity/azure/identity/_credentials/environment.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/environment.py
@@ -66,7 +66,7 @@ class EnvironmentCredential:
     def __init__(self, **kwargs: Any) -> None:
         self._credential: Optional[EnvironmentCredentialTypes] = None
 
-        if all(os.environ.get(v) is not None for v in EnvironmentVariables.CLIENT_SECRET_VARS):
+        if all(os.environ.get(v) for v in EnvironmentVariables.CLIENT_SECRET_VARS):
             self._credential = ClientSecretCredential(
                 client_id=os.environ[EnvironmentVariables.AZURE_CLIENT_ID],
                 client_secret=os.environ[EnvironmentVariables.AZURE_CLIENT_SECRET],

--- a/sdk/identity/azure-identity/tests/test_environment_credential.py
+++ b/sdk/identity/azure-identity/tests/test_environment_credential.py
@@ -105,6 +105,32 @@ def test_certificate_configuration():
     assert kwargs["foo"] == bar
 
 
+def test_secondary_certificate_configuration():
+    """the credential should not route to ClientSecretCredential when client secret is empty"""
+
+    client_id = "client-id"
+    certificate_path = "..."
+    tenant_id = "tenant_id"
+    bar = "bar"
+
+    environment = {
+        EnvironmentVariables.AZURE_CLIENT_ID: client_id,
+        EnvironmentVariables.AZURE_CLIENT_CERTIFICATE_PATH: certificate_path,
+        EnvironmentVariables.AZURE_CLIENT_SECRET: "",
+        EnvironmentVariables.AZURE_TENANT_ID: tenant_id,
+    }
+    with mock.patch(EnvironmentCredential.__module__ + ".CertificateCredential") as mock_credential:
+        with mock.patch.dict("os.environ", environment, clear=True):
+            EnvironmentCredential(foo=bar)
+
+    assert mock_credential.call_count == 1
+    _, kwargs = mock_credential.call_args
+    assert kwargs["client_id"] == client_id
+    assert kwargs["certificate_path"] == certificate_path
+    assert kwargs["tenant_id"] == tenant_id
+    assert kwargs["foo"] == bar
+
+
 def test_certificate_with_password_configuration():
     """the credential should pass expected values and any keyword arguments to its inner credential"""
 


### PR DESCRIPTION
# Description

`ClientSecretCredential` asserts all 3 of them to have value, not just exist:
- https://github.com/Azure/azure-sdk-for-python/blob/8fe60e912fa9f2074c39b70465f834675ca07e09/sdk/identity/azure-identity/azure/identity/_credentials/client_secret.py#L44-L49

Currently when any of these env var exist but empty, `EnvironmentCredential` routes the request to `ClientSecretCredential` and will fail the auth, with undocumented exception `ValueError` while only `CredentialUnavailableError` is allowed:
- https://learn.microsoft.com/en-us/python/api/azure-identity/azure.identity.environmentcredential?view=azure-python

This PR fixes the check.

Ideally we should cast `ValueError` or any other reasonable exceptions to `CredentialUnavailableError` as well, but that's out of the scope of this PR.