### PR TITLE
[Cosmos] Remove GeoSpatial index limitation

### DIFF
--- a/sdk/cosmos/azure-cosmos/README.md
+++ b/sdk/cosmos/azure-cosmos/README.md
@@ -164,7 +164,6 @@ Streamable queries like `SELECT * FROM WHERE` *do* support continuation tokens.
 ### Control Plane Limitations:
 
 * Get CollectionSizeUsage, DatabaseUsage, and DocumentUsage metrics
-* Create Geospatial Index
 * Get the connection string
 * Get the minimum RU/s of a container
 

--- a/sdk/cosmos/azure-cosmos/samples/index_management_async.py
+++ b/sdk/cosmos/azure-cosmos/samples/index_management_async.py
@@ -706,7 +706,7 @@ async def use_vector_embedding_policy(db):
         properties = await created_container.read()
         print(created_container)
 
-        print("\n" + "-" * 25 + "\n9. Container created with vector embedding policy and vector indexes")
+        print("\n" + "-" * 25 + "\n10. Container created with vector embedding policy and vector indexes")
         print_dictionary_items(properties["indexingPolicy"])
         print_dictionary_items(properties["vectorEmbeddingPolicy"])
 
@@ -771,7 +771,10 @@ async def run_sample():
             # 8. Perform Multi Orderby queries using composite indexes
             await perform_multi_orderby_query(created_db)
 
-            # 9. Create and use a vector embedding policy
+            # 9. Create and use a geospatial indexing policy
+            await use_geospatial_indexing_policy(created_db)
+
+            # 10. Create and use a vector embedding policy
             await use_vector_embedding_policy(created_db)
 
     except exceptions.AzureError as e:

--- a/sdk/cosmos/azure-cosmos/test/test_crud.py
+++ b/sdk/cosmos/azure-cosmos/test/test_crud.py
@@ -948,7 +948,7 @@ class TestCRUDOperations(unittest.TestCase):
             before_create_documents_count,
             'number of documents should remain same')
 
-    def _test_spatial_index(self):
+    def test_geospatial_index(self):
         db = self.databaseForTest
         # partial policy specified
         collection = db.create_container(

--- a/sdk/cosmos/azure-cosmos/test/test_crud_async.py
+++ b/sdk/cosmos/azure-cosmos/test/test_crud_async.py
@@ -881,8 +881,7 @@ class TestCRUDOperationsAsync(unittest.IsolatedAsyncioTestCase):
         document_list = [document async for document in created_collection.read_all_items()]
         assert len(document_list) == before_create_documents_count
 
-    async def _test_spatial_index(self):
-
+    async def test_geospatial_index_async(self):
         db = self.database_for_test
         # partial policy specified
         collection = await db.create_container(


### PR DESCRIPTION
The Python SDK never really had this limitation to begin with since our indexing policy is basically a raw JSON, but it was missing samples/ tests on our end. Even our public documents have had examples of how to set this up for a while now: https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/how-to-manage-indexing-policy?tabs=dotnetv3%2Cpythonv4#use-the-python-sdk

All this PR does is add the missing samples/ tests for the feature to remove the limitation altogether from our README.