### PR TITLE
[Test Proxy] Correctly support updates to redirection following setting

### DIFF
--- a/tools/azure-sdk-tools/devtools_testutils/sanitizers.py
+++ b/tools/azure-sdk-tools/devtools_testutils/sanitizers.py
@@ -542,10 +542,10 @@ def set_function_recording_options(**kwargs) -> None:
     This must be called during test case execution, rather than at a session, module, or class level. To set recording
     options for all tests, use `set_session_recording_options` instead.
 
-    :keyword bool handle_redirects: The test proxy does not perform transparent follow directs by default. That means
+    :keyword bool handle_redirects: The test proxy performs transparent follow directs by default. That means
         that if the initial request sent through the test proxy results in a 3XX redirect status, the test proxy will
-        not follow. It will return that redirect response to the client and allow it to handle the redirect. Setting
-        `handle_redirects` to True will set the proxy to instead handle redirects itself.
+        follow. Setting `handle_redirects` to False will instead make the test proxy return that redirect response to
+        the client and allow it to handle the redirect.
     :keyword str context_directory: This changes the "root" path that the test proxy uses when loading a recording.
     :keyword certificates: A list of `PemCertificate`s. Any number of certificates is allowed.
     :type certificates: Iterable[PemCertificate]
@@ -564,10 +564,10 @@ def set_session_recording_options(**kwargs) -> None:
     This will set the specified recording options for an entire test session. To set recording options for a single test
     -- which is recommended -- use `set_function_recording_options` instead.
 
-    :keyword bool handle_redirects: The test proxy does not perform transparent follow directs by default. That means
+    :keyword bool handle_redirects: The test proxy performs transparent follow directs by default. That means
         that if the initial request sent through the test proxy results in a 3XX redirect status, the test proxy will
-        not follow. It will return that redirect response to the client and allow it to handle the redirect. Setting
-        `handle_redirects` to True will set the proxy to instead handle redirects itself.
+        follow. Setting `handle_redirects` to False will instead make the test proxy return that redirect response to
+        the client and allow it to handle the redirect.
     :keyword str context_directory: This changes the "root" path that the test proxy uses when loading a recording.
     :keyword certificates: A list of `PemCertificate`s. Any number of certificates is allowed.
     :type certificates: Iterable[PemCertificate]

--- a/tools/azure-sdk-tools/devtools_testutils/sanitizers.py
+++ b/tools/azure-sdk-tools/devtools_testutils/sanitizers.py
@@ -703,10 +703,11 @@ def _send_recording_options_request(parameters: Dict, headers: Optional[Dict] = 
     if is_live_and_not_recording():
         return
 
-    headers_to_send = {}
-    for key in headers:
-        if headers[key] is not None:
-            headers_to_send[key] = headers[key]
+    headers_to_send = {"Content-Type": "application/json"}
+    if headers:
+        for key in headers:
+            if headers[key] is not None:
+                headers_to_send[key] = headers[key]
 
     http_client = get_http_client()
     http_client.request(
@@ -752,9 +753,10 @@ def _send_sanitizer_request(sanitizer: str, parameters: Dict, headers: Optional[
         return
 
     headers_to_send = {"x-abstraction-identifier": sanitizer, "Content-Type": "application/json"}
-    for key in headers:
-        if headers[key] is not None:
-            headers_to_send[key] = headers[key]
+    if headers:
+        for key in headers:
+            if headers[key] is not None:
+                headers_to_send[key] = headers[key]
 
     http_client = get_http_client()
     http_client.request(
@@ -778,9 +780,10 @@ def _send_transform_request(transform: str, parameters: Dict, headers: Optional[
         return
 
     headers_to_send = {"x-abstraction-identifier": transform, "Content-Type": "application/json"}
-    for key in headers:
-        if headers[key] is not None:
-            headers_to_send[key] = headers[key]
+    if headers:
+        for key in headers:
+            if headers[key] is not None:
+                headers_to_send[key] = headers[key]
 
     http_client = get_http_client()
     http_client.request(


### PR DESCRIPTION
# Description

This PR addresses a bug where Programmable Connectivity wasn't able to disable the test proxy's redirect following behavior. It turned out that the requested setting change was being rejected by the test proxy because the request wasn't including an `application/json` Content-Type header. We should have been including this header, so it's definitely an issue -- but what's surprising is that other services like Confidential Ledger have been successfully using the same code to update TLS certificate recording options, which hid the issue.

Documentation is also updated to align with the test proxy tool; we currently say that redirect following is disabled by default, but it's now enabled by default.

On the side, this also updates logic to be more bug-resilient and check for the `headers` parameter being None in `_send_*_request` methods (which they are by default, just not by convention).

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
