### PR TITLE
Change meta data service timeout to 200ms

### DIFF
--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
@@ -18,6 +18,9 @@
 
 ### Bugs Fixed
 
+- Reduce vm metadata service timeout to 200ms
+    ([#35039](https://github.com/Azure/azure-sdk-for-python/pull/35039))
+
 ### Other Changes
 
 - Updated FastAPI sample

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/statsbeat/_statsbeat_metrics.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/statsbeat/_statsbeat_metrics.py
@@ -212,7 +212,7 @@ class _StatsbeatMetrics:
             request_url = "{0}?{1}&{2}".format(
                 _AIMS_URI, _AIMS_API_VERSION, _AIMS_FORMAT)
             response = requests.get(
-                request_url, headers={"MetaData": "True"}, timeout=5.0)
+                request_url, headers={"MetaData": "True"}, timeout=0.2)
         except (requests.exceptions.ConnectionError, requests.Timeout):
             # Not in VM
             self._vm_retry = False


### PR DESCRIPTION
As per [spec](https://github.com/aep-health-and-standards/Telemetry-Collection-Spec/pull/249)