### PR TITLE
[Storage] [Typing] [File Share] Decoupled `_directory_client.py` and `_directory_client_async.py`

### DIFF
--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_directory_client.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_directory_client.py
@@ -42,7 +42,7 @@ else:
 
 if TYPE_CHECKING:
     from azure.core.credentials import AzureNamedKeyCredential, AzureSasCredential, TokenCredential
-    from ._models import DirectoryProperties, Handle, NTFSAttributes
+    from ._models import FileProperties, DirectoryProperties, Handle, NTFSAttributes
 
 
 class ShareDirectoryClient(StorageAccountHostsMixin):
@@ -493,7 +493,11 @@ class ShareDirectoryClient(StorageAccountHostsMixin):
             process_storage_error(error)
 
     @distributed_trace
-    def list_directories_and_files(self, name_starts_with: Optional[str] = None, **kwargs: Any) -> ItemPaged:
+    def list_directories_and_files(
+        self,
+        name_starts_with: Optional[str] = None,
+        **kwargs: Any
+    ) -> ItemPaged[Union["DirectoryProperties", "FileProperties"]]:
         """Lists all the directories and files under the directory.
 
         :param str name_starts_with:

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_directory_client_helpers.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_directory_client_helpers.py
@@ -1,0 +1,28 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+# pylint: disable=docstring-keyword-should-match-keyword-only
+
+from typing import (
+    TYPE_CHECKING
+)
+from urllib.parse import urlparse
+
+if TYPE_CHECKING:
+    from urllib.parse import ParseResult
+
+
+def _parse_url(account_url: str, share_name: str) -> "ParseResult":
+    try:
+        if not account_url.lower().startswith('http'):
+            account_url = "https://" + account_url
+    except AttributeError as exc:
+        raise ValueError("Account URL must be a string.") from exc
+    parsed_url = urlparse(account_url.rstrip('/'))
+    if not share_name:
+        raise ValueError("Please specify a share name.")
+    if not parsed_url.netloc:
+        raise ValueError(f"Invalid URL: {account_url}")
+    return parsed_url

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/aio/_directory_client_async.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/aio/_directory_client_async.py
@@ -47,7 +47,7 @@ else:
 if TYPE_CHECKING:
     from azure.core.credentials import AzureNamedKeyCredential, AzureSasCredential
     from azure.core.credentials_async import AsyncTokenCredential
-    from .._models import DirectoryProperties, Handle, NTFSAttributes
+    from .._models import FileProperties, DirectoryProperties, Handle, NTFSAttributes
 
 
 class ShareDirectoryClient(AsyncStorageAccountHostsMixin, StorageAccountHostsMixin):
@@ -499,7 +499,11 @@ class ShareDirectoryClient(AsyncStorageAccountHostsMixin, StorageAccountHostsMix
             process_storage_error(error)
 
     @distributed_trace
-    def list_directories_and_files(self, name_starts_with: Optional[str] = None, **kwargs: Any) -> AsyncItemPaged:
+    def list_directories_and_files(
+        self,
+        name_starts_with: Optional[str] = None,
+        **kwargs: Any
+    ) -> AsyncItemPaged[Union["DirectoryProperties", "FileProperties"]]:
         """Lists all the directories and files under the directory.
 
         :param str name_starts_with:


### PR DESCRIPTION
This PR contains these changes:

- Annotated class APIs
- Decoupled `_directory_client.py` and` _directory_client_async.py`
- Formatted comments, `# type: ignore` and `# pylint: disable=...` to our existing convention
- Refactored `snapshot` parsing logic

There are a few imports reordered, but all will be in order after resolving mypy issues :)