### PR TITLE
Set dev build during `analyze` stage

### DIFF
--- a/eng/pipelines/templates/steps/analyze.yml
+++ b/eng/pipelines/templates/steps/analyze.yml
@@ -70,12 +70,10 @@ steps:
       ServiceDirectory: ${{ parameters.ServiceDirectory }}
       VerifyAutorest: ${{ parameters.VerifyAutorest }}
 
-  - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
-    # ComponentGovernance is currently unable to run on pull requests of public projects. Running on non-PR
-    # builds should be sufficient.
-    condition: and(succeededOrFailed(), ne(variables['Build.Reason'],'PullRequest'))
-    displayName: 'Component Detection'
-
+  - template: ../steps/set-dev-build.yml
+    parameters:
+      ServiceDirectory: ${{ parameters.ServiceDirectory }}
+      
   - task: PythonScript@0
     displayName: 'Verify sdist'
     condition: and(succeededOrFailed(), ne(variables['Skip.VerifySdist'],'true'))


### PR DESCRIPTION
Last week we merged #35504

This worked for most of the `analyze` stage, but I failed to ensure that the stage worked on `nightly` builds. The packages from the `build` stage were produced using `dev` versions, but the `analyze` stage didn't align with that expectation. As a result, nightly builds were failing because they couldn't find the version of the package that they thought they were looking for.

This was the source of

> ERROR:root:Package is missing in prebuilt directory /mnt/vss/_work/1/a for package azure-core-experimental and version 1.0.0b5

Because during a nightly build the package version will be something like `1.0.0a20240524001` instead of `1.0.0b5`.

This PR simply updates the local code during the `analyze` job such that versions being looked for will be identical to those produced from the `build` job.
