### PR TITLE
Set `network traversal` to active

### DIFF
--- a/sdk/communication/azure-communication-networktraversal/setup.py
+++ b/sdk/communication/azure-communication-networktraversal/setup.py
@@ -45,8 +45,7 @@ setup(
     license='MIT License',
     # ensure that the development status reflects the status of your package
     classifiers=[
-        "Development Status :: 7 - Inactive",
-
+        "Development Status :: 4 - Beta",
         'Programming Language :: Python',
         "Programming Language :: Python :: 3 :: Only",
         'Programming Language :: Python :: 3',


### PR DESCRIPTION
This exercise exposed a hole in our release validation.

1) We allow `inactive` packages to release, because otherwise we can't release the package _after_ we've set them to inactive (to get that classifier up on pypi)
2) network traversal was set to `inactive`, meaning that tests didn't run against it. This is also an intentional decision, as packages that are no longer active development, but pending code deletion are in this state. We don't want to deal with build failures from them.

I'm as yet unsure how to judge `intentionally not running stuff` vs `accidentally not running tests and didn't look`. I'll file a follow-up issue.