### PR TITLE
[Monitor Query] MetricsClient sovereign cloud support

### DIFF
--- a/sdk/monitor/azure-monitor-query/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-query/CHANGELOG.md
@@ -4,8 +4,7 @@
 
 ### Features Added
 
-- Added sovereign cloud support for `MetricsClient`. ([#33752](https://github.com/Azure/azure-sdk-for-python/pull/33752))
-  - The audience for sovereign cloud authentication will be determined based on the provided endpoint. However, the `audience` parameter is provided as an override.
+- An `audience` keyword argument can now be passed to the `MetricsClient` constructor to specify the audience for the authentication token. This is useful when querying metrics in sovereign clouds. ([#35502](https://github.com/Azure/azure-sdk-for-python/pull/35502))
 
 ### Breaking Changes
 

--- a/sdk/monitor/azure-monitor-query/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-query/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Features Added
 
+- Added sovereign cloud support for `MetricsClient`. ([#33752](https://github.com/Azure/azure-sdk-for-python/pull/33752))
+  - The audience for sovereign cloud authentication will be determined based on the provided endpoint. However, the `audience` parameter is provided as an override.
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/monitor/azure-monitor-query/README.md
+++ b/sdk/monitor/azure-monitor-query/README.md
@@ -69,17 +69,18 @@ async_metrics_client = MetricsClient("https://<regional endpoint>", credential)
 
 #### Configure client for Azure sovereign cloud
 
-By default, `LogsQueryClient` and `MetricsQueryClient` are configured to use the Azure Public Cloud. To use a sovereign cloud instead, provide the correct `endpoint` argument. For example:
+By default, `LogsQueryClient` and `MetricsQueryClient` are configured to use the Azure Public Cloud. To use a sovereign cloud instead, provide the correct `endpoint` argument. `MetricsClient` will determine the correct cloud configuration based on the provided endpoint. For example:
 
 ```python
 from azure.identity import AzureAuthorityHosts, DefaultAzureCredential
-from azure.monitor.query import LogsQueryClient, MetricsQueryClient
+from azure.monitor.query import LogsQueryClient, MetricsQueryClient, MetricsClient
 
 # Authority can also be set via the AZURE_AUTHORITY_HOST environment variable.
 credential = DefaultAzureCredential(authority=AzureAuthorityHosts.AZURE_GOVERNMENT)
 
 logs_query_client = LogsQueryClient(credential, endpoint="https://api.loganalytics.us/v1")
 metrics_query_client = MetricsQueryClient(credential, endpoint="https://management.usgovcloudapi.net")
+metrics_client = MetricsClient("https://usgovvirginia.metrics.monitor.azure.us", credential)
 ```
 
 **Note**: Currently, `MetricsQueryClient` uses the Azure Resource Manager (ARM) endpoint for querying metrics. You need the corresponding management endpoint for your cloud when using this client. This detail is subject to change in the future.

--- a/sdk/monitor/azure-monitor-query/README.md
+++ b/sdk/monitor/azure-monitor-query/README.md
@@ -69,7 +69,7 @@ async_metrics_client = MetricsClient("https://<regional endpoint>", credential)
 
 #### Configure client for Azure sovereign cloud
 
-By default, `LogsQueryClient` and `MetricsQueryClient` are configured to use the Azure Public Cloud. To use a sovereign cloud instead, provide the correct `endpoint` argument. `MetricsClient` will determine the correct cloud configuration based on the provided endpoint. For example:
+By default, all clients are configured to use the Azure public cloud. To use a sovereign cloud, provide the correct `endpoint` argument when using `LogsQueryClient` or `MetricsQueryClient`. For `MetricsClient`, provide the correct `audience` argument instead. For example:
 
 ```python
 from azure.identity import AzureAuthorityHosts, DefaultAzureCredential
@@ -80,7 +80,9 @@ credential = DefaultAzureCredential(authority=AzureAuthorityHosts.AZURE_GOVERNME
 
 logs_query_client = LogsQueryClient(credential, endpoint="https://api.loganalytics.us/v1")
 metrics_query_client = MetricsQueryClient(credential, endpoint="https://management.usgovcloudapi.net")
-metrics_client = MetricsClient("https://usgovvirginia.metrics.monitor.azure.us", credential)
+metrics_client = MetricsClient(
+    "https://usgovvirginia.metrics.monitor.azure.us", credential, audience="https://metrics.monitor.azure.us"
+)
 ```
 
 **Note**: Currently, `MetricsQueryClient` uses the Azure Resource Manager (ARM) endpoint for querying metrics. You need the corresponding management endpoint for your cloud when using this client. This detail is subject to change in the future.

--- a/sdk/monitor/azure-monitor-query/azure/monitor/query/_metrics_client.py
+++ b/sdk/monitor/azure-monitor-query/azure/monitor/query/_metrics_client.py
@@ -7,7 +7,6 @@
 from datetime import timedelta, datetime
 from json import loads
 from typing import Any, List, MutableMapping, Sequence, Optional, Union, Tuple
-from urllib.parse import urlparse
 
 from azure.core.credentials import TokenCredential
 from azure.core.tracing.decorator import distributed_trace
@@ -29,8 +28,8 @@ class MetricsClient:  # pylint: disable=client-accepts-api-version-keyword
         resources. For global resources, the region should be 'global'. Required.
     :param credential: The credential to authenticate the client.
     :type credential: ~azure.core.credentials.TokenCredential
-    :keyword str audience: The audience to use when requesting tokens for Microsoft Entra ID. If an audience is not
-        provided, it will be inferred from the endpoint.
+    :keyword str audience: The audience to use when requesting tokens for Microsoft Entra ID. Defaults to the public
+        cloud audience (https://metrics.monitor.azure.com).
 
     .. admonition:: Example:
 
@@ -55,9 +54,7 @@ class MetricsClient:  # pylint: disable=client-accepts-api-version-keyword
         self._endpoint = endpoint
         if not self._endpoint.startswith("https://") and not self._endpoint.startswith("http://"):
             self._endpoint = "https://" + self._endpoint
-        parsed_endpoint = urlparse(endpoint)
-        region_removed_netloc = parsed_endpoint.netloc.split(".", 1)[1]
-        audience = kwargs.pop("audience", f"{parsed_endpoint.scheme}://{region_removed_netloc}")
+        audience = kwargs.pop("audience", "https://metrics.monitor.azure.com")
 
         authentication_policy = kwargs.pop("authentication_policy", None) or get_authentication_policy(
             credential, audience

--- a/sdk/monitor/azure-monitor-query/azure/monitor/query/aio/_metrics_client_async.py
+++ b/sdk/monitor/azure-monitor-query/azure/monitor/query/aio/_metrics_client_async.py
@@ -7,6 +7,7 @@
 from datetime import timedelta, datetime
 from json import loads
 from typing import Any, List, MutableMapping, Sequence, Optional, Union, Tuple
+from urllib.parse import urlparse
 
 from azure.core.credentials_async import AsyncTokenCredential
 from azure.core.tracing.decorator_async import distributed_trace_async
@@ -29,13 +30,35 @@ class MetricsClient:  # pylint: disable=client-accepts-api-version-keyword
         resources. For global resources, the region should be 'global'. Required.
     :param credential: The credential to authenticate the client.
     :type credential: ~azure.core.credentials_async.AsyncTokenCredential
+    :keyword str audience: The audience to use when requesting tokens for Microsoft Entra ID. If an audience is not
+        provided, it will be inferred from the endpoint.
+
+    .. admonition:: Example:
+
+        .. literalinclude:: ../samples/async_samples/sample_authentication_async.py
+            :start-after: [START create_metrics_client_async]
+            :end-before: [END create_metrics_client_async]
+            :language: python
+            :dedent: 4
+            :caption: Creating the asynchronous MetricsClient with a TokenCredential.
+
+    .. admonition:: Example:
+
+        .. literalinclude:: ../samples/async_samples/sample_authentication_async.py
+            :start-after: [START create_metrics_client_sovereign_cloud_async]
+            :end-before: [END create_metrics_client_sovereign_cloud_async]
+            :language: python
+            :dedent: 4
+            :caption: Creating the MetricsClient for use with a sovereign cloud (i.e. non-public cloud).
     """
 
     def __init__(self, endpoint: str, credential: AsyncTokenCredential, **kwargs: Any) -> None:
         self._endpoint = endpoint
         if not self._endpoint.startswith("https://") and not self._endpoint.startswith("http://"):
             self._endpoint = "https://" + self._endpoint
-        audience = kwargs.pop("audience", "https://metrics.monitor.azure.com")
+        parsed_endpoint = urlparse(endpoint)
+        region_removed_netloc = parsed_endpoint.netloc.split(".", 1)[1]
+        audience = kwargs.pop("audience", f"{parsed_endpoint.scheme}://{region_removed_netloc}")
 
         authentication_policy = kwargs.pop("authentication_policy", None) or get_authentication_policy(
             credential, audience
@@ -60,7 +83,7 @@ class MetricsClient:  # pylint: disable=client-accepts-api-version-keyword
         order_by: Optional[str] = None,
         filter: Optional[str] = None,
         roll_up_by: Optional[str] = None,
-        **kwargs: Any
+        **kwargs: Any,
     ) -> List[MetricsQueryResult]:
         """Lists the metric values for multiple resources.
 
@@ -155,7 +178,7 @@ class MetricsClient:  # pylint: disable=client-accepts-api-version-keyword
             orderby=order_by,
             filter=filter,
             rollupby=roll_up_by,  # cspell:ignore rollupby
-            **kwargs
+            **kwargs,
         )
 
         # In rare cases, the generated value is a JSON string instead of a dict. This potentially stems from a bug in

--- a/sdk/monitor/azure-monitor-query/azure/monitor/query/aio/_metrics_client_async.py
+++ b/sdk/monitor/azure-monitor-query/azure/monitor/query/aio/_metrics_client_async.py
@@ -7,7 +7,6 @@
 from datetime import timedelta, datetime
 from json import loads
 from typing import Any, List, MutableMapping, Sequence, Optional, Union, Tuple
-from urllib.parse import urlparse
 
 from azure.core.credentials_async import AsyncTokenCredential
 from azure.core.tracing.decorator_async import distributed_trace_async
@@ -30,8 +29,8 @@ class MetricsClient:  # pylint: disable=client-accepts-api-version-keyword
         resources. For global resources, the region should be 'global'. Required.
     :param credential: The credential to authenticate the client.
     :type credential: ~azure.core.credentials_async.AsyncTokenCredential
-    :keyword str audience: The audience to use when requesting tokens for Microsoft Entra ID. If an audience is not
-        provided, it will be inferred from the endpoint.
+    :keyword str audience: The audience to use when requesting tokens for Microsoft Entra ID. Defaults to the public
+        cloud audience (https://metrics.monitor.azure.com).
 
     .. admonition:: Example:
 
@@ -56,9 +55,7 @@ class MetricsClient:  # pylint: disable=client-accepts-api-version-keyword
         self._endpoint = endpoint
         if not self._endpoint.startswith("https://") and not self._endpoint.startswith("http://"):
             self._endpoint = "https://" + self._endpoint
-        parsed_endpoint = urlparse(endpoint)
-        region_removed_netloc = parsed_endpoint.netloc.split(".", 1)[1]
-        audience = kwargs.pop("audience", f"{parsed_endpoint.scheme}://{region_removed_netloc}")
+        audience = kwargs.pop("audience", "https://metrics.monitor.azure.com")
 
         authentication_policy = kwargs.pop("authentication_policy", None) or get_authentication_policy(
             credential, audience

--- a/sdk/monitor/azure-monitor-query/samples/async_samples/sample_authentication_async.py
+++ b/sdk/monitor/azure-monitor-query/samples/async_samples/sample_authentication_async.py
@@ -56,11 +56,34 @@ async def create_metrics_query_client_sovereign_cloud_async():
     # [END create_metrics_query_client_sovereign_cloud_async]
 
 
+async def create_metrics_client_async():
+    # [START create_metrics_client_async]
+    from azure.identity.aio import DefaultAzureCredential
+    from azure.monitor.query.aio import MetricsClient
+
+    credential = DefaultAzureCredential()
+    client = MetricsClient("https://eastus.metrics.monitor.azure.com", credential)
+    # [END create_metrics_client_async]
+
+
+async def create_metrics_client_sovereign_cloud_async():
+    # [START create_metrics_client_sovereign_cloud_async]
+    from azure.identity import AzureAuthorityHosts
+    from azure.identity.aio import DefaultAzureCredential
+    from azure.monitor.query.aio import MetricsClient
+
+    credential = DefaultAzureCredential(authority=AzureAuthorityHosts.AZURE_GOVERNMENT)
+    client = MetricsClient("https://usgovvirginia.metrics.monitor.azure.us", credential)
+    # [END create_metrics_client_sovereign_cloud_async]
+
+
 async def main():
     await create_logs_query_client_async()
     await create_logs_query_client_sovereign_cloud_async()
     await create_metrics_query_client_async()
     await create_metrics_query_client_sovereign_cloud_async()
+    await create_metrics_client_async()
+    await create_metrics_client_sovereign_cloud_async()
 
 
 if __name__ == '__main__':

--- a/sdk/monitor/azure-monitor-query/samples/async_samples/sample_authentication_async.py
+++ b/sdk/monitor/azure-monitor-query/samples/async_samples/sample_authentication_async.py
@@ -73,7 +73,11 @@ async def create_metrics_client_sovereign_cloud_async():
     from azure.monitor.query.aio import MetricsClient
 
     credential = DefaultAzureCredential(authority=AzureAuthorityHosts.AZURE_GOVERNMENT)
-    client = MetricsClient("https://usgovvirginia.metrics.monitor.azure.us", credential)
+    client = MetricsClient(
+        "https://usgovvirginia.metrics.monitor.azure.us",
+        credential,
+        audience="https://metrics.monitor.azure.us",
+    )
     # [END create_metrics_client_sovereign_cloud_async]
 
 

--- a/sdk/monitor/azure-monitor-query/samples/sample_authentication.py
+++ b/sdk/monitor/azure-monitor-query/samples/sample_authentication.py
@@ -69,7 +69,11 @@ def create_metrics_client_sovereign_cloud():
     from azure.monitor.query import MetricsClient
 
     credential = DefaultAzureCredential(authority=AzureAuthorityHosts.AZURE_GOVERNMENT)
-    client = MetricsClient("https://usgovvirginia.metrics.monitor.azure.us", credential)
+    client = MetricsClient(
+        "https://usgovvirginia.metrics.monitor.azure.us",
+        credential,
+        audience="https://metrics.monitor.azure.us",
+    )
     # [END create_metrics_client_sovereign_cloud]
 
 

--- a/sdk/monitor/azure-monitor-query/samples/sample_authentication.py
+++ b/sdk/monitor/azure-monitor-query/samples/sample_authentication.py
@@ -53,8 +53,30 @@ def create_metrics_query_client_sovereign_cloud():
     # [END create_metrics_query_client_sovereign_cloud]
 
 
+def create_metrics_client():
+    # [START create_metrics_client]
+    from azure.identity import DefaultAzureCredential
+    from azure.monitor.query import MetricsClient
+
+    credential = DefaultAzureCredential()
+    client = MetricsClient("https://eastus.metrics.monitor.azure.com", credential)
+    # [END create_metrics_client]
+
+
+def create_metrics_client_sovereign_cloud():
+    # [START create_metrics_client_sovereign_cloud]
+    from azure.identity import AzureAuthorityHosts, DefaultAzureCredential
+    from azure.monitor.query import MetricsClient
+
+    credential = DefaultAzureCredential(authority=AzureAuthorityHosts.AZURE_GOVERNMENT)
+    client = MetricsClient("https://usgovvirginia.metrics.monitor.azure.us", credential)
+    # [END create_metrics_client_sovereign_cloud]
+
+
 if __name__ == '__main__':
     create_logs_query_client()
     create_logs_query_client_sovereign_cloud()
     create_metrics_query_client()
     create_metrics_query_client_sovereign_cloud()
+    create_metrics_client()
+    create_metrics_client_sovereign_cloud()

--- a/sdk/monitor/azure-monitor-query/tests/base_testcase.py
+++ b/sdk/monitor/azure-monitor-query/tests/base_testcase.py
@@ -18,6 +18,12 @@ LOGS_ENVIRONMENT_ENDPOINT_MAP = {
     "AzureUSGovernment": "https://api.loganalytics.us/v1"
 }
 
+METRICS_CLIENT_ENVIRONMENT_AUDIENCE_MAP = {
+    "AzureCloud": "https://metrics.monitor.azure.com",
+    "AzureChinaCloud": "https://metrics.monitor.azure.cn",
+    "AzureUSGovernment": "https://metrics.monitor.azure.us"
+}
+
 TLD_MAP = {
     "AzureCloud": "com",
     "AzureChinaCloud": "cn",
@@ -57,6 +63,7 @@ class MetricsClientTestCase(AzureRecordedTestCase):
         kwargs = {}
         tld = "com"
         if environment:
+            kwargs["audience"] = METRICS_CLIENT_ENVIRONMENT_AUDIENCE_MAP.get(environment)
             tld = TLD_MAP.get(environment, "com")
 
         if not endpoint:

--- a/sdk/monitor/azure-monitor-query/tests/base_testcase.py
+++ b/sdk/monitor/azure-monitor-query/tests/base_testcase.py
@@ -18,12 +18,6 @@ LOGS_ENVIRONMENT_ENDPOINT_MAP = {
     "AzureUSGovernment": "https://api.loganalytics.us/v1"
 }
 
-METRICS_CLIENT_ENVIRONMENT_AUDIENCE_MAP = {
-    "AzureCloud": "https://metrics.monitor.azure.com",
-    "AzureChinaCloud": "https://metrics.monitor.azure.cn",
-    "AzureUSGovernment": "https:/metrics.monitor.azure.us"
-}
-
 TLD_MAP = {
     "AzureCloud": "com",
     "AzureChinaCloud": "cn",
@@ -63,7 +57,6 @@ class MetricsClientTestCase(AzureRecordedTestCase):
         kwargs = {}
         tld = "com"
         if environment:
-            kwargs["audience"] = METRICS_CLIENT_ENVIRONMENT_AUDIENCE_MAP.get(environment)
             tld = TLD_MAP.get(environment, "com")
 
         if not endpoint:

--- a/sdk/monitor/azure-monitor-query/tests/test_metrics_client.py
+++ b/sdk/monitor/azure-monitor-query/tests/test_metrics_client.py
@@ -48,7 +48,8 @@ class TestMetricsClient(MetricsClientTestCase):
     def test_client_different_endpoint(self):
         credential = self.get_credential(MetricsClient)
         endpoint = "https://usgovvirginia.metrics.monitor.azure.us"
-        client = MetricsClient(endpoint, credential)
+        audience = "https://metrics.monitor.azure.us"
+        client = MetricsClient(endpoint, credential, audience=audience)
 
         assert client._endpoint == endpoint
-        assert "https://metrics.monitor.azure.us/.default" in client._client._config.authentication_policy._scopes
+        assert f"{audience}/.default" in client._client._config.authentication_policy._scopes

--- a/sdk/monitor/azure-monitor-query/tests/test_metrics_client.py
+++ b/sdk/monitor/azure-monitor-query/tests/test_metrics_client.py
@@ -44,3 +44,11 @@ class TestMetricsClient(MetricsClientTestCase):
             assert metric.timeseries
             for t in metric.timeseries:
                 assert t.metadata_values is not None
+
+    def test_client_different_endpoint(self):
+        credential = self.get_credential(MetricsClient)
+        endpoint = "https://usgovvirginia.metrics.monitor.azure.us"
+        client = MetricsClient(endpoint, credential)
+
+        assert client._endpoint == endpoint
+        assert "https://metrics.monitor.azure.us/.default" in client._client._config.authentication_policy._scopes

--- a/sdk/monitor/azure-monitor-query/tests/test_metrics_client_async.py
+++ b/sdk/monitor/azure-monitor-query/tests/test_metrics_client_async.py
@@ -55,7 +55,7 @@ class TestMetricsClientAsync(MetricsClientTestCase):
 
     @pytest.mark.asyncio
     async def test_client_different_endpoint(self):
-        credential = self.get_credential(MetricsClient)
+        credential = self.get_credential(MetricsClient, is_async=True)
         endpoint = "https://usgovvirginia.metrics.monitor.azure.us"
         audience = "https://metrics.monitor.azure.us"
         client = MetricsClient(endpoint, credential, audience=audience)

--- a/sdk/monitor/azure-monitor-query/tests/test_metrics_client_async.py
+++ b/sdk/monitor/azure-monitor-query/tests/test_metrics_client_async.py
@@ -57,7 +57,8 @@ class TestMetricsClientAsync(MetricsClientTestCase):
     async def test_client_different_endpoint(self):
         credential = self.get_credential(MetricsClient)
         endpoint = "https://usgovvirginia.metrics.monitor.azure.us"
-        client = MetricsClient(endpoint, credential)
+        audience = "https://metrics.monitor.azure.us"
+        client = MetricsClient(endpoint, credential, audience=audience)
 
         assert client._endpoint == endpoint
-        assert "https://metrics.monitor.azure.us/.default" in client._client._config.authentication_policy._scopes
+        assert f"{audience}/.default" in client._client._config.authentication_policy._scopes

--- a/sdk/monitor/azure-monitor-query/tests/test_metrics_client_async.py
+++ b/sdk/monitor/azure-monitor-query/tests/test_metrics_client_async.py
@@ -52,3 +52,12 @@ class TestMetricsClientAsync(MetricsClientTestCase):
                 assert metric.timeseries
                 for t in metric.timeseries:
                     assert t.metadata_values is not None
+
+    @pytest.mark.asyncio
+    async def test_client_different_endpoint(self):
+        credential = self.get_credential(MetricsClient)
+        endpoint = "https://usgovvirginia.metrics.monitor.azure.us"
+        client = MetricsClient(endpoint, credential)
+
+        assert client._endpoint == endpoint
+        assert "https://metrics.monitor.azure.us/.default" in client._client._config.authentication_policy._scopes


### PR DESCRIPTION
# Description

This adds some documentation and samples regarding using MetricsClient with sovereign clouds. This adds a feature that extrapolates the correct audience based on the passed in endpoint. This saves the user from having to pass in extra information via the "audience" kwarg.

Closes: #34693

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
