### PR TITLE
docs: use named logger with the AzureMonitorLogExporter instead of root logger

### DIFF
--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/README.md
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/README.md
@@ -154,6 +154,14 @@ The following sections provide several code snippets covering some of the most c
 
 Review the [OpenTelemetry Logging SDK][ot_logging_sdk] to learn how to use OpenTelemetry components to collect logs.
 
+When integrating the `AzureMonitorLogExporter`, it's **strongly advised to utilize a named logger** rather
+than the root logger.
+This recommendation stems from the exporter's dependency on `azure-core` for constructing and dispatching requests.
+Since `azure-core` itself uses a Python logger, attaching the handler to the root logger would
+inadvertently capture and export these internal log messages as well.
+This triggers a recursive loop of logging and exporting, leading to an unnecessary proliferation of log data.
+To avoid this, configure a named logger for your application's logging needs or set up your logging handler to filter out logs originating from the SDK library.
+
 #### Export Hello World Log
 
 ```python
@@ -181,13 +189,12 @@ exporter = AzureMonitorLogExporter(
 )
 
 logger_provider.add_log_record_processor(BatchLogRecordProcessor(exporter))
+
+# Attach LoggingHandler to namespaced logger
 handler = LoggingHandler()
-
-# Attach LoggingHandler to root logger
-logging.getLogger().addHandler(handler)
-logging.getLogger().setLevel(logging.NOTSET)
-
 logger = logging.getLogger(__name__)
+logger.addHandler(handler)
+logger.setLevel(logging.NOTSET)
 
 logger.warning("Hello World!")
 
@@ -226,13 +233,12 @@ exporter = AzureMonitorLogExporter(
 )
 
 logger_provider.add_log_record_processor(BatchLogRecordProcessor(exporter))
+
+# Attach LoggingHandler to namespaced logger
 handler = LoggingHandler()
-
-# Attach LoggingHandler to root logger
-logging.getLogger().addHandler(handler)
-logging.getLogger().setLevel(logging.NOTSET)
-
 logger = logging.getLogger(__name__)
+logger.addHandler(handler)
+logger.setLevel(logging.NOTSET)
 
 logger.info("INFO: Outside of span")
 with tracer.start_as_current_span("foo"):
@@ -266,13 +272,12 @@ exporter = AzureMonitorLogExporter(
 )
 
 logger_provider.add_log_record_processor(BatchLogRecordProcessor(exporter))
+
+# Attach LoggingHandler to namespaced logger
 handler = LoggingHandler()
-
-# Attach LoggingHandler to root logger
-logging.getLogger().addHandler(handler)
-logging.getLogger().setLevel(logging.NOTSET)
-
 logger = logging.getLogger(__name__)
+logger.addHandler(handler)
+logger.setLevel(logging.NOTSET)
 
 # Custom properties
 logger.debug("DEBUG: Debug with properties", extra={"debug": "true"})


### PR DESCRIPTION
# Description

The example for the AzureMonitorLogExporter: [Export Hello World Log](https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/monitor/azure-monitor-opentelemetry-exporter#export-hello-world-log) fails if the LoggingHandler is added to the root logger because of recursive behaviour. Therefore it is recommended to add the LoggingHandler to a named logger instead or silence the azure-core sdk as discussed in https://github.com/Azure/azure-sdk-for-python/issues/34787.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
