### PR TITLE
[Core] remove redundant str.lower calls in http logging policy

### DIFF
--- a/sdk/core/azure-core/azure/core/pipeline/policies/_universal.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/_universal.py
@@ -431,16 +431,34 @@ class HttpLoggingPolicy(
 
     def __init__(self, logger: Optional[logging.Logger] = None, **kwargs: Any):  # pylint: disable=unused-argument
         self.logger: logging.Logger = logger or logging.getLogger("azure.core.pipeline.policies.http_logging_policy")
-        self.allowed_query_params: Set[str] = set()
-        self.allowed_header_names: Set[str] = set(self.__class__.DEFAULT_HEADERS_ALLOWLIST)
-        self.lower_case_allowed_query_params = [param.lower() for param in self.allowed_query_params]
-        self.lower_case_allowed_header_names = [header.lower() for header in self.__class__.DEFAULT_HEADERS_ALLOWLIST]
+        self._allowed_query_params: Set[str] = set()
+        self._allowed_header_names: Set[str] = set(self.__class__.DEFAULT_HEADERS_ALLOWLIST)
+        self._lower_case_allowed_query_params = [param.lower() for param in self._allowed_query_params]
+        self._lower_case_allowed_header_names = [header.lower() for header in self._allowed_header_names]
+    
+    @property
+    def allowed_query_params(self):
+        return self._allowed_query_params
+
+    @allowed_query_params.setter
+    def allowed_query_params(self, value: Set[str]):
+        self._allowed_query_params = value
+        self._lower_case_allowed_query_params = [param.lower() for param in self._allowed_query_params]
+
+    @property
+    def allowed_header_names(self):
+        return self._allowed_header_names
+
+    @allowed_header_names.setter
+    def allowed_header_names(self, value: Set[str]):
+        self._allowed_header_names = value
+        self._lower_case_allowed_header_names = [param.lower() for param in self._allowed_header_names]
 
     def _redact_query_param(self, key: str, value: str) -> str:
-        return value if key.lower() in self.lower_case_allowed_query_params else HttpLoggingPolicy.REDACTED_PLACEHOLDER
+        return value if key.lower() in self._lower_case_allowed_query_params else HttpLoggingPolicy.REDACTED_PLACEHOLDER
 
     def _redact_header(self, key: str, value: str) -> str:
-        return value if key.lower() in self.lower_case_allowed_header_names else HttpLoggingPolicy.REDACTED_PLACEHOLDER
+        return value if key.lower() in self._lower_case_allowed_header_names else HttpLoggingPolicy.REDACTED_PLACEHOLDER
 
     def on_request(  # pylint: disable=too-many-return-statements
         self, request: PipelineRequest[HTTPRequestType]

--- a/sdk/core/azure-core/azure/core/pipeline/policies/_universal.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/_universal.py
@@ -435,7 +435,7 @@ class HttpLoggingPolicy(
         self._allowed_header_names: Set[str] = set(self.__class__.DEFAULT_HEADERS_ALLOWLIST)
         self._lower_case_allowed_query_params = [param.lower() for param in self._allowed_query_params]
         self._lower_case_allowed_header_names = [header.lower() for header in self._allowed_header_names]
-    
+
     @property
     def allowed_query_params(self):
         return self._allowed_query_params

--- a/sdk/core/azure-core/azure/core/pipeline/policies/_universal.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/_universal.py
@@ -452,7 +452,7 @@ class HttpLoggingPolicy(
     @allowed_header_names.setter
     def allowed_header_names(self, value: Set[str]):
         self._allowed_header_names = value
-        self._lower_case_allowed_header_names = [param.lower() for param in self._allowed_header_names]
+        self._lower_case_allowed_header_names = [header.lower() for header in self._allowed_header_names]
 
     def _redact_query_param(self, key: str, value: str) -> str:
         return value if key.lower() in self._lower_case_allowed_query_params else HttpLoggingPolicy.REDACTED_PLACEHOLDER

--- a/sdk/core/azure-core/azure/core/pipeline/policies/_universal.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/_universal.py
@@ -433,14 +433,14 @@ class HttpLoggingPolicy(
         self.logger: logging.Logger = logger or logging.getLogger("azure.core.pipeline.policies.http_logging_policy")
         self.allowed_query_params: Set[str] = set()
         self.allowed_header_names: Set[str] = set(self.__class__.DEFAULT_HEADERS_ALLOWLIST)
+        self.lower_case_allowed_query_params = [param.lower() for param in self.allowed_query_params]
+        self.lower_case_allowed_header_names = [header.lower() for header in self.__class__.DEFAULT_HEADERS_ALLOWLIST]
 
     def _redact_query_param(self, key: str, value: str) -> str:
-        lower_case_allowed_query_params = [param.lower() for param in self.allowed_query_params]
-        return value if key.lower() in lower_case_allowed_query_params else HttpLoggingPolicy.REDACTED_PLACEHOLDER
+        return value if key.lower() in self.lower_case_allowed_query_params else HttpLoggingPolicy.REDACTED_PLACEHOLDER
 
     def _redact_header(self, key: str, value: str) -> str:
-        lower_case_allowed_header_names = [header.lower() for header in self.allowed_header_names]
-        return value if key.lower() in lower_case_allowed_header_names else HttpLoggingPolicy.REDACTED_PLACEHOLDER
+        return value if key.lower() in self.lower_case_allowed_header_names else HttpLoggingPolicy.REDACTED_PLACEHOLDER
 
     def on_request(  # pylint: disable=too-many-return-statements
         self, request: PipelineRequest[HTTPRequestType]

--- a/sdk/core/azure-core/perf-tests.yml
+++ b/sdk/core/azure-core/perf-tests.yml
@@ -12,7 +12,7 @@ Tests:
 - Test: upload-binary
   Class: UploadBinaryDataTest
   Arguments:
-  - --size 1024 --parallel 64 --duration 60 --policies all
+  - --size 1024 --parallel 64 --duration 60 --policies all -x https://localhost:5001
   - --size 1024 --parallel 64 --duration 60 --policies all --use-entra-id
   - --size 10240 --parallel 64 --duration 60
   - --size 10240 --parallel 64 --duration 60 --transport requests
@@ -23,7 +23,7 @@ Tests:
   - --size 1024 --parallel 64 --duration 60
   - --size 1024 --parallel 64 --duration 60 --transport requests
   - --size 1024 --parallel 64 --duration 60 --use-entra-id
-  - --size 10240 --parallel 64 --duration 60 --policies all
+  - --size 10240 --parallel 64 --duration 60 --policies all -x https://localhost:5001
 
 - Test: update-entity
   Class: UpdateEntityJSONTest
@@ -31,7 +31,7 @@ Tests:
   - --size 1024 --parallel 64 --duration 60
   - --size 1024 --parallel 64 --duration 60 --transport requests
   - --size 1024 --parallel 64 --duration 60 --use-entra-id
-  - --size 1024 --parallel 64 --duration 60 --policies all
+  - --size 1024 --parallel 64 --duration 60 --policies all -x https://localhost:5001
 
 - Test: query-entities
   Class: QueryEntitiesJSONTest
@@ -39,7 +39,7 @@ Tests:
   - --size 1024 --parallel 64 --duration 60
   - --size 1024 --parallel 64 --duration 60 --transport requests
   - --size 1024 --parallel 64 --duration 60 --use-entra-id
-  - --size 1024 --parallel 64 --duration 60 --policies all
+  - --size 1024 --parallel 64 --duration 60 --policies all -x https://localhost:5001
 
 - Test: list-entities
   Class: ListEntitiesPageableTest
@@ -47,4 +47,4 @@ Tests:
   - --count 500 --parallel 32 --warmup 60 --duration 60
   - --count 500 --parallel 32 --warmup 60 --duration 60 --transport requests
   - --count 500 --parallel 32 --warmup 60 --duration 60 --use-entra-id
-  - --count 500 --parallel 32 --warmup 60 --duration 60 --policies all
+  - --count 500 --parallel 32 --warmup 60 --duration 60 --policies all -x https://localhost:5001


### PR DESCRIPTION
Currently, in the HttpLoggingPolicy, the headers/query params in the request are checked to see if they should be redacted. They're compared against the values in the allowlist using key.lower(). The values in the allowlist can be lowered once in the constructor (or when the property is set), rather than on every header key comparison to improve perf.

Currently, in one run of [[this download binary data from storage blob perf test](https://github.com/Azure/azure-sdk-for-python/blob/394dc9a382db05dfae11d403b07e68d0828f5dbf/sdk/core/azure-core/tests/perf_tests/download_binary.py#L19)], lower is called 1001 times with a total time of 0.00029 .
```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        2  0.07027  0.03513  0.07027  0.03513 {method 'read' of '_ssl._SSLSocket' objects}
      278  0.00152  0.00001  0.00284  0.00001 <frozen os>:674(__getitem__)
        2  0.00075  0.00037  0.00501  0.00251 /usr/lib/python3.11/urllib/request.py:2499(getproxies_environment)
      333  0.00075  0.00000  0.00449  0.00001 <frozen _collections_abc>:859(__iter__)
      278  0.00060  0.00000  0.00088  0.00000 <frozen os>:756(encode)
      532  0.00052  0.00000  0.00085  0.00000 <frozen os>:760(decode)
      268  0.00045  0.00000  0.00085  0.00000 <frozen os>:697(__iter__)
      669  0.00038  0.00000  0.00038  0.00000 {method 'decode' of 'bytes' objects}
        4  0.00038  0.00009  0.00050  0.00013 /home/swathip/venvs/env311/lib/python3.11/site-packages/urllib3/util/url.py:227(_encode_invalid_chars)
     1001  0.00029  0.00000  0.00029  0.00000 {method 'lower' of 'str' objects}
```

Storing the lowercased keys in the headers allowlist once in the constructor results in lower being called 501 times with a total time of 0.00017.
```
 ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        2  0.06893  0.03447  0.06893  0.03447 {method 'read' of '_ssl._SSLSocket' objects}
        3  0.00088  0.00029  0.00179  0.00060 /home/swathip/venvs/env311/lib/python3.11/site-packages/urllib3/util/url.py:369(parse_url)
      278  0.00063  0.00000  0.00153  0.00001 <frozen os>:674(__getitem__)
      333  0.00059  0.00000  0.00277  0.00001 <frozen _collections_abc>:859(__iter__)
        2  0.00043  0.00021  0.00300  0.00150 /usr/lib/python3.11/urllib/request.py:2499(getproxies_environment)
      532  0.00038  0.00000  0.00062  0.00000 <frozen os>:760(decode)
      278  0.00038  0.00000  0.00057  0.00000 <frozen os>:756(encode)
       41  0.00037  0.00001  0.00037  0.00001 {method 'match' of 're.Pattern' objects}
      268  0.00032  0.00000  0.00061  0.00000 <frozen os>:697(__iter__)
        4  0.00030  0.00007  0.00040  0.00010 /home/swathip/venvs/env311/lib/python3.11/site-packages/urllib3/util/url.py:227(_encode_invalid_chars)
      669  0.00028  0.00000  0.00028  0.00000 {method 'decode' of 'bytes' objects}
        1  0.00023  0.00023  0.00023  0.00023 {method 'write' of '_ssl._SSLSocket' objects}
  506/502  0.00019  0.00000  0.00031  0.00000 {built-in method builtins.isinstance}
        5  0.00017  0.00003  0.00017  0.00003 {built-in method posix.stat}
      **501  0.00017  0.00000  0.00017  0.00000 {method 'lower' of 'str' objects}**
```