### PR TITLE
Transition Partner Release Pipeline to `yml` from `Designer`

### DIFF
--- a/eng/pipelines/templates/stages/partner-release.yml
+++ b/eng/pipelines/templates/stages/partner-release.yml
@@ -6,7 +6,7 @@ parameters:
 - name: BlobPath
   displayName: 'Container relative blob path'
   type: string
-  default: '<team>/java/<version>'
+  default: '<team>/python/<version>'
 
 extends:
   template: /eng/pipelines/templates/stages/1es-redirect.yml
@@ -44,7 +44,7 @@ extends:
 
           - template: /eng/common/pipelines/templates/steps/publish-1es-artifact.yml
             parameters:
-              ArtifactName: 'partner-artifacts'
+              ArtifactName: 'artifacts-for-release'
               ArtifactPath: $(Artifacts)
 
           - task: EsrpRelease@7

--- a/eng/pipelines/templates/stages/partner-release.yml
+++ b/eng/pipelines/templates/stages/partner-release.yml
@@ -11,43 +11,43 @@ parameters:
 # extends:
 #   template: /eng/pipelines/templates/stages/1es-redirect.yml
 #   parameters:
-    stages:
-      - stage:
-        displayName: 'Partner Release'
-        variables:
-          - name: Artifacts
-            value: $(Pipeline.Workspace)/artifacts
+stages:
+  - stage:
+    displayName: 'Partner Release'
+    variables:
+      - name: Artifacts
+        value: $(Pipeline.Workspace)/artifacts
 
-        jobs:
-        - job:
-          displayName: 'Download and publish artifacts'
-          pool:
-            name: $(WINDOWSPOOL)
-            image: $(WINDOWSVMIMAGE)
-            os: windows
+    jobs:
+    - job:
+      displayName: 'Download and publish artifacts'
+      pool:
+        name: $(WINDOWSPOOL)
+        image: $(WINDOWSVMIMAGE)
+        os: windows
 
-          steps:
-          - task: AzurePowerShell@5
-            displayName: 'Copy from azuresdkpartnerdrops'
-            condition: and(succeeded(), ne(variables['SkipCopyFromPartnerDrops'], 'true'))
-            inputs:
-              azureSubscription: 'azuresdkpartnerdrops - Storage Partner Drops'
-              ScriptType: 'InlineScript'
-              azurePowerShellVersion: LatestVersion 
-              pwsh: true
-              Inline: |
-                azcopy copy 'https://azuresdkpartnerdrops.blob.core.windows.net/drops/${{ parameters.BlobPath }}/*' '$(Artifacts)' --recursive=true
-                echo "Copied files:"
-                dir '$(Artifacts)' -r | % { $_.FullName }
-            env: 
-              AZCOPY_AUTO_LOGIN_TYPE: 'PSCRED'
+      steps:
+      - task: AzurePowerShell@5
+        displayName: 'Copy from azuresdkpartnerdrops'
+        condition: and(succeeded(), ne(variables['SkipCopyFromPartnerDrops'], 'true'))
+        inputs:
+          azureSubscription: 'azuresdkpartnerdrops - Storage Partner Drops'
+          ScriptType: 'InlineScript'
+          azurePowerShellVersion: LatestVersion 
+          pwsh: true
+          Inline: |
+            azcopy copy 'https://azuresdkpartnerdrops.blob.core.windows.net/drops/${{ parameters.BlobPath }}/*' '$(Artifacts)' --recursive=true
+            echo "Copied files:"
+            dir '$(Artifacts)' -r | % { $_.FullName }
+        env: 
+          AZCOPY_AUTO_LOGIN_TYPE: 'PSCRED'
 
-          # - template: /eng/common/pipelines/templates/steps/publish-1es-artifact.yml
-          #   parameters:
-          #     ArtifactName: 'artifacts-for-release'
-          #     ArtifactPath: $(Artifacts)
+      # - template: /eng/common/pipelines/templates/steps/publish-1es-artifact.yml
+      #   parameters:
+      #     ArtifactName: 'artifacts-for-release'
+      #     ArtifactPath: $(Artifacts)
 
-          - task: EsrpRelease@7
+      - task: EsrpRelease@7
             displayName: 'Publish via ESRP'
             inputs:
               ConnectedServiceName: 'Azure SDK Engineering System'

--- a/eng/pipelines/templates/stages/partner-release.yml
+++ b/eng/pipelines/templates/stages/partner-release.yml
@@ -8,59 +8,59 @@ parameters:
   type: string
   default: '<team>/python/<version>'
 
-# extends:
-#   template: /eng/pipelines/templates/stages/1es-redirect.yml
-#   parameters:
-stages:
-  - stage:
-    displayName: 'Partner Release'
-    variables:
-      - name: Artifacts
-        value: $(Pipeline.Workspace)/artifacts
-      - template: /eng/pipelines/templates/variables/image.yml
+extends:
+  template: /eng/pipelines/templates/stages/1es-redirect.yml
+  parameters:
+    stages:
+      - stage:
+        displayName: 'Partner Release'
+        variables:
+          - name: Artifacts
+            value: $(Pipeline.Workspace)/artifacts
+          - template: /eng/pipelines/templates/variables/image.yml
 
-    jobs:
-    - job:
-      displayName: 'Download and publish artifacts'
-      pool:
-        name: $(WINDOWSPOOL)
-        image: $(WINDOWSVMIMAGE)
-        os: windows
+        jobs:
+        - job:
+          displayName: 'Download and publish artifacts'
+          pool:
+            name: $(WINDOWSPOOL)
+            image: $(WINDOWSVMIMAGE)
+            os: windows
 
-      steps:
-      - task: AzurePowerShell@5
-        displayName: 'Copy from azuresdkpartnerdrops'
-        condition: and(succeeded(), ne(variables['SkipCopyFromPartnerDrops'], 'true'))
-        inputs:
-          azureSubscription: 'azuresdkpartnerdrops - Storage Partner Drops'
-          ScriptType: 'InlineScript'
-          azurePowerShellVersion: LatestVersion 
-          pwsh: true
-          Inline: |
-            azcopy copy 'https://azuresdkpartnerdrops.blob.core.windows.net/drops/${{ parameters.BlobPath }}/*' '$(Artifacts)' --recursive=true
-            echo "Copied files:"
-            dir '$(Artifacts)' -r | % { $_.FullName }
-        env: 
-          AZCOPY_AUTO_LOGIN_TYPE: 'PSCRED'
+          steps:
+          - task: AzurePowerShell@5
+            displayName: 'Copy from azuresdkpartnerdrops'
+            condition: and(succeeded(), ne(variables['SkipCopyFromPartnerDrops'], 'true'))
+            inputs:
+              azureSubscription: 'azuresdkpartnerdrops - Storage Partner Drops'
+              ScriptType: 'InlineScript'
+              azurePowerShellVersion: LatestVersion 
+              pwsh: true
+              Inline: |
+                azcopy copy 'https://azuresdkpartnerdrops.blob.core.windows.net/drops/${{ parameters.BlobPath }}/*' '$(Artifacts)' --recursive=true
+                echo "Copied files:"
+                dir '$(Artifacts)' -r | % { $_.FullName }
+            env: 
+              AZCOPY_AUTO_LOGIN_TYPE: 'PSCRED'
 
-      # - template: /eng/common/pipelines/templates/steps/publish-1es-artifact.yml
-      #   parameters:
-      #     ArtifactName: 'artifacts-for-release'
-      #     ArtifactPath: $(Artifacts)
+          - template: /eng/common/pipelines/templates/steps/publish-1es-artifact.yml
+            parameters:
+              ArtifactName: 'artifacts-for-release'
+              ArtifactPath: $(Artifacts)
 
-      - task: EsrpRelease@7
-        displayName: 'Publish via ESRP'
-        inputs:
-          ConnectedServiceName: 'Azure SDK Engineering System'
-          ClientId: '5f81938c-2544-4f1f-9251-dd9de5b8a81b'
-          KeyVaultName: 'AzureSDKEngKeyVault'
-          AuthCertName: 'azure-sdk-esrp-release-auth-certificate'
-          SignCertName: 'azure-sdk-esrp-release-sign-certificate'
-          Intent: 'PackageDistribution'
-          ContentType: 'PyPI'
-          FolderLocation: $(Artifacts)
-          Owners: $(Build.RequestedForEmail)
-          Approvers: $(Build.RequestedForEmail)
-          ServiceEndpointUrl: 'https://api.esrp.microsoft.com'
-          MainPublisher: 'ESRPRELPACMANTEST'
-          DomainTenantId: '72f988bf-86f1-41af-91ab-2d7cd011db47'
+          - task: EsrpRelease@7
+            displayName: 'Publish via ESRP'
+            inputs:
+              ConnectedServiceName: 'Azure SDK Engineering System'
+              ClientId: '5f81938c-2544-4f1f-9251-dd9de5b8a81b'
+              KeyVaultName: 'AzureSDKEngKeyVault'
+              AuthCertName: 'azure-sdk-esrp-release-auth-certificate'
+              SignCertName: 'azure-sdk-esrp-release-sign-certificate'
+              Intent: 'PackageDistribution'
+              ContentType: 'PyPI'
+              FolderLocation: $(Artifacts)
+              Owners: $(Build.RequestedForEmail)
+              Approvers: $(Build.RequestedForEmail)
+              ServiceEndpointUrl: 'https://api.esrp.microsoft.com'
+              MainPublisher: 'ESRPRELPACMANTEST'
+              DomainTenantId: '72f988bf-86f1-41af-91ab-2d7cd011db47'

--- a/eng/pipelines/templates/stages/partner-release.yml
+++ b/eng/pipelines/templates/stages/partner-release.yml
@@ -8,9 +8,9 @@ parameters:
   type: string
   default: '<team>/python/<version>'
 
-extends:
-  template: /eng/pipelines/templates/stages/1es-redirect.yml
-  parameters:
+# extends:
+#   template: /eng/pipelines/templates/stages/1es-redirect.yml
+#   parameters:
     stages:
       - stage:
         displayName: 'Partner Release'
@@ -42,10 +42,10 @@ extends:
             env: 
               AZCOPY_AUTO_LOGIN_TYPE: 'PSCRED'
 
-          - template: /eng/common/pipelines/templates/steps/publish-1es-artifact.yml
-            parameters:
-              ArtifactName: 'artifacts-for-release'
-              ArtifactPath: $(Artifacts)
+          # - template: /eng/common/pipelines/templates/steps/publish-1es-artifact.yml
+          #   parameters:
+          #     ArtifactName: 'artifacts-for-release'
+          #     ArtifactPath: $(Artifacts)
 
           - task: EsrpRelease@7
             displayName: 'Publish via ESRP'

--- a/eng/pipelines/templates/stages/partner-release.yml
+++ b/eng/pipelines/templates/stages/partner-release.yml
@@ -17,6 +17,7 @@ stages:
     variables:
       - name: Artifacts
         value: $(Pipeline.Workspace)/artifacts
+      - template: /eng/pipelines/templates/variables/image.yml
 
     jobs:
     - job:

--- a/eng/pipelines/templates/stages/partner-release.yml
+++ b/eng/pipelines/templates/stages/partner-release.yml
@@ -1,0 +1,65 @@
+trigger: none
+pr: none
+
+parameters:
+
+- name: BlobPath
+  displayName: 'Container relative blob path'
+  type: string
+  default: '<team>/java/<version>'
+
+extends:
+  template: /eng/pipelines/templates/stages/1es-redirect.yml
+  parameters:
+    stages:
+      - stage:
+        displayName: 'Partner Release'
+        variables:
+          - name: Artifacts
+            value: $(Pipeline.Workspace)/artifacts
+
+        jobs:
+        - job:
+          displayName: 'Download and publish artifacts'
+          pool:
+            name: $(WINDOWSPOOL)
+            image: $(WINDOWSVMIMAGE)
+            os: windows
+
+          steps:
+          - task: AzurePowerShell@5
+            displayName: 'Copy from azuresdkpartnerdrops'
+            condition: and(succeeded(), ne(variables['SkipCopyFromPartnerDrops'], 'true'))
+            inputs:
+              azureSubscription: 'azuresdkpartnerdrops - Storage Partner Drops'
+              ScriptType: 'InlineScript'
+              azurePowerShellVersion: LatestVersion 
+              pwsh: true
+              Inline: |
+                azcopy copy 'https://azuresdkpartnerdrops.blob.core.windows.net/drops/${{ parameters.BlobPath }}/*' '$(Artifacts)' --recursive=true
+                echo "Copied files:"
+                dir '$(Artifacts)' -r | % { $_.FullName }
+            env: 
+              AZCOPY_AUTO_LOGIN_TYPE: 'PSCRED'
+
+          - template: /eng/common/pipelines/templates/steps/publish-1es-artifact.yml
+            parameters:
+              ArtifactName: 'partner-artifacts'
+              ArtifactPath: $(Artifacts)
+
+          - task: EsrpRelease@7
+            displayName: 'Publish via ESRP'
+            inputs:
+              ConnectedServiceName: 'Azure SDK Engineering System'
+              ClientId: '5f81938c-2544-4f1f-9251-dd9de5b8a81b'
+              KeyVaultName: 'AzureSDKEngKeyVault'
+              AuthCertName: 'azure-sdk-esrp-release-auth-certificate'
+              SignCertName: 'azure-sdk-esrp-release-sign-certificate'
+              Intent: 'PackageDistribution'
+              ContentType: 'PyPI'
+              FolderLocation: $(Artifacts)
+              Owners: $(Build.RequestedForEmail)
+              Approvers: $(Build.RequestedForEmail)
+              ServiceEndpointUrl: 'https://api.esrp.microsoft.com'
+              MainPublisher: 'ESRPRELPACMANTEST'
+              DomainTenantId: '72f988bf-86f1-41af-91ab-2d7cd011db47'

--- a/eng/pipelines/templates/stages/partner-release.yml
+++ b/eng/pipelines/templates/stages/partner-release.yml
@@ -48,18 +48,18 @@ stages:
       #     ArtifactPath: $(Artifacts)
 
       - task: EsrpRelease@7
-            displayName: 'Publish via ESRP'
-            inputs:
-              ConnectedServiceName: 'Azure SDK Engineering System'
-              ClientId: '5f81938c-2544-4f1f-9251-dd9de5b8a81b'
-              KeyVaultName: 'AzureSDKEngKeyVault'
-              AuthCertName: 'azure-sdk-esrp-release-auth-certificate'
-              SignCertName: 'azure-sdk-esrp-release-sign-certificate'
-              Intent: 'PackageDistribution'
-              ContentType: 'PyPI'
-              FolderLocation: $(Artifacts)
-              Owners: $(Build.RequestedForEmail)
-              Approvers: $(Build.RequestedForEmail)
-              ServiceEndpointUrl: 'https://api.esrp.microsoft.com'
-              MainPublisher: 'ESRPRELPACMANTEST'
-              DomainTenantId: '72f988bf-86f1-41af-91ab-2d7cd011db47'
+        displayName: 'Publish via ESRP'
+        inputs:
+          ConnectedServiceName: 'Azure SDK Engineering System'
+          ClientId: '5f81938c-2544-4f1f-9251-dd9de5b8a81b'
+          KeyVaultName: 'AzureSDKEngKeyVault'
+          AuthCertName: 'azure-sdk-esrp-release-auth-certificate'
+          SignCertName: 'azure-sdk-esrp-release-sign-certificate'
+          Intent: 'PackageDistribution'
+          ContentType: 'PyPI'
+          FolderLocation: $(Artifacts)
+          Owners: $(Build.RequestedForEmail)
+          Approvers: $(Build.RequestedForEmail)
+          ServiceEndpointUrl: 'https://api.esrp.microsoft.com'
+          MainPublisher: 'ESRPRELPACMANTEST'
+          DomainTenantId: '72f988bf-86f1-41af-91ab-2d7cd011db47'


### PR DESCRIPTION
Taking us all the way to `1es-templates` as well. Supplanting [this release](https://dev.azure.com/azure-sdk/internal/_release?_a=releases&view=mine&definitionId=116) with [this build](https://dev.azure.com/azure-sdk/internal/_build?definitionId=6991&_a=summary).

Example successful [test release.](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3829487&view=results)

Related to Azure/azure-sdk-tools#7941