### PR TITLE
Update CODEOWNERS for eng/common

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1005,6 +1005,7 @@
 # Eng Sys
 ###########
 /eng/                                                                @scbedd @weshaggard @benbp
+/eng/common                                                          @Azure/azure-sdk-eng
 
 /tools/                                                              @scbedd @mccoyp
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1005,7 +1005,7 @@
 # Eng Sys
 ###########
 /eng/                                                                @scbedd @weshaggard @benbp
-/eng/common                                                          @Azure/azure-sdk-eng
+/eng/common/                                                         @Azure/azure-sdk-eng
 
 /tools/                                                              @scbedd @mccoyp
 


### PR DESCRIPTION
Add engsys team as owner for files under eng/common to enable engsys team to be able to approve and merge eng/common sync PRs.
