### PR TITLE
upgrade 0.23.10

### DIFF
--- a/eng/emitter-package-lock.json
+++ b/eng/emitter-package-lock.json
@@ -5,24 +5,24 @@
   "packages": {
     "": {
       "dependencies": {
-        "@azure-tools/typespec-python": "0.23.9"
+        "@azure-tools/typespec-python": "0.23.10"
       },
       "devDependencies": {
-        "@azure-tools/typespec-autorest": "~0.41.0",
-        "@azure-tools/typespec-azure-core": "~0.41.0",
-        "@azure-tools/typespec-azure-resource-manager": "~0.41.0",
-        "@azure-tools/typespec-client-generator-core": "~0.41.8",
-        "@typespec/compiler": "~0.55.0",
-        "@typespec/http": "~0.55.0",
-        "@typespec/openapi": "~0.55.0",
-        "@typespec/rest": "~0.55.0",
-        "@typespec/versioning": "~0.55.0"
+        "@azure-tools/typespec-autorest": "~0.42.0",
+        "@azure-tools/typespec-azure-core": "~0.42.0",
+        "@azure-tools/typespec-azure-resource-manager": "~0.42.0",
+        "@azure-tools/typespec-client-generator-core": "~0.42.2",
+        "@typespec/compiler": "~0.56.0",
+        "@typespec/http": "~0.56.0",
+        "@typespec/openapi": "~0.56.0",
+        "@typespec/rest": "~0.56.0",
+        "@typespec/versioning": "~0.56.0"
       }
     },
     "node_modules/@autorest/python": {
-      "version": "6.13.16",
-      "resolved": "https://registry.npmjs.org/@autorest/python/-/python-6.13.16.tgz",
-      "integrity": "sha512-Y7xq6bCFsVqrJe4wxPbV3LpmmxW6b9YfSgVQRN4jOhz9yfFUtHGHbiPOZ/BLC0v1B6xb6J074UDD35wbxI/ffQ==",
+      "version": "6.13.17",
+      "resolved": "https://registry.npmjs.org/@autorest/python/-/python-6.13.17.tgz",
+      "integrity": "sha512-LFqAZz08bssfcFP+AXFkFmD6vgmoSe05WRIRrPW2vK+lXNloDx4PixdoCJ8JsEi1Bkzm6NhS64nCAe/ogoqp7g==",
       "hasInstallScript": true,
       "dependencies": {
         "@autorest/system-requirements": "~1.0.2"
@@ -42,59 +42,41 @@
       }
     },
     "node_modules/@azure-tools/typespec-autorest": {
-      "version": "0.41.1",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-autorest/-/typespec-autorest-0.41.1.tgz",
-      "integrity": "sha512-m2Rq8aFMvICfkG/+B1kGSDepCUDHhiQ93y1/IcE+XU1+IU2iuNoSgUd0lHgksP5Aqnvs3Wm9JDmA9nMNjOM1Ww==",
+      "version": "0.42.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-autorest/-/typespec-autorest-0.42.0.tgz",
+      "integrity": "sha512-3cB5SiIbRDvGXpadnxwqsNhQ4A9pteGTHIpVlKpENpvzIoWU9phe+uBmGJDiQ/9CQPiLk7JncER95XYVOvn/vA==",
       "dev": true,
       "engines": {
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@azure-tools/typespec-azure-core": "~0.41.0",
-        "@azure-tools/typespec-client-generator-core": "~0.41.1",
-        "@typespec/compiler": "~0.55.0",
-        "@typespec/http": "~0.55.0",
-        "@typespec/openapi": "~0.55.0",
-        "@typespec/rest": "~0.55.0",
-        "@typespec/versioning": "~0.55.0"
+        "@azure-tools/typespec-azure-core": "~0.42.0",
+        "@azure-tools/typespec-client-generator-core": "~0.42.0",
+        "@typespec/compiler": "~0.56.0",
+        "@typespec/http": "~0.56.0",
+        "@typespec/openapi": "~0.56.0",
+        "@typespec/rest": "~0.56.0",
+        "@typespec/versioning": "~0.56.0"
       }
     },
     "node_modules/@azure-tools/typespec-azure-core": {
-      "version": "0.41.0",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-core/-/typespec-azure-core-0.41.0.tgz",
-      "integrity": "sha512-bnVrLxyjhMfKv75POL3m+lWjyqpLtWYEM9t2mrhFECHfW3+gWzTKIg98oNMKLXmev/sCc9QhbkKLs72jqxNL1Q==",
+      "version": "0.42.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-core/-/typespec-azure-core-0.42.0.tgz",
+      "integrity": "sha512-8C96RkgSWtgqsaHRMWCd2iDltFJZTGmFQiTZazZj/uRy0Wn1ikjSriSN8t1puL5SiUPd0BVJP/YXiwAfjfZYDA==",
       "dev": true,
       "engines": {
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "~0.55.0",
-        "@typespec/http": "~0.55.0",
-        "@typespec/rest": "~0.55.0"
+        "@typespec/compiler": "~0.56.0",
+        "@typespec/http": "~0.56.0",
+        "@typespec/rest": "~0.56.0"
       }
     },
     "node_modules/@azure-tools/typespec-azure-resource-manager": {
-      "version": "0.41.0",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-resource-manager/-/typespec-azure-resource-manager-0.41.0.tgz",
-      "integrity": "sha512-KPeQQle+hd508bkRjWHDsUXhoLjXVJg0DQyPM9wIxf+3cE0yH0aUxWPU6aj+aTio84226ExO2Qh8IadqgoQ5qg==",
-      "dev": true,
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "@azure-tools/typespec-autorest": "~0.41.0",
-        "@azure-tools/typespec-azure-core": "~0.41.0",
-        "@typespec/compiler": "~0.55.0",
-        "@typespec/http": "~0.55.0",
-        "@typespec/openapi": "~0.55.0",
-        "@typespec/rest": "~0.55.0",
-        "@typespec/versioning": "~0.55.0"
-      }
-    },
-    "node_modules/@azure-tools/typespec-client-generator-core": {
-      "version": "0.41.8",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-client-generator-core/-/typespec-client-generator-core-0.41.8.tgz",
-      "integrity": "sha512-d72LPwkEio/swqyAAgcuOaw+K4ghSbZcRjpjsvddxHWHh25ZukjD2hU/BfCtidnKptgKjs79fV++w2MYE6sTyw==",
+      "version": "0.42.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-resource-manager/-/typespec-azure-resource-manager-0.42.0.tgz",
+      "integrity": "sha512-RCqcrhE1yniAih5vDFOC5K4MpDr9XmG8qBB39G49/KyEKnWOQ3Nwvt/6fXaU42D9X2L6kfEAIz/AdiSJ/H5O6w==",
       "dev": true,
       "dependencies": {
         "change-case": "~5.4.4",
@@ -104,35 +86,57 @@
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@azure-tools/typespec-azure-core": "~0.41.0",
-        "@typespec/compiler": "~0.55.0",
-        "@typespec/http": "~0.55.0",
-        "@typespec/rest": "~0.55.0",
-        "@typespec/versioning": "~0.55.0"
+        "@azure-tools/typespec-autorest": "~0.42.0",
+        "@azure-tools/typespec-azure-core": "~0.42.0",
+        "@typespec/compiler": "~0.56.0",
+        "@typespec/http": "~0.56.0",
+        "@typespec/openapi": "~0.56.0",
+        "@typespec/rest": "~0.56.0",
+        "@typespec/versioning": "~0.56.0"
+      }
+    },
+    "node_modules/@azure-tools/typespec-client-generator-core": {
+      "version": "0.42.2",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-client-generator-core/-/typespec-client-generator-core-0.42.2.tgz",
+      "integrity": "sha512-Hei86GqNFfKpFhivZPpKo1ktSRQMnZKjLoMwIumklmMpeo5KgyzEgRSpJEiS+zmPZELs2Fu07VgfvpW0IXurUg==",
+      "dev": true,
+      "dependencies": {
+        "change-case": "~5.4.4",
+        "pluralize": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@azure-tools/typespec-azure-core": "~0.42.0",
+        "@typespec/compiler": "~0.56.0",
+        "@typespec/http": "~0.56.0",
+        "@typespec/rest": "~0.56.0",
+        "@typespec/versioning": "~0.56.0"
       }
     },
     "node_modules/@azure-tools/typespec-python": {
-      "version": "0.23.9",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-python/-/typespec-python-0.23.9.tgz",
-      "integrity": "sha512-mB/BAZMovCQi2NXX2RtAvtq7e+kkZdhsjPfHduXdBKKvFIGG88+ta2yBLCrxoGJno355XFhEATiVwaZGZjavwg==",
+      "version": "0.23.10",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-python/-/typespec-python-0.23.10.tgz",
+      "integrity": "sha512-FoDZ3Jt4x8N7UZn4xQmr+bxXACv6Azd0MRUBGkIvo27vsBNYgcahpBGIzk001L7J0VK2ZDwe+nL1ALHPmf96Kg==",
       "dependencies": {
-        "@autorest/python": "^6.13.16",
-        "@typespec/openapi3": "~0.55.0",
+        "@autorest/python": "^6.13.17",
+        "@typespec/openapi3": "~0.56.0",
         "js-yaml": "~4.1.0"
       },
       "engines": {
         "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "@azure-tools/typespec-autorest": ">=0.41.0 <1.0.0",
-        "@azure-tools/typespec-azure-core": ">=0.41.0 <1.0.0",
-        "@azure-tools/typespec-azure-resource-manager": ">=0.41.0 <1.0.0",
-        "@azure-tools/typespec-client-generator-core": ">=0.41.8 <1.0.0",
-        "@typespec/compiler": ">=0.55.0 <1.0.0",
-        "@typespec/http": ">=0.55.0 <1.0.0",
-        "@typespec/openapi": ">=0.55.0 <1.0.0",
-        "@typespec/rest": ">=0.55.0 <1.0.0",
-        "@typespec/versioning": ">=0.55.0 <1.0.0"
+        "@azure-tools/typespec-autorest": ">=0.42.0 <1.0.0",
+        "@azure-tools/typespec-azure-core": ">=0.42.0 <1.0.0",
+        "@azure-tools/typespec-azure-resource-manager": ">=0.42.0 <1.0.0",
+        "@azure-tools/typespec-client-generator-core": ">=0.42.2 <1.0.0",
+        "@typespec/compiler": ">=0.56.0 <1.0.0",
+        "@typespec/http": ">=0.56.0 <1.0.0",
+        "@typespec/openapi": ">=0.56.0 <1.0.0",
+        "@typespec/rest": ">=0.56.0 <1.0.0",
+        "@typespec/versioning": ">=0.56.0 <1.0.0"
       }
     },
     "node_modules/@azure/logger": {
@@ -231,14 +235,14 @@
       }
     },
     "node_modules/@typespec/compiler": {
-      "version": "0.55.0",
-      "resolved": "https://registry.npmjs.org/@typespec/compiler/-/compiler-0.55.0.tgz",
-      "integrity": "sha512-JxBkP7fTc3yzDYZ+Ms+ZHYlL2Ym22oloLDl6107SGaShNJBdQlabgE0aV8WvYRRBYt8g0RNb+sDLEcjvahj6Gw==",
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@typespec/compiler/-/compiler-0.56.0.tgz",
+      "integrity": "sha512-K+VhXycoeqcoSGtB0/l1XYco4V2qRsCOOwqklVM4Yew7kTcKVfz7CT7a6a2OKWDMNg5iijZtRBoM5YF50XtQug==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "~7.24.2",
         "ajv": "~8.12.0",
-        "change-case": "~5.4.3",
+        "change-case": "~5.4.4",
         "globby": "~14.0.1",
         "mustache": "~4.2.0",
         "picocolors": "~1.0.0",
@@ -259,34 +263,34 @@
       }
     },
     "node_modules/@typespec/http": {
-      "version": "0.55.0",
-      "resolved": "https://registry.npmjs.org/@typespec/http/-/http-0.55.0.tgz",
-      "integrity": "sha512-r30RWzMTJgbyRpdtZxezlvXI/nkAvgilX1OM+s3A039lGLA+JRukgvKIZ3LaNr3lNXHiqeWQDrIZNhqBnpW1zw==",
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@typespec/http/-/http-0.56.0.tgz",
+      "integrity": "sha512-f/tpHRWev9bnAtNPFkfCU/5SFou9glA/rPDY0m2W5bK6EG1/6/TKKKz5FoKPA4xvc2dQ5vu/ouGLb4i5UzXvWQ==",
       "dev": true,
       "engines": {
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "~0.55.0"
+        "@typespec/compiler": "~0.56.0"
       }
     },
     "node_modules/@typespec/openapi": {
-      "version": "0.55.0",
-      "resolved": "https://registry.npmjs.org/@typespec/openapi/-/openapi-0.55.0.tgz",
-      "integrity": "sha512-5T4VuJSOGfMFSs+1dOl3U3BC6VhKAxSTBrwcQDIEEygnqCSbj/tMFDhNfzKYKARRDotgM8ESOrZU6XH5srVR7A==",
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@typespec/openapi/-/openapi-0.56.0.tgz",
+      "integrity": "sha512-q8+IHRglXBm3slvonRLSNYN2fX7plbWA+ugIiMJZTeyc3enqfxPqMGA8BCiAFV3kwP0uPPpIXbCSIVhHgkONbA==",
       "dev": true,
       "engines": {
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "~0.55.0",
-        "@typespec/http": "~0.55.0"
+        "@typespec/compiler": "~0.56.0",
+        "@typespec/http": "~0.56.0"
       }
     },
     "node_modules/@typespec/openapi3": {
-      "version": "0.55.0",
-      "resolved": "https://registry.npmjs.org/@typespec/openapi3/-/openapi3-0.55.0.tgz",
-      "integrity": "sha512-dfn/wrKSF4Ls1dWMpAguQggoc4HGx2tf3FN2xhBln6EtahNZNgN5sOE+XY0hGPI4MCE5QexMUlXSiXpxzlNA/A==",
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@typespec/openapi3/-/openapi3-0.56.0.tgz",
+      "integrity": "sha512-55JPUP7dFk4iXn4fNKZEs76j7hAdlWfoMWNPsQPRJCP//KWCtNXfTP+/TTVPVv1L/6HztbXyPV0agKZwyS7gDw==",
       "dependencies": {
         "yaml": "~2.4.1"
       },
@@ -294,35 +298,35 @@
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "~0.55.0",
-        "@typespec/http": "~0.55.0",
-        "@typespec/openapi": "~0.55.0",
-        "@typespec/versioning": "~0.55.0"
+        "@typespec/compiler": "~0.56.0",
+        "@typespec/http": "~0.56.0",
+        "@typespec/openapi": "~0.56.0",
+        "@typespec/versioning": "~0.56.0"
       }
     },
     "node_modules/@typespec/rest": {
-      "version": "0.55.0",
-      "resolved": "https://registry.npmjs.org/@typespec/rest/-/rest-0.55.0.tgz",
-      "integrity": "sha512-RPZnx5D4xdTNiP0l++9IA8mUhnegPxetbdJ5RaG/QX2fTyF/gQ7t6AHIgdq8DfYVXqukQI/iGytJ135ObftbtQ==",
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@typespec/rest/-/rest-0.56.0.tgz",
+      "integrity": "sha512-8w4WhWDcpEQNW8bB1BHhiBxIQUChDJtyq/n9p2OI/Bm1wncd61y/ZNOtcxmlKq8uB9d+dzHiZdEfqFCR8HF8/Q==",
       "dev": true,
       "engines": {
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "~0.55.0",
-        "@typespec/http": "~0.55.0"
+        "@typespec/compiler": "~0.56.0",
+        "@typespec/http": "~0.56.0"
       }
     },
     "node_modules/@typespec/versioning": {
-      "version": "0.55.0",
-      "resolved": "https://registry.npmjs.org/@typespec/versioning/-/versioning-0.55.0.tgz",
-      "integrity": "sha512-89LTgkA3IBLnaaM4D4qfsrcEU0g3gasE1MmkrQ2HG21fYX88zKbmR1cKWeUxQx9MIXFOH4cPC9KhA/uLknRVMQ==",
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@typespec/versioning/-/versioning-0.56.0.tgz",
+      "integrity": "sha512-j7IN9XFyGn3LH6IOJkinEvk9sDncsxiWPULOAe0VQ+D/dtCfLawDMUALnvklMDRKeD1OOUPSCjjUAp9OB0f7YA==",
       "dev": true,
       "engines": {
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "~0.55.0"
+        "@typespec/compiler": "~0.56.0"
       }
     },
     "node_modules/ajv": {
@@ -630,17 +634,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -820,12 +813,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -1028,11 +1018,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yaml": {
       "version": "2.4.2",

--- a/eng/emitter-package.json
+++ b/eng/emitter-package.json
@@ -1,17 +1,17 @@
 {
   "main": "dist/src/index.js",
   "dependencies": {
-    "@azure-tools/typespec-python": "0.23.9"
+    "@azure-tools/typespec-python": "0.23.10"
   },
   "devDependencies": {
-    "@typespec/rest": "~0.55.0",
-    "@azure-tools/typespec-autorest": "~0.41.0",
-    "@typespec/http": "~0.55.0",
-    "@typespec/openapi": "~0.55.0",
-    "@azure-tools/typespec-client-generator-core": "~0.41.8",
-    "@typespec/compiler": "~0.55.0",
-    "@typespec/versioning": "~0.55.0",
-    "@azure-tools/typespec-azure-resource-manager": "~0.41.0",
-    "@azure-tools/typespec-azure-core": "~0.41.0"
+    "@typespec/rest": "~0.56.0",
+    "@azure-tools/typespec-autorest": "~0.42.0",
+    "@typespec/http": "~0.56.0",
+    "@typespec/openapi": "~0.56.0",
+    "@azure-tools/typespec-client-generator-core": "~0.42.2",
+    "@typespec/compiler": "~0.56.0",
+    "@typespec/versioning": "~0.56.0",
+    "@azure-tools/typespec-azure-resource-manager": "~0.42.0",
+    "@azure-tools/typespec-azure-core": "~0.42.0"
   }
 }


### PR DESCRIPTION
After https://github.com/Azure/azure-rest-api-specs/pull/29051/ merged, we can upgrade typespec-python

`PS D:\dev\azure-sdk-for-python> .\eng\common\scripts\typespec\New-EmitterPackageLock.ps1 .\eng\emitter-package.json .\eng\`