### PR TITLE
[Cosmos] User agent string validation tests

### DIFF
--- a/sdk/cosmos/azure-cosmos/test/test_user_agent_suffix.py
+++ b/sdk/cosmos/azure-cosmos/test/test_user_agent_suffix.py
@@ -3,9 +3,11 @@
 
 import unittest
 import test_config
+import pytest
 from azure.cosmos import CosmosClient
 
 
+@pytest.mark.cosmosEmulator
 class TestUserAgentSuffix(unittest.TestCase):
     client: CosmosClient = None
     host = test_config.TestConfig.host
@@ -52,7 +54,6 @@ class TestUserAgentSuffix(unittest.TestCase):
 
         read_result = self.created_database.read()
         assert read_result['id'] == self.created_database.id
-
 
 
 if __name__ == '__main__':

--- a/sdk/cosmos/azure-cosmos/test/test_user_agent_suffix.py
+++ b/sdk/cosmos/azure-cosmos/test/test_user_agent_suffix.py
@@ -1,0 +1,59 @@
+# The MIT License (MIT)
+# Copyright (c) Microsoft Corporation. All rights reserved.
+
+import unittest
+import test_config
+from azure.cosmos import CosmosClient
+
+
+class TestUserAgentSuffix(unittest.TestCase):
+    client: CosmosClient = None
+    host = test_config.TestConfig.host
+    masterKey = test_config.TestConfig.masterKey
+    connectionPolicy = test_config.TestConfig.connectionPolicy
+
+    @classmethod
+    def setUpClass(cls):
+        if (cls.masterKey == '[YOUR_KEY_HERE]' or
+                cls.host == '[YOUR_ENDPOINT_HERE]'):
+            raise Exception(
+                "You must specify your Azure Cosmos account values for "
+                "'masterKey' and 'host' at the top of this class to run the "
+                "tests.")
+
+    def test_user_agent_suffix_no_special_character(self):
+        user_agent_suffix = "TestUserAgent"
+        self.client = CosmosClient(self.host, self.masterKey, user_agent=user_agent_suffix)
+        self.created_database = self.client.get_database_client(test_config.TestConfig.TEST_DATABASE_ID)
+
+        read_result = self.created_database.read()
+        assert read_result['id'] == self.created_database.id
+
+    def test_user_agent_suffix_special_character(self):
+        user_agent_suffix = "TéstUserAgent's"
+        self.client = CosmosClient(self.host, self.masterKey, user_agent=user_agent_suffix)
+        self.created_database = self.client.get_database_client(test_config.TestConfig.TEST_DATABASE_ID)
+
+        read_result = self.created_database.read()
+        assert read_result['id'] == self.created_database.id
+
+    def test_user_agent_suffix_special_character(self):
+        user_agent_suffix = "UnicodeChar鱀InUserAgent"
+        self.client = CosmosClient(self.host, self.masterKey, user_agent=user_agent_suffix)
+        self.created_database = self.client.get_database_client(test_config.TestConfig.TEST_DATABASE_ID)
+
+        read_result = self.created_database.read()
+        assert read_result['id'] == self.created_database.id
+
+    def test_user_agent_suffix_special_character(self):
+        user_agent_suffix = "UserAgent with space$%_^()*&"
+        self.client = CosmosClient(self.host, self.masterKey, user_agent=user_agent_suffix)
+        self.created_database = self.client.get_database_client(test_config.TestConfig.TEST_DATABASE_ID)
+
+        read_result = self.created_database.read()
+        assert read_result['id'] == self.created_database.id
+
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/sdk/cosmos/azure-cosmos/test/test_user_agent_suffix.py
+++ b/sdk/cosmos/azure-cosmos/test/test_user_agent_suffix.py
@@ -44,11 +44,13 @@ class TestUserAgentSuffix(unittest.TestCase):
 
     def test_user_agent_suffix_unicode_character(self):
         user_agent_suffix = "UnicodeChar鱀InUserAgent"
-        self.client = CosmosClient(self.host, self.masterKey, user_agent=user_agent_suffix)
-        self.created_database = self.client.get_database_client(test_config.TestConfig.TEST_DATABASE_ID)
-
-        read_result = self.created_database.read()
-        assert read_result['id'] == self.created_database.id
+        try:
+            self.client = CosmosClient(self.host, self.masterKey, user_agent=user_agent_suffix)
+            self.created_database = self.client.get_database_client(test_config.TestConfig.TEST_DATABASE_ID)
+            self.created_database.read()
+            pytest.fail("Unicode characters should not be allowed.")
+        except UnicodeEncodeError as e:
+            assert "ordinal not in range(256)" in e.reason
 
     def test_user_agent_suffix_space_character(self):
         user_agent_suffix = "UserAgent with space$%_^()*&"

--- a/sdk/cosmos/azure-cosmos/test/test_user_agent_suffix_async.py
+++ b/sdk/cosmos/azure-cosmos/test/test_user_agent_suffix_async.py
@@ -2,20 +2,20 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 
 import unittest
-import test_config
 import pytest
-from azure.cosmos import CosmosClient
+import test_config
+from azure.cosmos.aio import CosmosClient
 
 
 @pytest.mark.cosmosEmulator
-class TestUserAgentSuffix(unittest.TestCase):
+class TestUserAgentSuffixAsync(unittest.IsolatedAsyncioTestCase):
     """Python User Agent Suffix Tests.
     """
 
-    client: CosmosClient = None
-    host = test_config.TestConfig.host
-    masterKey = test_config.TestConfig.masterKey
-    connectionPolicy = test_config.TestConfig.connectionPolicy
+    configs = test_config.TestConfig
+    host = configs.host
+    masterKey = configs.masterKey
+    TEST_DATABASE_ID = configs.TEST_DATABASE_ID
 
     @classmethod
     def setUpClass(cls):
@@ -26,38 +26,42 @@ class TestUserAgentSuffix(unittest.TestCase):
                 "'masterKey' and 'host' at the top of this class to run the "
                 "tests.")
 
-    def test_user_agent_suffix_no_special_character(self):
+    async def test_user_agent_suffix_no_special_character_async(self):
         user_agent_suffix = "TestUserAgent"
         self.client = CosmosClient(self.host, self.masterKey, user_agent=user_agent_suffix)
         self.created_database = self.client.get_database_client(test_config.TestConfig.TEST_DATABASE_ID)
 
-        read_result = self.created_database.read()
+        read_result = await self.created_database.read()
         assert read_result['id'] == self.created_database.id
+        await self.client.close()
 
-    def test_user_agent_suffix_special_character(self):
+    async def test_user_agent_suffix_special_character_async(self):
         user_agent_suffix = "TéstUserAgent's"  # cspell:disable-line
         self.client = CosmosClient(self.host, self.masterKey, user_agent=user_agent_suffix)
         self.created_database = self.client.get_database_client(test_config.TestConfig.TEST_DATABASE_ID)
 
-        read_result = self.created_database.read()
+        read_result = await self.created_database.read()
         assert read_result['id'] == self.created_database.id
+        await self.client.close()
 
-    def test_user_agent_suffix_unicode_character(self):
+    async def test_user_agent_suffix_unicode_character_async(self):
         user_agent_suffix = "UnicodeChar鱀InUserAgent"
         self.client = CosmosClient(self.host, self.masterKey, user_agent=user_agent_suffix)
         self.created_database = self.client.get_database_client(test_config.TestConfig.TEST_DATABASE_ID)
 
-        read_result = self.created_database.read()
+        read_result = await self.created_database.read()
         assert read_result['id'] == self.created_database.id
+        await self.client.close()
 
-    def test_user_agent_suffix_space_character(self):
+    async def test_user_agent_suffix_space_character_async(self):
         user_agent_suffix = "UserAgent with space$%_^()*&"
         self.client = CosmosClient(self.host, self.masterKey, user_agent=user_agent_suffix)
         self.created_database = self.client.get_database_client(test_config.TestConfig.TEST_DATABASE_ID)
 
-        read_result = self.created_database.read()
+        read_result = await self.created_database.read()
         assert read_result['id'] == self.created_database.id
+        await self.client.close()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/sdk/cosmos/azure-cosmos/test/test_user_agent_suffix_async.py
+++ b/sdk/cosmos/azure-cosmos/test/test_user_agent_suffix_async.py
@@ -46,11 +46,13 @@ class TestUserAgentSuffixAsync(unittest.IsolatedAsyncioTestCase):
 
     async def test_user_agent_suffix_unicode_character_async(self):
         user_agent_suffix = "UnicodeChar鱀InUserAgent"
-        self.client = CosmosClient(self.host, self.masterKey, user_agent=user_agent_suffix)
-        self.created_database = self.client.get_database_client(test_config.TestConfig.TEST_DATABASE_ID)
-
-        read_result = await self.created_database.read()
-        assert read_result['id'] == self.created_database.id
+        try:
+            self.client = CosmosClient(self.host, self.masterKey, user_agent=user_agent_suffix)
+            self.created_database = self.client.get_database_client(test_config.TestConfig.TEST_DATABASE_ID)
+            await self.created_database.read()
+            pytest.fail("Unicode characters should not be allowed.")
+        except UnicodeEncodeError as e:
+            assert "ordinal not in range(256)" in e.reason
         await self.client.close()
 
     async def test_user_agent_suffix_space_character_async(self):

--- a/sdk/cosmos/azure-cosmos/test/test_user_agent_suffix_async.py
+++ b/sdk/cosmos/azure-cosmos/test/test_user_agent_suffix_async.py
@@ -46,13 +46,11 @@ class TestUserAgentSuffixAsync(unittest.IsolatedAsyncioTestCase):
 
     async def test_user_agent_suffix_unicode_character_async(self):
         user_agent_suffix = "UnicodeChar鱀InUserAgent"
-        try:
-            self.client = CosmosClient(self.host, self.masterKey, user_agent=user_agent_suffix)
-            self.created_database = self.client.get_database_client(test_config.TestConfig.TEST_DATABASE_ID)
-            await self.created_database.read()
-            pytest.fail("Unicode characters should not be allowed.")
-        except UnicodeEncodeError as e:
-            assert "ordinal not in range(256)" in e.reason
+        self.client = CosmosClient(self.host, self.masterKey, user_agent=user_agent_suffix)
+        self.created_database = self.client.get_database_client(test_config.TestConfig.TEST_DATABASE_ID)
+
+        read_result = await self.created_database.read()
+        assert read_result['id'] == self.created_database.id
         await self.client.close()
 
     async def test_user_agent_suffix_space_character_async(self):


### PR DESCRIPTION
Porting changes from Java and .NET to verify we have validation on these user agent strings, adding additional validations on our end