### PR TITLE
[Event Hubs] Update URI used for consumer auth to include consumer group

### DIFF
--- a/sdk/eventhub/azure-eventhub/CHANGELOG.md
+++ b/sdk/eventhub/azure-eventhub/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fixed a bug where the correct URI was not being used for consumer authentication, causing issues when assigning roles at the consumer group level. ([#35337](https://github.com/Azure/azure-sdk-for-python/issues/35337))
+
 ### Other Changes
 
 ## 5.11.7 (2024-04-10)

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_client_base.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_client_base.py
@@ -329,7 +329,7 @@ class ClientBase:  # pylint:disable=too-many-instance-attributes
         else:
             self._credential = credential  # type: ignore
         self._auto_reconnect = kwargs.get("auto_reconnect", True)
-        self._auth_uri = f"sb://{self._address.hostname}{self._address.path}"
+        self._auth_uri: str
         self._config = Configuration(
             amqp_transport=self._amqp_transport,
             hostname=self._address.hostname,

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_client_base.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_client_base.py
@@ -330,6 +330,7 @@ class ClientBase:  # pylint:disable=too-many-instance-attributes
             self._credential = credential  # type: ignore
         self._auto_reconnect = kwargs.get("auto_reconnect", True)
         self._auth_uri: str
+        self._eventhub_auth_uri = f"sb://{self._address.hostname}{self._address.path}"
         self._config = Configuration(
             amqp_transport=self._amqp_transport,
             hostname=self._address.hostname,
@@ -359,7 +360,7 @@ class ClientBase:  # pylint:disable=too-many-instance-attributes
             kwargs["credential"] = EventHubSharedKeyCredential(policy, key)
         return kwargs
 
-    def _create_auth(self) -> Union["uamqp_JWTTokenAuth", JWTTokenAuth]:
+    def _create_auth(self, *, auth_uri: Optional[str] = None) -> Union["uamqp_JWTTokenAuth", JWTTokenAuth]:
         """
         Create an ~uamqp.authentication.SASTokenAuth instance
          to authenticate the session.
@@ -367,6 +368,9 @@ class ClientBase:  # pylint:disable=too-many-instance-attributes
         :return: The auth for the session.
         :rtype: JWTTokenAuth or uamqp_JWTTokenAuth
         """
+        # if auth_uri is not provided, use the default hub one
+        entity_auth_uri = auth_uri if auth_uri else self._eventhub_auth_uri
+
         try:
             # ignore mypy's warning because token_type is Optional
             token_type = self._credential.token_type  # type: ignore
@@ -374,14 +378,14 @@ class ClientBase:  # pylint:disable=too-many-instance-attributes
             token_type = b"jwt"
         if token_type == b"servicebus.windows.net:sastoken":
             return self._amqp_transport.create_token_auth(
-                self._auth_uri,
-                functools.partial(self._credential.get_token, self._auth_uri),
+                entity_auth_uri,
+                functools.partial(self._credential.get_token, entity_auth_uri),
                 token_type=token_type,
                 config=self._config,
                 update_token=True,
             )
         return self._amqp_transport.create_token_auth(
-            self._auth_uri,
+            entity_auth_uri,
             functools.partial(self._credential.get_token, JWT_TOKEN_SCOPE),
             token_type=token_type,
             config=self._config,
@@ -574,7 +578,7 @@ class ConsumerProducerMixin():
         if not self.running:
             if self._handler:
                 self._handler.close()
-            auth = self._client._create_auth()
+            auth = self._client._create_auth(auth_uri=self._client._auth_uri)
             self._create_handler(auth)
             conn = self._client._conn_manager.get_connection(  # pylint: disable=protected-access
                 endpoint=self._client._address.hostname, auth=auth

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_consumer.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_consumer.py
@@ -200,7 +200,7 @@ class EventHubConsumer(
         if not self.running:
             if self._handler:
                 self._handler.close()
-            auth = self._client._create_auth()
+            auth = self._client._create_auth(auth_uri=self._client._auth_uri)
             self._create_handler(auth)
             conn = self._client._conn_manager.get_connection(  # pylint: disable=protected-access
                 endpoint=self._client._address.hostname, auth=auth

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_consumer_client.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_consumer_client.py
@@ -178,6 +178,7 @@ class EventHubConsumerClient(
             network_tracing=network_tracing,
             **kwargs
         )
+        # consumer auth URI additionally includes consumer group
         self._auth_uri = f"sb://{self._address.hostname}{self._address.path}/consumergroups/{self._consumer_group}"
         self._lock = threading.Lock()
         self._event_processors: Dict[Tuple[str, str], EventProcessor] = {}

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_consumer_client.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_consumer_client.py
@@ -178,6 +178,7 @@ class EventHubConsumerClient(
             network_tracing=network_tracing,
             **kwargs
         )
+        self._auth_uri = f"sb://{self._address.hostname}{self._address.path}/consumergroups/{self._consumer_group}"
         self._lock = threading.Lock()
         self._event_processors: Dict[Tuple[str, str], EventProcessor] = {}
 

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_producer_client.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_producer_client.py
@@ -201,7 +201,7 @@ class EventHubProducerClient(
             network_tracing=kwargs.get("logging_enable"),
             **kwargs
         )
-
+        self._auth_uri = f"sb://{self._address.hostname}{self._address.path}"
         self._keep_alive = kwargs.get("keep_alive", None)
 
         self._producers: Dict[str, Optional[EventHubProducer]] = {

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_client_base_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_client_base_async.py
@@ -266,7 +266,9 @@ class ClientBaseAsync(ClientBase):
             kwargs["credential"] = EventHubSharedKeyCredential(policy, key)
         return kwargs
 
-    async def _create_auth_async(self, *, auth_uri: Optional[str] = None) -> Union["uamqp_JWTTokenAsync", JWTTokenAuthAsync]:
+    async def _create_auth_async(
+        self, *, auth_uri: Optional[str] = None
+    ) -> Union["uamqp_JWTTokenAsync", JWTTokenAuthAsync]:
         """
         Create an ~uamqp.authentication.SASTokenAuthAsync instance to authenticate
         the session.

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_client_base_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_client_base_async.py
@@ -46,16 +46,14 @@ if TYPE_CHECKING:
     from .._pyamqp.aio._authentication_async import JWTTokenAuthAsync
     try:
         from uamqp import (
-            authentication as uamqp_authentication,
             Message as uamqp_Message,
             AMQPClientAsync as uamqp_AMQPClientAsync,
         )
-        from uamqp.authentication import JWTTokenAsync
+        from uamqp.authentication import JWTTokenAsync as uamqp_JWTTokenAsync
     except ImportError:
-        uamqp_authentication = None
         uamqp_Message = None
         uamqp_AMQPClientAsync = None
-        JWTTokenAsync = None
+        uamqp_JWTTokenAsync = None
     from azure.core.credentials_async import AsyncTokenCredential
 
     try:
@@ -109,7 +107,7 @@ if TYPE_CHECKING:
         def running(self, value: bool) -> None:
             pass
 
-        def _create_handler(self, auth: Union["JWTTokenAsync", JWTTokenAuthAsync]) -> None:
+        def _create_handler(self, auth: Union["uamqp_JWTTokenAsync", JWTTokenAuthAsync]) -> None:
             pass
 
     _MIXIN_BASE = AbstractConsumerProducer
@@ -268,15 +266,17 @@ class ClientBaseAsync(ClientBase):
             kwargs["credential"] = EventHubSharedKeyCredential(policy, key)
         return kwargs
 
-    async def _create_auth_async(self) -> Union[uamqp_authentication.JWTTokenAsync, JWTTokenAuthAsync]:
+    async def _create_auth_async(self, *, auth_uri: Optional[str] = None) -> Union["uamqp_JWTTokenAsync", JWTTokenAuthAsync]:
         """
         Create an ~uamqp.authentication.SASTokenAuthAsync instance to authenticate
         the session.
 
         :return: A JWTTokenAuthAsync instance to authenticate the session.
         :rtype: ~uamqp.authentication.JWTTokenAsync or JWTTokenAuthAsync
-
         """
+        # if auth_uri is not provided, use the default hub one
+        entity_auth_uri = auth_uri if auth_uri else self._eventhub_auth_uri
+
         try:
             # ignore mypy's warning because token_type is Optional
             token_type = self._credential.token_type  # type: ignore
@@ -284,14 +284,14 @@ class ClientBaseAsync(ClientBase):
             token_type = b"jwt"
         if token_type == b"servicebus.windows.net:sastoken":
             return await self._amqp_transport.create_token_auth_async(
-                self._auth_uri,
-                functools.partial(self._credential.get_token, self._auth_uri),
+                entity_auth_uri,
+                functools.partial(self._credential.get_token, entity_auth_uri),
                 token_type=token_type,
                 config=self._config,
                 update_token=True,
             )
         return await self._amqp_transport.create_token_auth_async(
-            self._auth_uri,
+            entity_auth_uri,
             functools.partial(self._credential.get_token, JWT_TOKEN_SCOPE),
             token_type=token_type,
             config=self._config,
@@ -475,7 +475,7 @@ class ConsumerProducerMixin(_MIXIN_BASE):
         if not self.running:
             if self._handler:
                 await self._handler.close_async()
-            auth = await self._client._create_auth_async()
+            auth = await self._client._create_auth_async(auth_uri=self._client._auth_uri)
             self._create_handler(auth)
             conn = await self._client._conn_manager_async.get_connection(
                 endpoint=self._client._address.hostname, auth=auth

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_consumer_client_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_consumer_client_async.py
@@ -191,6 +191,7 @@ class EventHubConsumerClient(
             network_tracing=network_tracing,
             **kwargs,
         )
+        self._auth_uri = f"sb://{self._address.hostname}{self._address.path}/consumergroups/{self._consumer_group}"
         self._lock = asyncio.Lock(**self._internal_kwargs)
         self._event_processors: Dict[Tuple[str, str], EventProcessor] = {}
 

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_consumer_client_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_consumer_client_async.py
@@ -191,6 +191,7 @@ class EventHubConsumerClient(
             network_tracing=network_tracing,
             **kwargs,
         )
+        # consumer auth URI additionally includes consumer group
         self._auth_uri = f"sb://{self._address.hostname}{self._address.path}/consumergroups/{self._consumer_group}"
         self._lock = asyncio.Lock(**self._internal_kwargs)
         self._event_processors: Dict[Tuple[str, str], EventProcessor] = {}

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_producer_client_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/aio/_producer_client_async.py
@@ -188,6 +188,7 @@ class EventHubProducerClient(
             network_tracing=kwargs.pop("logging_enable", False),
             **kwargs
         )
+        self._auth_uri = f"sb://{self._address.hostname}{self._address.path}"
         self._keep_alive = kwargs.get("keep_alive", None)
         self._producers: Dict[str, Optional[EventHubProducer]] = {
             ALL_PARTITIONS: self._create_producer()

--- a/sdk/eventhub/azure-eventhub/samples/sync_samples/send_and_receive_amqp_annotated_message.py
+++ b/sdk/eventhub/azure-eventhub/samples/sync_samples/send_and_receive_amqp_annotated_message.py
@@ -17,6 +17,16 @@ from azure.eventhub.amqp import AmqpAnnotatedMessage, AmqpMessageBodyType
 CONNECTION_STR = os.environ['EVENT_HUB_CONN_STR']
 EVENTHUB_NAME = os.environ['EVENT_HUB_NAME']
 
+import logging
+import sys
+handler = logging.StreamHandler(stream=sys.stdout)
+logger = logging.getLogger('azure.eventhub')
+logger.setLevel(logging.DEBUG)
+logger.addHandler(handler)
+#uamqp_logger = logging.getLogger('uamqp')
+#uamqp_logger.setLevel(logging.DEBUG)
+#uamqp_logger.addHandler(handler)
+
 def send_data_message(producer):
     data_body = [b'aa', b'bb', b'cc']
     application_properties = {"body_type": "data"}
@@ -91,14 +101,14 @@ def receive_and_parse_message(consumer):
             print('Stopped receiving.')
 
 
-producer = EventHubProducerClient.from_connection_string(
-    conn_str=CONNECTION_STR,
-    eventhub_name=EVENTHUB_NAME
-)
-with producer:
-    send_data_message(producer)
-    send_sequence_message(producer)
-    send_value_message(producer)
+#producer = EventHubProducerClient.from_connection_string(
+#    conn_str=CONNECTION_STR,
+#    eventhub_name=EVENTHUB_NAME
+#)
+#with producer:
+#    send_data_message(producer)
+#    send_sequence_message(producer)
+#    send_value_message(producer)
 
 
 consumer = EventHubConsumerClient.from_connection_string(

--- a/sdk/eventhub/azure-eventhub/samples/sync_samples/send_and_receive_amqp_annotated_message.py
+++ b/sdk/eventhub/azure-eventhub/samples/sync_samples/send_and_receive_amqp_annotated_message.py
@@ -17,16 +17,6 @@ from azure.eventhub.amqp import AmqpAnnotatedMessage, AmqpMessageBodyType
 CONNECTION_STR = os.environ['EVENT_HUB_CONN_STR']
 EVENTHUB_NAME = os.environ['EVENT_HUB_NAME']
 
-import logging
-import sys
-handler = logging.StreamHandler(stream=sys.stdout)
-logger = logging.getLogger('azure.eventhub')
-logger.setLevel(logging.DEBUG)
-logger.addHandler(handler)
-#uamqp_logger = logging.getLogger('uamqp')
-#uamqp_logger.setLevel(logging.DEBUG)
-#uamqp_logger.addHandler(handler)
-
 def send_data_message(producer):
     data_body = [b'aa', b'bb', b'cc']
     application_properties = {"body_type": "data"}
@@ -101,14 +91,14 @@ def receive_and_parse_message(consumer):
             print('Stopped receiving.')
 
 
-#producer = EventHubProducerClient.from_connection_string(
-#    conn_str=CONNECTION_STR,
-#    eventhub_name=EVENTHUB_NAME
-#)
-#with producer:
-#    send_data_message(producer)
-#    send_sequence_message(producer)
-#    send_value_message(producer)
+producer = EventHubProducerClient.from_connection_string(
+    conn_str=CONNECTION_STR,
+    eventhub_name=EVENTHUB_NAME
+)
+with producer:
+    send_data_message(producer)
+    send_sequence_message(producer)
+    send_value_message(producer)
 
 
 consumer = EventHubConsumerClient.from_connection_string(


### PR DESCRIPTION
fixes #35337

Currently, the URI used for authentication on the receiver only includes the EH namespace and hub. We should include the consumer group.

When consumer group is not included, we get an error when we try receiving with the `Event Hubs Data Receiver` role assigned to either the User/Service Principal at the consumer group level. To test assigning the role at the consumer group level, follow [[these instructions](https://github.com/Azure/azure-sdk-for-python/issues/35337#issuecomment-2104230503)]. (If testing on the Portal, `consumergroups/<groupname>` should be added to the end of the url after the hub name.)

Tested locally for this scenario, which passes. Not adding a test, as it would require us to add the role using the azure-mgmt-authorization package, which we would have to add to the dev_requirements.txt, or define a separate namespace in the ARM template to assign the Event Hubs Data Owner role at the consumer group level only. However, this is resulting in an error, which says that the role needs to be assigned to the resource group.