### PR TITLE
azure-mgmt-core shouldn't use mgmt docs build

### DIFF
--- a/eng/tox/run_sphinx_apidoc.py
+++ b/eng/tox/run_sphinx_apidoc.py
@@ -25,7 +25,7 @@ root_dir = os.path.abspath(os.path.join(os.path.abspath(__file__), "..", "..", "
 generate_mgmt_script = os.path.join(root_dir, "doc/sphinx/generate_doc.py")
 
 def is_mgmt_package(pkg_name):
-    return "mgmt"  in pkg_name or "cognitiveservices" in pkg_name
+    return pkg_name != "azure-mgmt-core" and ("mgmt" in pkg_name or "cognitiveservices" in pkg_name)
 
 def copy_existing_docs(source, target):
     for file in os.listdir(source):


### PR DESCRIPTION
Resolves https://github.com/Azure/azure-sdk-for-python/issues/33582

Noticed this failure when trying to make strict-sphinx be the default in this PR: https://github.com/Azure/azure-sdk-for-python/pull/35914

We're trying to build azure-mgmt-core like a mgmt package for docs:

![image](https://github.com/Azure/azure-sdk-for-python/assets/31998003/5c43eaad-b018-4cce-a725-a5efbc2be1ab)

This leads to broken docs: https://azuresdkdocs.blob.core.windows.net/$web/python/azure-mgmt-core/1.4.0/index.html

Since azure-mgmt-core doesn't follow the mgmt package structure with `operations` and `models`, it should instead have its docs built like we do with data-plane packages. 