### PR TITLE
[Storage] Adjust Files OAuth "bad audience" tests

### DIFF
--- a/sdk/storage/azure-storage-file-share/assets.json
+++ b/sdk/storage/azure-storage-file-share/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "python",
   "TagPrefix": "python/storage/azure-storage-file-share",
-  "Tag": "python/storage/azure-storage-file-share_e105feb7fb"
+  "Tag": "python/storage/azure-storage-file-share_d41363cb87"
 }

--- a/sdk/storage/azure-storage-file-share/tests/test_directory.py
+++ b/sdk/storage/azure-storage-file-share/tests/test_directory.py
@@ -1394,8 +1394,7 @@ class TestStorageDirectory(StorageRecordedTestCase):
         )
 
         # Assert
-        with pytest.raises(ClientAuthenticationError):
-            directory_client.exists()
+        directory_client.exists()
 
 
 # ------------------------------------------------------------------------------

--- a/sdk/storage/azure-storage-file-share/tests/test_directory_async.py
+++ b/sdk/storage/azure-storage-file-share/tests/test_directory_async.py
@@ -1495,7 +1495,6 @@ class TestStorageDirectoryAsync(AsyncStorageRecordedTestCase):
         )
 
         # Assert
-        with pytest.raises(ClientAuthenticationError):
-            await directory_client.exists()
+        await directory_client.exists()
 
 # ------------------------------------------------------------------------------

--- a/sdk/storage/azure-storage-file-share/tests/test_file.py
+++ b/sdk/storage/azure-storage-file-share/tests/test_file.py
@@ -3761,7 +3761,6 @@ class TestStorageFile(StorageRecordedTestCase):
         )
 
         # Assert
-        with pytest.raises(ClientAuthenticationError):
-            file_client.exists()
+        file_client.exists()
 
 # ------------------------------------------------------------------------------

--- a/sdk/storage/azure-storage-file-share/tests/test_file_async.py
+++ b/sdk/storage/azure-storage-file-share/tests/test_file_async.py
@@ -3877,5 +3877,4 @@ class TestStorageFileAsync(AsyncStorageRecordedTestCase):
         )
 
         # Assert
-        with pytest.raises(ClientAuthenticationError):
-            await file_client.exists()
+        await file_client.exists()


### PR DESCRIPTION
This should fix pipeline failures such as:
https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3894685&view=ms.vss-test-web.build-test-results-tab

As it seems that BearerToken is now supported by Files OAuth. Will run live test to verify this fixes this before merging!