### PR TITLE
Export InputTypes from constants

### DIFF
--- a/sdk/ml/azure-ai-ml/CHANGELOG.md
+++ b/sdk/ml/azure-ai-ml/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features Added
 
 ### Bugs Fixed
+- InputTypes exported in constants module
 
 ### Breaking Changes
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/constants/__init__.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/constants/__init__.py
@@ -8,7 +8,7 @@ __path__ = __import__("pkgutil").extend_path(__path__, __name__)
 from azure.ai.ml._restclient.v2023_10_01.models import ListViewType
 
 from ._assets import IPProtectionLevel
-from ._common import AssetTypes, InputOutputModes, ModelType, Scope, TimeZone, WorkspaceKind
+from ._common import AssetTypes, InputTypes, InputOutputModes, ModelType, Scope, TimeZone, WorkspaceKind
 from ._component import ParallelTaskType
 from ._deployment import BatchDeploymentOutputAction
 from ._job import (
@@ -40,6 +40,7 @@ __all__ = [
     "JobType",
     "ParallelTaskType",
     "AssetTypes",
+    "InputTypes",
     "InputOutputModes",
     "DistributionType",
     "TimeZone",


### PR DESCRIPTION
# Description

InputTypes should be exported in the same way as AssetTypes in constants module, so there is no need to use literals types when using literal Inputs.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
