### PR TITLE
[Core][Corehttp] Update multipart test-server code

### DIFF
--- a/eng/tox/install_depend_packages.py
+++ b/eng/tox/install_depend_packages.py
@@ -45,6 +45,7 @@ MINIMUM_VERSION_GENERIC_OVERRIDES = {
     "six": "1.12.0",
     "cryptography": "3.3.2",
     "msal": "1.23.0",
+    "azure-storage-file-datalake": "12.2.0",
 }
 
 MAXIMUM_VERSION_GENERIC_OVERRIDES = {}

--- a/eng/tox/install_depend_packages.py
+++ b/eng/tox/install_depend_packages.py
@@ -47,9 +47,7 @@ MINIMUM_VERSION_GENERIC_OVERRIDES = {
     "msal": "1.23.0",
 }
 
-MAXIMUM_VERSION_GENERIC_OVERRIDES = {
-    "aiohttp": "3.9.3"
-}
+MAXIMUM_VERSION_GENERIC_OVERRIDES = {}
 
 # SPECIFIC OVERRIDES provide additional filtering of upper and lower bound by
 # binding an override to the specific package being processed. As an example, when

--- a/sdk/core/azure-core/tests/async_tests/test_rest_http_response_async.py
+++ b/sdk/core/azure-core/tests/async_tests/test_rest_http_response_async.py
@@ -271,32 +271,32 @@ async def test_text_and_encoding(send_request):
     assert response.encoding == "utf-16"
 
 
-# @pytest.mark.asyncio
-# async def test_multipart_encode_non_seekable_filelike(send_request):
-#     """
-#     Test that special readable but non-seekable filelike objects are supported,
-#     at the cost of reading them into memory at most once.
-#     """
+@pytest.mark.asyncio
+async def test_multipart_encode_non_seekable_filelike(send_request):
+    """
+    Test that special readable but non-seekable filelike objects are supported,
+    at the cost of reading them into memory at most once.
+    """
 
-#     class IteratorIO(io.IOBase):
-#         def __init__(self, iterator):
-#             self._iterator = iterator
+    class IteratorIO(io.IOBase):
+        def __init__(self, iterator):
+            self._iterator = iterator
 
-#         def read(self, *args):
-#             return b"".join(self._iterator)
+        def read(self, *args):
+            return b"".join(self._iterator)
 
-#     def data():
-#         yield b"Hello"
-#         yield b"World"
+    def data():
+        yield b"Hello"
+        yield b"World"
 
-#     fileobj = IteratorIO(data())
-#     files = {"file": fileobj}
-#     request = HttpRequest(
-#         "POST",
-#         "/multipart/non-seekable-filelike",
-#         files=files,
-#     )
-#     await send_request(request)
+    fileobj = IteratorIO(data())
+    files = {"file": fileobj}
+    request = HttpRequest(
+        "POST",
+        "/multipart/non-seekable-filelike",
+        files=files,
+    )
+    await send_request(request)
 
 
 def test_initialize_response_abc():

--- a/sdk/core/azure-core/tests/testserver_tests/coretestserver/coretestserver/test_routes/multipart.py
+++ b/sdk/core/azure-core/tests/testserver_tests/coretestserver/coretestserver/test_routes/multipart.py
@@ -25,12 +25,10 @@ def basic():
     assert_with_message("content type", multipart_header_start, request.content_type[: len(multipart_header_start)])
     if request.files:
         # aiohttp
-        assert_with_message("content length", 228, request.content_length)
         assert_with_message("num files", 1, len(request.files))
         assert_with_message("has file named fileContent", True, bool(request.files.get("fileContent")))
         file_content = request.files["fileContent"]
         assert_with_message("file content type", "application/octet-stream", file_content.content_type)
-        assert_with_message("file content length", 14, file_content.content_length)
         assert_with_message("filename", "fileContent", file_content.filename)
         assert_with_message(
             "has content disposition header", True, bool(file_content.headers.get("Content-Disposition"))
@@ -42,7 +40,6 @@ def basic():
         )
     elif request.form:
         # requests
-        assert_with_message("content length", 184, request.content_length)
         assert_with_message("fileContent", "<file content>", request.form["fileContent"])
     else:
         return Response(status=400)  # should be either of these
@@ -58,7 +55,6 @@ def data_and_files():
         assert_with_message("message", "Hello, world!", request.form["message"])
         file_content = request.files["fileContent"]
         assert_with_message("file content type", "application/octet-stream", file_content.content_type)
-        assert_with_message("file content length", 14, file_content.content_length)
         assert_with_message("filename", "fileContent", file_content.filename)
         assert_with_message(
             "has content disposition header", True, bool(file_content.headers.get("Content-Disposition"))
@@ -93,17 +89,15 @@ def non_seekable_filelike():
         # aiohttp
         len_files = len(request.files)
         assert_with_message("num files", 1, len_files)
-        # assert_with_message("content length", 258, request.content_length)
         assert_with_message("num files", 1, len(request.files))
         assert_with_message("has file named file", True, bool(request.files.get("file")))
         file = request.files["file"]
         assert_with_message("file content type", "application/octet-stream", file.content_type)
-        assert_with_message("file content length", 14, file.content_length)
         assert_with_message("filename", "file", file.filename)
         assert_with_message("has content disposition header", True, bool(file.headers.get("Content-Disposition")))
         assert_with_message(
             "content disposition",
-            'form-data; name="fileContent"; filename="fileContent"; filename*=utf-8\'\'fileContent',
+            'form-data; name="file"; filename="file"',
             file.headers["Content-Disposition"],
         )
     elif request.form:

--- a/sdk/core/corehttp/tests/async_tests/test_rest_http_response_async.py
+++ b/sdk/core/corehttp/tests/async_tests/test_rest_http_response_async.py
@@ -252,33 +252,33 @@ async def test_text_and_encoding(send_request, transport):
     assert response.encoding == "utf-16"
 
 
-# @pytest.mark.asyncio
-# @pytest.mark.parametrize("transport", ASYNC_TRANSPORTS)
-# async def test_multipart_encode_non_seekable_filelike(send_request, transport):
-#     """
-#     Test that special readable but non-seekable filelike objects are supported,
-#     at the cost of reading them into memory at most once.
-#     """
+@pytest.mark.asyncio
+@pytest.mark.parametrize("transport", ASYNC_TRANSPORTS)
+async def test_multipart_encode_non_seekable_filelike(send_request, transport):
+    """
+    Test that special readable but non-seekable filelike objects are supported,
+    at the cost of reading them into memory at most once.
+    """
 
-#     class IteratorIO(io.IOBase):
-#         def __init__(self, iterator):
-#             self._iterator = iterator
+    class IteratorIO(io.IOBase):
+        def __init__(self, iterator):
+            self._iterator = iterator
 
-#         def read(self, *args):
-#             return b"".join(self._iterator)
+        def read(self, *args):
+            return b"".join(self._iterator)
 
-#     def data():
-#         yield b"Hello"
-#         yield b"World"
+    def data():
+        yield b"Hello"
+        yield b"World"
 
-#     fileobj = IteratorIO(data())
-#     files = {"file": fileobj}
-#     request = HttpRequest(
-#         "POST",
-#         "/multipart/non-seekable-filelike",
-#         files=files,
-#     )
-#     await send_request(request, transport())
+    fileobj = IteratorIO(data())
+    files = {"file": fileobj}
+    request = HttpRequest(
+        "POST",
+        "/multipart/non-seekable-filelike",
+        files=files,
+    )
+    await send_request(request, transport())
 
 
 def test_initialize_response_abc():

--- a/sdk/core/corehttp/tests/testserver_tests/coretestserver/coretestserver/test_routes/multipart.py
+++ b/sdk/core/corehttp/tests/testserver_tests/coretestserver/coretestserver/test_routes/multipart.py
@@ -25,12 +25,10 @@ def basic():
     assert_with_message("content type", multipart_header_start, request.content_type[: len(multipart_header_start)])
     if request.files:
         # aiohttp
-        assert_with_message("content length", 228, request.content_length)
         assert_with_message("num files", 1, len(request.files))
         assert_with_message("has file named fileContent", True, bool(request.files.get("fileContent")))
         file_content = request.files["fileContent"]
         assert_with_message("file content type", "application/octet-stream", file_content.content_type)
-        assert_with_message("file content length", 14, file_content.content_length)
         assert_with_message("filename", "fileContent", file_content.filename)
         assert_with_message(
             "has content disposition header", True, bool(file_content.headers.get("Content-Disposition"))
@@ -42,7 +40,6 @@ def basic():
         )
     elif request.form:
         # requests
-        assert_with_message("content length", 184, request.content_length)
         assert_with_message("fileContent", "<file content>", request.form["fileContent"])
     else:
         return Response(status=400)  # should be either of these
@@ -58,7 +55,6 @@ def data_and_files():
         assert_with_message("message", "Hello, world!", request.form["message"])
         file_content = request.files["fileContent"]
         assert_with_message("file content type", "application/octet-stream", file_content.content_type)
-        assert_with_message("file content length", 14, file_content.content_length)
         assert_with_message("filename", "fileContent", file_content.filename)
         assert_with_message(
             "has content disposition header", True, bool(file_content.headers.get("Content-Disposition"))
@@ -93,17 +89,15 @@ def non_seekable_filelike():
         # aiohttp
         len_files = len(request.files)
         assert_with_message("num files", 1, len_files)
-        # assert_with_message("content length", 258, request.content_length)
         assert_with_message("num files", 1, len(request.files))
         assert_with_message("has file named file", True, bool(request.files.get("file")))
         file = request.files["file"]
         assert_with_message("file content type", "application/octet-stream", file.content_type)
-        assert_with_message("file content length", 14, file.content_length)
         assert_with_message("filename", "file", file.filename)
         assert_with_message("has content disposition header", True, bool(file.headers.get("Content-Disposition")))
         assert_with_message(
             "content disposition",
-            'form-data; name="fileContent"; filename="fileContent"; filename*=utf-8\'\'fileContent',
+            'form-data; name="file"; filename="file"',
             file.headers["Content-Disposition"],
         )
     elif request.form:


### PR DESCRIPTION
Aiohttp now doesn't set payload `Content-Length` headers in `multipart/form-data` requests. The motivation was to conform to this RFC: https://datatracker.ietf.org/doc/html/rfc7578#section-4.8 where the Content-Length header is not allowed.

Let's stop checking content length in the test server assertions to stop pipeline test failures. This also enables some multipart tests that were commented out.

Closes: https://github.com/Azure/azure-sdk-for-python/issues/35220