### PR TITLE
Update Custom Web Search clients to use correct API URLS for Bing API

### DIFF
--- a/sdk/cognitiveservices/azure-cognitiveservices-language-spellcheck/azure/cognitiveservices/language/spellcheck/_configuration.py
+++ b/sdk/cognitiveservices/azure-cognitiveservices-language-spellcheck/azure/cognitiveservices/language/spellcheck/_configuration.py
@@ -26,16 +26,26 @@ class SpellCheckClientConfiguration(Configuration):
     :param credentials: Subscription credentials which uniquely identify
      client subscription.
     :type credentials: None
+    :param api_suffix: Suffix of the URL, e.g. '/v7.0'. The default value is
+      '/bing/v7.0' for cognitive services endpoints and '/v7.0' for 
+      api.bing.microsoft.com endpoints.
+    :type api_suffix: str
     """
 
     def __init__(
-            self, endpoint, credentials):
+            self, endpoint, credentials, api_suffix=None):
 
         if endpoint is None:
             raise ValueError("Parameter 'endpoint' must not be None.")
         if credentials is None:
             raise ValueError("Parameter 'credentials' must not be None.")
-        base_url = '{Endpoint}/bing/v7.0'
+
+        if api_suffix:
+            base_url = '{Endpoint}{api_suffix}'
+        elif 'api.bing.microsoft.com' in endpoint:
+            base_url = '{Endpoint}/v7.0'
+        else:
+            base_url = '{Endpoint}/bing/v7.0'
 
         super(SpellCheckClientConfiguration, self).__init__(base_url)
 

--- a/sdk/cognitiveservices/azure-cognitiveservices-search-autosuggest/azure/cognitiveservices/search/autosuggest/_configuration.py
+++ b/sdk/cognitiveservices/azure-cognitiveservices-search-autosuggest/azure/cognitiveservices/search/autosuggest/_configuration.py
@@ -26,16 +26,26 @@ class AutoSuggestClientConfiguration(Configuration):
     :param credentials: Subscription credentials which uniquely identify
      client subscription.
     :type credentials: None
+    :param api_suffix: Suffix of the URL, e.g. '/v7.0'. The default value is
+      '/bing/v7.0' for cognitive services endpoints and '/v7.0' for 
+      api.bing.microsoft.com endpoints.
+    :type api_suffix: str
     """
 
     def __init__(
-            self, endpoint, credentials):
+            self, endpoint, credentials, api_suffix=None):
 
         if endpoint is None:
             raise ValueError("Parameter 'endpoint' must not be None.")
         if credentials is None:
             raise ValueError("Parameter 'credentials' must not be None.")
-        base_url = '{Endpoint}/bing/v7.0'
+
+        if api_suffix:
+            base_url = '{Endpoint}{api_suffix}'
+        elif 'api.bing.microsoft.com' in endpoint:
+            base_url = '{Endpoint}/v7.0'
+        else:
+            base_url = '{Endpoint}/bing/v7.0'
 
         super(AutoSuggestClientConfiguration, self).__init__(base_url)
 

--- a/sdk/cognitiveservices/azure-cognitiveservices-search-entitysearch/azure/cognitiveservices/search/entitysearch/_configuration.py
+++ b/sdk/cognitiveservices/azure-cognitiveservices-search-entitysearch/azure/cognitiveservices/search/entitysearch/_configuration.py
@@ -26,16 +26,26 @@ class EntitySearchClientConfiguration(Configuration):
     :param credentials: Subscription credentials which uniquely identify
      client subscription.
     :type credentials: None
+    :param api_suffix: Suffix of the URL, e.g. '/v7.0'. The default value is
+      '/bing/v7.0' for cognitive services endpoints and '/v7.0' for 
+      api.bing.microsoft.com endpoints.
+    :type api_suffix: str
     """
 
     def __init__(
-            self, endpoint, credentials):
+            self, endpoint, credentials, api_suffix=None):
 
         if endpoint is None:
             raise ValueError("Parameter 'endpoint' must not be None.")
         if credentials is None:
             raise ValueError("Parameter 'credentials' must not be None.")
-        base_url = '{Endpoint}/bing/v7.0'
+
+        if api_suffix:
+            base_url = '{Endpoint}{api_suffix}'
+        elif 'api.bing.microsoft.com' in endpoint:
+            base_url = '{Endpoint}/v7.0'
+        else:
+            base_url = '{Endpoint}/bing/v7.0'
 
         super(EntitySearchClientConfiguration, self).__init__(base_url)
 

--- a/sdk/cognitiveservices/azure-cognitiveservices-search-imagesearch/azure/cognitiveservices/search/imagesearch/_configuration.py
+++ b/sdk/cognitiveservices/azure-cognitiveservices-search-imagesearch/azure/cognitiveservices/search/imagesearch/_configuration.py
@@ -26,16 +26,26 @@ class ImageSearchClientConfiguration(Configuration):
     :param credentials: Subscription credentials which uniquely identify
      client subscription.
     :type credentials: None
+    :param api_suffix: Suffix of the URL, e.g. '/v7.0'. The default value is
+      '/bing/v7.0' for cognitive services endpoints and '/v7.0' for 
+      api.bing.microsoft.com endpoints.
+    :type api_suffix: str
     """
 
     def __init__(
-            self, endpoint, credentials):
+            self, endpoint, credentials, api_suffix=None):
 
         if endpoint is None:
             raise ValueError("Parameter 'endpoint' must not be None.")
         if credentials is None:
             raise ValueError("Parameter 'credentials' must not be None.")
-        base_url = '{Endpoint}/bing/v7.0'
+
+        if api_suffix:
+            base_url = '{Endpoint}{api_suffix}'
+        elif 'api.bing.microsoft.com' in endpoint:
+            base_url = '{Endpoint}/v7.0'
+        else:
+            base_url = '{Endpoint}/bing/v7.0'
 
         super(ImageSearchClientConfiguration, self).__init__(base_url)
 

--- a/sdk/cognitiveservices/azure-cognitiveservices-search-newssearch/azure/cognitiveservices/search/newssearch/_configuration.py
+++ b/sdk/cognitiveservices/azure-cognitiveservices-search-newssearch/azure/cognitiveservices/search/newssearch/_configuration.py
@@ -26,16 +26,26 @@ class NewsSearchClientConfiguration(Configuration):
     :param credentials: Subscription credentials which uniquely identify
      client subscription.
     :type credentials: None
+    :param api_suffix: Suffix of the URL, e.g. '/v7.0'. The default value is
+      '/bing/v7.0' for cognitive services endpoints and '/v7.0' for 
+      api.bing.microsoft.com endpoints.
+    :type api_suffix: str
     """
 
     def __init__(
-            self, endpoint, credentials):
+            self, endpoint, credentials, api_suffix=None):
 
         if endpoint is None:
             raise ValueError("Parameter 'endpoint' must not be None.")
         if credentials is None:
             raise ValueError("Parameter 'credentials' must not be None.")
-        base_url = '{Endpoint}/bing/v7.0'
+
+        if api_suffix:
+            base_url = '{Endpoint}{api_suffix}'
+        elif 'api.bing.microsoft.com' in endpoint:
+            base_url = '{Endpoint}/v7.0'
+        else:
+            base_url = '{Endpoint}/bing/v7.0'
 
         super(NewsSearchClientConfiguration, self).__init__(base_url)
 

--- a/sdk/cognitiveservices/azure-cognitiveservices-search-videosearch/azure/cognitiveservices/search/videosearch/_configuration.py
+++ b/sdk/cognitiveservices/azure-cognitiveservices-search-videosearch/azure/cognitiveservices/search/videosearch/_configuration.py
@@ -26,16 +26,26 @@ class VideoSearchClientConfiguration(Configuration):
     :param credentials: Subscription credentials which uniquely identify
      client subscription.
     :type credentials: None
+    :param api_suffix: Suffix of the URL, e.g. '/v7.0'. The default value is
+      '/bing/v7.0' for cognitive services endpoints and '/v7.0' for 
+      api.bing.microsoft.com endpoints.
+    :type api_suffix: str
     """
 
     def __init__(
-            self, endpoint, credentials):
+            self, endpoint, credentials, api_suffix=None):
 
         if endpoint is None:
             raise ValueError("Parameter 'endpoint' must not be None.")
         if credentials is None:
             raise ValueError("Parameter 'credentials' must not be None.")
-        base_url = '{Endpoint}/bing/v7.0'
+
+        if api_suffix:
+            base_url = '{Endpoint}{api_suffix}'
+        elif 'api.bing.microsoft.com' in endpoint:
+            base_url = '{Endpoint}/v7.0'
+        else:
+            base_url = '{Endpoint}/bing/v7.0'
 
         super(VideoSearchClientConfiguration, self).__init__(base_url)
 

--- a/sdk/cognitiveservices/azure-cognitiveservices-search-visualsearch/azure/cognitiveservices/search/visualsearch/visual_search_client.py
+++ b/sdk/cognitiveservices/azure-cognitiveservices-search-visualsearch/azure/cognitiveservices/search/visualsearch/visual_search_client.py
@@ -28,16 +28,26 @@ class VisualSearchClientConfiguration(Configuration):
     :param credentials: Subscription credentials which uniquely identify
      client subscription.
     :type credentials: None
+    :param api_suffix: Suffix of the URL, e.g. '/v7.0'. The default value is
+      '/bing/v7.0' for cognitive services endpoints and '/v7.0' for 
+      api.bing.microsoft.com endpoints.
+    :type api_suffix: str
     """
 
     def __init__(
-            self, endpoint, credentials):
+            self, endpoint, credentials, api_suffix=None):
 
         if endpoint is None:
             raise ValueError("Parameter 'endpoint' must not be None.")
         if credentials is None:
             raise ValueError("Parameter 'credentials' must not be None.")
-        base_url = '{Endpoint}/bing/v7.0'
+
+        if api_suffix:
+            base_url = '{Endpoint}{api_suffix}'
+        elif 'api.bing.microsoft.com' in endpoint:
+            base_url = '{Endpoint}/v7.0'
+        else:
+            base_url = '{Endpoint}/bing/v7.0'
 
         super(VisualSearchClientConfiguration, self).__init__(base_url)
 

--- a/sdk/cognitiveservices/azure-cognitiveservices-search-websearch/azure/cognitiveservices/search/websearch/_configuration.py
+++ b/sdk/cognitiveservices/azure-cognitiveservices-search-websearch/azure/cognitiveservices/search/websearch/_configuration.py
@@ -26,16 +26,26 @@ class WebSearchClientConfiguration(Configuration):
     :param credentials: Subscription credentials which uniquely identify
      client subscription.
     :type credentials: None
+    :param api_suffix: Suffix of the URL, e.g. '/v7.0'. The default value is
+      '/bing/v7.0' for cognitive services endpoints and '/v7.0' for 
+      api.bing.microsoft.com endpoints.
+    :type api_suffix: str
     """
 
     def __init__(
-            self, endpoint, credentials):
+            self, endpoint, credentials, api_suffix=None):
 
         if endpoint is None:
             raise ValueError("Parameter 'endpoint' must not be None.")
         if credentials is None:
             raise ValueError("Parameter 'credentials' must not be None.")
-        base_url = '{Endpoint}/bing/v7.0'
+
+        if api_suffix:
+            base_url = '{Endpoint}{api_suffix}'
+        elif 'api.bing.microsoft.com' in endpoint:
+            base_url = '{Endpoint}/v7.0'
+        else:
+            base_url = '{Endpoint}/bing/v7.0'
 
         super(WebSearchClientConfiguration, self).__init__(base_url)
 


### PR DESCRIPTION
# Description

Fixes #35082.

The current azure-cognitive-search-xxx SDKs are all broken because the API address changed from `/bing/v7.0` to `/v7.0` in October 2023.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
