### PR TITLE
Use a helper function to evaluate stringized annotations. (#35538)

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_inputs_outputs/utils.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_inputs_outputs/utils.py
@@ -10,7 +10,7 @@ from collections import OrderedDict
 from enum import Enum as PyEnum
 from enum import EnumMeta
 from inspect import Parameter, getmro, signature
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Type, Union, cast
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Type, Union, cast, get_type_hints
 
 from typing_extensions import Annotated, Literal, TypeAlias
 
@@ -331,7 +331,7 @@ def _get_param_with_standard_annotation(
     skip_params = skip_params or []
     inherited_fields = _get_inherited_fields()
     # From annotations get field with type
-    annotations: Dict[str, Annotation] = getattr(cls_or_func, "__annotations__", {})
+    annotations: Dict[str, Annotation] = get_type_hints(cls_or_func, include_extras=True)
     annotations = {k: v for k, v in annotations.items() if k not in skip_params}
     annotations = _update_io_from_mldesigner(annotations)
     annotation_fields = _get_fields(annotations)


### PR DESCRIPTION
# Description

This PR replaces the `getattr(cls_or_func, "__annotations__", {})` in [#L334](https://github.com/Azure/azure-sdk-for-python/blob/19bac3b570fbd55754b3c8e6f873663f1b5cf6e0/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_inputs_outputs/utils.py#L334) with a helper function `typing.get_type_hints(cls_or_func, include_extras=True)` to correctly evaluate the type back from its string form.

It is a solution to (#35538).

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
