### PR TITLE
remove fine-tune file list test

### DIFF
--- a/sdk/openai/azure-openai/tests/test_models.py
+++ b/sdk/openai/azure-openai/tests/test_models.py
@@ -56,10 +56,6 @@ class TestModels(AzureRecordedTestCase):
             for file in files:
                 assert file.id
 
-            files = client.files.list(purpose="fine-tune")
-            for file in files:
-                assert file.id
-
             files = client.files.list(purpose="assistants")
             for file in files:
                 assert file.id

--- a/sdk/openai/azure-openai/tests/test_models_async.py
+++ b/sdk/openai/azure-openai/tests/test_models_async.py
@@ -59,10 +59,6 @@ class TestModelsAsync(AzureRecordedTestCase):
             async for file in files:
                 assert file.id
 
-            files = client_async.files.list(purpose="fine-tune")
-            async for file in files:
-                assert file.id
-
             files = client_async.files.list(purpose="assistants")
             async for file in files:
                 assert file.id


### PR DESCRIPTION
Too flaky and we don't seem to have any fine-tuned purpose files in our testing resource