### PR TITLE
[SB] Fix Message Completion on Management Link

### DIFF
--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/_message_backcompat.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/_message_backcompat.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
         def settle_messages(
             self,
             delivery_id: Optional[int],
-            delivery_tag: Optional[str],
+            delivery_tag: Optional[bytes],
             outcome: str,
             *,
             error: Optional[AMQPError] = None,
@@ -86,7 +86,7 @@ class LegacyMessage(object):  # pylint: disable=too-many-instance-attributes
         self._settler: Optional["Settler"] = kwargs.pop("settler", None)
         self._encoding = kwargs.get("encoding")
         self.delivery_no: Optional[int] = kwargs.get("delivery_no")
-        self.delivery_tag: Optional[str] = kwargs.get("delivery_tag") or None
+        self.delivery_tag: Optional[bytes] = kwargs.get("delivery_tag") or None
         self.on_send_complete: Optional[Callable] = None
         self.properties: Optional[LegacyMessageProperties] = (
             LegacyMessageProperties(self._message.properties)

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/_message_backcompat.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/_message_backcompat.py
@@ -31,6 +31,7 @@ if TYPE_CHECKING:
         def settle_messages(
             self,
             delivery_id: Optional[int],
+            delivery_tag: Optional[str],
             outcome: str,
             *,
             error: Optional[AMQPError] = None,
@@ -159,7 +160,7 @@ class LegacyMessage(object):  # pylint: disable=too-many-instance-attributes
 
     def accept(self) -> bool:
         if self._can_settle_message() and self._settler:
-            self._settler.settle_messages(self.delivery_no, "accepted")
+            self._settler.settle_messages(self.delivery_no, self.delivery_tag, "accepted")
             self.state = MessageState.ReceivedSettled
             return True
         return False
@@ -173,6 +174,7 @@ class LegacyMessage(object):  # pylint: disable=too-many-instance-attributes
         if self._can_settle_message() and self._settler:
             self._settler.settle_messages(
                 self.delivery_no,
+                self.delivery_tag,
                 "rejected",
                 error=AMQPError(
                     condition=condition, description=description, info=info
@@ -184,7 +186,7 @@ class LegacyMessage(object):  # pylint: disable=too-many-instance-attributes
 
     def release(self) -> bool:
         if self._can_settle_message() and self._settler:
-            self._settler.settle_messages(self.delivery_no, "released")
+            self._settler.settle_messages(self.delivery_no, self.delivery_tag, "released")
             self.state = MessageState.ReceivedSettled
             return True
         return False
@@ -198,6 +200,7 @@ class LegacyMessage(object):  # pylint: disable=too-many-instance-attributes
         if self._can_settle_message() and self._settler:
             self._settler.settle_messages(
                 self.delivery_no,
+                self.delivery_tag,
                 "modified",
                 delivery_failed=failed,
                 undeliverable_here=deliverable,

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_client_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_client_async.py
@@ -931,6 +931,7 @@ class ReceiveClientAsync(ReceiveClientSync, AMQPClientAsync):
     async def settle_messages_async(
         self,
         delivery_id: Union[int, Tuple[int, int]],
+        delivery_tag: bytes,
         outcome: Literal["accepted"],
         *,
         batchable: Optional[bool] = None
@@ -941,6 +942,7 @@ class ReceiveClientAsync(ReceiveClientSync, AMQPClientAsync):
     async def settle_messages_async(
         self,
         delivery_id: Union[int, Tuple[int, int]],
+        delivery_tag: bytes,
         outcome: Literal["released"],
         *,
         batchable: Optional[bool] = None
@@ -951,6 +953,7 @@ class ReceiveClientAsync(ReceiveClientSync, AMQPClientAsync):
     async def settle_messages_async(
         self,
         delivery_id: Union[int, Tuple[int, int]],
+        delivery_tag: bytes,
         outcome: Literal["rejected"],
         *,
         error: Optional[AMQPError] = None,
@@ -962,6 +965,7 @@ class ReceiveClientAsync(ReceiveClientSync, AMQPClientAsync):
     async def settle_messages_async(
         self,
         delivery_id: Union[int, Tuple[int, int]],
+        delivery_tag: bytes,
         outcome: Literal["modified"],
         *,
         delivery_failed: Optional[bool] = None,
@@ -975,6 +979,7 @@ class ReceiveClientAsync(ReceiveClientSync, AMQPClientAsync):
     async def settle_messages_async(
         self,
         delivery_id: Union[int, Tuple[int, int]],
+        delivery_tag: bytes,
         outcome: Literal["received"],
         *,
         section_number: int,
@@ -983,7 +988,13 @@ class ReceiveClientAsync(ReceiveClientSync, AMQPClientAsync):
     ):
         ...
 
-    async def settle_messages_async(self, delivery_id: Union[int, Tuple[int, int]], outcome: str, **kwargs):
+    async def settle_messages_async(
+            self,
+            delivery_id: Union[int, Tuple[int, int]],
+            delivery_tag: bytes,
+            outcome: str,
+            **kwargs
+    ):
         batchable = kwargs.pop('batchable', None)
         if outcome.lower() == 'accepted':
             state: Outcomes = Accepted()
@@ -1005,6 +1016,7 @@ class ReceiveClientAsync(ReceiveClientSync, AMQPClientAsync):
         await self._link.send_disposition(
             first_delivery_id=first,
             last_delivery_id=last,
+            delivery_tag=delivery_tag,
             settled=True,
             delivery_state=state,
             batchable=batchable,

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_receiver_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_receiver_async.py
@@ -71,7 +71,7 @@ class ReceiverLink(Link):
         if self._received_payload or frame[5]:  # more
             self._received_payload.extend(frame[11])
         if not frame[5]:
-            self._received_messages.add(frame[2])
+            self._received_messages.add(self._first_frame[2])
             if self._received_payload:
                 message = decode_payload(memoryview(self._received_payload))
                 self._received_payload = bytearray()

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_receiver_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_receiver_async.py
@@ -82,7 +82,7 @@ class ReceiverLink(Link):
                 await self._outgoing_disposition(
                     first=self._first_frame[1],
                     last=self._first_frame[1],
-                    delivery_tag=frame[2],
+                    delivery_tag=self._first_frame[2],
                     settled=True,
                     state=delivery_state,
                     batchable=None

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_receiver_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_receiver_async.py
@@ -16,6 +16,7 @@ from ..performatives import (
     DispositionFrame,
 )
 from ..outcomes import Received, Accepted, Rejected, Released, Modified
+from ..error import AMQPLinkError, ErrorCondition
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -31,6 +32,7 @@ class ReceiverLink(Link):
         self._on_transfer = kwargs.pop("on_transfer")
         self._received_payload = bytearray()
         self._first_frame = None
+        self._received_messages = set()
 
     @classmethod
     def from_incoming_frame(cls, session, handle, frame):
@@ -69,6 +71,7 @@ class ReceiverLink(Link):
         if self._received_payload or frame[5]:  # more
             self._received_payload.extend(frame[11])
         if not frame[5]:
+            self._received_messages.add(frame[2])
             if self._received_payload:
                 message = decode_payload(memoryview(self._received_payload))
                 self._received_payload = bytearray()
@@ -79,6 +82,7 @@ class ReceiverLink(Link):
                 await self._outgoing_disposition(
                     first=self._first_frame[1],
                     last=self._first_frame[1],
+                    delivery_tag=frame[2],
                     settled=True,
                     state=delivery_state,
                     batchable=None
@@ -100,6 +104,7 @@ class ReceiverLink(Link):
         self,
         first: int,
         last: Optional[int],
+        delivery_tag: bytes,
         settled: Optional[bool],
         state: Optional[Union[Received, Accepted, Rejected, Released, Modified]],
         batchable: Optional[bool],
@@ -107,9 +112,13 @@ class ReceiverLink(Link):
         disposition_frame = DispositionFrame(
             role=self.role, first=first, last=last, settled=settled, state=state, batchable=batchable
         )
+        if delivery_tag not in self._received_messages:
+            raise AMQPLinkError(condition=ErrorCondition.InternalError, description = "Delivery tag not found.")
+
         if self.network_trace:
             _LOGGER.debug("-> %r", DispositionFrame(*disposition_frame), extra=self.network_trace_params)
         await self._session._outgoing_disposition(disposition_frame) # pylint: disable=protected-access
+        self._received_messages.remove(delivery_tag)
 
     async def attach(self):
         await super().attach()
@@ -121,12 +130,20 @@ class ReceiverLink(Link):
         wait: Union[bool, float] = False,
         first_delivery_id: int,
         last_delivery_id: Optional[int] = None,
+        delivery_tag: bytes,
         settled: Optional[bool] = None,
         delivery_state: Optional[Union[Received, Accepted, Rejected, Released, Modified]] = None,
         batchable: Optional[bool] = None
     ):
         if self._is_closed:
             raise ValueError("Link already closed.")
-        await self._outgoing_disposition(first_delivery_id, last_delivery_id, settled, delivery_state, batchable)
+        await self._outgoing_disposition(
+            first_delivery_id,
+            last_delivery_id,
+            delivery_tag,
+            settled,
+            delivery_state,
+            batchable
+        )
         if not settled:
             await self._wait_for_response(wait)

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_receiver_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_receiver_async.py
@@ -112,7 +112,7 @@ class ReceiverLink(Link):
         disposition_frame = DispositionFrame(
             role=self.role, first=first, last=last, settled=settled, state=state, batchable=batchable
         )
-        if delivery_tag not in self._received_messages:
+        if delivery_tag not in self._received_delivery_tags:
             raise AMQPLinkError(condition=ErrorCondition.InternalError, description = "Delivery tag not found.")
 
         if self.network_trace:

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_receiver_async.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/aio/_receiver_async.py
@@ -32,7 +32,7 @@ class ReceiverLink(Link):
         self._on_transfer = kwargs.pop("on_transfer")
         self._received_payload = bytearray()
         self._first_frame = None
-        self._received_messages = set()
+        self._received_delivery_tags = set()
 
     @classmethod
     def from_incoming_frame(cls, session, handle, frame):
@@ -71,7 +71,7 @@ class ReceiverLink(Link):
         if self._received_payload or frame[5]:  # more
             self._received_payload.extend(frame[11])
         if not frame[5]:
-            self._received_messages.add(self._first_frame[2])
+            self._received_delivery_tags.add(self._first_frame[2])
             if self._received_payload:
                 message = decode_payload(memoryview(self._received_payload))
                 self._received_payload = bytearray()
@@ -118,7 +118,7 @@ class ReceiverLink(Link):
         if self.network_trace:
             _LOGGER.debug("-> %r", DispositionFrame(*disposition_frame), extra=self.network_trace_params)
         await self._session._outgoing_disposition(disposition_frame) # pylint: disable=protected-access
-        self._received_messages.remove(delivery_tag)
+        self._received_delivery_tags.remove(delivery_tag)
 
     async def attach(self):
         await super().attach()

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/client.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/client.py
@@ -1031,6 +1031,7 @@ class ReceiveClient(AMQPClient): # pylint:disable=too-many-instance-attributes
     def settle_messages(
         self,
         delivery_id: Union[int, Tuple[int, int]],
+        delivery_tag: bytes,
         outcome: Literal["accepted"],
         *,
         batchable: Optional[bool] = None
@@ -1041,6 +1042,7 @@ class ReceiveClient(AMQPClient): # pylint:disable=too-many-instance-attributes
     def settle_messages(
         self,
         delivery_id: Union[int, Tuple[int, int]],
+        delivery_tag: bytes,
         outcome: Literal["released"],
         *,
         batchable: Optional[bool] = None
@@ -1051,6 +1053,7 @@ class ReceiveClient(AMQPClient): # pylint:disable=too-many-instance-attributes
     def settle_messages(
         self,
         delivery_id: Union[int, Tuple[int, int]],
+        delivery_tag: bytes,
         outcome: Literal["rejected"],
         *,
         error: Optional[AMQPError] = None,
@@ -1062,6 +1065,7 @@ class ReceiveClient(AMQPClient): # pylint:disable=too-many-instance-attributes
     def settle_messages(
         self,
         delivery_id: Union[int, Tuple[int, int]],
+        delivery_tag: bytes,
         outcome: Literal["modified"],
         *,
         delivery_failed: Optional[bool] = None,
@@ -1075,6 +1079,7 @@ class ReceiveClient(AMQPClient): # pylint:disable=too-many-instance-attributes
     def settle_messages(
         self,
         delivery_id: Union[int, Tuple[int, int]],
+        delivery_tag: bytes,
         outcome: Literal["received"],
         *,
         section_number: int,
@@ -1084,7 +1089,7 @@ class ReceiveClient(AMQPClient): # pylint:disable=too-many-instance-attributes
         ...
 
     def settle_messages(
-        self, delivery_id: Union[int, Tuple[int, int]], outcome: str, **kwargs
+        self, delivery_id: Union[int, Tuple[int, int]], delivery_tag: bytes, outcome: str, **kwargs
     ):
         batchable = kwargs.pop("batchable", None)
         if outcome.lower() == "accepted":
@@ -1107,6 +1112,7 @@ class ReceiveClient(AMQPClient): # pylint:disable=too-many-instance-attributes
         self._link.send_disposition(
             first_delivery_id=first,
             last_delivery_id=last,
+            delivery_tag=delivery_tag,
             settled=True,
             delivery_state=state,
             batchable=batchable,

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/receiver.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/receiver.py
@@ -13,6 +13,7 @@ from .link import Link
 from .constants import LinkState, Role
 from .performatives import TransferFrame, DispositionFrame
 from .outcomes import Received, Accepted, Rejected, Released, Modified
+from .error import AMQPLinkError, ErrorCondition
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -28,6 +29,7 @@ class ReceiverLink(Link):
         self._on_transfer = kwargs.pop("on_transfer")
         self._received_payload = bytearray()
         self._first_frame = None
+        self._received_messages = set()
 
     @classmethod
     def from_incoming_frame(cls, session, handle, frame):
@@ -54,6 +56,7 @@ class ReceiverLink(Link):
     def _incoming_transfer(self, frame):
         if self.network_trace:
             _LOGGER.debug("<- %r", TransferFrame(payload=b"***", *frame[:-1]), extra=self.network_trace_params)
+
         # If more is false --> this is the last frame of the message
         if not frame[5]:
             self.current_link_credit -= 1
@@ -66,16 +69,19 @@ class ReceiverLink(Link):
         if self._received_payload or frame[5]:  # more
             self._received_payload.extend(frame[11])
         if not frame[5]:
+            self._received_messages.add(frame[2])
             if self._received_payload:
                 message = decode_payload(memoryview(self._received_payload))
                 self._received_payload = bytearray()
             else:
                 message = decode_payload(frame[11])
             delivery_state = self._process_incoming_message(self._first_frame, message)
+
             if not frame[4] and delivery_state:  # settled
                 self._outgoing_disposition(
                     first=self._first_frame[1],
                     last=self._first_frame[1],
+                    delivery_tag=frame[2],
                     settled=True,
                     state=delivery_state,
                     batchable=None
@@ -97,16 +103,21 @@ class ReceiverLink(Link):
         self,
         first: int,
         last: Optional[int],
+        delivery_tag: bytes,
         settled: Optional[bool],
         state: Optional[Union[Received, Accepted, Rejected, Released, Modified]],
         batchable: Optional[bool],
     ):
+        if delivery_tag not in self._received_messages:
+            raise AMQPLinkError(condition=ErrorCondition.InternalError, description = "Delivery tag not found.")
+
         disposition_frame = DispositionFrame(
             role=self.role, first=first, last=last, settled=settled, state=state, batchable=batchable
         )
         if self.network_trace:
             _LOGGER.debug("-> %r", DispositionFrame(*disposition_frame), extra=self.network_trace_params)
         self._session._outgoing_disposition(disposition_frame) # pylint: disable=protected-access
+        self._received_messages.remove(delivery_tag)
 
     def attach(self):
         super().attach()
@@ -118,12 +129,20 @@ class ReceiverLink(Link):
         wait: Union[bool, float] = False,
         first_delivery_id: int,
         last_delivery_id: Optional[int] = None,
+        delivery_tag: bytes,
         settled: Optional[bool] = None,
         delivery_state: Optional[Union[Received, Accepted, Rejected, Released, Modified]] = None,
         batchable: Optional[bool] = None
     ):
         if self._is_closed:
             raise ValueError("Link already closed.")
-        self._outgoing_disposition(first_delivery_id, last_delivery_id, settled, delivery_state, batchable)
+        self._outgoing_disposition(
+            first_delivery_id,
+            last_delivery_id,
+            delivery_tag,
+            settled,
+            delivery_state,
+            batchable
+        )
         if not settled:
             self._wait_for_response(wait)

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/receiver.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/receiver.py
@@ -108,7 +108,7 @@ class ReceiverLink(Link):
         state: Optional[Union[Received, Accepted, Rejected, Released, Modified]],
         batchable: Optional[bool],
     ):
-        if delivery_tag not in self._received_messages:
+        if delivery_tag not in self._received_delivery_tags:
             raise AMQPLinkError(condition=ErrorCondition.InternalError, description = "Delivery tag not found.")
 
         disposition_frame = DispositionFrame(

--- a/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/receiver.py
+++ b/sdk/eventhub/azure-eventhub/azure/eventhub/_pyamqp/receiver.py
@@ -29,7 +29,7 @@ class ReceiverLink(Link):
         self._on_transfer = kwargs.pop("on_transfer")
         self._received_payload = bytearray()
         self._first_frame = None
-        self._received_messages = set()
+        self._received_delivery_tags = set()
 
     @classmethod
     def from_incoming_frame(cls, session, handle, frame):
@@ -69,7 +69,7 @@ class ReceiverLink(Link):
         if self._received_payload or frame[5]:  # more
             self._received_payload.extend(frame[11])
         if not frame[5]:
-            self._received_messages.add(frame[2])
+            self._received_delivery_tags.add(self._first_frame[2])
             if self._received_payload:
                 message = decode_payload(memoryview(self._received_payload))
                 self._received_payload = bytearray()
@@ -81,7 +81,7 @@ class ReceiverLink(Link):
                 self._outgoing_disposition(
                     first=self._first_frame[1],
                     last=self._first_frame[1],
-                    delivery_tag=frame[2],
+                    delivery_tag=self._first_frame[2],
                     settled=True,
                     state=delivery_state,
                     batchable=None
@@ -117,7 +117,7 @@ class ReceiverLink(Link):
         if self.network_trace:
             _LOGGER.debug("-> %r", DispositionFrame(*disposition_frame), extra=self.network_trace_params)
         self._session._outgoing_disposition(disposition_frame) # pylint: disable=protected-access
-        self._received_messages.remove(delivery_tag)
+        self._received_delivery_tags.remove(delivery_tag)
 
     def attach(self):
         super().attach()

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/_message_backcompat.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/_message_backcompat.py
@@ -31,6 +31,7 @@ if TYPE_CHECKING:
         def settle_messages(
             self,
             delivery_id: Optional[int],
+            delivery_tag: bytes,
             outcome: str,
             *,
             error: Optional[AMQPError] = None,
@@ -159,7 +160,7 @@ class LegacyMessage(object):  # pylint: disable=too-many-instance-attributes
 
     def accept(self) -> bool:
         if self._can_settle_message() and self._settler:
-            self._settler.settle_messages(self.delivery_no, "accepted")
+            self._settler.settle_messages(self.delivery_no, self.delivery_tag, "accepted")
             self.state = MessageState.ReceivedSettled
             return True
         return False
@@ -173,6 +174,7 @@ class LegacyMessage(object):  # pylint: disable=too-many-instance-attributes
         if self._can_settle_message() and self._settler:
             self._settler.settle_messages(
                 self.delivery_no,
+                self.delivery_tag,
                 "rejected",
                 error=AMQPError(
                     condition=condition, description=description, info=info
@@ -184,7 +186,7 @@ class LegacyMessage(object):  # pylint: disable=too-many-instance-attributes
 
     def release(self) -> bool:
         if self._can_settle_message() and self._settler:
-            self._settler.settle_messages(self.delivery_no, "released")
+            self._settler.settle_messages(self.delivery_no, self.delivery_tag, "released")
             self.state = MessageState.ReceivedSettled
             return True
         return False
@@ -198,6 +200,7 @@ class LegacyMessage(object):  # pylint: disable=too-many-instance-attributes
         if self._can_settle_message() and self._settler:
             self._settler.settle_messages(
                 self.delivery_no,
+                self.delivery_tag,
                 "modified",
                 delivery_failed=failed,
                 undeliverable_here=deliverable,

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/_message_backcompat.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/_message_backcompat.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
         def settle_messages(
             self,
             delivery_id: Optional[int],
-            delivery_tag: bytes,
+            delivery_tag: Optional[str],
             outcome: str,
             *,
             error: Optional[AMQPError] = None,

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/_message_backcompat.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/_message_backcompat.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
         def settle_messages(
             self,
             delivery_id: Optional[int],
-            delivery_tag: Optional[str],
+            delivery_tag: Optional[bytes],
             outcome: str,
             *,
             error: Optional[AMQPError] = None,
@@ -86,7 +86,7 @@ class LegacyMessage(object):  # pylint: disable=too-many-instance-attributes
         self._settler: Optional["Settler"] = kwargs.pop("settler", None)
         self._encoding = kwargs.get("encoding")
         self.delivery_no: Optional[int] = kwargs.get("delivery_no")
-        self.delivery_tag: Optional[str] = kwargs.get("delivery_tag") or None
+        self.delivery_tag: Optional[bytes] = kwargs.get("delivery_tag") or None
         self.on_send_complete: Optional[Callable] = None
         self.properties: Optional[LegacyMessageProperties] = (
             LegacyMessageProperties(self._message.properties)

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_client_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_client_async.py
@@ -933,6 +933,7 @@ class ReceiveClientAsync(ReceiveClientSync, AMQPClientAsync):
     async def settle_messages_async(
         self,
         delivery_id: Union[int, Tuple[int, int]],
+        delivery_tag: bytes,
         outcome: Literal["accepted"],
         *,
         batchable: Optional[bool] = None
@@ -943,6 +944,7 @@ class ReceiveClientAsync(ReceiveClientSync, AMQPClientAsync):
     async def settle_messages_async(
         self,
         delivery_id: Union[int, Tuple[int, int]],
+        delivery_tag: bytes,
         outcome: Literal["released"],
         *,
         batchable: Optional[bool] = None
@@ -953,6 +955,7 @@ class ReceiveClientAsync(ReceiveClientSync, AMQPClientAsync):
     async def settle_messages_async(
         self,
         delivery_id: Union[int, Tuple[int, int]],
+        delivery_tag: bytes,
         outcome: Literal["rejected"],
         *,
         error: Optional[AMQPError] = None,
@@ -964,6 +967,7 @@ class ReceiveClientAsync(ReceiveClientSync, AMQPClientAsync):
     async def settle_messages_async(
         self,
         delivery_id: Union[int, Tuple[int, int]],
+        delivery_tag: bytes,
         outcome: Literal["modified"],
         *,
         delivery_failed: Optional[bool] = None,
@@ -977,6 +981,7 @@ class ReceiveClientAsync(ReceiveClientSync, AMQPClientAsync):
     async def settle_messages_async(
         self,
         delivery_id: Union[int, Tuple[int, int]],
+        delivery_tag: bytes,
         outcome: Literal["received"],
         *,
         section_number: int,
@@ -985,7 +990,7 @@ class ReceiveClientAsync(ReceiveClientSync, AMQPClientAsync):
     ):
         ...
 
-    async def settle_messages_async(self, delivery_id: Union[int, Tuple[int, int]], outcome: str, **kwargs):
+    async def settle_messages_async(self, delivery_id: Union[int, Tuple[int, int]], delivery_tag: bytes, outcome: str, **kwargs):
         batchable = kwargs.pop('batchable', None)
         if outcome.lower() == 'accepted':
             state: Outcomes = Accepted()
@@ -1007,6 +1012,7 @@ class ReceiveClientAsync(ReceiveClientSync, AMQPClientAsync):
         await self._link.send_disposition(
             first_delivery_id=first,
             last_delivery_id=last,
+            delivery_tag=delivery_tag,
             settled=True,
             delivery_state=state,
             batchable=batchable,

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_client_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_client_async.py
@@ -990,7 +990,13 @@ class ReceiveClientAsync(ReceiveClientSync, AMQPClientAsync):
     ):
         ...
 
-    async def settle_messages_async(self, delivery_id: Union[int, Tuple[int, int]], delivery_tag: bytes, outcome: str, **kwargs):
+    async def settle_messages_async(
+            self,
+            delivery_id: Union[int, Tuple[int, int]],
+            delivery_tag: bytes,
+            outcome: str,
+            **kwargs
+    ):
         batchable = kwargs.pop('batchable', None)
         if outcome.lower() == 'accepted':
             state: Outcomes = Accepted()

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_receiver_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_receiver_async.py
@@ -83,6 +83,7 @@ class ReceiverLink(Link):
                 await self._outgoing_disposition(
                     first=self._first_frame[1],
                     last=self._first_frame[1],
+                    delivery_tag=frame[2],
                     settled=True,
                     state=delivery_state,
                     batchable=None
@@ -114,7 +115,7 @@ class ReceiverLink(Link):
         )
         if delivery_tag not in self._received_messages:
             raise AMQPLinkError(condition=ErrorCondition.InternalError, description = "Delivery tag not found.")
-        
+
         if self.network_trace:
             _LOGGER.debug("-> %r", DispositionFrame(*disposition_frame), extra=self.network_trace_params)
         await self._session._outgoing_disposition(disposition_frame) # pylint: disable=protected-access
@@ -137,6 +138,13 @@ class ReceiverLink(Link):
     ):
         if self._is_closed:
             raise ValueError("Link already closed.")
-        await self._outgoing_disposition(first_delivery_id, last_delivery_id, delivery_tag, settled, delivery_state, batchable)
+        await self._outgoing_disposition(
+            first_delivery_id,
+            last_delivery_id,
+            delivery_tag,
+            settled,
+            delivery_state,
+            batchable
+        )
         if not settled:
             await self._wait_for_response(wait)

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_receiver_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_receiver_async.py
@@ -59,7 +59,6 @@ class ReceiverLink(Link):
     async def _incoming_transfer(self, frame):
         if self.network_trace:
             _LOGGER.debug("<- %r", TransferFrame(payload=b"***", *frame[:-1]), extra=self.network_trace_params)
-        self._received_messages.add(frame[2])
         self.delivery_count += 1
         self.received_delivery_id = frame[1] # delivery_id
         # If more is false --> this is the last frame of the message
@@ -72,6 +71,7 @@ class ReceiverLink(Link):
         if self._received_payload or frame[5]:  # more
             self._received_payload.extend(frame[11])
         if not frame[5]:
+            self._received_messages.add(frame[2])
             if self._received_payload:
                 message = decode_payload(memoryview(self._received_payload))
                 self._received_payload = bytearray()

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_receiver_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_receiver_async.py
@@ -59,6 +59,7 @@ class ReceiverLink(Link):
     async def _incoming_transfer(self, frame):
         if self.network_trace:
             _LOGGER.debug("<- %r", TransferFrame(payload=b"***", *frame[:-1]), extra=self.network_trace_params)
+        self._received_messages.add(frame[2])
         self.delivery_count += 1
         self.received_delivery_id = frame[1] # delivery_id
         # If more is false --> this is the last frame of the message
@@ -77,8 +78,6 @@ class ReceiverLink(Link):
             else:
                 message = decode_payload(frame[11])
             delivery_state = await self._process_incoming_message(self._first_frame, message)
-            if not delivery_state:
-                self._received_messages.add(frame[2])
             if not frame[4] and delivery_state:  # settled
                 await self._outgoing_disposition(
                     first=self._first_frame[1],

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_receiver_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_receiver_async.py
@@ -16,7 +16,7 @@ from ..performatives import (
     DispositionFrame,
 )
 from ..outcomes import Received, Accepted, Rejected, Released, Modified
-from ..error import AMQPException, AMQPLinkError, ErrorCondition
+from ..error import AMQPException, ErrorCondition
 
 
 _LOGGER = logging.getLogger(__name__)

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_receiver_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_receiver_async.py
@@ -112,7 +112,7 @@ class ReceiverLink(Link):
         disposition_frame = DispositionFrame(
             role=self.role, first=first, last=last, settled=settled, state=state, batchable=batchable
         )
-        if delivery_tag not in self._received_messages:
+        if delivery_tag not in self._received_delivery_tags:
             raise AMQPLinkError(condition=ErrorCondition.InternalError, description = "Delivery tag not found.")
 
         if self.network_trace:

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_receiver_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_receiver_async.py
@@ -16,7 +16,7 @@ from ..performatives import (
     DispositionFrame,
 )
 from ..outcomes import Received, Accepted, Rejected, Released, Modified
-from ..error import AMQPLinkError, ErrorCondition
+from ..error import AMQPException, AMQPLinkError, ErrorCondition
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -113,7 +113,7 @@ class ReceiverLink(Link):
             role=self.role, first=first, last=last, settled=settled, state=state, batchable=batchable
         )
         if delivery_tag not in self._received_delivery_tags:
-            raise AMQPLinkError(condition=ErrorCondition.InternalError, description = "Delivery tag not found.")
+            raise AMQPException(condition=ErrorCondition.IllegalState, description = "Delivery tag not found.")
 
         if self.network_trace:
             _LOGGER.debug("-> %r", DispositionFrame(*disposition_frame), extra=self.network_trace_params)

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_receiver_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/aio/_receiver_async.py
@@ -32,7 +32,7 @@ class ReceiverLink(Link):
         self._on_transfer = kwargs.pop("on_transfer")
         self._received_payload = bytearray()
         self._first_frame = None
-        self._received_messages = set()
+        self._received_delivery_tags = set()
 
     @classmethod
     def from_incoming_frame(cls, session, handle, frame):
@@ -71,7 +71,7 @@ class ReceiverLink(Link):
         if self._received_payload or frame[5]:  # more
             self._received_payload.extend(frame[11])
         if not frame[5]:
-            self._received_messages.add(frame[2])
+            self._received_delivery_tags.add(self._first_frame[2])
             if self._received_payload:
                 message = decode_payload(memoryview(self._received_payload))
                 self._received_payload = bytearray()
@@ -82,7 +82,7 @@ class ReceiverLink(Link):
                 await self._outgoing_disposition(
                     first=self._first_frame[1],
                     last=self._first_frame[1],
-                    delivery_tag=frame[2],
+                    delivery_tag=self._first_frame[2],
                     settled=True,
                     state=delivery_state,
                     batchable=None
@@ -118,7 +118,7 @@ class ReceiverLink(Link):
         if self.network_trace:
             _LOGGER.debug("-> %r", DispositionFrame(*disposition_frame), extra=self.network_trace_params)
         await self._session._outgoing_disposition(disposition_frame) # pylint: disable=protected-access
-        self._received_messages.remove(delivery_tag)
+        self._received_delivery_tags.remove(delivery_tag)
 
     async def attach(self):
         await super().attach()

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/client.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/client.py
@@ -1030,6 +1030,7 @@ class ReceiveClient(AMQPClient): # pylint:disable=too-many-instance-attributes
     def settle_messages(
         self,
         delivery_id: Union[int, Tuple[int, int]],
+        delivery_tag: bytes,
         outcome: Literal["accepted"],
         *,
         batchable: Optional[bool] = None
@@ -1040,6 +1041,7 @@ class ReceiveClient(AMQPClient): # pylint:disable=too-many-instance-attributes
     def settle_messages(
         self,
         delivery_id: Union[int, Tuple[int, int]],
+        delivery_tag: bytes,
         outcome: Literal["released"],
         *,
         batchable: Optional[bool] = None
@@ -1050,6 +1052,7 @@ class ReceiveClient(AMQPClient): # pylint:disable=too-many-instance-attributes
     def settle_messages(
         self,
         delivery_id: Union[int, Tuple[int, int]],
+        delivery_tag: bytes,
         outcome: Literal["rejected"],
         *,
         error: Optional[AMQPError] = None,
@@ -1061,6 +1064,7 @@ class ReceiveClient(AMQPClient): # pylint:disable=too-many-instance-attributes
     def settle_messages(
         self,
         delivery_id: Union[int, Tuple[int, int]],
+        delivery_tag: bytes,
         outcome: Literal["modified"],
         *,
         delivery_failed: Optional[bool] = None,
@@ -1074,6 +1078,7 @@ class ReceiveClient(AMQPClient): # pylint:disable=too-many-instance-attributes
     def settle_messages(
         self,
         delivery_id: Union[int, Tuple[int, int]],
+        delivery_tag: bytes,
         outcome: Literal["received"],
         *,
         section_number: int,
@@ -1083,7 +1088,7 @@ class ReceiveClient(AMQPClient): # pylint:disable=too-many-instance-attributes
         ...
 
     def settle_messages(
-        self, delivery_id: Union[int, Tuple[int, int]], outcome: str, **kwargs
+        self, delivery_id: Union[int, Tuple[int, int]], delivery_tag: bytes, outcome: str, **kwargs
     ):
         batchable = kwargs.pop("batchable", None)
         if outcome.lower() == "accepted":
@@ -1106,6 +1111,7 @@ class ReceiveClient(AMQPClient): # pylint:disable=too-many-instance-attributes
         self._link.send_disposition(
             first_delivery_id=first,
             last_delivery_id=last,
+            delivery_tag=delivery_tag,
             settled=True,
             delivery_state=state,
             batchable=batchable,

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/receiver.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/receiver.py
@@ -13,7 +13,7 @@ from .link import Link
 from .constants import LinkState, Role
 from .performatives import TransferFrame, DispositionFrame
 from .outcomes import Received, Accepted, Rejected, Released, Modified
-from .error import AMQPLinkError, ErrorCondition
+from .error import AMQPException, AMQPLinkError, ErrorCondition
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -109,7 +109,7 @@ class ReceiverLink(Link):
         batchable: Optional[bool],
     ):
         if delivery_tag not in self._received_delivery_tags:
-            raise AMQPLinkError(condition=ErrorCondition.InternalError, description = "Delivery tag not found.")
+            raise AMQPException(condition=ErrorCondition.IllegalState, description = "Delivery tag not found.")
 
         disposition_frame = DispositionFrame(
             role=self.role, first=first, last=last, settled=settled, state=state, batchable=batchable

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/receiver.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/receiver.py
@@ -108,7 +108,7 @@ class ReceiverLink(Link):
         state: Optional[Union[Received, Accepted, Rejected, Released, Modified]],
         batchable: Optional[bool],
     ):
-        if delivery_tag not in self._received_messages:
+        if delivery_tag not in self._received_delivery_tags:
             raise AMQPLinkError(condition=ErrorCondition.InternalError, description = "Delivery tag not found.")
 
         disposition_frame = DispositionFrame(

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/receiver.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/receiver.py
@@ -56,7 +56,7 @@ class ReceiverLink(Link):
     def _incoming_transfer(self, frame):
         if self.network_trace:
             _LOGGER.debug("<- %r", TransferFrame(payload=b"***", *frame[:-1]), extra=self.network_trace_params)
-        self._received_messages.add(frame[2])
+
         # If more is false --> this is the last frame of the message
         if not frame[5]:
             self.current_link_credit -= 1
@@ -69,6 +69,7 @@ class ReceiverLink(Link):
         if self._received_payload or frame[5]:  # more
             self._received_payload.extend(frame[11])
         if not frame[5]:
+            self._received_messages.add(frame[2])
             if self._received_payload:
                 message = decode_payload(memoryview(self._received_payload))
                 self._received_payload = bytearray()

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/receiver.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/receiver.py
@@ -29,7 +29,7 @@ class ReceiverLink(Link):
         self._on_transfer = kwargs.pop("on_transfer")
         self._received_payload = bytearray()
         self._first_frame = None
-        self._received_messages = set()
+        self._received_delivery_tags = set()
 
     @classmethod
     def from_incoming_frame(cls, session, handle, frame):
@@ -69,7 +69,7 @@ class ReceiverLink(Link):
         if self._received_payload or frame[5]:  # more
             self._received_payload.extend(frame[11])
         if not frame[5]:
-            self._received_messages.add(frame[2])
+            self._received_delivery_tags.add(self._first_frame[2])
             if self._received_payload:
                 message = decode_payload(memoryview(self._received_payload))
                 self._received_payload = bytearray()
@@ -81,7 +81,7 @@ class ReceiverLink(Link):
                 self._outgoing_disposition(
                     first=self._first_frame[1],
                     last=self._first_frame[1],
-                    delivery_tag=frame[2],
+                    delivery_tag=self._first_frame[2],
                     settled=True,
                     state=delivery_state,
                     batchable=None
@@ -117,7 +117,7 @@ class ReceiverLink(Link):
         if self.network_trace:
             _LOGGER.debug("-> %r", DispositionFrame(*disposition_frame), extra=self.network_trace_params)
         self._session._outgoing_disposition(disposition_frame) # pylint: disable=protected-access
-        self._received_messages.remove(delivery_tag)
+        self._received_delivery_tags.remove(delivery_tag)
 
     def attach(self):
         super().attach()

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/receiver.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/receiver.py
@@ -13,6 +13,7 @@ from .link import Link
 from .constants import LinkState, Role
 from .performatives import TransferFrame, DispositionFrame
 from .outcomes import Received, Accepted, Rejected, Released, Modified
+from .error import AMQPLinkError, ErrorCondition
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -28,6 +29,7 @@ class ReceiverLink(Link):
         self._on_transfer = kwargs.pop("on_transfer")
         self._received_payload = bytearray()
         self._first_frame = None
+        self._received_messages = set()
 
     @classmethod
     def from_incoming_frame(cls, session, handle, frame):
@@ -72,6 +74,9 @@ class ReceiverLink(Link):
             else:
                 message = decode_payload(frame[11])
             delivery_state = self._process_incoming_message(self._first_frame, message)
+            
+            if not delivery_state:
+                self._received_messages.add(frame[2])
             if not frame[4] and delivery_state:  # settled
                 self._outgoing_disposition(
                     first=self._first_frame[1],
@@ -97,16 +102,21 @@ class ReceiverLink(Link):
         self,
         first: int,
         last: Optional[int],
+        delivery_tag: bytes,
         settled: Optional[bool],
         state: Optional[Union[Received, Accepted, Rejected, Released, Modified]],
         batchable: Optional[bool],
     ):
+        if delivery_tag not in self._received_messages:
+            raise AMQPLinkError(condition=ErrorCondition.InternalError, description = "Delivery tag not found.")
+
         disposition_frame = DispositionFrame(
             role=self.role, first=first, last=last, settled=settled, state=state, batchable=batchable
         )
         if self.network_trace:
             _LOGGER.debug("-> %r", DispositionFrame(*disposition_frame), extra=self.network_trace_params)
         self._session._outgoing_disposition(disposition_frame) # pylint: disable=protected-access
+        self._received_messages.remove(delivery_tag)
 
     def attach(self):
         super().attach()
@@ -118,12 +128,13 @@ class ReceiverLink(Link):
         wait: Union[bool, float] = False,
         first_delivery_id: int,
         last_delivery_id: Optional[int] = None,
+        delivery_tag: bytes,
         settled: Optional[bool] = None,
         delivery_state: Optional[Union[Received, Accepted, Rejected, Released, Modified]] = None,
         batchable: Optional[bool] = None
     ):
         if self._is_closed:
             raise ValueError("Link already closed.")
-        self._outgoing_disposition(first_delivery_id, last_delivery_id, settled, delivery_state, batchable)
+        self._outgoing_disposition(first_delivery_id, last_delivery_id, delivery_tag, settled, delivery_state, batchable)
         if not settled:
             self._wait_for_response(wait)

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/receiver.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/receiver.py
@@ -74,13 +74,14 @@ class ReceiverLink(Link):
             else:
                 message = decode_payload(frame[11])
             delivery_state = self._process_incoming_message(self._first_frame, message)
-            
+
             if not delivery_state:
                 self._received_messages.add(frame[2])
             if not frame[4] and delivery_state:  # settled
                 self._outgoing_disposition(
                     first=self._first_frame[1],
                     last=self._first_frame[1],
+                    delivery_tag=frame[2],
                     settled=True,
                     state=delivery_state,
                     batchable=None
@@ -135,6 +136,13 @@ class ReceiverLink(Link):
     ):
         if self._is_closed:
             raise ValueError("Link already closed.")
-        self._outgoing_disposition(first_delivery_id, last_delivery_id, delivery_tag, settled, delivery_state, batchable)
+        self._outgoing_disposition(
+            first_delivery_id,
+            last_delivery_id,
+            delivery_tag,
+            settled,
+            delivery_state,
+            batchable
+        )
         if not settled:
             self._wait_for_response(wait)

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/receiver.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/receiver.py
@@ -13,7 +13,7 @@ from .link import Link
 from .constants import LinkState, Role
 from .performatives import TransferFrame, DispositionFrame
 from .outcomes import Received, Accepted, Rejected, Released, Modified
-from .error import AMQPException, AMQPLinkError, ErrorCondition
+from .error import AMQPException, ErrorCondition
 
 
 _LOGGER = logging.getLogger(__name__)

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/receiver.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_pyamqp/receiver.py
@@ -56,6 +56,7 @@ class ReceiverLink(Link):
     def _incoming_transfer(self, frame):
         if self.network_trace:
             _LOGGER.debug("<- %r", TransferFrame(payload=b"***", *frame[:-1]), extra=self.network_trace_params)
+        self._received_messages.add(frame[2])
         # If more is false --> this is the last frame of the message
         if not frame[5]:
             self.current_link_credit -= 1
@@ -75,8 +76,6 @@ class ReceiverLink(Link):
                 message = decode_payload(frame[11])
             delivery_state = self._process_incoming_message(self._first_frame, message)
 
-            if not delivery_state:
-                self._received_messages.add(frame[2])
             if not frame[4] and delivery_state:  # settled
                 self._outgoing_disposition(
                     first=self._first_frame[1],

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_transport/_pyamqp_transport.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_transport/_pyamqp_transport.py
@@ -826,7 +826,7 @@ class PyamqpTransport(AmqpTransport):   # pylint: disable=too-many-public-method
             raise ServiceBusConnectionError(message="Link error occurred during settle operation.") from le
 
         except AMQPConnectionError as e:
-            raise ServiceBusConnectionError(message="Connection lost during settle operation.") from e
+            raise RuntimeError("Connection lost during settle operation.") from e
 
         raise ValueError(
             f"Unsupported settle operation type: {settle_operation}"

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_transport/_pyamqp_transport.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_transport/_pyamqp_transport.py
@@ -19,7 +19,6 @@ from .._pyamqp import (
     __version__,
 )
 from .._pyamqp.error import (
-    AMQPLinkError,
     ErrorCondition,
     AMQPException,
     AMQPError,
@@ -817,7 +816,7 @@ class PyamqpTransport(AmqpTransport):   # pylint: disable=too-many-public-method
 
         except AMQPConnectionError as e:
             raise RuntimeError("Connection lost during settle operation.") from e
-        
+
         except AMQPException as ae:
             if (
                 ae.condition == ErrorCondition.IllegalState

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_transport/_pyamqp_transport.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_transport/_pyamqp_transport.py
@@ -780,9 +780,6 @@ class PyamqpTransport(AmqpTransport):   # pylint: disable=too-many-public-method
     ) -> None:
         # pylint: disable=protected-access
         try:
-            # if message._receiver._handler._link != handler._link:  # pylint: disable=protected-access
-                # raise AMQPLinkError(condition=ErrorCondition.LinkDetachForced, 
-                                    # description="Message received on a different link than the current receiver link.")
             if settle_operation == MESSAGE_COMPLETE:
                 return handler.settle_messages(message._delivery_id, message._delivery_tag, 'accepted')
             if settle_operation == MESSAGE_ABANDON:
@@ -817,12 +814,12 @@ class PyamqpTransport(AmqpTransport):   # pylint: disable=too-many-public-method
                 )
         except AttributeError as ae:
             raise RuntimeError("handler is not initialized and cannot complete the message") from ae
-        
+
         except AMQPLinkError as le:
             # Remove all Dispositions sent because we have lost the link sent on
             if le.condition == ErrorCondition.InternalError and le.description.startswith("Delivery tag"):
                 raise RuntimeError("Link error occurred during settle operation.") from le
-            
+
             raise ServiceBusConnectionError(message="Link error occurred during settle operation.") from le
 
         except AMQPConnectionError as e:

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_transport/_pyamqp_transport.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_transport/_pyamqp_transport.py
@@ -816,7 +816,6 @@ class PyamqpTransport(AmqpTransport):   # pylint: disable=too-many-public-method
             raise RuntimeError("handler is not initialized and cannot complete the message") from ae
 
         except AMQPLinkError as le:
-            # Remove all Dispositions sent because we have lost the link sent on
             if (
                 le.condition == ErrorCondition.InternalError
                 and isinstance(le.description, str)

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/_transport/_pyamqp_transport.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/_transport/_pyamqp_transport.py
@@ -815,18 +815,16 @@ class PyamqpTransport(AmqpTransport):   # pylint: disable=too-many-public-method
         except AttributeError as ae:
             raise RuntimeError("handler is not initialized and cannot complete the message") from ae
 
-        except AMQPLinkError as le:
-            if (
-                le.condition == ErrorCondition.InternalError
-                and isinstance(le.description, str)
-                and le.description.startswith("Delivery tag")
-            ):
-                raise RuntimeError("Link error occurred during settle operation.") from le
-
-            raise ServiceBusConnectionError(message="Link error occurred during settle operation.") from le
-
         except AMQPConnectionError as e:
             raise RuntimeError("Connection lost during settle operation.") from e
+        
+        except AMQPException as ae:
+            if (
+                ae.condition == ErrorCondition.IllegalState
+            ):
+                raise RuntimeError("Link error occurred during settle operation.") from ae
+
+            raise ServiceBusConnectionError(message="Link error occurred during settle operation.") from ae
 
         raise ValueError(
             f"Unsupported settle operation type: {settle_operation}"

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_transport/_pyamqp_transport_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_transport/_pyamqp_transport_async.py
@@ -355,7 +355,6 @@ class PyamqpTransportAsync(PyamqpTransport, AmqpTransportAsync):
             raise RuntimeError("handler is not initialized and cannot complete the message") from ae
 
         except AMQPLinkError as le:
-            # Remove all Dispositions sent because we have lost the link sent on
             if (
                 le.condition == ErrorCondition.InternalError
                 and isinstance(le.description, str)

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_transport/_pyamqp_transport_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_transport/_pyamqp_transport_async.py
@@ -19,6 +19,7 @@ from ..._pyamqp.aio._connection_async import Connection as ConnectionAsync
 from ..._pyamqp.error import (
     AMQPConnectionError,
     AMQPError,
+    AMQPException,
     MessageException,
     AMQPLinkError,
     ErrorCondition,
@@ -357,7 +358,7 @@ class PyamqpTransportAsync(PyamqpTransport, AmqpTransportAsync):
         except AMQPConnectionError as e:
             raise RuntimeError("Connection lost during settle operation.") from e
         
-        except AMQPLinkError as ae:
+        except AMQPException as ae:
             if (
                 ae.condition == ErrorCondition.IllegalState
             ):

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_transport/_pyamqp_transport_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_transport/_pyamqp_transport_async.py
@@ -354,18 +354,17 @@ class PyamqpTransportAsync(PyamqpTransport, AmqpTransportAsync):
         except AttributeError as ae:
             raise RuntimeError("handler is not initialized and cannot complete the message") from ae
 
-        except AMQPLinkError as le:
-            if (
-                le.condition == ErrorCondition.InternalError
-                and isinstance(le.description, str)
-                and le.description.startswith("Delivery tag")
-            ):
-                raise RuntimeError("Link error occurred during settle operation.") from le
-
-            raise ServiceBusConnectionError(message="Link error occurred during settle operation.") from le
-
         except AMQPConnectionError as e:
             raise RuntimeError("Connection lost during settle operation.") from e
+        
+        except AMQPLinkError as ae:
+            if (
+                ae.condition == ErrorCondition.IllegalState
+            ):
+                raise RuntimeError("Link error occurred during settle operation.") from ae
+
+            raise ServiceBusConnectionError(message="Link error occurred during settle operation.") from ae
+
 
         raise ValueError(
             f"Unsupported settle operation type: {settle_operation}"

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_transport/_pyamqp_transport_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/aio/_transport/_pyamqp_transport_async.py
@@ -21,7 +21,6 @@ from ..._pyamqp.error import (
     AMQPError,
     AMQPException,
     MessageException,
-    AMQPLinkError,
     ErrorCondition,
 )
 
@@ -357,7 +356,7 @@ class PyamqpTransportAsync(PyamqpTransport, AmqpTransportAsync):
 
         except AMQPConnectionError as e:
             raise RuntimeError("Connection lost during settle operation.") from e
-        
+
         except AMQPException as ae:
             if (
                 ae.condition == ErrorCondition.IllegalState

--- a/sdk/servicebus/azure-servicebus/tests/async_tests/test_queues_async.py
+++ b/sdk/servicebus/azure-servicebus/tests/async_tests/test_queues_async.py
@@ -2978,8 +2978,8 @@ class TestServiceBusQueueAsync(AzureMgmtRecordedTestCase):
                 # of different os platforms, this is why a while loop is used here to receive the specific
                 # amount of message we want to receive
                 while len(received_msgs) < 5:
-                    # issue link credits more than 5, client should consume 5 msgs from the service in total,
-                    # leaving the extra credits on the wire
+                    # start receives on the first receiver and complete them on the other one. 
+                    # the messages should settle over the management of the second receiver.
                     for msg in await receiver1.receive_messages(max_message_count=10, max_wait_time=5):
                         await receiver2.complete_message(msg)
                         received_msgs.append(msg)

--- a/sdk/servicebus/azure-servicebus/tests/async_tests/test_queues_async.py
+++ b/sdk/servicebus/azure-servicebus/tests/async_tests/test_queues_async.py
@@ -2971,20 +2971,21 @@ class TestServiceBusQueueAsync(AzureMgmtRecordedTestCase):
             receiver1 = sb_client.get_queue_receiver(servicebus_queue.name)
             receiver2 = sb_client.get_queue_receiver(servicebus_queue.name)
             
-            await sender.send_messages([ServiceBusMessage('test') for _ in range(5)])
-            received_msgs = []
-            # the amount of messages returned by receive call is not stable, especially in live tests
-            # of different os platforms, this is why a while loop is used here to receive the specific
-            # amount of message we want to receive
-            while len(received_msgs) < 5:
-                # issue link credits more than 5, client should consume 5 msgs from the service in total,
-                # leaving the extra credits on the wire
-                for msg in await receiver1.receive_messages(max_message_count=10, max_wait_time=5):
-                    await receiver2.complete_message(msg)
-                    received_msgs.append(msg)
-            
-            assert len(received_msgs) == 5
-            
-            messages_in_queue = await receiver1.peek_messages()
-
-            assert len(messages_in_queue) == 0
+            async with sender, receiver1, receiver2:
+                await sender.send_messages([ServiceBusMessage('test') for _ in range(5)])
+                received_msgs = []
+                # the amount of messages returned by receive call is not stable, especially in live tests
+                # of different os platforms, this is why a while loop is used here to receive the specific
+                # amount of message we want to receive
+                while len(received_msgs) < 5:
+                    # issue link credits more than 5, client should consume 5 msgs from the service in total,
+                    # leaving the extra credits on the wire
+                    for msg in await receiver1.receive_messages(max_message_count=10, max_wait_time=5):
+                        await receiver2.complete_message(msg)
+                        received_msgs.append(msg)
+                
+                assert len(received_msgs) == 5
+                
+                messages_in_queue = await receiver1.peek_messages()
+    
+                assert len(messages_in_queue) == 0

--- a/sdk/servicebus/azure-servicebus/tests/async_tests/test_queues_async.py
+++ b/sdk/servicebus/azure-servicebus/tests/async_tests/test_queues_async.py
@@ -2379,7 +2379,7 @@ class TestServiceBusQueueAsync(AzureMgmtRecordedTestCase):
             def _hack_sb_receiver_settle_message(self, message, settle_operation, dead_letter_reason=None, dead_letter_error_description=None):
                 raise uamqp.errors.AMQPError()
         else:
-            async def _hack_amqp_message_complete(cls, _, settlement):
+            async def _hack_amqp_message_complete(cls, _, _unused, settlement):
                 if settlement == 'completed':
                     raise RuntimeError()
 

--- a/sdk/servicebus/azure-servicebus/tests/async_tests/test_queues_async.py
+++ b/sdk/servicebus/azure-servicebus/tests/async_tests/test_queues_async.py
@@ -2979,7 +2979,7 @@ class TestServiceBusQueueAsync(AzureMgmtRecordedTestCase):
             while len(received_msgs) < 5:
                 # issue link credits more than 5, client should consume 5 msgs from the service in total,
                 # leaving the extra credits on the wire
-                for msg in await receiver2.receive_messages(max_message_count=10, max_wait_time=5):
+                for msg in await receiver1.receive_messages(max_message_count=10, max_wait_time=5):
                     await receiver2.complete_message(msg)
                     received_msgs.append(msg)
             

--- a/sdk/servicebus/azure-servicebus/tests/test_queues.py
+++ b/sdk/servicebus/azure-servicebus/tests/test_queues.py
@@ -3387,20 +3387,21 @@ class TestServiceBusQueue(AzureMgmtRecordedTestCase):
             receiver1 = sb_client.get_queue_receiver(servicebus_queue.name)
             receiver2 = sb_client.get_queue_receiver(servicebus_queue.name)
             
-            sender.send_messages([ServiceBusMessage('test') for _ in range(5)])
-            received_msgs = []
-            # the amount of messages returned by receive call is not stable, especially in live tests
-            # of different os platforms, this is why a while loop is used here to receive the specific
-            # amount of message we want to receive
-            while len(received_msgs) < 5:
-                # issue link credits more than 5, client should consume 5 msgs from the service in total,
-                # leaving the extra credits on the wire
-                for msg in receiver1.receive_messages(max_message_count=10, max_wait_time=5):
-                    receiver2.complete_message(msg)
-                    received_msgs.append(msg)
-            
-            assert len(received_msgs) == 5
-            
-            messages_in_queue = receiver1.peek_messages()
-
-            assert len(messages_in_queue) == 0
+            with sender, receiver1, receiver2:
+                sender.send_messages([ServiceBusMessage('test') for _ in range(5)])
+                received_msgs = []
+                # the amount of messages returned by receive call is not stable, especially in live tests
+                # of different os platforms, this is why a while loop is used here to receive the specific
+                # amount of message we want to receive
+                while len(received_msgs) < 5:
+                    # issue link credits more than 5, client should consume 5 msgs from the service in total,
+                    # leaving the extra credits on the wire
+                    for msg in receiver1.receive_messages(max_message_count=10, max_wait_time=5):
+                        receiver2.complete_message(msg)
+                        received_msgs.append(msg)
+                
+                assert len(received_msgs) == 5
+                
+                messages_in_queue = receiver1.peek_messages()
+    
+                assert len(messages_in_queue) == 0

--- a/sdk/servicebus/azure-servicebus/tests/test_queues.py
+++ b/sdk/servicebus/azure-servicebus/tests/test_queues.py
@@ -2782,7 +2782,7 @@ class TestServiceBusQueue(AzureMgmtRecordedTestCase):
             def _hack_sb_receiver_settle_message(self, message, settle_operation, dead_letter_reason=None, dead_letter_error_description=None):
                 raise uamqp.errors.AMQPError()
         else:
-            def _hack_amqp_message_complete(cls, _, settlement):
+            def _hack_amqp_message_complete(cls, _, _unused, settlement):
                     if settlement == 'completed':
                         raise RuntimeError()
 

--- a/sdk/servicebus/azure-servicebus/tests/test_queues.py
+++ b/sdk/servicebus/azure-servicebus/tests/test_queues.py
@@ -3394,8 +3394,8 @@ class TestServiceBusQueue(AzureMgmtRecordedTestCase):
                 # of different os platforms, this is why a while loop is used here to receive the specific
                 # amount of message we want to receive
                 while len(received_msgs) < 5:
-                    # issue link credits more than 5, client should consume 5 msgs from the service in total,
-                    # leaving the extra credits on the wire
+                    # start receives on the first receiver and complete them on the other one. 
+                    # the messages should settle over the management of the second receiver.
                     for msg in receiver1.receive_messages(max_message_count=10, max_wait_time=5):
                         receiver2.complete_message(msg)
                         received_msgs.append(msg)

--- a/sdk/servicebus/azure-servicebus/tests/test_queues.py
+++ b/sdk/servicebus/azure-servicebus/tests/test_queues.py
@@ -3395,7 +3395,7 @@ class TestServiceBusQueue(AzureMgmtRecordedTestCase):
             while len(received_msgs) < 5:
                 # issue link credits more than 5, client should consume 5 msgs from the service in total,
                 # leaving the extra credits on the wire
-                for msg in receiver2.receive_messages(max_message_count=10, max_wait_time=5):
+                for msg in receiver1.receive_messages(max_message_count=10, max_wait_time=5):
                     receiver2.complete_message(msg)
                     received_msgs.append(msg)
             


### PR DESCRIPTION
Fixes an issue in azure amqp where messages received on one receiver could not be settled on another receiver. Typically this is not possible but using the management link as a fall back it is supported. 

The fix is done by keeping track of the delivery tags that arrive over a link and then check if the message to be settled was received over the link. If not, try the management link. 

fixes #35304