### PR TITLE
[Storage] [Blob Changefeed] Fixed next pylint errors in blob changefeed

### DIFF
--- a/sdk/storage/azure-storage-blob-changefeed/azure/storage/blob/changefeed/_change_feed_client.py
+++ b/sdk/storage/azure-storage-blob-changefeed/azure/storage/blob/changefeed/_change_feed_client.py
@@ -33,6 +33,11 @@ class ChangeFeedClient(object):
         - except in the case of AzureSasCredential, where the conflicting SAS tokens will raise a ValueError.
         If using an instance of AzureNamedKeyCredential, "name" should be the storage account name, and "key"
         should be the storage account key.
+    :type credential:
+        ~azure.core.credentials.AzureNamedKeyCredential or
+        ~azure.core.credentials.AzureSasCredential or
+        ~azure.core.credentials.TokenCredential or
+        str or dict[str, str] or None
     :keyword str secondary_hostname:
         The hostname of the secondary endpoint.
     :keyword int max_single_get_size:
@@ -79,7 +84,11 @@ class ChangeFeedClient(object):
             Credentials provided here will take precedence over those in the connection string.
             If using an instance of AzureNamedKeyCredential, "name" should be the storage account name, and "key"
             should be the storage account key.
-        :paramtype credential: Optional[Union[str, Dict[str, str], "AzureNamedKeyCredential", "AzureSasCredential", "TokenCredential"]] = None,  # pylint: disable=line-too-long
+        :type credential:
+            ~azure.core.credentials.AzureNamedKeyCredential or
+            ~azure.core.credentials.AzureSasCredential or
+            ~azure.core.credentials.TokenCredential or
+            str or dict[str, str] or None
         :returns: A change feed client.
         :rtype: ~azure.storage.blob.changefeed.ChangeFeedClient
 


### PR DESCRIPTION
Fixed all `next pylint` errors version 3.0.3 in `azure-storage-blob-changefeed` except for `docstring-keyword-should-match-keyword-only`. This is the fix for issue https://github.com/Azure/azure-sdk-for-python/issues/32645