### PR TITLE
[Key Vault] Add `__(a)enter__` methods to user-facing clients

### DIFF
--- a/sdk/keyvault/azure-keyvault-administration/CHANGELOG.md
+++ b/sdk/keyvault/azure-keyvault-administration/CHANGELOG.md
@@ -7,6 +7,8 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+- Typing errors from using Key Vault clients as context managers have been fixed
+  ([#34744](https://github.com/Azure/azure-sdk-for-python/issues/34744))
 
 ### Other Changes
 

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_access_control_client.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_access_control_client.py
@@ -248,3 +248,7 @@ class KeyVaultAccessControlClient(KeyVaultClientBase):
             cls=lambda result: [KeyVaultRoleDefinition._from_generated(d) for d in result],
             **kwargs
         )
+
+    def __enter__(self) -> "KeyVaultAccessControlClient":
+        self._client.__enter__()
+        return self

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_backup_client.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_backup_client.py
@@ -247,3 +247,7 @@ class KeyVaultBackupClient(KeyVaultClientBase):
             polling=polling,
             **kwargs,
         )
+
+    def __enter__(self) -> "KeyVaultBackupClient":
+        self._client.__enter__()
+        return self

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_settings_client.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_settings_client.py
@@ -82,3 +82,7 @@ class KeyVaultSettingsClient(KeyVaultClientBase):
             **kwargs
         )
         return KeyVaultSetting._from_generated(result)
+
+    def __enter__(self) -> "KeyVaultSettingsClient":
+        self._client.__enter__()
+        return self

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/aio/_access_control_client.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/aio/_access_control_client.py
@@ -249,3 +249,7 @@ class KeyVaultAccessControlClient(AsyncKeyVaultClientBase):
             cls=lambda result: [KeyVaultRoleDefinition._from_generated(d) for d in result],
             **kwargs
         )
+
+    async def __aenter__(self) -> "KeyVaultAccessControlClient":
+        await self._client.__aenter__()
+        return self

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/aio/_backup_client.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/aio/_backup_client.py
@@ -244,3 +244,7 @@ class KeyVaultBackupClient(AsyncKeyVaultClientBase):
             polling=polling,
             **kwargs,
         )
+
+    async def __aenter__(self) -> "KeyVaultBackupClient":
+        await self._client.__aenter__()
+        return self

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/aio/_settings_client.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/aio/_settings_client.py
@@ -85,3 +85,7 @@ class KeyVaultSettingsClient(AsyncKeyVaultClientBase):
             **kwargs
         )
         return KeyVaultSetting._from_generated(result)
+
+    async def __aenter__(self) -> "KeyVaultSettingsClient":
+        await self._client.__aenter__()
+        return self

--- a/sdk/keyvault/azure-keyvault-certificates/CHANGELOG.md
+++ b/sdk/keyvault/azure-keyvault-certificates/CHANGELOG.md
@@ -7,6 +7,8 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+- Typing errors from using Key Vault clients as context managers have been fixed
+  ([#34744](https://github.com/Azure/azure-sdk-for-python/issues/34744))
 
 ### Other Changes
 

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_client.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/_client.py
@@ -1041,3 +1041,7 @@ class CertificateClient(KeyVaultClientBase):
             cls=lambda objs: [IssuerProperties._from_issuer_item(issuer_item=x) for x in objs],
             **kwargs
         )
+
+    def __enter__(self) -> "CertificateClient":
+        self._client.__enter__()
+        return self

--- a/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/aio/_client.py
+++ b/sdk/keyvault/azure-keyvault-certificates/azure/keyvault/certificates/aio/_client.py
@@ -1046,3 +1046,7 @@ class CertificateClient(AsyncKeyVaultClientBase):
             cls=lambda objs: [IssuerProperties._from_issuer_item(x) for x in objs],
             **kwargs
         )
+
+    async def __aenter__(self) -> "CertificateClient":
+        await self._client.__aenter__()
+        return self

--- a/sdk/keyvault/azure-keyvault-keys/CHANGELOG.md
+++ b/sdk/keyvault/azure-keyvault-keys/CHANGELOG.md
@@ -7,6 +7,8 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+- Typing errors from using Key Vault clients as context managers have been fixed
+  ([#34744](https://github.com/Azure/azure-sdk-for-python/issues/34744))
 
 ### Other Changes
 

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/_client.py
@@ -874,3 +874,7 @@ class KeyClient(KeyVaultClientBase):
             vault_base_url=self._vault_url, key_name=key_name, key_rotation_policy=new_policy
         )
         return KeyRotationPolicy._from_generated(result)
+
+    def __enter__(self) -> "KeyClient":
+        self._client.__enter__()
+        return self

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/aio/_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/aio/_client.py
@@ -878,3 +878,7 @@ class KeyClient(AsyncKeyVaultClientBase):
             vault_base_url=self._vault_url, key_name=key_name, key_rotation_policy=new_policy
         )
         return KeyRotationPolicy._from_generated(result)
+
+    async def __aenter__(self) -> "KeyClient":
+        await self._client.__aenter__()
+        return self

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/_client.py
@@ -560,3 +560,7 @@ class CryptographyClient(KeyVaultClientBase):
         )
 
         return VerifyResult(key_id=self.key_id, algorithm=algorithm, is_valid=operation_result.value)
+
+    def __enter__(self) -> "CryptographyClient":
+        self._client.__enter__()
+        return self

--- a/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/aio/_client.py
+++ b/sdk/keyvault/azure-keyvault-keys/azure/keyvault/keys/crypto/aio/_client.py
@@ -482,3 +482,7 @@ class CryptographyClient(AsyncKeyVaultClientBase):
         )
 
         return VerifyResult(key_id=self.key_id, algorithm=algorithm, is_valid=operation_result.value)
+
+    async def __aenter__(self) -> "CryptographyClient":
+        await self._client.__aenter__()
+        return self

--- a/sdk/keyvault/azure-keyvault-secrets/CHANGELOG.md
+++ b/sdk/keyvault/azure-keyvault-secrets/CHANGELOG.md
@@ -7,6 +7,8 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+- Typing errors from using Key Vault clients as context managers have been fixed
+  ([#34744](https://github.com/Azure/azure-sdk-for-python/issues/34744))
 
 ### Other Changes
 

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_client.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_client.py
@@ -464,3 +464,7 @@ class SecretClient(KeyVaultClientBase):
             interval=polling_interval,
         )
         return KeyVaultOperationPoller(polling_method)
+
+    def __enter__(self) -> "SecretClient":
+        self._client.__enter__()
+        return self

--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/aio/_client.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/aio/_client.py
@@ -439,3 +439,7 @@ class SecretClient(AsyncKeyVaultClientBase):
         await polling_method.run()
 
         return polling_method.resource()
+
+    async def __aenter__(self) -> "SecretClient":
+        await self._client.__aenter__()
+        return self


### PR DESCRIPTION
# Description

Resolves https://github.com/Azure/azure-sdk-for-python/issues/34744. Our typing for KV clients is currently incorrect inside of `with` blocks because context manager methods are only implemented on base clients, and can therefore only give a base client as the return type hint.

`__(a)exit__` methods aren't implemented in user-facing clients because the base client implementation doesn't have this issue (all methods return `None`).

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
