### PR TITLE
More may apiview fixes (#35541)

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_ml_client.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_ml_client.py
@@ -78,7 +78,7 @@ from azure.ai.ml.operations import (
     BatchEndpointOperations,
     ComponentOperations,
     ComputeOperations,
-    ConnectionsOperations,
+    WorkspaceConnectionsOperations,
     DataOperations,
     DatastoreOperations,
     EnvironmentOperations,
@@ -493,7 +493,7 @@ class MLClient:
         )
         self._operation_container.add(AzureMLResourceType.REGISTRY, self._registries)  # type: ignore[arg-type]
 
-        self._connections = ConnectionsOperations(
+        self._connections = WorkspaceConnectionsOperations(
             self._operation_scope,
             self._operation_config,
             self._service_client_04_2024_preview,
@@ -934,11 +934,11 @@ class MLClient:
 
     @property
     @experimental
-    def connections(self) -> ConnectionsOperations:
+    def connections(self) -> WorkspaceConnectionsOperations:
         """A collection of connection related operations.
 
         :return: Connections operations
-        :rtype: ~azure.ai.ml.operations.ConnectionsOperations
+        :rtype: ~azure.ai.ml.operations.WorkspaceConnectionsOperations
         """
         return self._connections
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_workspace/_ai_workspaces/project.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_workspace/_ai_workspaces/project.py
@@ -5,12 +5,14 @@
 
 from typing import Any, Dict, Optional
 
+from azure.ai.ml._utils._experimental import experimental
 from azure.ai.ml._schema.workspace import ProjectSchema
 from azure.ai.ml.constants._common import WorkspaceKind
 from azure.ai.ml.entities import Workspace
 
 
 # Effectively a lightweight wrapper around a v2 SDK workspace
+@experimental
 class Project(Workspace):
     """A Project is a lightweight object for orchestrating AI applications, and is parented by a hub.
     Unlike a standard workspace, a project does not have a variety of sub-resources directly associated with it.

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/__init__.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/__init__.py
@@ -27,7 +27,7 @@ from ._online_deployment_operations import OnlineDeploymentOperations
 from ._online_endpoint_operations import OnlineEndpointOperations
 from ._registry_operations import RegistryOperations
 from ._schedule_operations import ScheduleOperations
-from ._connections_operations import ConnectionsOperations
+from ._workspace_connections_operations import WorkspaceConnectionsOperations
 from ._workspace_operations import WorkspaceOperations
 from ._workspace_outbound_rule_operations import WorkspaceOutboundRuleOperations
 from ._evaluator_operations import EvaluatorOperations
@@ -49,7 +49,7 @@ __all__ = [
     "DataOperations",
     "EnvironmentOperations",
     "ComponentOperations",
-    "ConnectionsOperations",
+    "WorkspaceConnectionsOperations",
     "RegistryOperations",
     "ScheduleOperations",
     "WorkspaceOutboundRuleOperations",

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_azure_openai_deployment_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_azure_openai_deployment_operations.py
@@ -11,7 +11,7 @@ from azure.ai.ml._restclient.v2024_04_01_preview import AzureMachineLearningWork
 from azure.ai.ml._scope_dependent_operations import OperationConfig, OperationScope, _ScopeDependentOperations
 from azure.ai.ml.entities._autogen_entities.models import AzureOpenAIDeployment
 
-from ._connections_operations import ConnectionsOperations
+from ._workspace_connections_operations import WorkspaceConnectionsOperations
 
 module_logger = logging.getLogger(__name__)
 
@@ -29,11 +29,11 @@ class AzureOpenAIDeploymentOperations(_ScopeDependentOperations):
         operation_scope: OperationScope,
         operation_config: OperationConfig,
         service_client: ServiceClient2020404Preview,
-        connections_operations: ConnectionsOperations,
+        connections_operations: WorkspaceConnectionsOperations,
     ):
         super().__init__(operation_scope, operation_config)
         self._service_client = service_client.connection
-        self._connections_operations = connections_operations
+        self._workspace_connections_operations = connections_operations
 
     def list(self, connection_name: str, **kwargs) -> Iterable[AzureOpenAIDeployment]:
         """List Azure OpenAI deployments of the workspace.
@@ -43,7 +43,7 @@ class AzureOpenAIDeploymentOperations(_ScopeDependentOperations):
         :return: A list of Azure OpenAI deployments
         :rtype: ~typing.Iterable[~azure.ai.ml.entities.AzureOpenAIDeployment]
         """
-        connection = self._connections_operations.get(connection_name)
+        connection = self._workspace_connections_operations.get(connection_name)
 
         def _from_rest_add_connection_name(obj):
             from_rest_deployment = AzureOpenAIDeployment._from_rest_object(obj)

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_workspace_connections_operations.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_workspace_connections_operations.py
@@ -26,8 +26,8 @@ ops_logger = OpsLogger(__name__)
 module_logger = ops_logger.module_logger
 
 
-class ConnectionsOperations(_ScopeDependentOperations):
-    """ConnectionsOperations.
+class WorkspaceConnectionsOperations(_ScopeDependentOperations):
+    """WorkspaceConnectionsOperations.
 
     You should not instantiate this class directly. Instead, you should create
     an MLClient instance that instantiates it for you and attaches it as an attribute.
@@ -42,7 +42,7 @@ class ConnectionsOperations(_ScopeDependentOperations):
         credentials: Optional[TokenCredential] = None,
         **kwargs: Dict,
     ):
-        super(ConnectionsOperations, self).__init__(operation_scope, operation_config)
+        super(WorkspaceConnectionsOperations, self).__init__(operation_scope, operation_config)
         ops_logger.update_info(kwargs)
         self._all_operations = all_operations
         self._operation = service_client.workspace_connections

--- a/sdk/ml/azure-ai-ml/tests/connection/unittests/test_connection_operations.py
+++ b/sdk/ml/azure-ai-ml/tests/connection/unittests/test_connection_operations.py
@@ -8,7 +8,7 @@ from azure.ai.ml._restclient.v2022_01_01_preview.models import ConnectionCategor
 from azure.ai.ml._scope_dependent_operations import OperationConfig, OperationScope
 from azure.ai.ml._utils.utils import camel_to_snake
 from azure.ai.ml.entities import PatTokenConfiguration, Connection
-from azure.ai.ml.operations import ConnectionsOperations
+from azure.ai.ml.operations import WorkspaceConnectionsOperations
 
 
 @pytest.fixture
@@ -23,8 +23,8 @@ def mock_workspace_connection_operation(
     mock_aml_services_2022_01_01_preview: Mock,
     mock_machinelearning_client: Mock,
     mock_credential: Mock,
-) -> ConnectionsOperations:
-    yield ConnectionsOperations(
+) -> WorkspaceConnectionsOperations:
+    yield WorkspaceConnectionsOperations(
         operation_scope=mock_workspace_scope,
         operation_config=mock_operation_config,
         service_client=mock_aml_services_2022_01_01_preview,
@@ -39,7 +39,7 @@ class TestWorkspaceConnectionsOperation:
     @pytest.mark.parametrize(
         "arg", [ConnectionCategory.GIT, ConnectionCategory.PYTHON_FEED, ConnectionCategory.CONTAINER_REGISTRY]
     )
-    def test_list(self, arg: str, mock_workspace_connection_operation: ConnectionsOperations) -> None:
+    def test_list(self, arg: str, mock_workspace_connection_operation: WorkspaceConnectionsOperations) -> None:
         mock_workspace_connection_operation.list(connection_type=arg)
         mock_workspace_connection_operation._operation.list.assert_called_once()
 
@@ -47,7 +47,7 @@ class TestWorkspaceConnectionsOperation:
     def test_get(
         self,
         mock_from_rest,
-        mock_workspace_connection_operation: ConnectionsOperations,
+        mock_workspace_connection_operation: WorkspaceConnectionsOperations,
     ) -> None:
         mock_from_rest.return_value = Connection(
             target="dummy_target",
@@ -62,7 +62,7 @@ class TestWorkspaceConnectionsOperation:
     def test_create_or_update(
         self,
         mock_from_rest,
-        mock_workspace_connection_operation: ConnectionsOperations,
+        mock_workspace_connection_operation: WorkspaceConnectionsOperations,
     ):
         mock_from_rest.return_value = Connection(
             target="dummy_target",
@@ -77,7 +77,7 @@ class TestWorkspaceConnectionsOperation:
 
     def test_delete(
         self,
-        mock_workspace_connection_operation: ConnectionsOperations,
+        mock_workspace_connection_operation: WorkspaceConnectionsOperations,
     ) -> None:
         mock_workspace_connection_operation.delete("randstr")
         mock_workspace_connection_operation._operation.delete.assert_called_once()

--- a/sdk/ml/azure-ai-ml/tests/feature_store/unittests/test_feature_store_operations.py
+++ b/sdk/ml/azure-ai-ml/tests/feature_store/unittests/test_feature_store_operations.py
@@ -278,7 +278,7 @@ class TestFeatureStoreOperation:
             return_value=None,
         )
         mocker.patch(
-            "azure.ai.ml.operations._connections_operations.ConnectionsOperations.get",
+            "azure.ai.ml.operations._workspace_connections_operations.WorkspaceConnectionsOperations.get",
             return_value=None,
         )
 


### PR DESCRIPTION
Cherry picking apiview fixes that do 2 things:
- change name of ConnectionsOperations class back to WorkspaceConnectionsOperations
- Add experimental tag to Project class.
