### PR TITLE
[Identity] Update ChainedTokenCredential

### DIFF
--- a/sdk/identity/azure-identity/CHANGELOG.md
+++ b/sdk/identity/azure-identity/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fixed issue with `ChainedTokenCredential` where it wouldn't use the stored successful credential if one was available. ([#35045](https://github.com/Azure/azure-sdk-for-python/pull/35045))
+
 ### Other Changes
 
 ## 1.16.0b2 (2024-03-05)

--- a/sdk/identity/azure-identity/azure/identity/_credentials/chained.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/chained.py
@@ -87,6 +87,13 @@ class ChainedTokenCredential:
         :rtype: ~azure.core.credentials.AccessToken
         :raises ~azure.core.exceptions.ClientAuthenticationError: no credential in the chain provided a token
         """
+        if self._successful_credential:
+            token = self._successful_credential.get_token(*scopes, claims=claims, tenant_id=tenant_id, **kwargs)
+            _LOGGER.info(
+                "%s acquired a token from %s", self.__class__.__name__, self._successful_credential.__class__.__name__
+            )
+            return token
+
         within_credential_chain.set(True)
         history = []
         for credential in self.credentials:

--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/chained.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/chained.py
@@ -71,6 +71,13 @@ class ChainedTokenCredential(AsyncContextManager):
         :rtype: ~azure.core.credentials.AccessToken
         :raises ~azure.core.exceptions.ClientAuthenticationError: no credential in the chain provided a token
         """
+        if self._successful_credential:
+            token = await self._successful_credential.get_token(*scopes, claims=claims, tenant_id=tenant_id, **kwargs)
+            _LOGGER.info(
+                "%s acquired a token from %s", self.__class__.__name__, self._successful_credential.__class__.__name__
+            )
+            return token
+
         within_credential_chain.set(True)
         history = []
         for credential in self.credentials:


### PR DESCRIPTION
Ensure that subsequent calls  to `get_token` for people using `ChainedTokenCredential` directly use the stored successful credential instead of looping through the list of credentials.


