### PR TITLE
fix enum value manually

### DIFF
--- a/sdk/devopsinfrastructure/azure-mgmt-devopsinfrastructure/azure/mgmt/devopsinfrastructure/models/_enums.py
+++ b/sdk/devopsinfrastructure/azure-mgmt-devopsinfrastructure/azure/mgmt/devopsinfrastructure/models/_enums.py
@@ -72,7 +72,7 @@ class ManagedServiceIdentityType(str, Enum, metaclass=CaseInsensitiveEnumMeta):
     """System assigned managed identity."""
     USER_ASSIGNED = "UserAssigned"
     """User assigned managed identity."""
-    SYSTEM_AND_USER_ASSIGNED = "SystemAssigned, UserAssigned"
+    SYSTEM_AND_USER_ASSIGNED = "SystemAssigned,UserAssigned"
     """System and user assigned managed identity."""
 
 


### PR DESCRIPTION
please pay attention for this enum value difference when your language try to release sdk from typespec directly:
typespec: [typespec-azure/packages/typespec-azure-resource-manager/lib/common-types/managed-identity.tsp at main · Azure/typespec-azure (github.com)](https://github.com/Azure/typespec-azure/blob/main/packages/typespec-azure-resource-manager/lib/common-types/managed-identity.tsp#L118)
swagger: [azure-rest-api-specs/specification/common-types/resource-management/v5/managedidentity.json at main · Azure/azure-rest-api-specs (github.com)](https://github.com/Azure/azure-rest-api-specs/blob/main/specification/common-types/resource-management/v5/managedidentity.json#L42)

we have to fix it manually for now