### PR TITLE
Disable distributed tracing for live metrics calls

### DIFF
--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Handle invalid status codes in std metric payload
     ([#35762](https://github.com/Azure/azure-sdk-for-python/pull/35762))
 - Disable distributed tracing for live metrics client calls
-    ([#35753](https://github.com/Azure/azure-sdk-for-python/pull/35753))
+    ([#35822](https://github.com/Azure/azure-sdk-for-python/pull/35822))
 
 ### Other Changes
 

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Handle invalid status codes in std metric payload
     ([#35762](https://github.com/Azure/azure-sdk-for-python/pull/35762))
+- Disable distributed tracing for live metrics client calls
+    ([#35753](https://github.com/Azure/azure-sdk-for-python/pull/35753))
 
 ### Other Changes
 

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_quickpulse/_exporter.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_quickpulse/_exporter.py
@@ -97,7 +97,11 @@ class _QuickpulseExporter(MetricExporter):
             # Explicitly disabling to avoid tracing live metrics calls
             # DistributedTracingPolicy(),
         ]
-        self._client = QuickpulseClient(credential=None, endpoint=self._live_endpoint, policies=policies)  # type: ignore
+        self._client = QuickpulseClient(
+            credential=None,
+            endpoint=self._live_endpoint,
+            policies=policies
+        )  # type: ignore
 
         MetricExporter.__init__(
             self,

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_quickpulse/_exporter.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_quickpulse/_exporter.py
@@ -23,11 +23,19 @@ from opentelemetry.sdk.metrics.export import (
 )
 
 from azure.core.exceptions import HttpResponseError
+from azure.core.pipeline.policies import (
+    ContentDecodePolicy,
+    DistributedTracingPolicy,
+    HttpLoggingPolicy,
+    RedirectPolicy,
+    RequestIdPolicy,
+)
 from azure.monitor.opentelemetry.exporter._quickpulse._constants import (
     _LONG_PING_INTERVAL_SECONDS,
     _POST_CANCEL_INTERVAL_SECONDS,
     _POST_INTERVAL_SECONDS,
 )
+from azure.monitor.opentelemetry.exporter._quickpulse._generated._configuration import QuickpulseClientConfiguration
 from azure.monitor.opentelemetry.exporter._quickpulse._generated._client import QuickpulseClient
 from azure.monitor.opentelemetry.exporter._quickpulse._generated.models import MonitoringDataPoint
 from azure.monitor.opentelemetry.exporter._quickpulse._state import (
@@ -82,8 +90,20 @@ class _QuickpulseExporter(MetricExporter):
         self._instrumentation_key = parsed_connection_string.instrumentation_key
         # TODO: Support AADaudience (scope)/credentials
         # Pass `None` for now until swagger definition is fixed
-        self._client = QuickpulseClient(credential=None, endpoint=self._live_endpoint)  # type: ignore
-        # TODO: Support redirect
+        config = QuickpulseClientConfiguration(credential=None)
+        policies = [
+            # TODO: Support redirect
+            config.redirect_policy,
+            # Needed for serialization
+            ContentDecodePolicy(),
+            # Logging for client calls
+            config.http_logging_policy,
+            # TODO: Support AADaudience (scope)/credentials
+            config.authentication_policy,
+            # Explicitly disabling to avoid tracing live metrics calls
+            # DistributedTracingPolicy(),
+        ]
+        self._client = QuickpulseClient(credential=None, endpoint=self._live_endpoint, policies=policies)  # type: ignore
 
         MetricExporter.__init__(
             self,

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_quickpulse/_exporter.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_quickpulse/_exporter.py
@@ -98,10 +98,10 @@ class _QuickpulseExporter(MetricExporter):
             # DistributedTracingPolicy(),
         ]
         self._client = QuickpulseClient(
-            credential=None,
+            credential=None, # type: ignore
             endpoint=self._live_endpoint,
             policies=policies
-        )  # type: ignore
+        )
 
         MetricExporter.__init__(
             self,

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_quickpulse/_exporter.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_quickpulse/_exporter.py
@@ -23,13 +23,7 @@ from opentelemetry.sdk.metrics.export import (
 )
 
 from azure.core.exceptions import HttpResponseError
-from azure.core.pipeline.policies import (
-    ContentDecodePolicy,
-    DistributedTracingPolicy,
-    HttpLoggingPolicy,
-    RedirectPolicy,
-    RequestIdPolicy,
-)
+from azure.core.pipeline.policies import ContentDecodePolicy
 from azure.monitor.opentelemetry.exporter._quickpulse._constants import (
     _LONG_PING_INTERVAL_SECONDS,
     _POST_CANCEL_INTERVAL_SECONDS,
@@ -90,7 +84,7 @@ class _QuickpulseExporter(MetricExporter):
         self._instrumentation_key = parsed_connection_string.instrumentation_key
         # TODO: Support AADaudience (scope)/credentials
         # Pass `None` for now until swagger definition is fixed
-        config = QuickpulseClientConfiguration(credential=None)
+        config = QuickpulseClientConfiguration(credential=None)  # type: ignore
         policies = [
             # TODO: Support redirect
             config.redirect_policy,

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_quickpulse/_generated/_operations/_operations.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_quickpulse/_generated/_operations/_operations.py
@@ -230,7 +230,7 @@ class QuickpulseClientOperationsMixin(QuickpulseClientMixinABC):
         :raises ~azure.core.exceptions.HttpResponseError:
         """
 
-    @distributed_trace
+    # @distributed_trace
     def is_subscribed(
         self,
         endpoint: str = "https://global.livediagnostics.monitor.azure.com",
@@ -440,7 +440,7 @@ class QuickpulseClientOperationsMixin(QuickpulseClientMixinABC):
         :raises ~azure.core.exceptions.HttpResponseError:
         """
 
-    @distributed_trace
+    # @distributed_trace
     def publish(
         self,
         endpoint: str = "https://global.livediagnostics.monitor.azure.com",

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_quickpulse/_generated/aio/_operations/_operations.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_quickpulse/_generated/aio/_operations/_operations.py
@@ -150,7 +150,7 @@ class QuickpulseClientOperationsMixin(QuickpulseClientMixinABC):
         :raises ~azure.core.exceptions.HttpResponseError:
         """
 
-    @distributed_trace_async
+    # @distributed_trace_async
     async def is_subscribed(
         self,
         endpoint: str = "https://global.livediagnostics.monitor.azure.com",
@@ -360,7 +360,7 @@ class QuickpulseClientOperationsMixin(QuickpulseClientMixinABC):
         :raises ~azure.core.exceptions.HttpResponseError:
         """
 
-    @distributed_trace_async
+    # @distributed_trace_async
     async def publish(
         self,
         endpoint: str = "https://global.livediagnostics.monitor.azure.com",


### PR DESCRIPTION
Live metrics calls are generating spans when combined with `azure.core.opentelemetry.tracing`.

![image](https://github.com/Azure/azure-sdk-for-python/assets/11580155/987f3eb8-6be9-4fdc-8bb2-da39f5783738)

The swaggers are generated incorrectly with `distributed-tracing` decorators, will work with Benke to get this fixed. In the meantime, we will be commenting this out in the generated code. This was generating the `Inproc` span.

The other span of type `WCFService` is created automatically using the `DistrbutedTracingPolicy` created automatically by default when using the QuickPulseClient. We are now passing in our own list of policies that we care about, and explicitly omitting the DT policy so calls using the client won't be traced.