### PR TITLE
[pipeline][typespec] import new package `@azure-tools/typespec-azure-rulesets`

### DIFF
--- a/eng/emitter-package-lock.json
+++ b/eng/emitter-package-lock.json
@@ -11,6 +11,7 @@
         "@azure-tools/typespec-autorest": "~0.42.0",
         "@azure-tools/typespec-azure-core": "~0.42.0",
         "@azure-tools/typespec-azure-resource-manager": "~0.42.1",
+        "@azure-tools/typespec-azure-rulesets": "~0.42.1",
         "@azure-tools/typespec-client-generator-core": "~0.42.3",
         "@typespec/compiler": "~0.56.0",
         "@typespec/http": "~0.56.0",
@@ -93,6 +94,21 @@
         "@typespec/openapi": "~0.56.0",
         "@typespec/rest": "~0.56.0",
         "@typespec/versioning": "~0.56.0"
+      }
+    },
+    "node_modules/@azure-tools/typespec-azure-rulesets": {
+      "version": "0.42.1",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-rulesets/-/typespec-azure-rulesets-0.42.1.tgz",
+      "integrity": "sha512-GRiMErWJ96DvDBQMVgGI1sgMTOegXxpx7w6enZyEF0BaodxGfObJyl1TrMb9Pj6NAZfV5Q6uJAfXFbpF1MVDCw==",
+      "dev": true,
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@azure-tools/typespec-azure-core": "~0.42.0",
+        "@azure-tools/typespec-azure-resource-manager": "~0.42.1",
+        "@azure-tools/typespec-client-generator-core": "~0.42.3",
+        "@typespec/compiler": "~0.56.0"
       }
     },
     "node_modules/@azure-tools/typespec-client-generator-core": {

--- a/eng/emitter-package.json
+++ b/eng/emitter-package.json
@@ -7,6 +7,7 @@
     "@typespec/http": "~0.56.0",
     "@typespec/openapi": "~0.56.0",
     "@azure-tools/typespec-azure-resource-manager": "~0.42.1",
+    "@azure-tools/typespec-azure-rulesets": "~0.42.1",
     "@typespec/versioning": "~0.56.0",
     "@azure-tools/typespec-azure-core": "~0.42.0",
     "@azure-tools/typespec-autorest": "~0.42.0",


### PR DESCRIPTION
After https://github.com/Azure/azure-rest-api-specs/pull/29193/files merged, Python SDK generation fails. It seems that adding  new dependency `@azure-tools/typespec-azure-rulesets` could resolve it.