### PR TITLE
[Core] Make OTel the preferred tracing plugin

### DIFF
--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+- The Azure Core OpenTelemetry tracing plugin will now be the preferred tracing plugin over the OpenCensus plugin. If both plugins are installed and `opentelemetry` is imported, then OpenTelemetry will be used to trace Azure SDK operations.  #35050
+
 ## 1.30.2 (2024-06-06)
 
 ### Features Added

--- a/sdk/core/azure-core/azure/core/settings.py
+++ b/sdk/core/azure-core/azure/core/settings.py
@@ -181,7 +181,7 @@ def convert_tracing_impl(value: Optional[Union[str, Type[AbstractSpan]]]) -> Opt
     """
     if value is None:
         return (
-            _get_opencensus_span_if_opencensus_is_imported() or _get_opentelemetry_span_if_opentelemetry_is_imported()
+            _get_opentelemetry_span_if_opentelemetry_is_imported() or _get_opencensus_span_if_opencensus_is_imported()
         )
 
     if not isinstance(value, str):


### PR DESCRIPTION
This changes the order for which we try to use tracing plugins. Now, the OTel plugin will be checked first.

OpenCensus has been [sunsetted](https://opentelemetry.io/blog/2023/sunsetting-opencensus) and the recommendation has been to use OpenTelemetry for quite a while now.