### PR TITLE
[ServiceBus] Fix for Lock

### DIFF
--- a/sdk/servicebus/azure-servicebus/CHANGELOG.md
+++ b/sdk/servicebus/azure-servicebus/CHANGELOG.md
@@ -7,6 +7,8 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+ 
+ - Fixed a bug where token refreshes were not happening on long running operations ([35717](https://github.com/Azure/azure-sdk-for-python/issues/35717))
 
 ### Other Changes
 

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_common/auto_lock_renewer.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_common/auto_lock_renewer.py
@@ -293,7 +293,9 @@ class AutoLockRenewer(object):  # pylint:disable=too-many-instance-attributes
             )
 
         _log.debug(
-            "Running lock auto-renew for %r for %r seconds", renewable, max_lock_renewal_duration or self._max_lock_renewal_duration
+            "Running lock auto-renew for %r for %r seconds",
+            renewable,
+            max_lock_renewal_duration or self._max_lock_renewal_duration
         )
 
         self._init_workers()

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_common/auto_lock_renewer.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_common/auto_lock_renewer.py
@@ -293,7 +293,7 @@ class AutoLockRenewer(object):  # pylint:disable=too-many-instance-attributes
             )
 
         _log.debug(
-            "Running lock auto-renew for %r for %r seconds", renewable, max_lock_renewal_duration
+            "Running lock auto-renew for %r for %r seconds", renewable, max_lock_renewal_duration or self._max_lock_renewal_duration
         )
 
         self._init_workers()

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_client_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_client_async.py
@@ -387,6 +387,9 @@ class AMQPClientAsync(AMQPClientSync):
                 mgmt_link = ManagementOperation(self._session, endpoint=node, **kwargs)
                 self._mgmt_links[node] = mgmt_link
                 await mgmt_link.open()
+        
+        while not self.client_ready_async():
+            time.sleep(0.05)
 
         while not await mgmt_link.ready():
             await self._connection.listen(wait=False)

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_client_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_client_async.py
@@ -389,7 +389,7 @@ class AMQPClientAsync(AMQPClientSync):
                 await mgmt_link.open()
 
         while not self.client_ready_async():
-            time.sleep(0.05)
+            await asyncio.sleep(0.05)
 
         while not await mgmt_link.ready():
             await self._connection.listen(wait=False)

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_client_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_client_async.py
@@ -387,7 +387,7 @@ class AMQPClientAsync(AMQPClientSync):
                 mgmt_link = ManagementOperation(self._session, endpoint=node, **kwargs)
                 self._mgmt_links[node] = mgmt_link
                 await mgmt_link.open()
-        
+
         while not self.client_ready_async():
             time.sleep(0.05)
 

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/client.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/client.py
@@ -463,6 +463,9 @@ class AMQPClient(
                 self._mgmt_links[node] = mgmt_link
                 mgmt_link.open()
 
+        while not self.client_ready():
+            time.sleep(0.05)
+
         while not mgmt_link.ready():
             self._connection.listen(wait=False)
         operation_type = operation_type or b"empty"

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_async_auto_lock_renewer.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_async_auto_lock_renewer.py
@@ -214,6 +214,12 @@ class AutoLockRenewer:
             renew_period_override = (
                 time_until_expiry.seconds * SHORT_RENEW_SCALING_FACTOR
             )
+        
+        _log.debug(
+            "Running lock auto-renew for %r for %r seconds",
+            renewable,
+            max_lock_renewal_duration or self._max_lock_renewal_duration
+        )
 
         renew_future = asyncio.ensure_future(
             self._auto_lock_renew(

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_async_auto_lock_renewer.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_async_auto_lock_renewer.py
@@ -214,12 +214,6 @@ class AutoLockRenewer:
             renew_period_override = (
                 time_until_expiry.seconds * SHORT_RENEW_SCALING_FACTOR
             )
-        
-        _log.debug(
-            "Running lock auto-renew for %r for %r seconds",
-            renewable,
-            max_lock_renewal_duration or self._max_lock_renewal_duration
-        )
 
         renew_future = asyncio.ensure_future(
             self._auto_lock_renew(


### PR DESCRIPTION
This PR fixes an issue where token refreshes were not being handled in management operations. If folks were running operations for over an hour after receiving a message with auto lock renewer, the token would never refresh even as ALR ran. 

Fixes #35717