### PR TITLE
[Identity] Fix device code tests

### DIFF
--- a/sdk/identity/azure-identity/tests/helpers.py
+++ b/sdk/identity/azure-identity/tests/helpers.py
@@ -162,7 +162,12 @@ def get_discovery_response(endpoint="https://a/b"):
     sufficient. MSAL will send token requests to "{endpoint}/oauth2/v2.0/token_endpoint" after receiving a tenant
     discovery response created by this method.
     """
-    aad_metadata_endpoint_names = ("authorization_endpoint", "token_endpoint", "tenant_discovery_endpoint")
+    aad_metadata_endpoint_names = (
+        "authorization_endpoint",
+        "token_endpoint",
+        "tenant_discovery_endpoint",
+        "device_authorization_endpoint",
+    )
     payload = {name: endpoint + "/oauth2/v2.0/" + name for name in aad_metadata_endpoint_names}
     payload["metadata"] = ""
     return mock_response(json_payload=payload)

--- a/sdk/identity/azure-identity/tests/test_device_code_credential.py
+++ b/sdk/identity/azure-identity/tests/test_device_code_credential.py
@@ -178,7 +178,7 @@ def test_device_code_credential():
         requests=[Request()] * 3,  # not validating requests because they're formed by MSAL
         responses=[
             # expected requests: discover tenant, start device code flow, poll for completion
-            mock_response(json_payload={"authorization_endpoint": "https://a/b", "token_endpoint": "https://a/b"}),
+            get_discovery_response(),
             mock_response(
                 json_payload={
                     "device_code": "_",
@@ -237,7 +237,7 @@ def test_tenant_id():
         requests=[Request()] * 3,  # not validating requests because they're formed by MSAL
         responses=[
             # expected requests: discover tenant, start device code flow, poll for completion
-            mock_response(json_payload={"authorization_endpoint": "https://a/b", "token_endpoint": "https://a/b"}),
+            get_discovery_response(),
             mock_response(
                 json_payload={
                     "device_code": "_",


### PR DESCRIPTION
A recent [change](https://github.com/AzureAD/microsoft-authentication-library-for-python/commit/3a5990ad504abd3c3cbaa038d15df8963a6284e4) in MSAL made it so that the "device_authorization_endpoint" is no longer faked/populated as it's always expected to be in the discovery response ([example](https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration)). Our tests seemingly relied on this fallback behavior since our mock discovery response didn't return a "device_authorization_endpoint" value. This updates our mock response accordingly.

