### PR TITLE
Resolve issues with pinned setuptools version

### DIFF
--- a/eng/pipelines/templates/steps/build-package-artifacts.yml
+++ b/eng/pipelines/templates/steps/build-package-artifacts.yml
@@ -44,14 +44,18 @@ steps:
     displayName: 'Tag scheduled builds'
     condition: and(eq(variables['Build.SourceBranchName'], variables['DefaultBranch']), eq(variables['Build.Reason'],'Schedule'))
 
+  - pwsh: |
+      sudo python -m pip uninstall -y setuptools
+    displayName: Remove bad setuptools global install
+
   - task: UsePythonVersion@0
     displayName: 'Use Python $(PythonVersion)'
     inputs:
       versionSpec: $(PythonVersion)
 
   - script: |
-      python -m pip install setuptools==58.3.0
-      python -m pip install -r eng/ci_tools.txt
+      python -m pip install --force -r eng/ci_tools.txt
+      python -m pip freeze --all
     displayName: 'Prep Environment'
 
   - template: set-dev-build.yml@self

--- a/tools/azure-sdk-tools/setup.py
+++ b/tools/azure-sdk-tools/setup.py
@@ -58,7 +58,7 @@ setup(
     extras_require={
         ":python_version>='3.5'": ["pytest-asyncio>=0.9.0"],
         ":python_version<'3.11'": ["tomli==2.0.1"],
-        "build": ["six", "setuptools==67.6.0", "pyparsing", "certifi", "cibuildwheel"],
+        "build": ["six", "setuptools", "pyparsing", "certifi", "cibuildwheel"],
         "conda": ["beautifulsoup4"],
         "systemperf": ["aiohttp>=3.0", "requests>=2.0", "tornado==6.0.3", "httpx>=0.21", "azure-core"],
         "ghtools": ["GitPython", "PyGithub>=1.59.0", "requests>=2.0"],


### PR DESCRIPTION
This PR addresses the mystery behind #35204

Effectively, there are some _weird_ file permissions on the agent. Due to this, the `setuptools` available on the path by default _cannot be uninstalled_ because its installed with privileges that the default user account does not have. This also means that we can't modify it to REPLACE it either. `pip` silently thinks it's done, but due to the permissions issues never actually reflects the `setuptools` version that it SAYS it does in `pip freeze`.

I believe that removing the faulty default version should resolve this going forward. Let's see if this PR bears out!