### PR TITLE
[Text Translation] Change scopes to audiences

### DIFF
--- a/sdk/translation/azure-ai-translation-text/azure/ai/translation/text/_patch.py
+++ b/sdk/translation/azure-ai-translation-text/azure/ai/translation/text/_patch.py
@@ -111,7 +111,7 @@ def set_authentication_policy(credential, kwargs):
                          regional resource authentication."""
                     )
                 kwargs["authentication_policy"] = BearerTokenCredentialPolicy(
-                    credential, *kwargs.pop("audience", [DEFAULT_TOKEN_SCOPE]), kwargs
+                    credential, *[kwargs.pop("audience", DEFAULT_TOKEN_SCOPE)], kwargs
                 )
 
 

--- a/sdk/translation/azure-ai-translation-text/azure/ai/translation/text/_patch.py
+++ b/sdk/translation/azure-ai-translation-text/azure/ai/translation/text/_patch.py
@@ -48,6 +48,9 @@ class TranslatorEntraIdAuthenticationPolicy(BearerTokenCredentialPolicy):
 
     :param credential: Translator Entra Id Credentials used to access Translator Resource for global endpoint.
     :type credential: ~azure.core.credentials.TokenCredential
+    :keyword str region: Used for National Clouds.
+    :keyword str resource_id: Used with both a TokenCredential combined with a region.
+    :keyword str audience: Scopes of the credentials.
     """
 
     def __init__(

--- a/sdk/translation/azure-ai-translation-text/azure/ai/translation/text/_patch.py
+++ b/sdk/translation/azure-ai-translation-text/azure/ai/translation/text/_patch.py
@@ -49,8 +49,8 @@ class TranslatorEntraIdAuthenticationPolicy(BearerTokenCredentialPolicy):
     :type credential: ~azure.core.credentials.TokenCredential
     """
 
-    def __init__(self, credential: TokenCredential, resource_id: str, region: str, audiences: str, **kwargs: Any) -> None:
-        super(TranslatorEntraIdAuthenticationPolicy, self).__init__(credential, audiences, **kwargs)
+    def __init__(self, credential: TokenCredential, resource_id: str, region: str, audience: str, **kwargs: Any) -> None:
+        super(TranslatorEntraIdAuthenticationPolicy, self).__init__(credential, audience, **kwargs)
         self.resource_id = resource_id
         self.region = region
         self.translator_credential = credential
@@ -90,15 +90,15 @@ def set_authentication_policy(credential, kwargs):
                     credential,
                     kwargs["resource_id"],
                     kwargs["region"],
-                    kwargs.pop("audiences", DEFAULT_ENTRA_ID_SCOPE),
+                    kwargs.pop("audience", DEFAULT_ENTRA_ID_SCOPE),
                 )
             else:
                 if kwargs.get("resource_id") or kwargs.get("region"):
                     raise ValueError(
-                        "Both 'resource_id' and 'region' must be provided with a TokenCredential for authentication."
+                        "Both 'resource_id' and 'region' must be provided with a TokenCredential for regional resource authentication."
                     )
                 kwargs["authentication_policy"] = BearerTokenCredentialPolicy(
-                    credential, *kwargs.pop("audiences", [DEFAULT_TOKEN_SCOPE]), kwargs
+                    credential, *kwargs.pop("audience", [DEFAULT_TOKEN_SCOPE]), kwargs
                 )
 
 
@@ -134,15 +134,16 @@ class TextTranslationClient(ServiceClientGenerated):
     None + AzureKeyCredential - used for global translator endpoint with global Translator resource
     None + TokenCredential - general translator endpoint with token authentication
     None + TokenCredential + Region - general translator endpoint with regional Translator resource
+
     :keyword str endpoint: Supported Text Translation endpoints (protocol and hostname, for example:
-    https://api.cognitive.microsofttranslator.com). If not provided, global translator endpoint will be used.
+     https://api.cognitive.microsofttranslator.com). If not provided, global translator endpoint will be used.
     :keyword credential: Credential used to authenticate with the Translator service
     :paramtype credential: Union[AzureKeyCredential, TokenCredential]
     :keyword str region: Used for National Clouds.
     :keyword str resource_id: Used with both a TokenCredential combined with a region.
-    :keyword str audiences: Scopes of the credentials.
+    :keyword str audience: Scopes of the credentials.
     :keyword  str api_version: Default value is "3.0". Note that overriding this default value may
-    result in unsupported behavior.
+     result in unsupported behavior.
     """
 
     @overload
@@ -153,8 +154,8 @@ class TextTranslationClient(ServiceClientGenerated):
         region: Optional[str] = None,
         endpoint: Optional[str] = None,
         resource_id: Optional[str] = None,
-        audiences: Optional[str] = None,
-        api_version="3.0",
+        audience: Optional[str] = None,
+        api_version: str = "3.0",
         **kwargs
     ): ...
 
@@ -165,7 +166,7 @@ class TextTranslationClient(ServiceClientGenerated):
         credential: AzureKeyCredential,
         region: Optional[str] = None,
         endpoint: Optional[str] = None,
-        api_version="3.0",
+        api_version: str = "3.0",
         **kwargs
     ): ...
 
@@ -174,7 +175,7 @@ class TextTranslationClient(ServiceClientGenerated):
         self,
         *,
         endpoint: str,
-        api_version="3.0",
+        api_version: str ="3.0",
         **kwargs
     ): ...
 

--- a/sdk/translation/azure-ai-translation-text/azure/ai/translation/text/_patch.py
+++ b/sdk/translation/azure-ai-translation-text/azure/ai/translation/text/_patch.py
@@ -49,8 +49,8 @@ class TranslatorEntraIdAuthenticationPolicy(BearerTokenCredentialPolicy):
     :type credential: ~azure.core.credentials.TokenCredential
     """
 
-    def __init__(self, credential: TokenCredential, resource_id: str, region: str, scopes: str, **kwargs: Any) -> None:
-        super(TranslatorEntraIdAuthenticationPolicy, self).__init__(credential, scopes, **kwargs)
+    def __init__(self, credential: TokenCredential, resource_id: str, region: str, audiences: str, **kwargs: Any) -> None:
+        super(TranslatorEntraIdAuthenticationPolicy, self).__init__(credential, audiences, **kwargs)
         self.resource_id = resource_id
         self.region = region
         self.translator_credential = credential
@@ -90,7 +90,7 @@ def set_authentication_policy(credential, kwargs):
                     credential,
                     kwargs["resource_id"],
                     kwargs["region"],
-                    kwargs.pop("scopes", DEFAULT_ENTRA_ID_SCOPE),
+                    kwargs.pop("audiences", DEFAULT_ENTRA_ID_SCOPE),
                 )
             else:
                 if kwargs.get("resource_id") or kwargs.get("region"):
@@ -98,7 +98,7 @@ def set_authentication_policy(credential, kwargs):
                         "Both 'resource_id' and 'region' must be provided with a TokenCredential for authentication."
                     )
                 kwargs["authentication_policy"] = BearerTokenCredentialPolicy(
-                    credential, *kwargs.pop("scopes", [DEFAULT_TOKEN_SCOPE]), kwargs
+                    credential, *kwargs.pop("audiences", [DEFAULT_TOKEN_SCOPE]), kwargs
                 )
 
 
@@ -140,7 +140,7 @@ class TextTranslationClient(ServiceClientGenerated):
     :paramtype credential: Union[AzureKeyCredential, TokenCredential]
     :keyword str region: Used for National Clouds.
     :keyword str resource_id: Used with both a TokenCredential combined with a region.
-    :keyword str scopes: Scopes of the credentials.
+    :keyword str audiences: Scopes of the credentials.
     :keyword  str api_version: Default value is "3.0". Note that overriding this default value may
     result in unsupported behavior.
     """
@@ -153,7 +153,7 @@ class TextTranslationClient(ServiceClientGenerated):
         region: Optional[str] = None,
         endpoint: Optional[str] = None,
         resource_id: Optional[str] = None,
-        scopes: Optional[str] = None,
+        audiences: Optional[str] = None,
         api_version="3.0",
         **kwargs
     ): ...

--- a/sdk/translation/azure-ai-translation-text/azure/ai/translation/text/aio/_patch.py
+++ b/sdk/translation/azure-ai-translation-text/azure/ai/translation/text/aio/_patch.py
@@ -16,6 +16,7 @@ from azure.core.credentials_async import AsyncTokenCredential
 from .._patch import (
     DEFAULT_TOKEN_SCOPE,
     DEFAULT_ENTRA_ID_SCOPE,
+    DEFAULT_SCOPE,
     get_translation_endpoint,
     TranslatorAuthenticationPolicy,
 )
@@ -68,16 +69,18 @@ def set_authentication_policy(credential, kwargs):
     elif hasattr(credential, "get_token"):
         if not kwargs.get("authentication_policy"):
             if kwargs.get("region") and kwargs.get("resource_id"):
+                scope = kwargs.pop("audience", DEFAULT_ENTRA_ID_SCOPE) + DEFAULT_SCOPE
                 kwargs["authentication_policy"] = AsyncTranslatorEntraIdAuthenticationPolicy(
                     credential,
                     kwargs["resource_id"],
                     kwargs["region"],
-                    kwargs.pop("audience", DEFAULT_ENTRA_ID_SCOPE),
+                    scope,
                 )
             else:
                 if kwargs.get("resource_id") or kwargs.get("region"):
                     raise ValueError(
-                        "Both 'resource_id' and 'region' must be provided with a TokenCredential for regional resource authentication."
+                        """Both 'resource_id' and 'region' must be provided with a TokenCredential
+                         for regional resource authentication."""
                     )
                 kwargs["authentication_policy"] = AsyncBearerTokenCredentialPolicy(
                     credential, *kwargs.pop("audience", [DEFAULT_TOKEN_SCOPE]), kwargs

--- a/sdk/translation/azure-ai-translation-text/azure/ai/translation/text/aio/_patch.py
+++ b/sdk/translation/azure-ai-translation-text/azure/ai/translation/text/aio/_patch.py
@@ -43,9 +43,9 @@ class AsyncTranslatorEntraIdAuthenticationPolicy(AsyncBearerTokenCredentialPolic
     """
 
     def __init__(
-        self, credential: AsyncTokenCredential, resource_id: str, region: str, audiences: str, **kwargs: Any
+        self, credential: AsyncTokenCredential, resource_id: str, region: str, audience: str, **kwargs: Any
     ) -> None:
-        super(AsyncTranslatorEntraIdAuthenticationPolicy, self).__init__(credential, audiences, **kwargs)
+        super(AsyncTranslatorEntraIdAuthenticationPolicy, self).__init__(credential, audience, **kwargs)
         self.resource_id = resource_id
         self.region = region
         self.translator_credential = credential
@@ -72,15 +72,15 @@ def set_authentication_policy(credential, kwargs):
                     credential,
                     kwargs["resource_id"],
                     kwargs["region"],
-                    kwargs.pop("audiences", DEFAULT_ENTRA_ID_SCOPE),
+                    kwargs.pop("audience", DEFAULT_ENTRA_ID_SCOPE),
                 )
             else:
                 if kwargs.get("resource_id") or kwargs.get("region"):
                     raise ValueError(
-                        "Both 'resource_id' and 'region' must be provided with a TokenCredential for authentication."
+                        "Both 'resource_id' and 'region' must be provided with a TokenCredential for regional resource authentication."
                     )
                 kwargs["authentication_policy"] = AsyncBearerTokenCredentialPolicy(
-                    credential, *kwargs.pop("audiences", [DEFAULT_TOKEN_SCOPE]), kwargs
+                    credential, *kwargs.pop("audience", [DEFAULT_TOKEN_SCOPE]), kwargs
                 )
 
 
@@ -116,15 +116,16 @@ class TextTranslationClient(ServiceClientGenerated):
     None + AzureKeyCredential - used for global translator endpoint with global Translator resource
     None + AsyncTokenCredential - general translator endpoint with token authentication
     None + AsyncTokenCredential + Region - general translator endpoint with regional Translator resource
+
     :keyword str endpoint: Supported Text Translation endpoints (protocol and hostname, for example:
-    https://api.cognitive.microsofttranslator.com). If not provided, global translator endpoint will be used.
+     https://api.cognitive.microsofttranslator.com). If not provided, global translator endpoint will be used.
     :keyword credential: Credential used to authenticate with the Translator service
     :paramtype credential: Union[AzureKeyCredential, AsyncTokenCredential]
     :keyword str region: Used for National Clouds.
     :keyword str resource_id: Used with both a TokenCredential combined with a region.
-    :keyword str audiences: Scopes of the credentials.
+    :keyword str audience: Scopes of the credentials.
     :keyword  str api_version: Default value is "3.0". Note that overriding this default value may
-    result in unsupported behavior.
+     result in unsupported behavior.
     """
 
     @overload
@@ -135,8 +136,8 @@ class TextTranslationClient(ServiceClientGenerated):
         region: Optional[str] = None,
         endpoint: Optional[str] = None,
         resource_id: Optional[str] = None,
-        audiences: Optional[str] = None,
-        api_version="3.0",
+        audience: Optional[str] = None,
+        api_version: str = "3.0",
         **kwargs
     ): ...
 
@@ -147,7 +148,7 @@ class TextTranslationClient(ServiceClientGenerated):
         credential: AzureKeyCredential,
         region: Optional[str] = None,
         endpoint: Optional[str] = None,
-        api_version="3.0",
+        api_version: str = "3.0",
         **kwargs
     ): ...
 
@@ -156,7 +157,7 @@ class TextTranslationClient(ServiceClientGenerated):
         self,
         *,
         endpoint: str,
-        api_version="3.0",
+        api_version: str = "3.0",
         **kwargs
     ): ...
 

--- a/sdk/translation/azure-ai-translation-text/azure/ai/translation/text/aio/_patch.py
+++ b/sdk/translation/azure-ai-translation-text/azure/ai/translation/text/aio/_patch.py
@@ -43,9 +43,9 @@ class AsyncTranslatorEntraIdAuthenticationPolicy(AsyncBearerTokenCredentialPolic
     """
 
     def __init__(
-        self, credential: AsyncTokenCredential, resource_id: str, region: str, scopes: str, **kwargs: Any
+        self, credential: AsyncTokenCredential, resource_id: str, region: str, audiences: str, **kwargs: Any
     ) -> None:
-        super(AsyncTranslatorEntraIdAuthenticationPolicy, self).__init__(credential, scopes, **kwargs)
+        super(AsyncTranslatorEntraIdAuthenticationPolicy, self).__init__(credential, audiences, **kwargs)
         self.resource_id = resource_id
         self.region = region
         self.translator_credential = credential
@@ -72,7 +72,7 @@ def set_authentication_policy(credential, kwargs):
                     credential,
                     kwargs["resource_id"],
                     kwargs["region"],
-                    kwargs.pop("scopes", DEFAULT_ENTRA_ID_SCOPE),
+                    kwargs.pop("audiences", DEFAULT_ENTRA_ID_SCOPE),
                 )
             else:
                 if kwargs.get("resource_id") or kwargs.get("region"):
@@ -80,7 +80,7 @@ def set_authentication_policy(credential, kwargs):
                         "Both 'resource_id' and 'region' must be provided with a TokenCredential for authentication."
                     )
                 kwargs["authentication_policy"] = AsyncBearerTokenCredentialPolicy(
-                    credential, *kwargs.pop("scopes", [DEFAULT_TOKEN_SCOPE]), kwargs
+                    credential, *kwargs.pop("audiences", [DEFAULT_TOKEN_SCOPE]), kwargs
                 )
 
 
@@ -122,7 +122,7 @@ class TextTranslationClient(ServiceClientGenerated):
     :paramtype credential: Union[AzureKeyCredential, AsyncTokenCredential]
     :keyword str region: Used for National Clouds.
     :keyword str resource_id: Used with both a TokenCredential combined with a region.
-    :keyword str scopes: Scopes of the credentials.
+    :keyword str audiences: Scopes of the credentials.
     :keyword  str api_version: Default value is "3.0". Note that overriding this default value may
     result in unsupported behavior.
     """
@@ -135,7 +135,7 @@ class TextTranslationClient(ServiceClientGenerated):
         region: Optional[str] = None,
         endpoint: Optional[str] = None,
         resource_id: Optional[str] = None,
-        scopes: Optional[str] = None,
+        audiences: Optional[str] = None,
         api_version="3.0",
         **kwargs
     ): ...

--- a/sdk/translation/azure-ai-translation-text/azure/ai/translation/text/aio/_patch.py
+++ b/sdk/translation/azure-ai-translation-text/azure/ai/translation/text/aio/_patch.py
@@ -41,6 +41,9 @@ class AsyncTranslatorEntraIdAuthenticationPolicy(AsyncBearerTokenCredentialPolic
 
     :param credential: Translator Entra Id Credentials used to access Translator Resource for global endpoint.
     :type credential: ~azure.core.credentials_async.AsyncTokenCredential
+    :keyword str region: Used for National Clouds.
+    :keyword str resource_id: Used with both a TokenCredential combined with a region.
+    :keyword str audience: Scopes of the credentials.
     """
 
     def __init__(

--- a/sdk/translation/azure-ai-translation-text/azure/ai/translation/text/aio/_patch.py
+++ b/sdk/translation/azure-ai-translation-text/azure/ai/translation/text/aio/_patch.py
@@ -72,7 +72,7 @@ def set_authentication_policy(credential, kwargs):
     elif hasattr(credential, "get_token"):
         if not kwargs.get("authentication_policy"):
             if kwargs.get("region") and kwargs.get("resource_id"):
-                scope = kwargs.pop("audience", DEFAULT_ENTRA_ID_SCOPE) + DEFAULT_SCOPE
+                scope = kwargs.pop("audience", DEFAULT_ENTRA_ID_SCOPE).rstrip("/") + DEFAULT_SCOPE
                 kwargs["authentication_policy"] = AsyncTranslatorEntraIdAuthenticationPolicy(
                     credential,
                     kwargs["resource_id"],
@@ -86,7 +86,7 @@ def set_authentication_policy(credential, kwargs):
                          for regional resource authentication."""
                     )
                 kwargs["authentication_policy"] = AsyncBearerTokenCredentialPolicy(
-                    credential, *kwargs.pop("audience", [DEFAULT_TOKEN_SCOPE]), kwargs
+                    credential, *[kwargs.pop("audience", DEFAULT_TOKEN_SCOPE)], kwargs
                 )
 
 

--- a/sdk/translation/azure-ai-translation-text/tests/static_access_token_credential.py
+++ b/sdk/translation/azure-ai-translation-text/tests/static_access_token_credential.py
@@ -16,7 +16,7 @@ class StaticAccessTokenCredential(object):
             region, apikey
         )
 
-    def get_token(self, *audiences, **kwargs):
+    def get_token(self, *audience, **kwargs):
         response = requests.post(self.request_url)
         access_token = response.content.decode("UTF-8")
         expires_on = datetime.datetime.now() + datetime.timedelta(days=1)

--- a/sdk/translation/azure-ai-translation-text/tests/static_access_token_credential.py
+++ b/sdk/translation/azure-ai-translation-text/tests/static_access_token_credential.py
@@ -16,7 +16,7 @@ class StaticAccessTokenCredential(object):
             region, apikey
         )
 
-    def get_token(self, *scopes, **kwargs):
+    def get_token(self, *audiences, **kwargs):
         response = requests.post(self.request_url)
         access_token = response.content.decode("UTF-8")
         expires_on = datetime.datetime.now() + datetime.timedelta(days=1)


### PR DESCRIPTION
# Description

Change `scopes` to `audiences` to align with sdk naming convention.
