### PR TITLE
Add central sleep patching fixtures

### DIFF
--- a/doc/dev/tests.md
+++ b/doc/dev/tests.md
@@ -248,17 +248,23 @@ value of `"appId"`, and `AZURE_CLIENT_SECRET` to the value of `"password"`.
 The test proxy has to be available in order for tests to work; this is done automatically with a `pytest` fixture.
 
 Create a `conftest.py` file within your package's test directory (`sdk/{service}/{package}/tests`), and inside it add a
-session-level fixture that accepts `devtools_testutils.test_proxy` as a parameter (and has `autouse` set to `True`):
+session-level fixture that accepts the `test_proxy` fixture as a parameter (and has `autouse` set to `True`):
 
 ```python
 import pytest
-from devtools_testutils import test_proxy
 
 # autouse=True will trigger this fixture on each pytest run, even if it's not explicitly used by a test method
+# test_proxy auto-starts the test proxy
+# patch_sleep and patch_async_sleep streamline tests by disabling wait times during LRO polling
 @pytest.fixture(scope="session", autouse=True)
-def start_proxy(test_proxy):
+def start_proxy(test_proxy, patch_sleep, patch_async_sleep):
     return
 ```
+
+As shown in the example, it's recommended to also request the `patch_sleep` and `patch_async_sleep` fixtures unless
+your tests have a unique need to use `time.sleep` or `asyncio.sleep` during playback tests (this is unusual). All of
+these fixtures are imported by the central [`/sdk/conftest.py`][central_conftest], so `pytest` will automatically
+resolve the references.
 
 For more details about how this fixture starts up the test proxy, or the test proxy itself, refer to the
 [test proxy migration guide][test_proxy_startup].
@@ -576,6 +582,7 @@ For information about more advanced testing scenarios, refer to the [advanced te
 [azure_cli_service_principal]: https://docs.microsoft.com/cli/azure/ad/sp?view=azure-cli-latest#az-ad-sp-create-for-rbac
 [azure_portal]: https://portal.azure.com/
 [azure_recorded_test_case]: https://github.com/Azure/azure-sdk-for-python/blob/7e66e3877519a15c1d4304eb69abf0a2281773/tools/azure-sdk-tools/devtools_testutils/azure_recorded_testcase.py#L44
+[central_conftest]: https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/conftest.py
 [env_var_docs]: https://github.com/Azure/azure-sdk-for-python/tree/main/tools/azure-sdk-tools/devtools_testutils#use-the-environmentvariableloader
 [env_var_loader]: https://github.com/Azure/azure-sdk-for-python/blob/main/tools/azure-sdk-tools/devtools_testutils/envvariable_loader.py
 [generate_sas]: https://github.com/Azure/azure-sdk-for-python/blob/bf4749babb363e2dc972775f4408036e31f361b4/tools/azure-sdk-tools/devtools_testutils/azure_recorded_testcase.py#L196

--- a/sdk/conftest.py
+++ b/sdk/conftest.py
@@ -85,3 +85,35 @@ def reduce_logging_volume(caplog, pytestconfig):
     if not (pytestconfig.getoption("log_level") or pytestconfig.getoption("log_cli_level")):
         caplog.set_level(30)
     yield
+
+
+@pytest.fixture(scope="session")
+def patch_async_sleep():
+    from unittest import mock
+    from devtools_testutils import is_live
+
+    async def immediate_return(_):
+        return
+
+    if not is_live():
+        with mock.patch("asyncio.sleep", immediate_return):
+            yield
+
+    else:
+        yield
+
+
+@pytest.fixture(scope="session")
+def patch_sleep():
+    from unittest import mock
+    from devtools_testutils import is_live
+
+    def immediate_return(_):
+        return
+
+    if not is_live():
+        with mock.patch("time.sleep", immediate_return):
+            yield
+
+    else:
+        yield


### PR DESCRIPTION
# Description

Iterates on https://github.com/Azure/azure-sdk-for-python/pull/35670. Since automatically applying these patches universally is problematic for some test suites, this PR instead makes the fixtures available for easy use by anyone who needs them. Documentation is also updated to explain their purpose and show how to include them in the proxy startup fixtures that most tests already use.

This has been locally tested to confirm that the change is compatible with libraries that do and don't use `azure-sdk-tools`.

Storage CI run: https://dev.azure.com/azure-sdk/public/_build/results?buildId=3796135&view=results
Core CI run: https://dev.azure.com/azure-sdk/public/_build/results?buildId=3796137&view=results

cc @scbedd 

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
