### PR TITLE
Set AZURESUBSCRIPTION_CLIENT_ID and AZURESUBSCRIPTION_TENANT_ID

### DIFF
--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -75,6 +75,10 @@ steps:
         pwsh: true
         ScriptType: InlineScript
         Inline: >-
+          $account = (Get-AzContext).Account;
+          $env:AZURESUBSCRIPTION_CLIENT_ID = $account.Id;
+          $env:AZURESUBSCRIPTION_TENANT_ID = $account.Tenants;
+
           python scripts/devops_tasks/dispatch_tox.py
           "$(TargetingString)"
           ${{ parameters.AdditionalTestArgs }}
@@ -135,6 +139,10 @@ steps:
         pwsh: true
         ScriptType: InlineScript
         Inline: >-
+          $account = (Get-AzContext).Account;
+          $env:AZURESUBSCRIPTION_CLIENT_ID = $account.Id;
+          $env:AZURESUBSCRIPTION_TENANT_ID = $account.Tenants;
+
           scripts/devops_tasks/dispatch_tox.py
           "$(TargetingString)"
           --service="${{ parameters.ServiceDirectory }}"


### PR DESCRIPTION
Needed to ensure the variables are set when running in a Windows context