### PR TITLE
[Test Proxy] Skip sanitizer removal if test proxy isn't running

### DIFF
--- a/tools/azure-sdk-tools/devtools_testutils/sanitizers.py
+++ b/tools/azure-sdk-tools/devtools_testutils/sanitizers.py
@@ -484,6 +484,9 @@ def remove_batch_sanitizers(sanitizers: List[str], headers: Optional[Dict] = Non
     :type headers: dict
     """
 
+    if is_live_and_not_recording():
+        return
+
     data = {"Sanitizers" : sanitizers}
 
     headers_to_send = {"Content-Type": "application/json"}


### PR DESCRIPTION
# Description

We skip a number of test proxy requests if we're in live, non-recording mode, since this means the test proxy hasn't been started up. This check wasn't implemented for sanitizer removal requests, leading to failures in live test pipelines: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3768765&view=results

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
