### PR TITLE
Fix workspace arm template

### DIFF
--- a/sdk/ml/azure-ai-ml/assets.json
+++ b/sdk/ml/azure-ai-ml/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "python",
   "TagPrefix": "python/ml/azure-ai-ml",
-  "Tag": "python/ml/azure-ai-ml_ae30eb5b40"
+  "Tag": "python/ml/azure-ai-ml_67cbe1a754"
 }

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_workspace_operations_base.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_workspace_operations_base.py
@@ -148,8 +148,6 @@ class WorkspaceOperationsBase(ABC):
             workspace.tags = {}
         if workspace.tags.get("createdByToolkit") is None:
             workspace.tags["createdByToolkit"] = "sdk-v2-{}".format(VERSION)
-        if workspace.tags.get("AttachAppInsightsToWorkspace") is None:
-            workspace.tags["AttachAppInsightsToWorkspace"] = "false"
 
         workspace.resource_group = resource_group
         (

--- a/sdk/ml/azure-ai-ml/tests/workspace/e2etests/test_workspace.py
+++ b/sdk/ml/azure-ai-ml/tests/workspace/e2etests/test_workspace.py
@@ -156,8 +156,9 @@ class TestWorkspace(AzureRecordedTestCase):
         assert poller
         assert isinstance(poller, LROPoller)
 
-    pytest.mark.skip(
-        "This test was refactored out from the original workspace CRUD test because not everyone has access to the " +
+    @pytest.mark.skipif(
+        condition=True,
+        reason="This test was refactored out from the original workspace CRUD test because not everyone has access to the " +
         "static resources referenced here. We need to refactor the testing of ACR and appinsights to " +
         "not be dependent on user access rights."
     )

--- a/sdk/ml/azure-ai-ml/tests/workspace/e2etests/test_workspace.py
+++ b/sdk/ml/azure-ai-ml/tests/workspace/e2etests/test_workspace.py
@@ -161,7 +161,6 @@ class TestWorkspace(AzureRecordedTestCase):
         "static resources referenced here. We need to refactor the testing of ACR and appinsights to " +
         "not be dependent on user access rights."
     )
-
     def test_acr_and_appinsights_in_create(self, client: MLClient, randstr: Callable[[], str], location: str) -> None:
         wps_name = f"e2etest_{randstr('wps_name')}"
         wps_description = f"{wps_name} description"

--- a/sdk/ml/azure-ai-ml/tests/workspace/e2etests/test_workspace.py
+++ b/sdk/ml/azure-ai-ml/tests/workspace/e2etests/test_workspace.py
@@ -31,11 +31,9 @@ from azure.mgmt.msi._managed_service_identity_client import ManagedServiceIdenti
     "recorded_test", "mock_workspace_arm_template_deployment_name", "mock_workspace_dependent_resource_name_generator"
 )
 class TestWorkspace(AzureRecordedTestCase):
-    @pytest.mark.skipif(
-        condition=not is_live(),
-        reason="ARM template makes playback complex, so the test is flaky when run against recording",
-    )
-    def test_workspace_create_update_and_delete(
+
+    # WARNING: This test takes a long time to run in live mode.
+    def test_workspace_create_and_delete(
         self, client: MLClient, randstr: Callable[[], str], location: str
     ) -> None:
         wps_name = f"e2etest_{randstr('wps_name')}"
@@ -77,8 +75,53 @@ class TestWorkspace(AzureRecordedTestCase):
         assert isinstance(workspace, Workspace)
         assert workspace.name == wps_name
 
-        static_acr = "/subscriptions/8f338f6e-4fce-44ae-969c-fc7d8fda030e/resourceGroups/rg-mhe-e2e-test-dont-remove/providers/Microsoft.ContainerRegistry/registries/acrmhetest2"
-        static_appinsights = "/subscriptions/8f338f6e-4fce-44ae-969c-fc7d8fda030e/resourceGroups/rg-mhe-e2e-test-dont-remove/providers/microsoft.insights/components/aimhetest2"
+        poller = client.workspaces.begin_delete(wps_name, delete_dependent_resources=True, permanently_delete=True)
+        # verify that request was accepted by checking if poller is returned
+        assert poller
+        assert isinstance(poller, LROPoller)
+
+    # Despite the name, also tests create and delete by necessity to have an update-able workspace.
+    # WARNING: This test takes a LONG time to run in live mode.
+    def test_workspace_update(
+        self, client: MLClient, randstr: Callable[[], str], location: str
+    ) -> None:
+        wps_name = f"e2etest_{randstr('wps_name')}"
+        wps_description = f"{wps_name} description"
+        wps_display_name = f"{wps_name} display name"
+        params_override = [
+            {"name": wps_name},
+            {"location": location},
+            {"description": wps_description},
+            {"display_name": wps_display_name},
+            {"enable_data_isolation": True},
+        ]
+
+        def workspace_validation(wps):
+            workspace_poller = client.workspaces.begin_create(workspace=wps)
+            assert isinstance(workspace_poller, LROPoller)
+            workspace = workspace_poller.result()
+            assert isinstance(workspace, Workspace)
+            assert workspace.name == wps_name
+            assert workspace.location == location
+            assert workspace.description == wps_description
+            assert workspace.display_name == wps_display_name
+            assert workspace.public_network_access == PublicNetworkAccess.ENABLED
+            # TODO uncomment this when enableDataIsolation flag change bug resolved for PATCH on the service side
+            # assert workspace.enable_data_isolation == True
+
+        workspace = verify_entity_load_and_dump(
+            load_workspace,
+            workspace_validation,
+            "./tests/test_configs/workspace/workspace_min.yaml",
+            params_override=params_override,
+        )[0]
+
+        workspace_list = client.workspaces.list()
+        assert isinstance(workspace_list, ItemPaged)
+        workspace = client.workspaces.get(wps_name)
+        assert isinstance(workspace, Workspace)
+        assert workspace.name == wps_name
+
         param_image_build_compute = "compute"
         param_display_name = "Test display name"
         param_description = "Test description"
@@ -90,8 +133,6 @@ class TestWorkspace(AzureRecordedTestCase):
             description=param_description,
             image_build_compute=param_image_build_compute,
             public_network_access=PublicNetworkAccess.DISABLED,
-            container_registry=static_acr,
-            application_insights=static_appinsights,
             update_dependent_resources=True,
             tags=param_tags,
         )
@@ -102,12 +143,61 @@ class TestWorkspace(AzureRecordedTestCase):
         assert workspace.description == param_description
         assert workspace.image_build_compute == param_image_build_compute
         assert workspace.public_network_access == PublicNetworkAccess.DISABLED
-        assert workspace.container_registry.lower() == static_acr.lower()
-        assert workspace.application_insights.lower() == static_appinsights.lower()
         assert workspace.tags == param_tags
         # enable_data_isolation flag can be only set at workspace creation stage, update for both put/patch is invliad
         # TODO uncomment this when enableDataIsolation flag change bug resolved for PATCH on the service side
         # assert workspace.enable_data_isolation == True
+        poller = client.workspaces.begin_delete(wps_name, delete_dependent_resources=True, permanently_delete=True)
+        # verify that request was accepted by checking if poller is returned
+        assert poller
+        assert isinstance(poller, LROPoller)
+
+    pytest.mark.skip("This test was refactored out from the original workspace CRUD test because not everyone has access to the static resources referenced here. We need to refactor the testing of ACR and appinsights to not be depenedent on user access rights.")
+    def test_acr_and_appinsights_in_create(
+        self, client: MLClient, randstr: Callable[[], str], location: str
+    ) -> None:
+        wps_name = f"e2etest_{randstr('wps_name')}"
+        wps_description = f"{wps_name} description"
+        wps_display_name = f"{wps_name} display name"
+        params_override = [
+            {"name": wps_name},
+            {"location": location},
+            {"description": wps_description},
+            {"display_name": wps_display_name},
+            {"enable_data_isolation": True},
+            {"container_registry": "/subscriptions/8f338f6e-4fce-44ae-969c-fc7d8fda030e/resourceGroups/rg-mhe-e2e-test-dont-remove/providers/Microsoft.ContainerRegistry/registries/acrmhetest2"},
+            {"application_insights": "/subscriptions/8f338f6e-4fce-44ae-969c-fc7d8fda030e/resourceGroups/rg-mhe-e2e-test-dont-remove/providers/microsoft.insights/components/aimhetest2"},
+        ]
+
+        # only test simple aspects of both a pointer and path-loaded workspace
+        # save actual service calls for a single object (below).
+        def workspace_validation(wps):
+            workspace_poller = client.workspaces.begin_create(workspace=wps)
+            assert isinstance(workspace_poller, LROPoller)
+            workspace = workspace_poller.result()
+            assert isinstance(workspace, Workspace)
+            assert workspace.name == wps_name
+            assert workspace.location == location
+            assert workspace.description == wps_description
+            assert workspace.display_name == wps_display_name
+            assert workspace.public_network_access == PublicNetworkAccess.ENABLED
+            # TODO uncomment this when enableDataIsolation flag change bug resolved for PATCH on the service side
+            # assert workspace.enable_data_isolation == True
+
+        workspace = verify_entity_load_and_dump(
+            load_workspace,
+            workspace_validation,
+            "./tests/test_configs/workspace/workspace_min.yaml",
+            params_override=params_override,
+        )[0]
+
+        workspace_list = client.workspaces.list()
+        assert isinstance(workspace_list, ItemPaged)
+        workspace = client.workspaces.get(wps_name)
+        assert isinstance(workspace, Workspace)
+        assert workspace.name == wps_name
+        assert workspace.container_registry.lower() == params_override["container_registry"].lower()
+        assert workspace.application_insights.lower() == params_override["application_insights"].lower()
 
         poller = client.workspaces.begin_delete(wps_name, delete_dependent_resources=True, permanently_delete=True)
         # verify that request was accepted by checking if poller is returned

--- a/sdk/ml/azure-ai-ml/tests/workspace/e2etests/test_workspace.py
+++ b/sdk/ml/azure-ai-ml/tests/workspace/e2etests/test_workspace.py
@@ -33,9 +33,11 @@ from azure.mgmt.msi._managed_service_identity_client import ManagedServiceIdenti
 class TestWorkspace(AzureRecordedTestCase):
 
     # WARNING: This test takes a long time to run in live mode.
-    def test_workspace_create_and_delete(
-        self, client: MLClient, randstr: Callable[[], str], location: str
-    ) -> None:
+    @pytest.mark.skipif(
+        condition=not is_live(),
+        reason="ARM template makes playback complex, so the test is flaky when run against recording",
+    )
+    def test_workspace_create_and_delete(self, client: MLClient, randstr: Callable[[], str], location: str) -> None:
         wps_name = f"e2etest_{randstr('wps_name')}"
         wps_description = f"{wps_name} description"
         wps_display_name = f"{wps_name} display name"
@@ -82,9 +84,11 @@ class TestWorkspace(AzureRecordedTestCase):
 
     # Despite the name, also tests create and delete by necessity to have an update-able workspace.
     # WARNING: This test takes a LONG time to run in live mode.
-    def test_workspace_update(
-        self, client: MLClient, randstr: Callable[[], str], location: str
-    ) -> None:
+    @pytest.mark.skipif(
+        condition=not is_live(),
+        reason="ARM template makes playback complex, so the test is flaky when run against recording",
+    )
+    def test_workspace_update(self, client: MLClient, randstr: Callable[[], str], location: str) -> None:
         wps_name = f"e2etest_{randstr('wps_name')}"
         wps_description = f"{wps_name} description"
         wps_display_name = f"{wps_name} display name"
@@ -152,10 +156,13 @@ class TestWorkspace(AzureRecordedTestCase):
         assert poller
         assert isinstance(poller, LROPoller)
 
-    pytest.mark.skip("This test was refactored out from the original workspace CRUD test because not everyone has access to the static resources referenced here. We need to refactor the testing of ACR and appinsights to not be depenedent on user access rights.")
-    def test_acr_and_appinsights_in_create(
-        self, client: MLClient, randstr: Callable[[], str], location: str
-    ) -> None:
+    pytest.mark.skip(
+        "This test was refactored out from the original workspace CRUD test because not everyone has access to the " +
+        "static resources referenced here. We need to refactor the testing of ACR and appinsights to " +
+        "not be dependent on user access rights."
+    )
+
+    def test_acr_and_appinsights_in_create(self, client: MLClient, randstr: Callable[[], str], location: str) -> None:
         wps_name = f"e2etest_{randstr('wps_name')}"
         wps_description = f"{wps_name} description"
         wps_display_name = f"{wps_name} display name"
@@ -165,8 +172,12 @@ class TestWorkspace(AzureRecordedTestCase):
             {"description": wps_description},
             {"display_name": wps_display_name},
             {"enable_data_isolation": True},
-            {"container_registry": "/subscriptions/8f338f6e-4fce-44ae-969c-fc7d8fda030e/resourceGroups/rg-mhe-e2e-test-dont-remove/providers/Microsoft.ContainerRegistry/registries/acrmhetest2"},
-            {"application_insights": "/subscriptions/8f338f6e-4fce-44ae-969c-fc7d8fda030e/resourceGroups/rg-mhe-e2e-test-dont-remove/providers/microsoft.insights/components/aimhetest2"},
+            {
+                "container_registry": "/subscriptions/8f338f6e-4fce-44ae-969c-fc7d8fda030e/resourceGroups/rg-mhe-e2e-test-dont-remove/providers/Microsoft.ContainerRegistry/registries/acrmhetest2"
+            },
+            {
+                "application_insights": "/subscriptions/8f338f6e-4fce-44ae-969c-fc7d8fda030e/resourceGroups/rg-mhe-e2e-test-dont-remove/providers/microsoft.insights/components/aimhetest2"
+            },
         ]
 
         # only test simple aspects of both a pointer and path-loaded workspace

--- a/sdk/ml/azure-ai-ml/tests/workspace/e2etests/test_workspace.py
+++ b/sdk/ml/azure-ai-ml/tests/workspace/e2etests/test_workspace.py
@@ -158,9 +158,9 @@ class TestWorkspace(AzureRecordedTestCase):
 
     @pytest.mark.skipif(
         condition=True,
-        reason="This test was refactored out from the original workspace CRUD test because not everyone has access to the " +
-        "static resources referenced here. We need to refactor the testing of ACR and appinsights to " +
-        "not be dependent on user access rights."
+        reason="This test was refactored out from the original workspace CRUD test because not everyone has access to the "
+        + "static resources referenced here. We need to refactor the testing of ACR and appinsights to "
+        + "not be dependent on user access rights.",
     )
     def test_acr_and_appinsights_in_create(self, client: MLClient, randstr: Callable[[], str], location: str) -> None:
         wps_name = f"e2etest_{randstr('wps_name')}"


### PR DESCRIPTION
A full PR revert that was aimed at fixing a different error fully broke workspace create operations by re-introducing a no longer supported workspace tag as a default value. This PR removes that, and also refactors some workspace e2e tests to be runnable when you don't have access to certain static resources.

The new tests passed for me locally, but still fail in playback mode due to longstanding issues with workspace recordings.