### PR TITLE
[Key Vault] Add support for pre-backup and pre-restore operations

### DIFF
--- a/sdk/keyvault/azure-keyvault-administration/CHANGELOG.md
+++ b/sdk/keyvault/azure-keyvault-administration/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 - Added support for service API version `7.6-preview.1`
+- Added `KeyVaultBackupClient.begin_pre_backup` and `KeyVaultBackupClient.begin_pre_restore` methods for checking if it
+  is possible to perform a full key backup or full key restore.
 
 ### Breaking Changes
 

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/__init__.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/__init__.py
@@ -7,8 +7,10 @@ from ._backup_client import KeyVaultBackupClient
 from ._enums import KeyVaultRoleScope, KeyVaultDataAction, KeyVaultSettingType
 from ._internal.client_base import ApiVersion
 from ._models import (
+    KeyVaultBackupOperation,
     KeyVaultBackupResult,
     KeyVaultPermission,
+    KeyVaultRestoreOperation,
     KeyVaultRoleAssignment,
     KeyVaultRoleAssignmentProperties,
     KeyVaultRoleDefinition,
@@ -19,11 +21,13 @@ from ._settings_client import KeyVaultSettingsClient
 
 __all__ = [
     "ApiVersion",
+    "KeyVaultBackupOperation",
     "KeyVaultBackupResult",
     "KeyVaultAccessControlClient",
     "KeyVaultBackupClient",
     "KeyVaultDataAction",
     "KeyVaultPermission",
+    "KeyVaultRestoreOperation",
     "KeyVaultRoleAssignment",
     "KeyVaultRoleAssignmentProperties",
     "KeyVaultRoleDefinition",

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_backup_client.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_backup_client.py
@@ -5,7 +5,7 @@
 import base64
 import functools
 import pickle
-from typing import Any, Optional, overload
+from typing import Any, Callable, Optional, overload
 from urllib.parse import urlparse
 
 from typing_extensions import Literal
@@ -13,7 +13,7 @@ from typing_extensions import Literal
 from azure.core.polling import LROPoller
 from azure.core.tracing.decorator import distributed_trace
 
-from ._models import KeyVaultBackupResult
+from ._models import KeyVaultBackupOperation, KeyVaultBackupResult, KeyVaultRestoreOperation
 from ._internal import KeyVaultClientBase, parse_folder_url
 from ._internal.polling import KeyVaultBackupClientPolling, KeyVaultBackupClientPollingMethod
 
@@ -39,6 +39,23 @@ class KeyVaultBackupClient(KeyVaultClientBase):
     :keyword bool verify_challenge_resource: Whether to verify the authentication challenge resource matches the Key
         Vault or Managed HSM domain. Defaults to True.
     """
+
+    def _use_continuation_token(self, continuation_token: str, status_method: Callable) -> str:
+        status_url = base64.b64decode(continuation_token.encode()).decode("ascii")
+        try:
+            job_id = _parse_status_url(status_url)
+        except Exception as ex:  # pylint: disable=broad-except
+            raise ValueError(
+                "The provided continuation_token is malformed. A valid token can be obtained from the "
+                + "operation poller's continuation_token() method"
+            ) from ex
+
+        pipeline_response = status_method(
+            vault_base_url=self._vault_url, job_id=job_id, cls=lambda pipeline_response, _, __: pipeline_response
+        )
+        if "azure-asyncoperation" not in pipeline_response.http_response.headers:
+            pipeline_response.http_response.headers["azure-asyncoperation"] = status_url
+        return base64.b64encode(pickle.dumps(pipeline_response)).decode("ascii")
 
     @overload
     def begin_backup(
@@ -94,7 +111,7 @@ class KeyVaultBackupClient(KeyVaultClientBase):
         """
         polling_interval = kwargs.pop("_polling_interval", 5)
         continuation_token = kwargs.pop("continuation_token", None)
-        use_managed_identity = kwargs.pop("use_managed_identity", None)
+        use_managed_identity = kwargs.pop("use_managed_identity", False)
         # `sas_token` was formerly a required positional parameter
         try:
             sas_token: Optional[str] = args[0]
@@ -106,21 +123,7 @@ class KeyVaultBackupClient(KeyVaultClientBase):
 
         status_response = None
         if continuation_token:
-            status_url = base64.b64decode(continuation_token.encode()).decode("ascii")
-            try:
-                job_id = _parse_status_url(status_url)
-            except Exception as ex:  # pylint: disable=broad-except
-                raise ValueError(
-                    "The provided continuation_token is malformed. A valid token can be obtained from the "
-                    + "operation poller's continuation_token() method"
-                ) from ex
-
-            pipeline_response = self._client.full_backup_status(
-                vault_base_url=self._vault_url, job_id=job_id, cls=lambda pipeline_response, _, __: pipeline_response
-            )
-            if "azure-asyncoperation" not in pipeline_response.http_response.headers:
-                pipeline_response.http_response.headers["azure-asyncoperation"] = status_url
-            status_response = base64.b64encode(pickle.dumps(pipeline_response)).decode("ascii")
+            status_response = self._use_continuation_token(continuation_token, self._client.full_backup_status)
 
         return self._client.begin_full_backup(
             vault_base_url=self._vault_url,
@@ -198,33 +201,19 @@ class KeyVaultBackupClient(KeyVaultClientBase):
                 :caption: Restore a single key
                 :dedent: 8
         """
-        status_response = None
         polling_interval = kwargs.pop("_polling_interval", 5)
         continuation_token = kwargs.pop("continuation_token", None)
         key_name = kwargs.pop("key_name", None)
-        use_managed_identity = kwargs.pop("use_managed_identity", None)
+        use_managed_identity = kwargs.pop("use_managed_identity", False)
         # `sas_token` was formerly a required positional parameter
         try:
             sas_token: Optional[str] = args[0]
         except IndexError:
             sas_token = kwargs.pop("sas_token", None)
 
+        status_response = None
         if continuation_token:
-            status_url = base64.b64decode(continuation_token.encode()).decode("ascii")
-            try:
-                job_id = _parse_status_url(status_url)
-            except Exception as ex:  # pylint: disable=broad-except
-                raise ValueError(
-                    "The provided continuation_token is malformed. A valid token can be obtained from the "
-                    + "operation poller's continuation_token() method"
-                ) from ex
-
-            pipeline_response = self._client.restore_status(
-                vault_base_url=self._vault_url, job_id=job_id, cls=lambda pipeline_response, _, __: pipeline_response
-            )
-            if "azure-asyncoperation" not in pipeline_response.http_response.headers:
-                pipeline_response.http_response.headers["azure-asyncoperation"] = status_url
-            status_response = base64.b64encode(pickle.dumps(pipeline_response)).decode("ascii")
+            status_response = self._use_continuation_token(continuation_token, self._client.restore_status)
 
         container_url, folder_name = parse_folder_url(folder_url)
         sas_parameter = self._models.SASTokenParameter(
@@ -251,6 +240,154 @@ class KeyVaultBackupClient(KeyVaultClientBase):
             cls=lambda *_: None,  # poller.result() returns None
             continuation_token=status_response,
             polling=polling,
+            **kwargs,
+        )
+
+    @overload
+    def begin_pre_backup(
+        self,
+        blob_storage_url: str,
+        *,
+        use_managed_identity: Literal[True],
+        continuation_token: Optional[str] = None,
+        **kwargs: Any,
+    ) -> LROPoller[KeyVaultBackupOperation]:
+        ...
+
+    @overload
+    def begin_pre_backup(
+        self,
+        blob_storage_url: str,
+        *,
+        sas_token: str,
+        continuation_token: Optional[str] = None,
+        **kwargs: Any,
+    ) -> LROPoller[KeyVaultBackupOperation]:
+        ...
+
+    @distributed_trace
+    def begin_pre_backup(
+        self, blob_storage_url: str, **kwargs: Any
+    ) -> LROPoller[KeyVaultBackupOperation]:
+        """Initiates a pre-backup check of whether a full Key Vault backup can be performed.
+
+        A :class:`KeyVaultBackupOperation` instance will be returned by the poller's `result()` method. If the
+        pre-backup check is successful, the object will have a string `folder_url` attribute, pointing to the blob
+        storage container where the backup will be stored. If the check fails, the object will have a string `error`
+        attribute.
+
+        :param str blob_storage_url: URL of the blob storage container in which the backup will be stored, for example
+            https://<account>.blob.core.windows.net/backup.
+
+        :keyword str sas_token: Optional Shared Access Signature (SAS) token to authorize access to the blob. Required
+            unless `use_managed_identity` is set to True.
+        :keyword use_managed_identity: Indicates which authentication method should be used. If set to True, Managed HSM
+            will use the configured user-assigned managed identity to authenticate with Azure Storage. Otherwise, a SAS
+            token has to be specified.
+        :paramtype use_managed_identity: bool
+        :keyword str continuation_token: A continuation token to restart polling from a saved state.
+
+        :returns: An :class:`~azure.core.polling.LROPoller` instance. Call `result()` on this object to wait for the
+            operation to complete and get a :class:`KeyVaultBackupOperation`. If the pre-backup check is successful, the
+            object will have a string `folder_url` attribute, pointing to the blob storage container where the backup
+            will be stored. If the check fails, the object will have a string `error` attribute.
+        :rtype: ~azure.core.polling.LROPoller[~azure.keyvault.administration.KeyVaultBackupOperation]
+        """
+        polling_interval = kwargs.pop("_polling_interval", 5)
+        continuation_token = kwargs.pop("continuation_token", None)
+        use_managed_identity = kwargs.pop("use_managed_identity", False)
+        sas_token = kwargs.pop("sas_token", None)
+
+        parameters = self._models.PreBackupOperationParameters(
+            storage_resource_uri=blob_storage_url, token=sas_token, use_managed_identity=use_managed_identity
+        )
+        status_response = None
+        if continuation_token:
+            status_response = self._use_continuation_token(continuation_token, self._client.full_backup_status)
+
+        return self._client.begin_pre_full_backup(
+            vault_base_url=self._vault_url,
+            pre_backup_operation_parameters=parameters,
+            cls=KeyVaultBackupOperation._from_generated,  # pylint: disable=protected-access
+            polling=KeyVaultBackupClientPollingMethod(
+                lro_algorithms=[KeyVaultBackupClientPolling()], timeout=polling_interval, **kwargs
+            ),
+            continuation_token=status_response,
+            **kwargs,
+        )
+
+    @overload
+    def begin_pre_restore(
+        self,
+        folder_url: str,
+        *,
+        use_managed_identity: Literal[True],
+        continuation_token: Optional[str] = None,
+        **kwargs: Any,
+    ) -> LROPoller[KeyVaultRestoreOperation]:
+        ...
+
+    @overload
+    def begin_pre_restore(
+        self,
+        folder_url: str,
+        *,
+        sas_token: str,
+        continuation_token: Optional[str] = None,
+        **kwargs: Any,
+    ) -> LROPoller[KeyVaultRestoreOperation]:
+        ...
+
+    @distributed_trace
+    def begin_pre_restore(
+        self, folder_url: str, **kwargs: Any
+    ) -> LROPoller[KeyVaultRestoreOperation]:
+        """Initiates a pre-restore check of whether a full Key Vault restore can be performed.
+
+        A :class:`KeyVaultRestoreOperation` instance will be returned by the poller's `result()` method. If the
+        pre-restore check fails, the object will have a string `error` attribute.
+
+        :param str folder_url: URL of the blob holding the backup. This would be the `folder_url` of a
+            :class:`KeyVaultBackupResult` returned by :func:`begin_backup`, for example
+            https://<account>.blob.core.windows.net/backup/mhsm-account-2020090117323313
+
+        :keyword str sas_token: Optional Shared Access Signature (SAS) token to authorize access to the blob. Required
+            unless `use_managed_identity` is set to True.
+        :keyword use_managed_identity: Indicates which authentication method should be used. If set to True, Managed HSM
+            will use the configured user-assigned managed identity to authenticate with Azure Storage. Otherwise, a SAS
+            token has to be specified.
+        :paramtype use_managed_identity: bool
+        :keyword str continuation_token: A continuation token to restart polling from a saved state.
+
+        :returns: An :class:`~azure.core.polling.LROPoller` instance. Call `result()` on this object to wait for the
+            operation to complete and get a :class:`KeyVaultRestoreOperation`. If the pre-restore check fails, the
+            object will have a string `error` attribute.
+        :rtype: ~azure.core.polling.LROPoller[~azure.keyvault.administration.KeyVaultRestoreOperation]
+        """
+        polling_interval = kwargs.pop("_polling_interval", 5)
+        continuation_token = kwargs.pop("continuation_token", None)
+        use_managed_identity = kwargs.pop("use_managed_identity", False)
+        sas_token = kwargs.pop("sas_token", None)
+
+        container_url, folder_name = parse_folder_url(folder_url)
+        sas_parameter = self._models.SASTokenParameter(
+            storage_resource_uri=container_url, token=sas_token, use_managed_identity=use_managed_identity
+        )
+        parameters = self._models.PreRestoreOperationParameters(
+            folder_to_restore=folder_name, sas_token_parameters=sas_parameter
+        )
+        status_response = None
+        if continuation_token:
+            status_response = self._use_continuation_token(continuation_token, self._client.restore_status)
+
+        return self._client.begin_pre_full_restore_operation(
+            vault_base_url=self._vault_url,
+            pre_restore_operation_parameters=parameters,
+            cls=KeyVaultRestoreOperation._from_generated,  # pylint: disable=protected-access
+            polling=KeyVaultBackupClientPollingMethod(
+                lro_algorithms=[KeyVaultBackupClientPolling()], timeout=polling_interval, **kwargs
+            ),
+            continuation_token=status_response,
             **kwargs,
         )
 

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_backup_client.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_backup_client.py
@@ -13,6 +13,7 @@ from typing_extensions import Literal
 from azure.core.polling import LROPoller
 from azure.core.tracing.decorator import distributed_trace
 
+from ._generated.models import PreBackupOperationParameters, PreRestoreOperationParameters, SASTokenParameter
 from ._models import KeyVaultBackupOperation, KeyVaultBackupResult, KeyVaultRestoreOperation
 from ._internal import KeyVaultClientBase, parse_folder_url
 from ._internal.polling import KeyVaultBackupClientPolling, KeyVaultBackupClientPollingMethod
@@ -293,15 +294,15 @@ class KeyVaultBackupClient(KeyVaultClientBase):
             will be stored. If the check fails, the object will have a string `error` attribute.
         :rtype: ~azure.core.polling.LROPoller[~azure.keyvault.administration.KeyVaultBackupOperation]
         """
-        polling_interval = kwargs.pop("_polling_interval", 5)
-        continuation_token = kwargs.pop("continuation_token", None)
-        use_managed_identity = kwargs.pop("use_managed_identity", False)
-        sas_token = kwargs.pop("sas_token", None)
+        polling_interval: int = kwargs.pop("_polling_interval", 5)
+        continuation_token: Optional[str] = kwargs.pop("continuation_token", None)
+        use_managed_identity: bool = kwargs.pop("use_managed_identity", False)
+        sas_token: Optional[str] = kwargs.pop("sas_token", None)
 
-        parameters = self._models.PreBackupOperationParameters(
+        parameters: PreBackupOperationParameters = PreBackupOperationParameters(
             storage_resource_uri=blob_storage_url, token=sas_token, use_managed_identity=use_managed_identity
         )
-        status_response = None
+        status_response: Optional[str] = None
         if continuation_token:
             status_response = self._use_continuation_token(continuation_token, self._client.full_backup_status)
 
@@ -364,19 +365,19 @@ class KeyVaultBackupClient(KeyVaultClientBase):
             object will have a string `error` attribute.
         :rtype: ~azure.core.polling.LROPoller[~azure.keyvault.administration.KeyVaultRestoreOperation]
         """
-        polling_interval = kwargs.pop("_polling_interval", 5)
-        continuation_token = kwargs.pop("continuation_token", None)
-        use_managed_identity = kwargs.pop("use_managed_identity", False)
-        sas_token = kwargs.pop("sas_token", None)
+        polling_interval: int = kwargs.pop("_polling_interval", 5)
+        continuation_token: Optional[str] = kwargs.pop("continuation_token", None)
+        use_managed_identity: bool = kwargs.pop("use_managed_identity", False)
+        sas_token: Optional[str] = kwargs.pop("sas_token", None)
 
         container_url, folder_name = parse_folder_url(folder_url)
-        sas_parameter = self._models.SASTokenParameter(
+        sas_parameter: SASTokenParameter = SASTokenParameter(
             storage_resource_uri=container_url, token=sas_token, use_managed_identity=use_managed_identity
         )
-        parameters = self._models.PreRestoreOperationParameters(
+        parameters: PreRestoreOperationParameters = PreRestoreOperationParameters(
             folder_to_restore=folder_name, sas_token_parameters=sas_parameter
         )
-        status_response = None
+        status_response: Optional[str] = None
         if continuation_token:
             status_response = self._use_continuation_token(continuation_token, self._client.restore_status)
 

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_models.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_models.py
@@ -10,6 +10,7 @@ from ._enums import KeyVaultSettingType
 from ._generated.models import (
     FullBackupOperation,
     Permission,
+    RestoreOperation,
     RoleAssignment,
     RoleAssignmentProperties,
     RoleAssignmentPropertiesWithScope,
@@ -153,6 +154,46 @@ class KeyVaultRoleDefinition(object):
         )
 
 
+class KeyVaultBackupOperation:
+    """The details of a Key Vault backup operation.
+
+    :ivar str status: The status of the backup operation.
+    :ivar str status_details: The status details of the backup operation.
+    :ivar str error: The error details of the backup operation.
+    :ivar start_time: The start time of the backup operation in UTC.
+    :vartype start_time: ~datetime.datetime or None
+    :ivar end_time: The end time of the backup operation in UTC.
+    :vartype end_time: ~datetime.datetime or None
+    :ivar str job_id: The job identifier of the backup operation.
+    :ivar str folder_url: The URL of the Azure Blob Storage container where the backup is stored.
+    """
+
+    # pylint:disable=unused-argument
+
+    def __init__(self, **kwargs: Any) -> None:
+        self.status = kwargs.get("status")
+        self.status_details = kwargs.get("status_details")
+        self.error = kwargs.get("error")
+        self.start_time = kwargs.get("start_time")
+        self.end_time = kwargs.get("end_time")
+        self.job_id = kwargs.get("job_id")
+        self.folder_url = kwargs.get("folder_url")
+
+    @classmethod
+    def _from_generated(
+        cls, response: HttpResponse, deserialized_operation: FullBackupOperation, response_headers: Dict
+    ) -> "KeyVaultBackupOperation":
+        return cls(
+            status=deserialized_operation.status,
+            status_details=deserialized_operation.status_details,
+            error=deserialized_operation.error,
+            start_time=deserialized_operation.start_time,
+            end_time=deserialized_operation.end_time,
+            job_id=deserialized_operation.job_id,
+            folder_url=deserialized_operation.azure_storage_blob_container_uri,
+        )
+
+
 class KeyVaultBackupResult(object):
     """A Key Vault full backup operation result
 
@@ -169,6 +210,43 @@ class KeyVaultBackupResult(object):
         cls, response: HttpResponse, deserialized_operation: FullBackupOperation, response_headers: Dict
     ) -> "KeyVaultBackupResult":
         return cls(folder_url=deserialized_operation.azure_storage_blob_container_uri)
+
+
+class KeyVaultRestoreOperation:
+    """The details of a Key Vault restore operation.
+
+    :ivar str status: The status of the restore operation.
+    :ivar str status_details: The status details of the restore operation.
+    :ivar str error: The error details of the restore operation.
+    :ivar start_time: The start time of the restore operation in UTC.
+    :vartype start_time: ~datetime.datetime or None
+    :ivar end_time: The end time of the restore operation in UTC.
+    :vartype end_time: ~datetime.datetime or None
+    :ivar str job_id: The job identifier of the restore operation.
+    """
+
+    # pylint:disable=unused-argument
+
+    def __init__(self, **kwargs: Any) -> None:
+        self.status = kwargs.get("status")
+        self.status_details = kwargs.get("status_details")
+        self.error = kwargs.get("error")
+        self.start_time = kwargs.get("start_time")
+        self.end_time = kwargs.get("end_time")
+        self.job_id = kwargs.get("job_id")
+
+    @classmethod
+    def _from_generated(
+        cls, response: HttpResponse, deserialized_operation: RestoreOperation, response_headers: Dict
+    ) -> "KeyVaultRestoreOperation":
+        return cls(
+            status=deserialized_operation.status,
+            status_details=deserialized_operation.status_details,
+            error=deserialized_operation.error,
+            start_time=deserialized_operation.start_time,
+            end_time=deserialized_operation.end_time,
+            job_id=deserialized_operation.job_id,
+        )
 
 
 class KeyVaultSetting(object):

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_models.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/_models.py
@@ -2,6 +2,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
+from datetime import datetime
 from typing import Any, Dict, Optional, Union
 
 from azure.core.rest import HttpResponse
@@ -171,22 +172,26 @@ class KeyVaultBackupOperation:
     # pylint:disable=unused-argument
 
     def __init__(self, **kwargs: Any) -> None:
-        self.status = kwargs.get("status")
-        self.status_details = kwargs.get("status_details")
-        self.error = kwargs.get("error")
-        self.start_time = kwargs.get("start_time")
-        self.end_time = kwargs.get("end_time")
-        self.job_id = kwargs.get("job_id")
-        self.folder_url = kwargs.get("folder_url")
+        self.status: Optional[str] = kwargs.get("status")
+        self.status_details: Optional[str] = kwargs.get("status_details")
+        self.error: Optional[str] = kwargs.get("error")
+        self.start_time: Optional[datetime] = kwargs.get("start_time")
+        self.end_time: Optional[datetime] = kwargs.get("end_time")
+        self.job_id: Optional[str] = kwargs.get("job_id")
+        self.folder_url: Optional[str] = kwargs.get("folder_url")
 
     @classmethod
     def _from_generated(
         cls, response: HttpResponse, deserialized_operation: FullBackupOperation, response_headers: Dict
     ) -> "KeyVaultBackupOperation":
+        error = deserialized_operation.error
+        error_message: Optional[str] = None
+        if error and error.message:
+            error_message = f"{error.code}: {error.message}"
         return cls(
             status=deserialized_operation.status,
             status_details=deserialized_operation.status_details,
-            error=deserialized_operation.error,
+            error=error_message,
             start_time=deserialized_operation.start_time,
             end_time=deserialized_operation.end_time,
             job_id=deserialized_operation.job_id,
@@ -228,21 +233,25 @@ class KeyVaultRestoreOperation:
     # pylint:disable=unused-argument
 
     def __init__(self, **kwargs: Any) -> None:
-        self.status = kwargs.get("status")
-        self.status_details = kwargs.get("status_details")
-        self.error = kwargs.get("error")
-        self.start_time = kwargs.get("start_time")
-        self.end_time = kwargs.get("end_time")
-        self.job_id = kwargs.get("job_id")
+        self.status: Optional[str] = kwargs.get("status")
+        self.status_details: Optional[str] = kwargs.get("status_details")
+        self.error: Optional[str] = kwargs.get("error")
+        self.start_time: Optional[datetime] = kwargs.get("start_time")
+        self.end_time: Optional[datetime] = kwargs.get("end_time")
+        self.job_id: Optional[str] = kwargs.get("job_id")
 
     @classmethod
     def _from_generated(
         cls, response: HttpResponse, deserialized_operation: RestoreOperation, response_headers: Dict
     ) -> "KeyVaultRestoreOperation":
+        error = deserialized_operation.error
+        error_message: Optional[str] = None
+        if error and error.message:
+            error_message = f"{error.code}: {error.message}"
         return cls(
             status=deserialized_operation.status,
             status_details=deserialized_operation.status_details,
-            error=deserialized_operation.error,
+            error=error_message,
             start_time=deserialized_operation.start_time,
             end_time=deserialized_operation.end_time,
             job_id=deserialized_operation.job_id,

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/aio/_backup_client.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/aio/_backup_client.py
@@ -5,7 +5,7 @@
 import base64
 import functools
 import pickle
-from typing import Any, Optional, overload
+from typing import Any, Callable, Optional, overload
 
 from typing_extensions import Literal
 
@@ -16,7 +16,7 @@ from .._backup_client import _parse_status_url
 from .._internal import AsyncKeyVaultClientBase, parse_folder_url
 from .._internal.async_polling import KeyVaultAsyncBackupClientPollingMethod
 from .._internal.polling import KeyVaultBackupClientPolling
-from .._models import KeyVaultBackupResult
+from .._models import KeyVaultBackupOperation, KeyVaultBackupResult, KeyVaultRestoreOperation
 
 
 class KeyVaultBackupClient(AsyncKeyVaultClientBase):
@@ -34,6 +34,23 @@ class KeyVaultBackupClient(AsyncKeyVaultClientBase):
     :keyword bool verify_challenge_resource: Whether to verify the authentication challenge resource matches the Key
         Vault or Managed HSM domain. Defaults to True.
     """
+
+    async def _use_continuation_token(self, continuation_token: str, status_method: Callable) -> str:
+        status_url = base64.b64decode(continuation_token.encode()).decode("ascii")
+        try:
+            job_id = _parse_status_url(status_url)
+        except Exception as ex:  # pylint: disable=broad-except
+            raise ValueError(
+                "The provided continuation_token is malformed. A valid token can be obtained from the operation "
+                + "poller's continuation_token() method"
+            ) from ex
+
+        pipeline_response = await status_method(
+            vault_base_url=self._vault_url, job_id=job_id, cls=lambda pipeline_response, _, __: pipeline_response
+        )
+        if "azure-asyncoperation" not in pipeline_response.http_response.headers:
+            pipeline_response.http_response.headers["azure-asyncoperation"] = status_url
+        return base64.b64encode(pickle.dumps(pipeline_response)).decode("ascii")
 
     @overload
     async def begin_backup(
@@ -88,7 +105,7 @@ class KeyVaultBackupClient(AsyncKeyVaultClientBase):
         """
         polling_interval = kwargs.pop("_polling_interval", 5)
         continuation_token = kwargs.pop("continuation_token", None)
-        use_managed_identity = kwargs.pop("use_managed_identity", None)
+        use_managed_identity = kwargs.pop("use_managed_identity", False)
         # `sas_token` was formerly a required positional parameter
         try:
             sas_token: Optional[str] = args[0]
@@ -100,21 +117,7 @@ class KeyVaultBackupClient(AsyncKeyVaultClientBase):
 
         status_response = None
         if continuation_token:
-            status_url = base64.b64decode(continuation_token.encode()).decode("ascii")
-            try:
-                job_id = _parse_status_url(status_url)
-            except Exception as ex:  # pylint: disable=broad-except
-                raise ValueError(
-                    "The provided continuation_token is malformed. A valid token can be obtained from the operation "
-                    + "poller's continuation_token() method"
-                ) from ex
-
-            pipeline_response = await self._client.full_backup_status(
-                vault_base_url=self._vault_url, job_id=job_id, cls=lambda pipeline_response, _, __: pipeline_response
-            )
-            if "azure-asyncoperation" not in pipeline_response.http_response.headers:
-                pipeline_response.http_response.headers["azure-asyncoperation"] = status_url
-            status_response = base64.b64encode(pickle.dumps(pipeline_response)).decode("ascii")
+            status_response = await self._use_continuation_token(continuation_token, self._client.full_backup_status)
 
         return await self._client.begin_full_backup(
             vault_base_url=self._vault_url,
@@ -193,33 +196,19 @@ class KeyVaultBackupClient(AsyncKeyVaultClientBase):
                 :caption: Restore a single key
                 :dedent: 8
         """
-        status_response = None
         polling_interval = kwargs.pop("_polling_interval", 5)
         continuation_token = kwargs.pop("continuation_token", None)
         key_name = kwargs.pop("key_name", None)
-        use_managed_identity = kwargs.pop("use_managed_identity", None)
+        use_managed_identity = kwargs.pop("use_managed_identity", False)
         # `sas_token` was formerly a required positional parameter
         try:
             sas_token: Optional[str] = args[0]
         except IndexError:
             sas_token = kwargs.pop("sas_token", None)
 
+        status_response = None
         if continuation_token:
-            status_url = base64.b64decode(continuation_token.encode()).decode("ascii")
-            try:
-                job_id = _parse_status_url(status_url)
-            except Exception as ex:  # pylint: disable=broad-except
-                raise ValueError(
-                    "The provided continuation_token is malformed. A valid token can be obtained from the operation "
-                    + "poller's continuation_token() method"
-                ) from ex
-
-            pipeline_response = await self._client.restore_status(
-                vault_base_url=self._vault_url, job_id=job_id, cls=lambda pipeline_response, _, __: pipeline_response
-            )
-            if "azure-asyncoperation" not in pipeline_response.http_response.headers:
-                pipeline_response.http_response.headers["azure-asyncoperation"] = status_url
-            status_response = base64.b64encode(pickle.dumps(pipeline_response)).decode("ascii")
+            status_response = await self._use_continuation_token(continuation_token, self._client.restore_status)
 
         container_url, folder_name = parse_folder_url(folder_url)
         sas_parameter = self._models.SASTokenParameter(
@@ -246,6 +235,154 @@ class KeyVaultBackupClient(AsyncKeyVaultClientBase):
             cls=lambda *_: None,  # poller.result() returns None
             continuation_token=status_response,
             polling=polling,
+            **kwargs,
+        )
+
+    @overload
+    async def begin_pre_backup(
+        self,
+        blob_storage_url: str,
+        *,
+        use_managed_identity: Literal[True],
+        continuation_token: Optional[str] = None,
+        **kwargs: Any,
+    ) -> AsyncLROPoller[KeyVaultBackupOperation]:
+        ...
+
+    @overload
+    async def begin_pre_backup(
+        self,
+        blob_storage_url: str,
+        *,
+        sas_token: str,
+        continuation_token: Optional[str] = None,
+        **kwargs: Any,
+    ) -> AsyncLROPoller[KeyVaultBackupOperation]:
+        ...
+
+    @distributed_trace_async
+    async def begin_pre_backup(
+        self, blob_storage_url: str, **kwargs: Any
+    ) -> AsyncLROPoller[KeyVaultBackupOperation]:
+        """Initiates a pre-backup check of whether a full Key Vault backup can be performed.
+
+        A :class:`KeyVaultBackupOperation` instance will be returned by the poller's `result()` method. If the
+        pre-backup check is successful, the object will have a string `folder_url` attribute, pointing to the blob
+        storage container where the backup will be stored. If the check fails, the object will have a string `error`
+        attribute.
+
+        :param str blob_storage_url: URL of the blob storage container in which the backup will be stored, for example
+            https://<account>.blob.core.windows.net/backup.
+
+        :keyword str sas_token: Optional Shared Access Signature (SAS) token to authorize access to the blob. Required
+            unless `use_managed_identity` is set to True.
+        :keyword use_managed_identity: Indicates which authentication method should be used. If set to True, Managed HSM
+            will use the configured user-assigned managed identity to authenticate with Azure Storage. Otherwise, a SAS
+            token has to be specified.
+        :paramtype use_managed_identity: bool
+        :keyword str continuation_token: A continuation token to restart polling from a saved state.
+
+        :returns: An AsyncLROPoller. Call `result()` on this object to wait for the operation to complete and get a
+            :class:`KeyVaultBackupOperation`. If the pre-backup check is successful, the object will have a string
+            `folder_url` attribute, pointing to the blob storage container where the backup will be stored. If the check
+            fails, the object will have a string `error` attribute.
+        :rtype: ~azure.core.polling.AsyncLROPoller[~azure.keyvault.administration.KeyVaultBackupOperation]
+        """
+        polling_interval = kwargs.pop("_polling_interval", 5)
+        continuation_token = kwargs.pop("continuation_token", None)
+        use_managed_identity = kwargs.pop("use_managed_identity", False)
+        sas_token = kwargs.pop("sas_token", None)
+
+        parameters = self._models.PreBackupOperationParameters(
+            storage_resource_uri=blob_storage_url, token=sas_token, use_managed_identity=use_managed_identity
+        )
+        status_response = None
+        if continuation_token:
+            status_response = await self._use_continuation_token(continuation_token, self._client.full_backup_status)
+
+        return await self._client.begin_pre_full_backup(
+            vault_base_url=self._vault_url,
+            pre_backup_operation_parameters=parameters,
+            cls=KeyVaultBackupOperation._from_generated,  # pylint: disable=protected-access
+            polling=KeyVaultAsyncBackupClientPollingMethod(
+                lro_algorithms=[KeyVaultBackupClientPolling()], timeout=polling_interval, **kwargs
+            ),
+            continuation_token=status_response,
+            **kwargs,
+        )
+
+    @overload
+    async def begin_pre_restore(
+        self,
+        folder_url: str,
+        *,
+        use_managed_identity: Literal[True],
+        continuation_token: Optional[str] = None,
+        **kwargs: Any,
+    ) -> AsyncLROPoller[KeyVaultRestoreOperation]:
+        ...
+
+    @overload
+    async def begin_pre_restore(
+        self,
+        folder_url: str,
+        *,
+        sas_token: str,
+        continuation_token: Optional[str] = None,
+        **kwargs: Any,
+    ) -> AsyncLROPoller[KeyVaultRestoreOperation]:
+        ...
+
+    @distributed_trace_async
+    async def begin_pre_restore(
+        self, folder_url: str, **kwargs: Any
+    ) -> AsyncLROPoller[KeyVaultRestoreOperation]:
+        """Initiates a pre-restore check of whether a full Key Vault restore can be performed.
+
+        A :class:`KeyVaultRestoreOperation` instance will be returned by the poller's `result()` method. If the
+        pre-restore check fails, the object will have a string `error` attribute.
+
+        :param str folder_url: URL of the blob holding the backup. This would be the `folder_url` of a
+            :class:`KeyVaultBackupResult` returned by :func:`begin_backup`, for example
+            https://<account>.blob.core.windows.net/backup/mhsm-account-2020090117323313
+
+        :keyword str sas_token: Optional Shared Access Signature (SAS) token to authorize access to the blob. Required
+            unless `use_managed_identity` is set to True.
+        :keyword use_managed_identity: Indicates which authentication method should be used. If set to True, Managed HSM
+            will use the configured user-assigned managed identity to authenticate with Azure Storage. Otherwise, a SAS
+            token has to be specified.
+        :paramtype use_managed_identity: bool
+        :keyword str continuation_token: A continuation token to restart polling from a saved state.
+
+        :returns: An AsyncLROPoller. Call `result()` on this object to wait for the operation to complete and get a
+            :class:`KeyVaultRestoreOperation`. If the pre-restore check fails, the object will have a string `error`
+            attribute.
+        :rtype: ~azure.core.polling.AsyncLROPoller[~azure.keyvault.administration.KeyVaultRestoreOperation]
+        """
+        polling_interval = kwargs.pop("_polling_interval", 5)
+        continuation_token = kwargs.pop("continuation_token", None)
+        use_managed_identity = kwargs.pop("use_managed_identity", False)
+        sas_token = kwargs.pop("sas_token", None)
+
+        container_url, folder_name = parse_folder_url(folder_url)
+        sas_parameter = self._models.SASTokenParameter(
+            storage_resource_uri=container_url, token=sas_token, use_managed_identity=use_managed_identity
+        )
+        parameters = self._models.PreRestoreOperationParameters(
+            folder_to_restore=folder_name, sas_token_parameters=sas_parameter
+        )
+        status_response = None
+        if continuation_token:
+            status_response = await self._use_continuation_token(continuation_token, self._client.restore_status)
+
+        return await self._client.begin_pre_full_restore_operation(
+            vault_base_url=self._vault_url,
+            pre_restore_operation_parameters=parameters,
+            cls=KeyVaultRestoreOperation._from_generated,  # pylint: disable=protected-access
+            polling=KeyVaultAsyncBackupClientPollingMethod(
+                lro_algorithms=[KeyVaultBackupClientPolling()], timeout=polling_interval, **kwargs
+            ),
+            continuation_token=status_response,
             **kwargs,
         )
 

--- a/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/aio/_backup_client.py
+++ b/sdk/keyvault/azure-keyvault-administration/azure/keyvault/administration/aio/_backup_client.py
@@ -12,6 +12,7 @@ from typing_extensions import Literal
 from azure.core.polling import AsyncLROPoller
 from azure.core.tracing.decorator_async import distributed_trace_async
 
+from .._generated.models import PreBackupOperationParameters, PreRestoreOperationParameters, SASTokenParameter
 from .._backup_client import _parse_status_url
 from .._internal import AsyncKeyVaultClientBase, parse_folder_url
 from .._internal.async_polling import KeyVaultAsyncBackupClientPollingMethod
@@ -288,15 +289,15 @@ class KeyVaultBackupClient(AsyncKeyVaultClientBase):
             fails, the object will have a string `error` attribute.
         :rtype: ~azure.core.polling.AsyncLROPoller[~azure.keyvault.administration.KeyVaultBackupOperation]
         """
-        polling_interval = kwargs.pop("_polling_interval", 5)
-        continuation_token = kwargs.pop("continuation_token", None)
-        use_managed_identity = kwargs.pop("use_managed_identity", False)
-        sas_token = kwargs.pop("sas_token", None)
+        polling_interval: int = kwargs.pop("_polling_interval", 5)
+        continuation_token: Optional[str] = kwargs.pop("continuation_token", None)
+        use_managed_identity: bool = kwargs.pop("use_managed_identity", False)
+        sas_token: Optional[str] = kwargs.pop("sas_token", None)
 
-        parameters = self._models.PreBackupOperationParameters(
+        parameters: PreBackupOperationParameters = PreBackupOperationParameters(
             storage_resource_uri=blob_storage_url, token=sas_token, use_managed_identity=use_managed_identity
         )
-        status_response = None
+        status_response: Optional[str] = None
         if continuation_token:
             status_response = await self._use_continuation_token(continuation_token, self._client.full_backup_status)
 
@@ -359,19 +360,19 @@ class KeyVaultBackupClient(AsyncKeyVaultClientBase):
             attribute.
         :rtype: ~azure.core.polling.AsyncLROPoller[~azure.keyvault.administration.KeyVaultRestoreOperation]
         """
-        polling_interval = kwargs.pop("_polling_interval", 5)
-        continuation_token = kwargs.pop("continuation_token", None)
-        use_managed_identity = kwargs.pop("use_managed_identity", False)
-        sas_token = kwargs.pop("sas_token", None)
+        polling_interval: int = kwargs.pop("_polling_interval", 5)
+        continuation_token: Optional[str] = kwargs.pop("continuation_token", None)
+        use_managed_identity: bool = kwargs.pop("use_managed_identity", False)
+        sas_token: Optional[str] = kwargs.pop("sas_token", None)
 
         container_url, folder_name = parse_folder_url(folder_url)
-        sas_parameter = self._models.SASTokenParameter(
+        sas_parameter: SASTokenParameter = SASTokenParameter(
             storage_resource_uri=container_url, token=sas_token, use_managed_identity=use_managed_identity
         )
-        parameters = self._models.PreRestoreOperationParameters(
+        parameters: PreRestoreOperationParameters = PreRestoreOperationParameters(
             folder_to_restore=folder_name, sas_token_parameters=sas_parameter
         )
-        status_response = None
+        status_response: Optional[str] = None
         if continuation_token:
             status_response = await self._use_continuation_token(continuation_token, self._client.restore_status)
 


### PR DESCRIPTION
# Description

Resolves https://github.com/Azure/azure-sdk-for-python/issues/35252. This adds client-facing support for pre-backup and pre-restore methods, for checking whether a full backup or full restore operation can be performed.

As a draft, this PR doesn't include tests because of default feature unavailability in the service. Once the feature can be easily enabled, tests and samples will be added.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
