### PR TITLE
Sanitize version field in recorded SAS tokens

### DIFF
--- a/tools/azure-sdk-tools/devtools_testutils/proxy_startup.py
+++ b/tools/azure-sdk-tools/devtools_testutils/proxy_startup.py
@@ -316,7 +316,11 @@ def set_common_sanitizers() -> None:
 
     # General regex sanitizers for sensitive patterns throughout interactions
     batch_sanitizers[Sanitizer.GENERAL_REGEX] = [
-        {"regex": "(?:[\\?&](sig|se|st)=)(?<secret>[^&\\\"\\s]*)", "group_for_replace": "secret", "value": SANITIZED},
+        {
+            "regex": "(?:[\\?&](sig|se|st|sv)=)(?<secret>[^&\\\"\\s]*)",
+            "group_for_replace": "secret",
+            "value": SANITIZED
+        },
     ]
 
     # Header regex sanitizers for sensitive patterns in request/response headers


### PR DESCRIPTION
# Description

Per a request from the Storage team, this PR updates our SAS token sanitizer to clean up the `sv` field. The field changes with each release, which historically has forced Storage to update the version in all recordings. By sanitizing the field, we can avoid this extra work -- and because of how the test proxy now applies sanitizers in playback matching, we don't need to update recordings to make this change.

The change was locally tested on `azure-storage-blob` with current recordings and with modified recordings that have different values for `sv`.

Storage CI run: https://dev.azure.com/azure-sdk/public/_build/results?buildId=3796487&view=results

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
