### PR TITLE
Search readme update: removing reference to high dimensional space per customer feedback

### DIFF
--- a/sdk/search/azure-search-documents/README.md
+++ b/sdk/search/azure-search-documents/README.md
@@ -167,7 +167,7 @@ Azure AI Search provides two powerful features: **semantic ranking** and **vecto
 
 To learn more about semantic ranking, you can refer to the [documentation](https://learn.microsoft.com/azure/search/vector-search-overview).
 
-**Vector search** is an information retrieval technique that overcomes the limitations of traditional keyword-based search. Instead of relying solely on lexical analysis and matching individual query terms, vector search uses algorithms for similarity and concept search. It represents documents and queries as vectors in a high-dimensional space called an embedding. By searching on vector representations of content, a vector query can find relevant matches, even if the exact terms of the query are not present in the index. Moreover, vector search can be applied to various types of content, including images and videos and translated text, not just same-language text.
+**Vector search** is an information retrieval technique that uses numeric representations of searchable documents and query strings. By searching for numeric representations of content that are most similar to the numeric query, vector search can find relevant matches, even if the exact terms of the query are not present in the index. Moreover, vector search can be applied to various types of content, including images and videos and translated text, not just same-language text.
 
 To learn how to index vector fields and perform vector search, you can refer to the [sample](https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/search/azure-search-documents/samples/sample_vector_search.py). This sample provides detailed guidance on indexing vector fields and demonstrates how to perform vector search.
 


### PR DESCRIPTION
A customer filed a GH issue on the readme for Azure AI Search.  This edit removes the claim that vectors reside in high dimensional space.

https://github.com/Azure/azure-sdk-for-python/issues/34832#issuecomment-2040198872
