### PR TITLE
Resolve `setuptools`-related permissions issues

### DIFF
--- a/eng/pipelines/templates/steps/build-package-artifacts.yml
+++ b/eng/pipelines/templates/steps/build-package-artifacts.yml
@@ -61,7 +61,7 @@ steps:
 
   - script: |
       python -m venv $(Build.SourcesDirectory)/venv
-      pushd $(Build.SourcesDirectory)/venv/bin/
+      pushd $(Build.SourcesDirectory)/venv/Scripts/
       activate
       popd
       which python
@@ -105,7 +105,7 @@ steps:
       CIBW_BUILD_VERBOSITY: 3
 
   - script: |
-      pushd $(Build.SourcesDirectory)/venv/bin/
+      pushd $(Build.SourcesDirectory)/venv/Scripts/
       activate
       popd
       which python

--- a/eng/pipelines/templates/steps/build-package-artifacts.yml
+++ b/eng/pipelines/templates/steps/build-package-artifacts.yml
@@ -59,11 +59,6 @@ steps:
     displayName: 'Prep Environment Linux'
     condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'))
 
-  - bash: |
-      which python
-    displayName: 'Where is python?'
-    condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'))
-
   - script: |
       python -m pip install --force -r eng/ci_tools.txt
       python -m pip freeze --all
@@ -93,9 +88,22 @@ steps:
     displayName: 'Install QEMU Dependencies'
     condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'))
 
+  - bash: |
+      source $(Build.SourcesDirectory)/venv/bin/activate
+      which python
+      sdk_build -d "$(Build.ArtifactStagingDirectory)" "$(TargetingString)" --service=${{parameters.ServiceDirectory}} --inactive
+    displayName: 'Generate Packages'
+    condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'))
+    condition: succeededOrFailed()
+    timeoutInMinutes: 80
+    env:
+      CIBW_BUILD_VERBOSITY: 3
+
+
   - pwsh: |
       sdk_build -d "$(Build.ArtifactStagingDirectory)" "$(TargetingString)" --service=${{parameters.ServiceDirectory}} --inactive
     displayName: 'Generate Packages'
+    condition: and(succeeded(), ne(variables['Agent.OS'], 'Linux'))
     condition: succeededOrFailed()
     timeoutInMinutes: 80
     env:

--- a/eng/pipelines/templates/steps/build-package-artifacts.yml
+++ b/eng/pipelines/templates/steps/build-package-artifacts.yml
@@ -59,6 +59,11 @@ steps:
     displayName: 'Prep Environment Linux'
     condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'))
 
+  - bash: |
+      which python
+    displayName: 'Where is python?'
+    condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'))
+
   - script: |
       python -m pip install --force -r eng/ci_tools.txt
       python -m pip freeze --all

--- a/eng/pipelines/templates/steps/build-package-artifacts.yml
+++ b/eng/pipelines/templates/steps/build-package-artifacts.yml
@@ -56,7 +56,7 @@ steps:
       python -m pip install --force -r eng/ci_tools.txt
       python -m pip freeze --all
       echo "##vso[task.setvariable variable=PATH;]$PATH"
-    displayName: 'Prep Environment Linux'
+    displayName: 'Prep Environment Linux/Mac'
     condition: and(succeeded(), or(eq(variables['Agent.OS'], 'Linux'), eq(variables['Agent.OS'], 'Darwin')))
 
   - script: |
@@ -68,7 +68,7 @@ steps:
       python -m pip install --force -r eng\ci_tools.txt
       python -m pip freeze --all
       echo "##vso[task.setvariable variable=PATH;]$PATH"
-    displayName: 'Prep Environment'
+    displayName: 'Prep Environment Windows'
     condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
 
   - template: set-dev-build.yml@self
@@ -98,8 +98,8 @@ steps:
       source $(Build.SourcesDirectory)/venv/bin/activate
       which python
       sdk_build -d "$(Build.ArtifactStagingDirectory)" "$(TargetingString)" --service=${{parameters.ServiceDirectory}} --inactive
-    displayName: 'Generate Packages'
-    condition: and(succeeded(), or(eq(variables['Agent.OS'], 'Linux'), eq(variables['Agent.OS'], 'MacOS')))
+    displayName: 'Generate Packages Linux/Mac'
+    condition: and(succeeded(), or(eq(variables['Agent.OS'], 'Linux'), eq(variables['Agent.OS'], 'Darwin')))
     timeoutInMinutes: 80
     env:
       CIBW_BUILD_VERBOSITY: 3
@@ -110,7 +110,7 @@ steps:
       popd
       which python
       sdk_build -d "$(Build.ArtifactStagingDirectory)" "$(TargetingString)" --service=${{parameters.ServiceDirectory}} --inactive
-    displayName: 'Generate Packages'
+    displayName: 'Generate Packages Windows'
     condition: and(succeededOrFailed(), eq(variables['Agent.OS'], 'Windows_NT'))
     timeoutInMinutes: 80
     env:
@@ -121,6 +121,7 @@ steps:
       twine check $(Build.ArtifactStagingDirectory)/**/*.whl
       twine check $(Build.ArtifactStagingDirectory)/**/*.tar.gz
     displayName: 'Verify Readme'
+    condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'))
 
   - ${{ parameters.BeforePublishSteps }}
 

--- a/eng/pipelines/templates/steps/build-package-artifacts.yml
+++ b/eng/pipelines/templates/steps/build-package-artifacts.yml
@@ -44,19 +44,26 @@ steps:
     displayName: 'Tag scheduled builds'
     condition: and(eq(variables['Build.SourceBranchName'], variables['DefaultBranch']), eq(variables['Build.Reason'],'Schedule'))
 
-  - pwsh: |
-      sudo python -m pip uninstall -y setuptools
-    displayName: Remove bad setuptools global install
-
   - task: UsePythonVersion@0
     displayName: 'Use Python $(PythonVersion)'
     inputs:
       versionSpec: $(PythonVersion)
 
+  - bash: |
+      python -m venv $(Build.SourcesDirectory)/venv
+      source $(Build.SourcesDirectory)/venv/bin/activate
+      which python
+      python -m pip install --force -r eng/ci_tools.txt
+      python -m pip freeze --all
+      echo "##vso[task.setvariable variable=PATH;]$PATH"
+    displayName: 'Prep Environment Linux'
+    condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'))
+
   - script: |
       python -m pip install --force -r eng/ci_tools.txt
       python -m pip freeze --all
     displayName: 'Prep Environment'
+    condition: and(succeeded(), ne(variables['Agent.OS'], 'Linux'))
 
   - template: set-dev-build.yml@self
     parameters:

--- a/eng/pipelines/templates/steps/build-package-artifacts.yml
+++ b/eng/pipelines/templates/steps/build-package-artifacts.yml
@@ -66,7 +66,7 @@ steps:
       python -m pip install --force -r eng\ci_tools.txt
       python -m pip freeze --all
 
-      $path = $env:$PATH
+      $path = $env:PATH
       Write-Host "##vso[task.setvariable variable=PATH]$path"
     displayName: 'Prep Environment Windows'
     condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))

--- a/eng/pipelines/templates/steps/build-package-artifacts.yml
+++ b/eng/pipelines/templates/steps/build-package-artifacts.yml
@@ -65,7 +65,9 @@ steps:
       which python
       python -m pip install --force -r eng\ci_tools.txt
       python -m pip freeze --all
-      Write-Host "##vso[task.setvariable variable=PATH]$env:$PATH"
+
+      $path = $env:$PATH
+      Write-Host "##vso[task.setvariable variable=PATH]$path"
     displayName: 'Prep Environment Windows'
     condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
 

--- a/eng/pipelines/templates/steps/build-package-artifacts.yml
+++ b/eng/pipelines/templates/steps/build-package-artifacts.yml
@@ -93,18 +93,15 @@ steps:
       which python
       sdk_build -d "$(Build.ArtifactStagingDirectory)" "$(TargetingString)" --service=${{parameters.ServiceDirectory}} --inactive
     displayName: 'Generate Packages'
-    condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'))
-    condition: succeededOrFailed()
+    condition: and(succeededOrFailed(), eq(variables['Agent.OS'], 'Linux'))
     timeoutInMinutes: 80
     env:
       CIBW_BUILD_VERBOSITY: 3
 
-
   - pwsh: |
       sdk_build -d "$(Build.ArtifactStagingDirectory)" "$(TargetingString)" --service=${{parameters.ServiceDirectory}} --inactive
     displayName: 'Generate Packages'
-    condition: and(succeeded(), ne(variables['Agent.OS'], 'Linux'))
-    condition: succeededOrFailed()
+    condition: and(succeededOrFailed(), ne(variables['Agent.OS'], 'Linux'))
     timeoutInMinutes: 80
     env:
       CIBW_BUILD_VERBOSITY: 3

--- a/eng/pipelines/templates/steps/build-package-artifacts.yml
+++ b/eng/pipelines/templates/steps/build-package-artifacts.yml
@@ -57,7 +57,7 @@ steps:
       python -m pip freeze --all
       echo "##vso[task.setvariable variable=PATH;]$PATH"
     displayName: 'Prep Environment Linux'
-    condition: and(succeeded(), or(eq(variables['Agent.OS'], 'Linux'), eq(variables['Agent.OS'], 'MacOS')))
+    condition: and(succeeded(), or(eq(variables['Agent.OS'], 'Linux'), eq(variables['Agent.OS'], 'Darwin')))
 
   - script: |
       python -m venv $(Build.SourcesDirectory)/venv
@@ -69,7 +69,7 @@ steps:
       python -m pip freeze --all
       echo "##vso[task.setvariable variable=PATH;]$PATH"
     displayName: 'Prep Environment'
-    condition: and(succeeded(), ne(variables['Agent.OS'], 'Linux'))
+    condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
 
   - template: set-dev-build.yml@self
     parameters:
@@ -105,13 +105,13 @@ steps:
       CIBW_BUILD_VERBOSITY: 3
 
   - script: |
-      pushd $(Build.SourcesDirectory)/venv/Scripts/
+      pushd $(Build.SourcesDirectory)\venv\Scripts
       activate
       popd
       which python
       sdk_build -d "$(Build.ArtifactStagingDirectory)" "$(TargetingString)" --service=${{parameters.ServiceDirectory}} --inactive
     displayName: 'Generate Packages'
-    condition: and(succeededOrFailed(), ne(variables['Agent.OS'], 'Linux'))
+    condition: and(succeededOrFailed(), eq(variables['Agent.OS'], 'Windows_NT'))
     timeoutInMinutes: 80
     env:
       CIBW_BUILD_VERBOSITY: 3

--- a/eng/pipelines/templates/steps/build-package-artifacts.yml
+++ b/eng/pipelines/templates/steps/build-package-artifacts.yml
@@ -44,14 +44,18 @@ steps:
     displayName: 'Tag scheduled builds'
     condition: and(eq(variables['Build.SourceBranchName'], variables['DefaultBranch']), eq(variables['Build.Reason'],'Schedule'))
 
+  - pwsh: |
+      sudo python -m pip uninstall -y setuptools
+    displayName: Remove bad setuptools global install
+
   - task: UsePythonVersion@0
     displayName: 'Use Python $(PythonVersion)'
     inputs:
       versionSpec: $(PythonVersion)
 
   - script: |
-      python -m pip install setuptools==58.3.0
-      python -m pip install -r eng/ci_tools.txt
+      python -m pip install --force -r eng/ci_tools.txt
+      python -m pip freeze --all
     displayName: 'Prep Environment'
 
   - template: set-dev-build.yml@self

--- a/eng/pipelines/templates/steps/build-package-artifacts.yml
+++ b/eng/pipelines/templates/steps/build-package-artifacts.yml
@@ -57,11 +57,15 @@ steps:
       python -m pip freeze --all
       echo "##vso[task.setvariable variable=PATH;]$PATH"
     displayName: 'Prep Environment Linux'
-    condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'))
+    condition: and(succeeded(), or(eq(variables['Agent.OS'], 'Linux'), eq(variables['Agent.OS'], 'MacOS')))
 
   - script: |
+      python -m venv $(Build.SourcesDirectory)/venv
+      source $(Build.SourcesDirectory)/venv/bin/activate
+      which python
       python -m pip install --force -r eng/ci_tools.txt
       python -m pip freeze --all
+      echo "##vso[task.setvariable variable=PATH;]$PATH"
     displayName: 'Prep Environment'
     condition: and(succeeded(), ne(variables['Agent.OS'], 'Linux'))
 
@@ -93,12 +97,16 @@ steps:
       which python
       sdk_build -d "$(Build.ArtifactStagingDirectory)" "$(TargetingString)" --service=${{parameters.ServiceDirectory}} --inactive
     displayName: 'Generate Packages'
-    condition: and(succeededOrFailed(), eq(variables['Agent.OS'], 'Linux'))
+    condition: and(succeeded(), or(eq(variables['Agent.OS'], 'Linux'), eq(variables['Agent.OS'], 'MacOS')))
     timeoutInMinutes: 80
     env:
       CIBW_BUILD_VERBOSITY: 3
 
-  - pwsh: |
+  - script: |
+      pushd $(Build.SourcesDirectory)/venv/bin/
+      activate
+      popd
+      which python
       sdk_build -d "$(Build.ArtifactStagingDirectory)" "$(TargetingString)" --service=${{parameters.ServiceDirectory}} --inactive
     displayName: 'Generate Packages'
     condition: and(succeededOrFailed(), ne(variables['Agent.OS'], 'Linux'))

--- a/eng/pipelines/templates/steps/build-package-artifacts.yml
+++ b/eng/pipelines/templates/steps/build-package-artifacts.yml
@@ -61,11 +61,11 @@ steps:
 
   - script: |
       python -m venv $(Build.SourcesDirectory)/venv
-      pushd $(Build.SourcesDirectory)/venv/Scripts/
+      pushd $(Build.SourcesDirectory)\venv\Scripts
       activate
       popd
       which python
-      python -m pip install --force -r eng/ci_tools.txt
+      python -m pip install --force -r eng\ci_tools.txt
       python -m pip freeze --all
       echo "##vso[task.setvariable variable=PATH;]$PATH"
     displayName: 'Prep Environment'

--- a/eng/pipelines/templates/steps/build-package-artifacts.yml
+++ b/eng/pipelines/templates/steps/build-package-artifacts.yml
@@ -55,7 +55,7 @@ steps:
       which python
       python -m pip install --force -r eng/ci_tools.txt
       python -m pip freeze --all
-      echo "##vso[task.setvariable variable=PATH;]$PATH"
+      echo "##vso[task.setvariable variable=PATH]$PATH"
     displayName: 'Prep Environment Linux/Mac'
     condition: and(succeeded(), or(eq(variables['Agent.OS'], 'Linux'), eq(variables['Agent.OS'], 'Darwin')))
 
@@ -65,7 +65,7 @@ steps:
       which python
       python -m pip install --force -r eng\ci_tools.txt
       python -m pip freeze --all
-      echo "##vso[task.setvariable variable=PATH;]$PATH"
+      Write-Host "##vso[task.setvariable variable=PATH]$env:$PATH"
     displayName: 'Prep Environment Windows'
     condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
 

--- a/eng/pipelines/templates/steps/build-package-artifacts.yml
+++ b/eng/pipelines/templates/steps/build-package-artifacts.yml
@@ -59,11 +59,9 @@ steps:
     displayName: 'Prep Environment Linux/Mac'
     condition: and(succeeded(), or(eq(variables['Agent.OS'], 'Linux'), eq(variables['Agent.OS'], 'Darwin')))
 
-  - script: |
+  - pwsh: |
       python -m venv $(Build.SourcesDirectory)/venv
-      pushd $(Build.SourcesDirectory)\venv\Scripts
-      activate
-      popd
+      ./venv/Scripts/Activate.ps1
       which python
       python -m pip install --force -r eng\ci_tools.txt
       python -m pip freeze --all
@@ -104,10 +102,8 @@ steps:
     env:
       CIBW_BUILD_VERBOSITY: 3
 
-  - script: |
-      pushd $(Build.SourcesDirectory)\venv\Scripts
-      activate
-      popd
+  - pwsh: |
+      ./venv/Scripts/Activate.ps1
       which python
       sdk_build -d "$(Build.ArtifactStagingDirectory)" "$(TargetingString)" --service=${{parameters.ServiceDirectory}} --inactive
     displayName: 'Generate Packages Windows'

--- a/eng/pipelines/templates/steps/build-package-artifacts.yml
+++ b/eng/pipelines/templates/steps/build-package-artifacts.yml
@@ -61,7 +61,9 @@ steps:
 
   - script: |
       python -m venv $(Build.SourcesDirectory)/venv
-      source $(Build.SourcesDirectory)/venv/bin/activate
+      pushd $(Build.SourcesDirectory)/venv/bin/
+      activate
+      popd
       which python
       python -m pip install --force -r eng/ci_tools.txt
       python -m pip freeze --all

--- a/tools/azure-sdk-tools/ci_tools/functions.py
+++ b/tools/azure-sdk-tools/ci_tools/functions.py
@@ -395,17 +395,20 @@ def find_sdist(dist_dir: str, pkg_name: str, pkg_version: str) -> str:
         logging.error("Package name cannot be empty to find sdist")
         return
 
-    pkg_name_format = f"{pkg_name}-{pkg_version}.tar.gz"
+    pkg_name_legacy_format = f"{pkg_name}-{pkg_version}.tar.gz"
+    pkg_name_normalized_format = f"{pkg_name}_{pkg_version}.tar.gz"
 
     packages = []
     for root, dirnames, filenames in os.walk(dist_dir):
-        for filename in fnmatch.filter(filenames, pkg_name_format):
+        for filename in fnmatch.filter(filenames, [pkg_name_legacy_format, pkg_name_normalized_format]):
             packages.append(os.path.join(root, filename))
 
     packages = [os.path.relpath(w, dist_dir) for w in packages]
 
     if not packages:
-        logging.error("No sdist is found in directory %s with package name format %s", dist_dir, pkg_name_format)
+        logging.error(
+            f"No sdist is found in directory {dist_dir} with package name format {[pkg_name_legacy_format, pkg_name_normalized_format]}"
+        )
         return
     return packages[0]
 

--- a/tools/azure-sdk-tools/ci_tools/functions.py
+++ b/tools/azure-sdk-tools/ci_tools/functions.py
@@ -394,20 +394,22 @@ def find_sdist(dist_dir: str, pkg_name: str, pkg_version: str) -> str:
     if pkg_name is None:
         logging.error("Package name cannot be empty to find sdist")
         return
+    else:
+        # ensure package name matches cananonicalized package name
+        pkg_name = pkg_name.replace("-", "[-_]")
 
-    pkg_name_legacy_format = f"{pkg_name}-{pkg_version}.tar.gz"
-    pkg_name_normalized_format = f"{pkg_name}_{pkg_version}.tar.gz"
+    pkg_format = f"{pkg_name}-{pkg_version}.tar.gz"
 
     packages = []
     for root, dirnames, filenames in os.walk(dist_dir):
-        for filename in fnmatch.filter(filenames, [pkg_name_legacy_format, pkg_name_normalized_format]):
+        for filename in fnmatch.filter(filenames, pkg_format):
             packages.append(os.path.join(root, filename))
 
     packages = [os.path.relpath(w, dist_dir) for w in packages]
 
     if not packages:
         logging.error(
-            f"No sdist is found in directory {dist_dir} with package name format {[pkg_name_legacy_format, pkg_name_normalized_format]}"
+            f"No sdist is found in directory {dist_dir} with package name format {pkg_format}."
         )
         return
     return packages[0]

--- a/tools/azure-sdk-tools/setup.py
+++ b/tools/azure-sdk-tools/setup.py
@@ -58,7 +58,7 @@ setup(
     extras_require={
         ":python_version>='3.5'": ["pytest-asyncio>=0.9.0"],
         ":python_version<'3.11'": ["tomli==2.0.1"],
-        "build": ["six", "setuptools==67.6.0", "pyparsing", "certifi", "cibuildwheel"],
+        "build": ["six", "setuptools", "pyparsing", "certifi", "cibuildwheel"],
         "conda": ["beautifulsoup4"],
         "systemperf": ["aiohttp>=3.0", "requests>=2.0", "tornado==6.0.3", "httpx>=0.21", "azure-core"],
         "ghtools": ["GitPython", "PyGithub>=1.59.0", "requests>=2.0"],


### PR DESCRIPTION
This resolves PR resolves the mystery behind https://github.com/Azure/azure-sdk-for-python/issues/35204 

Effectively, there are some weird file permissions on the agent. Due to this, the setuptools available on the path by default cannot be uninstalled because its installed with privileges that the default user account does not have. (I've also attempted `sudo pip uninstall`-ing but that still leaves behind remnants that mess with the build) This also means that we can't modify it to REPLACE it either. pip silently thinks it's done, but due to the permissions issues never actually reflects the setuptools version that it SAYS it does in pip freeze. 

Moving to a venv for the build task to see if we can bypass these problems.