### PR TITLE
Always run analyze weekly

### DIFF
--- a/tools/azure-sdk-tools/ci_tools/environment_exclusions.py
+++ b/tools/azure-sdk-tools/ci_tools/environment_exclusions.py
@@ -5,7 +5,7 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 from ci_tools.parsing import get_config_setting
-from ci_tools.variables import in_public
+from ci_tools.variables import in_public, in_analyze_weekly
 import os
 from typing import Any
 
@@ -53,7 +53,7 @@ def is_check_enabled(package_path: str, check: str, default: Any = True) -> bool
         package_path = os.getcwd()
 
     ci_enabled = get_config_setting(package_path, "ci_enabled", True)
-    if not in_public() and ci_enabled is False:
+    if not in_public() and not in_analyze_weekly() and ci_enabled is False:
         return False
 
     # now pull the new pyproject.toml configuration

--- a/tools/azure-sdk-tools/ci_tools/variables.py
+++ b/tools/azure-sdk-tools/ci_tools/variables.py
@@ -67,6 +67,15 @@ def in_public() -> int:
 
     return 0
 
+def in_analyze_weekly() -> int:
+    # Returns 4 if the build originates from the tests-weekly analyze job
+    # 0 otherwise
+    print(f"SYSTEM_DEFINITIONNAME={os.getenv('SYSTEM_DEFINITIONNAME', '')}")
+    print(f"SYSTEM_STAGENAME={os.getenv('SYSTEM_STAGENAME', '')}")
+    if "tests-weekly" in os.getenv("SYSTEM_DEFINITIONNAME", "") and os.getenv("SYSTEM_STAGENAME", "") == "Analyze_Test":
+        return 4
+    return 0
+
 
 DEV_BUILD_IDENTIFIER = os.getenv("SDK_DEV_BUILD_IDENTIFIER", "a")
 DEFAULT_BUILD_ID = os.getenv("GITHUB_RUN_ID", os.getenv("BUILD.BUILDID", os.getenv("SDK_BUILD_ID", "20220101.1")))

--- a/tools/azure-sdk-tools/ci_tools/variables.py
+++ b/tools/azure-sdk-tools/ci_tools/variables.py
@@ -71,8 +71,8 @@ def in_analyze_weekly() -> int:
     # Returns 4 if the build originates from the tests-weekly analyze job
     # 0 otherwise
     print(f"SYSTEM_DEFINITIONNAME={os.getenv('SYSTEM_DEFINITIONNAME', '')}")
-    print(f"SYSTEM_STAGENAME={os.getenv('SYSTEM_STAGENAME', '')}")
-    if "tests-weekly" in os.getenv("SYSTEM_DEFINITIONNAME", "") and os.getenv("SYSTEM_STAGENAME", "") == "Analyze_Test":
+    print(f"SYSTEM_STAGEDISPLAYNAME={os.getenv('SYSTEM_STAGEDISPLAYNAME', '')}")
+    if "tests-weekly" in os.getenv("SYSTEM_DEFINITIONNAME", "") and os.getenv("SYSTEM_STAGEDISPLAYNAME", "") == "Analyze_Test":
         return 4
     return 0
 

--- a/tools/azure-sdk-tools/ci_tools/variables.py
+++ b/tools/azure-sdk-tools/ci_tools/variables.py
@@ -70,8 +70,6 @@ def in_public() -> int:
 def in_analyze_weekly() -> int:
     # Returns 4 if the build originates from the tests-weekly analyze job
     # 0 otherwise
-    print(f"SYSTEM_DEFINITIONNAME={os.getenv('SYSTEM_DEFINITIONNAME', '')}")
-    print(f"SYSTEM_STAGEDISPLAYNAME={os.getenv('SYSTEM_STAGEDISPLAYNAME', '')}")
     if "tests-weekly" in os.getenv("SYSTEM_DEFINITIONNAME", "") and os.getenv("SYSTEM_STAGEDISPLAYNAME", "") == "Analyze_Test":
         return 4
     return 0


### PR DESCRIPTION
Some libraries have their ci_enabled=false due to non-compliance with required checks. This leads to their issues for mypy/pyright/sphinx getting stale:

Example: https://github.com/Azure/azure-sdk-for-python/issues/33225

The above issue has a link to a build from January and shows targeting an old mypy version. Because ci_enabled=false for this library, its analyze weekly job skips checks and so the issue never gets updated. This PR makes an exception for the Analyze weekly stage so we can continue to monitor CI checks against libraries and produce up-to-date issues with build links.

Test runs:

1. ci_enabled=false: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3404548&view=logs&j=e5b925a9-9650-5321-24fd-5d9499fe02b8&t=59f5c573-b3ce-57f7-6a79-55fe2db3a175
Expected: CI checks run

2. ci_enabled=true: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3856105&view=logs&j=e5b925a9-9650-5321-24fd-5d9499fe02b8&t=59f5c573-b3ce-57f7-6a79-55fe2db3a175&l=386
Expected: CI checks continue to run