### PR TITLE
Default missing/invalid status codes to "0" for standard metrics and trace payloads and fix success criteria

### DIFF
--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Bugs Fixed
 
+
 - Default missing/invalid status codes to "0" for standard metrics/trace payloads, change
     success criteria to `False` for those invalid cases
     ([#36079](https://github.com/Azure/azure-sdk-for-python/pull/36079))

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
@@ -11,6 +11,9 @@
 
 ### Bugs Fixed
 
+- Ignore missing status codes for standard metric payloads
+    ([#35910](https://github.com/Azure/azure-sdk-for-python/pull/35910))
+
 ### Other Changes
 
 ## 1.0.0b26 (2024-05-29)

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
@@ -11,7 +11,8 @@
 
 ### Bugs Fixed
 
-- Ignore missing status codes for standard metric payloads
+- Default missing/invalid status codes to "0" for standard metrics/trace payloads, change
+    success criteria to `False` for those invalid cases
     ([#36079](https://github.com/Azure/azure-sdk-for-python/pull/36079))
 
 ### Other Changes

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
@@ -11,7 +11,6 @@
 
 ### Bugs Fixed
 
-
 - Default missing/invalid status codes to "0" for standard metrics/trace payloads, change
     success criteria to `False` for those invalid cases
     ([#36079](https://github.com/Azure/azure-sdk-for-python/pull/36079))

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
@@ -12,7 +12,8 @@
 ### Bugs Fixed
 
 - Default missing/invalid status codes to "0" for standard metrics/trace payloads, change
-    success criteria to `False` for those invalid cases
+    success criteria to `False` for those invalid cases, change success criteria to status_code < 400 for
+    both client and server standard metrics
     ([#36079](https://github.com/Azure/azure-sdk-for-python/pull/36079))
 
 ### Other Changes

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/CHANGELOG.md
@@ -12,7 +12,7 @@
 ### Bugs Fixed
 
 - Ignore missing status codes for standard metric payloads
-    ([#35910](https://github.com/Azure/azure-sdk-for-python/pull/35910))
+    ([#36079](https://github.com/Azure/azure-sdk-for-python/pull/36079))
 
 ### Other Changes
 

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/metrics/_exporter.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/metrics/_exporter.py
@@ -240,7 +240,7 @@ def _handle_std_metric_envelope(
         properties["_MS.MetricId"] = "dependencies/duration"
         properties["_MS.IsAutocollected"] = "True"
         properties["Dependency.Type"] = "http"
-        properties["Dependency.Success"] = str(_is_status_code_success(status_code, 400)) # type: ignore
+        properties["Dependency.Success"] = str(_is_status_code_success(status_code)) # type: ignore
         target = None
         if "peer.service" in attributes:
             target = attributes["peer.service"] # type: ignore
@@ -267,7 +267,7 @@ def _handle_std_metric_envelope(
         # TODO: operation/synthetic
         properties["cloud/roleInstance"] = tags["ai.cloud.roleInstance"] # type: ignore
         properties["cloud/roleName"] = tags["ai.cloud.role"] # type: ignore
-        properties["Request.Success"] = str(_is_status_code_success(status_code, 500)) # type: ignore
+        properties["Request.Success"] = str(_is_status_code_success(status_code)) # type: ignore
     else:
         # Any other autocollected metrics are not supported yet for standard metrics
         # We ignore these envelopes in these cases
@@ -280,11 +280,13 @@ def _handle_std_metric_envelope(
     return envelope
 
 
-def _is_status_code_success(status_code: Optional[str], threshold: int) -> bool:
+def _is_status_code_success(status_code: Optional[str]) -> bool:
     if status_code is None or status_code == 0:
         return False
     try:
-        return int(status_code) < threshold
+        # Success criteria based solely off status code is True only if status_code < 400
+        # for both client and server spans
+        return int(status_code) < 400
     except ValueError:
         return False
 

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/metrics/_exporter.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/metrics/_exporter.py
@@ -235,7 +235,7 @@ def _handle_std_metric_envelope(
         properties["Dependency.Type"] = "http"
         properties["Dependency.Success"] = str(_is_status_code_success(status_code, 400)) # type: ignore
         target = None
-        if "peer.service" in attributes:
+        if attributes.get("peer.service"):
             target = attributes["peer.service"] # type: ignore
         elif "net.peer.name" in attributes:
             if attributes["net.peer.name"] is None: # type: ignore
@@ -249,14 +249,16 @@ def _handle_std_metric_envelope(
             else:
                 target = attributes["net.peer.name"] # type: ignore
         properties["dependency/target"] = target # type: ignore
-        properties["dependency/resultCode"] = str(status_code)
+        if status_code:
+            properties["dependency/resultCode"] = str(status_code)
         # TODO: operation/synthetic
         properties["cloud/roleInstance"] = tags["ai.cloud.roleInstance"] # type: ignore
         properties["cloud/roleName"] = tags["ai.cloud.role"] # type: ignore
     elif name == "http.server.duration":
         properties["_MS.MetricId"] = "requests/duration"
         properties["_MS.IsAutocollected"] = "True"
-        properties["request/resultCode"] = str(status_code)
+        if status_code:
+            properties["request/resultCode"] = str(status_code)
         # TODO: operation/synthetic
         properties["cloud/roleInstance"] = tags["ai.cloud.roleInstance"] # type: ignore
         properties["cloud/roleName"] = tags["ai.cloud.role"] # type: ignore

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/metrics/_exporter.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/metrics/_exporter.py
@@ -229,6 +229,13 @@ def _handle_std_metric_envelope(
         attributes = {}
     # TODO: switch to semconv constants
     status_code = attributes.get("http.status_code")
+    if status_code:
+        try:
+            status_code = int(status_code) # type: ignore
+        except ValueError:
+            status_code = 0
+    else:
+        status_code = 0
     if name == "http.client.duration":
         properties["_MS.MetricId"] = "dependencies/duration"
         properties["_MS.IsAutocollected"] = "True"
@@ -249,16 +256,14 @@ def _handle_std_metric_envelope(
             else:
                 target = attributes["net.peer.name"] # type: ignore
         properties["dependency/target"] = target # type: ignore
-        if status_code:
-            properties["dependency/resultCode"] = str(status_code)
+        properties["dependency/resultCode"] = str(status_code)
         # TODO: operation/synthetic
         properties["cloud/roleInstance"] = tags["ai.cloud.roleInstance"] # type: ignore
         properties["cloud/roleName"] = tags["ai.cloud.role"] # type: ignore
     elif name == "http.server.duration":
         properties["_MS.MetricId"] = "requests/duration"
         properties["_MS.IsAutocollected"] = "True"
-        if status_code:
-            properties["request/resultCode"] = str(status_code)
+        properties["request/resultCode"] = str(status_code)
         # TODO: operation/synthetic
         properties["cloud/roleInstance"] = tags["ai.cloud.roleInstance"] # type: ignore
         properties["cloud/roleName"] = tags["ai.cloud.role"] # type: ignore
@@ -276,7 +281,7 @@ def _handle_std_metric_envelope(
 
 
 def _is_status_code_success(status_code: Optional[str], threshold: int) -> bool:
-    if status_code is None:
+    if status_code is None or status_code == 0:
         return False
     try:
         return int(status_code) < threshold

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/metrics/_exporter.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/metrics/_exporter.py
@@ -235,7 +235,7 @@ def _handle_std_metric_envelope(
         properties["Dependency.Type"] = "http"
         properties["Dependency.Success"] = str(_is_status_code_success(status_code, 400)) # type: ignore
         target = None
-        if attributes.get("peer.service"):
+        if "peer.service" in attributes:
             target = attributes["peer.service"] # type: ignore
         elif "net.peer.name" in attributes:
             if attributes["net.peer.name"] is None: # type: ignore

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/trace/_exporter.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/export/trace/_exporter.py
@@ -284,6 +284,7 @@ def _convert_span_to_envelope(span: ReadableSpan) -> TelemetryItem:
             else:
                 status_code = 0
             data.response_code = str(status_code)
+            # Success criteria for server spans depends on span.success and the actual status code
             data.success = span.status.is_ok and status_code and status_code not in range(400, 500)
         elif SpanAttributes.MESSAGING_SYSTEM in span.attributes:  # Messaging
             if SpanAttributes.NET_PEER_IP in span.attributes:
@@ -322,7 +323,7 @@ def _convert_span_to_envelope(span: ReadableSpan) -> TelemetryItem:
             id="{:016x}".format(span.context.span_id),
             result_code="0",
             duration=_utils.ns_to_duration(time),
-            success=span.status.is_ok,
+            success=span.status.is_ok, # Success depends only on span status
             properties={},
         )
         envelope.data = MonitorBase(

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/metrics/test_metrics.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/metrics/test_metrics.py
@@ -347,10 +347,12 @@ class TestAzureMetricExporter(unittest.TestCase):
         point.attributes["http.status_code"] = None
         envelope = exporter._point_to_envelope(point, "http.client.duration", resource)
         self.assertEqual(envelope.data.base_data.properties['Dependency.Success'], "False")
+        self.assertIsNone(envelope.data.base_data.properties.get('dependency/resultCode'))
 
         point.attributes["http.status_code"] = "None"
         envelope = exporter._point_to_envelope(point, "http.client.duration", resource)
         self.assertEqual(envelope.data.base_data.properties['Dependency.Success'], "False")
+        self.assertEqual(envelope.data.base_data.properties['dependency/resultCode'], "None")
 
 
     def test_point_to_envelope_std_metric_server_duration(self):
@@ -393,10 +395,12 @@ class TestAzureMetricExporter(unittest.TestCase):
         point.attributes["http.status_code"] = None
         envelope = exporter._point_to_envelope(point, "http.server.duration", resource)
         self.assertEqual(envelope.data.base_data.properties['Request.Success'], "False")
+        self.assertIsNone(envelope.data.base_data.properties.get('request/resultCode'))
 
         point.attributes["http.status_code"] = "None"
         envelope = exporter._point_to_envelope(point, "http.server.duration", resource)
         self.assertEqual(envelope.data.base_data.properties['Request.Success'], "False")
+        self.assertEqual(envelope.data.base_data.properties['request/resultCode'], "None")
 
 
     def test_point_to_envelope_std_metric_unsupported(self):

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/metrics/test_metrics.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/metrics/test_metrics.py
@@ -347,12 +347,12 @@ class TestAzureMetricExporter(unittest.TestCase):
         point.attributes["http.status_code"] = None
         envelope = exporter._point_to_envelope(point, "http.client.duration", resource)
         self.assertEqual(envelope.data.base_data.properties['Dependency.Success'], "False")
-        self.assertIsNone(envelope.data.base_data.properties.get('dependency/resultCode'))
+        self.assertEqual(envelope.data.base_data.properties['dependency/resultCode'], "0")
 
         point.attributes["http.status_code"] = "None"
         envelope = exporter._point_to_envelope(point, "http.client.duration", resource)
         self.assertEqual(envelope.data.base_data.properties['Dependency.Success'], "False")
-        self.assertEqual(envelope.data.base_data.properties['dependency/resultCode'], "None")
+        self.assertEqual(envelope.data.base_data.properties['dependency/resultCode'], "0")
 
 
     def test_point_to_envelope_std_metric_server_duration(self):
@@ -395,12 +395,12 @@ class TestAzureMetricExporter(unittest.TestCase):
         point.attributes["http.status_code"] = None
         envelope = exporter._point_to_envelope(point, "http.server.duration", resource)
         self.assertEqual(envelope.data.base_data.properties['Request.Success'], "False")
-        self.assertIsNone(envelope.data.base_data.properties.get('request/resultCode'))
+        self.assertEqual(envelope.data.base_data.properties.get('request/resultCode'), "0")
 
         point.attributes["http.status_code"] = "None"
         envelope = exporter._point_to_envelope(point, "http.server.duration", resource)
         self.assertEqual(envelope.data.base_data.properties['Request.Success'], "False")
-        self.assertEqual(envelope.data.base_data.properties['request/resultCode'], "None")
+        self.assertEqual(envelope.data.base_data.properties.get('request/resultCode'), "0")
 
 
     def test_point_to_envelope_std_metric_unsupported(self):

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/metrics/test_metrics.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/metrics/test_metrics.py
@@ -388,7 +388,7 @@ class TestAzureMetricExporter(unittest.TestCase):
         self.assertEqual(envelope.data.base_data.metrics[0].value, 15.0)
 
         # Success/Failure
-        point.attributes["http.status_code"] = 600
+        point.attributes["http.status_code"] = 500
         envelope = exporter._point_to_envelope(point, "http.server.duration", resource)
         self.assertEqual(envelope.data.base_data.properties['Request.Success'], "False")
 

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/trace/test_trace.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/trace/test_trace.py
@@ -346,6 +346,34 @@ class TestAzureTraceExporter(unittest.TestCase):
         envelope = exporter._span_to_envelope(span)
         self.assertEqual(envelope.data.base_data.data, "https://192.168.0.1:8080/path/12314/?q=ddds#123")
 
+        # result_code
+        span._attributes = {
+            "http.method": "GET",
+            "http.scheme": "https",
+            "http.url": "https://www.example.com",
+            "http.status_code": None
+        }
+        envelope = exporter._span_to_envelope(span)
+        envelope = exporter._span_to_envelope(span)
+        self.assertEqual(envelope.data.base_data.result_code, "0")
+
+        span._attributes = {
+            "http.method": "GET",
+            "http.scheme": "https",
+            "http.url": "https://www.example.com",
+        }
+        envelope = exporter._span_to_envelope(span)
+        self.assertEqual(envelope.data.base_data.result_code, "0")
+
+        span._attributes = {
+            "http.method": "GET",
+            "http.scheme": "https",
+            "http.url": "https://www.example.com",
+            "http.status_code": "",
+        }
+        envelope = exporter._span_to_envelope(span)
+        self.assertEqual(envelope.data.base_data.result_code, "0")
+
     def test_span_to_envelope_client_db(self):
         exporter = self._exporter
         start_time = 1575494316027613500
@@ -857,7 +885,24 @@ class TestAzureTraceExporter(unittest.TestCase):
         }
         envelope = exporter._span_to_envelope(span)
         self.assertFalse(envelope.data.base_data.success)
+        self.assertEqual(envelope.data.base_data.response_code, "400")
 
+        span._attributes = {
+            "http.method": "GET",
+            "net.peer.ip": "peer_ip",
+        }
+        envelope = exporter._span_to_envelope(span)
+        self.assertFalse(envelope.data.base_data.success)
+        self.assertEqual(envelope.data.base_data.response_code, "0")
+
+        span._attributes = {
+            "http.method": "GET",
+            "net.peer.ip": "peer_ip",
+            "http.status_code": "",
+        }
+        envelope = exporter._span_to_envelope(span)
+        self.assertFalse(envelope.data.base_data.success)
+        self.assertEqual(envelope.data.base_data.response_code, "0")
 
         # location
         span._attributes = {


### PR DESCRIPTION
1. Default missing/invalid status codes to "0" for standard metrics and trace payloads
2. Treat missing/invalid status codes as "Success=False" cases
3. Success criteria for std metrics depend on status code < 400 for both client and server spans