### PR TITLE
[Core] Update API ref link in README

### DIFF
--- a/sdk/core/azure-core/README.md
+++ b/sdk/core/azure-core/README.md
@@ -9,7 +9,7 @@ If you are a client library developer, please reference [client library develope
 [Source code](https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/core/azure-core/) 
 | [Package (Pypi)][package]
 | [Package (Conda)](https://anaconda.org/microsoft/azure-core/)
-| [API reference documentation](https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/core/azure-core/)
+| [API reference documentation](https://docs.microsoft.com/python/api/overview/azure/core-readme)
 
 ## _Disclaimer_
 


### PR DESCRIPTION
Core API reference docs link in README is currently pointing to source code rather than API.