### PR TITLE
Fix storage live test pool matrix replace

### DIFF
--- a/sdk/storage/tests.yml
+++ b/sdk/storage/tests.yml
@@ -21,7 +21,8 @@ extends:
       Packages: ${{ parameters.Services }}
       MatrixReplace:
         # Use dedicated storage pool in canadacentral with higher memory capacity
-        - Pool=(.*)-general/$1-storage
+        - Pool=.*LINUXPOOL.*/azsdk-pool-mms-ubuntu-2004-storage
+        - Pool=.*WINDOWSPOOL.*/azsdk-pool-mms-win-2022-general
       ${{ if contains(variables['Build.DefinitionName'], 'tests-weekly') }}:
         MatrixConfigs:
           - Name: Storage_all_versions_live_test


### PR DESCRIPTION
This got missed in some of our underlying updates to change the pool values. Updating this will run tests out of a canada central VM