### PR TITLE
Support redirect in live metrics

### DIFF
--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Features Added
 
 - Implement redirect for live metrics
-    ([#35762](https://github.com/Azure/azure-sdk-for-python/pull/35762))
+    ([#35910](https://github.com/Azure/azure-sdk-for-python/pull/35910))
 
 ### Breaking Changes
 

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Features Added
 
+- Implement redirect for live metrics
+    ([#35762](https://github.com/Azure/azure-sdk-for-python/pull/35762))
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_quickpulse/_constants.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_quickpulse/_constants.py
@@ -52,4 +52,11 @@ class _DocumentIngressDocumentType(Enum):
     Event = "Event"
     Trace = "Trace"
 
+# Response Headers
+
+_QUICKPULSE_ETAG_HEADER_NAME = "x-ms-qps-configuration-etag"
+_QUICKPULSE_POLLING_HEADER_NAME = "x-ms-qps-service-polling-interval-hint"
+_QUICKPULSE_REDIRECT_HEADER_NAME = "x-ms-qps-service-endpoint-redirect-v2"
+_QUICKPULSE_SUBSCRIBED_HEADER_NAME = "x-ms-qps-subscribed"
+
 # cSpell:enable

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_quickpulse/_exporter.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_quickpulse/_exporter.py
@@ -28,6 +28,7 @@ from azure.monitor.opentelemetry.exporter._quickpulse._constants import (
     _LONG_PING_INTERVAL_SECONDS,
     _POST_CANCEL_INTERVAL_SECONDS,
     _POST_INTERVAL_SECONDS,
+    _QUICKPULSE_SUBSCRIBED_HEADER_NAME,
 )
 from azure.monitor.opentelemetry.exporter._quickpulse._generated._configuration import QuickpulseClientConfiguration
 from azure.monitor.opentelemetry.exporter._quickpulse._generated._client import QuickpulseClient
@@ -146,7 +147,7 @@ class _QuickpulseExporter(MetricExporter):
                 # If no response, assume unsuccessful
                 result = MetricExportResult.FAILURE
             else:
-                header = post_response._response_headers.get("x-ms-qps-subscribed")  # pylint: disable=protected-access
+                header = post_response._response_headers.get(_QUICKPULSE_SUBSCRIBED_HEADER_NAME)  # pylint: disable=protected-access
                 if header != "true":
                     # User leaving the live metrics page will be treated as an unsuccessful
                     result = MetricExportResult.FAILURE
@@ -240,7 +241,7 @@ class _QuickpulseMetricReader(MetricReader):
                     self._base_monitoring_data_point,
                 )
                 if ping_response:
-                    header = ping_response._response_headers.get("x-ms-qps-subscribed")  # pylint: disable=protected-access
+                    header = ping_response._response_headers.get(_QUICKPULSE_SUBSCRIBED_HEADER_NAME)  # pylint: disable=protected-access
                     if header and header == "true":
                         # Switch state to post if subscribed
                         _set_global_quickpulse_state(_QuickpulseState.POST_SHORT)

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_quickpulse/_exporter.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_quickpulse/_exporter.py
@@ -90,6 +90,7 @@ class _QuickpulseExporter(MetricExporter):
         config = QuickpulseClientConfiguration(credential=None)  # type: ignore
         qp_redirect_policy = _QuickpulseRedirectPolicy(permit_redirects=False)
         policies = [
+            # Custom redirect policy for QP
             qp_redirect_policy,
             # Needed for serialization
             ContentDecodePolicy(),

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_quickpulse/_exporter.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_quickpulse/_exporter.py
@@ -106,7 +106,7 @@ class _QuickpulseExporter(MetricExporter):
             endpoint=self._live_endpoint,
             policies=policies
         )
-        # Create a weakref of the client to the redirect policy so the endpoint can be 
+        # Create a weakref of the client to the redirect policy so the endpoint can be
         # dynamically modified if redirect does occur
         qp_redirect_policy._qp_client_ref = weakref.ref(self._client)
 

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_quickpulse/_exporter.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_quickpulse/_exporter.py
@@ -106,9 +106,9 @@ class _QuickpulseExporter(MetricExporter):
             endpoint=self._live_endpoint,
             policies=policies
         )
-        # Create a weakref of the client to the redirect policy so the endpoint can be dynamically modified if redirect does occur
+        # Create a weakref of the client to the redirect policy so the endpoint can be 
+        # dynamically modified if redirect does occur
         qp_redirect_policy._qp_client_ref = weakref.ref(self._client)
-        
 
         MetricExporter.__init__(
             self,

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_quickpulse/_policy.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_quickpulse/_policy.py
@@ -15,7 +15,8 @@ from azure.monitor.opentelemetry.exporter._quickpulse._constants import _QUICKPU
 class _QuickpulseRedirectPolicy(policies.RedirectPolicy):
 
     def __init__(self, **kwargs: Any) -> None:
-        self._qp_client_ref = None
+        # Weakref to QuickPulseClient instance
+        self._qp_client_ref  = None
         super().__init__(**kwargs)
 
     # Gets the redirect location from header

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_quickpulse/_policy.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_quickpulse/_policy.py
@@ -1,0 +1,33 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+from urllib.parse import urlparse
+from typing import Any, Optional
+
+from azure.core.pipeline import PipelineResponse, policies
+from azure.core.pipeline.policies._redirect import AllHttpResponseType
+
+from azure.monitor.opentelemetry.exporter._quickpulse._constants import _QUICKPULSE_REDIRECT_HEADER_NAME
+
+
+# Quickpulse endpoint handles redirects via header instead of status codes
+# We use a custom RedirectPolicy to handle this use case
+class _QuickpulseRedirectPolicy(policies.RedirectPolicy):
+
+    def __init__(self, **kwargs: Any) -> None:
+        self._qp_client_ref = None
+        super().__init__(**kwargs)
+
+    # Gets the redirect location from header
+    def get_redirect_location(self, response: PipelineResponse[Any, AllHttpResponseType]) -> Optional[str] :
+        redirect_location = response.http_response.headers.get(_QUICKPULSE_REDIRECT_HEADER_NAME)
+        qp_client = None
+        if redirect_location:
+            redirected_url = urlparse(redirect_location)
+            if redirected_url.scheme and redirected_url.netloc:
+                if self._qp_client_ref:
+                    qp_client = self._qp_client_ref()
+                if qp_client and qp_client._client:
+                    # Set new endpoint to redirect location
+                    qp_client._client._base_url = f"{redirected_url.scheme}://{redirected_url.netloc}"
+        return redirect_location

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_quickpulse/_policy.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_quickpulse/_policy.py
@@ -5,7 +5,6 @@ from urllib.parse import urlparse
 from typing import Any, Optional
 
 from azure.core.pipeline import PipelineResponse, policies
-from azure.core.pipeline.policies._redirect import AllHttpResponseType
 
 from azure.monitor.opentelemetry.exporter._quickpulse._constants import _QUICKPULSE_REDIRECT_HEADER_NAME
 
@@ -20,7 +19,7 @@ class _QuickpulseRedirectPolicy(policies.RedirectPolicy):
         super().__init__(**kwargs)
 
     # Gets the redirect location from header
-    def get_redirect_location(self, response: PipelineResponse[Any, AllHttpResponseType]) -> Optional[str] :
+    def get_redirect_location(self, response: PipelineResponse) -> Optional[str] :
         redirect_location = response.http_response.headers.get(_QUICKPULSE_REDIRECT_HEADER_NAME)
         qp_client = None
         if redirect_location:

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_quickpulse/_policy.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_quickpulse/_policy.py
@@ -1,21 +1,24 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-from urllib.parse import urlparse
 from typing import Any, Optional
+from urllib.parse import urlparse
+from weakref import ReferenceType
 
 from azure.core.pipeline import PipelineResponse, policies
 
 from azure.monitor.opentelemetry.exporter._quickpulse._constants import _QUICKPULSE_REDIRECT_HEADER_NAME
+from azure.monitor.opentelemetry.exporter._quickpulse._generated import QuickpulseClient
 
 
 # Quickpulse endpoint handles redirects via header instead of status codes
 # We use a custom RedirectPolicy to handle this use case
+# pylint: disable=protected-access
 class _QuickpulseRedirectPolicy(policies.RedirectPolicy):
 
     def __init__(self, **kwargs: Any) -> None:
         # Weakref to QuickPulseClient instance
-        self._qp_client_ref  = None
+        self._qp_client_ref: Optional[ReferenceType[QuickpulseClient]] = None
         super().__init__(**kwargs)
 
     # Gets the redirect location from header
@@ -30,4 +33,4 @@ class _QuickpulseRedirectPolicy(policies.RedirectPolicy):
                 if qp_client and qp_client._client:
                     # Set new endpoint to redirect location
                     qp_client._client._base_url = f"{redirected_url.scheme}://{redirected_url.netloc}"
-        return redirect_location
+        return redirect_location  # type: ignore

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/quickpulse/test_policy.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/quickpulse/test_policy.py
@@ -1,0 +1,81 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+import weakref
+import unittest
+from unittest import mock
+
+from azure.monitor.opentelemetry.exporter._quickpulse._policy import _QuickpulseRedirectPolicy
+
+
+class TestQuickpulseRedirectPolicy(unittest.TestCase):
+
+    def test_get_redirect_location(self):
+        policy = _QuickpulseRedirectPolicy()
+        pipeline_resp_mock = mock.Mock()
+        http_resp_mock = mock.Mock()
+        headers = {
+            "x-ms-qps-service-endpoint-redirect-v2": "https://eastus.livediagnostics.monitor.azure.com/QuickPulseService.svc"
+        }
+        http_resp_mock.headers = headers
+        pipeline_resp_mock.http_response = http_resp_mock
+        policy = _QuickpulseRedirectPolicy()
+        qp_client_mock = mock.Mock()
+        client_mock = mock.Mock()
+        client_mock._base_url = "previous_url"
+        qp_client_mock._client = client_mock
+        qp_client_ref = weakref.ref(qp_client_mock)
+        policy._qp_client_ref = qp_client_ref
+        redirect_location = policy.get_redirect_location(pipeline_resp_mock)
+        self.assertEqual(
+            redirect_location,
+            "https://eastus.livediagnostics.monitor.azure.com/QuickPulseService.svc",
+        )
+        self.assertEqual(
+            client_mock._base_url,
+            "https://eastus.livediagnostics.monitor.azure.com",
+        )
+
+    def test_get_redirect_location_no_header(self):
+        policy = _QuickpulseRedirectPolicy()
+        pipeline_resp_mock = mock.Mock()
+        http_resp_mock = mock.Mock()
+        headers = {}
+        http_resp_mock.headers = headers
+        pipeline_resp_mock.http_response = http_resp_mock
+        policy = _QuickpulseRedirectPolicy()
+        self.assertIsNone(policy.get_redirect_location(pipeline_resp_mock))
+        redirect_location = policy.get_redirect_location(pipeline_resp_mock)
+ 
+    def test_get_redirect_location_invalid_url(self):
+        policy = _QuickpulseRedirectPolicy()
+        pipeline_resp_mock = mock.Mock()
+        http_resp_mock = mock.Mock()
+        headers = {
+            "x-ms-qps-service-endpoint-redirect-v2": "invalid_url"
+        }
+        http_resp_mock.headers = headers
+        pipeline_resp_mock.http_response = http_resp_mock
+        policy = _QuickpulseRedirectPolicy()
+        qp_client_mock = mock.Mock()
+        client_mock = mock.Mock()
+        client_mock._base_url = "previous_url"
+        qp_client_mock._client = client_mock
+        qp_client_ref = weakref.ref(qp_client_mock)
+        policy._qp_client_ref = qp_client_ref
+        redirect_location = policy.get_redirect_location(pipeline_resp_mock)
+        self.assertEqual(redirect_location, "invalid_url")
+        self.assertEqual(client_mock._base_url,"previous_url")
+
+    def test_get_redirect_location_no_client(self):
+        policy = _QuickpulseRedirectPolicy()
+        pipeline_resp_mock = mock.Mock()
+        http_resp_mock = mock.Mock()
+        headers = {
+            "x-ms-qps-service-endpoint-redirect-v2": "https://eastus.livediagnostics.monitor.azure.com/QuickPulseService.svc"
+        }
+        http_resp_mock.headers = headers
+        pipeline_resp_mock.http_response = http_resp_mock
+        policy = _QuickpulseRedirectPolicy()
+        redirect_location = policy.get_redirect_location(pipeline_resp_mock)
+        self.assertEqual(redirect_location, "https://eastus.livediagnostics.monitor.azure.com/QuickPulseService.svc")
+        self.assertIsNone(policy._qp_client_ref)


### PR DESCRIPTION
Live metrics redirect is handled through the header `x-ms-qps-service-endpoint-redirect-v2` instead of through status code 3XX unlike normal redirect policies.

This PR adds a custom policy for quickpulse that disables automatic redirect and changes the client endpoint to the endpoint returned from the header.