### PR TITLE
Fixes to start time for change feed query

### DIFF
--- a/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_container.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_container.py
@@ -487,8 +487,8 @@ class ContainerProxy:
 
         :keyword bool is_start_from_beginning: Get whether change feed should start from
             beginning (true) or from current (false). By default, it's start from current (false).
-        :keyword datetime start_time: Specifies a point of time to start change feed. Start time in
-            '%a, %d %b %Y %H:%M:%S GMT' format. Converts datetime to UTC regardless of timezone.
+        :keyword ~datetime.datetime start_time: Specifies a point of time to start change feed. Provided value will be
+            converted to UTC. This value will be ignored if `is_start_from_beginning` is set to true.
         :keyword str partition_key_range_id: ChangeFeed requests can be executed against specific partition key
             ranges. This is used to process the change feed in parallel across multiple consumers.
         :keyword str continuation: e_tag value to be used as continuation for reading change feed.
@@ -508,7 +508,7 @@ class ContainerProxy:
             kwargs['priority'] = priority
         feed_options = _build_options(kwargs)
         feed_options["isStartFromBeginning"] = is_start_from_beginning
-        if start_time is not None and is_start_from_beginning is False and isinstance(start_time, datetime):
+        if start_time is not None and is_start_from_beginning is False:
             feed_options["startTime"] = start_time.astimezone(timezone.utc).strftime('%a, %d %b %Y %H:%M:%S GMT')
         if partition_key_range_id is not None:
             feed_options["partitionKeyRangeId"] = partition_key_range_id

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/container.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/container.py
@@ -307,10 +307,10 @@ class ContainerProxy:  # pylint: disable=too-many-public-methods
         self,
         partition_key_range_id: Optional[str] = None,
         is_start_from_beginning: bool = False,
-        start_time: Optional[datetime] = None,
         continuation: Optional[str] = None,
         max_item_count: Optional[int] = None,
         *,
+        start_time: Optional[datetime] = None,
         partition_key: Optional[PartitionKeyType] = None,
         priority: Optional[Literal["High", "Low"]] = None,
         **kwargs: Any
@@ -321,11 +321,11 @@ class ContainerProxy:  # pylint: disable=too-many-public-methods
             This is used to process the change feed in parallel across multiple consumers.
         :param bool is_start_from_beginning: Get whether change feed should start from
             beginning (true) or from current (false). By default, it's start from current (false).
-        :param datetime start_time: Specifies a point of time to start change feed. Start time in
-            '%a, %d %b %Y %H:%M:%S GMT' format. Converts datetime to UTC regardless of timezone.
         :param max_item_count: Max number of items to be returned in the enumeration operation.
         :param str continuation: e_tag value to be used as continuation for reading change feed.
         :param int max_item_count: Max number of items to be returned in the enumeration operation.
+        :keyword ~datetime.datetime start_time: Specifies a point of time to start change feed. Provided value will be
+            converted to UTC. This value will be ignored if `is_start_from_beginning` is set to true.
         :keyword partition_key: partition key at which ChangeFeed requests are targeted.
         :paramtype partition_key: Union[str, int, float, bool, List[Union[str, int, float, bool]]]
         :keyword Callable response_hook: A callable invoked with the response metadata.
@@ -345,7 +345,7 @@ class ContainerProxy:  # pylint: disable=too-many-public-methods
             feed_options["partitionKey"] = self._set_partition_key(partition_key)
         if is_start_from_beginning is not None:
             feed_options["isStartFromBeginning"] = is_start_from_beginning
-        if start_time is not None and is_start_from_beginning is False and isinstance(start_time, datetime):
+        if start_time is not None and is_start_from_beginning is False:
             feed_options["startTime"] = start_time.astimezone(timezone.utc).strftime('%a, %d %b %Y %H:%M:%S GMT')
         if max_item_count is not None:
             feed_options["maxItemCount"] = max_item_count

--- a/sdk/cosmos/azure-cosmos/test/test_query.py
+++ b/sdk/cosmos/azure-cosmos/test/test_query.py
@@ -337,12 +337,13 @@ class TestQuery(unittest.TestCase):
         # Should equal batch size
         self.assertEqual(totalCount, batchSize)
 
-        # test an invalid value, will ignore start time option
+        # test an invalid value, Attribute error will be raised for passing non datetime object
         invalid_time = "Invalid value"
-        change_feed_iter = list(created_collection.query_items_change_feed(start_time=invalid_time))
-        totalCount = len(change_feed_iter)
-        # Should not equal batch size
-        self.assertNotEqual(totalCount, batchSize)
+        try:
+            change_feed_iter = list(created_collection.query_items_change_feed(start_time=invalid_time))
+            self.fail("Cannot format date on a non datetime object.")
+        except AttributeError as e:
+            self.assertTrue("'str' object has no attribute 'astimezone'" == e.args[0])
 
     def test_populate_query_metrics(self):
         created_collection = self.created_db.create_container("query_metrics_test",

--- a/sdk/cosmos/azure-cosmos/test/test_query_async.py
+++ b/sdk/cosmos/azure-cosmos/test/test_query_async.py
@@ -379,12 +379,13 @@ class TestQueryAsync(unittest.IsolatedAsyncioTestCase):
         # Should equal batch size
         assert totalCount == batchSize
 
-        # test an invalid value, will ignore start time option
+        # test an invalid value, Attribute error will be raised for passing non datetime object
         invalid_time = "Invalid value"
-        change_feed_iter = [i async for i in created_collection.query_items_change_feed(start_time=invalid_time)]
-        totalCount = len(change_feed_iter)
-        # Should not equal batch size
-        assert totalCount != batchSize
+        try:
+            change_feed_iter = [i async for i in created_collection.query_items_change_feed(start_time=invalid_time)]
+            self.fail("Cannot format date on a non datetime object.")
+        except AttributeError as e:
+            assert ("'str' object has no attribute 'astimezone'" == e.args[0])
 
         await self.created_db.delete_container(created_collection.id)
 


### PR DESCRIPTION
# Description
Some fixes to start time in query change feed. Will raise attribute error if non datetime object is passed.