### PR TITLE
Connections ga and metadata

### DIFF
--- a/sdk/ml/azure-ai-ml/CHANGELOG.md
+++ b/sdk/ml/azure-ai-ml/CHANGELOG.md
@@ -6,10 +6,12 @@
 
 ### Bugs Fixed
 - InputTypes exported in constants module
+- WorkspaceConnection tags are now listed as deprecated, and the erroneously-deprecated metadata field has been un-deprecated and added as a initialization field. These two fields still point to the same underlying object property, and actual API usage of this value is unchanged.
 
 ### Breaking Changes
 
 ### Other Changes
+- WorkspaceConnections are officially GA'd and no longer experimental. But its much newer subclasses remain experimental.
 
 ## 1.17.0 (2024-06-18)
 

--- a/sdk/ml/azure-ai-ml/assets.json
+++ b/sdk/ml/azure-ai-ml/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "python",
   "TagPrefix": "python/ml/azure-ai-ml",
-  "Tag": "python/ml/azure-ai-ml_67cbe1a754"
+  "Tag": "python/ml/azure-ai-ml_b0ebee3471"
 }

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/workspace/connections/workspace_connection.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/workspace/connections/workspace_connection.py
@@ -70,6 +70,7 @@ class WorkspaceConnectionSchema(ResourceSchema):
     )
 
     is_shared = fields.Bool(load_default=True)
+    metadata = fields.Dict(required=False)
 
     @post_load
     def make(self, data, **kwargs):

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_workspace/connections/connection_subtypes.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_workspace/connections/connection_subtypes.py
@@ -4,7 +4,7 @@
 
 # pylint: disable=protected-access
 
-from typing import Any, List, Optional, Type, Union
+from typing import Any, List, Optional, Type, Union, Dict
 import re
 
 from azure.ai.ml._restclient.v2024_04_01_preview.models import ConnectionCategory
@@ -54,8 +54,6 @@ class AzureBlobStoreConnection(WorkspaceConnection):
     :type name: str
     :param url: The URL or ARM resource ID of the external resource.
     :type url: str
-    :param tags: Tag dictionary. Tags can be added, removed, and updated.
-    :type tags: dict
     :param container_name: The name of the container.
     :type container_name: str
     :param account_name: The name of the account.
@@ -68,6 +66,8 @@ class AzureBlobStoreConnection(WorkspaceConnection):
         ~azure.ai.ml.entities.SasTokenConfiguration,
         ~azure.ai.ml.entities.AadCredentialConfiguration,
         ]
+    :param metadata: Metadata dictionary.
+    :type metadata: Optional[dict[str,str]]
     """
 
     def __init__(
@@ -76,23 +76,25 @@ class AzureBlobStoreConnection(WorkspaceConnection):
         url: str,
         container_name: str,
         account_name: str,
+        metadata: Optional[Dict[Any, Any]] = None,
         **kwargs,
     ):
         kwargs.pop("type", None)  # make sure we never somehow use wrong type
         # Blob store connections returned from the API generally have no credentials, but we still don't want
         # to silently run over user inputted connections if they want to play with them locally, so double-check
         # kwargs for them.
+        if metadata is None:
+            metadata = {}
+        metadata[CONNECTION_CONTAINER_NAME_KEY] = container_name
+        metadata[CONNECTION_ACCOUNT_NAME_KEY] = account_name
+
         super().__init__(
             url=url,
             type=camel_to_snake(ConnectionCategory.AZURE_BLOB),
             from_child=True,
+            metadata=metadata,
             **kwargs,
         )
-
-        if not hasattr(self, "tags") or self.tags is None:
-            self.tags = {}
-        self.tags[CONNECTION_CONTAINER_NAME_KEY] = container_name
-        self.tags[CONNECTION_ACCOUNT_NAME_KEY] = account_name
 
     @classmethod
     def _get_required_metadata_fields(cls) -> List[str]:
@@ -109,8 +111,8 @@ class AzureBlobStoreConnection(WorkspaceConnection):
         :return: The name of the container.
         :rtype: Optional[str]
         """
-        if self.tags is not None:
-            return self.tags.get(CONNECTION_CONTAINER_NAME_KEY, None)
+        if self.metadata is not None:
+            return self.metadata.get(CONNECTION_CONTAINER_NAME_KEY, None)
         return None
 
     @container_name.setter
@@ -120,9 +122,9 @@ class AzureBlobStoreConnection(WorkspaceConnection):
         :param value: The new container name to set.
         :type value: str
         """
-        if self.tags is None:
-            self.tags = {}
-        self.tags[CONNECTION_CONTAINER_NAME_KEY] = value
+        if self.metadata is None:
+            self.metadata = {}
+        self.metadata[CONNECTION_CONTAINER_NAME_KEY] = value
 
     @property
     def account_name(self) -> Optional[str]:
@@ -131,8 +133,8 @@ class AzureBlobStoreConnection(WorkspaceConnection):
         :return: The name of the account.
         :rtype: Optional[str]
         """
-        if self.tags is not None:
-            return self.tags.get(CONNECTION_ACCOUNT_NAME_KEY, None)
+        if self.metadata is not None:
+            return self.metadata.get(CONNECTION_ACCOUNT_NAME_KEY, None)
         return None
 
     @account_name.setter
@@ -142,9 +144,9 @@ class AzureBlobStoreConnection(WorkspaceConnection):
         :param value: The new account name to set.
         :type value: str
         """
-        if self.tags is None:
-            self.tags = {}
-        self.tags[CONNECTION_ACCOUNT_NAME_KEY] = value
+        if self.metadata is None:
+            self.metadata = {}
+        self.metadata[CONNECTION_ACCOUNT_NAME_KEY] = value
 
 
 # Dev note: One lake connections are unfortunately unique in that it's extremely
@@ -174,8 +176,8 @@ class MicrosoftOneLakeConnection(WorkspaceConnection):
         ~azure.ai.ml.entities.SasTokenConfiguration,
         ~azure.ai.ml.entities.AadCredentialConfiguration,
         ]
-    :param tags: Tag dictionary. Tags can be added, removed, and updated.
-    :type tags: dict
+    :param metadata: Metadata dictionary.
+    :type metadata: Optional[dict[str,str]]
     """
 
     def __init__(
@@ -184,6 +186,7 @@ class MicrosoftOneLakeConnection(WorkspaceConnection):
         endpoint: str,
         artifact: Optional[OneLakeConnectionArtifact] = None,
         one_lake_workspace_name: Optional[str] = None,
+        metadata: Optional[Dict[Any, Any]] = None,
         **kwargs,
     ):
         kwargs.pop("type", None)  # make sure we never somehow use wrong type
@@ -203,15 +206,9 @@ class MicrosoftOneLakeConnection(WorkspaceConnection):
             target=target,
             type=camel_to_snake(ConnectionCategory.AZURE_ONE_LAKE),
             from_child=True,
+            metadata=metadata,
             **kwargs,
         )
-
-        if not hasattr(self, "tags") or self.tags is None:
-            self.tags = {}
-
-    @classmethod
-    def _get_required_metadata_fields(cls) -> List[str]:
-        return []
 
     @classmethod
     def _get_schema_class(cls) -> Type:
@@ -232,8 +229,6 @@ class MicrosoftOneLakeConnection(WorkspaceConnection):
 # or just an api key credential or no credentials, that it merits a parent class for
 # all of them. One that's slightly more specific than the base Connection.
 # This file contains that parent class, as well as all of its children.
-
-
 # Not experimental since users should never see this,
 # No need to add an extra warning.
 class ApiOrAadConnection(WorkspaceConnection):
@@ -262,6 +257,7 @@ class ApiOrAadConnection(WorkspaceConnection):
         api_key: Optional[str] = None,
         allow_entra: bool = True,
         type: str,
+        metadata: Optional[Dict[Any, Any]] = None,
         **kwargs: Any,
     ):
         # See if credentials directly inputted via kwargs
@@ -282,6 +278,7 @@ class ApiOrAadConnection(WorkspaceConnection):
         super().__init__(
             type=type,
             credentials=credentials,
+            metadata=metadata,
             **kwargs,
         )
 
@@ -326,8 +323,8 @@ class AzureOpenAIConnection(ApiOrAadConnection):
     :type open_ai_resource_id: Optional[str]
     :param api_version: The api version that this connection was created for.
     :type api_version: Optional[str]
-    :param tags: Tag dictionary. Tags can be added, removed, and updated.
-    :type tags: dict
+    :param metadata: Metadata dictionary.
+    :type metadata: Optional[dict[str,str]]
     """
 
     def __init__(
@@ -338,6 +335,7 @@ class AzureOpenAIConnection(ApiOrAadConnection):
         api_version: Optional[str] = None,
         api_type: str = "Azure",  # Required API input, hidden to allow for rare overrides
         open_ai_resource_id: Optional[str] = None,
+        metadata: Optional[Dict[Any, Any]] = None,
         **kwargs: Any,
     ):
         kwargs.pop("type", None)  # make sure we never somehow use wrong type
@@ -345,19 +343,21 @@ class AzureOpenAIConnection(ApiOrAadConnection):
         from_rest_resource_id = kwargs.pop("resource_id", None)
         if open_ai_resource_id is None and from_rest_resource_id is not None:
             open_ai_resource_id = from_rest_resource_id
+
+        if metadata is None:
+            metadata = {}
+        metadata[CONNECTION_API_VERSION_KEY] = api_version
+        metadata[CONNECTION_API_TYPE_KEY] = api_type
+        metadata[CONNECTION_RESOURCE_ID_KEY] = open_ai_resource_id
+
         super().__init__(
             azure_endpoint=azure_endpoint,
             api_key=api_key,
             type=camel_to_snake(ConnectionCategory.AZURE_OPEN_AI),
             from_child=True,
+            metadata=metadata,
             **kwargs,
         )
-
-        if not hasattr(self, "tags") or self.tags is None:
-            self.tags = {}
-        self.tags[CONNECTION_API_VERSION_KEY] = api_version
-        self.tags[CONNECTION_API_TYPE_KEY] = api_type
-        self.tags[CONNECTION_RESOURCE_ID_KEY] = open_ai_resource_id
 
     @classmethod
     def _get_required_metadata_fields(cls) -> List[str]:
@@ -374,8 +374,8 @@ class AzureOpenAIConnection(ApiOrAadConnection):
         :return: The API version of the connection.
         :rtype: Optional[str]
         """
-        if self.tags is not None and CONNECTION_API_VERSION_KEY in self.tags:
-            res: str = self.tags[CONNECTION_API_VERSION_KEY]
+        if self.metadata is not None and CONNECTION_API_VERSION_KEY in self.metadata:
+            res: str = self.metadata[CONNECTION_API_VERSION_KEY]
             return res
         return None
 
@@ -386,9 +386,9 @@ class AzureOpenAIConnection(ApiOrAadConnection):
         :param value: The new api version to set.
         :type value: str
         """
-        if not hasattr(self, "tags") or self.tags is None:
-            self.tags = {}
-        self.tags[CONNECTION_API_VERSION_KEY] = value
+        if not hasattr(self, "metadata") or self.metadata is None:
+            self.metadata = {}
+        self.metadata[CONNECTION_API_VERSION_KEY] = value
 
     @property
     def open_ai_resource_id(self) -> Optional[str]:
@@ -397,8 +397,8 @@ class AzureOpenAIConnection(ApiOrAadConnection):
         :return: The fully qualified ID of the Azure Open AI resource this connects to.
         :rtype: Optional[str]
         """
-        if self.tags is not None and CONNECTION_RESOURCE_ID_KEY in self.tags:
-            res: str = self.tags[CONNECTION_RESOURCE_ID_KEY]
+        if self.metadata is not None and CONNECTION_RESOURCE_ID_KEY in self.metadata:
+            res: str = self.metadata[CONNECTION_RESOURCE_ID_KEY]
             return res
         return None
 
@@ -409,12 +409,12 @@ class AzureOpenAIConnection(ApiOrAadConnection):
         :param value: The new resource id to set.
         :type value: Optional[str]
         """
-        if not hasattr(self, "tags") or self.tags is None:
-            self.tags = {}
+        if not hasattr(self, "metadata") or self.metadata is None:
+            self.metadata = {}
         if value is None:
-            self.tags.pop(CONNECTION_RESOURCE_ID_KEY, None)
+            self.metadata.pop(CONNECTION_RESOURCE_ID_KEY, None)
             return
-        self.tags[CONNECTION_RESOURCE_ID_KEY] = value
+        self.metadata[CONNECTION_RESOURCE_ID_KEY] = value
 
 
 @experimental
@@ -430,8 +430,8 @@ class AzureAIServicesConnection(ApiOrAadConnection):
     :type api_key: Optional[str]
     :param ai_services_resource_id: The fully qualified ID of the Azure AI service resource to connect to.
     :type ai_services_resource_id: str
-    :param tags: Tag dictionary. Tags can be added, removed, and updated.
-    :type tags: dict
+    :param metadata: Metadata dictionary.
+    :type metadata: Optional[dict[str,str]]
     """
 
     def __init__(
@@ -440,19 +440,21 @@ class AzureAIServicesConnection(ApiOrAadConnection):
         endpoint: str,
         api_key: Optional[str] = None,
         ai_services_resource_id: str,
+        metadata: Optional[Dict[Any, Any]] = None,
         **kwargs: Any,
     ):
         kwargs.pop("type", None)  # make sure we never somehow use wrong type
+        if metadata is None:
+            metadata = {}
+        metadata[CONNECTION_RESOURCE_ID_KEY] = ai_services_resource_id
         super().__init__(
             endpoint=endpoint,
             api_key=api_key,
             type=ConnectionTypes.AZURE_AI_SERVICES,
             from_child=True,
+            metadata=metadata,
             **kwargs,
         )
-        if not hasattr(self, "tags") or self.tags is None:
-            self.tags = {}
-        self.tags[CONNECTION_RESOURCE_ID_KEY] = ai_services_resource_id
 
     @classmethod
     def _get_schema_class(cls) -> Type:
@@ -469,8 +471,8 @@ class AzureAIServicesConnection(ApiOrAadConnection):
         :return: The resource id of the ai service being connected to.
         :rtype: Optional[str]
         """
-        if self.tags is not None and CONNECTION_RESOURCE_ID_KEY in self.tags:
-            res: str = self.tags[CONNECTION_RESOURCE_ID_KEY]
+        if self.metadata is not None and CONNECTION_RESOURCE_ID_KEY in self.metadata:
+            res: str = self.metadata[CONNECTION_RESOURCE_ID_KEY]
             return res
         return None
 
@@ -481,9 +483,9 @@ class AzureAIServicesConnection(ApiOrAadConnection):
         :param value: The new ai service resource id to set.
         :type value: str
         """
-        if not hasattr(self, "tags") or self.tags is None:
-            self.tags = {}
-        self.tags[CONNECTION_RESOURCE_ID_KEY] = value
+        if not hasattr(self, "metadata") or self.metadata is None:
+            self.metadata = {}
+        self.metadata[CONNECTION_RESOURCE_ID_KEY] = value
 
 
 @experimental
@@ -497,8 +499,8 @@ class AzureAISearchConnection(ApiOrAadConnection):
     :type endpoint: str
     :param api_key: The API key needed to connect to the Azure AI Search Service.
     :type api_key: Optional[str]
-    :param tags: Tag dictionary. Tags can be added, removed, and updated.
-    :type tags: dict
+    :param metadata: Metadata dictionary.
+    :type metadata: Optional[dict[str,str]]
     """
 
     def __init__(
@@ -506,6 +508,7 @@ class AzureAISearchConnection(ApiOrAadConnection):
         *,
         endpoint: str,
         api_key: Optional[str] = None,
+        metadata: Optional[Dict[Any, Any]] = None,
         **kwargs: Any,
     ):
         kwargs.pop("type", None)  # make sure we never somehow use wrong type
@@ -515,6 +518,7 @@ class AzureAISearchConnection(ApiOrAadConnection):
             api_key=api_key,
             type=ConnectionTypes.AZURE_SEARCH,
             from_child=True,
+            metadata=metadata,
             **kwargs,
         )
 
@@ -534,8 +538,8 @@ class AzureContentSafetyConnection(ApiOrAadConnection):
     :param api_key: The api key to connect to the azure endpoint.
         If unset, tries to use the user's Entra ID as credentials instead.
     :type api_key: Optional[str]
-    :param tags: Tag dictionary. Tags can be added, removed, and updated.
-    :type tags: dict
+    :param metadata: Metadata dictionary.
+    :type metadata: Optional[dict[str,str]]
     """
 
     def __init__(
@@ -543,20 +547,23 @@ class AzureContentSafetyConnection(ApiOrAadConnection):
         *,
         endpoint: str,
         api_key: Optional[str] = None,
+        metadata: Optional[Dict[Any, Any]] = None,
         **kwargs: Any,
     ):
         kwargs.pop("type", None)  # make sure we never somehow use wrong type
+
+        if metadata is None:
+            metadata = {}
+        metadata[CONNECTION_KIND_KEY] = CognitiveServiceKinds.CONTENT_SAFETY
+
         super().__init__(
             endpoint=endpoint,
             api_key=api_key,
             type=ConnectionTypes.AZURE_CONTENT_SAFETY,
             from_child=True,
+            metadata=metadata,
             **kwargs,
         )
-
-        if not hasattr(self, "tags") or self.tags is None:
-            self.tags = {}
-        self.tags[CONNECTION_KIND_KEY] = CognitiveServiceKinds.CONTENT_SAFETY
 
     @classmethod
     def _get_schema_class(cls) -> Type:
@@ -574,8 +581,8 @@ class AzureSpeechServicesConnection(ApiOrAadConnection):
     :param api_key: The api key to connect to the azure endpoint.
         If unset, tries to use the user's Entra ID as credentials instead.
     :type api_key: Optional[str]
-    :param tags: Tag dictionary. Tags can be added, removed, and updated.
-    :type tags: dict
+    :param metadata: Metadata dictionary.
+    :type metadata: Optional[dict[str,str]]
     """
 
     # kinds AzureOpenAI", "ContentSafety", and "Speech"
@@ -585,20 +592,22 @@ class AzureSpeechServicesConnection(ApiOrAadConnection):
         *,
         endpoint: str,
         api_key: Optional[str] = None,
+        metadata: Optional[Dict[Any, Any]] = None,
         **kwargs: Any,
     ):
         kwargs.pop("type", None)  # make sure we never somehow use wrong type
+
+        if metadata is None:
+            metadata = {}
+        metadata[CONNECTION_KIND_KEY] = CognitiveServiceKinds.SPEECH
         super().__init__(
             endpoint=endpoint,
             api_key=api_key,
             type=ConnectionTypes.AZURE_SPEECH_SERVICES,
             from_child=True,
+            metadata=metadata,
             **kwargs,
         )
-
-        if not hasattr(self, "tags") or self.tags is None:
-            self.tags = {}
-        self.tags[CONNECTION_KIND_KEY] = CognitiveServiceKinds.SPEECH
 
     @classmethod
     def _get_schema_class(cls) -> Type:
@@ -615,8 +624,8 @@ class APIKeyConnection(ApiOrAadConnection):
     :type api_base: str
     :param api_key: The API key needed to connect to the api_base.
     :type api_key: Optional[str]
-    :param tags: Tag dictionary. Tags can be added, removed, and updated.
-    :type tags: dict
+    :param metadata: Metadata dictionary.
+    :type metadata: Optional[dict[str,str]]
     """
 
     def __init__(
@@ -624,6 +633,7 @@ class APIKeyConnection(ApiOrAadConnection):
         *,
         api_base: str,
         api_key: Optional[str] = None,
+        metadata: Optional[Dict[Any, Any]] = None,
         **kwargs,
     ):
         kwargs.pop("type", None)  # make sure we never somehow use wrong type
@@ -633,6 +643,7 @@ class APIKeyConnection(ApiOrAadConnection):
             type=camel_to_snake(ConnectionCategory.API_KEY),
             allow_entra=False,
             from_child=True,
+            metadata=metadata,
             **kwargs,
         )
 
@@ -650,14 +661,15 @@ class OpenAIConnection(ApiOrAadConnection):
     :type name: str
     :param api_key: The API key needed to connect to the Open AI.
     :type api_key: Optional[str]
-    :param tags: Tag dictionary. Tags can be added, removed, and updated.
-    :type tags: dict
+    :param metadata: Metadata dictionary.
+    :type metadata: Optional[dict[str,str]]
     """
 
     def __init__(
         self,
         *,
         api_key: Optional[str] = None,
+        metadata: Optional[Dict[Any, Any]] = None,
         **kwargs,
     ):
         kwargs.pop("type", None)  # make sure we never somehow use wrong type
@@ -666,6 +678,7 @@ class OpenAIConnection(ApiOrAadConnection):
             api_key=api_key,
             allow_entra=False,
             from_child=True,
+            metadata=metadata,
             **kwargs,
         )
 
@@ -682,14 +695,15 @@ class SerpConnection(ApiOrAadConnection):
     :type name: str
     :param api_key: The API key needed to connect to the Open AI.
     :type api_key: Optional[str]
-    :param tags: Tag dictionary. Tags can be added, removed, and updated.
-    :type tags: dict
+    :param metadata: Metadata dictionary.
+    :type metadata: Optional[dict[str,str]]
     """
 
     def __init__(
         self,
         *,
         api_key: Optional[str] = None,
+        metadata: Optional[Dict[Any, Any]] = None,
         **kwargs,
     ):
         kwargs.pop("type", None)  # make sure we never somehow use wrong type
@@ -698,6 +712,7 @@ class SerpConnection(ApiOrAadConnection):
             api_key=api_key,
             allow_entra=False,
             from_child=True,
+            metadata=metadata,
             **kwargs,
         )
 
@@ -716,8 +731,8 @@ class ServerlessConnection(ApiOrAadConnection):
     :type endpoint: str
     :param api_key: The API key needed to connect to the endpoint.
     :type api_key: Optional[str]
-    :param tags: Tag dictionary. Tags can be added, removed, and updated.
-    :type tags: dict
+    :param metadata: Metadata dictionary.
+    :type metadata: Optional[dict[str,str]]
     """
 
     def __init__(
@@ -725,6 +740,7 @@ class ServerlessConnection(ApiOrAadConnection):
         *,
         endpoint: str,
         api_key: Optional[str] = None,
+        metadata: Optional[Dict[Any, Any]] = None,
         **kwargs,
     ):
         kwargs.pop("type", None)  # make sure we never somehow use wrong type
@@ -734,6 +750,7 @@ class ServerlessConnection(ApiOrAadConnection):
             api_key=api_key,
             allow_entra=False,
             from_child=True,
+            metadata=metadata,
             **kwargs,
         )
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_workspace/connections/workspace_connection.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_workspace/connections/workspace_connection.py
@@ -84,8 +84,8 @@ class WorkspaceConnection(Resource):
     :type name: str
     :param target: The URL or ARM resource ID of the external resource.
     :type target: str
-    :param tags: Tag dictionary. Tags can be added, removed, and updated.
-    :type tags: dict
+    :param metadata: Metadata dictionary.
+    :type metadata: Optional[Dict[Any, Any]]
     :param type: The category of external resource for this connection.
     :type type: The type of connection, possible values are: "git", "python_feed", "container_registry",
         "feature_store", "s3", "snowflake", "azure_sql_db", "azure_synapse_analytics", "azure_my_sql_db",
@@ -128,6 +128,7 @@ class WorkspaceConnection(Resource):
             AadCredentialConfiguration,
         ],
         is_shared: bool = True,
+        metadata: Optional[Dict[str, Any]] = None,
         **kwargs: Any,
     ):
 
@@ -157,12 +158,27 @@ class WorkspaceConnection(Resource):
         if target is None and type not in {ConnectionCategory.SERP, ConnectionCategory.Open_AI}:
             raise ValueError("target is a required field for Connection.")
 
+        tags = kwargs.pop("tags", None)
+        if tags is not None:
+            if metadata is not None:
+                # Update tags updated with metadata to make sure metadata values are preserved in case of conflicts.
+                tags.update(metadata)
+                metadata = tags
+                warnings.warn(
+                    "Tags are a deprecated field for connections, use metadata instead. Since both "
+                    + "metadata and tags are assigned, metadata values will take precedence in the event of conflicts."
+                )
+            else:
+                metadata = tags
+                warnings.warn("Tags are a deprecated field for connections, use metadata instead.")
+
         super().__init__(**kwargs)
 
         self.type = type
         self._target = target
         self._credentials = credentials
         self._is_shared = is_shared
+        self._metadata = metadata
         self._validate_cred_for_conn_cat()
 
     def _validate_cred_for_conn_cat(self) -> None:
@@ -299,23 +315,45 @@ class WorkspaceConnection(Resource):
         return self._credentials
 
     @property
-    def metadata(self) -> Dict[str, Any]:
-        """Deprecated. Use tags.
-        :return: This connection's tags.
-        :rtype: Dict[str, Any]
+    def metadata(self) -> Optional[Dict[Any, Any]]:
+        """The connection's metadata dictionary.
+        :return: This connection's metadata.
+        :rtype: Optional[Dict[Any, Any]]
         """
-        return self.tags if self.tags is not None else {}
+        return self._metadata if self._metadata is not None else {}
 
     @metadata.setter
-    def metadata(self, value: Dict[str, Any]) -> None:
-        """Deprecated. Use tags.
+    def metadata(self, value: Optional[Dict[Any, Any]]) -> None:
+        """Set the metadata for the connection. Be warned that setting this will override
+        ALL metadata values, including those implicitly set by certain connection types to manage their
+        extra data. Usually, you should probably access the metadata dictionary, then add or remove values
+        individually as needed.
         :param value: The new metadata for connection.
-            This completely overwrites the existing tags/metadata dictionary.
-        :type value: Dict[str, Any]
+            This completely overwrites the existing metadata dictionary.
+        :type value: Optional[Dict[Any, Any]]
         """
         if not value:
             return
-        self.tags = value
+        self._metadata = value
+
+    @property
+    def tags(self) -> Optional[Dict[Any, Any]]:
+        """Deprecated. Use metadata instead.
+        :return: This connection's metadata.
+        :rtype: Optional[Dict[Any, Any]]
+        """
+        return self._metadata if self._metadata is not None else {}
+
+    @tags.setter
+    def tags(self, value: Optional[Dict[Any, Any]]) -> None:
+        """Deprecated use metadata instead
+        :param value: The new metadata for connection.
+            This completely overwrites the existing metadata dictionary.
+        :type value: Optional[Dict[Any, Any]]
+        """
+        if not value:
+            return
+        self._metadata = value
 
     @property
     def is_shared(self) -> bool:
@@ -392,9 +430,9 @@ class WorkspaceConnection(Resource):
 
         conn_class = cls._get_entity_class_from_rest_obj(rest_obj)
 
-        popped_tags = conn_class._get_required_metadata_fields()
+        popped_metadata = conn_class._get_required_metadata_fields()
 
-        rest_kwargs = cls._extract_kwargs_from_rest_obj(rest_obj=rest_obj, popped_tags=popped_tags)
+        rest_kwargs = cls._extract_kwargs_from_rest_obj(rest_obj=rest_obj, popped_metadata=popped_metadata)
         # Check for alternative name for custom connection type (added for client clarity).
         if rest_kwargs["type"].lower() == camel_to_snake(ConnectionCategory.CUSTOM_KEYS).lower():
             rest_kwargs["type"] = ConnectionTypes.CUSTOM
@@ -452,7 +490,7 @@ class WorkspaceConnection(Resource):
         }:
             properties = connection_properties_class(
                 target=self.target,
-                metadata=self.tags,
+                metadata=self.metadata,
                 category=_snake_to_camel(conn_type),
                 is_shared_to_all=self.is_shared,
             )
@@ -460,7 +498,7 @@ class WorkspaceConnection(Resource):
             properties = connection_properties_class(
                 target=self.target,
                 credentials=self.credentials._to_workspace_connection_rest_object() if self._credentials else None,
-                metadata=self.tags,
+                metadata=self.metadata,
                 category=_snake_to_camel(conn_type),
                 is_shared_to_all=self.is_shared,
             )
@@ -468,17 +506,20 @@ class WorkspaceConnection(Resource):
         return RestWorkspaceConnection(properties=properties)
 
     @classmethod
-    def _extract_kwargs_from_rest_obj(cls, rest_obj: RestWorkspaceConnection, popped_tags: List[str]) -> Dict[str, str]:
+    def _extract_kwargs_from_rest_obj(
+        cls, rest_obj: RestWorkspaceConnection, popped_metadata: List[str]
+    ) -> Dict[str, str]:
         """Internal helper function with extracts all the fields needed to initialize a connection object
-        from its associated restful object. Pulls extra fields based on the supplied popped_tags. Returns all the
-        fields as a dictionary, which is expected to then be supplied to a connection initializer as kwargs.
+        from its associated restful object. Pulls extra fields based on the supplied `popped_metadata` input.
+        Returns all the fields as a dictionary, which is expected to then be supplied to a
+        connection initializer as kwargs.
 
         :param rest_obj: The rest object representation of a connection
         :type rest_obj: RestWorkspaceConnection
-        :param popped_tags: Tags that should be pulled from the rest object's metadata and injected as top-level
-            fields into the connection's initializer. Needed for subclasses that require extra inputs compared
-            to the base Connection class.
-        :type popped_tags: List[str]
+        :param popped_metadata: Key names that should be pulled from the rest object's metadata and
+            injected as top-level fields into the client connection's initializer.
+            This is needed for subclasses that require extra inputs compared to the base Connection class.
+        :type popped_metadata: List[str]
 
         :return: A dictionary containing all kwargs needed to construct a connection.
         :rtype: Dict[str, str]
@@ -495,7 +536,7 @@ class WorkspaceConnection(Resource):
         elif credentials_class is not NoneCredentialConfiguration:
             credentials = credentials_class._from_workspace_connection_rest_object(properties.credentials)
 
-        tags = properties.metadata if hasattr(properties, "metadata") else None
+        metadata = properties.metadata if hasattr(properties, "metadata") else {}
         rest_kwargs = {
             "id": rest_obj.id,
             "name": rest_obj.name,
@@ -503,13 +544,13 @@ class WorkspaceConnection(Resource):
             "creation_context": SystemData._from_rest_object(rest_obj.system_data) if rest_obj.system_data else None,
             "type": camel_to_snake(properties.category),
             "credentials": credentials,
-            "tags": tags,
+            "metadata": metadata,
             "is_shared": properties.is_shared_to_all if hasattr(properties, "is_shared_to_all") else True,
         }
 
-        for name in popped_tags:
-            if name in tags:
-                rest_kwargs[camel_to_snake(name)] = tags[name]
+        for name in popped_metadata:
+            if name in metadata:
+                rest_kwargs[camel_to_snake(name)] = metadata[name]
         return rest_kwargs
 
     @classmethod

--- a/sdk/ml/azure-ai-ml/tests/connection/e2etests/test_connections.py
+++ b/sdk/ml/azure-ai-ml/tests/connection/e2etests/test_connections.py
@@ -40,6 +40,7 @@ from azure.ai.ml.entities._datastore.datastore import Datastore
 @pytest.mark.core_sdk_test
 @pytest.mark.usefixtures("recorded_test")
 class TestWorkspaceConnections(AzureRecordedTestCase):
+    @pytest.mark.live_test_only("Needs re-recording to work with new common sanitizers")
     def test_secret_population(
         self,
         client: MLClient,

--- a/sdk/ml/azure-ai-ml/tests/connection/e2etests/test_connections.py
+++ b/sdk/ml/azure-ai-ml/tests/connection/e2etests/test_connections.py
@@ -112,7 +112,7 @@ class TestWorkspaceConnections(AzureRecordedTestCase):
             assert wps_connection.name == wps_connection_name
             assert wps_connection.credentials.type == camel_to_snake(ConnectionAuthType.PAT)
             assert wps_connection.type == camel_to_snake(ConnectionCategory.GIT)
-            assert wps_connection.tags == {}
+            assert wps_connection.metadata == {}
             # TODO : Uncomment once service side returns creds correctly
             # assert wps_connection.credentials.pat == "dummpy_pat_update"
         finally:
@@ -139,7 +139,7 @@ class TestWorkspaceConnections(AzureRecordedTestCase):
             assert wps_connection.name == wps_connection_name
             assert wps_connection.credentials.type == camel_to_snake(ConnectionAuthType.USERNAME_PASSWORD)
             assert wps_connection.type == camel_to_snake(ConnectionCategory.SNOWFLAKE)
-            assert wps_connection.tags == {}
+            assert wps_connection.metadata == {}
 
             wps_connection.credentials.username = "dummy"
             wps_connection.credentials.password = "dummy"
@@ -153,7 +153,7 @@ class TestWorkspaceConnections(AzureRecordedTestCase):
             assert wps_connection.name == wps_connection_name
             assert wps_connection.credentials.type == camel_to_snake(ConnectionAuthType.USERNAME_PASSWORD)
             assert wps_connection.type == camel_to_snake(ConnectionCategory.SNOWFLAKE)
-            assert wps_connection.tags == {}
+            assert wps_connection.metadata == {}
         finally:
             client.connections.delete(name=wps_connection_name)
 
@@ -179,7 +179,7 @@ class TestWorkspaceConnections(AzureRecordedTestCase):
             assert wps_connection.name == wps_connection_name
             assert wps_connection.credentials.type == camel_to_snake(ConnectionAuthType.ACCESS_KEY)
             assert wps_connection.type == camel_to_snake(ConnectionCategory.S3)
-            assert wps_connection.tags == {}
+            assert wps_connection.metadata == {}
 
             wps_connection.credentials.access_key_id = "dummy"
             wps_connection.credentials.secret_access_key = "dummy"
@@ -193,7 +193,7 @@ class TestWorkspaceConnections(AzureRecordedTestCase):
             assert wps_connection.name == wps_connection_name
             assert wps_connection.credentials.type == camel_to_snake(ConnectionAuthType.ACCESS_KEY)
             assert wps_connection.type == camel_to_snake(ConnectionCategory.S3)
-            assert wps_connection.tags == {}
+            assert wps_connection.metadata == {}
         finally:
             client.connections.delete(name=wps_connection_name)
 
@@ -216,7 +216,7 @@ class TestWorkspaceConnections(AzureRecordedTestCase):
         assert wps_connection.name == wps_connection_name
         assert wps_connection.credentials.type == camel_to_snake(ConnectionAuthType.API_KEY)
         assert wps_connection.type == ConnectionTypes.AZURE_CONTENT_SAFETY
-        assert wps_connection.tags is not None
+        assert wps_connection.metadata is not None
 
         with pytest.raises(Exception):
             client.connections.get(name=wps_connection_name)
@@ -237,7 +237,7 @@ class TestWorkspaceConnections(AzureRecordedTestCase):
         assert wps_connection.name == wps_connection_name
         assert wps_connection.credentials.type == camel_to_snake(ConnectionAuthType.API_KEY)
         assert wps_connection.type == ConnectionTypes.AZURE_SPEECH_SERVICES
-        assert wps_connection.tags is not None
+        assert wps_connection.metadata is not None
 
         with pytest.raises(Exception):
             client.connections.get(name=wps_connection_name)
@@ -260,7 +260,7 @@ class TestWorkspaceConnections(AzureRecordedTestCase):
         assert wps_connection.credentials.type == camel_to_snake(ConnectionAuthType.API_KEY)
         # assert wps_connection.api_key == "3333" # TODO add api key retrieval everywhere
         assert wps_connection.type == ConnectionTypes.AZURE_SEARCH
-        assert wps_connection.tags is not None
+        assert wps_connection.metadata is not None
 
         with pytest.raises(Exception):
             client.connections.get(name=wps_connection_name)
@@ -468,7 +468,7 @@ class TestWorkspaceConnections(AzureRecordedTestCase):
         assert created_connection.name == wps_connection_name
         assert created_connection.type == ConnectionTypes.AZURE_DATA_LAKE_GEN_2
         assert created_connection.credentials.type == camel_to_snake(ConnectionAuthType.SERVICE_PRINCIPAL)
-        assert created_connection.tags["four"] == "five"
+        assert created_connection.metadata["four"] == "five"
         assert created_connection.target == "my_endpoint"
 
         with pytest.raises(Exception):
@@ -485,7 +485,7 @@ class TestWorkspaceConnections(AzureRecordedTestCase):
         assert created_connection.name == wps_connection_name
         assert created_connection.type == ConnectionTypes.AZURE_DATA_LAKE_GEN_2
         assert created_connection.credentials.type == ConnectionAuthType.AAD.lower()
-        assert created_connection.tags["four"] == "five"
+        assert created_connection.metadata["four"] == "five"
         assert created_connection.target == "my_endpoint"
 
         with pytest.raises(Exception):
@@ -550,8 +550,8 @@ class TestWorkspaceConnections(AzureRecordedTestCase):
         assert created_connection.type == camel_to_snake(ConnectionCategory.AZURE_OPEN_AI)
         expected_key = "12344" if is_live() else "dGhpcyBpcyBmYWtlIGtleQ=="
         assert created_connection.api_key == expected_key
-        assert created_connection.tags is not None
-        assert created_connection.tags["hello"] == "world"
+        assert created_connection.metadata is not None
+        assert created_connection.metadata["hello"] == "world"
         assert created_connection.api_version == "1.0"
         assert created_connection.open_ai_resource_id == None
 
@@ -571,8 +571,8 @@ class TestWorkspaceConnections(AzureRecordedTestCase):
         assert created_connection.name == wps_connection_name
         assert created_connection.credentials.type == ConnectionAuthType.AAD.lower()
         assert created_connection.type == camel_to_snake(ConnectionCategory.AZURE_OPEN_AI)
-        assert created_connection.tags is not None
-        assert created_connection.tags["hello"] == "world"
+        assert created_connection.metadata is not None
+        assert created_connection.metadata["hello"] == "world"
         assert created_connection.api_version is None
         assert created_connection.open_ai_resource_id == None
 
@@ -784,7 +784,7 @@ class TestWorkspaceConnections(AzureRecordedTestCase):
         assert created_connection.name == wps_connection_name
         assert created_connection.credentials.type == camel_to_snake(ConnectionAuthType.API_KEY)
         assert created_connection.type == camel_to_snake(ConnectionTypes.CUSTOM)
-        assert created_connection.tags is not None
+        assert created_connection.metadata is not None
         assert created_connection.is_shared
 
         with pytest.raises(Exception):
@@ -873,7 +873,7 @@ class TestWorkspaceConnections(AzureRecordedTestCase):
             assert wps_connection.name == wps_connection_name
             assert wps_connection.credentials.type == camel_to_snake(ConnectionAuthType.PAT)
             assert wps_connection.type == camel_to_snake(ConnectionCategory.PYTHON_FEED)
-            assert wps_connection.tags == {}
+            assert wps_connection.metadata == {}
             # TODO : Uncomment once service side returns creds correctly
             # assert wps_connection.credentials.pat == "dummy_pat"
 
@@ -888,7 +888,7 @@ class TestWorkspaceConnections(AzureRecordedTestCase):
             assert wps_connection.name == wps_connection_name
             assert wps_connection.credentials.type == camel_to_snake(ConnectionAuthType.PAT)
             assert wps_connection.type == camel_to_snake(ConnectionCategory.PYTHON_FEED)
-            assert wps_connection.tags == {}
+            assert wps_connection.metadata == {}
             # TODO : Uncomment once service side returns creds correctly
             # assert wps_connection.credentials.pat == "dummpy_pat_update"
         finally:
@@ -916,7 +916,7 @@ class TestWorkspaceConnections(AzureRecordedTestCase):
             assert wps_connection.name == wps_connection_name
             assert wps_connection.credentials.type == camel_to_snake(ConnectionAuthType.MANAGED_IDENTITY)
             assert wps_connection.type == camel_to_snake(ConnectionCategory.CONTAINER_REGISTRY)
-            assert wps_connection.tags == {}
+            assert wps_connection.metadata == {}
             # TODO : Uncomment once service side returns creds correctly
             # assert wps_connection.credentials.pat == "dummy_pat"
 

--- a/sdk/ml/azure-ai-ml/tests/test_configs/connection/alds_gen2_entra.yaml
+++ b/sdk/ml/azure-ai-ml/tests/test_configs/connection/alds_gen2_entra.yaml
@@ -1,5 +1,5 @@
 name: test_gen2_conn2
 type: azure_data_lake_gen2
 target: my_endpoint
-tags:
+metadata:
   four: five

--- a/sdk/ml/azure-ai-ml/tests/test_configs/connection/alds_gen2_sp.yaml
+++ b/sdk/ml/azure-ai-ml/tests/test_configs/connection/alds_gen2_sp.yaml
@@ -1,7 +1,7 @@
 name: test_gen2_conn1
 type: azure_data_lake_gen2
 target: my_endpoint
-tags:
+metadata:
   four: five
 credentials:
   type: service_principal

--- a/sdk/ml/azure-ai-ml/tests/test_configs/connection/azure_open_ai_entra.yaml
+++ b/sdk/ml/azure-ai-ml/tests/test_configs/connection/azure_open_ai_entra.yaml
@@ -1,5 +1,5 @@
 name: azure_open_ai_conn_entra
 type: azure_open_ai
 azure_endpoint: dummy
-tags:
+metadata:
   hello: world

--- a/sdk/ml/azure-ai-ml/tests/test_configs/connection/blob_store_acc_key.yaml
+++ b/sdk/ml/azure-ai-ml/tests/test_configs/connection/blob_store_acc_key.yaml
@@ -1,7 +1,7 @@
 name: test_ws_conn_blob_store1
 type: azure_blob
 url: my_endpoint
-tags:
+metadata:
   four: five
 credentials:
   type: account_key

--- a/sdk/ml/azure-ai-ml/tests/test_configs/connection/blob_store_bad_cred.yaml
+++ b/sdk/ml/azure-ai-ml/tests/test_configs/connection/blob_store_bad_cred.yaml
@@ -1,7 +1,7 @@
 name: test_ws_conn_blob_store
 type: azure_blob
 target: my_endpoint
-tags:
+metadata:
   four: five
 credentials:
   type: api_key

--- a/sdk/ml/azure-ai-ml/tests/test_configs/connection/blob_store_entra.yaml
+++ b/sdk/ml/azure-ai-ml/tests/test_configs/connection/blob_store_entra.yaml
@@ -1,7 +1,7 @@
 name: test_ws_conn_blob_store3
 type: azure_blob
 url: my_endpoint
-tags:
+metadata:
   four: five
 container_name: some_container
 account_name: some_account

--- a/sdk/ml/azure-ai-ml/tests/test_configs/connection/blob_store_sas.yaml
+++ b/sdk/ml/azure-ai-ml/tests/test_configs/connection/blob_store_sas.yaml
@@ -1,7 +1,7 @@
 name: test_ws_conn_blob_store2
 type: azure_blob
 url: my_endpoint
-tags:
+metadata:
   four: five
 credentials:
   type: sas

--- a/sdk/ml/azure-ai-ml/tests/test_configs/connection/custom.yaml
+++ b/sdk/ml/azure-ai-ml/tests/test_configs/connection/custom.yaml
@@ -1,7 +1,7 @@
 name: test_ws_conn_custom_keys
 type: custom
 target: my_endpoint
-tags:
+metadata:
   one: two
 credentials:
   type: api_key


### PR DESCRIPTION
Several months ago there was an ask to replace the 'metadata' field of workspace connections with 'tags' to align with other resource naming conventions. This was a mistake, and this PR rectifies that. Both values still work, but tags is now listed as deprecated, and metadata is a documented input of workspace connections, and its property docstrings no longer tell you to use tags.

Also, this PR GA's the base workspace connection class, but not its myriad, newer subclasses.