### PR TITLE
Expose public ip in AmlComputeNodeInfo

### DIFF
--- a/sdk/ml/azure-ai-ml/CHANGELOG.md
+++ b/sdk/ml/azure-ai-ml/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+Expose `public_ip_address` in `AmlComputeNodeInfo`, to get the public ip address with the ssh port when calling `ml_client.compute.list_nodes`
+
 ### Bugs Fixed
 
 ### Breaking Changes

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_compute/_aml_compute_node_info.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_compute/_aml_compute_node_info.py
@@ -15,6 +15,7 @@ class AmlComputeNodeInfo:
     def __init__(self) -> None:
         self.node_id = None
         self.private_ip_address = None
+        self.public_ip_address = None
         self.port = None
         self.node_state = None
         self.run_id: Optional[str] = None


### PR DESCRIPTION
# Description

`AmlComputeNodeInfo` should expose the attribute `public_ip_address`, otherwise is not possible to connect through ssh with only the information provided in the class. As the public ip address is already retrieved in the rest request, just adding the attribute is sufficient to populate it when calling `_from_rest_object`.

Fix #35961

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
