### PR TITLE
Fixing pylint failure during azure-mixedreality-remoterendering build.

### DIFF
--- a/sdk/remoterendering/azure-mixedreality-remoterendering/azure/mixedreality/remoterendering/_polling.py
+++ b/sdk/remoterendering/azure-mixedreality-remoterendering/azure/mixedreality/remoterendering/_polling.py
@@ -40,7 +40,7 @@ class RemoteRenderingPolling(PollingMethod):
     def _update_status(self):
         # type: () -> None
         if self._query_status is None:
-            raise Exception("this poller has not been initialized")
+            raise RuntimeError("this poller has not been initialized")
         self._response = self._query_status()  # pylint: disable=E1102
         if self._response.error is not None:
             error = HttpResponseError("Polling returned a status indicating an error state.", model=self._response)

--- a/sdk/remoterendering/azure-mixedreality-remoterendering/azure/mixedreality/remoterendering/_remote_rendering_client.py
+++ b/sdk/remoterendering/azure-mixedreality-remoterendering/azure/mixedreality/remoterendering/_remote_rendering_client.py
@@ -288,6 +288,8 @@ class RemoteRenderingClient:
         :keyword continuation_token:
             A continuation token retrieved from a poller of a session.
         :paramtype continuation_token: str
+        :return: A session poller for the given session
+        :rtype: LROPoller[RenderingSession]
         :raises ~azure.core.exceptions.HttpResponseError:
         """
 

--- a/sdk/remoterendering/azure-mixedreality-remoterendering/azure/mixedreality/remoterendering/aio/_polling_async.py
+++ b/sdk/remoterendering/azure-mixedreality-remoterendering/azure/mixedreality/remoterendering/aio/_polling_async.py
@@ -12,9 +12,9 @@ from azure.core.polling import AsyncPollingMethod
 from azure.core.exceptions import HttpResponseError, ODataV4Format
 
 from .._generated.aio import RemoteRenderingRestClient
-from .._generated.models import (AssetConversion, AssetConversionInputSettings,
+from .._generated.models import (AssetConversion,
                                  AssetConversionStatus,
-                                 RenderingSession, RenderingSessionSize,
+                                 RenderingSession,
                                  RenderingSessionStatus)
 
 if TYPE_CHECKING:
@@ -41,7 +41,7 @@ class RemoteRenderingPollingAsync(AsyncPollingMethod):
     async def _update_status(self):
         # type: () -> None
         if self._query_status is None:
-            raise Exception("this poller has not been initialized")
+            raise RuntimeError("this poller has not been initialized")
         self._response = await self._query_status()  # pylint: disable=E1102
         if self._response is not None and self._response.error is not None:
             error = HttpResponseError("Polling returned a status indicating an error state.", model=self._response)

--- a/sdk/remoterendering/azure-mixedreality-remoterendering/azure/mixedreality/remoterendering/aio/_remote_rendering_client_async.py
+++ b/sdk/remoterendering/azure-mixedreality-remoterendering/azure/mixedreality/remoterendering/aio/_remote_rendering_client_async.py
@@ -333,6 +333,7 @@ class RemoteRenderingClient(object):
         :keyword lease_time_minutes: The new lease time of the rendering session. Has to be strictly larger than
             the previous lease time.
         :paramtype lease_time_minutes: int
+        :return: The updated rendering session
         :rtype: ~azure.mixedreality.remoterendering.models.RenderingSession
         :raises ~azure.core.exceptions.HttpResponseError:
         """


### PR DESCRIPTION
# Description

There are a couple of pylint errors and warnings for the in the azure-mixedreality-remoterendering package which cause the current build to fail. These are all fixed here.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
