### PR TITLE
[ServiceBus] prepare for release

### DIFF
--- a/sdk/servicebus/azure-mgmt-servicebus/tests/conftest.py
+++ b/sdk/servicebus/azure-mgmt-servicebus/tests/conftest.py
@@ -30,7 +30,7 @@ import sys
 
 from dotenv import load_dotenv
 
-from devtools_testutils import test_proxy, add_general_regex_sanitizer
+from devtools_testutils import test_proxy, add_general_regex_sanitizer, remove_batch_sanitizers
 from devtools_testutils import add_header_regex_sanitizer, add_body_key_sanitizer
 
 # Ignore async tests for Python < 3.5
@@ -56,3 +56,7 @@ def add_sanitizers(test_proxy):
     add_body_key_sanitizer(json_path="$..access_token", value="access_token")
     add_body_key_sanitizer(json_path="$..primaryKey", value="primaryKey")
     add_body_key_sanitizer(json_path="$..secondaryKey", value="secondaryKey")
+
+    # Remove the following sanitizers since certain fields are needed in tests and are non-sensitive:
+    #  - AZSDK2003: Location
+    remove_batch_sanitizers(["AZSDK2003"])

--- a/sdk/servicebus/azure-servicebus/CHANGELOG.md
+++ b/sdk/servicebus/azure-servicebus/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bugs Fixed
 
-- Fixed a bug where WebsocketConnectionClosedException was not being caught when using receiving with AmqpOverWebsocket ([34859](https://github.com/Azure/azure-sdk-for-python/pull/34859))
+- Fixed a bug where WebsocketConnectionClosedException was not being caught when receiving with AmqpOverWebsocket ([34859](https://github.com/Azure/azure-sdk-for-python/pull/34859))
 - Fixed incorrect dependency on typing-extensions ([34869](https://github.com/Azure/azure-sdk-for-python/issues/34869), thanks @YaroBear).
 
 ## 7.12.1 (2024-03-20)

--- a/sdk/servicebus/azure-servicebus/CHANGELOG.md
+++ b/sdk/servicebus/azure-servicebus/CHANGELOG.md
@@ -1,16 +1,11 @@
 # Release History
 
-## 7.12.2 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 7.12.2 (2024-05-08)
 
 ### Bugs Fixed
 
-- Fixed incorrect dependency on typing-extensions ([34868](https://github.com/Azure/azure-sdk-for-python/issues/34868))
-
-### Other Changes
+- Fixed a bug where WebsocketConnectionClosedException was not being caught when using receiving with AmqpOverWebsocket ([34859](https://github.com/Azure/azure-sdk-for-python/pull/34859))
+- Fixed incorrect dependency on typing-extensions ([34869](https://github.com/Azure/azure-sdk-for-python/issues/34869), thanks @YaroBear).
 
 ## 7.12.1 (2024-03-20)
 


### PR DESCRIPTION
Fixing mgmt tests that are failing due to the recent addition of batch sanitizers to unblock release of `azure-servicebus`. Following #35385, opting out of the `Location` batch sanitizer.