### PR TITLE
[Test Proxy] Centrally sanitize sensitive patterns for all tests

### DIFF
--- a/sdk/keyvault/azure-keyvault-secrets/tests/test_samples_secrets_async.py
+++ b/sdk/keyvault/azure-keyvault-secrets/tests/test_samples_secrets_async.py
@@ -109,8 +109,6 @@ class TestExamplesKeyVault(KeyVaultTestCase):
     @AsyncSecretsClientPreparer()
     @recorded_by_proxy_async
     async def test_example_secret_list_operations(self, client, **kwargs):
-        if not is_live():
-            set_custom_default_matcher(excluded_headers="Authorization")
         secret_client = client
         async with secret_client:
             for i in range(7):

--- a/tools/azure-sdk-tools/devtools_testutils/__init__.py
+++ b/tools/azure-sdk-tools/devtools_testutils/__init__.py
@@ -23,6 +23,7 @@ from .proxy_startup import start_test_proxy, stop_test_proxy, test_proxy
 from .proxy_testcase import recorded_by_proxy
 from .sanitizers import (
     add_api_version_transform,
+    add_batch_sanitizers,
     add_body_key_sanitizer,
     add_body_regex_sanitizer,
     add_body_string_sanitizer,
@@ -40,6 +41,7 @@ from .sanitizers import (
     add_uri_string_sanitizer,
     add_uri_subscription_id_sanitizer,
     PemCertificate,
+    Sanitizer,
     set_bodiless_matcher,
     set_custom_default_matcher,
     set_default_function_settings,
@@ -56,6 +58,7 @@ PowerShellPreparer = EnvironmentVariableLoader  # Backward compat
 
 __all__ = [
     "add_api_version_transform",
+    "add_batch_sanitizers",
     "add_body_key_sanitizer",
     "add_body_regex_sanitizer",
     "add_body_string_sanitizer",
@@ -79,6 +82,7 @@ __all__ = [
     "FakeResource",
     "ReservedResourceNameError",
     "ResourceGroupPreparer",
+    "Sanitizer",
     "StorageAccountPreparer",
     "BlobAccountPreparer",
     "CachedStorageAccountPreparer",

--- a/tools/azure-sdk-tools/devtools_testutils/fake_credentials.py
+++ b/tools/azure-sdk-tools/devtools_testutils/fake_credentials.py
@@ -2,11 +2,17 @@ from azure.core.credentials import AccessToken
 
 
 # General-use fake credentials
+FAKE_ACCESS_TOKEN = "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJlbWFpbCI6IkJvYkBjb250b3NvLmNvbSIsImdpdmVuX25hbWUiOiJCb2I" \
+    "iLCJpc3MiOiJodHRwOi8vRGVmYXVsdC5Jc3N1ZXIuY29tIiwiYXVkIjoiaHR0cDovL0RlZmF1bHQuQXVkaWVuY2UuY29tIiwiaWF0IjoiMTYwNz" \
+    "k3ODY4MyIsIm5iZiI6IjE2MDc5Nzg2ODMiLCJleHAiOiIxNjA3OTc4OTgzIn0."
+FAKE_ID = "00000000-0000-0000-0000-000000000000"
 FAKE_LOGIN_PASSWORD = "F4ke_L0gin_P4ss"
 
 # Service-specific fake credentials
 BATCH_TEST_PASSWORD = "kt#_gahr!@aGERDXA"
 MGMT_HDINSIGHT_FAKE_KEY = "qFmud5LfxcCxWUvWcGMhKDp0v0KuBRLsO/AIddX734W7lzdInsVMsB5ILVoOrF+0fCfk/IYYy5SJ9Q+2v4aihQ=="
+SERVICEBUS_FAKE_SAS = "SharedAccessSignature sr=https%3A%2F%2Ffoo.servicebus.windows.net&sig=dummyValue%3D&se=168726" \
+    "7490&skn=dummyKey"
 STORAGE_ACCOUNT_FAKE_KEY = "NzhL3hKZbJBuJ2484dPTR+xF30kYaWSSCbs2BzLgVVI1woqeST/1IgqaLm6QAOTxtGvxctSNbIR/1hW8yH+bJg=="
 
 

--- a/tools/azure-sdk-tools/devtools_testutils/proxy_startup.py
+++ b/tools/azure-sdk-tools/devtools_testutils/proxy_startup.py
@@ -370,7 +370,12 @@ def set_common_sanitizers() -> None:
         {"json_path": "$..appkey", "value": SANITIZED},
         {"json_path": "$..acrToken", "value": SANITIZED},
         {"json_path": "$..accountKey", "value": SANITIZED},
+        {"json_path": "$..accountName", "value": SANITIZED},
         {"json_path": "$..decryptionKey", "value": SANITIZED},
+        {"json_path": "$..applicationId", "value": SANITIZED},
+        {"json_path": "$..apiKey", "value": SANITIZED},
+        {"json_path": "$..userName", "value": SANITIZED},
+        {"json_path": "$.properties.DOCKER_REGISTRY_SERVER_PASSWORD", "value": SANITIZED},
         {"json_path": "$.value[*].key", "value": SANITIZED},
         {"json_path": "$.key", "value": SANITIZED},
         {"json_path": "$..clientId", "value": FAKE_ID},
@@ -388,6 +393,13 @@ def set_common_sanitizers() -> None:
         {"regex": "access_token=(?<group>.*?)(?=&|$)", "group_for_replace": "group", "value": SANITIZED},
         {"regex": "token=(?<token>[^\\u0026]+)($|\\u0026)", "group_for_replace": "token", "value": SANITIZED},
         {"regex": "-----BEGIN PRIVATE KEY-----\\n(.+\\n)*-----END PRIVATE KEY-----\\n", "value": SANITIZED},
+        {"regex": "(?<=<UserDelegationKey>).*?(?:<SignedTid>)(.*)(?:</SignedTid>)", "value": SANITIZED},
+        {"regex": "(?<=<UserDelegationKey>).*?(?:<SignedOid>)(.*)(?:</SignedOid>)", "value": SANITIZED},
+        {"regex": "(?<=<UserDelegationKey>).*?(?:<Value>)(.*)(?:</Value>)", "value": SANITIZED},
+        {"regex": "(?:Password=)(.*?)(?:;)", "value": SANITIZED},
+        {"regex": "(?:User ID=)(.*?)(?:;)", "value": SANITIZED},
+        {"regex": "(?:<PrimaryKey>)(.*)(?:</PrimaryKey>)", "value": SANITIZED},
+        {"regex": "(?:<SecondaryKey>)(.*)(?:</SecondaryKey>)", "value": SANITIZED},
     ]
 
     # General regex sanitizers for sensitive patterns throughout interactions

--- a/tools/azure-sdk-tools/devtools_testutils/proxy_startup.py
+++ b/tools/azure-sdk-tools/devtools_testutils/proxy_startup.py
@@ -24,8 +24,13 @@ from urllib3.exceptions import SSLError
 from ci_tools.variables import in_ci
 
 from .config import PROXY_URL
+from .fake_credentials import FAKE_ACCESS_TOKEN, FAKE_ID, SERVICEBUS_FAKE_SAS
 from .helpers import get_http_client, is_live_and_not_recording
-from .sanitizers import add_oauth_response_sanitizer, add_remove_header_sanitizer, set_custom_default_matcher
+from .sanitizers import (
+    add_batch_sanitizers,
+    Sanitizer,
+    set_custom_default_matcher,
+)
 
 
 load_dotenv(find_dotenv())
@@ -280,6 +285,146 @@ def prepare_local_tool(repo_root: str) -> str:
         )
 
 
+def set_common_sanitizers() -> None:
+    """Register sanitizers that will apply to all recordings throughout the SDK."""
+    SANITIZED = "Sanitized"
+    batch_sanitizers = {}
+
+    # Remove headers from recordings if we don't need them, and ignore them if present
+    # Authorization, for example, can contain sensitive info and can cause matching failures during challenge auth
+    headers_to_ignore = "Authorization, x-ms-client-request-id, x-ms-request-id"
+    set_custom_default_matcher(excluded_headers=headers_to_ignore)
+    batch_sanitizers[Sanitizer.REMOVE_HEADER] = [{"headers": headers_to_ignore}]
+
+    # Remove OAuth interactions, which can contain client secrets and aren't necessary for playback testing
+    batch_sanitizers[Sanitizer.OAUTH_RESPONSE] = [None]
+
+    # Body key sanitizers for sensitive fields in JSON requests/responses
+    batch_sanitizers[Sanitizer.BODY_KEY] = [
+        {"json_path": "$..access_token", "value": FAKE_ACCESS_TOKEN},
+        {"json_path": "$..AccessToken", "value": FAKE_ACCESS_TOKEN},
+        {"json_path": "$..targetModelLocation", "value": SANITIZED},
+        {"json_path": "$..targetResourceId", "value": SANITIZED},
+        {"json_path": "$..urlSource", "value": SANITIZED},
+        {"json_path": "$..azureBlobSource.containerUrl", "value": SANITIZED},
+        {"json_path": "$..source", "value": SANITIZED},
+        {"json_path": "$..resourceLocation", "value": SANITIZED},
+        {"json_path": "Location", "value": SANITIZED},
+        {"json_path": "$..to", "value": SANITIZED},
+        {"json_path": "$..from", "value": SANITIZED},
+        {"json_path": "$..sasUri", "value": SANITIZED},
+        {"json_path": "$..containerUri", "value": SANITIZED},
+        {"json_path": "$..inputDataUri", "value": SANITIZED},
+        {"json_path": "$..outputDataUri", "value": SANITIZED},
+        {"json_path": "$..id", "value": SANITIZED},
+        {"json_path": "$..token", "value": SANITIZED},
+        {"json_path": "$..appId", "value": SANITIZED},
+        {"json_path": "$..userId", "value": SANITIZED},
+        {"json_path": "$..storageAccount", "value": SANITIZED},
+        {"json_path": "$..resourceGroup", "value": SANITIZED},
+        {"json_path": "$..guardian", "value": SANITIZED},
+        {"json_path": "$..scan", "value": SANITIZED},
+        {"json_path": "$..catalog", "value": SANITIZED},
+        {"json_path": "$..lastModifiedBy", "value": SANITIZED},
+        {"json_path": "$..managedResourceGroupName", "value": SANITIZED},
+        {"json_path": "$..friendlyName", "value": SANITIZED},
+        {"json_path": "$..createdBy", "value": SANITIZED},
+        {"json_path": "$..credential", "value": SANITIZED},
+        {"json_path": "$..aliasPrimaryConnectionString", "value": SANITIZED},
+        {"json_path": "$..aliasSecondaryConnectionString", "value": SANITIZED},
+        {"json_path": "$..connectionString", "value": SANITIZED},
+        {"json_path": "$..primaryConnectionString", "value": SANITIZED},
+        {"json_path": "$..secondaryConnectionString", "value": SANITIZED},
+        {"json_path": "$..sshPassword", "value": SANITIZED},
+        {"json_path": "$..primaryKey", "value": SANITIZED},
+        {"json_path": "$..secondaryKey", "value": SANITIZED},
+        {"json_path": "$..runAsPassword", "value": SANITIZED},
+        {"json_path": "$..adminPassword", "value": SANITIZED},
+        {"json_path": "$..adminPassword.value", "value": SANITIZED},
+        {"json_path": "$..administratorLoginPassword", "value": SANITIZED},
+        {"json_path": "$..accessSAS", "value": SANITIZED},
+        {"json_path": "$..WEBSITE_AUTH_ENCRYPTION_KEY", "value": SANITIZED},
+        {"json_path": "$..storageContainerWriteSas", "value": SANITIZED},
+        {"json_path": "$..storageContainerUri", "value": SANITIZED},
+        {"json_path": "$..storageContainerReadListSas", "value": SANITIZED},
+        {"json_path": "$..storageAccountPrimaryKey", "value": SANITIZED},
+        {"json_path": "$..uploadUrl", "value": SANITIZED},
+        {"json_path": "$..secondaryReadonlyMasterKey", "value": SANITIZED},
+        {"json_path": "$..primaryMasterKey", "value": SANITIZED},
+        {"json_path": "$..primaryReadonlyMasterKey", "value": SANITIZED},
+        {"json_path": "$..secondaryMasterKey", "value": SANITIZED},
+        {"json_path": "$..scriptUrlSasToken", "value": SANITIZED},
+        {"json_path": "$..privateKey", "value": SANITIZED},
+        {"json_path": "$..password", "value": SANITIZED},
+        {"json_path": "$..logLink", "value": SANITIZED},
+        {"json_path": "$..keyVaultClientSecret", "value": SANITIZED},
+        {"json_path": "$..httpHeader", "value": SANITIZED},
+        {"json_path": "$..functionKey", "value": SANITIZED},
+        {"json_path": "$..fencingClientPassword", "value": SANITIZED},
+        {"json_path": "$..encryptedCredential", "value": SANITIZED},
+        {"json_path": "$..clientSecret", "value": SANITIZED},
+        {"json_path": "$..certificatePassword", "value": SANITIZED},
+        {"json_path": "$..authHeader", "value": SANITIZED},
+        {"json_path": "$..atlasKafkaSecondaryEndpoint", "value": SANITIZED},
+        {"json_path": "$..atlasKafkaPrimaryEndpoint", "value": SANITIZED},
+        {"json_path": "$..appkey", "value": SANITIZED},
+        {"json_path": "$..acrToken", "value": SANITIZED},
+        {"json_path": "$..accountKey", "value": SANITIZED},
+        {"json_path": "$..decryptionKey", "value": SANITIZED},
+        {"json_path": "$.value[*].key", "value": SANITIZED},
+        {"json_path": "$.key", "value": SANITIZED},
+        {"json_path": "$..clientId", "value": FAKE_ID},
+        {"json_path": "$..principalId", "value": FAKE_ID},
+        {"json_path": "$..tenantId", "value": FAKE_ID},
+    ]
+
+    # Body regex sanitizers for sensitive patterns in request/response bodies
+    batch_sanitizers[Sanitizer.BODY_REGEX] = [
+        {"regex": "(client_id=)[^&]+", "value": "$1sanitized"},
+        {"regex": "(client_secret=)[^&]+", "value": "$1sanitized"},
+        {"regex": "(client_assertion=)[^&]+", "value": "$1sanitized"},
+        {"regex": "(?:(sv|sig|se|srt|ss|sp)=)(?<secret>(([^&\\s]*)))", "value": SANITIZED},
+        {"regex": "refresh_token=(?<group>.*?)(?=&|$)", "group_for_replace": "group", "value": SANITIZED},
+        {"regex": "access_token=(?<group>.*?)(?=&|$)", "group_for_replace": "group", "value": SANITIZED},
+        {"regex": "token=(?<token>[^\\u0026]+)($|\\u0026)", "group_for_replace": "token", "value": SANITIZED},
+        {"regex": "-----BEGIN PRIVATE KEY-----\\n(.+\\n)*-----END PRIVATE KEY-----\\n", "value": SANITIZED},
+    ]
+
+    # General regex sanitizers for sensitive patterns throughout interactions
+    batch_sanitizers[Sanitizer.GENERAL_REGEX] = [
+        {"regex": "SharedAccessKey=(?<key>[^;\\\"]+)", "group_for_replace": "key", "value": SANITIZED},
+        {"regex": "AccountKey=(?<key>[^;\\\"]+)", "group_for_replace": "key", "value": SANITIZED},
+        {"regex": "accesskey=(?<key>[^;\\\"]+)", "group_for_replace": "key", "value": SANITIZED},
+        {"regex": "Accesskey=(?<key>[^;\\\"]+)", "group_for_replace": "key", "value": SANITIZED},
+        {"regex": "Secret=(?<key>[^;\\\"]+)", "group_for_replace": "key", "value": SANITIZED},
+    ]
+
+    # Header regex sanitizers for sensitive patterns in request/response headers
+    batch_sanitizers[Sanitizer.HEADER_REGEX] = [
+        {"key": "subscription-key", "value": SANITIZED},
+        {"key": "x-ms-encryption-key", "value": SANITIZED},
+        {"key": "x-ms-rename-source", "value": SANITIZED},
+        {"key": "x-ms-file-rename-source", "value": SANITIZED},
+        {"key": "x-ms-copy-source", "value": SANITIZED},
+        {"key": "x-ms-copy-source-authorization", "value": SANITIZED},
+        {"key": "x-ms-file-rename-source-authorization", "value": SANITIZED},
+        {"key": "x-ms-encryption-key-sha256", "value": SANITIZED},
+        {"key": "api-key", "value": SANITIZED},
+        {"key": "aeg-sas-token", "value": SANITIZED},
+        {"key": "aeg-sas-key", "value": SANITIZED},
+        {"key": "aeg-channel-name", "value": SANITIZED},
+        {"key": "SupplementaryAuthorization", "value": SERVICEBUS_FAKE_SAS},
+    ]
+
+    # URI regex sanitizers for sensitive patterns in request/response URLs
+    batch_sanitizers[Sanitizer.URI_REGEX] = [
+        {"regex": "sig=(?<sig>[^&]+)", "group_for_replace": "sig", "value": SANITIZED}
+    ]
+
+    # Send all the above sanitizers to the test proxy in a single, batch request
+    add_batch_sanitizers(sanitizers=batch_sanitizers)
+
+
 def start_test_proxy(request) -> None:
     """Starts the test proxy and returns when the proxy server is ready to receive requests.
 
@@ -334,12 +479,7 @@ def start_test_proxy(request) -> None:
 
     # Wait for the proxy server to become available
     check_proxy_availability()
-    # Remove headers from recordings if we don't need them, and ignore them if present
-    # Authorization, for example, can contain sensitive info and can cause matching failures during challenge auth
-    headers_to_ignore = "Authorization, x-ms-client-request-id, x-ms-request-id"
-    add_remove_header_sanitizer(headers=headers_to_ignore)
-    set_custom_default_matcher(excluded_headers=headers_to_ignore)
-    add_oauth_response_sanitizer()
+    set_common_sanitizers()
 
 
 def stop_test_proxy() -> None:


### PR DESCRIPTION
# Description

This adds a `Sanitizer` enum and batch sanitizer registration method -- `add_batch_sanitizers` -- that make it possible to easily set a number of sanitizers in a single request.

Sanitizer registration has been centralized to take place just after the test proxy is started up and before recordings are loaded up, meaning that they will apply to the entire session.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
