### PR TITLE
[Cognitive Services] prepare TA and AD for deprecation release

### DIFF
--- a/sdk/cognitiveservices/azure-cognitiveservices-anomalydetector/CHANGELOG.md
+++ b/sdk/cognitiveservices/azure-cognitiveservices-anomalydetector/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 0.3.1 (2024-04-30)
+## 0.3.1 (2024-05-01)
 
 This package is no longer being maintained. Use the [azure-ai-anomalydetector](https://pypi.org/project/azure-ai-anomalydetector/) package instead for latest features and support.
 

--- a/sdk/cognitiveservices/azure-cognitiveservices-language-textanalytics/CHANGELOG.md
+++ b/sdk/cognitiveservices/azure-cognitiveservices-language-textanalytics/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 0.2.2 (2024-04-30)
+## 0.2.2 (2024-05-01)
 
 - This package is no longer being maintained. Please install the [azure-ai-textanalytics](https://pypi.org/project/azure-ai-textanalytics/) package for the latest features and support.
 

--- a/sdk/cognitiveservices/ci.yml
+++ b/sdk/cognitiveservices/ci.yml
@@ -29,12 +29,16 @@ extends:
     ServiceDirectory: cognitiveservices
     TestTimeoutInMinutes: 150
     Artifacts:
+    - name: azure-cognitiveservices-anomalydetector
+      safeName: azurecognitiveservicesanomalydetector
     - name: azure-cognitiveservices-knowledge-qnamaker
       safeName: azurecognitiveservicesknowledgeqnamaker
     - name: azure-cognitiveservices-language-luis
       safeName: azurecognitiveserviceslanguageluis
     - name: azure-cognitiveservices-language-spellcheck
       safeName: azurecognitiveserviceslanguagespellcheck
+    - name: azure-cognitiveservices-language-textanalytics
+      safeName: azurecognitiveserviceslanguagetextanalytics
     - name: azure-cognitiveservices-personalizer
       safeName: azurecognitiveservicespersonalizer
     - name: azure-cognitiveservices-search-autosuggest


### PR DESCRIPTION
Adding `textanalytics` and `anomalydetector` back to ci.yml for releasing deprecated packages.