### PR TITLE
Add federated identity capabilities to live tests

### DIFF
--- a/eng/pipelines/templates/jobs/live.tests.yml
+++ b/eng/pipelines/templates/jobs/live.tests.yml
@@ -63,6 +63,9 @@ parameters:
   - name: ToxTestEnv
     type: string
     default: 'whl'
+  - name: UseFederatedAuth
+    type: boolean
+    default: false
 
 jobs:
   - job:
@@ -123,6 +126,9 @@ jobs:
               ServiceDirectory: '${{ directory }}'
               SubscriptionConfiguration: $(SubscriptionConfiguration)
               ArmTemplateParameters: $(ArmTemplateParameters)
+              UseFederatedAuth: ${{ parameters.UseFederatedAuth }}
+              ServiceConnection: ${{ parameters.CloudConfig.ServiceConnection }}
+              SubscriptionConfigurationFilePath: ${{ parameters.CloudConfig.SubscriptionConfigurationFilePath }}
       - ${{ if not(parameters.TestResourceDirectories) }}:
           - template: /eng/common/TestResources/deploy-test-resources.yml
             parameters:
@@ -130,6 +136,9 @@ jobs:
               ServiceDirectory: '${{ parameters.ServiceDirectory }}'
               SubscriptionConfiguration: $(SubscriptionConfiguration)
               ArmTemplateParameters: $(ArmTemplateParameters)
+              UseFederatedAuth: ${{ parameters.UseFederatedAuth }}
+              ServiceConnection: ${{ parameters.CloudConfig.ServiceConnection }}
+              SubscriptionConfigurationFilePath: ${{ parameters.CloudConfig.SubscriptionConfigurationFilePath }}
 
       - template: ../steps/build-test.yml
         parameters:
@@ -149,7 +158,9 @@ jobs:
           InjectedPackages: ${{ parameters.InjectedPackages }}
           BuildDocs: ${{ parameters.BuildDocs }}
           TestProxy: ${{ parameters.TestProxy }}
-
+          UseFederatedAuth: ${{ parameters.UseFederatedAuth }}
+          ServiceConnection: ${{ parameters.CloudConfig.ServiceConnection }}
+          SubscriptionConfigurationFilePath: ${{ parameters.CloudConfig.SubscriptionConfigurationFilePath }}
 
       - ${{ if parameters.TestResourceDirectories }}:
         - ${{ each directory in parameters.TestResourceDirectories }}:
@@ -157,8 +168,14 @@ jobs:
             parameters:
               ServiceDirectory: '${{ directory }}'
               SubscriptionConfiguration: $(SubscriptionConfiguration)
+              UseFederatedAuth: ${{ parameters.UseFederatedAuth }}
+              ServiceConnection: ${{ parameters.CloudConfig.ServiceConnection }}
+              SubscriptionConfigurationFilePath: ${{ parameters.CloudConfig.SubscriptionConfigurationFilePath }}
       - ${{ if not(parameters.TestResourceDirectories) }}:
         - template: /eng/common/TestResources/remove-test-resources.yml
           parameters:
             ServiceDirectory: '${{ parameters.ServiceDirectory }}'
             SubscriptionConfiguration: $(SubscriptionConfiguration)
+            UseFederatedAuth: ${{ parameters.UseFederatedAuth }}
+            ServiceConnection: ${{ parameters.CloudConfig.ServiceConnection }}
+            SubscriptionConfigurationFilePath: ${{ parameters.CloudConfig.SubscriptionConfigurationFilePath }}

--- a/eng/pipelines/templates/stages/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tests.yml
@@ -58,6 +58,8 @@ parameters:
     default:
       Public:
         SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
+        ServiceConnection: azure-sdk-tests
+        SubscriptionConfigurationFilePath: eng/common/TestResources/sub-config/AzurePublicMsft.json
       Preview:
         SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources-preview)
       Canary:
@@ -98,7 +100,9 @@ parameters:
   - name: Packages
     type: object
     default: []
-
+  - name: UseFederatedAuth
+    type: boolean
+    default: false
 
 extends:
   template: /eng/pipelines/templates/stages/1es-redirect.yml
@@ -141,6 +145,7 @@ extends:
                                 TestTimeoutInMinutes: ${{ parameters.TestTimeoutInMinutes }}
                                 TestProxy: ${{ parameters.TestProxy }}
                                 ToxTestEnv: ${{ parameters.ToxTestEnv }}
+                                UseFederatedAuth: ${{ parameters.UseFederatedAuth }}
                               MatrixConfigs:
                                 # Enumerate platforms and additional platforms based on supported clouds (sparse platform<-->cloud matrix).
                                 - ${{ each config in parameters.MatrixConfigs }}:
@@ -160,6 +165,8 @@ extends:
                                 SubscriptionConfigurations: ${{ cloud.value.SubscriptionConfigurations }}
                                 Location: ${{ coalesce(parameters.Location, cloud.value.Location) }}
                                 Cloud: ${{ cloud.key }}
+                                ServiceConnection: ${{ cloud.value.ServiceConnection }}
+                                SubscriptionConfigurationFilePath: ${{ cloud.value.SubscriptionConfigurationFilePath }}
       - ${{ else }}:
         - ${{ each cloud in parameters.CloudConfig }}:
             - ${{ if or(contains(parameters.Clouds, cloud.key), and(contains(variables['Build.DefinitionName'], 'tests-weekly'), contains(parameters.SupportedClouds, cloud.key))) }}:
@@ -195,6 +202,7 @@ extends:
                               TestTimeoutInMinutes: ${{ parameters.TestTimeoutInMinutes }}
                               TestProxy: ${{ parameters.TestProxy }}
                               ToxTestEnv: ${{ parameters.ToxTestEnv }}
+                              UseFederatedAuth: ${{ parameters.UseFederatedAuth }}
                             MatrixConfigs:
                               # Enumerate platforms and additional platforms based on supported clouds (sparse platform<-->cloud matrix).
                               - ${{ each config in parameters.MatrixConfigs }}:
@@ -214,6 +222,8 @@ extends:
                               SubscriptionConfigurations: ${{ cloud.value.SubscriptionConfigurations }}
                               Location: ${{ coalesce(parameters.Location, cloud.value.Location) }}
                               Cloud: ${{ cloud.key }}
+                              ServiceConnection: ${{ cloud.value.ServiceConnection }}
+                              SubscriptionConfigurationFilePath: ${{ cloud.value.SubscriptionConfigurationFilePath }}
       - template: /eng/pipelines/templates/stages/python-analyze-weekly.yml
         parameters:
           BuildTargetingString: ${{ parameters.BuildTargetingString }}

--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -70,6 +70,7 @@ steps:
       inputs:
         azureSubscription: ${{ parameters.ServiceConnection }}
         azurePowerShellVersion: LatestVersion
+        pwsh: true
         ScriptType: InlineScript
         Inline: >-
           python scripts/devops_tasks/dispatch_tox.py
@@ -124,6 +125,7 @@ steps:
       inputs:
         azureSubscription: ${{ parameters.ServiceConnection }}
         azurePowerShellVersion: LatestVersion
+        pwsh: true
         ScriptType: InlineScript
         Inline: >-
           scripts/devops_tasks/dispatch_tox.py

--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -15,6 +15,8 @@ parameters:
   InjectedPackages: ''
   DevFeedName: 'public/azure-sdk-for-python'
   TestProxy: false
+  UseFederatedAuth: false
+  ServiceConnection: ''
 
 # The variable TargetingString is set by template `eng/pipelines/templates/steps/targeting-string-resolve.yml`. This template is invoked from yml files:
 #     eng/pipelines/templates/jobs/ci.tests.yml
@@ -61,20 +63,39 @@ steps:
 
   - template: /eng/pipelines/templates/steps/seed-virtualenv-wheels.yml
 
-  - task: PythonScript@0
-    displayName: 'Run Tests'
-    inputs:
-      scriptPath: 'scripts/devops_tasks/dispatch_tox.py'
-      arguments: >-
-        "$(TargetingString)"
-        ${{ parameters.AdditionalTestArgs }}
-        ${{ parameters.CoverageArg }}
-        --mark_arg="${{ parameters.TestMarkArgument }}"
-        --service="${{ parameters.ServiceDirectory }}"
-        --toxenv="${{ parameters.ToxTestEnv }}"
-        --injected-packages="${{ parameters.InjectedPackages }}"
-        ${{ parameters.ToxEnvParallel }}
-    env: ${{ parameters.EnvVars }}
+  - ${{ if eq('true', parameters.UseFederatedAuth) }}:
+    - task: AzurePowerShell@5
+      displayName: Run Tests (AzurePowerShell@5)
+      env: ${{ parameters.EnvVars }}
+      inputs:
+        azureSubscription: ${{ parameters.ServiceConnection }}
+        azurePowerShellVersion: LatestVersion
+        ScriptType: InlineScript
+        Inline: >-
+          python scripts/devops_tasks/dispatch_tox.py
+          "$(TargetingString)"
+          ${{ parameters.AdditionalTestArgs }}
+          ${{ parameters.CoverageArg }}
+          --mark_arg="${{ parameters.TestMarkArgument }}"
+          --service="${{ parameters.ServiceDirectory }}"
+          --toxenv="${{ parameters.ToxTestEnv }}"
+          --injected-packages="${{ parameters.InjectedPackages }}"
+          ${{ parameters.ToxEnvParallel }}
+  - ${{ else }}:
+    - task: PythonScript@0
+      displayName: 'Run Tests'
+      inputs:
+        scriptPath: 'scripts/devops_tasks/dispatch_tox.py'
+        arguments: >-
+          "$(TargetingString)"
+          ${{ parameters.AdditionalTestArgs }}
+          ${{ parameters.CoverageArg }}
+          --mark_arg="${{ parameters.TestMarkArgument }}"
+          --service="${{ parameters.ServiceDirectory }}"
+          --toxenv="${{ parameters.ToxTestEnv }}"
+          --injected-packages="${{ parameters.InjectedPackages }}"
+          ${{ parameters.ToxEnvParallel }}
+      env: ${{ parameters.EnvVars }}
 
   - ${{if eq(parameters.TestProxy, true) }}:
     - pwsh: |
@@ -95,16 +116,32 @@ steps:
     displayName: Create Coverage Report
     condition: and(succeeded(), ${{ parameters.RunCoverage }})
 
-  - task: PythonScript@0
-    displayName: 'Test Samples'
-    condition: and(succeeded(), eq(variables['TestSamples'], 'true'))
-    inputs:
-      scriptPath: 'scripts/devops_tasks/dispatch_tox.py'
-      arguments: >-
-        "$(TargetingString)"
-        --service="${{ parameters.ServiceDirectory }}"
-        --toxenv="samples"
-    env: ${{ parameters.EnvVars }}
+  - ${{ if eq('true', parameters.UseFederatedAuth) }}:
+    - task: AzurePowerShell@5
+      displayName: Test Samples (AzurePowerShell@5)
+      condition: and(succeeded(), eq(variables['TestSamples'], 'true'))
+      env: ${{ parameters.EnvVars }}
+      inputs:
+        azureSubscription: ${{ parameters.ServiceConnection }}
+        azurePowerShellVersion: LatestVersion
+        ScriptType: InlineScript
+        Inline: >-
+          scripts/devops_tasks/dispatch_tox.py
+          "$(TargetingString)"
+          --service="${{ parameters.ServiceDirectory }}"
+          --toxenv="samples"
+
+  - ${{ else }}: 
+    - task: PythonScript@0
+      displayName: 'Test Samples'
+      condition: and(succeeded(), eq(variables['TestSamples'], 'true'))
+      inputs:
+        scriptPath: 'scripts/devops_tasks/dispatch_tox.py'
+        arguments: >-
+          "$(TargetingString)"
+          --service="${{ parameters.ServiceDirectory }}"
+          --toxenv="samples"
+      env: ${{ parameters.EnvVars }}
 
   - task: PublishTestResults@2
     condition: always()


### PR DESCRIPTION
Fixes #35674 

Add support for federated identity and use `AzurePowerShell` to provide auth.

Example run with federated auth enabled: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3828659&view=results (failures are expected... note that test and sample test tasks run in `Azure PowerShell`) 
Example run without federated auth: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3828822&view=results