### PR TITLE
allow for futher embedded snippets

### DIFF
--- a/tools/azure-sdk-tools/ci_tools/snippet_update/python_snippet_updater.py
+++ b/tools/azure-sdk-tools/ci_tools/snippet_update/python_snippet_updater.py
@@ -15,7 +15,7 @@ _LOGGER = logging.getLogger(__name__)
 snippets = {}
 not_up_to_date = False
 
-target_snippet_sources = ["samples/*.py", "samples/*/*.py", "samples/*/*/*.py"]
+target_snippet_sources = ["samples/*.py", "samples/**/*.py"]
 target_md_files = ["README.md"]
 
 

--- a/tools/azure-sdk-tools/ci_tools/snippet_update/python_snippet_updater.py
+++ b/tools/azure-sdk-tools/ci_tools/snippet_update/python_snippet_updater.py
@@ -15,7 +15,7 @@ _LOGGER = logging.getLogger(__name__)
 snippets = {}
 not_up_to_date = False
 
-target_snippet_sources = ["samples/*.py", "samples/*/*.py"]
+target_snippet_sources = ["samples/*.py", "samples/*/*.py", "samples/*/*/*.py"]
 target_md_files = ["README.md"]
 
 


### PR DESCRIPTION
For EG I have a path as follows

samples:

-  -> basic
-        ->sync_samples
-                ->sample_authentication.py
-         -> async_samples

-   -> namespace
-           ->sync_samples
-           ->async_samples

I reference the authentication snippet in the README is there a reason we can't go further down the samples path?