### PR TITLE
Conditionals within `run_apistub.yml` should all align

### DIFF
--- a/eng/pipelines/templates/steps/run_apistub.yml
+++ b/eng/pipelines/templates/steps/run_apistub.yml
@@ -17,6 +17,7 @@ steps:
   - script: |
       python -m pip install -r eng/ci_tools.txt
     displayName: 'Prep Environment'
+    condition: and(succeededOrFailed(), ne(variables['Skip.ApiStubGen'],'true'))
 
   - task: PythonScript@0
     condition: and(succeededOrFailed(), ne(variables['Skip.ApiStubGen'],'true'))


### PR DESCRIPTION
See title. Discovered by failure [over here](https://dev.azure.com/azure-sdk/public/_build/results?buildId=3759266&view=logs&j=4259cd7e-6a4b-5ca5-581a-0ae020cd9d20&t=4d670c9c-5acd-5cc3-aede-d35282ac764a&l=2546)