### PR TITLE
[Storage] [Typing] [File Share] Decoupled `_file_client.py` and `_file_client_async.py`

### DIFF
--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_file_client.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_file_client.py
@@ -298,8 +298,7 @@ class ShareFileClient(StorageAccountHostsMixin):
             account_url, share_name=share_name, file_path=file_path, snapshot=snapshot, credential=credential, **kwargs)
 
     @distributed_trace
-    def acquire_lease(self, lease_id=None, **kwargs):
-        # type: (Optional[str], **Any) -> ShareLeaseClient
+    def acquire_lease(self, lease_id: Optional[str] = None, **kwargs: Any) -> ShareLeaseClient:
         """Requests a new lease.
 
         If the file does not have an active lease, the File
@@ -357,15 +356,14 @@ class ShareFileClient(StorageAccountHostsMixin):
 
     @distributed_trace
     def create_file(
-            self, size,  # type: int
-            file_attributes="none",  # type: Union[str, NTFSAttributes]
-            file_creation_time="now",  # type: Optional[Union[str, datetime]]
-            file_last_write_time="now",  # type: Optional[Union[str, datetime]]
-            file_permission=None,   # type: Optional[str]
-            permission_key=None,  # type: Optional[str]
-            **kwargs  # type: Any
-    ):
-        # type: (...) -> Dict[str, Any]
+        self, size: int,
+        file_attributes: Optional[Union[str, "NTFSAttributes"]] = "none",
+        file_creation_time: Optional[Union[str, datetime]] = "now",
+        file_last_write_time: Optional[Union[str, datetime]] = "now",
+        file_permission: Optional[str] = None,
+        permission_key: Optional[str] = None,
+        **kwargs: Any
+    ) -> Dict[str, Any]:
         """Creates a new file.
 
         Note that it only initializes the file with no content.
@@ -472,15 +470,15 @@ class ShareFileClient(StorageAccountHostsMixin):
 
     @distributed_trace
     def upload_file(
-            self, data: Union[bytes, str, Iterable[AnyStr], IO[AnyStr]],
-            length: Optional[int] = None,
-            file_attributes: Union[str, "NTFSAttributes"] = "none",
-            file_creation_time: Optional[Union[str, datetime]] = "now",
-            file_last_write_time: Optional[Union[str, datetime]] = "now",
-            file_permission: Optional[str] = None,
-            permission_key: Optional[str] = None,
-            **kwargs
-        ) -> Dict[str, Any]:
+        self, data: Union[bytes, str, Iterable[AnyStr], IO[AnyStr]],
+        length: Optional[int] = None,
+        file_attributes: Union[str, "NTFSAttributes"] = "none",
+        file_creation_time: Optional[Union[str, datetime]] = "now",
+        file_last_write_time: Optional[Union[str, datetime]] = "now",
+        file_permission: Optional[str] = None,
+        permission_key: Optional[str] = None,
+        **kwargs
+    ) -> Dict[str, Any]:
         """Uploads a new file.
 
         :param data:
@@ -607,8 +605,7 @@ class ShareFileClient(StorageAccountHostsMixin):
             **kwargs)
 
     @distributed_trace
-    def start_copy_from_url(self, source_url, **kwargs):
-        # type: (str, Any) -> Dict[str, Any]
+    def start_copy_from_url(self, source_url: str, **kwargs: Any) -> Dict[str, Any]:
         """Initiates the copying of data from a source URL into the file
         referenced by the client.
 
@@ -735,8 +732,7 @@ class ShareFileClient(StorageAccountHostsMixin):
             process_storage_error(error)
 
     @distributed_trace
-    def abort_copy(self, copy_id, **kwargs):
-        # type: (Union[str, FileProperties], Any) -> None
+    def abort_copy(self, copy_id: Union[str, "FileProperties"], **kwargs: Any) -> None:
         """Abort an ongoing copy operation.
 
         This will leave a destination file with zero length and full metadata.
@@ -779,11 +775,10 @@ class ShareFileClient(StorageAccountHostsMixin):
 
     @distributed_trace
     def download_file(
-            self, offset=None,  # type: Optional[int]
-            length=None,  # type: Optional[int]
-            **kwargs  # type: Any
-        ):
-        # type: (...) -> StorageStreamDownloader
+        self, offset: Optional[int] = None,
+        length: Optional[int] = None,
+        **kwargs: Any
+    ) -> StorageStreamDownloader:
         """Downloads a file to the StorageStreamDownloader. The readall() method must
         be used to read all the content or readinto() must be used to download the file into
         a stream. Using chunks() returns an iterator which allows the user to iterate over the content in chunks.
@@ -857,8 +852,7 @@ class ShareFileClient(StorageAccountHostsMixin):
             **kwargs)
 
     @distributed_trace
-    def delete_file(self, **kwargs):
-        # type: (Any) -> None
+    def delete_file(self, **kwargs: Any) -> None:
         """Marks the specified file for deletion. The file is
         later deleted during garbage collection.
 
@@ -894,11 +888,7 @@ class ShareFileClient(StorageAccountHostsMixin):
             process_storage_error(error)
 
     @distributed_trace
-    def rename_file(
-            self, new_name, # type: str
-            **kwargs # type: Any
-        ):
-        # type: (...) -> ShareFileClient
+    def rename_file(self, new_name: str, **kwargs: Any) -> Self:
         """
         Rename the source file.
 
@@ -1017,8 +1007,7 @@ class ShareFileClient(StorageAccountHostsMixin):
             process_storage_error(error)
 
     @distributed_trace
-    def get_file_properties(self, **kwargs):
-        # type: (Any) -> FileProperties
+    def get_file_properties(self, **kwargs: Any) -> "FileProperties":
         """Returns all user-defined metadata, standard HTTP properties, and
         system properties for the file.
 
@@ -1056,15 +1045,15 @@ class ShareFileClient(StorageAccountHostsMixin):
         return file_props
 
     @distributed_trace
-    def set_http_headers(self, content_settings,  # type: ContentSettings
-                         file_attributes="preserve",  # type: Union[str, NTFSAttributes]
-                         file_creation_time="preserve",  # type: Optional[Union[str, datetime]]
-                         file_last_write_time="preserve",  # type: Optional[Union[str, datetime]]
-                         file_permission=None,  # type: Optional[str]
-                         permission_key=None,  # type: Optional[str]
-                         **kwargs  # type: Any
-                         ):
-        # type: (...) -> Dict[str, Any]
+    def set_http_headers(
+        self, content_settings: "ContentSettings",
+        file_attributes: Union[str, "NTFSAttributes"] = "preserve",
+        file_creation_time: Optional[Union[str, datetime]] = "preserve",
+        file_last_write_time: Optional[Union[str, datetime]] = "preserve",
+        file_permission: Optional[str] = None,
+        permission_key: Optional[str] = None,
+        **kwargs: Any
+    ) -> Dict[str, Any]:
         """Sets HTTP headers on the file.
 
         :param ~azure.storage.fileshare.ContentSettings content_settings:
@@ -1146,8 +1135,7 @@ class ShareFileClient(StorageAccountHostsMixin):
             process_storage_error(error)
 
     @distributed_trace
-    def set_file_metadata(self, metadata=None, **kwargs):
-        # type: (Optional[Dict[str, Any]], Any) -> Dict[str, Any]
+    def set_file_metadata(self, metadata: Optional[Dict[str, Any]] = None, **kwargs: Any) -> Dict[str, Any]:
         """Sets user-defined metadata for the specified file as one or more
         name-value pairs.
 
@@ -1191,12 +1179,11 @@ class ShareFileClient(StorageAccountHostsMixin):
 
     @distributed_trace
     def upload_range(
-            self, data,  # type: bytes
-            offset,  # type: int
-            length,  # type: int
-            **kwargs
-        ):
-        # type: (...) -> Dict[str, Any]
+        self, data: bytes,
+        offset: int,
+        length: int,
+        **kwargs: Any
+    ) -> Dict[str, Any]:
         """Upload a range of bytes to a file.
 
         :param bytes data:
@@ -1394,8 +1381,7 @@ class ShareFileClient(StorageAccountHostsMixin):
 
     @distributed_trace
     def get_ranges_diff(
-        self,
-        previous_sharesnapshot: Union[str, Dict[str, Any]],
+        self, previous_sharesnapshot: Union[str, Dict[str, Any]],
         offset: Optional[int] = None,
         length: Optional[int] = None,
         *,
@@ -1449,12 +1435,7 @@ class ShareFileClient(StorageAccountHostsMixin):
         return get_file_ranges_result(ranges)
 
     @distributed_trace
-    def clear_range(
-            self, offset,  # type: int
-            length,  # type: int
-            **kwargs
-        ):
-        # type: (...) -> Dict[str, Any]
+    def clear_range(self, offset: int, length: int, **kwargs: Any) -> Dict[str, Any]:
         """Clears the specified range and releases the space used in storage for
         that range.
 
@@ -1503,8 +1484,7 @@ class ShareFileClient(StorageAccountHostsMixin):
             process_storage_error(error)
 
     @distributed_trace
-    def resize_file(self, size, **kwargs):
-        # type: (int, Any) -> Dict[str, Any]
+    def resize_file(self, size: int, **kwargs: Any) -> Dict[str, Any]:
         """Resizes a file to the specified size.
 
         :param int size:
@@ -1542,8 +1522,7 @@ class ShareFileClient(StorageAccountHostsMixin):
             process_storage_error(error)
 
     @distributed_trace
-    def list_handles(self, **kwargs):
-        # type: (Any) -> ItemPaged[Handle]
+    def list_handles(self, **kwargs: Any) -> ItemPaged["Handle"]:
         """Lists handles for file.
 
         :keyword int timeout:
@@ -1567,8 +1546,7 @@ class ShareFileClient(StorageAccountHostsMixin):
             page_iterator_class=HandlesPaged)
 
     @distributed_trace
-    def close_handle(self, handle, **kwargs):
-        # type: (Union[str, Handle], Any) -> Dict[str, int]
+    def close_handle(self, handle: Union[str, "Handle"], **kwargs: Any) -> Dict[str, int]:
         """Close an open file handle.
 
         :param handle:
@@ -1607,8 +1585,7 @@ class ShareFileClient(StorageAccountHostsMixin):
             process_storage_error(error)
 
     @distributed_trace
-    def close_all_handles(self, **kwargs):
-        # type: (Any) -> Dict[str, int]
+    def close_all_handles(self, **kwargs: Any) -> Dict[str, int]:
         """Close any open file handles.
 
         This operation will block until the service has closed all open handles.

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_file_client.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_file_client.py
@@ -3,7 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for
 # license information.
 # --------------------------------------------------------------------------
-# pylint: disable=too-many-lines, too-many-public-methods, docstring-keyword-should-match-keyword-only
+# pylint: disable=docstring-keyword-should-match-keyword-only, too-many-lines, too-many-public-methods
 
 import functools
 import sys
@@ -189,10 +189,10 @@ class ShareFileClient(StorageAccountHostsMixin):
             raise ValueError(
                 'You need to provide either an account shared key or SAS token when creating a storage service.')
         try:
-            self.snapshot = snapshot.snapshot # type: ignore
+            self.snapshot = snapshot.snapshot
         except AttributeError:
             try:
-                self.snapshot = snapshot['snapshot'] # type: ignore
+                self.snapshot = snapshot['snapshot']
             except TypeError:
                 self.snapshot = snapshot or path_snapshot
 
@@ -358,7 +358,7 @@ class ShareFileClient(StorageAccountHostsMixin):
                 :caption: Acquiring a lease on a file.
         """
         kwargs['lease_duration'] = -1
-        lease = ShareLeaseClient(self, lease_id=lease_id)  # type: ignore
+        lease = ShareLeaseClient(self, lease_id=lease_id)
         lease.acquire(**kwargs)
         return lease
 
@@ -386,7 +386,7 @@ class ShareFileClient(StorageAccountHostsMixin):
                 return False
 
     @distributed_trace
-    def create_file(  # type: ignore
+    def create_file(
             self, size,  # type: int
             file_attributes="none",  # type: Union[str, NTFSAttributes]
             file_creation_time="now",  # type: Optional[Union[str, datetime]]
@@ -482,7 +482,7 @@ class ShareFileClient(StorageAccountHostsMixin):
         file_permission = _get_file_permission(file_permission, permission_key, 'Inherit')
         file_change_time = kwargs.pop('file_change_time', None)
         try:
-            return self._client.file.create(  # type: ignore
+            return self._client.file.create(
                 file_content_length=size,
                 metadata=metadata,
                 file_attributes=_str(file_attributes),
@@ -1083,7 +1083,7 @@ class ShareFileClient(StorageAccountHostsMixin):
         file_props.share = self.share_name
         file_props.snapshot = self.snapshot
         file_props.path = '/'.join(self.file_path)
-        return file_props # type: ignore
+        return file_props
 
     @distributed_trace
     def set_http_headers(self, content_settings,  # type: ContentSettings
@@ -1159,7 +1159,7 @@ class ShareFileClient(StorageAccountHostsMixin):
         file_permission = _get_file_permission(file_permission, permission_key, 'preserve')
         file_change_time = kwargs.pop('file_change_time', None)
         try:
-            return self._client.file.set_http_headers(  # type: ignore
+            return self._client.file.set_http_headers(
                 file_content_length=file_content_length,
                 file_http_headers=file_http_headers,
                 file_attributes=_str(file_attributes),
@@ -1207,9 +1207,9 @@ class ShareFileClient(StorageAccountHostsMixin):
         access_conditions = get_access_conditions(kwargs.pop('lease', None))
         timeout = kwargs.pop('timeout', None)
         headers = kwargs.pop('headers', {})
-        headers.update(add_metadata_headers(metadata)) # type: ignore
+        headers.update(add_metadata_headers(metadata))
         try:
-            return self._client.file.set_metadata( # type: ignore
+            return self._client.file.set_metadata(
                 timeout=timeout,
                 cls=return_response_headers,
                 headers=headers,
@@ -1220,7 +1220,7 @@ class ShareFileClient(StorageAccountHostsMixin):
             process_storage_error(error)
 
     @distributed_trace
-    def upload_range(  # type: ignore
+    def upload_range(
             self, data,  # type: bytes
             offset,  # type: int
             length,  # type: int
@@ -1282,7 +1282,7 @@ class ShareFileClient(StorageAccountHostsMixin):
         content_range = f'bytes={offset}-{end_range}'
         access_conditions = get_access_conditions(kwargs.pop('lease', None))
         try:
-            return self._client.file.upload_range( # type: ignore
+            return self._client.file.upload_range(
                 range=content_range,
                 content_length=length,
                 optionalbody=data,
@@ -1416,11 +1416,11 @@ class ShareFileClient(StorageAccountHostsMixin):
             **kwargs
         )
         try:
-            return self._client.file.upload_range_from_url(**options)  # type: ignore
+            return self._client.file.upload_range_from_url(**options)
         except HttpResponseError as error:
             process_storage_error(error)
 
-    def _get_ranges_options( # type: ignore
+    def _get_ranges_options(
             self, offset=None, # type: Optional[int]
             length=None, # type: Optional[int]
             previous_sharesnapshot=None,  # type: Optional[Union[str, Dict[str, Any]]]
@@ -1443,17 +1443,17 @@ class ShareFileClient(StorageAccountHostsMixin):
             'range': content_range}
         if previous_sharesnapshot:
             try:
-                options['prevsharesnapshot'] = previous_sharesnapshot.snapshot # type: ignore
+                options['prevsharesnapshot'] = previous_sharesnapshot.snapshot
             except AttributeError:
                 try:
-                    options['prevsharesnapshot'] = previous_sharesnapshot['snapshot'] # type: ignore
+                    options['prevsharesnapshot'] = previous_sharesnapshot['snapshot']
                 except TypeError:
                     options['prevsharesnapshot'] = previous_sharesnapshot
         options.update(kwargs)
         return options
 
     @distributed_trace
-    def get_ranges(  # type: ignore
+    def get_ranges(
             self, offset=None,  # type: Optional[int]
             length=None,  # type: Optional[int]
             **kwargs  # type: Any
@@ -1549,7 +1549,7 @@ class ShareFileClient(StorageAccountHostsMixin):
         return get_file_ranges_result(ranges)
 
     @distributed_trace
-    def clear_range( # type: ignore
+    def clear_range(
             self, offset,  # type: int
             length,  # type: int
             **kwargs
@@ -1590,7 +1590,7 @@ class ShareFileClient(StorageAccountHostsMixin):
         end_range = length + offset - 1  # Reformat to an inclusive range index
         content_range = f'bytes={offset}-{end_range}'
         try:
-            return self._client.file.upload_range( # type: ignore
+            return self._client.file.upload_range(
                 timeout=timeout,
                 cls=return_response_headers,
                 content_length=0,
@@ -1628,7 +1628,7 @@ class ShareFileClient(StorageAccountHostsMixin):
         access_conditions = get_access_conditions(kwargs.pop('lease', None))
         timeout = kwargs.pop('timeout', None)
         try:
-            return self._client.file.set_http_headers( # type: ignore
+            return self._client.file.set_http_headers(
                 file_content_length=size,
                 file_attributes="preserve",
                 file_creation_time="preserve",
@@ -1686,7 +1686,7 @@ class ShareFileClient(StorageAccountHostsMixin):
         :rtype: dict[str, int]
         """
         try:
-            handle_id = handle.id # type: ignore
+            handle_id = handle.id
         except AttributeError:
             handle_id = handle
         if handle_id == '*':

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_file_client.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_file_client.py
@@ -14,22 +14,19 @@ from typing import (
     Any, AnyStr, Dict, IO, Iterable, List, Optional, Tuple, Union,
     TYPE_CHECKING
 )
-from urllib.parse import urlparse, quote, unquote
-
+from urllib.parse import quote, unquote, urlparse
 from typing_extensions import Self
 
 from azure.core.exceptions import HttpResponseError, ResourceNotFoundError
 from azure.core.paging import ItemPaged
 from azure.core.tracing.decorator import distributed_trace
+from ._deserialize import deserialize_file_properties, deserialize_file_stream, get_file_ranges_result
+from ._download import StorageStreamDownloader
 from ._generated import AzureFileStorage
 from ._generated.models import FileHTTPHeaders
-from ._shared.uploads import IterStreamer, FileChunkUploader, upload_data_chunks
-from ._shared.base_client import StorageAccountHostsMixin, parse_connection_str, parse_query
-from ._shared.request_handlers import add_metadata_headers, get_length
-from ._shared.response_handlers import return_response_headers, process_storage_error
-from ._shared.parser import _str
-from ._parser import _get_file_permission, _datetime_to_str
 from ._lease import ShareLeaseClient
+from ._models import HandlesPaged
+from ._parser import _get_file_permission, _datetime_to_str
 from ._serialize import (
     get_access_conditions,
     get_api_version,
@@ -37,10 +34,13 @@ from ._serialize import (
     get_rename_smb_properties,
     get_smb_properties,
     get_source_conditions,
-    get_source_access_conditions)
-from ._deserialize import deserialize_file_properties, deserialize_file_stream, get_file_ranges_result
-from ._models import HandlesPaged
-from ._download import StorageStreamDownloader
+    get_source_access_conditions
+)
+from ._shared.base_client import StorageAccountHostsMixin, parse_connection_str, parse_query
+from ._shared.parser import _str
+from ._shared.request_handlers import add_metadata_headers, get_length
+from ._shared.response_handlers import return_response_headers, process_storage_error
+from ._shared.uploads import IterStreamer, FileChunkUploader, upload_data_chunks
 
 if sys.version_info >= (3, 8):
     from typing import Literal  # pylint: disable=no-name-in-module, ungrouped-imports

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_file_client.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_file_client.py
@@ -212,7 +212,7 @@ class ShareFileClient(StorageAccountHostsMixin):
                                         allow_trailing_dot=self.allow_trailing_dot,
                                         allow_source_trailing_dot=self.allow_source_trailing_dot,
                                         file_request_intent=self.file_request_intent)
-        self._client._config.version = get_api_version(kwargs) # pylint: disable=protected-access
+        self._client._config.version = get_api_version(kwargs)  # pylint: disable=protected-access
 
     @classmethod
     def from_file_url(

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_file_client.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_file_client.py
@@ -25,7 +25,6 @@ from ._file_client_helpers import (
     _format_url,
     _from_file_url,
     _get_ranges_options,
-    _parse_snapshot,
     _parse_url,
     _upload_range_from_url_options
 )
@@ -33,7 +32,7 @@ from ._generated import AzureFileStorage
 from ._generated.models import FileHTTPHeaders
 from ._lease import ShareLeaseClient
 from ._models import HandlesPaged
-from ._parser import _get_file_permission, _datetime_to_str
+from ._parser import _datetime_to_str, _get_file_permission, _parse_snapshot
 from ._serialize import (
     get_access_conditions,
     get_api_version,

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_file_client_helpers.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_file_client_helpers.py
@@ -1,0 +1,151 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+# pylint: disable=docstring-keyword-should-match-keyword-only
+
+from typing import (
+    Any, Dict, Optional, Tuple, Union,
+    TYPE_CHECKING
+)
+from urllib.parse import quote, unquote, urlparse
+
+from ._serialize import get_access_conditions, get_source_conditions
+from ._shared.base_client import parse_query
+from ._shared.response_handlers import return_response_headers
+
+if TYPE_CHECKING:
+    from urllib.parse import ParseResult
+
+
+def _parse_url(account_url: str, share_name: str, file_path: str) -> "ParseResult":
+    try:
+        if not account_url.lower().startswith('http'):
+            account_url = "https://" + account_url
+    except AttributeError as exc:
+        raise ValueError("Account URL must be a string.") from exc
+    parsed_url = urlparse(account_url.rstrip('/'))
+    if not (share_name and file_path):
+        raise ValueError("Please specify a share name and file name.")
+    if not parsed_url.netloc:
+        raise ValueError(f"Invalid URL: {account_url}")
+    return parsed_url
+
+
+def _parse_snapshot(
+    snapshot: Optional[Union[str, Dict[str, Any]]] = None,
+    path_snapshot: Optional[str] = None
+) -> Optional[str]:
+    if hasattr(snapshot, 'snapshot'):
+        return snapshot.snapshot
+    if isinstance(snapshot, Dict):
+        return snapshot['snapshot']
+    return snapshot or path_snapshot
+
+
+def _from_file_url(
+    file_url: str,
+    snapshot: Optional[Union[str, Dict[str, Any]]] = None
+) -> Tuple[str, str, str, Optional[Union[str, Dict[str, Any]]]]:
+    try:
+        if not file_url.lower().startswith('http'):
+            file_url = "https://" + file_url
+    except AttributeError as exc:
+        raise ValueError("File URL must be a string.") from exc
+    parsed_url = urlparse(file_url.rstrip('/'))
+
+    if not (parsed_url.netloc and parsed_url.path):
+        raise ValueError(f"Invalid URL: {file_url}")
+    account_url = parsed_url.netloc.rstrip('/') + "?" + parsed_url.query
+
+    path_share, _, path_file = parsed_url.path.lstrip('/').partition('/')
+    path_snapshot, _ = parse_query(parsed_url.query)
+    snapshot = snapshot or path_snapshot
+    share_name = unquote(path_share)
+    file_path = '/'.join([unquote(p) for p in path_file.split('/')])
+
+    return account_url, share_name, file_path, snapshot
+
+
+def _format_url(scheme: str, hostname: str, share_name: str, file_path: str, query_str: str) -> str:
+    if isinstance(share_name, str):
+        share_name = share_name.encode('UTF-8')
+    return (f"{scheme}://{hostname}/{quote(share_name)}"
+            f"/{'/'.join([quote(p, safe='~') for p in file_path])}{query_str}")
+
+
+def _upload_range_from_url_options(
+    source_url: str,
+    offset: int,
+    length: int,
+    source_offset: int,
+    **kwargs: Any
+) -> Dict[str, Any]:
+    if offset is None:
+        raise ValueError("offset must be provided.")
+    if length is None:
+        raise ValueError("length must be provided.")
+    if source_offset is None:
+        raise ValueError("source_offset must be provided.")
+
+    # Format range
+    end_range = offset + length - 1
+    destination_range = f'bytes={offset}-{end_range}'
+    source_range = f'bytes={source_offset}-{source_offset + length - 1}'
+    source_authorization = kwargs.pop('source_authorization', None)
+    source_mod_conditions = get_source_conditions(kwargs)
+    access_conditions = get_access_conditions(kwargs.pop('lease', None))
+    file_last_write_mode = kwargs.pop('file_last_write_mode', None)
+
+    options = {
+        'copy_source_authorization': source_authorization,
+        'copy_source': source_url,
+        'content_length': 0,
+        'source_range': source_range,
+        'range': destination_range,
+        'file_last_written_mode': file_last_write_mode,
+        'source_modified_access_conditions': source_mod_conditions,
+        'lease_access_conditions': access_conditions,
+        'timeout': kwargs.pop('timeout', None),
+        'cls': return_response_headers
+    }
+
+    options.update(kwargs)
+    return options
+
+
+def _get_ranges_options(
+    snapshot: str,
+    offset: Optional[int] = None,
+    length: Optional[int] = None,
+    previous_sharesnapshot: Optional[Union[str, Dict[str, Any]]] = None,
+    **kwargs: Any
+) -> Dict[str, Any]:
+    access_conditions = get_access_conditions(kwargs.pop('lease', None))
+
+    content_range = None
+    if offset:
+        if length:
+            end_range = offset + length - 1  # Reformat to an inclusive range index
+            content_range = f'bytes={offset}-{end_range}'
+        else:
+            content_range = f'bytes={offset}-'
+
+    options = {
+        'sharesnapshot': snapshot,
+        'lease_access_conditions': access_conditions,
+        'timeout': kwargs.pop('timeout', None),
+        'range': content_range
+    }
+
+    if previous_sharesnapshot:
+        if hasattr(previous_sharesnapshot, 'snapshot'):
+            options['prevsharesnapshot'] = previous_sharesnapshot.snapshot
+        elif isinstance(previous_sharesnapshot, Dict):
+            options['prevsharesnapshot'] = previous_sharesnapshot['snapshot']
+        else:
+            options['prevsharesnapshot'] = previous_sharesnapshot
+
+    options.update(kwargs)
+    return options

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_file_client_helpers.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_file_client_helpers.py
@@ -33,17 +33,6 @@ def _parse_url(account_url: str, share_name: str, file_path: str) -> "ParseResul
     return parsed_url
 
 
-def _parse_snapshot(
-    snapshot: Optional[Union[str, Dict[str, Any]]] = None,
-    path_snapshot: Optional[str] = None
-) -> Optional[str]:
-    if hasattr(snapshot, 'snapshot'):
-        return snapshot.snapshot
-    if isinstance(snapshot, Dict):
-        return snapshot['snapshot']
-    return snapshot or path_snapshot
-
-
 def _from_file_url(
     file_url: str,
     snapshot: Optional[Union[str, Dict[str, Any]]] = None

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_parser.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_parser.py
@@ -5,6 +5,8 @@
 # --------------------------------------------------------------------------
 
 from datetime import datetime, timedelta
+from typing import Any, Dict, Optional, Union
+
 from ._generated._serialization import Serializer
 
 _ERROR_TOO_MANY_FILE_PERMISSIONS = 'file_permission and file_permission_key should not be set at the same time'
@@ -45,3 +47,14 @@ def _datetime_to_str(datetime_obj):
     if isinstance(datetime_obj, str):
         return datetime_obj
     return Serializer.serialize_iso(datetime_obj)[:-1].ljust(27, "0") + "Z"
+
+
+def _parse_snapshot(
+    snapshot: Optional[Union[str, Dict[str, Any]]] = None,
+    path_snapshot: Optional[str] = None
+) -> Optional[str]:
+    if hasattr(snapshot, 'snapshot'):
+        return snapshot.snapshot
+    if isinstance(snapshot, Dict):
+        return snapshot['snapshot']
+    return snapshot or path_snapshot

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/aio/_file_client_async.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/aio/_file_client_async.py
@@ -21,27 +21,28 @@ from azure.core.async_paging import AsyncItemPaged
 from azure.core.exceptions import HttpResponseError, ResourceNotFoundError
 from azure.core.tracing.decorator import distributed_trace
 from azure.core.tracing.decorator_async import distributed_trace_async
-from .._parser import _datetime_to_str, _get_file_permission
-from .._shared.parser import _str
+from .._deserialize import deserialize_file_properties, deserialize_file_stream, get_file_ranges_result
+from .._file_client import ShareFileClient as ShareFileClientBase
 from .._generated.aio import AzureFileStorage
 from .._generated.models import FileHTTPHeaders
-from .._shared.policies_async import ExponentialRetry
-from .._shared.uploads_async import AsyncIterStreamer, FileChunkUploader, IterStreamer, upload_data_chunks
-from .._shared.base_client_async import AsyncStorageAccountHostsMixin
-from .._shared.request_handlers import add_metadata_headers, get_length
-from .._shared.response_handlers import return_response_headers, process_storage_error
-from .._deserialize import deserialize_file_properties, deserialize_file_stream, get_file_ranges_result
+from .._parser import _datetime_to_str, _get_file_permission
 from .._serialize import (
     get_access_conditions,
     get_api_version,
     get_dest_access_conditions,
     get_rename_smb_properties,
     get_smb_properties,
-    get_source_access_conditions)
-from .._file_client import ShareFileClient as ShareFileClientBase
-from ._models import HandlesPaged
-from ._lease_async import ShareLeaseClient
+    get_source_access_conditions
+)
+from .._shared.base_client_async import AsyncStorageAccountHostsMixin
+from .._shared.parser import _str
+from .._shared.policies_async import ExponentialRetry
+from .._shared.request_handlers import add_metadata_headers, get_length
+from .._shared.response_handlers import process_storage_error, return_response_headers
+from .._shared.uploads_async import AsyncIterStreamer, FileChunkUploader, IterStreamer, upload_data_chunks
 from ._download_async import StorageStreamDownloader
+from ._lease_async import ShareLeaseClient
+from ._models import HandlesPaged
 
 if sys.version_info >= (3, 8):
     from typing import Literal  # pylint: disable=no-name-in-module, ungrouped-imports

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/aio/_file_client_async.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/aio/_file_client_async.py
@@ -303,8 +303,7 @@ class ShareFileClient(AsyncStorageAccountHostsMixin, StorageAccountHostsMixin):
             account_url, share_name=share_name, file_path=file_path, snapshot=snapshot, credential=credential, **kwargs)
 
     @distributed_trace_async
-    async def acquire_lease(self, lease_id=None, **kwargs):
-        # type: (Optional[str], **Any) -> ShareLeaseClient
+    async def acquire_lease(self, lease_id: Optional[str] = None, **kwargs: Any) -> ShareLeaseClient:
         """Requests a new lease.
 
         If the file does not have an active lease, the File
@@ -362,16 +361,14 @@ class ShareFileClient(AsyncStorageAccountHostsMixin, StorageAccountHostsMixin):
 
     @distributed_trace_async
     async def create_file(
-        self,
-        size,  # type: int
-        file_attributes="none",  # type: Union[str, NTFSAttributes]
-        file_creation_time="now",  # type: Optional[Union[str, datetime]]
-        file_last_write_time="now",  # type: Optional[Union[str, datetime]]
-        file_permission=None,  # type: Optional[str]
-        permission_key=None,  # type: Optional[str]
-        **kwargs  # type: Any
-    ):
-        # type: (...) -> Dict[str, Any]
+        self, size: int,
+        file_attributes: Optional[Union[str, "NTFSAttributes"]] = "none",
+        file_creation_time: Optional[Union[str, datetime]] = "now",
+        file_last_write_time: Optional[Union[str, datetime]] = "now",
+        file_permission: Optional[str] = None,
+        permission_key: Optional[str] = None,
+        **kwargs: Any
+    ) -> Dict[str, Any]:
         """Creates a new file.
 
         Note that it only initializes the file with no content.
@@ -480,14 +477,14 @@ class ShareFileClient(AsyncStorageAccountHostsMixin, StorageAccountHostsMixin):
     @distributed_trace_async
     async def upload_file(
         self, data: Union[bytes, str, Iterable[AnyStr], AsyncIterable[AnyStr], IO[AnyStr]],
-            length: Optional[int] = None,
-            file_attributes: Union[str, "NTFSAttributes"] = "none",
-            file_creation_time: Optional[Union[str, datetime]] = "now",
-            file_last_write_time: Optional[Union[str, datetime]] = "now",
-            file_permission: Optional[str] = None,
-            permission_key: Optional[str] = None,
-            **kwargs
-        ) -> Dict[str, Any]:
+        length: Optional[int] = None,
+        file_attributes: Union[str, "NTFSAttributes"] = "none",
+        file_creation_time: Optional[Union[str, datetime]] = "now",
+        file_last_write_time: Optional[Union[str, datetime]] = "now",
+        file_permission: Optional[str] = None,
+        permission_key: Optional[str] = None,
+        **kwargs
+    ) -> Dict[str, Any]:
         """Uploads a new file.
 
         :param data:
@@ -617,8 +614,7 @@ class ShareFileClient(AsyncStorageAccountHostsMixin, StorageAccountHostsMixin):
         )
 
     @distributed_trace_async
-    async def start_copy_from_url(self, source_url, **kwargs):
-        # type: (str, Any) -> Any
+    async def start_copy_from_url(self, source_url: str, **kwargs: Any) -> Dict[str, Any]:
         """Initiates the copying of data from a source URL into the file
         referenced by the client.
 
@@ -746,8 +742,7 @@ class ShareFileClient(AsyncStorageAccountHostsMixin, StorageAccountHostsMixin):
             process_storage_error(error)
 
     @distributed_trace_async
-    async def abort_copy(self, copy_id, **kwargs):
-        # type: (Union[str, FileProperties], Any) -> None
+    async def abort_copy(self, copy_id: Union[str, "FileProperties"], **kwargs: Any) -> None:
         """Abort an ongoing copy operation.
 
         This will leave a destination file with zero length and full metadata.
@@ -790,12 +785,10 @@ class ShareFileClient(AsyncStorageAccountHostsMixin, StorageAccountHostsMixin):
 
     @distributed_trace_async
     async def download_file(
-        self,
-        offset=None,  # type: Optional[int]
-        length=None,  # type: Optional[int]
-        **kwargs  # type: Any
-    ):
-        # type: (...) -> StorageStreamDownloader
+        self, offset: Optional[int] = None,
+        length: Optional[int] = None,
+        **kwargs: Any
+    ) -> StorageStreamDownloader:
         """Downloads a file to the StorageStreamDownloader. The readall() method must
         be used to read all the content or readinto() must be used to download the file into
         a stream. Using chunks() returns an async iterator which allows the user to iterate over the content in chunks.
@@ -872,8 +865,7 @@ class ShareFileClient(AsyncStorageAccountHostsMixin, StorageAccountHostsMixin):
         return downloader
 
     @distributed_trace_async
-    async def delete_file(self, **kwargs):
-        # type: (Any) -> None
+    async def delete_file(self, **kwargs: Any) -> None:
         """Marks the specified file for deletion. The file is
         later deleted during garbage collection.
 
@@ -909,11 +901,7 @@ class ShareFileClient(AsyncStorageAccountHostsMixin, StorageAccountHostsMixin):
             process_storage_error(error)
 
     @distributed_trace_async
-    async def rename_file(
-            self, new_name, # type: str
-            **kwargs # type: Any
-        ):
-        # type: (...) -> ShareFileClient
+    async def rename_file(self, new_name: str, **kwargs: Any) -> Self:
         """
         Rename the source file.
 
@@ -1032,8 +1020,7 @@ class ShareFileClient(AsyncStorageAccountHostsMixin, StorageAccountHostsMixin):
             process_storage_error(error)
 
     @distributed_trace_async
-    async def get_file_properties(self, **kwargs):
-        # type: (Any) -> FileProperties
+    async def get_file_properties(self, **kwargs: Any) -> "FileProperties":
         """Returns all user-defined metadata, standard HTTP properties, and
         system properties for the file.
 
@@ -1072,15 +1059,15 @@ class ShareFileClient(AsyncStorageAccountHostsMixin, StorageAccountHostsMixin):
         return file_props
 
     @distributed_trace_async
-    async def set_http_headers(self, content_settings,  # type: ContentSettings
-                               file_attributes="preserve",  # type: Union[str, NTFSAttributes]
-                               file_creation_time="preserve",  # type: Optional[Union[str, datetime]]
-                               file_last_write_time="preserve",  # type: Optional[Union[str, datetime]]
-                               file_permission=None,  # type: Optional[str]
-                               permission_key=None,  # type: Optional[str]
-                               **kwargs  # type: Any
-                               ):
-        # type: (...) -> Dict[str, Any]
+    async def set_http_headers(
+        self, content_settings: "ContentSettings",
+        file_attributes: Union[str, "NTFSAttributes"] = "preserve",
+        file_creation_time: Optional[Union[str, datetime]] = "preserve",
+        file_last_write_time: Optional[Union[str, datetime]] = "preserve",
+        file_permission: Optional[str] = None,
+        permission_key: Optional[str] = None,
+        **kwargs: Any
+    ) -> Dict[str, Any]:
         """Sets HTTP headers on the file.
 
         :param ~azure.storage.fileshare.ContentSettings content_settings:
@@ -1163,8 +1150,7 @@ class ShareFileClient(AsyncStorageAccountHostsMixin, StorageAccountHostsMixin):
             process_storage_error(error)
 
     @distributed_trace_async
-    async def set_file_metadata(self, metadata=None, **kwargs):
-        # type: (Optional[Dict[str, Any]], Any) -> Dict[str, Any]
+    async def set_file_metadata(self, metadata: Optional[Dict[str, Any]] = None, **kwargs: Any) -> Dict[str, Any]:
         """Sets user-defined metadata for the specified file as one or more
         name-value pairs.
 
@@ -1205,13 +1191,11 @@ class ShareFileClient(AsyncStorageAccountHostsMixin, StorageAccountHostsMixin):
 
     @distributed_trace_async
     async def upload_range(
-        self,
-        data,  # type: bytes
-        offset,  # type: int
-        length,  # type: int
-        **kwargs
-    ):
-        # type: (...) -> Dict[str, Any]
+        self, data: bytes,
+        offset: int,
+        length: int,
+        **kwargs: Any
+    ) -> Dict[str, Any]:
         """Upload a range of bytes to a file.
 
         :param bytes data:
@@ -1409,8 +1393,7 @@ class ShareFileClient(AsyncStorageAccountHostsMixin, StorageAccountHostsMixin):
 
     @distributed_trace_async
     async def get_ranges_diff(
-        self,
-        previous_sharesnapshot: Union[str, Dict[str, Any]],
+        self, previous_sharesnapshot: Union[str, Dict[str, Any]],
         offset: Optional[int] = None,
         length: Optional[int] = None,
         *,
@@ -1464,13 +1447,7 @@ class ShareFileClient(AsyncStorageAccountHostsMixin, StorageAccountHostsMixin):
         return get_file_ranges_result(ranges)
 
     @distributed_trace_async
-    async def clear_range(
-        self,
-        offset,  # type: int
-        length,  # type: int
-        **kwargs
-    ):
-        # type: (...) -> Dict[str, Any]
+    async def clear_range(self, offset: int, length: int, **kwargs: Any) -> Dict[str, Any]:
         """Clears the specified range and releases the space used in storage for
         that range.
 
@@ -1520,8 +1497,7 @@ class ShareFileClient(AsyncStorageAccountHostsMixin, StorageAccountHostsMixin):
             process_storage_error(error)
 
     @distributed_trace_async
-    async def resize_file(self, size, **kwargs):
-        # type: (int, Any) -> Dict[str, Any]
+    async def resize_file(self, size: int, **kwargs: Any) -> Dict[str, Any]:
         """Resizes a file to the specified size.
 
         :param int size:
@@ -1560,8 +1536,7 @@ class ShareFileClient(AsyncStorageAccountHostsMixin, StorageAccountHostsMixin):
             process_storage_error(error)
 
     @distributed_trace
-    def list_handles(self, **kwargs):
-        # type: (Any) -> AsyncItemPaged[Handle]
+    def list_handles(self, **kwargs: Any) -> AsyncItemPaged["Handle"]:
         """Lists handles for file.
 
         :keyword int timeout:
@@ -1585,8 +1560,7 @@ class ShareFileClient(AsyncStorageAccountHostsMixin, StorageAccountHostsMixin):
             page_iterator_class=HandlesPaged)
 
     @distributed_trace_async
-    async def close_handle(self, handle, **kwargs):
-        # type: (Union[str, Handle], Any) -> Dict[str, int]
+    async def close_handle(self, handle: Union[str, "Handle"], **kwargs: Any) -> Dict[str, int]:
         """Close an open file handle.
 
         :param handle:
@@ -1625,8 +1599,7 @@ class ShareFileClient(AsyncStorageAccountHostsMixin, StorageAccountHostsMixin):
             process_storage_error(error)
 
     @distributed_trace_async
-    async def close_all_handles(self, **kwargs):
-        # type: (Any) -> Dict[str, int]
+    async def close_all_handles(self, **kwargs: Any) -> Dict[str, int]:
         """Close any open file handles.
 
         This operation will block until the service has closed all open handles.

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/aio/_file_client_async.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/aio/_file_client_async.py
@@ -27,13 +27,12 @@ from .._file_client_helpers import (
     _format_url,
     _from_file_url,
     _get_ranges_options,
-    _parse_snapshot,
     _parse_url,
     _upload_range_from_url_options
 )
 from .._generated.aio import AzureFileStorage
 from .._generated.models import FileHTTPHeaders
-from .._parser import _datetime_to_str, _get_file_permission
+from .._parser import _datetime_to_str, _get_file_permission, _parse_snapshot
 from .._serialize import (
     get_access_conditions,
     get_api_version,

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/aio/_file_client_async.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/aio/_file_client_async.py
@@ -213,7 +213,7 @@ class ShareFileClient(AsyncStorageAccountHostsMixin, ShareFileClientBase):
                 :caption: Acquiring a lease on a blob.
         """
         kwargs['lease_duration'] = -1
-        lease = ShareLeaseClient(self, lease_id=lease_id)  # type: ignore
+        lease = ShareLeaseClient(self, lease_id=lease_id)
         await lease.acquire(**kwargs)
         return lease
 
@@ -241,7 +241,7 @@ class ShareFileClient(AsyncStorageAccountHostsMixin, ShareFileClientBase):
                 return False
 
     @distributed_trace_async
-    async def create_file(  # type: ignore
+    async def create_file(
         self,
         size,  # type: int
         file_attributes="none",  # type: Union[str, NTFSAttributes]
@@ -338,7 +338,7 @@ class ShareFileClient(AsyncStorageAccountHostsMixin, ShareFileClientBase):
         file_permission = _get_file_permission(file_permission, permission_key, 'Inherit')
         file_change_time = kwargs.pop('file_change_time', None)
         try:
-            return await self._client.file.create(  # type: ignore
+            return await self._client.file.create(
                 file_content_length=size,
                 metadata=metadata,
                 file_attributes=_str(file_attributes),
@@ -949,7 +949,7 @@ class ShareFileClient(AsyncStorageAccountHostsMixin, ShareFileClientBase):
         file_props.share = self.share_name
         file_props.snapshot = self.snapshot
         file_props.path = "/".join(self.file_path)
-        return file_props  # type: ignore
+        return file_props
 
     @distributed_trace_async
     async def set_http_headers(self, content_settings,  # type: ContentSettings
@@ -1025,7 +1025,7 @@ class ShareFileClient(AsyncStorageAccountHostsMixin, ShareFileClientBase):
         file_permission = _get_file_permission(file_permission, permission_key, 'preserve')
         file_change_time = kwargs.pop('file_change_time', None)
         try:
-            return await self._client.file.set_http_headers(  # type: ignore
+            return await self._client.file.set_http_headers(
                 file_content_length=file_content_length,
                 file_http_headers=file_http_headers,
                 file_attributes=_str(file_attributes),
@@ -1043,7 +1043,7 @@ class ShareFileClient(AsyncStorageAccountHostsMixin, ShareFileClientBase):
             process_storage_error(error)
 
     @distributed_trace_async
-    async def set_file_metadata(self, metadata=None, **kwargs):  # type: ignore
+    async def set_file_metadata(self, metadata=None, **kwargs):
         # type: (Optional[Dict[str, Any]], Any) -> Dict[str, Any]
         """Sets user-defined metadata for the specified file as one or more
         name-value pairs.
@@ -1074,9 +1074,9 @@ class ShareFileClient(AsyncStorageAccountHostsMixin, ShareFileClientBase):
         access_conditions = get_access_conditions(kwargs.pop('lease', None))
         timeout = kwargs.pop('timeout', None)
         headers = kwargs.pop("headers", {})
-        headers.update(add_metadata_headers(metadata))  # type: ignore
+        headers.update(add_metadata_headers(metadata))
         try:
-            return await self._client.file.set_metadata(  # type: ignore
+            return await self._client.file.set_metadata(
                 metadata=metadata, lease_access_conditions=access_conditions,
                 timeout=timeout, cls=return_response_headers, headers=headers, **kwargs
             )
@@ -1084,7 +1084,7 @@ class ShareFileClient(AsyncStorageAccountHostsMixin, ShareFileClientBase):
             process_storage_error(error)
 
     @distributed_trace_async
-    async def upload_range(  # type: ignore
+    async def upload_range(
         self,
         data,  # type: bytes
         offset,  # type: int
@@ -1146,7 +1146,7 @@ class ShareFileClient(AsyncStorageAccountHostsMixin, ShareFileClientBase):
         content_range = f'bytes={offset}-{end_range}'
         access_conditions = get_access_conditions(kwargs.pop('lease', None))
         try:
-            return await self._client.file.upload_range(  # type: ignore
+            return await self._client.file.upload_range(
                 range=content_range,
                 content_length=length,
                 optionalbody=data,
@@ -1242,12 +1242,12 @@ class ShareFileClient(AsyncStorageAccountHostsMixin, ShareFileClientBase):
             **kwargs
         )
         try:
-            return await self._client.file.upload_range_from_url(**options)  # type: ignore
+            return await self._client.file.upload_range_from_url(**options)
         except HttpResponseError as error:
             process_storage_error(error)
 
     @distributed_trace_async
-    async def get_ranges(  # type: ignore
+    async def get_ranges(
             self, offset=None,  # type: Optional[int]
             length=None,  # type: Optional[int]
             **kwargs  # type: Any
@@ -1343,7 +1343,7 @@ class ShareFileClient(AsyncStorageAccountHostsMixin, ShareFileClientBase):
         return get_file_ranges_result(ranges)
 
     @distributed_trace_async
-    async def clear_range(  # type: ignore
+    async def clear_range(
         self,
         offset,  # type: int
         length,  # type: int
@@ -1385,7 +1385,7 @@ class ShareFileClient(AsyncStorageAccountHostsMixin, ShareFileClientBase):
         end_range = length + offset - 1  # Reformat to an inclusive range index
         content_range = f"bytes={offset}-{end_range}"
         try:
-            return await self._client.file.upload_range(  # type: ignore
+            return await self._client.file.upload_range(
                 timeout=timeout,
                 cls=return_response_headers,
                 content_length=0,
@@ -1424,7 +1424,7 @@ class ShareFileClient(AsyncStorageAccountHostsMixin, ShareFileClientBase):
         access_conditions = get_access_conditions(kwargs.pop('lease', None))
         timeout = kwargs.pop('timeout', None)
         try:
-            return await self._client.file.set_http_headers(  # type: ignore
+            return await self._client.file.set_http_headers(
                 file_content_length=size,
                 file_attributes="preserve",
                 file_creation_time="preserve",
@@ -1483,7 +1483,7 @@ class ShareFileClient(AsyncStorageAccountHostsMixin, ShareFileClientBase):
         :rtype: dict[str, int]
         """
         try:
-            handle_id = handle.id # type: ignore
+            handle_id = handle.id
         except AttributeError:
             handle_id = handle
         if handle_id == '*':

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/aio/_file_client_async.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/aio/_file_client_async.py
@@ -180,7 +180,7 @@ class ShareFileClient(AsyncStorageAccountHostsMixin, ShareFileClientBase):
                                         allow_trailing_dot=self.allow_trailing_dot,
                                         allow_source_trailing_dot=self.allow_source_trailing_dot,
                                         file_request_intent=self.file_request_intent)
-        self._client._config.version = get_api_version(kwargs) # pylint: disable=protected-access
+        self._client._config.version = get_api_version(kwargs)  # pylint: disable=protected-access
 
     @distributed_trace_async
     async def acquire_lease(self, lease_id=None, **kwargs):


### PR DESCRIPTION
This PR contains these changes:

- Annotated class APIs
- Decoupled `_file_client.py` and `_file_client_async.py`
- Removed `# type: ignore` comments
- Formatted `# pylint: disable=...` to our existing convention
- Refactored URL and snapshot parsing logic
- Refactored `options` code
- Reordered imports