### PR TITLE
[Key Vault] Update tests to only record with Managed Identity

### DIFF
--- a/sdk/keyvault/azure-keyvault-administration/README.md
+++ b/sdk/keyvault/azure-keyvault-administration/README.md
@@ -65,20 +65,28 @@ client = KeyVaultAccessControlClient(vault_url=MANAGED_HSM_URL, credential=crede
 > **NOTE:** For an asynchronous client, import `azure.keyvault.administration.aio`'s `KeyVaultAccessControlClient` instead.
 
 #### Create a KeyVaultBackupClient
-After configuring your environment for the [DefaultAzureCredential][default_cred_ref] to use a suitable method of authentication, you can do the following to create a backup client (replacing the value of `vault_url` with your Managed HSM's URL):
+After creating a user-assigned [managed identity][managed_identity] and granting it access to your Managed HSM, you can
+do the following to create a backup client (setting the value of `CLIENT_ID` to your managed identity's client ID):
 
 <!-- SNIPPET:backup_restore_operations.create_a_backup_restore_client -->
 
 ```python
-from azure.identity import DefaultAzureCredential
+from azure.identity import ManagedIdentityCredential
 from azure.keyvault.administration import KeyVaultBackupClient
 
 MANAGED_HSM_URL = os.environ["MANAGED_HSM_URL"]
-credential = DefaultAzureCredential()
+MANAGED_IDENTITY_CLIENT_ID = os.environ["CLIENT_ID"]
+credential = ManagedIdentityCredential(client_id=MANAGED_IDENTITY_CLIENT_ID)
 client = KeyVaultBackupClient(vault_url=MANAGED_HSM_URL, credential=credential)
 ```
 
 <!-- END SNIPPET -->
+
+Using the `ManagedIdentityCredential` is preferred in order to enable authenticating backup and restore operations with
+Managed Identity. Any other `azure-identity` credential could be provided instead if SAS tokens are used in these
+operations.
+
+See [azure-identity][managed_identity_ref] documentation for more information on Managed Identity authentication.
 
 > **NOTE:** For an asynchronous client, import `azure.keyvault.administration.aio`'s `KeyVaultBackupClient` instead.
 
@@ -265,7 +273,8 @@ client.delete_role_assignment(scope=scope, name=role_assignment.name)
 
 ### Perform a full key backup
 The `KeyVaultBackupClient` can be used to back up your entire collection of keys. The backing store for full key
-backups is a blob storage container using Shared Access Signature (SAS) authentication.
+backups is a blob storage container using either Managed Identity (which is preferred) or Shared Access Signature (SAS)
+authentication.
 
 For more details on creating a SAS token using a `BlobServiceClient` from [`azure-storage-blob`][storage_blob], refer
 to the library's [credential documentation][sas_docs]. Alternatively, it is possible to
@@ -275,9 +284,8 @@ to the library's [credential documentation][sas_docs]. Alternatively, it is poss
 
 ```python
 CONTAINER_URL = os.environ["CONTAINER_URL"]
-SAS_TOKEN = os.environ["SAS_TOKEN"]
 
-backup_result: KeyVaultBackupResult = client.begin_backup(CONTAINER_URL, sas_token=SAS_TOKEN).result()
+backup_result: KeyVaultBackupResult = client.begin_backup(CONTAINER_URL, use_managed_identity=True).result()
 print(f"Azure Storage Blob URL of the backup: {backup_result.folder_url}")
 ```
 
@@ -289,8 +297,9 @@ the operation is complete without returning an object.
 
 ### Perform a full key restore
 The `KeyVaultBackupClient` can be used to restore your entire collection of keys from a backup. The data source for a
-full key restore is a storage blob accessed using Shared Access Signature authentication. You will also need the URL of
-the backup (`KeyVaultBackupResult.folder_url`) from the [above snippet](#perform-a-full-key-backup).
+full key restore is a storage blob accessed using either Managed Identity (which is preferred) or Shared Access
+Signature authentication. You will also need the URL of the backup (`KeyVaultBackupResult.folder_url`) from the
+[above snippet](#perform-a-full-key-backup).
 
 For more details on creating a SAS token using a `BlobServiceClient` from [`azure-storage-blob`][storage_blob], refer
 to the library's [credential documentation][sas_docs]. Alternatively, it is possible to
@@ -299,10 +308,8 @@ to the library's [credential documentation][sas_docs]. Alternatively, it is poss
 <!-- SNIPPET:backup_restore_operations.begin_restore -->
 
 ```python
-SAS_TOKEN = os.environ["SAS_TOKEN"]
-
 # `backup_result` is the KeyVaultBackupResult returned by `begin_backup`
-client.begin_restore(backup_result.folder_url, sas_token=SAS_TOKEN).wait()
+client.begin_restore(backup_result.folder_url, use_managed_identity=True).wait()
 print("Vault restored successfully.")
 ```
 
@@ -398,7 +405,8 @@ contact opencode@microsoft.com with any additional questions or comments.
 
 [managed_hsm]: https://docs.microsoft.com/azure/key-vault/managed-hsm/overview
 [managed_hsm_cli]: https://docs.microsoft.com/azure/key-vault/managed-hsm/quick-create-cli
-[managed_identity]: https://docs.microsoft.com/azure/active-directory/managed-identities-azure-resources/overview
+[managed_identity]: https://learn.microsoft.com/entra/identity/managed-identities-azure-resources/overview
+[managed_identity_ref]: https://aka.ms/azsdk/python/identity/docs#azure.identity.ManagedIdentityCredential
 
 [pip]: https://pypi.org/project/pip/
 [pypi_package_administration]: https://pypi.org/project/azure-keyvault-administration

--- a/sdk/keyvault/azure-keyvault-administration/README.md
+++ b/sdk/keyvault/azure-keyvault-administration/README.md
@@ -65,8 +65,9 @@ client = KeyVaultAccessControlClient(vault_url=MANAGED_HSM_URL, credential=crede
 > **NOTE:** For an asynchronous client, import `azure.keyvault.administration.aio`'s `KeyVaultAccessControlClient` instead.
 
 #### Create a KeyVaultBackupClient
-After creating a user-assigned [managed identity][managed_identity] and granting it access to your Managed HSM, you can
-do the following to create a backup client (setting the value of `CLIENT_ID` to your managed identity's client ID):
+After creating a user-assigned [managed identity][managed_identity] and
+[granting it access to your Managed HSM][managed_identity_backup_setup], you can do the following to create a backup
+client (setting the value of `CLIENT_ID` to your managed identity's client ID):
 
 <!-- SNIPPET:backup_restore_operations.create_a_backup_restore_client -->
 
@@ -276,6 +277,9 @@ The `KeyVaultBackupClient` can be used to back up your entire collection of keys
 backups is a blob storage container using either Managed Identity (which is preferred) or Shared Access Signature (SAS)
 authentication.
 
+If using Managed Identity, first make sure your user-assigned managed identity has the correct access to your Storage
+account and Managed HSM per [the service's guidance][managed_identity_backup_setup].
+
 For more details on creating a SAS token using a `BlobServiceClient` from [`azure-storage-blob`][storage_blob], refer
 to the library's [credential documentation][sas_docs]. Alternatively, it is possible to
 [generate a SAS token in Storage Explorer][storage_explorer].
@@ -300,6 +304,9 @@ The `KeyVaultBackupClient` can be used to restore your entire collection of keys
 full key restore is a storage blob accessed using either Managed Identity (which is preferred) or Shared Access
 Signature authentication. You will also need the URL of the backup (`KeyVaultBackupResult.folder_url`) from the
 [above snippet](#perform-a-full-key-backup).
+
+If using Managed Identity, first make sure your user-assigned managed identity has the correct access to your Storage
+account and Managed HSM per [the service's guidance][managed_identity_backup_setup].
 
 For more details on creating a SAS token using a `BlobServiceClient` from [`azure-storage-blob`][storage_blob], refer
 to the library's [credential documentation][sas_docs]. Alternatively, it is possible to
@@ -406,6 +413,7 @@ contact opencode@microsoft.com with any additional questions or comments.
 [managed_hsm]: https://docs.microsoft.com/azure/key-vault/managed-hsm/overview
 [managed_hsm_cli]: https://docs.microsoft.com/azure/key-vault/managed-hsm/quick-create-cli
 [managed_identity]: https://learn.microsoft.com/entra/identity/managed-identities-azure-resources/overview
+[managed_identity_backup_setup]: https://learn.microsoft.com/azure/key-vault/managed-hsm/backup-restore#prerequisites-if-backing-up-and-restoring-using-user-assigned-managed-identity
 [managed_identity_ref]: https://aka.ms/azsdk/python/identity/docs#azure.identity.ManagedIdentityCredential
 
 [pip]: https://pypi.org/project/pip/

--- a/sdk/keyvault/azure-keyvault-administration/README.md
+++ b/sdk/keyvault/azure-keyvault-administration/README.md
@@ -302,7 +302,7 @@ the operation is complete without returning an object.
 ### Perform a full key restore
 The `KeyVaultBackupClient` can be used to restore your entire collection of keys from a backup. The data source for a
 full key restore is a storage blob accessed using either Managed Identity (which is preferred) or Shared Access
-Signature authentication. You will also need the URL of the backup (`KeyVaultBackupResult.folder_url`) from the
+Signature (SAS) authentication. You will also need the URL of the backup (`KeyVaultBackupResult.folder_url`) from the
 [above snippet](#perform-a-full-key-backup).
 
 If using Managed Identity, first make sure your user-assigned managed identity has the correct access to your Storage

--- a/sdk/keyvault/azure-keyvault-administration/assets.json
+++ b/sdk/keyvault/azure-keyvault-administration/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "python",
   "TagPrefix": "python/keyvault/azure-keyvault-administration",
-  "Tag": "python/keyvault/azure-keyvault-administration_ee2ddfc306"
+  "Tag": "python/keyvault/azure-keyvault-administration_df93633a52"
 }

--- a/sdk/keyvault/azure-keyvault-administration/assets.json
+++ b/sdk/keyvault/azure-keyvault-administration/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "python",
   "TagPrefix": "python/keyvault/azure-keyvault-administration",
-  "Tag": "python/keyvault/azure-keyvault-administration_3353e6edf1"
+  "Tag": "python/keyvault/azure-keyvault-administration_ee2ddfc306"
 }

--- a/sdk/keyvault/azure-keyvault-administration/samples/backup_restore_operations.py
+++ b/sdk/keyvault/azure-keyvault-administration/samples/backup_restore_operations.py
@@ -13,15 +13,16 @@ from azure.keyvault.administration import KeyVaultBackupResult
 # 2. azure-keyvault-administration and azure-identity libraries (pip install these)
 #
 # 3. Set environment variable MANAGED_HSM_URL with the URL of your managed HSM
-#    
-# 4. Set up your environment to use azure-identity's DefaultAzureCredential. For more information about how to configure
-#    the DefaultAzureCredential, refer to https://aka.ms/azsdk/python/identity/docs#azure.identity.DefaultAzureCredential
 #
-# 5. A storage account containing a blob storage container
+# 4. A user-assigned managed identity that has access to your managed HSM. For more information about how to create a
+#    user-assigned managed identity, refer to
+#    https://learn.microsoft.com/entra/identity/managed-identities-azure-resources/overview
+#    
+# 5. A storage account, that your managed identity has access to, containing a blob storage container
 #    (See https://docs.microsoft.com/azure/storage/blobs/storage-blobs-introduction)
 #
-# 6. Set environment variables CONTAINER_URL and SAS_TOKEN corresponding to your blob container's URI and SAS
-#    (See https://docs.microsoft.com/azure/storage/common/storage-sas-overview)
+# 6. Set environment variables CONTAINER_URL and CLIENT_ID, corresponding to your blob container's URI and your
+#    user-assigned managed identity's client ID, respectively.
 #
 # For more details, see https://docs.microsoft.com/azure/key-vault/managed-hsm/backup-restore
 #
@@ -34,13 +35,15 @@ from azure.keyvault.administration import KeyVaultBackupResult
 # ----------------------------------------------------------------------------------------------------------
 
 # Instantiate a backup client that will be used to call the service.
-# Here we use the DefaultAzureCredential, but any azure-identity credential can be used.
+# Here we use the ManagedIdentityCredential to use Managed Identity, but any azure-identity credential can be used if
+# opting for SAS token authentication.
 # [START create_a_backup_restore_client]
-from azure.identity import DefaultAzureCredential
+from azure.identity import ManagedIdentityCredential
 from azure.keyvault.administration import KeyVaultBackupClient
 
 MANAGED_HSM_URL = os.environ["MANAGED_HSM_URL"]
-credential = DefaultAzureCredential()
+MANAGED_IDENTITY_CLIENT_ID = os.environ["CLIENT_ID"]
+credential = ManagedIdentityCredential(client_id=MANAGED_IDENTITY_CLIENT_ID)
 client = KeyVaultBackupClient(vault_url=MANAGED_HSM_URL, credential=credential)
 # [END create_a_backup_restore_client]
 
@@ -50,9 +53,8 @@ client = KeyVaultBackupClient(vault_url=MANAGED_HSM_URL, credential=credential)
 print("\n.. Back up the vault")
 # [START begin_backup]
 CONTAINER_URL = os.environ["CONTAINER_URL"]
-SAS_TOKEN = os.environ["SAS_TOKEN"]
 
-backup_result: KeyVaultBackupResult = client.begin_backup(CONTAINER_URL, sas_token=SAS_TOKEN).result()
+backup_result: KeyVaultBackupResult = client.begin_backup(CONTAINER_URL, use_managed_identity=True).result()
 print(f"Azure Storage Blob URL of the backup: {backup_result.folder_url}")
 # [END begin_backup]
 print("Vault backed up successfully.")
@@ -63,9 +65,7 @@ assert backup_result.folder_url
 # To restore a single key from the backed up vault instead, pass the key_name keyword argument.
 print("\n.. Restore the full vault")
 # [START begin_restore]
-SAS_TOKEN = os.environ["SAS_TOKEN"]
-
 # `backup_result` is the KeyVaultBackupResult returned by `begin_backup`
-client.begin_restore(backup_result.folder_url, sas_token=SAS_TOKEN).wait()
+client.begin_restore(backup_result.folder_url, use_managed_identity=True).wait()
 print("Vault restored successfully.")
 # [END begin_restore]

--- a/sdk/keyvault/azure-keyvault-administration/tests/test_backup_client.py
+++ b/sdk/keyvault/azure-keyvault-administration/tests/test_backup_client.py
@@ -4,18 +4,18 @@
 # ------------------------------------
 import time
 from functools import partial
-from unittest import mock
 
 import pytest
 from azure.core.exceptions import ResourceExistsError
-from azure.keyvault.administration import KeyVaultBackupClient
 from azure.keyvault.administration._internal import parse_folder_url
+from azure.keyvault.administration._internal.client_base import DEFAULT_VERSION
 from devtools_testutils import recorded_by_proxy, set_bodiless_matcher
 
 from _shared.test_case import KeyVaultTestCase
-from _test_case import KeyVaultBackupClientPreparer, get_decorator
+from _test_case import KeyVaultBackupClientPreparer, KeyVaultBackupClientSasPreparer, get_decorator
 
 all_api_versions = get_decorator()
+only_default = get_decorator(api_versions=[DEFAULT_VERSION])
 
 
 class TestBackupClientTests(KeyVaultTestCase):
@@ -25,39 +25,36 @@ class TestBackupClientTests(KeyVaultTestCase):
         credential = self.get_credential(KeyClient)
         return self.create_client_from_credential(KeyClient, credential=credential, vault_url=vault_uri, **kwargs )
 
-    @pytest.mark.parametrize("api_version", all_api_versions)
+    @pytest.mark.parametrize("api_version", only_default)
     @KeyVaultBackupClientPreparer()
     @recorded_by_proxy
     def test_full_backup_and_restore(self, client, **kwargs):
         set_bodiless_matcher()
         # backup the vault
         container_uri = kwargs.pop("container_uri")
-        sas_token = kwargs.pop("sas_token")
-        backup_poller = client.begin_backup(container_uri, sas_token)
+        backup_poller = client.begin_backup(container_uri, use_managed_identity=True)
         backup_operation = backup_poller.result()
         assert backup_operation.folder_url
 
         # restore the backup
-        restore_poller = client.begin_restore(backup_operation.folder_url, sas_token)
+        restore_poller = client.begin_restore(backup_operation.folder_url, use_managed_identity=True)
         restore_poller.wait()
         if self.is_live:
             time.sleep(60)  # additional waiting to avoid conflicts with resources in other tests
 
-    @pytest.mark.parametrize("api_version", all_api_versions)
+    @pytest.mark.parametrize("api_version", only_default)
     @KeyVaultBackupClientPreparer()
     @recorded_by_proxy
     def test_full_backup_and_restore_rehydration(self, client, **kwargs):
         set_bodiless_matcher()
         container_uri = kwargs.pop("container_uri")
-        sas_token = kwargs.pop("sas_token")
 
         # backup the vault
-        backup_poller = client.begin_backup(blob_storage_url=container_uri, sas_token=sas_token)
+        backup_poller = client.begin_backup(blob_storage_url=container_uri, use_managed_identity=True)
 
         # create a new poller from a continuation token
-        # pass `sas_token` as a positional parameter to ensure backwards compatibility
         token = backup_poller.continuation_token()
-        rehydrated = client.begin_backup(container_uri, sas_token, continuation_token=token)
+        rehydrated = client.begin_backup(container_uri, use_managed_identity=True, continuation_token=token)
 
         rehydrated_operation = rehydrated.result()
         assert rehydrated_operation.folder_url
@@ -65,19 +62,20 @@ class TestBackupClientTests(KeyVaultTestCase):
         assert backup_operation.folder_url == rehydrated_operation.folder_url
 
         # restore the backup
-        restore_poller = client.begin_restore(folder_url=backup_operation.folder_url, sas_token=sas_token)
+        restore_poller = client.begin_restore(folder_url=backup_operation.folder_url, use_managed_identity=True)
 
         # create a new poller from a continuation token
-        # pass `sas_token` as a positional parameter to ensure backwards compatibility
         token = restore_poller.continuation_token()
-        rehydrated = client.begin_restore(backup_operation.folder_url, sas_token, continuation_token=token)
+        rehydrated = client.begin_restore(
+            backup_operation.folder_url, use_managed_identity=True, continuation_token=token
+        )
 
         rehydrated.wait()
         restore_poller.wait()
         if self.is_live:
             time.sleep(60)  # additional waiting to avoid conflicts with resources in other tests
 
-    @pytest.mark.parametrize("api_version", all_api_versions)
+    @pytest.mark.parametrize("api_version", only_default)
     @KeyVaultBackupClientPreparer()
     @recorded_by_proxy
     def test_selective_key_restore(self, client, **kwargs):
@@ -91,12 +89,11 @@ class TestBackupClientTests(KeyVaultTestCase):
 
         # backup the vault
         container_uri = kwargs.pop("container_uri")
-        sas_token = kwargs.pop("sas_token")
-        backup_poller = client.begin_backup(container_uri, sas_token)
+        backup_poller = client.begin_backup(container_uri, use_managed_identity=True)
         backup_operation = backup_poller.result()
 
         # restore the key
-        restore_poller = client.begin_restore(backup_operation.folder_url, sas_token, key_name=key_name)
+        restore_poller = client.begin_restore(backup_operation.folder_url, use_managed_identity=True, key_name=key_name)
         restore_poller.wait()
 
         # delete the key
@@ -107,7 +104,7 @@ class TestBackupClientTests(KeyVaultTestCase):
         if self.is_live:
             time.sleep(60)  # additional waiting to avoid conflicts with resources in other tests
 
-    @pytest.mark.parametrize("api_version", all_api_versions)
+    @pytest.mark.parametrize("api_version", only_default)
     @KeyVaultBackupClientPreparer()
     @recorded_by_proxy
     def test_backup_client_polling(self, client, **kwargs):
@@ -115,12 +112,11 @@ class TestBackupClientTests(KeyVaultTestCase):
 
         # backup the vault
         container_uri = kwargs.pop("container_uri")
-        sas_token = kwargs.pop("sas_token")
-        backup_poller = client.begin_backup(container_uri, sas_token)
+        backup_poller = client.begin_backup(container_uri, use_managed_identity=True)
 
         # create a new poller from a continuation token
         token = backup_poller.continuation_token()
-        rehydrated = client.begin_backup(container_uri, sas_token, continuation_token=token)
+        rehydrated = client.begin_backup(container_uri, use_managed_identity=True, continuation_token=token)
 
         # check that pollers and polling methods behave as expected
         if self.is_live:
@@ -136,16 +132,18 @@ class TestBackupClientTests(KeyVaultTestCase):
         assert backup_operation.folder_url == rehydrated_operation.folder_url
 
         # rehydrate a poller with a continuation token of a completed operation
-        late_rehydrated = client.begin_backup(container_uri, sas_token, continuation_token=token)
+        late_rehydrated = client.begin_backup(container_uri, use_managed_identity=True, continuation_token=token)
         assert late_rehydrated.status() == "Succeeded"
         late_rehydrated.wait()
 
         # restore the backup
-        restore_poller = client.begin_restore(backup_operation.folder_url, sas_token)
+        restore_poller = client.begin_restore(backup_operation.folder_url, use_managed_identity=True)
 
         # create a new poller from a continuation token
         token = restore_poller.continuation_token()
-        rehydrated = client.begin_restore(backup_operation.folder_url, sas_token, continuation_token=token)
+        rehydrated = client.begin_restore(
+            backup_operation.folder_url, use_managed_identity=True, continuation_token=token
+        )
 
         # check that pollers and polling methods behave as expected
         if self.is_live:
@@ -162,36 +160,22 @@ class TestBackupClientTests(KeyVaultTestCase):
         if self.is_live:
             time.sleep(60)  # additional waiting to avoid conflicts with resources in other tests
 
+    @pytest.mark.live_test_only
+    @pytest.mark.parametrize("api_version", only_default)
+    @KeyVaultBackupClientSasPreparer()
+    def test_backup_restore_sas(self, client, **kwargs):
+        # backup the vault
+        container_uri = kwargs.pop("container_uri")
+        sas_token = kwargs.pop("sas_token")
+        backup_poller = client.begin_backup(container_uri, sas_token)
+        backup_operation = backup_poller.result()
+        assert backup_operation.folder_url
 
-def test_backup_restore_managed_identity():
-    """Try first with a non-MI credential to authenticate the client."""
-    # backup
-    mock_client = mock.Mock()
-    client = KeyVaultBackupClient("https://vault-url.vault.azure.net", mock.Mock())
-    client._client = mock_client
-    client.begin_backup("container_uri", use_managed_identity=True)
-
-    called_with = mock_client.begin_full_backup.call_args
-    assert "use_managed_identity" not in called_with[1]  # ensure we pop off the kwarg correctly
-    sas_token_parameters = called_with[1]["azure_storage_blob_container_uri"]
-    assert sas_token_parameters.use_managed_identity is True
-
-    # full restore
-    client.begin_restore("folder_uri", use_managed_identity=True)
-    called_with = mock_client.begin_full_restore_operation.call_args
-    assert "use_managed_identity" not in called_with[1]  # ensure we pop off the kwarg correctly
-    restore_details = called_with[1]["restore_blob_details"]
-    sas_token_parameters = restore_details.sas_token_parameters
-    assert sas_token_parameters.use_managed_identity is True
-
-    # selective restore
-    client.begin_restore("folder_uri", use_managed_identity=True, key_name="key-name")
-    called_with = mock_client.begin_selective_key_restore_operation.call_args
-    assert "use_managed_identity" not in called_with[1]  # ensure we pop off the kwarg correctly
-    assert called_with[1]["key_name"] == "key-name"
-    restore_details = called_with[1]["restore_blob_details"]
-    sas_token_parameters = restore_details.sas_token_parameters
-    assert sas_token_parameters.use_managed_identity is True
+        # restore the backup
+        restore_poller = client.begin_restore(backup_operation.folder_url, sas_token)
+        restore_poller.wait()
+        if self.is_live:
+            time.sleep(60)  # additional waiting to avoid conflicts with resources in other tests
 
 
 @pytest.mark.parametrize(

--- a/sdk/keyvault/azure-keyvault-administration/tests/test_backup_client_async.py
+++ b/sdk/keyvault/azure-keyvault-administration/tests/test_backup_client_async.py
@@ -3,19 +3,18 @@
 # Licensed under the MIT License.
 # ------------------------------------
 import asyncio
-from functools import wraps
-from unittest import mock
 
 import pytest
 from azure.core.exceptions import ResourceExistsError
-from azure.keyvault.administration.aio import KeyVaultBackupClient
+from azure.keyvault.administration._internal.client_base import DEFAULT_VERSION
 from devtools_testutils import set_bodiless_matcher
 from devtools_testutils.aio import recorded_by_proxy_async
 
-from _async_test_case import KeyVaultBackupClientPreparer, get_decorator
+from _async_test_case import KeyVaultBackupClientPreparer, KeyVaultBackupClientSasPreparer, get_decorator
 from _shared.test_case_async import KeyVaultTestCase
 
 all_api_versions = get_decorator(is_async=True)
+only_default = get_decorator(is_async=True, api_versions=[DEFAULT_VERSION])
 
 
 class TestBackupClientTests(KeyVaultTestCase):
@@ -25,26 +24,25 @@ class TestBackupClientTests(KeyVaultTestCase):
          return self.create_client_from_credential(KeyClient, credential=credential, vault_url=vault_uri, **kwargs )
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("api_version", all_api_versions)
+    @pytest.mark.parametrize("api_version", only_default)
     @KeyVaultBackupClientPreparer()
     @recorded_by_proxy_async
     async def test_full_backup_and_restore(self, client, **kwargs):
         set_bodiless_matcher()
         # backup the vault
         container_uri = kwargs.pop("container_uri")
-        sas_token = kwargs.pop("sas_token")
-        backup_poller = await client.begin_backup(container_uri, sas_token)
+        backup_poller = await client.begin_backup(container_uri, use_managed_identity=True)
         backup_operation = await backup_poller.result()
         assert backup_operation.folder_url
 
         # restore the backup
-        restore_poller = await client.begin_restore(backup_operation.folder_url, sas_token)
+        restore_poller = await client.begin_restore(backup_operation.folder_url, use_managed_identity=True)
         await restore_poller.wait()
         if self.is_live:
             await asyncio.sleep(60)  # additional waiting to avoid conflicts with resources in other tests
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("api_version", all_api_versions)
+    @pytest.mark.parametrize("api_version", only_default)
     @KeyVaultBackupClientPreparer()
     @recorded_by_proxy_async
     async def test_full_backup_and_restore_rehydration(self, client, **kwargs):
@@ -52,13 +50,11 @@ class TestBackupClientTests(KeyVaultTestCase):
 
         # backup the vault
         container_uri = kwargs.pop("container_uri")
-        sas_token = kwargs.pop("sas_token")
-        backup_poller = await client.begin_backup(blob_storage_url=container_uri, sas_token=sas_token)
+        backup_poller = await client.begin_backup(blob_storage_url=container_uri, use_managed_identity=True)
 
         # create a new poller from a continuation token
-        # pass `sas_token` as a positional parameter to ensure backwards compatibility
         token = backup_poller.continuation_token()
-        rehydrated = await client.begin_backup(container_uri, sas_token, continuation_token=token)
+        rehydrated = await client.begin_backup(container_uri, use_managed_identity=True, continuation_token=token)
 
         rehydrated_operation = await rehydrated.result()
         assert rehydrated_operation.folder_url
@@ -66,12 +62,13 @@ class TestBackupClientTests(KeyVaultTestCase):
         assert backup_operation.folder_url == rehydrated_operation.folder_url
 
         # restore the backup
-        restore_poller = await client.begin_restore(backup_operation.folder_url, sas_token)
+        restore_poller = await client.begin_restore(backup_operation.folder_url, use_managed_identity=True)
 
         # create a new poller from a continuation token
-        # pass `sas_token` as a positional parameter to ensure backwards compatibility
         token = restore_poller.continuation_token()
-        rehydrated = await client.begin_restore(backup_operation.folder_url, sas_token, continuation_token=token)
+        rehydrated = await client.begin_restore(
+            backup_operation.folder_url, use_managed_identity=True, continuation_token=token
+        )
 
         await rehydrated.wait()
         await restore_poller.wait()
@@ -79,7 +76,7 @@ class TestBackupClientTests(KeyVaultTestCase):
             await asyncio.sleep(60)  # additional waiting to avoid conflicts with resources in other tests
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("api_version", all_api_versions)
+    @pytest.mark.parametrize("api_version", only_default)
     @KeyVaultBackupClientPreparer()
     @recorded_by_proxy_async
     async def test_selective_key_restore(self, client, **kwargs):
@@ -92,12 +89,13 @@ class TestBackupClientTests(KeyVaultTestCase):
 
         # backup the vault
         container_uri = kwargs.pop("container_uri")
-        sas_token = kwargs.pop("sas_token")
-        backup_poller = await client.begin_backup(container_uri, sas_token)
+        backup_poller = await client.begin_backup(container_uri, use_managed_identity=True)
         backup_operation = await backup_poller.result()
 
         # restore the key
-        restore_poller = await client.begin_restore(backup_operation.folder_url, sas_token, key_name=key_name)
+        restore_poller = await client.begin_restore(
+            backup_operation.folder_url, use_managed_identity=True, key_name=key_name
+        )
         await restore_poller.wait()
 
         # delete the key
@@ -107,7 +105,7 @@ class TestBackupClientTests(KeyVaultTestCase):
             await asyncio.sleep(60)  # additional waiting to avoid conflicts with resources in other tests
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("api_version", all_api_versions)
+    @pytest.mark.parametrize("api_version", only_default)
     @KeyVaultBackupClientPreparer()
     @recorded_by_proxy_async
     async def test_backup_client_polling(self, client, **kwargs):
@@ -115,12 +113,11 @@ class TestBackupClientTests(KeyVaultTestCase):
 
         # backup the vault
         container_uri = kwargs.pop("container_uri")
-        sas_token = kwargs.pop("sas_token")
-        backup_poller = await client.begin_backup(container_uri, sas_token)
+        backup_poller = await client.begin_backup(container_uri, use_managed_identity=True)
         
         # create a new poller from a continuation token
         token = backup_poller.continuation_token()
-        rehydrated = await client.begin_backup(container_uri, sas_token, continuation_token=token)
+        rehydrated = await client.begin_backup(container_uri, use_managed_identity=True, continuation_token=token)
 
         # check that pollers and polling methods behave as expected
         if self.is_live:
@@ -136,16 +133,18 @@ class TestBackupClientTests(KeyVaultTestCase):
         assert backup_operation.folder_url == rehydrated_operation.folder_url
 
         # rehydrate a poller with a continuation token of a completed operation
-        late_rehydrated = await client.begin_backup(container_uri, sas_token, continuation_token=token)
+        late_rehydrated = await client.begin_backup(container_uri, use_managed_identity=True, continuation_token=token)
         assert late_rehydrated.status() == "Succeeded"
         await late_rehydrated.wait()
 
         # restore the backup
-        restore_poller = await client.begin_restore(backup_operation.folder_url, sas_token)
+        restore_poller = await client.begin_restore(backup_operation.folder_url, use_managed_identity=True)
 
         # create a new poller from a continuation token
         token = restore_poller.continuation_token()
-        rehydrated = await client.begin_restore(backup_operation.folder_url, sas_token, continuation_token=token)
+        rehydrated = await client.begin_restore(
+            backup_operation.folder_url, use_managed_identity=True, continuation_token=token
+        )
 
         # check that pollers and polling methods behave as expected
         if self.is_live:
@@ -162,59 +161,20 @@ class TestBackupClientTests(KeyVaultTestCase):
         if self.is_live:
             await asyncio.sleep(60)  # additional waiting to avoid conflicts with resources in other tests
 
+    @pytest.mark.live_test_only
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("api_version", only_default)
+    @KeyVaultBackupClientSasPreparer()
+    async def test_backup_restore_sas(self, client, **kwargs):
+        # backup the vault
+        container_uri = kwargs.pop("container_uri")
+        sas_token = kwargs.pop("sas_token")
+        backup_poller = await client.begin_backup(container_uri, sas_token)
+        backup_operation = await backup_poller.result()
+        assert backup_operation.folder_url
 
-@pytest.mark.asyncio
-async def test_backup_restore_managed_identity():
-    """Try first with a non-MI credential to authenticate the client."""
-
-    def get_completed_future(result=None):
-        future = asyncio.Future()
-        future.set_result(result)
-        return future
-
-    def wrap_in_future(fn):
-        """Return a completed Future whose result is the return of fn.
-
-        Added to simplify using unittest.Mock in async code. Python 3.8's AsyncMock would be preferable.
-        """
-
-        @wraps(fn)
-        def wrapper(*args, **kwargs):
-            result = fn(*args, **kwargs)
-            return get_completed_future(result)
-
-        return wrapper
-
-    # backup
-    mock_client = mock.Mock()
-    client = KeyVaultBackupClient("https://vault-url.vault.azure.net", mock.Mock())
-    client._client = mock_client
-    begin_full_backup = mock.Mock()
-    mock_client.begin_full_backup = wrap_in_future(begin_full_backup)
-    await client.begin_backup("container_uri", use_managed_identity=True)
-
-    called_with = begin_full_backup.call_args
-    assert "use_managed_identity" not in called_with[1]  # ensure we pop off the kwarg correctly
-    sas_token_parameters = called_with[1]["azure_storage_blob_container_uri"]
-    assert sas_token_parameters.use_managed_identity is True
-
-    # full restore
-    begin_full_restore_operation = mock.Mock()
-    mock_client.begin_full_restore_operation = wrap_in_future(begin_full_restore_operation)
-    await client.begin_restore("folder_uri", use_managed_identity=True)
-    called_with = begin_full_restore_operation.call_args
-    assert "use_managed_identity" not in called_with[1]  # ensure we pop off the kwarg correctly
-    restore_details = called_with[1]["restore_blob_details"]
-    sas_token_parameters = restore_details.sas_token_parameters
-    assert sas_token_parameters.use_managed_identity is True
-
-    # selective restore
-    begin_selective_key_restore_operation = mock.Mock()
-    mock_client.begin_selective_key_restore_operation = wrap_in_future(begin_selective_key_restore_operation)
-    await client.begin_restore("folder_uri", use_managed_identity=True, key_name="key-name")
-    called_with = begin_selective_key_restore_operation.call_args
-    assert "use_managed_identity" not in called_with[1]  # ensure we pop off the kwarg correctly
-    assert called_with[1]["key_name"] == "key-name"
-    restore_details = called_with[1]["restore_blob_details"]
-    sas_token_parameters = restore_details.sas_token_parameters
-    assert sas_token_parameters.use_managed_identity is True
+        # restore the backup
+        restore_poller = await client.begin_restore(backup_operation.folder_url, sas_token)
+        await restore_poller.wait()
+        if self.is_live:
+            await asyncio.sleep(60)  # additional waiting to avoid conflicts with resources in other tests

--- a/sdk/keyvault/azure-keyvault-administration/tests/test_examples_administration.py
+++ b/sdk/keyvault/azure-keyvault-administration/tests/test_examples_administration.py
@@ -5,12 +5,14 @@
 import time
 
 import pytest
+from azure.keyvault.administration._internal.client_base import DEFAULT_VERSION
 from devtools_testutils import recorded_by_proxy, set_bodiless_matcher
 
 from _shared.test_case import KeyVaultTestCase
 from _test_case import KeyVaultBackupClientPreparer, get_decorator
 
 all_api_versions = get_decorator()
+only_default = get_decorator(api_versions=[DEFAULT_VERSION])
 
 
 class TestExamplesTests(KeyVaultTestCase):
@@ -19,18 +21,17 @@ class TestExamplesTests(KeyVaultTestCase):
         credential = self.get_credential(KeyClient)
         return self.create_client_from_credential(KeyClient, credential=credential, vault_url=vault_uri, **kwargs )
 
-    @pytest.mark.parametrize("api_version", all_api_versions)
+    @pytest.mark.parametrize("api_version", only_default)
     @KeyVaultBackupClientPreparer()
     @recorded_by_proxy
     def test_example_backup_and_restore(self, client, **kwargs):
         set_bodiless_matcher()
         backup_client = client
         container_uri = kwargs.pop("container_uri")
-        sas_token = kwargs.pop("sas_token")
 
         # [START begin_backup]
         # begin a vault backup
-        backup_poller = backup_client.begin_backup(container_uri, sas_token)
+        backup_poller = backup_client.begin_backup(container_uri, use_managed_identity=True)
 
         # check if the backup completed
         done = backup_poller.done()
@@ -44,7 +45,7 @@ class TestExamplesTests(KeyVaultTestCase):
 
         # [START begin_restore]
         # begin a full vault restore
-        restore_poller = backup_client.begin_restore(folder_url, sas_token)
+        restore_poller = backup_client.begin_restore(folder_url, use_managed_identity=True)
 
         # check if the restore completed
         done = restore_poller.done()
@@ -56,7 +57,7 @@ class TestExamplesTests(KeyVaultTestCase):
         if self.is_live:
             time.sleep(60)  # additional waiting to avoid conflicts with resources in other tests
 
-    @pytest.mark.parametrize("api_version", all_api_versions)
+    @pytest.mark.parametrize("api_version", only_default)
     @KeyVaultBackupClientPreparer()
     @recorded_by_proxy
     def test_example_selective_key_restore(self, client,**kwargs):
@@ -68,15 +69,14 @@ class TestExamplesTests(KeyVaultTestCase):
         key_client.create_rsa_key(key_name)
 
         backup_client = client
-        sas_token = kwargs.pop("sas_token")
         container_uri = kwargs.pop("container_uri")
-        backup_poller = backup_client.begin_backup(container_uri, sas_token)
+        backup_poller = backup_client.begin_backup(container_uri, use_managed_identity=True)
         backup_operation = backup_poller.result()
         folder_url = backup_operation.folder_url
 
         # [START begin_selective_restore]
         # begin a restore of a single key from a backed up vault
-        restore_poller = backup_client.begin_restore(folder_url, sas_token, key_name=key_name)
+        restore_poller = backup_client.begin_restore(folder_url, use_managed_identity=True, key_name=key_name)
 
         # check if the restore completed
         done = restore_poller.done()


### PR DESCRIPTION
# Description

In `azure-keyvault-administration`, backup and restore operations can be authenticated with either Managed Identity or SAS tokens. Since support for the former was only recently added and the setup is harder to record with, recorded tests have used the latter method. This PR updates tests to instead use Managed Identity for recorded tests, and also updates KV documentation to lead users toward Managed Identity instead of SAS tokens.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
