### PR TITLE
re-add WorksapceConnection as importable class

### DIFF
--- a/sdk/ml/azure-ai-ml/CHANGELOG.md
+++ b/sdk/ml/azure-ai-ml/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features Added
 - Add experimental support for working with Promptflow evaluators: `ml_client.evaluators`.
 - Many changes to the Connection entity class and its associated operations.
+- WorkspaceConnection class renamed to Connection, however the WorkspaceConnection class name now acts as a mask over the Connection class, allowing either to be imported and functional to maintain backwards compatibility.
 - Workspace Connection `list`, `get`, and `create_or_update` operations now include an optional `populate_secrets` input, which causes the operations to try making a secondary call to fill in the returned connections' credential info if possible. Only works with api key-based credentials for now.
 - Many workspace connection subtypes added. The full list of subclasses is now:
   - `AzureBlobStoreConnection`
@@ -33,7 +34,6 @@
 
 ### Breaking Changes
 
-- WorkspaceConnection and subclasses renamed to just Connection
 - Removed WorkspaceHubConfig entity, and renamed WorkspaceHub to Hub.
 - workspace_hub input of Workspace class hidden, renamed to hub_id, and re-surfaced in child class Project.
 - Removed Workspace Hub Operations from ML Client.

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/__init__.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/__init__.py
@@ -306,6 +306,10 @@ from ._workspace.workspace_keys import (
     WorkspaceKeys,
 )
 
+# Prevents breaking change of WC name change, allowing users
+# to continue to the old name of "WorkspaceConnection".
+WorkspaceConnection = Connection
+
 __all__ = [
     "Resource",
     "Job",
@@ -360,6 +364,7 @@ __all__ = [
     "Workspace",
     "WorkspaceKeys",
     "Connection",
+    "WorkspaceConnection",
     "AzureBlobStoreConnection",
     "MicrosoftOneLakeConnection",
     "AzureOpenAIConnection",

--- a/sdk/ml/azure-ai-ml/tests/connection/unittests/test_connection_entity.py
+++ b/sdk/ml/azure-ai-ml/tests/connection/unittests/test_connection_entity.py
@@ -34,6 +34,7 @@ from azure.ai.ml.entities import (
     OpenAIConnection,
     SerpConnection,
     ServerlessConnection,
+    WorkspaceConnection,
 )
 
 
@@ -368,6 +369,29 @@ class TestWorkspaceConnectionEntity:
         assert ws_connection.credentials.type == ConnectionAuthType.NONE
         assert ws_connection.name == "git_no_cred_conn"
         assert ws_connection.target == "https://test-git-feed.com2"
+        self.check_all_conversions_stable(ws_connection)
+
+    def test_old_connection_class(self):
+        ws_connection = load_connection(source="./tests/test_configs/connection/git_pat.yaml")
+
+        assert type(ws_connection) == WorkspaceConnection
+        assert type(ws_connection) == Connection
+        assert ws_connection.type == camel_to_snake(ConnectionCategory.GIT)
+        assert ws_connection.credentials.type == camel_to_snake(ConnectionAuthType.PAT)
+        assert ws_connection.credentials.pat == "dummy_pat"
+        assert ws_connection.name == "test_ws_conn_git_pat"
+        assert ws_connection.target == "https://test-git-feed.com"
+        self.check_all_conversions_stable(ws_connection)
+
+        ws_connection = WorkspaceConnection(
+            target="123", name="1234", type="git", credentials=NoneCredentialConfiguration()
+        )
+        assert type(ws_connection) == WorkspaceConnection
+        assert type(ws_connection) == Connection
+        assert ws_connection.type == camel_to_snake(ConnectionCategory.GIT)
+        assert ws_connection.credentials.type == ConnectionAuthType.NONE
+        assert ws_connection.name == "1234"
+        assert ws_connection.target == "123"
         self.check_all_conversions_stable(ws_connection)
 
     def test_python_feed(self):


### PR DESCRIPTION
Perform some minor trickery to allow both `Connection` and `WorkspaceConnection` to be importable classes from the `azure.ai.ml.entities` package to prevent pseudo-breaking changes. (I use the term 'pseudo-breaking' because technically the `WorkspaceConnection` class was experimental and thus name-changeable, but in practice it's been around and relied upon for so long that actually making a breaking change on its name will cause many problems).