### PR TITLE
[Storage] Implement CRC64 support for single upload Blob APIs

### DIFF
--- a/sdk/storage/azure-storage-blob/assets.json
+++ b/sdk/storage/azure-storage-blob/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "python",
   "TagPrefix": "python/storage/azure-storage-blob",
-  "Tag": "python/storage/azure-storage-blob_bf50be897d"
+  "Tag": "python/storage/azure-storage-blob_fe4595d522"
 }

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_client.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_client.py
@@ -27,10 +27,14 @@ from ._shared.uploads_async import AsyncIterStreamer
 from ._shared.request_handlers import (
     add_metadata_headers,
     get_length,
-    read_length,
     validate_and_format_range_headers)
 from ._shared.response_handlers import return_response_headers, process_storage_error, return_headers_and_deserialized
-from ._shared.validation import ChecksumAlgorithm, parse_validation_option, SM_HEADER_V1_CRC64
+from ._shared.validation import (
+    calculate_crc64,
+    calculate_md5,
+    ChecksumAlgorithm,
+    parse_validation_option,
+    SM_HEADER_V1_CRC64)
 from ._generated import AzureBlobStorage
 from ._generated.models import (
     DeleteSnapshotsOptionType,
@@ -3524,22 +3528,23 @@ class BlobClient(StorageAccountHostsMixin, StorageEncryptionMixin):  # pylint: d
         except HttpResponseError as error:
             process_storage_error(error)
 
-    def _upload_page_options( # type: ignore
-            self, page,  # type: bytes
-            offset,  # type: int
-            length,  # type: int
-            **kwargs
-        ):
-        # type: (...) -> Dict[str, Any]
-        if isinstance(page, str):
-            page = page.encode(kwargs.pop('encoding', 'UTF-8'))
+    def _upload_page_options(
+        self, page: Union[bytes, str],
+        offset: int,
+        length: int,
+        **kwargs: Any
+    ) -> Dict[str, Any]:
         if self.require_encryption or (self.key_encryption_key is not None):
             raise ValueError(_ERROR_UNSUPPORTED_METHOD_FOR_ENCRYPTION)
-
         if offset is None or offset % 512 != 0:
             raise ValueError("offset must be an integer that aligns with 512 page size")
         if length is None or length % 512 != 0:
             raise ValueError("length must be an integer that aligns with 512 page size")
+
+        if isinstance(page, str):
+            page = page.encode(kwargs.pop('encoding', 'UTF-8'))
+        page = page[:length]
+
         end_range = offset + length - 1  # Reformat to an inclusive range index
         content_range = f'bytes={offset}-{end_range}' # type: ignore
         access_conditions = get_access_conditions(kwargs.pop('lease', None))
@@ -3550,7 +3555,6 @@ class BlobClient(StorageAccountHostsMixin, StorageEncryptionMixin):  # pylint: d
         )
         mod_conditions = get_modify_conditions(kwargs)
         cpk_scope_info = get_cpk_scope_info(kwargs)
-        validate_content = kwargs.pop('validate_content', False)
         cpk = kwargs.pop('cpk', None)
         cpk_info = None
         if cpk:
@@ -3558,10 +3562,19 @@ class BlobClient(StorageAccountHostsMixin, StorageEncryptionMixin):  # pylint: d
                 raise ValueError("Customer provided encryption key must be used over HTTPS.")
             cpk_info = CpkInfo(encryption_key=cpk.key_value, encryption_key_sha256=cpk.key_hash,
                                encryption_algorithm=cpk.algorithm)
+
+        validate_content = parse_validation_option(kwargs.pop('validate_content', None))
+        content_md5, content_crc64 = None, None
+        if validate_content == ChecksumAlgorithm.MD5:
+            content_md5 = calculate_md5(page)
+        elif validate_content == ChecksumAlgorithm.CRC64:
+            content_crc64 = calculate_crc64(page, 0)
+
         options = {
-            'body': page[:length],
+            'body': page,
             'content_length': length,
-            'transactional_content_md5': None,
+            'transactional_content_md5': content_md5,
+            'transactional_content_crc64': content_crc64,
             'timeout': kwargs.pop('timeout', None),
             'range': content_range,
             'lease_access_conditions': access_conditions,
@@ -3575,17 +3588,17 @@ class BlobClient(StorageAccountHostsMixin, StorageEncryptionMixin):  # pylint: d
         return options
 
     @distributed_trace
-    def upload_page( # type: ignore
-            self, page,  # type: bytes
-            offset,  # type: int
-            length,  # type: int
-            **kwargs
-        ):
-        # type: (...) -> Dict[str, Union[str, datetime]]
+    def upload_page(
+        self, page: Union[bytes, str],
+        offset: int,
+        length: int,
+        **kwargs: Any
+    ) -> Dict[str, Union[str, "datetime"]]:
         """The Upload Pages operation writes a range of pages to a page blob.
 
-        :param bytes page:
+        :param page:
             Content of the page.
+        :type page: bytes or str
         :param int offset:
             Start of byte range to use for writing to a section of the blob.
             Pages must be aligned with 512-byte boundaries, the start offset
@@ -3600,13 +3613,25 @@ class BlobClient(StorageAccountHostsMixin, StorageEncryptionMixin):  # pylint: d
             Required if the blob has an active lease. Value can be a BlobLeaseClient object
             or the lease ID as a string.
         :paramtype lease: ~azure.storage.blob.BlobLeaseClient or str
-        :keyword bool validate_content:
-            If true, calculates an MD5 hash of the page content. The storage
-            service checks the hash of the content that has arrived
-            with the hash that was sent. This is primarily valuable for detecting
-            bitflips on the wire if using http instead of https, as https (the default),
-            will already validate. Note that this MD5 hash is not stored with the
-            blob.
+        :keyword validate_content:
+            Enables checksum validation for the transfer. Any hash calculated is NOT stored with the blob.
+            The possible options for content validation are as follows:
+
+            bool - Passing a boolean is now deprecated. Will perform basic checksum validation via a pipeline
+                   policy that calculates an MD5 hash for each request body and sends it to the service to verify
+                   it matches. This is primarily valuable for detecting bit-flips on the wire if using http instead
+                   of https. If using this option, the memory-efficient upload algorithm will not be used.
+            'auto' - Allows the SDK to choose the best checksum algorithm to use. Currently, chooses 'crc64'.
+            'crc64' - This is currently the preferred choice for performance reasons and the level of validation.
+                      Performs validation using Azure Storage's specific implementation of CRC64 with a custom
+                      polynomial. This also uses a more sophisticated algorithm internally that may help catch
+                      client-side data integrity issues.
+
+                      NOTE: This requires the `azure-storage-extensions` package to be installed.
+            'md5' - Performs validation using MD5. Where available this may use a more sophisticated algorithm
+                    internally that may help catch client-side data integrity issues (similar to 'crc64') but it is
+                    not possible in all scenarios and may revert to the naive approach of using a pipeline policy.
+        :paramtype validate_content: Literal['auto', 'crc64', 'md5']
         :keyword int if_sequence_number_lte:
             If the blob's sequence number is less than or equal to
             the specified value, the request proceeds; otherwise it fails.

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_client.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_client.py
@@ -2492,7 +2492,7 @@ class BlobClient(StorageAccountHostsMixin, StorageEncryptionMixin):  # pylint: d
         data, data_length, content_length = prepare_upload_data(data, encoding, length, validate_content)
 
         structured_type, structured_length = None, None
-        if validate_content == 'crc64':
+        if validate_content == ChecksumAlgorithm.CRC64:
             structured_type = SM_HEADER_V1_CRC64
             structured_length = data_length
 
@@ -2512,7 +2512,7 @@ class BlobClient(StorageAccountHostsMixin, StorageEncryptionMixin):  # pylint: d
             'body': data,
             'timeout': kwargs.pop('timeout', None),
             'lease_access_conditions': access_conditions,
-            'validate_content': validate_content if validate_content is True else None,
+            'validate_content': True if validate_content is True or validate_content == ChecksumAlgorithm.MD5 else None,
             'cpk_scope_info': cpk_scope_info,
             'cpk_info': cpk_info,
             'structured_body_type': structured_type,
@@ -3580,7 +3580,7 @@ class BlobClient(StorageAccountHostsMixin, StorageEncryptionMixin):  # pylint: d
             'lease_access_conditions': access_conditions,
             'sequence_number_access_conditions': seq_conditions,
             'modified_access_conditions': mod_conditions,
-            'validate_content': validate_content,
+            'validate_content': validate_content if validate_content is True else None,
             'cpk_scope_info': cpk_scope_info,
             'cpk_info': cpk_info,
             'cls': return_response_headers}
@@ -4001,7 +4001,7 @@ class BlobClient(StorageAccountHostsMixin, StorageEncryptionMixin):  # pylint: d
         data, data_length, content_length = prepare_upload_data(data, encoding, length, validate_content)
 
         structured_type, structured_length = None, None
-        if validate_content == 'crc64':
+        if validate_content == ChecksumAlgorithm.CRC64:
             structured_type = SM_HEADER_V1_CRC64
             structured_length = data_length
 
@@ -4030,7 +4030,7 @@ class BlobClient(StorageAccountHostsMixin, StorageEncryptionMixin):  # pylint: d
             'lease_access_conditions': access_conditions,
             'append_position_access_conditions': append_conditions,
             'modified_access_conditions': mod_conditions,
-            'validate_content': validate_content if validate_content is True else None,
+            'validate_content': True if validate_content is True or validate_content == ChecksumAlgorithm.MD5 else None,
             'cpk_scope_info': cpk_scope_info,
             'cpk_info': cpk_info,
             'structured_body_type': structured_type,

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_client.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_client.py
@@ -30,7 +30,7 @@ from ._shared.request_handlers import (
     validate_and_format_range_headers)
 from ._shared.response_handlers import return_response_headers, process_storage_error, return_headers_and_deserialized
 from ._shared.validation import (
-    calculate_crc64,
+    calculate_crc64_bytes,
     calculate_md5,
     ChecksumAlgorithm,
     parse_validation_option,
@@ -3568,7 +3568,7 @@ class BlobClient(StorageAccountHostsMixin, StorageEncryptionMixin):  # pylint: d
         if validate_content == ChecksumAlgorithm.MD5:
             content_md5 = calculate_md5(page)
         elif validate_content == ChecksumAlgorithm.CRC64:
-            content_crc64 = calculate_crc64(page, 0)
+            content_crc64 = calculate_crc64_bytes(page)
 
         options = {
             'body': page,

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/base_client.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/base_client.py
@@ -80,7 +80,7 @@ class StorageAccountHostsMixin(object):  # pylint: disable=too-many-instance-att
         if service not in ["blob", "queue", "file-share", "dfs"]:
             raise ValueError(f"Invalid service: {service}")
         service_name = service.split('-')[0]
-        account = parsed_url.netloc.split(f".{service_name}.core.")
+        account = parsed_url.netloc.split(f".{service_name}.preprod.core.")
 
         self.account_name = account[0] if len(account) > 1 else None
         if not self.account_name and parsed_url.netloc.startswith("localhost") \

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/base_client.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/base_client.py
@@ -80,7 +80,7 @@ class StorageAccountHostsMixin(object):  # pylint: disable=too-many-instance-att
         if service not in ["blob", "queue", "file-share", "dfs"]:
             raise ValueError(f"Invalid service: {service}")
         service_name = service.split('-')[0]
-        account = parsed_url.netloc.split(f".{service_name}.preprod.core.")
+        account = parsed_url.netloc.split(f".{service_name}.core.")
 
         self.account_name = account[0] if len(account) > 1 else None
         if not self.account_name and parsed_url.netloc.startswith("localhost") \

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/streams.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/streams.py
@@ -11,7 +11,7 @@ from enum import auto, Enum, IntFlag
 from io import BytesIO, IOBase, UnsupportedOperation, SEEK_CUR, SEEK_END, SEEK_SET
 from typing import IO, Optional
 
-from azure.storage.extensions import crc64
+from .validation import calculate_crc64
 
 DEFAULT_MESSAGE_VERSION = 1
 DEFAULT_SEGMENT_SIZE = 4 * 1024 * 1024
@@ -356,8 +356,8 @@ class StructuredMessageEncodeStream(IOBase):
         if StructuredMessageProperties.CRC64 in self.flags:
             if checksum_offset == 0:
                 self._segment_crc64s[self._current_segment_number] = \
-                    crc64.compute_crc64(content, self._segment_crc64s[self._current_segment_number])
-                self._message_crc64 = crc64.compute_crc64(content, self._message_crc64)
+                    calculate_crc64(content, self._segment_crc64s[self._current_segment_number])
+                self._message_crc64 = calculate_crc64(content, self._message_crc64)
 
         self._content_offset += read_size
         # Only update the checksum offset if we've read new data
@@ -462,8 +462,8 @@ class StructuredMessageDecodeStream:
 
             # Update the running CRC64 for the segment and message
             if StructuredMessageProperties.CRC64 in self.flags:
-                self._segment_crc64 = crc64.compute_crc64(segment_content, self._segment_crc64)
-                self._message_crc64 = crc64.compute_crc64(segment_content, self._message_crc64)
+                self._segment_crc64 = calculate_crc64(segment_content, self._segment_crc64)
+                self._message_crc64 = calculate_crc64(segment_content, self._message_crc64)
 
             self._segment_content_offset += read_size
             self._message_offset += read_size

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/uploads.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/uploads.py
@@ -9,18 +9,60 @@ from io import BytesIO, IOBase, SEEK_CUR, SEEK_END, SEEK_SET, UnsupportedOperati
 from itertools import islice
 from math import ceil
 from threading import Lock
-from typing import Optional, Union
+from typing import AnyStr, IO, Iterable, Optional, Tuple, Union
 
 from azure.core.tracing.common import with_current_context
 
 from . import encode_base64, url_quote
-from .request_handlers import get_length
+from .request_handlers import get_length, read_length
 from .response_handlers import return_response_headers
+from .streams import StructuredMessageEncodeStream, StructuredMessageProperties
 from .validation import calculate_crc64, calculate_md5, ChecksumAlgorithm
 
 
 _LARGE_BLOB_UPLOAD_MAX_READ_BUFFER_SIZE = 4 * 1024 * 1024
 _ERROR_VALUE_SHOULD_BE_SEEKABLE_STREAM = "{0} should be a seekable file-like/io.IOBase type stream object."
+
+
+def prepare_upload_data(
+    data: Union[bytes, str, IO[bytes], Iterable[AnyStr]],
+    encoding: str,
+    data_length: Optional[int],
+    validate_content: Union[bool, str, None]
+) -> Tuple[Union[bytes, IO[bytes]], int, int]:
+    # Trim the incoming data per provided length
+    if data_length is not None and isinstance(data, (str, bytes)) and data_length != len(data):
+        data = data[:data_length]
+    # Encode raw string data
+    if isinstance(data, str):
+        data = data.encode(encoding)
+
+    # Attempt to determine length of data if it's not provided
+    if data_length is None:
+        data_length = get_length(data)
+    # If we still can't get the length, read all the data into memory
+    if data_length is None:
+        data_length, data = read_length(data)
+
+    structured_message = validate_content == ChecksumAlgorithm.CRC64
+    if isinstance(data, bytes):
+        # Structured message requires a stream
+        if structured_message:
+            data = BytesIO(data)
+    elif hasattr(data, 'read'):
+        # TODO: Block IO[str] here?
+        pass
+    elif hasattr(data, '__iter__') and not isinstance(data, (list, tuple, set, dict)):
+        data = IterStreamer(data, encoding=encoding)
+    else:
+        raise TypeError(f"Unsupported data type: {type(data)}")
+
+    content_length = data_length
+    if structured_message:
+        data = StructuredMessageEncodeStream(data, data_length, StructuredMessageProperties.CRC64)
+        content_length = len(data)
+
+    return data, data_length, content_length
 
 
 def _parallel_uploads(executor, uploader, pending, running):

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/uploads.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/uploads.py
@@ -17,7 +17,7 @@ from . import encode_base64, url_quote
 from .request_handlers import get_length, read_length
 from .response_handlers import return_response_headers
 from .streams import StructuredMessageEncodeStream, StructuredMessageProperties
-from .validation import calculate_crc64, calculate_md5, ChecksumAlgorithm
+from .validation import calculate_crc64_bytes, calculate_md5, ChecksumAlgorithm
 
 
 _LARGE_BLOB_UPLOAD_MAX_READ_BUFFER_SIZE = 4 * 1024 * 1024
@@ -174,7 +174,7 @@ class ChunkInfo:
         if checksum_algorithm == ChecksumAlgorithm.MD5:
             self.md5 = calculate_md5(self.data)
         if checksum_algorithm == ChecksumAlgorithm.CRC64:
-            self.crc64 = calculate_crc64(self.data, 0)
+            self.crc64 = calculate_crc64_bytes(self.data)
 
 
 class _ChunkUploader(object):  # pylint: disable=too-many-instance-attributes

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/validation.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/validation.py
@@ -60,8 +60,15 @@ def calculate_md5(data: bytes) -> bytes:
     return md5.digest()
 
 
-def calculate_crc64(data: bytes, initial_crc: int) -> bytes:
+def calculate_crc64(data: bytes, initial_crc: int) -> int:
     # Locally import to avoid error if not installed.
     from azure.storage.extensions import crc64
 
-    return crc64.compute_crc64(data, initial_crc).to_bytes(CRC64_LENGTH, 'little')
+    return crc64.compute_crc64(data, initial_crc)
+
+
+def calculate_crc64_bytes(data: bytes) -> bytes:
+    # Locally import to avoid error if not installed.
+    from azure.storage.extensions import crc64
+
+    return crc64.compute_crc64(data, 0).to_bytes(CRC64_LENGTH, 'little')

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/validation.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/validation.py
@@ -3,6 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for
 # license information.
 # --------------------------------------------------------------------------
+from __future__ import annotations
 
 import hashlib
 from enum import Enum
@@ -11,6 +12,7 @@ from typing import Optional, Union
 from azure.core import CaseInsensitiveEnumMeta
 
 CRC64_LENGTH = 8
+SM_HEADER_V1_CRC64 = "XSM/1.0; properties=crc64"
 
 
 class ChecksumAlgorithm(str, Enum, metaclass=CaseInsensitiveEnumMeta):

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_upload_helpers.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_upload_helpers.py
@@ -18,7 +18,7 @@ from ._shared.uploads import (
     PageBlobChunkUploader,
     AppendBlobChunkUploader
 )
-from ._shared.validation import calculate_crc64, calculate_md5, ChecksumAlgorithm
+from ._shared.validation import calculate_crc64_bytes, calculate_md5, ChecksumAlgorithm
 from ._generated.models import (
     BlockLookupList,
     AppendPositionAccessConditions,
@@ -105,7 +105,7 @@ def upload_block_blob(  # pylint: disable=too-many-locals, too-many-statements
                 content_md5 = calculate_md5(data)
             content_crc64 = None
             if validate_content == ChecksumAlgorithm.CRC64:
-                content_crc64 = calculate_crc64(data, 0)
+                content_crc64 = calculate_crc64_bytes(data)
 
             response = client.upload(
                 body=data,

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_blob_client_async.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_blob_client_async.py
@@ -2380,17 +2380,17 @@ class BlobClient(AsyncStorageAccountHostsMixin, BlobClientBase, StorageEncryptio
             process_storage_error(error)
 
     @distributed_trace_async
-    async def upload_page( # type: ignore
-            self, page,  # type: bytes
-            offset,  # type: int
-            length,  # type: int
-            **kwargs
-        ):
-        # type: (...) -> Dict[str, Union[str, datetime]]
+    async def upload_page(
+        self, page: Union[bytes, str],
+        offset: int,
+        length: int,
+        **kwargs: Any
+    ) -> Dict[str, Union[str, "datetime"]]:
         """The Upload Pages operation writes a range of pages to a page blob.
 
-        :param bytes page:
+        :param page:
             Content of the page.
+        :type page: bytes or str
         :param int offset:
             Start of byte range to use for writing to a section of the blob.
             Pages must be aligned with 512-byte boundaries, the start offset
@@ -2405,13 +2405,25 @@ class BlobClient(AsyncStorageAccountHostsMixin, BlobClientBase, StorageEncryptio
             Required if the blob has an active lease. Value can be a BlobLeaseClient object
             or the lease ID as a string.
         :paramtype lease: ~azure.storage.blob.aio.BlobLeaseClient or str
-        :keyword bool validate_content:
-            If true, calculates an MD5 hash of the page content. The storage
-            service checks the hash of the content that has arrived
-            with the hash that was sent. This is primarily valuable for detecting
-            bitflips on the wire if using http instead of https, as https (the default),
-            will already validate. Note that this MD5 hash is not stored with the
-            blob.
+        :keyword validate_content:
+            Enables checksum validation for the transfer. Any hash calculated is NOT stored with the blob.
+            The possible options for content validation are as follows:
+
+            bool - Passing a boolean is now deprecated. Will perform basic checksum validation via a pipeline
+                   policy that calculates an MD5 hash for each request body and sends it to the service to verify
+                   it matches. This is primarily valuable for detecting bit-flips on the wire if using http instead
+                   of https. If using this option, the memory-efficient upload algorithm will not be used.
+            'auto' - Allows the SDK to choose the best checksum algorithm to use. Currently, chooses 'crc64'.
+            'crc64' - This is currently the preferred choice for performance reasons and the level of validation.
+                      Performs validation using Azure Storage's specific implementation of CRC64 with a custom
+                      polynomial. This also uses a more sophisticated algorithm internally that may help catch
+                      client-side data integrity issues.
+
+                      NOTE: This requires the `azure-storage-extensions` package to be installed.
+            'md5' - Performs validation using MD5. Where available this may use a more sophisticated algorithm
+                    internally that may help catch client-side data integrity issues (similar to 'crc64') but it is
+                    not possible in all scenarios and may revert to the naive approach of using a pipeline policy.
+        :paramtype validate_content: Literal['auto', 'crc64', 'md5']
         :keyword int if_sequence_number_lte:
             If the blob's sequence number is less than or equal to
             the specified value, the request proceeds; otherwise it fails.

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_blob_client_async.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_blob_client_async.py
@@ -2671,12 +2671,11 @@ class BlobClient(AsyncStorageAccountHostsMixin, BlobClientBase, StorageEncryptio
             process_storage_error(error)
 
     @distributed_trace_async
-    async def append_block( # type: ignore
-            self, data,  # type: Union[bytes, str, Iterable[AnyStr], IO[AnyStr]]
-            length=None,  # type: Optional[int]
-            **kwargs
-        ):
-        # type: (...) -> Dict[str, Union[str, datetime, int]]
+    async def append_block(
+        self, data: Union[bytes, str, Iterable[AnyStr], IO[bytes]],
+        length: Optional[int] = None,
+        **kwargs: Any
+    ) -> Dict[str, Any]:
         """Commits a new block of data to the end of the existing append blob.
 
         :param data:
@@ -2684,13 +2683,25 @@ class BlobClient(AsyncStorageAccountHostsMixin, BlobClientBase, StorageEncryptio
         :type data: Union[bytes, str, Iterable[AnyStr], IO[AnyStr]]
         :param int length:
             Size of the block in bytes.
-        :keyword bool validate_content:
-            If true, calculates an MD5 hash of the block content. The storage
-            service checks the hash of the content that has arrived
-            with the hash that was sent. This is primarily valuable for detecting
-            bitflips on the wire if using http instead of https, as https (the default),
-            will already validate. Note that this MD5 hash is not stored with the
-            blob.
+        :keyword validate_content:
+            Enables checksum validation for the transfer. Any hash calculated is NOT stored with the blob.
+            The possible options for content validation are as follows:
+
+            bool - Passing a boolean is now deprecated. Will perform basic checksum validation via a pipeline
+                   policy that calculates an MD5 hash for each request body and sends it to the service to verify
+                   it matches. This is primarily valuable for detecting bit-flips on the wire if using http instead
+                   of https. If using this option, the memory-efficient upload algorithm will not be used.
+            'auto' - Allows the SDK to choose the best checksum algorithm to use. Currently, chooses 'crc64'.
+            'crc64' - This is currently the preferred choice for performance reasons and the level of validation.
+                      Performs validation using Azure Storage's specific implementation of CRC64 with a custom
+                      polynomial. This also uses a more sophisticated algorithm internally that may help catch
+                      client-side data integrity issues.
+
+                      NOTE: This requires the `azure-storage-extensions` package to be installed.
+            'md5' - Performs validation using MD5. Where available this may use a more sophisticated algorithm
+                    internally that may help catch client-side data integrity issues (similar to 'crc64') but it is
+                    not possible in all scenarios and may revert to the naive approach of using a pipeline policy.
+        :paramtype validate_content: Literal['auto', 'crc64', 'md5']
         :keyword int maxsize_condition:
             Optional conditional header. The max length in bytes permitted for
             the append blob. If the Append Block operation would cause the blob

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_blob_client_async.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_blob_client_async.py
@@ -1597,12 +1597,11 @@ class BlobClient(AsyncStorageAccountHostsMixin, BlobClientBase, StorageEncryptio
 
     @distributed_trace_async
     async def stage_block(
-            self, block_id,  # type: str
-            data,  # type: Union[Iterable[AnyStr], IO[AnyStr]]
-            length=None,  # type: Optional[int]
-            **kwargs
-        ):
-        # type: (...) -> Dict[str, Any]
+        self, block_id: str,
+        data: Union[bytes, str, Iterable[AnyStr], IO[bytes]],
+        length: Optional[int] = None,
+        **kwargs: Any
+    ) -> Dict[str, Any]:
         """Creates a new block to be committed as part of a blob.
 
         :param str block_id: A string value that identifies the block.
@@ -1611,15 +1610,25 @@ class BlobClient(AsyncStorageAccountHostsMixin, BlobClientBase, StorageEncryptio
         :param data: The blob data.
         :type data: Union[Iterable[AnyStr], IO[AnyStr]]
         :param int length: Size of the block.
-        :keyword bool validate_content:
-            If true, calculates an MD5 hash for each chunk of the blob. The storage
-            service checks the hash of the content that has arrived with the hash
-            that was sent. This is primarily valuable for detecting bitflips on
-            the wire if using http instead of https, as https (the default), will
-            already validate. Note that this MD5 hash is not stored with the
-            blob. Also note that if enabled, the memory-efficient upload algorithm
-            will not be used because computing the MD5 hash requires buffering
-            entire blocks, and doing so defeats the purpose of the memory-efficient algorithm.
+        :keyword validate_content:
+            Enables checksum validation for the transfer. Any hash calculated is NOT stored with the blob.
+            The possible options for content validation are as follows:
+
+            bool - Passing a boolean is now deprecated. Will perform basic checksum validation via a pipeline
+                   policy that calculates an MD5 hash for each request body and sends it to the service to verify
+                   it matches. This is primarily valuable for detecting bit-flips on the wire if using http instead
+                   of https. If using this option, the memory-efficient upload algorithm will not be used.
+            'auto' - Allows the SDK to choose the best checksum algorithm to use. Currently, chooses 'crc64'.
+            'crc64' - This is currently the preferred choice for performance reasons and the level of validation.
+                      Performs validation using Azure Storage's specific implementation of CRC64 with a custom
+                      polynomial. This also uses a more sophisticated algorithm internally that may help catch
+                      client-side data integrity issues.
+
+                      NOTE: This requires the `azure-storage-extensions` package to be installed.
+            'md5' - Performs validation using MD5. Where available this may use a more sophisticated algorithm
+                    internally that may help catch client-side data integrity issues (similar to 'crc64') but it is
+                    not possible in all scenarios and may revert to the naive approach of using a pipeline policy.
+        :paramtype validate_content: Literal['auto', 'crc64', 'md5']
         :keyword lease:
             Required if the blob has an active lease. Value can be a BlobLeaseClient object
             or the lease ID as a string.

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_upload_helpers.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_upload_helpers.py
@@ -18,7 +18,7 @@ from .._shared.uploads_async import (
     PageBlobChunkUploader,
     AppendBlobChunkUploader
 )
-from .._shared.validation import ChecksumAlgorithm, calculate_crc64, calculate_md5
+from .._shared.validation import calculate_crc64_bytes, calculate_md5, ChecksumAlgorithm
 from .._generated.models import (
     BlockLookupList,
     AppendPositionAccessConditions,
@@ -83,7 +83,7 @@ async def upload_block_blob(  # pylint: disable=too-many-locals, too-many-statem
                 content_md5 = calculate_md5(data)
             content_crc64 = None
             if validate_content == ChecksumAlgorithm.CRC64:
-                content_crc64 = calculate_crc64(data, 0)
+                content_crc64 = calculate_crc64_bytes(data)
 
             response = await client.upload(
                 body=data,

--- a/sdk/storage/azure-storage-blob/tests/test_content_validation.py
+++ b/sdk/storage/azure-storage-blob/tests/test_content_validation.py
@@ -267,7 +267,7 @@ class TestStorageContentValidation(StorageRecordedTestCase):
         self._setup(storage_account_name, storage_account_key)
         blob = self.container.get_blob_client(self._get_blob_reference())
 
-        content = b'abc' * 1030  # 3 KiB + 18
+        content = b'abcde' * 1030  # 5 KiB + 30
         byte_io = BytesIO(content)
 
         def generator():

--- a/sdk/storage/azure-storage-blob/tests/test_content_validation.py
+++ b/sdk/storage/azure-storage-blob/tests/test_content_validation.py
@@ -8,6 +8,7 @@ from io import BytesIO
 
 import pytest
 from azure.storage.blob import (
+    BlobBlock,
     BlobClient,
     BlobServiceClient,
     BlobType,
@@ -18,6 +19,7 @@ from devtools_testutils.storage import StorageRecordedTestCase
 from settings.testcase import BlobPreparer
 
 from encryption_test_helper import KeyWrapper
+from test_helpers import GenericTestProxyParametrize1
 
 
 def assert_content_md5(request):
@@ -210,3 +212,82 @@ class TestStorageContentValidation(StorageRecordedTestCase):
         assert resp1
         assert resp2
         assert resp3
+
+    @BlobPreparer()
+    @pytest.mark.parametrize('a', [True, 'md5', 'crc64'])  # a: validate_content
+    @GenericTestProxyParametrize1()
+    @recorded_by_proxy
+    def test_stage_block(self, a, **kwargs):
+        storage_account_name = kwargs.pop("storage_account_name")
+        storage_account_key = kwargs.pop("storage_account_key")
+
+        self._setup(storage_account_name, storage_account_key)
+        blob = self.container.get_blob_client(self._get_blob_reference())
+        data1 = b'abc' * 512
+        data2 = '你好世界' * 10
+
+        # Act
+        blob.stage_block('1', data1, validate_content=a)
+        blob.stage_block('2', data2, encoding='utf-8-sig', validate_content=a)
+        blob.commit_block_list([BlobBlock('1'), BlobBlock('2')])
+
+        # Assert
+        content = blob.download_blob()
+        assert content.readall() == data1 + data2.encode('utf-8-sig')
+
+    @BlobPreparer()
+    @pytest.mark.parametrize('a', [True, 'md5', 'crc64'])  # a: validate_content
+    @pytest.mark.live_test_only
+    def test_stage_block_large(self, a, **kwargs):
+        storage_account_name = kwargs.pop("storage_account_name")
+        storage_account_key = kwargs.pop("storage_account_key")
+
+        self._setup(storage_account_name, storage_account_key)
+        blob = self.container.get_blob_client(self._get_blob_reference())
+        data1 = b'abcde' * 1024 * 1024  # 5 MiB
+        data2 = b'12345' * 1024 * 1024 + b'abcdefg'  # 10 MiB + 7
+
+        # Act
+        blob.stage_block('1', data1, validate_content=a)
+        blob.stage_block('2', data2, encoding='utf-8-sig', validate_content=a)
+        blob.commit_block_list([BlobBlock('1'), BlobBlock('2')])
+
+        # Assert
+        content = blob.download_blob()
+        assert content.readall() == data1 + data2
+
+    @BlobPreparer()
+    @pytest.mark.parametrize('a', [True, 'md5', 'crc64'])  # a: validate_content
+    @GenericTestProxyParametrize1()
+    @recorded_by_proxy
+    def test_stage_block_data_types(self, a, **kwargs):
+        storage_account_name = kwargs.pop("storage_account_name")
+        storage_account_key = kwargs.pop("storage_account_key")
+
+        self._setup(storage_account_name, storage_account_key)
+        blob = self.container.get_blob_client(self._get_blob_reference())
+
+        content = b'abc' * 1030  # 3 KiB + 18
+        byte_io = BytesIO(content)
+
+        def generator():
+            for i in range(0, len(content), 500):
+                yield content[i: i + 500]
+
+        # TODO: Fix Iterable[str]? (Or just require length)
+        # def text_generator():
+        #     s_content = str(content, encoding='utf-8')
+        #     for i in range(0, len(s_content), 500):
+        #         yield s_content[i: i + 500]
+
+        data_list = [byte_io, generator()]
+
+        blocks = []
+        for j in range(len(data_list)):
+            blob.stage_block(str(j), data_list[j], validate_content=a)
+            blocks.append(BlobBlock(str(j)))
+        blob.commit_block_list(blocks)
+
+        # Assert
+        result = blob.download_blob()
+        assert result.readall() == content * 2

--- a/sdk/storage/azure-storage-blob/tests/test_content_validation.py
+++ b/sdk/storage/azure-storage-blob/tests/test_content_validation.py
@@ -23,26 +23,18 @@ from test_helpers import GenericTestProxyParametrize1
 
 
 def assert_content_md5(request):
-    if request.http_request.query.get('comp') in ('block', 'page'):
-        assert request.http_request.headers.get('Content-MD5')
+    if request.http_request.query.get('comp') in ('block', 'page') or request.http_request.headers.get('x-ms-blob-type') == 'BlockBlob':
+        assert request.http_request.headers.get('Content-MD5') is not None
 
 
 def assert_content_crc64(request):
-    if request.http_request.query.get('comp') in ('block', 'page'):
-        assert request.http_request.headers.get('x-ms-content-crc64')
+    if request.http_request.query.get('comp') in ('block', 'page') or request.http_request.headers.get('x-ms-blob-type') == 'BlockBlob':
+        assert request.http_request.headers.get('x-ms-content-crc64') is not None
 
 
 def assert_structured_message(request):
-    if request.http_request.query.get('comp') in ('block', 'page'):
-        assert request.http_request.headers.get('x-ms-structured-body')
-
-
-class BlobTypeParameterize:
-    def __call__(self, fn):
-        # _wrapper accepts the `a` and `b` arguments we want to parametrize with
-        def _wrapper(test_class, blob_type, **kwargs):
-            fn(test_class, blob_type, **kwargs)
-        return _wrapper
+    if request.http_request.query.get('comp') in ('block', 'page') or request.http_request.headers.get('x-ms-blob-type') == 'BlockBlob':
+        assert request.http_request.headers.get('x-ms-structured-body') is not None
 
 
 class TestStorageContentValidation(StorageRecordedTestCase):
@@ -83,10 +75,10 @@ class TestStorageContentValidation(StorageRecordedTestCase):
             blob.upload_blob(b'123', validate_content='crc64')
 
     @BlobPreparer()
-    @pytest.mark.parametrize('blob_type', [BlobType.BLOCKBLOB, BlobType.PAGEBLOB, BlobType.APPENDBLOB])
-    @BlobTypeParameterize()
+    @pytest.mark.parametrize('a', [BlobType.BLOCKBLOB, BlobType.PAGEBLOB, BlobType.APPENDBLOB])  # a: blob_type
+    @GenericTestProxyParametrize1()
     @recorded_by_proxy
-    def test_upload_blob_legacy_bool(self, blob_type, **kwargs):
+    def test_upload_blob_legacy_bool(self, a, **kwargs):
         storage_account_name = kwargs.pop("storage_account_name")
         storage_account_key = kwargs.pop("storage_account_key")
 
@@ -95,16 +87,16 @@ class TestStorageContentValidation(StorageRecordedTestCase):
         data = b'abc' * 512
 
         # Act
-        response = blob.upload_blob(data, blob_type, validate_content=True, raw_request_hook=assert_content_md5)
+        response = blob.upload_blob(data, a, validate_content=True, raw_request_hook=assert_content_md5)
 
         # Assert
         assert response
 
     @BlobPreparer()
-    @pytest.mark.parametrize('blob_type', [BlobType.BLOCKBLOB, BlobType.PAGEBLOB, BlobType.APPENDBLOB])
-    @BlobTypeParameterize()
+    @pytest.mark.parametrize('a', [BlobType.BLOCKBLOB, BlobType.PAGEBLOB, BlobType.APPENDBLOB])  # a: blob_type
+    @GenericTestProxyParametrize1()
     @recorded_by_proxy
-    def test_upload_blob_legacy_bool_chunks(self, blob_type, **kwargs):
+    def test_upload_blob_legacy_bool_chunks(self, a, **kwargs):
         storage_account_name = kwargs.pop("storage_account_name")
         storage_account_key = kwargs.pop("storage_account_key")
 
@@ -115,16 +107,16 @@ class TestStorageContentValidation(StorageRecordedTestCase):
         data = b'abc' * 512
 
         # Act
-        response = blob.upload_blob(data, blob_type, validate_content=True, raw_request_hook=assert_content_md5)
+        response = blob.upload_blob(data, a, validate_content=True, raw_request_hook=assert_content_md5)
 
         # Assert
         assert response
 
     @BlobPreparer()
-    @pytest.mark.parametrize('blob_type', [BlobType.BLOCKBLOB, BlobType.PAGEBLOB, BlobType.APPENDBLOB])
-    @BlobTypeParameterize()
+    @pytest.mark.parametrize('a', [BlobType.BLOCKBLOB, BlobType.PAGEBLOB, BlobType.APPENDBLOB])  # a: blob_type
+    @GenericTestProxyParametrize1()
     @recorded_by_proxy
-    def test_upload_blob_md5(self, blob_type, **kwargs):
+    def test_upload_blob_md5(self, a, **kwargs):
         storage_account_name = kwargs.pop("storage_account_name")
         storage_account_key = kwargs.pop("storage_account_key")
 
@@ -133,16 +125,16 @@ class TestStorageContentValidation(StorageRecordedTestCase):
         data = b'abc' * 512
 
         # Act
-        response = blob.upload_blob(data, blob_type, validate_content='md5', raw_request_hook=assert_content_md5)
+        response = blob.upload_blob(data, a, validate_content='md5', raw_request_hook=assert_content_md5)
 
         # Assert
         assert response
 
     @BlobPreparer()
-    @pytest.mark.parametrize('blob_type', [BlobType.BLOCKBLOB, BlobType.PAGEBLOB, BlobType.APPENDBLOB])
-    @BlobTypeParameterize()
+    @pytest.mark.parametrize('a', [BlobType.BLOCKBLOB, BlobType.PAGEBLOB, BlobType.APPENDBLOB])  # a: blob_type
+    @GenericTestProxyParametrize1()
     @recorded_by_proxy
-    def test_upload_blob_md5_chunks(self, blob_type, **kwargs):
+    def test_upload_blob_md5_chunks(self, a, **kwargs):
         storage_account_name = kwargs.pop("storage_account_name")
         storage_account_key = kwargs.pop("storage_account_key")
 
@@ -153,16 +145,16 @@ class TestStorageContentValidation(StorageRecordedTestCase):
         data = b'abc' * 512
 
         # Act
-        response = blob.upload_blob(data, blob_type, validate_content='md5', raw_request_hook=assert_content_md5)
+        response = blob.upload_blob(data, a, validate_content='md5', raw_request_hook=assert_content_md5)
 
         # Assert
         assert response
 
     @BlobPreparer()
-    @pytest.mark.parametrize('blob_type', [BlobType.BLOCKBLOB, BlobType.PAGEBLOB, BlobType.APPENDBLOB])
-    @BlobTypeParameterize()
+    @pytest.mark.parametrize('a', [BlobType.BLOCKBLOB, BlobType.PAGEBLOB, BlobType.APPENDBLOB])  # a: blob_type
+    @GenericTestProxyParametrize1()
     @recorded_by_proxy
-    def test_upload_blob_crc64(self, blob_type, **kwargs):
+    def test_upload_blob_crc64(self, a, **kwargs):
         storage_account_name = kwargs.pop("storage_account_name")
         storage_account_key = kwargs.pop("storage_account_key")
 
@@ -175,11 +167,11 @@ class TestStorageContentValidation(StorageRecordedTestCase):
         stream = BytesIO(byte_data)
 
         # Act
-        resp1 = blob.upload_blob(byte_data, blob_type, overwrite=True, validate_content='crc64',
+        resp1 = blob.upload_blob(byte_data, a, overwrite=True, validate_content='crc64',
                                  raw_request_hook=assert_content_crc64)
-        resp2 = blob.upload_blob(str_data, blob_type, overwrite=True, validate_content='crc64',
+        resp2 = blob.upload_blob(str_data, a, overwrite=True, validate_content='crc64',
                                  raw_request_hook=assert_content_crc64)
-        resp3 = blob.upload_blob(stream, blob_type, overwrite=True, validate_content='crc64',
+        resp3 = blob.upload_blob(stream, a, overwrite=True, validate_content='crc64',
                                  raw_request_hook=assert_content_crc64)
 
         # Assert
@@ -188,10 +180,10 @@ class TestStorageContentValidation(StorageRecordedTestCase):
         assert resp3
 
     @BlobPreparer()
-    @pytest.mark.parametrize('blob_type', [BlobType.BLOCKBLOB, BlobType.PAGEBLOB, BlobType.APPENDBLOB])
-    @BlobTypeParameterize()
+    @pytest.mark.parametrize('a', [BlobType.BLOCKBLOB, BlobType.PAGEBLOB, BlobType.APPENDBLOB])  # a: blob_type
+    @GenericTestProxyParametrize1()
     @recorded_by_proxy
-    def test_upload_blob_crc64_chunks(self, blob_type, **kwargs):
+    def test_upload_blob_crc64_chunks(self, a, **kwargs):
         storage_account_name = kwargs.pop("storage_account_name")
         storage_account_key = kwargs.pop("storage_account_key")
 
@@ -206,11 +198,11 @@ class TestStorageContentValidation(StorageRecordedTestCase):
         stream = BytesIO(byte_data)
 
         # Act
-        resp1 = blob.upload_blob(byte_data, blob_type, overwrite=True, validate_content='crc64',
+        resp1 = blob.upload_blob(byte_data, a, overwrite=True, validate_content='crc64',
                                  raw_request_hook=assert_content_crc64)
-        resp2 = blob.upload_blob(str_data, blob_type, overwrite=True, validate_content='crc64',
+        resp2 = blob.upload_blob(str_data, a, overwrite=True, validate_content='crc64',
                                  raw_request_hook=assert_content_crc64)
-        resp3 = blob.upload_blob(stream, blob_type, overwrite=True, validate_content='crc64',
+        resp3 = blob.upload_blob(stream, a, overwrite=True, validate_content='crc64',
                                  raw_request_hook=assert_content_crc64)
 
         # Assert

--- a/sdk/storage/azure-storage-blob/tests/test_content_validation_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_content_validation_async.py
@@ -22,14 +22,6 @@ from test_content_validation import assert_content_crc64, assert_content_md5, as
 from test_helpers_async import GenericTestProxyParametrize1
 
 
-class BlobTypeParameterize:
-    def __call__(self, fn):
-        # _wrapper accepts the `a` and `b` arguments we want to parametrize with
-        async def _wrapper(test_class, blob_type, **kwargs):
-            await fn(test_class, blob_type, **kwargs)
-        return _wrapper
-
-
 class TestStorageContentValidationAsync(AsyncStorageRecordedTestCase):
     bsc: BlobServiceClient = None
     container: ContainerClient = None
@@ -69,10 +61,10 @@ class TestStorageContentValidationAsync(AsyncStorageRecordedTestCase):
             await blob.upload_blob(b'123', validate_content='crc64')
 
     @BlobPreparer()
-    @pytest.mark.parametrize('blob_type', [BlobType.BLOCKBLOB, BlobType.PAGEBLOB, BlobType.APPENDBLOB])
-    @BlobTypeParameterize()
+    @pytest.mark.parametrize('a', [BlobType.BLOCKBLOB, BlobType.PAGEBLOB, BlobType.APPENDBLOB])  # a: blob_type
+    @GenericTestProxyParametrize1()
     @recorded_by_proxy_async
-    async def test_upload_blob_legacy_bool(self, blob_type, **kwargs):
+    async def test_upload_blob_legacy_bool(self, a, **kwargs):
         storage_account_name = kwargs.pop("storage_account_name")
         storage_account_key = kwargs.pop("storage_account_key")
 
@@ -81,17 +73,17 @@ class TestStorageContentValidationAsync(AsyncStorageRecordedTestCase):
         data = b'abc' * 512
 
         # Act
-        response = await blob.upload_blob(data, blob_type, validate_content=True, raw_request_hook=assert_content_md5)
+        response = await blob.upload_blob(data, a, validate_content=True, raw_request_hook=assert_content_md5)
 
         # Assert
         assert response
         await self._teardown()
 
     @BlobPreparer()
-    @pytest.mark.parametrize('blob_type', [BlobType.BLOCKBLOB, BlobType.PAGEBLOB, BlobType.APPENDBLOB])
-    @BlobTypeParameterize()
+    @pytest.mark.parametrize('a', [BlobType.BLOCKBLOB, BlobType.PAGEBLOB, BlobType.APPENDBLOB])  # a: blob_type
+    @GenericTestProxyParametrize1()
     @recorded_by_proxy_async
-    async def test_upload_blob_legacy_bool_chunks(self, blob_type, **kwargs):
+    async def test_upload_blob_legacy_bool_chunks(self, a, **kwargs):
         storage_account_name = kwargs.pop("storage_account_name")
         storage_account_key = kwargs.pop("storage_account_key")
 
@@ -102,17 +94,17 @@ class TestStorageContentValidationAsync(AsyncStorageRecordedTestCase):
         data = b'abc' * 512
 
         # Act
-        response = await blob.upload_blob(data, blob_type, validate_content=True, raw_request_hook=assert_content_md5)
+        response = await blob.upload_blob(data, a, validate_content=True, raw_request_hook=assert_content_md5)
 
         # Assert
         assert response
         await self._teardown()
 
     @BlobPreparer()
-    @pytest.mark.parametrize('blob_type', [BlobType.BLOCKBLOB, BlobType.PAGEBLOB, BlobType.APPENDBLOB])
-    @BlobTypeParameterize()
+    @pytest.mark.parametrize('a', [BlobType.BLOCKBLOB, BlobType.PAGEBLOB, BlobType.APPENDBLOB])  # a: blob_type
+    @GenericTestProxyParametrize1()
     @recorded_by_proxy_async
-    async def test_upload_blob_md5(self, blob_type, **kwargs):
+    async def test_upload_blob_md5(self, a, **kwargs):
         storage_account_name = kwargs.pop("storage_account_name")
         storage_account_key = kwargs.pop("storage_account_key")
 
@@ -121,17 +113,17 @@ class TestStorageContentValidationAsync(AsyncStorageRecordedTestCase):
         data = b'abc' * 512
 
         # Act
-        response = await blob.upload_blob(data, blob_type, validate_content='md5', raw_request_hook=assert_content_md5)
+        response = await blob.upload_blob(data, a, validate_content='md5', raw_request_hook=assert_content_md5)
 
         # Assert
         assert response
         await self._teardown()
 
     @BlobPreparer()
-    @pytest.mark.parametrize('blob_type', [BlobType.BLOCKBLOB, BlobType.PAGEBLOB, BlobType.APPENDBLOB])
-    @BlobTypeParameterize()
+    @pytest.mark.parametrize('a', [BlobType.BLOCKBLOB, BlobType.PAGEBLOB, BlobType.APPENDBLOB])  # a: blob_type
+    @GenericTestProxyParametrize1()
     @recorded_by_proxy_async
-    async def test_upload_blob_md5_chunks(self, blob_type, **kwargs):
+    async def test_upload_blob_md5_chunks(self, a, **kwargs):
         storage_account_name = kwargs.pop("storage_account_name")
         storage_account_key = kwargs.pop("storage_account_key")
 
@@ -142,17 +134,17 @@ class TestStorageContentValidationAsync(AsyncStorageRecordedTestCase):
         data = b'abc' * 512
 
         # Act
-        response = await blob.upload_blob(data, blob_type, validate_content='md5', raw_request_hook=assert_content_md5)
+        response = await blob.upload_blob(data, a, validate_content='md5', raw_request_hook=assert_content_md5)
 
         # Assert
         assert response
         await self._teardown()
 
     @BlobPreparer()
-    @pytest.mark.parametrize('blob_type', [BlobType.BLOCKBLOB, BlobType.PAGEBLOB, BlobType.APPENDBLOB])
-    @BlobTypeParameterize()
+    @pytest.mark.parametrize('a', [BlobType.BLOCKBLOB, BlobType.PAGEBLOB, BlobType.APPENDBLOB])  # a: blob_type
+    @GenericTestProxyParametrize1()
     @recorded_by_proxy_async
-    async def test_upload_blob_crc64(self, blob_type, **kwargs):
+    async def test_upload_blob_crc64(self, a, **kwargs):
         storage_account_name = kwargs.pop("storage_account_name")
         storage_account_key = kwargs.pop("storage_account_key")
 
@@ -165,11 +157,11 @@ class TestStorageContentValidationAsync(AsyncStorageRecordedTestCase):
         stream = BytesIO(byte_data)
 
         # Act
-        resp1 = await blob.upload_blob(byte_data, blob_type, overwrite=True, validate_content='crc64',
+        resp1 = await blob.upload_blob(byte_data, a, overwrite=True, validate_content='crc64',
                                  raw_request_hook=assert_content_crc64)
-        resp2 = await blob.upload_blob(str_data, blob_type, overwrite=True, validate_content='crc64',
+        resp2 = await blob.upload_blob(str_data, a, overwrite=True, validate_content='crc64',
                                  raw_request_hook=assert_content_crc64)
-        resp3 = await blob.upload_blob(stream, blob_type, overwrite=True, validate_content='crc64',
+        resp3 = await blob.upload_blob(stream, a, overwrite=True, validate_content='crc64',
                                  raw_request_hook=assert_content_crc64)
 
         # Assert
@@ -179,10 +171,10 @@ class TestStorageContentValidationAsync(AsyncStorageRecordedTestCase):
         await self._teardown()
 
     @BlobPreparer()
-    @pytest.mark.parametrize('blob_type', [BlobType.BLOCKBLOB, BlobType.PAGEBLOB, BlobType.APPENDBLOB])
-    @BlobTypeParameterize()
+    @pytest.mark.parametrize('a', [BlobType.BLOCKBLOB, BlobType.PAGEBLOB, BlobType.APPENDBLOB])  # a: blob_type
+    @GenericTestProxyParametrize1()
     @recorded_by_proxy_async
-    async def test_upload_blob_crc64_chunks(self, blob_type, **kwargs):
+    async def test_upload_blob_crc64_chunks(self, a, **kwargs):
         storage_account_name = kwargs.pop("storage_account_name")
         storage_account_key = kwargs.pop("storage_account_key")
 
@@ -197,11 +189,11 @@ class TestStorageContentValidationAsync(AsyncStorageRecordedTestCase):
         stream = BytesIO(byte_data)
 
         # Act
-        resp1 = await blob.upload_blob(byte_data, blob_type, overwrite=True, validate_content='crc64',
+        resp1 = await blob.upload_blob(byte_data, a, overwrite=True, validate_content='crc64',
                                  raw_request_hook=assert_content_crc64)
-        resp2 = await blob.upload_blob(str_data, blob_type, overwrite=True, validate_content='crc64',
+        resp2 = await blob.upload_blob(str_data, a, overwrite=True, validate_content='crc64',
                                  raw_request_hook=assert_content_crc64)
-        resp3 = await blob.upload_blob(stream, blob_type, overwrite=True, validate_content='crc64',
+        resp3 = await blob.upload_blob(stream, a, overwrite=True, validate_content='crc64',
                                  raw_request_hook=assert_content_crc64)
 
         # Assert
@@ -365,3 +357,4 @@ class TestStorageContentValidationAsync(AsyncStorageRecordedTestCase):
         # Assert
         content = await blob.download_blob(offset=0, length=len(data1) + data2_encoded_len)
         assert await content.readall() == data1 + data2.encode('utf-8')
+        await self._teardown()

--- a/sdk/storage/azure-storage-blob/tests/test_helpers.py
+++ b/sdk/storage/azure-storage-blob/tests/test_helpers.py
@@ -7,6 +7,20 @@ from io import IOBase, UnsupportedOperation
 from typing import Optional
 
 
+class GenericTestProxyParametrize1:
+    def __call__(self, fn):
+        def _wrapper(test_class, a, **kwargs):
+            fn(test_class, a, **kwargs)
+        return _wrapper
+
+
+class GenericTestProxyParametrize2:
+    def __call__(self, fn):
+        def _wrapper(test_class, a, b, **kwargs):
+            fn(test_class, a, b, **kwargs)
+        return _wrapper
+
+
 class ProgressTracker:
     def __init__(self, total: int, step: int):
         self.total = total

--- a/sdk/storage/azure-storage-blob/tests/test_helpers_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_helpers_async.py
@@ -7,6 +7,19 @@ from io import IOBase, UnsupportedOperation
 from typing import Optional
 
 
+class GenericTestProxyParametrize1:
+    def __call__(self, fn):
+        async def _wrapper(test_class, a, **kwargs):
+            await fn(test_class, a, **kwargs)
+        return _wrapper
+
+
+class GenericTestProxyParametrize2:
+    def __call__(self, fn):
+        async def _wrapper(test_class, a, b, **kwargs):
+            await fn(test_class, a, b, **kwargs)
+        return _wrapper
+
 class ProgressTracker:
     def __init__(self, total: int, step: int):
         self.total = total


### PR DESCRIPTION
This change adds support for content validation with CRC64 to the single-shot upload APIs for Blob, `stage_block`, `append_block`, and `upload_page`.

As part of this, the input parsing code for the input data parameter has been refactored a bit to address several existing issues and facilitate that introduction of Structured Message streams. This refactor comes with a few minor breaking changes so is subject to change pending conversations with the architects.