### PR TITLE
Wire up SubscriptionConfigurationFilePaths

### DIFF
--- a/eng/pipelines/templates/jobs/live.tests.yml
+++ b/eng/pipelines/templates/jobs/live.tests.yml
@@ -117,6 +117,7 @@ jobs:
           SubscriptionConfiguration: ${{ parameters.CloudConfig.SubscriptionConfiguration }}
           SubscriptionConfigurations: ${{ parameters.CloudConfig.SubscriptionConfigurations }}
           EnvVars: ${{ parameters.EnvVars }}
+          SubscriptionConfigurationFilePaths: ${{ parameters.CloudConfig.SubscriptionConfigurationFilePaths }}
 
       - ${{ if parameters.TestResourceDirectories }}:
         - ${{ each directory in parameters.TestResourceDirectories }}:


### PR DESCRIPTION
After merging eng/common changes, those changes need to be wired up. 

Traced yaml through to invocation of `build-test-resource-config.yml` 