### PR TITLE
[corehttp] Linting updates

### DIFF
--- a/sdk/core/corehttp/corehttp/rest/_aiohttp.py
+++ b/sdk/core/corehttp/corehttp/rest/_aiohttp.py
@@ -30,7 +30,7 @@ import logging
 from itertools import groupby
 from typing import Iterator, cast, TYPE_CHECKING
 from multidict import CIMultiDict
-import aiohttp.client_exceptions  # pylint: disable=all
+import aiohttp.client_exceptions  # pylint: disable=networking-import-outside-azure-core-transport
 
 from ._http_response_impl_async import AsyncHttpResponseImpl
 from ..exceptions import (

--- a/sdk/core/corehttp/corehttp/rest/_http_response_impl.py
+++ b/sdk/core/corehttp/corehttp/rest/_http_response_impl.py
@@ -292,12 +292,7 @@ class HttpResponseImpl(_HttpResponseBaseImpl, _HttpResponse):
                 yield self.content[i : i + chunk_size]
         else:
             self._stream_download_check()
-            for part in self._stream_download_generator(
-                response=self,
-                pipeline=None,
-                decompress=True,
-            ):
-                yield part
+            yield from self._stream_download_generator(response=self, pipeline=None, decompress=True)
         self.close()
 
     def iter_raw(self, **kwargs) -> Iterator[bytes]:
@@ -307,6 +302,5 @@ class HttpResponseImpl(_HttpResponseBaseImpl, _HttpResponse):
         :rtype: Iterator[str]
         """
         self._stream_download_check()
-        for part in self._stream_download_generator(response=self, pipeline=None, decompress=False):
-            yield part
+        yield from self._stream_download_generator(response=self, pipeline=None, decompress=False)
         self.close()

--- a/sdk/core/corehttp/corehttp/rest/_requests_basic.py
+++ b/sdk/core/corehttp/corehttp/rest/_requests_basic.py
@@ -27,8 +27,8 @@ from __future__ import annotations
 import logging
 import collections.abc as collections
 from typing import TYPE_CHECKING, Any
-import requests  # pylint: disable=all
-from requests.structures import CaseInsensitiveDict  # pylint: disable=all
+import requests  # pylint: disable=networking-import-outside-azure-core-transport
+from requests.structures import CaseInsensitiveDict  # pylint: disable=networking-import-outside-azure-core-transport
 from urllib3.exceptions import (
     DecodeError as CoreDecodeError,
     ReadTimeoutError,
@@ -172,8 +172,7 @@ def _read_raw_stream(response, chunk_size=1):
     # Special case for urllib3.
     if hasattr(response.raw, "stream"):
         try:
-            for chunk in response.raw.stream(chunk_size, decode_content=False):
-                yield chunk
+            yield from response.raw.stream(chunk_size, decode_content=False)
         except ProtocolError as e:
             raise ServiceResponseError(e, error=e) from e
         except CoreDecodeError as e:

--- a/sdk/core/corehttp/corehttp/transport/aiohttp/_aiohttp.py
+++ b/sdk/core/corehttp/corehttp/transport/aiohttp/_aiohttp.py
@@ -29,8 +29,8 @@ from types import TracebackType
 
 import logging
 import asyncio
-import aiohttp  # pylint: disable=all
-import aiohttp.client_exceptions  # pylint: disable=all
+import aiohttp  # pylint: disable=networking-import-outside-azure-core-transport
+import aiohttp.client_exceptions  # pylint: disable=networking-import-outside-azure-core-transport
 
 from ...exceptions import (
     ServiceRequestError,

--- a/sdk/core/corehttp/corehttp/transport/requests/_bigger_block_size_http_adapters.py
+++ b/sdk/core/corehttp/corehttp/transport/requests/_bigger_block_size_http_adapters.py
@@ -27,7 +27,7 @@
 import sys
 from typing import MutableMapping, Optional
 
-from requests.adapters import HTTPAdapter  # pylint: disable=all
+from requests.adapters import HTTPAdapter  # pylint: disable=networking-import-outside-azure-core-transport
 from urllib3.connectionpool import ConnectionPool
 
 

--- a/sdk/core/corehttp/corehttp/transport/requests/_requests_basic.py
+++ b/sdk/core/corehttp/corehttp/transport/requests/_requests_basic.py
@@ -31,7 +31,7 @@ from urllib3.exceptions import (
     NewConnectionError,
     ConnectTimeoutError,
 )
-import requests  # pylint: disable=all
+import requests  # pylint: disable=networking-import-outside-azure-core-transport
 
 from ...exceptions import (
     ServiceRequestError,


### PR DESCRIPTION
Found that `pylint: disable=all` comments on a line disables pylint checking for the rest of the file and not just the line. These comments were updated, and code changes were made to pass the next pylint check.
