### PR TITLE
[Monitor Distro] Update fastapi dev dependency

### DIFF
--- a/sdk/monitor/azure-monitor-opentelemetry/dev_requirements.txt
+++ b/sdk/monitor/azure-monitor-opentelemetry/dev_requirements.txt
@@ -1,7 +1,7 @@
 -e ../../../tools/azure-sdk-tools
 pytest
 django
-fastapi
+fastapi-slim
 flask
 psycopg2
 requests


### PR DESCRIPTION
The standard install of `fastapi` has introduced a dependency `orjson` which is incompatible with pypy, causing pypy pipeline test failures.

This changes the dev dependency to [`fastapi-slim`](https://github.com/tiangolo/fastapi?tab=readme-ov-file#fastapi-slim) which doesn't install the standard optional dependencies.