### PR TITLE
Ensure that the integration stage only "appears" on `internal`

### DIFF
--- a/eng/pipelines/templates/stages/archetype-python-release.yml
+++ b/eng/pipelines/templates/stages/archetype-python-release.yml
@@ -258,83 +258,83 @@ stages:
                 ArtifactName: ${{ parameters.ArtifactName }}
                 Artifact: ${{ artifact }}
 
-
-  - stage: Integration
-    dependsOn: ${{parameters.DependsOn}}
-    condition: succeededOrFailed('${{parameters.DependsOn}}')
-    jobs:
-    - job: PublishPackages
-      displayName: "Publish package to daily feed"
-      condition: or(eq(variables['SetDevVersion'], 'true'), and(eq(variables['Build.Reason'],'Schedule'), eq(variables['System.TeamProject'], 'internal')))
-      pool:
-        image: azsdk-pool-mms-ubuntu-2004-1espt
-        name: azsdk-pool-mms-ubuntu-2004-general
-        os: linux
-      steps:
-      - checkout: none
-      - download: current
-        artifact: ${{parameters.ArtifactName}}
-        timeoutInMinutes: 5
-      - task: UsePythonVersion@0
-      - script: |
-          set -e
-          python -m pip install twine
-        displayName: Install Twine
-
-      - template: ../steps/auth-dev-feed.yml
-        parameters:
-          DevFeedName: ${{ parameters.DevFeedName }}
-
-      - ${{ each artifact in parameters.Artifacts }}:
-        - ${{if ne(artifact.skipPublishDevFeed, 'true')}}:
-
-          - pwsh: |
-              $fileCount = (Get-ChildItem $(Pipeline.Workspace)/${{parameters.ArtifactName}}/${{artifact.name}} | ? {$_.Name -match "-[0-9]*.[0-9]*.[0-9]*a[0-9]*" } | Measure-Object).Count
-
-              if ($fileCount -eq 0) {
-                Write-Host "No alpha packages for ${{artifact.name}} to publish."
-                exit 0
-              }
-
-              twine upload --repository $(DevFeedName) --config-file $(PYPIRC_PATH) $(Pipeline.Workspace)/${{parameters.ArtifactName}}/${{artifact.name}}/*-*a*.whl
-              echo "Uploaded whl to devops feed $(DevFeedName)"
-              twine upload --repository $(DevFeedName) --config-file $(PYPIRC_PATH) $(Pipeline.Workspace)/${{parameters.ArtifactName}}/${{artifact.name}}/*-*a*.tar.gz
-              echo "Uploaded sdist to devops feed $(DevFeedName)"
-            displayName: 'Publish ${{artifact.name}} alpha package'
-
-    - job: PublishDocsToNightlyBranch
-      dependsOn: PublishPackages
-      condition: or(eq(variables['SetDevVersion'], 'true'), and(eq(variables['Build.Reason'],'Schedule'), eq(variables['System.TeamProject'], 'internal')))
-      pool:
-        image: azsdk-pool-mms-ubuntu-2004-1espt
-        name: azsdk-pool-mms-ubuntu-2004-general
-        os: linux
-      steps:
-        - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
-          parameters:
-            Paths:
-              - sdk/**/*.md
-              - .github/CODEOWNERS
+  - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+    - stage: Integration
+      dependsOn: ${{parameters.DependsOn}}
+      condition: succeededOrFailed('${{parameters.DependsOn}}')
+      jobs:
+      - job: PublishPackages
+        displayName: "Publish package to daily feed"
+        condition: or(eq(variables['SetDevVersion'], 'true'), and(eq(variables['Build.Reason'],'Schedule'), eq(variables['System.TeamProject'], 'internal')))
+        pool:
+          image: azsdk-pool-mms-ubuntu-2004-1espt
+          name: azsdk-pool-mms-ubuntu-2004-general
+          os: linux
+        steps:
+        - checkout: none
         - download: current
-        - pwsh: |
-            Get-ChildItem -Recurse $(Pipeline.Workspace)/${{parameters.ArtifactName}}/
-          displayName: Show visible artifacts
+          artifact: ${{parameters.ArtifactName}}
+          timeoutInMinutes: 5
+        - task: UsePythonVersion@0
+        - script: |
+            set -e
+            python -m pip install twine
+          displayName: Install Twine
 
-        - template: /eng/common/pipelines/templates/steps/update-docsms-metadata.yml
+        - template: ../steps/auth-dev-feed.yml
           parameters:
-            PackageInfoLocations:
-              - ${{ each artifact in parameters.Artifacts }}:
-                - ${{if ne(artifact.skipPublishDocMs, 'true')}}:
-                  - $(Pipeline.Workspace)/${{parameters.ArtifactName}}/PackageInfo/${{artifact.name}}.json
-            WorkingDirectory: $(System.DefaultWorkingDirectory)
-            TargetDocRepoOwner: ${{parameters.TargetDocRepoOwner}}
-            TargetDocRepoName: ${{parameters.TargetDocRepoName}}
-            Language: 'python'
-            DailyDocsBuild: true
-            SparseCheckoutPaths:
-              - docs-ref-services/
-              - metadata/
-            PackageSourceOverride: ${{parameters.PackageSourceOverride}}
-            DocValidationImageId: ${{parameters.DocValidationImageId}}
+            DevFeedName: ${{ parameters.DevFeedName }}
 
-        - template: /eng/common/pipelines/templates/steps/docsms-ensure-validation.yml
+        - ${{ each artifact in parameters.Artifacts }}:
+          - ${{if ne(artifact.skipPublishDevFeed, 'true')}}:
+
+            - pwsh: |
+                $fileCount = (Get-ChildItem $(Pipeline.Workspace)/${{parameters.ArtifactName}}/${{artifact.name}} | ? {$_.Name -match "-[0-9]*.[0-9]*.[0-9]*a[0-9]*" } | Measure-Object).Count
+
+                if ($fileCount -eq 0) {
+                  Write-Host "No alpha packages for ${{artifact.name}} to publish."
+                  exit 0
+                }
+
+                twine upload --repository $(DevFeedName) --config-file $(PYPIRC_PATH) $(Pipeline.Workspace)/${{parameters.ArtifactName}}/${{artifact.name}}/*-*a*.whl
+                echo "Uploaded whl to devops feed $(DevFeedName)"
+                twine upload --repository $(DevFeedName) --config-file $(PYPIRC_PATH) $(Pipeline.Workspace)/${{parameters.ArtifactName}}/${{artifact.name}}/*-*a*.tar.gz
+                echo "Uploaded sdist to devops feed $(DevFeedName)"
+              displayName: 'Publish ${{artifact.name}} alpha package'
+
+      - job: PublishDocsToNightlyBranch
+        dependsOn: PublishPackages
+        condition: or(eq(variables['SetDevVersion'], 'true'), and(eq(variables['Build.Reason'],'Schedule'), eq(variables['System.TeamProject'], 'internal')))
+        pool:
+          image: azsdk-pool-mms-ubuntu-2004-1espt
+          name: azsdk-pool-mms-ubuntu-2004-general
+          os: linux
+        steps:
+          - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
+            parameters:
+              Paths:
+                - sdk/**/*.md
+                - .github/CODEOWNERS
+          - download: current
+          - pwsh: |
+              Get-ChildItem -Recurse $(Pipeline.Workspace)/${{parameters.ArtifactName}}/
+            displayName: Show visible artifacts
+
+          - template: /eng/common/pipelines/templates/steps/update-docsms-metadata.yml
+            parameters:
+              PackageInfoLocations:
+                - ${{ each artifact in parameters.Artifacts }}:
+                  - ${{if ne(artifact.skipPublishDocMs, 'true')}}:
+                    - $(Pipeline.Workspace)/${{parameters.ArtifactName}}/PackageInfo/${{artifact.name}}.json
+              WorkingDirectory: $(System.DefaultWorkingDirectory)
+              TargetDocRepoOwner: ${{parameters.TargetDocRepoOwner}}
+              TargetDocRepoName: ${{parameters.TargetDocRepoName}}
+              Language: 'python'
+              DailyDocsBuild: true
+              SparseCheckoutPaths:
+                - docs-ref-services/
+                - metadata/
+              PackageSourceOverride: ${{parameters.PackageSourceOverride}}
+              DocValidationImageId: ${{parameters.DocValidationImageId}}
+
+          - template: /eng/common/pipelines/templates/steps/docsms-ensure-validation.yml


### PR DESCRIPTION
The yaml even existing (regardless of whether jobs skipped) was causing 1ES templates to error on us.

This changes the `integration` stage to only ever appear when triggered from `internal`.