### PR TITLE
Add Dependency as a new rule category

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/workspace/networking.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/workspace/networking.py
@@ -113,6 +113,7 @@ class PrivateEndpointOutboundRuleSchema(metaclass=PatchedSchemaMeta):
             OutboundRuleCategory.REQUIRED,
             OutboundRuleCategory.RECOMMENDED,
             OutboundRuleCategory.USER_DEFINED,
+            OutboundRuleCategory.DEPENDENCY,
         ],
         casing_transform=camel_to_snake,
         metadata={"description": "outbound rule category."},

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/constants/_workspace.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/constants/_workspace.py
@@ -29,6 +29,7 @@ class OutboundRuleCategory:
     REQUIRED = "Required"
     RECOMMENDED = "Recommended"
     USER_DEFINED = "UserDefined"
+    DEPENDENCY = "Dependency"
 
 
 class OutboundRuleType:


### PR DESCRIPTION
# Description

Add a new rule category as Dependency. Changes are introduced in swagger and backend code for automatically creating rules of category Dependency and adding this category in the sdk to avoid `az ml workspace show` cannot show workspace details when there are dependency rules.
Current SDK behavior:
![image](https://github.com/Azure/azure-sdk-for-python/assets/156231306/eff68876-8066-4d15-9301-60f050978a1b)

Behavior after fix:
![image](https://github.com/Azure/azure-sdk-for-python/assets/156231306/48edff21-2629-4e71-a62f-ac6f52fc081c)


# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
