### PR TITLE
[CognitiveLanguage] Update tests

### DIFF
--- a/sdk/cognitivelanguage/azure-ai-language-questionanswering/assets.json
+++ b/sdk/cognitivelanguage/azure-ai-language-questionanswering/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "python",
   "TagPrefix": "python/cognitivelanguage/azure-ai-language-questionanswering",
-  "Tag": "python/cognitivelanguage/azure-ai-language-questionanswering_bc3330c503"
+  "Tag": "python/cognitivelanguage/azure-ai-language-questionanswering_936ab500e0"
 }

--- a/sdk/cognitivelanguage/azure-ai-language-questionanswering/tests/test_query_knowledgebase.py
+++ b/sdk/cognitivelanguage/azure-ai-language-questionanswering/tests/test_query_knowledgebase.py
@@ -254,7 +254,7 @@ class TestQnAKnowledgeBase(QuestionAnsweringTestCase):
         query_params = {
             "question": "How long should my Surface battery last?",
             "top": 3,
-            "userId": "sd53lsY=",
+            "userId": "Sanitized",
             "confidenceScoreThreshold": 0.2,
             "answerSpanRequest": {
                 "enable": True,
@@ -284,7 +284,7 @@ class TestQnAKnowledgeBase(QuestionAnsweringTestCase):
                 deployment_name='test',
                 question="How long should my Surface battery last?",
                 top=3,
-                user_id="sd53lsY=",
+                user_id="Sanitized",
                 confidence_threshold=0.2,
                 short_answer_options=ShortAnswerOptions(
                     confidence_threshold=0.2,
@@ -304,7 +304,7 @@ class TestQnAKnowledgeBase(QuestionAnsweringTestCase):
             query_params = AnswersOptions(
                 question="How long should my Surface battery last?",
                 top=3,
-                user_id="sd53lsY=",
+                user_id="Sanitized",
                 confidence_threshold=0.2,
                 short_answer_options=ShortAnswerOptions(
                     confidence_threshold=0.2,
@@ -325,7 +325,7 @@ class TestQnAKnowledgeBase(QuestionAnsweringTestCase):
             query_params = AnswersOptions(
                 question="How long it takes to charge Surface?",
                 top=3,
-                user_id="sd53lsY=",
+                user_id="Sanitized",
                 confidence_threshold=0.2,
                 answer_context=KnowledgeBaseAnswerContext(
                     previous_question="How long should my Surface battery last?",

--- a/sdk/cognitivelanguage/azure-ai-language-questionanswering/tests/test_query_knowledgebase_async.py
+++ b/sdk/cognitivelanguage/azure-ai-language-questionanswering/tests/test_query_knowledgebase_async.py
@@ -259,7 +259,7 @@ class TestQnAKnowledgeBaseAsync(QuestionAnsweringTestCase):
         query_params = {
             "question": "How long should my Surface battery last?",
             "top": 3,
-            "userId": "sd53lsY=",
+            "userId": "Sanitized",
             "confidenceScoreThreshold": 0.2,
             "answerSpanRequest": {
                 "enable": True,
@@ -290,7 +290,7 @@ class TestQnAKnowledgeBaseAsync(QuestionAnsweringTestCase):
                 deployment_name='test',
                 question="How long should my Surface battery last?",
                 top=3,
-                user_id="sd53lsY=",
+                user_id="Sanitized",
                 confidence_threshold=0.2,
                 short_answer_options=ShortAnswerOptions(
                     confidence_threshold=0.2,
@@ -311,7 +311,7 @@ class TestQnAKnowledgeBaseAsync(QuestionAnsweringTestCase):
             query_params = AnswersOptions(
                 question="How long should my Surface battery last?",
                 top=3,
-                user_id="sd53lsY=",
+                user_id="Sanitized",
                 confidence_threshold=0.2,
                 short_answer_options=ShortAnswerOptions(
                     confidence_threshold=0.2,
@@ -332,7 +332,7 @@ class TestQnAKnowledgeBaseAsync(QuestionAnsweringTestCase):
             query_params = AnswersOptions(
                 question="How long it takes to charge Surface?",
                 top=3,
-                user_id="sd53lsY=",
+                user_id="Sanitized",
                 confidence_threshold=0.2,
                 answer_context=KnowledgeBaseAnswerContext(
                     previous_question="How long should my Surface battery last?",

--- a/tools/azure-sdk-tools/devtools_testutils/proxy_startup.py
+++ b/tools/azure-sdk-tools/devtools_testutils/proxy_startup.py
@@ -306,7 +306,7 @@ def set_common_sanitizers() -> None:
         {"json_path": "$..targetResourceId", "value": SANITIZED},
         {"json_path": "$..urlSource", "value": SANITIZED},
         {"json_path": "$..azureBlobSource.containerUrl", "value": SANITIZED},
-        {"json_path": "$..source", "value": SANITIZED},
+        # {"json_path": "$..source", "value": SANITIZED},
         {"json_path": "$..resourceLocation", "value": SANITIZED},
         {"json_path": "Location", "value": SANITIZED},
         {"json_path": "$..to", "value": SANITIZED},


### PR DESCRIPTION
With new central sanitizers in test proxy, some modifications were needed to get the cognitivelanguage pipeline to pass again.

Commenting out the `source` sanitizer has that seems to be causing more headache then help.