### PR TITLE
Add __aenter__ to Keyvault's SecretClient

### DIFF
--- a/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_client.py
+++ b/sdk/keyvault/azure-keyvault-secrets/azure/keyvault/secrets/_client.py
@@ -468,3 +468,7 @@ class SecretClient(KeyVaultClientBase):
     def __enter__(self) -> "SecretClient":
         self._client.__enter__()
         return self
+
+    async def __aenter__(self) -> "SecretClient":
+        await super().__aenter__()
+        return self


### PR DESCRIPTION

# Description

Recently SecretClient had an __enter__ override added (in PR #35115) but not __aenter__. Adding the override to get the concrete type so that when used SecretClient is used in a context manager, the type checker knows that SecretClient's methods and properties are available.

If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.

# All SDK Contribution checklist:
- [X] **The pull request does not introduce [breaking changes]**
- [Not Sig] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [X] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [X] Title of the pull request is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
