### PR TITLE
SearchIndexClient.get_search_client inherits the API version

### DIFF
--- a/sdk/search/azure-search-documents/CHANGELOG.md
+++ b/sdk/search/azure-search-documents/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+- `SearchIndexClient`.`get_search_client` inherits the API version.
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/search/azure-search-documents/azure/search/documents/indexes/_search_index_client.py
+++ b/sdk/search/azure-search-documents/azure/search/documents/indexes/_search_index_client.py
@@ -50,7 +50,7 @@ class SearchIndexClient(HeadersMixin):  # pylint:disable=too-many-public-methods
         self._api_version = kwargs.pop("api_version", DEFAULT_VERSION)
         self._endpoint = normalize_endpoint(endpoint)
         self._credential = credential
-        audience = kwargs.pop("audience", None)
+        self._audience = kwargs.pop("audience", None)
         if isinstance(credential, AzureKeyCredential):
             self._aad = False
             self._client = _SearchServiceClient(
@@ -58,7 +58,7 @@ class SearchIndexClient(HeadersMixin):  # pylint:disable=too-many-public-methods
             )
         else:
             self._aad = True
-            authentication_policy = get_authentication_policy(credential, audience=audience)
+            authentication_policy = get_authentication_policy(credential, audience=self._audience)
             self._client = _SearchServiceClient(
                 endpoint=endpoint,
                 authentication_policy=authentication_policy,
@@ -90,7 +90,14 @@ class SearchIndexClient(HeadersMixin):  # pylint:disable=too-many-public-methods
         :rtype: ~azure.search.documents.SearchClient
 
         """
-        return SearchClient(self._endpoint, index_name, self._credential, api_version=self._api_version, **kwargs)
+        return SearchClient(
+            self._endpoint,
+            index_name,
+            self._credential,
+            audience=self._audience,
+            api_version=self._api_version,
+            **kwargs
+        )
 
     @distributed_trace
     def list_indexes(self, *, select: Optional[List[str]] = None, **kwargs: Any) -> ItemPaged[SearchIndex]:

--- a/sdk/search/azure-search-documents/azure/search/documents/indexes/_search_index_client.py
+++ b/sdk/search/azure-search-documents/azure/search/documents/indexes/_search_index_client.py
@@ -90,7 +90,7 @@ class SearchIndexClient(HeadersMixin):  # pylint:disable=too-many-public-methods
         :rtype: ~azure.search.documents.SearchClient
 
         """
-        return SearchClient(self._endpoint, index_name, self._credential, **kwargs)
+        return SearchClient(self._endpoint, index_name, self._credential, api_version=self._api_version, **kwargs)
 
     @distributed_trace
     def list_indexes(self, *, select: Optional[List[str]] = None, **kwargs: Any) -> ItemPaged[SearchIndex]:

--- a/sdk/search/azure-search-documents/azure/search/documents/indexes/aio/_search_index_client.py
+++ b/sdk/search/azure-search-documents/azure/search/documents/indexes/aio/_search_index_client.py
@@ -51,7 +51,7 @@ class SearchIndexClient(HeadersMixin):  # pylint:disable=too-many-public-methods
         self._api_version = kwargs.pop("api_version", DEFAULT_VERSION)
         self._endpoint = normalize_endpoint(endpoint)
         self._credential = credential
-        audience = kwargs.pop("audience", None)
+        self._audience = kwargs.pop("audience", None)
         if isinstance(credential, AzureKeyCredential):
             self._aad = False
             self._client = _SearchServiceClient(
@@ -59,7 +59,7 @@ class SearchIndexClient(HeadersMixin):  # pylint:disable=too-many-public-methods
             )
         else:
             self._aad = True
-            authentication_policy = get_authentication_policy(credential, audience=audience, is_async=True)
+            authentication_policy = get_authentication_policy(credential, audience=self._audience, is_async=True)
             self._client = _SearchServiceClient(
                 endpoint=endpoint,
                 authentication_policy=authentication_policy,
@@ -90,7 +90,14 @@ class SearchIndexClient(HeadersMixin):  # pylint:disable=too-many-public-methods
         :return: SearchClient
         :rtype: ~azure.search.documents.aio.SearchClient
         """
-        return SearchClient(self._endpoint, index_name, self._credential, api_version=self._api_version, **kwargs)
+        return SearchClient(
+            self._endpoint,
+            index_name,
+            self._credential,
+            audience=self._audience,
+            api_version=self._api_version,
+            **kwargs
+        )
 
     @distributed_trace
     def list_indexes(self, *, select: Optional[List[str]] = None, **kwargs) -> AsyncItemPaged[SearchIndex]:

--- a/sdk/search/azure-search-documents/azure/search/documents/indexes/aio/_search_index_client.py
+++ b/sdk/search/azure-search-documents/azure/search/documents/indexes/aio/_search_index_client.py
@@ -90,7 +90,7 @@ class SearchIndexClient(HeadersMixin):  # pylint:disable=too-many-public-methods
         :return: SearchClient
         :rtype: ~azure.search.documents.aio.SearchClient
         """
-        return SearchClient(self._endpoint, index_name, self._credential, **kwargs)
+        return SearchClient(self._endpoint, index_name, self._credential, api_version=self._api_version, **kwargs)
 
     @distributed_trace
     def list_indexes(self, *, select: Optional[List[str]] = None, **kwargs) -> AsyncItemPaged[SearchIndex]:

--- a/sdk/search/azure-search-documents/tests/async_tests/test_search_index_client_async.py
+++ b/sdk/search/azure-search-documents/tests/async_tests/test_search_index_client_async.py
@@ -7,6 +7,7 @@ import functools
 import pytest
 from unittest import mock
 from azure.core.credentials import AzureKeyCredential
+from azure.search.documents import ApiVersion
 from azure.search.documents.aio import SearchClient
 from azure.search.documents.indexes.aio import SearchIndexClient, SearchIndexerClient
 from devtools_testutils import trim_kwargs_from_test_function
@@ -54,6 +55,13 @@ class TestSearchIndexClient:
         client = SearchIndexClient("endpoint", credential)
         search_client = client.get_search_client("index")
         assert isinstance(search_client, SearchClient)
+
+    def test_get_search_client_inherit_api_version(self):
+        credential = AzureKeyCredential(key="old_api_key")
+        client = SearchIndexClient("endpoint", credential, api_version=ApiVersion.V2020_06_30)
+        search_client = client.get_search_client("index")
+        assert isinstance(search_client, SearchClient)
+        assert search_client._api_version == ApiVersion.V2020_06_30
 
     def test_index_endpoint_https(self):
         credential = AzureKeyCredential(key="old_api_key")

--- a/sdk/search/azure-search-documents/tests/test_search_index_client.py
+++ b/sdk/search/azure-search-documents/tests/test_search_index_client.py
@@ -44,6 +44,13 @@ class TestSearchIndexClient:
         search_client = client.get_search_client("index")
         assert isinstance(search_client, SearchClient)
 
+    def test_get_search_client_inherit_api_version(self):
+        credential = AzureKeyCredential(key="old_api_key")
+        client = SearchIndexClient("endpoint", credential, api_version=ApiVersion.V2020_06_30)
+        search_client = client.get_search_client("index")
+        assert isinstance(search_client, SearchClient)
+        assert search_client._api_version == ApiVersion.V2020_06_30
+
     @mock.patch(
         "azure.search.documents.indexes._generated.operations._search_service_client_operations.SearchServiceClientOperationsMixin.get_service_statistics"
     )


### PR DESCRIPTION
To fix #36168