### PR TITLE
[Key Vault] Change location for weekly China cloud tests

### DIFF
--- a/sdk/keyvault/azure-keyvault-administration/tests.yml
+++ b/sdk/keyvault/azure-keyvault-administration/tests.yml
@@ -21,7 +21,7 @@ extends:
           SubscriptionConfiguration: $(sub-config-cn-test-resources)
           MatrixFilters:
             - ArmTemplateParameters=^(?!.*enableHsm.*true)
-          Location: chinanorth3
+          Location: chinaeast2
         # Test azure-keyvault-administration on *only* Managed HSM for weekly tests only
         MatrixConfigs:
           - Name: keyvault_admin_weekly_matrix

--- a/sdk/keyvault/azure-keyvault-keys/tests.yml
+++ b/sdk/keyvault/azure-keyvault-keys/tests.yml
@@ -21,7 +21,7 @@ extends:
           SubscriptionConfiguration: $(sub-config-cn-test-resources)
           MatrixFilters:
             - ArmTemplateParameters=^(?!.*enableHsm.*true)
-          Location: chinanorth3
+          Location: chinaeast2
       ${{ if contains(variables['Build.DefinitionName'], 'tests-weekly') }}:
         # Test azure-keyvault-keys on Managed HSM for weekly tests only
         AdditionalMatrixConfigs:

--- a/sdk/keyvault/tests.yml
+++ b/sdk/keyvault/tests.yml
@@ -25,7 +25,7 @@ extends:
           SubscriptionConfiguration: $(sub-config-cn-test-resources)
           MatrixFilters:
             - ArmTemplateParameters=^(?!.*enableHsm.*true)
-          Location: chinanorth3
+          Location: chinaeast2
       EnvVars:
         AZURE_TEST_RUN_LIVE: true
         AZURE_SKIP_LIVE_RECORDING: 'True'


### PR DESCRIPTION
# Description

Key Vault's weekly test pipeline recently started failing because the location we used to use for China cloud testing -- `chinanorth3` -- no longer supports resources that we need: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3859079&view=logs&j=f80a6caf-0d70-5eb2-1403-823bf39d4bdd&t=3a9714ad-ac3f-595c-7cce-6819c9203636

This updates our configuration to now target the suggested location, `chinaeast2`.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
