### PR TITLE
[Core] Add new attribute to resent HTTP request spans

### DIFF
--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+- Tracing: `DistributedTracingPolicy` will now set an attribute, `http.request.resend_count`, on HTTP spans for resent requests to indicate the resend attempt number.  #35069
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/core/azure-core/azure/core/pipeline/policies/_distributed_tracing.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/_distributed_tracing.py
@@ -76,6 +76,7 @@ class DistributedTracingPolicy(SansIOHTTPPolicy[HTTPRequestType, HTTPResponseTyp
     TRACING_CONTEXT = "TRACING_CONTEXT"
     _REQUEST_ID = "x-ms-client-request-id"
     _RESPONSE_ID = "x-ms-request-id"
+    _HTTP_RESEND_COUNT = "http.request.resend_count"
 
     def __init__(self, **kwargs: Any):
         self._network_span_namer = kwargs.get("network_span_namer", _default_network_span_namer)
@@ -125,6 +126,8 @@ class DistributedTracingPolicy(SansIOHTTPPolicy[HTTPRequestType, HTTPResponseTyp
         http_request: Union[HttpRequest, LegacyHttpRequest] = request.http_request
         if span is not None:
             span.set_http_attributes(http_request, response=response)
+            if request.context.get("retry_count"):
+                span.add_attribute(self._HTTP_RESEND_COUNT, request.context["retry_count"])
             request_id = http_request.headers.get(self._REQUEST_ID)
             if request_id is not None:
                 span.add_attribute(self._REQUEST_ID, request_id)

--- a/sdk/core/azure-core/azure/core/pipeline/policies/_retry.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/_retry.py
@@ -528,6 +528,7 @@ class RetryPolicy(RetryPolicyBase, HTTPPolicy[HTTPRequestType, HTTPResponseType]
             )
             try:
                 self._configure_timeout(request, absolute_timeout, is_response_error)
+                request.context["retry_count"] = len(retry_settings["history"])
                 response = self.next.send(request)
                 if self.is_retry(retry_settings, response):
                     retry_active = self.increment(retry_settings, response=response)

--- a/sdk/core/azure-core/azure/core/pipeline/policies/_retry_async.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/_retry_async.py
@@ -176,6 +176,7 @@ class AsyncRetryPolicy(RetryPolicyBase, AsyncHTTPPolicy[HTTPRequestType, AsyncHT
             )
             try:
                 self._configure_timeout(request, absolute_timeout, is_response_error)
+                request.context["retry_count"] = len(retry_settings["history"])
                 response = await self.next.send(request)
                 if self.is_retry(retry_settings, response):
                     retry_active = self.increment(retry_settings, response=response)

--- a/sdk/core/azure-core/tests/async_tests/test_tracing_policy_async.py
+++ b/sdk/core/azure-core/tests/async_tests/test_tracing_policy_async.py
@@ -1,0 +1,58 @@
+# ------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------
+"""Tests for the distributed tracing policy in an async pipeline."""
+
+import pytest
+
+
+from azure.core.pipeline import AsyncPipeline
+from azure.core.pipeline.policies import AsyncRetryPolicy, DistributedTracingPolicy
+from azure.core.pipeline.transport import (
+    HttpResponse,
+    AsyncHttpTransport,
+)
+from azure.core.settings import settings
+
+from tracing_common import FakeSpan
+from utils import HTTP_REQUESTS
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("http_request", HTTP_REQUESTS)
+async def test_span_retry_attributes(http_request):
+    class MockTransport(AsyncHttpTransport):
+        def __init__(self):
+            self._count = 0
+
+        async def __aexit__(self, exc_type, exc_val, exc_tb):
+            pass
+
+        async def close(self):
+            pass
+
+        async def open(self):
+            pass
+
+        async def send(self, request, **kwargs):
+            self._count += 1
+            response = HttpResponse(request, None)
+            response.status_code = 429
+            return response
+
+    http_request = http_request("GET", "http://localhost/")
+    retry_policy = AsyncRetryPolicy(retry_total=2)
+    distributed_tracing_policy = DistributedTracingPolicy()
+    transport = MockTransport()
+
+    settings.tracing_implementation.set_value(FakeSpan)
+    with FakeSpan(name="parent") as root_span:
+        pipeline = AsyncPipeline(transport, [retry_policy, distributed_tracing_policy])
+        await pipeline.run(http_request)
+
+    assert transport._count == 3
+    assert len(root_span.children) == 3
+    assert root_span.children[0].attributes.get("http.request.resend_count") is None
+    assert root_span.children[1].attributes.get("http.request.resend_count") == 1
+    assert root_span.children[2].attributes.get("http.request.resend_count") == 2


### PR DESCRIPTION
`DistributedTracingPolicy` will now set an attribute, `http.request.resend_count`, on HTTP spans for resent requests to indicate the resend attempt count.

Part of: https://github.com/Azure/azure-sdk-for-python/issues/32803