### PR TITLE
[DI][FR] Change the default polling interval

### DIFF
--- a/sdk/documentintelligence/azure-ai-documentintelligence/CHANGELOG.md
+++ b/sdk/documentintelligence/azure-ai-documentintelligence/CHANGELOG.md
@@ -1,14 +1,9 @@
 # Release History
 
-## 1.0.0b3 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 1.0.0b3 (2024-04-09)
 
 ### Other Changes
+- Changed the default polling interval from 5s to 1s.
 
 ## 1.0.0b2 (2024-03-07)
 

--- a/sdk/documentintelligence/azure-ai-documentintelligence/azure/ai/documentintelligence/_patch.py
+++ b/sdk/documentintelligence/azure-ai-documentintelligence/azure/ai/documentintelligence/_patch.py
@@ -39,8 +39,8 @@ class DocumentIntelligenceClient(DIClientGenerated):  # pylint: disable=client-a
         credential: Union[AzureKeyCredential, TokenCredential],
         **kwargs: Any,
     ) -> None:
-        # The default polling interval should be 5 seconds.
-        polling_interval = kwargs.pop("polling_interval", 5)
+        # Patch the default polling interval to be 1s.
+        polling_interval = kwargs.pop("polling_interval", 1)
         super().__init__(
             endpoint=endpoint,
             credential=credential,
@@ -74,8 +74,8 @@ class DocumentIntelligenceAdministrationClient(
         credential: Union[AzureKeyCredential, TokenCredential],
         **kwargs: Any,
     ) -> None:
-        # The default polling interval should be 5 seconds.
-        polling_interval = kwargs.pop("polling_interval", 5)
+        # Patch the default polling interval to be 1s.
+        polling_interval = kwargs.pop("polling_interval", 1)
         super().__init__(
             endpoint=endpoint,
             credential=credential,

--- a/sdk/documentintelligence/azure-ai-documentintelligence/azure/ai/documentintelligence/aio/_patch.py
+++ b/sdk/documentintelligence/azure-ai-documentintelligence/azure/ai/documentintelligence/aio/_patch.py
@@ -38,8 +38,8 @@ class DocumentIntelligenceClient(DIClientGenerated):  # pylint: disable=client-a
         credential: Union[AzureKeyCredential, AsyncTokenCredential],
         **kwargs: Any,
     ) -> None:
-        # The default polling interval should be 5 seconds.
-        polling_interval = kwargs.pop("polling_interval", 5)
+        # Patch the default polling interval to be 1s.
+        polling_interval = kwargs.pop("polling_interval", 1)
         super().__init__(
             endpoint=endpoint,
             credential=credential,
@@ -71,8 +71,8 @@ class DocumentIntelligenceAdministrationClient(
         credential: Union[AzureKeyCredential, AsyncTokenCredential],
         **kwargs: Any,
     ) -> None:
-        # The default polling interval should be 5 seconds.
-        polling_interval = kwargs.pop("polling_interval", 5)
+        # Patch the default polling interval to be 1s.
+        polling_interval = kwargs.pop("polling_interval", 1)
         super().__init__(
             endpoint=endpoint,
             credential=credential,

--- a/sdk/documentintelligence/azure-ai-documentintelligence/tests/test_dac_analyze_layout.py
+++ b/sdk/documentintelligence/azure-ai-documentintelligence/tests/test_dac_analyze_layout.py
@@ -221,7 +221,7 @@ class TestDACAnalyzeLayout(DocumentIntelligenceTest):
         client = DocumentIntelligenceClient(
             documentintelligence_endpoint, AzureKeyCredential(documentintelligence_api_key)
         )
-        assert client._config.polling_interval == 5
+        assert client._config.polling_interval == 1
 
         client = DocumentIntelligenceClient(
             documentintelligence_endpoint, AzureKeyCredential(documentintelligence_api_key), polling_interval=7

--- a/sdk/documentintelligence/azure-ai-documentintelligence/tests/test_dac_analyze_layout_async.py
+++ b/sdk/documentintelligence/azure-ai-documentintelligence/tests/test_dac_analyze_layout_async.py
@@ -232,7 +232,7 @@ class TestDACAnalyzeLayoutAsync(AsyncDocumentIntelligenceTest):
         client = DocumentIntelligenceClient(
             documentintelligence_endpoint, AzureKeyCredential(documentintelligence_api_key)
         )
-        assert client._config.polling_interval == 5
+        assert client._config.polling_interval == 1
 
         client = DocumentIntelligenceClient(
             documentintelligence_endpoint, AzureKeyCredential(documentintelligence_api_key), polling_interval=7

--- a/sdk/formrecognizer/azure-ai-formrecognizer/CHANGELOG.md
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/CHANGELOG.md
@@ -1,16 +1,11 @@
 # Release History
 
-## 3.3.3 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 3.3.3 (2024-04-09)
 
 ### Other Changes
 - Added support for Python 3.12.
 - Python 3.7 is no longer supported. Please use Python version 3.8 or later.
+- Changed the default polling interval from 5s to 1s.
 
 ## 3.3.2 (2023-11-07)
 

--- a/sdk/formrecognizer/azure-ai-formrecognizer/azure/ai/formrecognizer/_helpers.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/azure/ai/formrecognizer/_helpers.py
@@ -11,7 +11,7 @@ from azure.core.pipeline.transport import HttpTransport
 from azure.core.exceptions import HttpResponseError
 
 
-POLLING_INTERVAL = 5
+POLLING_INTERVAL = 1
 COGNITIVE_KEY_HEADER = "Ocp-Apim-Subscription-Key"
 
 

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dmac_training.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dmac_training.py
@@ -29,7 +29,7 @@ class TestDMACTraining(FormRecognizerTest):
         set_bodiless_matcher()
         def check_poll_value(poll):
             if self.is_live:
-                assert poll == 5
+                assert poll == 1
             else:
                 assert poll == 0
         check_poll_value(client._client._config.polling_interval)

--- a/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dmac_training_async.py
+++ b/sdk/formrecognizer/azure-ai-formrecognizer/tests/test_dmac_training_async.py
@@ -32,7 +32,7 @@ class TestDMACTrainingAsync(AsyncFormRecognizerTest):
         set_bodiless_matcher()
         def check_poll_value(poll):
             if self.is_live:
-                assert poll == 5
+                assert poll == 1
             else:
                 assert poll == 0
         check_poll_value(client._client._config.polling_interval)


### PR DESCRIPTION
We got feedback from customers about Python latency comparing with other languages, this PR changes the default polling interval in DI and FR packages from 5s to 1s.