### PR TITLE
[ML]: fix: Index Operation Fixes

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_ml_client.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_ml_client.py
@@ -1033,6 +1033,7 @@ class MLClient:
         """
         return self._marketplace_subscriptions
 
+    @property
     def indexes(self) -> IndexOperations:
         """A collection of index related operations.
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_ml_client.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_ml_client.py
@@ -44,11 +44,11 @@ from azure.ai.ml._restclient.workspace_dataplane import (
 from azure.ai.ml._scope_dependent_operations import OperationConfig, OperationsContainer, OperationScope
 from azure.ai.ml._telemetry.logging_handler import get_appinsights_log_handler
 from azure.ai.ml._user_agent import USER_AGENT
+from azure.ai.ml._utils._experimental import experimental
 from azure.ai.ml._utils._http_utils import HttpPipeline
 from azure.ai.ml._utils._preflight_utils import get_deployments_operation
 from azure.ai.ml._utils._registry_utils import get_registry_client
 from azure.ai.ml._utils.utils import _is_https_url
-from azure.ai.ml._utils._experimental import experimental
 from azure.ai.ml.constants._common import AzureMLResourceType, DefaultOpenEncoding
 from azure.ai.ml.entities import (
     BatchDeployment,
@@ -59,6 +59,7 @@ from azure.ai.ml.entities import (
     Environment,
     Index,
     Job,
+    MarketplaceSubscription,
     Model,
     ModelBatchDeployment,
     OnlineDeployment,
@@ -66,9 +67,8 @@ from azure.ai.ml.entities import (
     PipelineComponentBatchDeployment,
     Registry,
     Schedule,
-    Workspace,
     ServerlessEndpoint,
-    MarketplaceSubscription,
+    Workspace,
 )
 from azure.ai.ml.entities._assets import WorkspaceAssetReference
 from azure.ai.ml.exceptions import ErrorCategory, ErrorTarget, ValidationException
@@ -77,19 +77,19 @@ from azure.ai.ml.operations import (
     BatchEndpointOperations,
     ComponentOperations,
     ComputeOperations,
+    ConnectionsOperations,
     DataOperations,
     DatastoreOperations,
     EnvironmentOperations,
     IndexOperations,
     JobOperations,
+    MarketplaceSubscriptionOperations,
     ModelOperations,
     OnlineDeploymentOperations,
     OnlineEndpointOperations,
     RegistryOperations,
-    ConnectionsOperations,
-    WorkspaceOperations,
     ServerlessEndpointOperations,
-    MarketplaceSubscriptionOperations,
+    WorkspaceOperations,
 )
 from azure.ai.ml.operations._code_operations import CodeOperations
 from azure.ai.ml.operations._feature_set_operations import FeatureSetOperations

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_assets/_artifacts/index.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_assets/_artifacts/index.py
@@ -6,8 +6,9 @@ from typing import Any, Dict, Optional, Union
 
 # cspell:disable-next-line
 from azure.ai.ml._restclient.azure_ai_assets_v2024_04_01.azureaiassetsv20240401.models import Index as RestIndex
-from azure.ai.ml._utils._arm_id_utils import AMLAssetId
+from azure.ai.ml._utils._arm_id_utils import AMLAssetId, AMLNamedArmId
 from azure.ai.ml._utils._experimental import experimental
+from azure.ai.ml.constants._common import LONG_URI_FORMAT
 from azure.ai.ml.entities._assets import Artifact
 from azure.ai.ml.entities._assets._artifacts.artifact import ArtifactStorageInfo
 from azure.ai.ml.entities._system_data import RestSystemData, SystemData
@@ -117,4 +118,11 @@ class Index(Artifact):
 
         :param ArtifactStorageInfo asset_artifact: The asset storage info of the artifact
         """
-        self.path = asset_artifact.full_storage_path
+        aml_datastore_id = AMLNamedArmId(asset_artifact.datastore_arm_id)
+        self.path = LONG_URI_FORMAT.format(
+            aml_datastore_id.subscription_id,
+            aml_datastore_id.resource_group_name,
+            aml_datastore_id.workspace_name,
+            aml_datastore_id.asset_name,
+            asset_artifact.relative_path,
+        )

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_assets/_artifacts/index.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_assets/_artifacts/index.py
@@ -42,7 +42,7 @@ class Index(Artifact):
         *,
         name: str,
         version: str,
-        stage: str,
+        stage: str = "Development",
         description: Optional[str] = None,
         tags: Optional[Dict[str, str]] = None,
         properties: Optional[Dict[str, str]] = None,


### PR DESCRIPTION
# Description

This pull request is a follow up to #35251 

* It fixes a bug introduced in that accidentally removed the `@property` decorator from `ml_client.indexes` in #34474
* Sets the default value of `Index.stage` to `Development`
* It changes the format format of `Index.path` from a storage uri (`https://STORAGEACCOUNT.blob.core.windows.net/path/to/files`) to a datastore uri  (`azureml://subscriptions/{subscription}/resourcegroups/{resourcegroup}/workspaces/{workspace}/datastores/{datastore}/paths/{path}`)

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
