### PR TITLE
Bugfix/imds get token to fix #35166

### DIFF
--- a/sdk/identity/azure-identity/CHANGELOG.md
+++ b/sdk/identity/azure-identity/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- For IMDS requests in `ManagedIdentityCredential`, a try/catch clause was added to the _check_forbidden_response which was previously crashing the ChainedIdentityCredential chain if the response gave a HttpResponseException with an error message in HTML (i.e. from a proxy server or gateway)
+
 ### Other Changes
 
 ## 1.16.0 (2024-04-09)

--- a/sdk/identity/azure-identity/azure/identity/_credentials/imds.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/imds.py
@@ -111,8 +111,8 @@ class ImdsCredential(GetTokenMixin):
         except HttpResponseError as ex:
             # 400 in response to a token request indicates managed identity is disabled,
             # or the identity with the specified client_id is not available
+            error_message = "ManagedIdentityCredential authentication unavailable. "
             if ex.status_code == 400:
-                error_message = "ManagedIdentityCredential authentication unavailable. "
                 if self._user_assigned_identity:
                     error_message += "The requested identity has not been assigned to this resource."
                 else:

--- a/sdk/identity/azure-identity/azure/identity/_credentials/imds.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/imds.py
@@ -89,7 +89,11 @@ class ImdsCredential(GetTokenMixin):
                 self._endpoint_available = True
             except HttpResponseError as ex:
                 # IMDS responded
-                _check_forbidden_response(ex)
+                try:
+                    _check_forbidden_response(ex)
+                except Exception as ex: # pylint:disable=broad-except
+                    error_message = "ManagedIdentityCredential authentication unavailable, error parsing the response from the server."
+                    raise CredentialUnavailableError(error_message) from ex
                 self._endpoint_available = True
             except Exception as ex:  # pylint:disable=broad-except
                 error_message = (
@@ -114,7 +118,11 @@ class ImdsCredential(GetTokenMixin):
 
                 raise CredentialUnavailableError(message=error_message) from ex
 
-            _check_forbidden_response(ex)
+            try:
+                _check_forbidden_response(ex)
+            except Exception as ex: # pylint:disable=broad-except
+                error_message = "ManagedIdentityCredential authentication unavailable, error parsing the response from the server."
+                raise CredentialUnavailableError(error_message) from ex
             # any other error is unexpected
             raise ClientAuthenticationError(message=ex.message, response=ex.response) from ex
         except Exception as ex:  # pylint:disable=broad-except

--- a/sdk/identity/azure-identity/tests/test_imds_credential.py
+++ b/sdk/identity/azure-identity/tests/test_imds_credential.py
@@ -44,6 +44,24 @@ def test_identity_not_available():
         credential.get_token("scope")
 
 
+def test_html_parsing_error():
+    """The credential should raise CredentialUnavailableError when the endpoint returns a non-JSON response"""
+
+    def send(request, **kwargs):
+        # ensure the `claims` and `tenant_id` kwargs from credential's `get_token` method don't make it to transport
+        assert "claims" not in kwargs
+        assert "tenant_id" not in kwargs
+        return mock_response(status_code=504)
+    
+    mock_send = mock.Mock(send=send)
+    mock_send.side_effect = ValueError("HTML parsing error")
+
+    credential = ImdsCredential(transport=mock.Mock(send=send))
+
+    with pytest.raises(CredentialUnavailableError):
+        credential.get_token("scope")
+
+
 def test_unexpected_error():
     """The credential should raise ClientAuthenticationError when the endpoint returns an unexpected error"""
 

--- a/sdk/identity/azure-identity/tests/test_imds_credential.py
+++ b/sdk/identity/azure-identity/tests/test_imds_credential.py
@@ -52,9 +52,6 @@ def test_html_parsing_error():
         assert "claims" not in kwargs
         assert "tenant_id" not in kwargs
         return mock_response(status_code=504)
-    
-    mock_send = mock.Mock(send=send)
-    mock_send.side_effect = ValueError("HTML parsing error")
 
     credential = ImdsCredential(transport=mock.Mock(send=send))
 


### PR DESCRIPTION
# Description

Please add an informative description that covers that changes made by the pull request and link all relevant issues.

If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.

If the ImdsCredential obtains an HttpResponseError with a status code other than 400 (such as a 504), the ChainedIdentityCredential crashes unexpectedly. That is due to the _check_forbidden_response call which can't handle HTML. If the call to the Imds server is made behind a corporate proxy (other another API gateway), the request times out with a 504 and the gateway returns an HTML response. At this point, the Imds -> ManagedIdentityCredential should fail and move on to the next auth mechanism, but instead it fails. This PR fixes that bug.

# All SDK Contribution checklist:
- [X] **The pull request does not introduce [breaking changes]**
- [X] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [X] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [X] Title of the pull request is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
