### PR TITLE
Fix Conda Build

### DIFF
--- a/eng/pipelines/templates/stages/conda-sdk-client.yml
+++ b/eng/pipelines/templates/stages/conda-sdk-client.yml
@@ -146,7 +146,7 @@ extends:
           - template: /eng/pipelines/templates/variables/globals.yml@self
 
         jobs:
-          - template: eng/pipelines/templates/jobs/build-conda-dependencies.yml@self
+          - template: /eng/pipelines/templates/jobs/build-conda-dependencies.yml@self
             parameters:
               CondaArtifacts:
                 - name: uamqp


### PR DESCRIPTION
[Example Build](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3792398&view=results)

I'm not exactly certain how this is broken, given that we checked the execution of the job before merging the `1es-template-migration` branch.

![image](https://github.com/Azure/azure-sdk-for-python/assets/45376673/2f6011b3-3cbe-4a79-8fde-6535068499d7)

However, it's a fairly straightforward fix.