### PR TITLE
[Storage] add entra id auth to blob perf tests

### DIFF
--- a/sdk/storage/azure-storage-blob/perf-tests.yml
+++ b/sdk/storage/azure-storage-blob/perf-tests.yml
@@ -15,6 +15,7 @@ Tests:
   Class: DownloadTest
   Arguments: &sizes
   - --size 10240 --parallel 64
+  - --size 10240 --parallel 64 --use-entra-id
   - --size 10485760 --parallel 32
   - --size 1073741824 --parallel 1 --warmup 60 --duration 60
   - --size 1073741824 --parallel 8 --warmup 60 --duration 60
@@ -28,4 +29,5 @@ Tests:
   Arguments:
   - --count 5 --parallel 64
   - --count 500 --parallel 32
+  - --count 500 --parallel 32 --use-entra-id
   - --count 50000 --parallel 32 --warmup 60 --duration 60

--- a/sdk/storage/azure-storage-blob/tests/perfstress_tests/README.md
+++ b/sdk/storage/azure-storage-blob/tests/perfstress_tests/README.md
@@ -6,10 +6,19 @@ Note that tests for T1 and T2 SDKs cannot be run from the same environment, and 
 
 ### Setup for test resources
 
-These tests will run against a pre-configured Storage account. The following environment variable will need to be set for the tests to access the live resources:
+These tests will run against a pre-configured Storage account. The following environment variable will need to be set for the tests to access the live resources using the connection string for authentication:
 ```
 AZURE_STORAGE_CONNECTION_STRING=<live storage account connection string>
 ```
+
+The following environment variables will need to be set for the tests to access the live resources using Microsoft Entra ID for authentication:
+```
+AZURE-STORAGE-BLOB_TENANT_ID=<Microsoft Entra ID tenant ID>
+AZURE-STORAGE-BLOB_CLIENT_ID=<Microsoft Entra ID client ID>
+AZURE-STORAGE-BLOB_CLIENT_SECRET=<Microsoft Entra ID client secret>
+AZURE_STORAGE_ACCOUNT_NAME=<live storage account name>
+```
+
 
 ### Setup for T2 perf test runs
 
@@ -46,6 +55,7 @@ These options are available for all perf tests:
 - `--no-cleanup` Whether to keep newly created resources after test run. Default is False (resources will be deleted).
 - `-x --test-proxies` Whether to run the tests against the test proxy server. Specfiy the URL(s) for the proxy endpoint(s) (e.g. "https://localhost:5001"). WARNING: When using with Legacy tests - only HTTPS is supported.
 - `--profile` Whether to run the perftest with cProfile. If enabled (default is False), the output file of the **last completed single iteration** will be written to the current working directory in the format `"cProfile-<TestClassName>-<TestID>-<sync/async>.pstats"`.
+- `--use-entra-id` - Flag to pass in to use Microsoft Entra ID as the authentication. By default, set to False.
 
 ### Common Blob command line options
 The options are available for all Blob perf tests:

--- a/sdk/storage/azure-storage-blob/tests/perfstress_tests/_test_base.py
+++ b/sdk/storage/azure-storage-blob/tests/perfstress_tests/_test_base.py
@@ -48,6 +48,7 @@ class _ServiceTest(PerfStressTest):
                     client_secret
                 )
                 account_name = self.get_from_env("AZURE_STORAGE_ACCOUNT_NAME")
+                # We assume these tests will only be run on the Azure public cloud for now.
                 url = f"https://{account_name}.blob.core.windows.net"
                 _ServiceTest.service_client = SyncBlobServiceClient(account_url=url, credential=sync_token_credential, **self._client_kwargs)
                 _ServiceTest.async_service_client = AsyncBlobServiceClient(account_url=url, credential=async_token_credential, **self._client_kwargs)

--- a/sdk/storage/azure-storage-blob/tests/perfstress_tests/_test_base.py
+++ b/sdk/storage/azure-storage-blob/tests/perfstress_tests/_test_base.py
@@ -8,6 +8,8 @@ import uuid
 from devtools_testutils.perfstress_tests import PerfStressTest
 from azure.storage.blob import BlobServiceClient as SyncBlobServiceClient
 from azure.storage.blob.aio import BlobServiceClient as AsyncBlobServiceClient
+from azure.identity import ClientSecretCredential as SyncClientSecretCredential
+from azure.identity.aio import ClientSecretCredential as AsyncClientSecretCredential
 
 from .key_wrapper import KeyWrapper
 
@@ -18,7 +20,6 @@ class _ServiceTest(PerfStressTest):
 
     def __init__(self, arguments):
         super().__init__(arguments)
-        connection_string = self.get_from_env("AZURE_STORAGE_CONNECTION_STRING")
         if self.args.test_proxies:
             self._client_kwargs['_additional_pipeline_policies'] = self._client_kwargs['per_retry_policies']
         self._client_kwargs['max_single_put_size'] = self.args.max_put_size
@@ -32,8 +33,28 @@ class _ServiceTest(PerfStressTest):
         # self._client_kwargs['api_version'] = '2019-02-02'  # Used only for comparison with T1 legacy tests
 
         if not _ServiceTest.service_client or self.args.no_client_share:
-            _ServiceTest.service_client = SyncBlobServiceClient.from_connection_string(conn_str=connection_string, **self._client_kwargs)
-            _ServiceTest.async_service_client = AsyncBlobServiceClient.from_connection_string(conn_str=connection_string, **self._client_kwargs)
+            if self.args.use_entra_id:
+                tenant_id = self.get_from_env("AZURE-STORAGE-BLOB_TENANT_ID")
+                client_id = self.get_from_env("AZURE-STORAGE-BLOB_CLIENT_ID")
+                client_secret = self.get_from_env("AZURE-STORAGE-BLOB_CLIENT_SECRET")
+                token_credential = SyncClientSecretCredential(
+                    tenant_id,
+                    client_id,
+                    client_secret
+                )
+                token_credential = AsyncClientSecretCredential(
+                    tenant_id,
+                    client_id,
+                    client_secret
+                )
+                account_name = self.get_from_env("AZURE_STORAGE_ACCOUNT_NAME")
+                url = f"https://{account_name}.blob.core.windows.net"
+                _ServiceTest.service_client = SyncBlobServiceClient(account_url=url, credential=token_credential, **self._client_kwargs)
+                _ServiceTest.async_service_client = AsyncBlobServiceClient(account_url=url, credential=token_credential, **self._client_kwargs)
+            else:
+                connection_string = self.get_from_env("AZURE_STORAGE_CONNECTION_STRING")
+                _ServiceTest.service_client = SyncBlobServiceClient.from_connection_string(conn_str=connection_string, **self._client_kwargs)
+                _ServiceTest.async_service_client = AsyncBlobServiceClient.from_connection_string(conn_str=connection_string, **self._client_kwargs)
         self.service_client = _ServiceTest.service_client
         self.async_service_client = _ServiceTest.async_service_client
 
@@ -51,6 +72,9 @@ class _ServiceTest(PerfStressTest):
         parser.add_argument('--max-concurrency', nargs='?', type=int, help='Maximum number of concurrent threads used for data transfer. Defaults to 1', default=1)
         parser.add_argument('-s', '--size', nargs='?', type=int, help='Size of data to transfer.  Default is 10240.', default=10240)
         parser.add_argument('--no-client-share', action='store_true', help='Create one ServiceClient per test instance.  Default is to share a single ServiceClient.', default=False)
+        parser.add_argument(
+            "--use-entra-id", action="store_true", help="Use Microsoft Entra ID authentication instead of connection string."
+        )
 
 
 class _ContainerTest(_ServiceTest):

--- a/sdk/storage/azure-storage-blob/tests/perfstress_tests/_test_base.py
+++ b/sdk/storage/azure-storage-blob/tests/perfstress_tests/_test_base.py
@@ -37,20 +37,20 @@ class _ServiceTest(PerfStressTest):
                 tenant_id = self.get_from_env("AZURE-STORAGE-BLOB_TENANT_ID")
                 client_id = self.get_from_env("AZURE-STORAGE-BLOB_CLIENT_ID")
                 client_secret = self.get_from_env("AZURE-STORAGE-BLOB_CLIENT_SECRET")
-                token_credential = SyncClientSecretCredential(
+                sync_token_credential = SyncClientSecretCredential(
                     tenant_id,
                     client_id,
                     client_secret
                 )
-                token_credential = AsyncClientSecretCredential(
+                async_token_credential = AsyncClientSecretCredential(
                     tenant_id,
                     client_id,
                     client_secret
                 )
                 account_name = self.get_from_env("AZURE_STORAGE_ACCOUNT_NAME")
                 url = f"https://{account_name}.blob.core.windows.net"
-                _ServiceTest.service_client = SyncBlobServiceClient(account_url=url, credential=token_credential, **self._client_kwargs)
-                _ServiceTest.async_service_client = AsyncBlobServiceClient(account_url=url, credential=token_credential, **self._client_kwargs)
+                _ServiceTest.service_client = SyncBlobServiceClient(account_url=url, credential=sync_token_credential, **self._client_kwargs)
+                _ServiceTest.async_service_client = AsyncBlobServiceClient(account_url=url, credential=async_token_credential, **self._client_kwargs)
             else:
                 connection_string = self.get_from_env("AZURE_STORAGE_CONNECTION_STRING")
                 _ServiceTest.service_client = SyncBlobServiceClient.from_connection_string(conn_str=connection_string, **self._client_kwargs)


### PR DESCRIPTION
Currently, storage perf tests authenticate only with the connection string. Adding Entra ID auth and checking if there are any bottlenecks/gaps there.

Perf run here: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3669358&view=logs&j=42ded549-05ee-5cdb-7ba7-7a948a0cc056&t=1c1d21ee-87c3-56e5-9bff-a84d921988f6&l=32

No significant difference in perf between connection string and Entra ID auth.