### PR TITLE
[Core][Corehttp] Fix stream tests

### DIFF
--- a/sdk/core/azure-core/tests/async_tests/test_rest_stream_responses_async.py
+++ b/sdk/core/azure-core/tests/async_tests/test_rest_stream_responses_async.py
@@ -138,9 +138,7 @@ async def test_cannot_read_after_response_closed(port, client):
 @pytest.mark.asyncio
 async def test_decompress_plain_no_header(client):
     # thanks to Xiang Yan for this test!
-    account_name = "coretests"
-    url = "https://{}.blob.core.windows.net/tests/test.txt".format(account_name)
-    request = HttpRequest("GET", url)
+    request = HttpRequest("GET", "/streams/string")
     async with client:
         response = await client.send_request(request, stream=True)
         with pytest.raises(ResponseNotReadError):
@@ -152,9 +150,7 @@ async def test_decompress_plain_no_header(client):
 @pytest.mark.asyncio
 async def test_compress_plain_no_header(client):
     # thanks to Xiang Yan for this test!
-    account_name = "coretests"
-    url = "https://{}.blob.core.windows.net/tests/test.txt".format(account_name)
-    request = HttpRequest("GET", url)
+    request = HttpRequest("GET", "/streams/string")
     async with client:
         response = await client.send_request(request, stream=True)
         iter = response.iter_raw()

--- a/sdk/core/azure-core/tests/async_tests/test_streaming_async.py
+++ b/sdk/core/azure-core/tests/async_tests/test_streaming_async.py
@@ -31,162 +31,6 @@ from azure.core.exceptions import DecodeError
 from utils import HTTP_REQUESTS
 
 
-@pytest.mark.live_test_only
-@pytest.mark.asyncio
-@pytest.mark.parametrize("http_request", HTTP_REQUESTS)
-async def test_decompress_plain_no_header(http_request):
-    # expect plain text
-    account_name = "coretests"
-    account_url = "https://{}.blob.core.windows.net".format(account_name)
-    url = "https://{}.blob.core.windows.net/tests/test.txt".format(account_name)
-    client = AsyncPipelineClient(account_url)
-    async with client:
-        request = http_request("GET", url)
-        pipeline_response = await client._pipeline.run(request, stream=True)
-        response = pipeline_response.http_response
-        data = response.stream_download(client._pipeline, decompress=True)
-        content = b""
-        async for d in data:
-            content += d
-        decoded = content.decode("utf-8")
-        assert decoded == "test"
-
-
-@pytest.mark.live_test_only
-@pytest.mark.asyncio
-@pytest.mark.parametrize("http_request", HTTP_REQUESTS)
-async def test_compress_plain_no_header(http_request):
-    # expect plain text
-    account_name = "coretests"
-    account_url = "https://{}.blob.core.windows.net".format(account_name)
-    url = "https://{}.blob.core.windows.net/tests/test.txt".format(account_name)
-    client = AsyncPipelineClient(account_url)
-    async with client:
-        request = http_request("GET", url)
-        pipeline_response = await client._pipeline.run(request, stream=True)
-        response = pipeline_response.http_response
-        data = response.stream_download(client._pipeline, decompress=False)
-        content = b""
-        async for d in data:
-            content += d
-        decoded = content.decode("utf-8")
-        assert decoded == "test"
-
-
-@pytest.mark.live_test_only
-@pytest.mark.asyncio
-@pytest.mark.parametrize("http_request", HTTP_REQUESTS)
-async def test_decompress_compressed_no_header(http_request):
-    # expect compressed text
-    account_name = "coretests"
-    account_url = "https://{}.blob.core.windows.net".format(account_name)
-    url = "https://{}.blob.core.windows.net/tests/test.tar.gz".format(account_name)
-    client = AsyncPipelineClient(account_url)
-    async with client:
-        request = http_request("GET", url)
-        pipeline_response = await client._pipeline.run(request, stream=True)
-        response = pipeline_response.http_response
-        data = response.stream_download(client._pipeline, decompress=True)
-        content = b""
-        async for d in data:
-            content += d
-        try:
-            decoded = content.decode("utf-8")
-            assert False
-        except UnicodeDecodeError:
-            pass
-
-
-@pytest.mark.live_test_only
-@pytest.mark.asyncio
-@pytest.mark.parametrize("http_request", HTTP_REQUESTS)
-async def test_compress_compressed_no_header(http_request):
-    # expect compressed text
-    account_name = "coretests"
-    account_url = "https://{}.blob.core.windows.net".format(account_name)
-    url = "https://{}.blob.core.windows.net/tests/test.tar.gz".format(account_name)
-    client = AsyncPipelineClient(account_url)
-    async with client:
-        request = http_request("GET", url)
-        pipeline_response = await client._pipeline.run(request, stream=True)
-        response = pipeline_response.http_response
-        data = response.stream_download(client._pipeline, decompress=False)
-        content = b""
-        async for d in data:
-            content += d
-        try:
-            decoded = content.decode("utf-8")
-            assert False
-        except UnicodeDecodeError:
-            pass
-
-
-@pytest.mark.live_test_only
-@pytest.mark.asyncio
-@pytest.mark.parametrize("http_request", HTTP_REQUESTS)
-async def test_decompress_plain_header(http_request):
-    # expect error
-
-    account_name = "coretests"
-    account_url = "https://{}.blob.core.windows.net".format(account_name)
-    url = "https://{}.blob.core.windows.net/tests/test_with_header.txt".format(account_name)
-    client = AsyncPipelineClient(account_url)
-    async with client:
-        request = http_request("GET", url)
-        pipeline_response = await client._pipeline.run(request, stream=True)
-        response = pipeline_response.http_response
-        data = response.stream_download(client._pipeline, decompress=True)
-        try:
-            content = b""
-            async for d in data:
-                content += d
-            assert False
-        except (zlib.error, DecodeError):
-            pass
-
-
-@pytest.mark.live_test_only
-@pytest.mark.asyncio
-@pytest.mark.parametrize("http_request", HTTP_REQUESTS)
-async def test_compress_plain_header(http_request):
-    # expect plain text
-    account_name = "coretests"
-    account_url = "https://{}.blob.core.windows.net".format(account_name)
-    url = "https://{}.blob.core.windows.net/tests/test_with_header.txt".format(account_name)
-    client = AsyncPipelineClient(account_url)
-    async with client:
-        request = http_request("GET", url)
-        pipeline_response = await client._pipeline.run(request, stream=True)
-        response = pipeline_response.http_response
-        data = response.stream_download(client._pipeline, decompress=False)
-        content = b""
-        async for d in data:
-            content += d
-        decoded = content.decode("utf-8")
-        assert decoded == "test"
-
-
-@pytest.mark.live_test_only
-@pytest.mark.asyncio
-@pytest.mark.parametrize("http_request", HTTP_REQUESTS)
-async def test_decompress_compressed_header(http_request):
-    # expect plain text
-    account_name = "coretests"
-    account_url = "https://{}.blob.core.windows.net".format(account_name)
-    url = "https://{}.blob.core.windows.net/tests/test_with_header.tar.gz".format(account_name)
-    client = AsyncPipelineClient(account_url)
-    async with client:
-        request = http_request("GET", url)
-        pipeline_response = await client._pipeline.run(request, stream=True)
-        response = pipeline_response.http_response
-        data = response.stream_download(client._pipeline, decompress=True)
-        content = b""
-        async for d in data:
-            content += d
-        decoded = content.decode("utf-8")
-        assert decoded == "test"
-
-
 @pytest.mark.asyncio
 @pytest.mark.parametrize("http_request", HTTP_REQUESTS)
 async def test_compress_compressed_no_header_offline(port, http_request):
@@ -194,24 +38,6 @@ async def test_compress_compressed_no_header_offline(port, http_request):
     client = AsyncPipelineClient("")
     async with client:
         request = http_request(method="GET", url="http://localhost:{}/streams/compressed_no_header".format(port))
-        pipeline_response = await client._pipeline.run(request, stream=True)
-        response = pipeline_response.http_response
-        data = response.stream_download(client._pipeline, decompress=False)
-        with pytest.raises(UnicodeDecodeError):
-            b"".join([d async for d in data]).decode("utf-8")
-
-
-@pytest.mark.live_test_only
-@pytest.mark.asyncio
-@pytest.mark.parametrize("http_request", HTTP_REQUESTS)
-async def test_compress_compressed_header(http_request):
-    # expect compressed text
-    account_name = "coretests"
-    account_url = "https://{}.blob.core.windows.net".format(account_name)
-    url = "https://{}.blob.core.windows.net/tests/test_with_header.tar.gz".format(account_name)
-    client = AsyncPipelineClient(account_url)
-    async with client:
-        request = http_request("GET", url)
         pipeline_response = await client._pipeline.run(request, stream=True)
         response = pipeline_response.http_response
         data = response.stream_download(client._pipeline, decompress=False)
@@ -257,9 +83,10 @@ async def test_decompress_compressed_no_header_offline(port, http_request):
         pipeline_response = await client._pipeline.run(request, stream=True)
         response = pipeline_response.http_response
         data = response.stream_download(client._pipeline, decompress=True)
-
+        content = b"".join([d async for d in data])
+        assert content.startswith(b"\x1f\x8b")  # gzip magic number
         with pytest.raises(UnicodeDecodeError):
-            b"".join([d async for d in data]).decode("utf-8")
+            content.decode("utf-8")
 
 
 @pytest.mark.asyncio

--- a/sdk/core/azure-core/tests/test_rest_stream_responses.py
+++ b/sdk/core/azure-core/tests/test_rest_stream_responses.py
@@ -147,9 +147,7 @@ def test_cannot_read_after_response_closed(port, client):
 
 def test_decompress_plain_no_header(client):
     # thanks to Xiang Yan for this test!
-    account_name = "coretests"
-    url = "https://{}.blob.core.windows.net/tests/test.txt".format(account_name)
-    request = HttpRequest("GET", url)
+    request = HttpRequest("GET", "/streams/string")
     response = client.send_request(request, stream=True)
     with pytest.raises(ResponseNotReadError):
         response.content
@@ -159,9 +157,7 @@ def test_decompress_plain_no_header(client):
 
 def test_compress_plain_no_header(client):
     # thanks to Xiang Yan for this test!
-    account_name = "coretests"
-    url = "https://{}.blob.core.windows.net/tests/test.txt".format(account_name)
-    request = HttpRequest("GET", url)
+    request = HttpRequest("GET", "/streams/string")
     response = client.send_request(request, stream=True)
     iter = response.iter_raw()
     data = b"".join(list(iter))
@@ -170,25 +166,11 @@ def test_compress_plain_no_header(client):
 
 def test_decompress_compressed_no_header(client):
     # thanks to Xiang Yan for this test!
-    account_name = "coretests"
-    url = "https://{}.blob.core.windows.net/tests/test.tar.gz".format(account_name)
-    request = HttpRequest("GET", url)
+    request = HttpRequest("GET", "/streams/compressed_no_header")
     response = client.send_request(request, stream=True)
     iter = response.iter_bytes()
     data = b"".join(list(iter))
-    assert data == b"\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\n+I-.\x01\x00\x0c~\x7f\xd8\x04\x00\x00\x00"
-
-
-def test_decompress_compressed_header(client):
-    # thanks to Xiang Yan for this test!
-    account_name = "coretests"
-    account_url = "https://{}.blob.core.windows.net".format(account_name)
-    url = "https://{}.blob.core.windows.net/tests/test_with_header.tar.gz".format(account_name)
-    request = HttpRequest("GET", url)
-    response = client.send_request(request, stream=True)
-    iter = response.iter_bytes()
-    data = b"".join(list(iter))
-    assert data == b"test"
+    assert data.startswith(b"\x1f\x8b")  # gzip magic number
 
 
 def test_iter_read(client):

--- a/sdk/core/azure-core/tests/test_streaming.py
+++ b/sdk/core/azure-core/tests/test_streaming.py
@@ -26,26 +26,9 @@
 import pytest
 from azure.core.pipeline.transport import RequestsTransport
 from azure.core import PipelineClient
-from azure.core.exceptions import DecodeError, HttpResponseError
+from azure.core.exceptions import DecodeError
 from azure.core.pipeline.transport import RequestsTransport
 from utils import HTTP_REQUESTS
-
-
-@pytest.mark.live_test_only
-@pytest.mark.parametrize("http_request", HTTP_REQUESTS)
-def test_decompress_plain_no_header(http_request):
-    # expect plain text
-    account_name = "coretests"
-    account_url = "https://{}.blob.core.windows.net".format(account_name)
-    url = "https://{}.blob.core.windows.net/tests/test.txt".format(account_name)
-    client = PipelineClient(account_url)
-    request = http_request("GET", url)
-    pipeline_response = client._pipeline.run(request, stream=True)
-    response = pipeline_response.http_response
-    data = response.stream_download(client._pipeline, decompress=True)
-    content = b"".join(list(data))
-    decoded = content.decode("utf-8")
-    assert decoded == "test"
 
 
 @pytest.mark.parametrize("http_request", HTTP_REQUESTS)
@@ -63,43 +46,6 @@ def test_compress_plain_no_header_offline(port, http_request):
         assert decoded == "test"
 
 
-@pytest.mark.live_test_only
-@pytest.mark.parametrize("http_request", HTTP_REQUESTS)
-def test_compress_plain_no_header(http_request):
-    # expect plain text
-    account_name = "coretests"
-    account_url = "https://{}.blob.core.windows.net".format(account_name)
-    url = "https://{}.blob.core.windows.net/tests/test.txt".format(account_name)
-    client = PipelineClient(account_url)
-    request = http_request("GET", url)
-    pipeline_response = client._pipeline.run(request, stream=True)
-    response = pipeline_response.http_response
-    data = response.stream_download(client._pipeline, decompress=False)
-    content = b"".join(list(data))
-    decoded = content.decode("utf-8")
-    assert decoded == "test"
-
-
-@pytest.mark.live_test_only
-@pytest.mark.parametrize("http_request", HTTP_REQUESTS)
-def test_decompress_compressed_no_header(http_request):
-    # expect compressed text
-    account_name = "coretests"
-    account_url = "https://{}.blob.core.windows.net".format(account_name)
-    url = "https://{}.blob.core.windows.net/tests/test.tar.gz".format(account_name)
-    client = PipelineClient(account_url)
-    request = http_request("GET", url)
-    pipeline_response = client._pipeline.run(request, stream=True)
-    response = pipeline_response.http_response
-    data = response.stream_download(client._pipeline, decompress=True)
-    content = b"".join(list(data))
-    try:
-        decoded = content.decode("utf-8")
-        assert False
-    except UnicodeDecodeError:
-        pass
-
-
 @pytest.mark.parametrize("http_request", HTTP_REQUESTS)
 def test_compress_compressed_no_header_offline(port, http_request):
     # expect compressed text
@@ -113,42 +59,6 @@ def test_compress_compressed_no_header_offline(port, http_request):
         decoded = content.decode("utf-8")
 
 
-@pytest.mark.live_test_only
-@pytest.mark.parametrize("http_request", HTTP_REQUESTS)
-def test_compress_compressed_no_header(http_request):
-    # expect compressed text
-    account_name = "coretests"
-    account_url = "https://{}.blob.core.windows.net".format(account_name)
-    url = "https://{}.blob.core.windows.net/tests/test.tar.gz".format(account_name)
-    client = PipelineClient(account_url)
-    request = http_request("GET", url)
-    pipeline_response = client._pipeline.run(request, stream=True)
-    response = pipeline_response.http_response
-    data = response.stream_download(client._pipeline, decompress=False)
-    content = b"".join(list(data))
-    try:
-        decoded = content.decode("utf-8")
-        assert False
-    except UnicodeDecodeError:
-        pass
-
-
-@pytest.mark.live_test_only
-@pytest.mark.parametrize("http_request", HTTP_REQUESTS)
-def test_decompress_plain_header(http_request):
-    # expect error
-    account_name = "coretests"
-    account_url = "https://{}.blob.core.windows.net".format(account_name)
-    url = "https://{}.blob.core.windows.net/tests/test_with_header.txt".format(account_name)
-    client = PipelineClient(account_url)
-    request = http_request("GET", url)
-    pipeline_response = client._pipeline.run(request, stream=True)
-    response = pipeline_response.http_response
-    data = response.stream_download(client._pipeline, decompress=True)
-    with pytest.raises(DecodeError):
-        list(data)
-
-
 @pytest.mark.parametrize("http_request", HTTP_REQUESTS)
 def test_decompress_plain_header_offline(port, http_request):
     request = http_request(method="GET", url="http://localhost:{}/streams/compressed".format(port))
@@ -158,40 +68,6 @@ def test_decompress_plain_header_offline(port, http_request):
         data = response.stream_download(sender, decompress=True)
         with pytest.raises(DecodeError):
             list(data)
-
-
-@pytest.mark.live_test_only
-@pytest.mark.parametrize("http_request", HTTP_REQUESTS)
-def test_compress_plain_header(http_request):
-    # expect plain text
-    account_name = "coretests"
-    account_url = "https://{}.blob.core.windows.net".format(account_name)
-    url = "https://{}.blob.core.windows.net/tests/test_with_header.txt".format(account_name)
-    client = PipelineClient(account_url)
-    request = http_request("GET", url)
-    pipeline_response = client._pipeline.run(request, stream=True)
-    response = pipeline_response.http_response
-    data = response.stream_download(client._pipeline, decompress=False)
-    content = b"".join(list(data))
-    decoded = content.decode("utf-8")
-    assert decoded == "test"
-
-
-@pytest.mark.live_test_only
-@pytest.mark.parametrize("http_request", HTTP_REQUESTS)
-def test_decompress_compressed_header(http_request):
-    # expect plain text
-    account_name = "coretests"
-    account_url = "https://{}.blob.core.windows.net".format(account_name)
-    url = "https://{}.blob.core.windows.net/tests/test_with_header.tar.gz".format(account_name)
-    client = PipelineClient(account_url)
-    request = http_request("GET", url)
-    pipeline_response = client._pipeline.run(request, stream=True)
-    response = pipeline_response.http_response
-    data = response.stream_download(client._pipeline, decompress=True)
-    content = b"".join(list(data))
-    decoded = content.decode("utf-8")
-    assert decoded == "test"
 
 
 @pytest.mark.parametrize("http_request", HTTP_REQUESTS)
@@ -205,26 +81,6 @@ def test_decompress_compressed_header_offline(port, http_request):
         content = b"".join(list(data))
         decoded = content.decode("utf-8")
         assert decoded == "test"
-
-
-@pytest.mark.live_test_only
-@pytest.mark.parametrize("http_request", HTTP_REQUESTS)
-def test_compress_compressed_header(http_request):
-    # expect compressed text
-    account_name = "coretests"
-    account_url = "https://{}.blob.core.windows.net".format(account_name)
-    url = "https://{}.blob.core.windows.net/tests/test_with_header.tar.gz".format(account_name)
-    client = PipelineClient(account_url)
-    request = http_request("GET", url)
-    pipeline_response = client._pipeline.run(request, stream=True)
-    response = pipeline_response.http_response
-    data = response.stream_download(client._pipeline, decompress=False)
-    content = b"".join(list(data))
-    try:
-        decoded = content.decode("utf-8")
-        assert False
-    except UnicodeDecodeError:
-        pass
 
 
 @pytest.mark.parametrize("http_request", HTTP_REQUESTS)
@@ -262,6 +118,7 @@ def test_decompress_compressed_no_header_offline(port, http_request):
     response.raise_for_status()
     data = response.stream_download(client._pipeline, decompress=True)
     content = b"".join(list(data))
+    assert content.startswith(b"\x1f\x8b")  # gzip magic number
     with pytest.raises(UnicodeDecodeError):
         content.decode("utf-8")
 

--- a/sdk/core/corehttp/tests/async_tests/test_rest_stream_responses_async.py
+++ b/sdk/core/corehttp/tests/async_tests/test_rest_stream_responses_async.py
@@ -129,9 +129,7 @@ async def test_cannot_read_after_response_closed(port, transport):
 @pytest.mark.parametrize("transport", ASYNC_TRANSPORTS)
 async def test_decompress_plain_no_header(port, transport):
     # thanks to Xiang Yan for this test!
-    account_name = "coretests"
-    url = "https://{}.blob.core.windows.net/tests/test.txt".format(account_name)
-    request = HttpRequest("GET", url)
+    request = HttpRequest("GET", "/streams/string")
     client = AsyncMockRestClient(port, transport=transport())
     async with client:
         response = await client.send_request(request, stream=True)
@@ -145,9 +143,7 @@ async def test_decompress_plain_no_header(port, transport):
 @pytest.mark.parametrize("transport", ASYNC_TRANSPORTS)
 async def test_compress_plain_no_header(port, transport):
     # thanks to Xiang Yan for this test!
-    account_name = "coretests"
-    url = "https://{}.blob.core.windows.net/tests/test.txt".format(account_name)
-    request = HttpRequest("GET", url)
+    request = HttpRequest("GET", "/streams/string")
     client = AsyncMockRestClient(port, transport=transport())
     async with client:
         response = await client.send_request(request, stream=True)

--- a/sdk/core/corehttp/tests/async_tests/test_rest_stream_responses_async.py
+++ b/sdk/core/corehttp/tests/async_tests/test_rest_stream_responses_async.py
@@ -127,35 +127,6 @@ async def test_cannot_read_after_response_closed(port, transport):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("transport", ASYNC_TRANSPORTS)
-async def test_decompress_plain_no_header(port, transport):
-    # thanks to Xiang Yan for this test!
-    request = HttpRequest("GET", "/streams/string")
-    client = AsyncMockRestClient(port, transport=transport())
-    async with client:
-        response = await client.send_request(request, stream=True)
-        with pytest.raises(ResponseNotReadError):
-            response.content
-        await response.read()
-        assert response.content == b"test"
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize("transport", ASYNC_TRANSPORTS)
-async def test_compress_plain_no_header(port, transport):
-    # thanks to Xiang Yan for this test!
-    request = HttpRequest("GET", "/streams/string")
-    client = AsyncMockRestClient(port, transport=transport())
-    async with client:
-        response = await client.send_request(request, stream=True)
-        iter = response.iter_raw()
-        data = b""
-        async for d in iter:
-            data += d
-        assert data == b"test"
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize("transport", ASYNC_TRANSPORTS)
 async def test_iter_read_back_and_forth(port, transport):
     # thanks to McCoy Patiño for this test!
 

--- a/sdk/core/corehttp/tests/async_tests/test_streaming_async.py
+++ b/sdk/core/corehttp/tests/async_tests/test_streaming_async.py
@@ -27,159 +27,12 @@ from corehttp.exceptions import DecodeError
 from utils import ASYNC_TRANSPORTS
 
 
-@pytest.mark.live_test_only
-@pytest.mark.asyncio
-@pytest.mark.parametrize("transport", ASYNC_TRANSPORTS)
-async def test_decompress_plain_no_header(transport):
-    # expect plain text
-    account_name = "coretests"
-    account_url = "https://{}.blob.core.windows.net".format(account_name)
-    url = "https://{}.blob.core.windows.net/tests/test.txt".format(account_name)
-    client = AsyncPipelineClient(account_url, transport=transport())
-    async with client:
-        request = HttpRequest("GET", url)
-        pipeline_response = await client.pipeline.run(request, stream=True)
-        response = pipeline_response.http_response
-        data = response.iter_bytes()
-        decoded = b"".join([d async for d in data]).decode("utf-8")
-        assert decoded == "test"
-
-
-@pytest.mark.live_test_only
-@pytest.mark.asyncio
-@pytest.mark.parametrize("transport", ASYNC_TRANSPORTS)
-async def test_compress_plain_no_header(transport):
-    # expect plain text
-    account_name = "coretests"
-    account_url = "https://{}.blob.core.windows.net".format(account_name)
-    url = "https://{}.blob.core.windows.net/tests/test.txt".format(account_name)
-    client = AsyncPipelineClient(account_url, transport=transport())
-    async with client:
-        request = HttpRequest("GET", url)
-        pipeline_response = await client.pipeline.run(request, stream=True)
-        response = pipeline_response.http_response
-        data = response.iter_raw()
-        decoded = b"".join([d async for d in data]).decode("utf-8")
-        assert decoded == "test"
-
-
-@pytest.mark.live_test_only
-@pytest.mark.asyncio
-@pytest.mark.parametrize("transport", ASYNC_TRANSPORTS)
-async def test_decompress_compressed_no_header(transport):
-    # expect compressed text
-    account_name = "coretests"
-    account_url = "https://{}.blob.core.windows.net".format(account_name)
-    url = "https://{}.blob.core.windows.net/tests/test.tar.gz".format(account_name)
-    client = AsyncPipelineClient(account_url, transport=transport())
-    async with client:
-        request = HttpRequest("GET", url)
-        pipeline_response = await client.pipeline.run(request, stream=True)
-        response = pipeline_response.http_response
-        data = response.iter_bytes()
-        content = b"".join([d async for d in data])
-        with pytest.raises(UnicodeDecodeError):
-            content.decode("utf-8")
-
-
-@pytest.mark.live_test_only
-@pytest.mark.asyncio
-@pytest.mark.parametrize("transport", ASYNC_TRANSPORTS)
-async def test_compress_compressed_no_header(transport):
-    # expect compressed text
-    account_name = "coretests"
-    account_url = "https://{}.blob.core.windows.net".format(account_name)
-    url = "https://{}.blob.core.windows.net/tests/test.tar.gz".format(account_name)
-    client = AsyncPipelineClient(account_url, transport=transport())
-    async with client:
-        request = HttpRequest("GET", url)
-        pipeline_response = await client.pipeline.run(request, stream=True)
-        response = pipeline_response.http_response
-        data = response.iter_raw()
-        content = b"".join([d async for d in data])
-        with pytest.raises(UnicodeDecodeError):
-            content.decode("utf-8")
-
-
 @pytest.mark.asyncio
 @pytest.mark.parametrize("transport", ASYNC_TRANSPORTS)
 async def test_compress_compressed_no_header_offline(port, transport):
     # expect compressed text
     url = "http://localhost:{}/streams/compressed_no_header".format(port)
     client = AsyncPipelineClient(url, transport=transport())
-    async with client:
-        request = HttpRequest("GET", url)
-        pipeline_response = await client.pipeline.run(request, stream=True)
-        response = pipeline_response.http_response
-        data = response.iter_raw()
-        content = b"".join([d async for d in data])
-        with pytest.raises(UnicodeDecodeError):
-            content.decode("utf-8")
-
-
-@pytest.mark.live_test_only
-@pytest.mark.asyncio
-@pytest.mark.parametrize("transport", ASYNC_TRANSPORTS)
-async def test_decompress_plain_header(transport):
-    # expect error
-    account_name = "coretests"
-    account_url = "https://{}.blob.core.windows.net".format(account_name)
-    url = "https://{}.blob.core.windows.net/tests/test_with_header.txt".format(account_name)
-    client = AsyncPipelineClient(account_url, transport=transport())
-    async with client:
-        request = HttpRequest("GET", url)
-        pipeline_response = await client.pipeline.run(request, stream=True)
-        response = pipeline_response.http_response
-        data = response.iter_bytes()
-        with pytest.raises((zlib.error, DecodeError)):
-            b"".join([d async for d in data])
-
-
-@pytest.mark.live_test_only
-@pytest.mark.asyncio
-@pytest.mark.parametrize("transport", ASYNC_TRANSPORTS)
-async def test_compress_plain_header(transport):
-    # expect plain text
-    account_name = "coretests"
-    account_url = "https://{}.blob.core.windows.net".format(account_name)
-    url = "https://{}.blob.core.windows.net/tests/test_with_header.txt".format(account_name)
-    client = AsyncPipelineClient(account_url, transport=transport())
-    async with client:
-        request = HttpRequest("GET", url)
-        pipeline_response = await client.pipeline.run(request, stream=True)
-        response = pipeline_response.http_response
-        data = response.iter_raw()
-        decoded = b"".join([d async for d in data]).decode("utf-8")
-        assert decoded == "test"
-
-
-@pytest.mark.live_test_only
-@pytest.mark.asyncio
-@pytest.mark.parametrize("transport", ASYNC_TRANSPORTS)
-async def test_decompress_compressed_header(transport):
-    # expect plain text
-    account_name = "coretests"
-    account_url = "https://{}.blob.core.windows.net".format(account_name)
-    url = "https://{}.blob.core.windows.net/tests/test_with_header.tar.gz".format(account_name)
-    client = AsyncPipelineClient(account_url, transport=transport())
-    async with client:
-        request = HttpRequest("GET", url)
-        pipeline_response = await client.pipeline.run(request, stream=True)
-        response = pipeline_response.http_response
-        data = response.iter_bytes()
-        decoded = b"".join([d async for d in data]).decode("utf-8")
-        assert decoded == "test"
-
-
-@pytest.mark.live_test_only
-@pytest.mark.asyncio
-@pytest.mark.parametrize("transport", ASYNC_TRANSPORTS)
-async def test_compress_compressed_header(transport):
-    # expect compressed text
-    account_name = "coretests"
-    account_url = "https://{}.blob.core.windows.net".format(account_name)
-    url = "https://{}.blob.core.windows.net/tests/test_with_header.tar.gz".format(account_name)
-    client = AsyncPipelineClient(account_url, transport=transport())
     async with client:
         request = HttpRequest("GET", url)
         pipeline_response = await client.pipeline.run(request, stream=True)
@@ -232,6 +85,7 @@ async def test_decompress_compressed_no_header_offline(port, transport):
         response = pipeline_response.http_response
         data = response.iter_bytes()
         content = b"".join([d async for d in data])
+        assert content.startswith(b"\x1f\x8b")  # gzip magic number
         with pytest.raises(UnicodeDecodeError):
             content.decode("utf-8")
 

--- a/sdk/core/corehttp/tests/test_rest_stream_responses.py
+++ b/sdk/core/corehttp/tests/test_rest_stream_responses.py
@@ -121,40 +121,6 @@ def test_cannot_read_after_response_closed(port, transport):
 
 
 @pytest.mark.parametrize("transport", SYNC_TRANSPORTS)
-def test_decompress_plain_no_header(port, transport):
-    # thanks to Xiang Yan for this test!
-    request = HttpRequest("GET", "/streams/string")
-    client = MockRestClient(port, transport=transport())
-    response = client.send_request(request, stream=True)
-    with pytest.raises(ResponseNotReadError):
-        response.content
-    response.read()
-    assert response.content == b"test"
-
-
-@pytest.mark.parametrize("transport", SYNC_TRANSPORTS)
-def test_compress_plain_no_header(port, transport):
-    # thanks to Xiang Yan for this test!
-    request = HttpRequest("GET", "/streams/string")
-    client = MockRestClient(port, transport=transport())
-    response = client.send_request(request, stream=True)
-    iter = response.iter_raw()
-    data = b"".join(list(iter))
-    assert data == b"test"
-
-
-@pytest.mark.parametrize("transport", SYNC_TRANSPORTS)
-def test_decompress_compressed_no_header(port, transport):
-    # thanks to Xiang Yan for this test!
-    request = HttpRequest("GET", "streams/compressed_no_header")
-    client = MockRestClient(port, transport=transport())
-    response = client.send_request(request, stream=True)
-    iter = response.iter_bytes()
-    data = b"".join(list(iter))
-    assert data.startswith(b"\x1f\x8b")  # gzip magic number
-
-
-@pytest.mark.parametrize("transport", SYNC_TRANSPORTS)
 def test_iter_read(port, transport):
     # thanks to McCoy Patiño for this test!
     request = HttpRequest("GET", "/basic/string")

--- a/sdk/core/corehttp/tests/test_rest_stream_responses.py
+++ b/sdk/core/corehttp/tests/test_rest_stream_responses.py
@@ -123,9 +123,7 @@ def test_cannot_read_after_response_closed(port, transport):
 @pytest.mark.parametrize("transport", SYNC_TRANSPORTS)
 def test_decompress_plain_no_header(port, transport):
     # thanks to Xiang Yan for this test!
-    account_name = "coretests"
-    url = "https://{}.blob.core.windows.net/tests/test.txt".format(account_name)
-    request = HttpRequest("GET", url)
+    request = HttpRequest("GET", "/streams/string")
     client = MockRestClient(port, transport=transport())
     response = client.send_request(request, stream=True)
     with pytest.raises(ResponseNotReadError):
@@ -137,9 +135,7 @@ def test_decompress_plain_no_header(port, transport):
 @pytest.mark.parametrize("transport", SYNC_TRANSPORTS)
 def test_compress_plain_no_header(port, transport):
     # thanks to Xiang Yan for this test!
-    account_name = "coretests"
-    url = "https://{}.blob.core.windows.net/tests/test.txt".format(account_name)
-    request = HttpRequest("GET", url)
+    request = HttpRequest("GET", "/streams/string")
     client = MockRestClient(port, transport=transport())
     response = client.send_request(request, stream=True)
     iter = response.iter_raw()
@@ -150,27 +146,12 @@ def test_compress_plain_no_header(port, transport):
 @pytest.mark.parametrize("transport", SYNC_TRANSPORTS)
 def test_decompress_compressed_no_header(port, transport):
     # thanks to Xiang Yan for this test!
-    account_name = "coretests"
-    url = "https://{}.blob.core.windows.net/tests/test.tar.gz".format(account_name)
-    request = HttpRequest("GET", url)
+    request = HttpRequest("GET", "streams/compressed_no_header")
     client = MockRestClient(port, transport=transport())
     response = client.send_request(request, stream=True)
     iter = response.iter_bytes()
     data = b"".join(list(iter))
-    assert data == b"\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\n+I-.\x01\x00\x0c~\x7f\xd8\x04\x00\x00\x00"
-
-
-@pytest.mark.parametrize("transport", SYNC_TRANSPORTS)
-def test_decompress_compressed_header_targz(port, transport):
-    # thanks to Xiang Yan for this test!
-    account_name = "coretests"
-    url = "https://{}.blob.core.windows.net/tests/test_with_header.tar.gz".format(account_name)
-    request = HttpRequest("GET", url)
-    client = MockRestClient(port, transport=transport())
-    response = client.send_request(request, stream=True)
-    iter = response.iter_bytes()
-    data = b"".join(list(iter))
-    assert data == b"test"
+    assert data.startswith(b"\x1f\x8b")  # gzip magic number
 
 
 @pytest.mark.parametrize("transport", SYNC_TRANSPORTS)

--- a/sdk/core/corehttp/tests/test_streaming.py
+++ b/sdk/core/corehttp/tests/test_streaming.py
@@ -26,22 +26,6 @@ from corehttp.exceptions import DecodeError
 from utils import SYNC_TRANSPORTS
 
 
-@pytest.mark.live_test_only
-@pytest.mark.parametrize("transport", SYNC_TRANSPORTS)
-def test_decompress_plain_no_header(transport):
-    # expect plain text
-    account_name = "coretests"
-    account_url = "https://{}.blob.core.windows.net".format(account_name)
-    url = "https://{}.blob.core.windows.net/tests/test.txt".format(account_name)
-    client = PipelineClient(account_url, transport=transport())
-    request = HttpRequest("GET", url)
-    pipeline_response = client.pipeline.run(request, stream=True)
-    response = pipeline_response.http_response
-    content = response.read()
-    decoded = content.decode("utf-8")
-    assert decoded == "test"
-
-
 @pytest.mark.parametrize("transport", SYNC_TRANSPORTS)
 def test_compress_plain_no_header_offline(port, transport):
     # cspell:disable-next-line
@@ -57,38 +41,6 @@ def test_compress_plain_no_header_offline(port, transport):
         assert decoded == "test"
 
 
-@pytest.mark.live_test_only
-@pytest.mark.parametrize("transport", SYNC_TRANSPORTS)
-def test_compress_plain_no_header(transport):
-    # expect plain text
-    account_name = "coretests"
-    account_url = "https://{}.blob.core.windows.net".format(account_name)
-    url = "https://{}.blob.core.windows.net/tests/test.txt".format(account_name)
-    client = PipelineClient(account_url, transport=transport())
-    request = HttpRequest("GET", url)
-    pipeline_response = client.pipeline.run(request, stream=True)
-    response = pipeline_response.http_response
-    content = response.read()
-    decoded = content.decode("utf-8")
-    assert decoded == "test"
-
-
-@pytest.mark.live_test_only
-@pytest.mark.parametrize("transport", SYNC_TRANSPORTS)
-def test_decompress_compressed_no_header(transport):
-    # expect compressed text
-    account_name = "coretests"
-    account_url = "https://{}.blob.core.windows.net".format(account_name)
-    url = "https://{}.blob.core.windows.net/tests/test.tar.gz".format(account_name)
-    client = PipelineClient(account_url, transport=transport())
-    request = HttpRequest("GET", url)
-    pipeline_response = client.pipeline.run(request, stream=True)
-    response = pipeline_response.http_response
-    content = response.read()
-    with pytest.raises(UnicodeDecodeError):
-        content.decode("utf-8")
-
-
 @pytest.mark.parametrize("transport", SYNC_TRANSPORTS)
 def test_compress_compressed_no_header_offline(port, transport):
     # expect compressed text
@@ -102,38 +54,6 @@ def test_compress_compressed_no_header_offline(port, transport):
         content.decode("utf-8")
 
 
-@pytest.mark.live_test_only
-@pytest.mark.parametrize("transport", SYNC_TRANSPORTS)
-def test_compress_compressed_no_header(transport):
-    # expect compressed text
-    account_name = "coretests"
-    account_url = "https://{}.blob.core.windows.net".format(account_name)
-    url = "https://{}.blob.core.windows.net/tests/test.tar.gz".format(account_name)
-    client = PipelineClient(account_url, transport=transport())
-    request = HttpRequest("GET", url)
-    pipeline_response = client.pipeline.run(request, stream=True)
-    response = pipeline_response.http_response
-    content = response.read()
-    with pytest.raises(UnicodeDecodeError):
-        content.decode("utf-8")
-
-
-@pytest.mark.live_test_only
-@pytest.mark.parametrize("transport", SYNC_TRANSPORTS)
-def test_decompress_plain_header(transport):
-    # expect error
-    account_name = "coretests"
-    account_url = "https://{}.blob.core.windows.net".format(account_name)
-    url = "https://{}.blob.core.windows.net/tests/test_with_header.txt".format(account_name)
-    client = PipelineClient(account_url, transport=transport())
-    request = HttpRequest("GET", url)
-    pipeline_response = client.pipeline.run(request, stream=True)
-    response = pipeline_response.http_response
-    data = response.iter_bytes()
-    with pytest.raises(DecodeError):
-        list(data)
-
-
 @pytest.mark.parametrize("transport", SYNC_TRANSPORTS)
 def test_decompress_plain_header_offline(port, transport):
     request = HttpRequest(method="GET", url="http://localhost:{}/streams/compressed".format(port))
@@ -143,39 +63,6 @@ def test_decompress_plain_header_offline(port, transport):
         data = response.iter_bytes()
         with pytest.raises(DecodeError):
             list(data)
-
-
-@pytest.mark.live_test_only
-@pytest.mark.parametrize("transport", SYNC_TRANSPORTS)
-def test_compress_plain_header(transport):
-    # expect plain text
-    account_name = "coretests"
-    account_url = "https://{}.blob.core.windows.net".format(account_name)
-    url = "https://{}.blob.core.windows.net/tests/test_with_header.txt".format(account_name)
-    client = PipelineClient(account_url, transport=transport())
-    request = HttpRequest("GET", url)
-    pipeline_response = client.pipeline.run(request, stream=True)
-    response = pipeline_response.http_response
-    data = response.iter_raw()
-    content = b"".join(list(data))
-    decoded = content.decode("utf-8")
-    assert decoded == "test"
-
-
-@pytest.mark.live_test_only
-@pytest.mark.parametrize("transport", SYNC_TRANSPORTS)
-def test_decompress_compressed_header(transport):
-    # expect plain text
-    account_name = "coretests"
-    account_url = "https://{}.blob.core.windows.net".format(account_name)
-    url = "https://{}.blob.core.windows.net/tests/test_with_header.tar.gz".format(account_name)
-    client = PipelineClient(account_url, transport=transport())
-    request = HttpRequest("GET", url)
-    pipeline_response = client.pipeline.run(request, stream=True)
-    response = pipeline_response.http_response
-    content = response.read()
-    decoded = content.decode("utf-8")
-    assert decoded == "test"
 
 
 @pytest.mark.parametrize("transport", SYNC_TRANSPORTS)
@@ -188,23 +75,6 @@ def test_decompress_compressed_header_offline(port, transport):
         content = response.read()
         decoded = content.decode("utf-8")
         assert decoded == "test"
-
-
-@pytest.mark.live_test_only
-@pytest.mark.parametrize("transport", SYNC_TRANSPORTS)
-def test_compress_compressed_header(transport):
-    # expect compressed text
-    account_name = "coretests"
-    account_url = "https://{}.blob.core.windows.net".format(account_name)
-    url = "https://{}.blob.core.windows.net/tests/test_with_header.tar.gz".format(account_name)
-    client = PipelineClient(account_url, transport=transport())
-    request = HttpRequest("GET", url)
-    pipeline_response = client.pipeline.run(request, stream=True)
-    response = pipeline_response.http_response
-    data = response.iter_raw()
-    content = b"".join(list(data))
-    with pytest.raises(UnicodeDecodeError):
-        content.decode("utf-8")
 
 
 @pytest.mark.parametrize("transport", SYNC_TRANSPORTS)
@@ -243,6 +113,7 @@ def test_decompress_compressed_no_header_offline(port, transport):
     pipeline_response = client.pipeline.run(request, stream=True)
     response = pipeline_response.http_response
     content = response.read()
+    assert content.startswith(b"\x1f\x8b")  # gzip magic number
     with pytest.raises(UnicodeDecodeError):
         content.decode("utf-8")
 

--- a/sdk/core/corehttp/tests/testserver_tests/coretestserver/coretestserver/test_routes/streams.py
+++ b/sdk/core/corehttp/tests/testserver_tests/coretestserver/coretestserver/test_routes/streams.py
@@ -80,6 +80,7 @@ def compressed():
 
 
 def compressed_stream():
+
     with tempfile.TemporaryFile(mode="w+b") as f:
         gzf = gzip.GzipFile(mode="w+b", fileobj=f)
         gzf.write(b"test")


### PR DESCRIPTION
Pipeline failure fixes. Some tests hit an external endpoint that we no longer have access to. These are adjusted to hit the local endpoint if possible.

In core, there were also two tests with the same name `test_decompress_compressed_header`. The one that hits the external endpoint was removed since it's testing similar functionality as the other one. A similar removal was also made in `corehttp`.