### PR TITLE
Add client endpoint type to get_client_access_token

### DIFF
--- a/sdk/webpubsub/azure-messaging-webpubsubservice/azure/messaging/webpubsubservice/_operations/_operations.py
+++ b/sdk/webpubsub/azure-messaging-webpubsubservice/azure/messaging/webpubsubservice/_operations/_operations.py
@@ -692,6 +692,7 @@ class WebPubSubServiceClientOperationsMixin(MixinABC):  # pylint: disable=too-ma
         roles: Optional[List[str]] = None,
         minutes_to_expire: int = 60,
         groups: Optional[List[str]] = None,
+        client_endpoint_type: Optional[str] = "default",
         **kwargs: Any
     ) -> JSON:
         """Generate token for the client to connect Azure Web PubSub service.
@@ -707,6 +708,8 @@ class WebPubSubServiceClientOperationsMixin(MixinABC):  # pylint: disable=too-ma
         :paramtype minutes_to_expire: int
         :keyword groups: Groups that the connection will join when it connects. Default value is None.
         :paramtype groups: list[str]
+        :keyword client_endpoint_type: The client endpoint type. Default value is "default".
+        :paramtype client_endpoint_type: str
         :return: JSON object
         :rtype: JSON
         :raises ~azure.core.exceptions.HttpResponseError:

--- a/sdk/webpubsub/azure-messaging-webpubsubservice/azure/messaging/webpubsubservice/_operations/_operations.py
+++ b/sdk/webpubsub/azure-messaging-webpubsubservice/azure/messaging/webpubsubservice/_operations/_operations.py
@@ -7,6 +7,7 @@
 # Changes may cause incorrect behavior and will be lost if the code is regenerated.
 # --------------------------------------------------------------------------
 import sys
+from enum import Enum
 from typing import Any, Callable, Dict, IO, List, Optional, TypeVar, cast
 
 from azure.core.exceptions import (
@@ -627,6 +628,11 @@ def build_add_user_to_group_request(group: str, user_id: str, hub: str, **kwargs
     return HttpRequest(method="PUT", url=_url, params=_params, headers=_headers, **kwargs)
 
 
+class ClientEndpointType(Enum):
+    Default = "default"
+    MQTT = "mqtt"
+
+
 class WebPubSubServiceClientOperationsMixin(MixinABC):  # pylint: disable=too-many-public-methods
     @distributed_trace
     def close_all_connections(  # pylint: disable=inconsistent-return-statements
@@ -692,7 +698,7 @@ class WebPubSubServiceClientOperationsMixin(MixinABC):  # pylint: disable=too-ma
         roles: Optional[List[str]] = None,
         minutes_to_expire: int = 60,
         groups: Optional[List[str]] = None,
-        client_endpoint_type: Optional[str] = "default",
+        client_endpoint_type: Optional[ClientEndpointType] = ClientEndpointType.Default,
         **kwargs: Any
     ) -> JSON:
         """Generate token for the client to connect Azure Web PubSub service.

--- a/sdk/webpubsub/azure-messaging-webpubsubservice/azure/messaging/webpubsubservice/_operations/_patch.py
+++ b/sdk/webpubsub/azure-messaging-webpubsubservice/azure/messaging/webpubsubservice/_operations/_patch.py
@@ -92,6 +92,8 @@ class WebPubSubServiceClientOperationsMixin(WebPubSubServiceClientOperationsMixi
         :keyword dict[str, any] jwt_headers: Any headers you want to pass to jwt encoding.
         :keyword groups: Groups that the connection will join when it connects. Default value is None.
         :paramtype groups: list[str]
+        :keyword client_endpoint_type: The client endpoint type. Default value is "default".
+        :paramtype client_endpoint_type: str
         :returns: JSON response containing the web socket endpoint, the token and a url with the generated access token.
         :rtype: JSON
 


### PR DESCRIPTION
# Description

Add interface to support generating MQTT JWT Token for Azure WebPubSub. Essentially we need to identify if clients want to establish a default WebPubSub connection or an MQTT connection, then we will generate the service URL for them accordingly.

- Example Service URL for:
  - Default Connection: `wss://exampleHost.com/client/hubs/exampleHub`
  - MQTT Connection: `wss://exampleHost.com/client/mqtt/hubs/exampleHub`

# All SDK Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
