### PR TITLE
Customize LRO to return LROPoller[None]

### DIFF
--- a/sdk/devcenter/azure-developer-devcenter/azure/developer/devcenter/_operations/_patch.py
+++ b/sdk/devcenter/azure-developer-devcenter/azure/developer/devcenter/_operations/_patch.py
@@ -6,10 +6,45 @@
 
 Follow our quickstart for examples: https://aka.ms/azsdk/python/dpcodegen/python/customize
 """
-from typing import List
 
-__all__: List[str] = []  # Add all objects you want publicly available to users at this package level
+from ._operations import DevCenterClientOperationsMixin as DevCenterClientOperationsMixinGenerated
+from azure.core.polling import LROPoller
+from azure.core.tracing.decorator import distributed_trace
+from typing import Any, List, Optional
 
+class DevCenterClientOperationsMixin(DevCenterClientOperationsMixinGenerated):
+
+    @distributed_trace
+    def begin_delete_dev_box(
+        self, project_name: str, user_id: str, dev_box_name: str, **kwargs: Any
+    ) -> LROPoller[None]:
+        return super.begin_delete_dev_box(project_name, user_id, dev_box_name, **kwargs)
+
+    @distributed_trace
+    def begin_start_dev_box(
+        self, project_name: str, user_id: str, dev_box_name: str, **kwargs: Any
+    ) -> LROPoller[None]:
+        return super.begin_start_dev_box(project_name, user_id, dev_box_name, **kwargs)
+
+    @distributed_trace
+    def begin_stop_dev_box(
+        self, project_name: str, user_id: str, dev_box_name: str, *, hibernate: Optional[bool] = None, **kwargs: Any
+    ) -> LROPoller[None]:
+        return super.begin_stop_dev_box(project_name, user_id, dev_box_name, hibernate, **kwargs)
+
+    @distributed_trace
+    def begin_restart_dev_box(
+        self, project_name: str, user_id: str, dev_box_name: str, **kwargs: Any
+    ) -> LROPoller[None]:
+        return super.begin_restart_dev_box(project_name, user_id, dev_box_name, **kwargs)
+
+    @distributed_trace
+    def begin_delete_environment(
+        self, project_name: str, user_id: str, environment_name: str, **kwargs: Any
+    ) -> LROPoller[None]:
+        return super().begin_delete_environment(project_name, user_id, environment_name, **kwargs)
+
+__all__: List[str] = ["DevCenterClientOperationsMixin"]  # Add all objects you want publicly available to users at this package level
 
 def patch_sdk():
     """Do not remove from this file.

--- a/sdk/devcenter/azure-developer-devcenter/azure/developer/devcenter/_operations/_patch.py
+++ b/sdk/devcenter/azure-developer-devcenter/azure/developer/devcenter/_operations/_patch.py
@@ -18,25 +18,25 @@ class DevCenterClientOperationsMixin(DevCenterClientOperationsMixinGenerated):
     def begin_delete_dev_box(
         self, project_name: str, user_id: str, dev_box_name: str, **kwargs: Any
     ) -> LROPoller[None]:
-        return super.begin_delete_dev_box(project_name, user_id, dev_box_name, **kwargs)
+        return super().begin_delete_dev_box(project_name, user_id, dev_box_name, **kwargs)
 
     @distributed_trace
     def begin_start_dev_box(
         self, project_name: str, user_id: str, dev_box_name: str, **kwargs: Any
     ) -> LROPoller[None]:
-        return super.begin_start_dev_box(project_name, user_id, dev_box_name, **kwargs)
+        return super().begin_start_dev_box(project_name, user_id, dev_box_name, **kwargs)
 
     @distributed_trace
     def begin_stop_dev_box(
         self, project_name: str, user_id: str, dev_box_name: str, *, hibernate: Optional[bool] = None, **kwargs: Any
     ) -> LROPoller[None]:
-        return super.begin_stop_dev_box(project_name, user_id, dev_box_name, hibernate, **kwargs)
+        return super().begin_stop_dev_box(project_name, user_id, dev_box_name, hibernate, **kwargs)
 
     @distributed_trace
     def begin_restart_dev_box(
         self, project_name: str, user_id: str, dev_box_name: str, **kwargs: Any
     ) -> LROPoller[None]:
-        return super.begin_restart_dev_box(project_name, user_id, dev_box_name, **kwargs)
+        return super().begin_restart_dev_box(project_name, user_id, dev_box_name, **kwargs)
 
     @distributed_trace
     def begin_delete_environment(

--- a/sdk/devcenter/azure-developer-devcenter/azure/developer/devcenter/aio/_operations/_patch.py
+++ b/sdk/devcenter/azure-developer-devcenter/azure/developer/devcenter/aio/_operations/_patch.py
@@ -17,25 +17,25 @@ class DevCenterClientOperationsMixin(DevCenterClientOperationsMixinGenerated):
     async def begin_delete_dev_box(
         self, project_name: str, user_id: str, dev_box_name: str, **kwargs: Any
     ) -> AsyncLROPoller[None]:
-        return super.begin_delete_dev_box(project_name, user_id, dev_box_name, **kwargs)
+        return super().begin_delete_dev_box(project_name, user_id, dev_box_name, **kwargs)
 
     @distributed_trace_async
     async def begin_start_dev_box(
         self, project_name: str, user_id: str, dev_box_name: str, **kwargs: Any
     ) -> AsyncLROPoller[None]:
-        return super.begin_start_dev_box(project_name, user_id, dev_box_name, **kwargs)
+        return super().begin_start_dev_box(project_name, user_id, dev_box_name, **kwargs)
 
     @distributed_trace_async
     async def begin_stop_dev_box(
         self, project_name: str, user_id: str, dev_box_name: str, *, hibernate: Optional[bool] = None, **kwargs: Any
     ) -> AsyncLROPoller[None]:
-        return super.begin_stop_dev_box(project_name, user_id, dev_box_name, hibernate, **kwargs)
+        return super().begin_stop_dev_box(project_name, user_id, dev_box_name, hibernate, **kwargs)
 
     @distributed_trace_async
     async def begin_restart_dev_box(
         self, project_name: str, user_id: str, dev_box_name: str, **kwargs: Any
     ) -> AsyncLROPoller[None]:
-        return super.begin_restart_dev_box(project_name, user_id, dev_box_name, **kwargs)
+        return super().begin_restart_dev_box(project_name, user_id, dev_box_name, **kwargs)
 
     @distributed_trace_async
     async def begin_delete_environment(

--- a/sdk/devcenter/azure-developer-devcenter/azure/developer/devcenter/aio/_operations/_patch.py
+++ b/sdk/devcenter/azure-developer-devcenter/azure/developer/devcenter/aio/_operations/_patch.py
@@ -6,9 +6,44 @@
 
 Follow our quickstart for examples: https://aka.ms/azsdk/python/dpcodegen/python/customize
 """
-from typing import List
+from ._operations import DevCenterClientOperationsMixin as DevCenterClientOperationsMixinGenerated
+from azure.core.polling import AsyncLROPoller
+from azure.core.tracing.decorator_async import distributed_trace_async
+from typing import Any, List, Optional
 
-__all__: List[str] = []  # Add all objects you want publicly available to users at this package level
+class DevCenterClientOperationsMixin(DevCenterClientOperationsMixinGenerated):
+
+    @distributed_trace_async
+    async def begin_delete_dev_box(
+        self, project_name: str, user_id: str, dev_box_name: str, **kwargs: Any
+    ) -> AsyncLROPoller[None]:
+        return super.begin_delete_dev_box(project_name, user_id, dev_box_name, **kwargs)
+
+    @distributed_trace_async
+    async def begin_start_dev_box(
+        self, project_name: str, user_id: str, dev_box_name: str, **kwargs: Any
+    ) -> AsyncLROPoller[None]:
+        return super.begin_start_dev_box(project_name, user_id, dev_box_name, **kwargs)
+
+    @distributed_trace_async
+    async def begin_stop_dev_box(
+        self, project_name: str, user_id: str, dev_box_name: str, *, hibernate: Optional[bool] = None, **kwargs: Any
+    ) -> AsyncLROPoller[None]:
+        return super.begin_stop_dev_box(project_name, user_id, dev_box_name, hibernate, **kwargs)
+
+    @distributed_trace_async
+    async def begin_restart_dev_box(
+        self, project_name: str, user_id: str, dev_box_name: str, **kwargs: Any
+    ) -> AsyncLROPoller[None]:
+        return super.begin_restart_dev_box(project_name, user_id, dev_box_name, **kwargs)
+
+    @distributed_trace_async
+    async def begin_delete_environment(
+        self, project_name: str, user_id: str, environment_name: str, **kwargs: Any
+    ) -> AsyncLROPoller[None]:
+        return super().begin_delete_environment(project_name, user_id, environment_name, **kwargs)
+
+__all__: List[str] = ["DevCenterClientOperationsMixin"]  # Add all objects you want publicly available to users at this package level
 
 
 def patch_sdk():

--- a/sdk/devcenter/azure-developer-devcenter/tests/test_devcenter_operations.py
+++ b/sdk/devcenter/azure-developer-devcenter/tests/test_devcenter_operations.py
@@ -255,8 +255,7 @@ class TestDevcenter(AzureRecordedTestCase):
         client = self.create_client(endpoint)
 
         restart_response = client.begin_restart_dev_box(project_name, default_user, devbox_name)
-        restart_result = restart_response.result()
-        assert restart_result.status == OperationStatus.SUCCEEDED
+        restart_result = restart_response.wait()
 
     @DevcenterPowerShellPreparer()
     @recorded_by_proxy
@@ -270,16 +269,13 @@ class TestDevcenter(AzureRecordedTestCase):
         client = self.create_client(endpoint)
 
         stop_response = client.begin_stop_dev_box(project_name, default_user, devbox_name)
-        stop_result = stop_response.result()
-        assert stop_result.status == OperationStatus.SUCCEEDED
+        stop_result = stop_response.wait()
 
         start_response = client.begin_start_dev_box(project_name, default_user, devbox_name)
-        start_result = start_response.result()
-        assert start_result.status == OperationStatus.SUCCEEDED
+        start_result = start_response.wait()
 
         delete_response = client.begin_delete_dev_box(project_name, default_user, devbox_name)
-        delete_result = delete_response.result()
-        assert delete_result.status == OperationStatus.SUCCEEDED
+        delete_result = delete_response.wait()
 
     @DevcenterPowerShellPreparer()
     @recorded_by_proxy
@@ -418,5 +414,4 @@ class TestDevcenter(AzureRecordedTestCase):
         assert len(all_envs_response) == 1 and all_envs_response[0].name == env_response.name
 
         delete_response = client.begin_delete_environment(project_name, default_user, env_name)
-        delete_result = delete_response.result()
-        assert delete_result.status == OperationStatus.SUCCEEDED
+        delete_result = delete_response.wait()

--- a/sdk/devcenter/azure-developer-devcenter/tests/test_devcenter_operations_async.py
+++ b/sdk/devcenter/azure-developer-devcenter/tests/test_devcenter_operations_async.py
@@ -284,8 +284,7 @@ class TestDevcenterAsync(AzureRecordedTestCase):
 
         async with client:
             restart_response = await client.begin_restart_dev_box(project_name, default_user, devbox_name)
-            restart_result = await restart_response.result()
-            assert restart_result.status == OperationStatus.SUCCEEDED
+            restart_result = await restart_response.wait()
 
     @DevcenterPowerShellPreparer()
     @recorded_by_proxy_async
@@ -300,16 +299,13 @@ class TestDevcenterAsync(AzureRecordedTestCase):
 
         async with client:
             stop_response = await client.begin_stop_dev_box(project_name, default_user, devbox_name)
-            stop_result = await stop_response.result()
-            assert stop_result.status == OperationStatus.SUCCEEDED
+            stop_result = await stop_response.wait()
 
             start_response = await client.begin_start_dev_box(project_name, default_user, devbox_name)
-            start_result = await start_response.result()
-            assert start_result.status == OperationStatus.SUCCEEDED
+            start_result = await start_response.wait()
 
             delete_response = await client.begin_delete_dev_box(project_name, default_user, devbox_name)
-            delete_result = await delete_response.result()
-            assert delete_result.status == OperationStatus.SUCCEEDED
+            delete_result = await delete_response.wait()
 
     @DevcenterPowerShellPreparer()
     @recorded_by_proxy_async
@@ -464,5 +460,4 @@ class TestDevcenterAsync(AzureRecordedTestCase):
             assert all_envs[0].name == env_name
     
             delete_response = await client.begin_delete_environment(project_name, default_user, env_name)
-            delete_result = await delete_response.result()
-            assert delete_result.status == OperationStatus.SUCCEEDED
+            delete_result = await delete_response.wait()


### PR DESCRIPTION
# Description

Current generation returns `LROPoller[OperationDetails]`, but if the LRO fails an exception is raised. Therefore, `operationDetails` models can only be accessed when operation is successful, which doesn't bring any value and can cause confusion. Customizing it to return `LROPoller[None]` for delete, start, stop and restart methods. 