### PR TITLE
[Eventhub] Update CI test matrix

### DIFF
--- a/sdk/eventhub/ci.yml
+++ b/sdk/eventhub/ci.yml
@@ -29,12 +29,6 @@ extends:
   template: ../../eng/pipelines/templates/stages/archetype-sdk-client.yml
   parameters:
     ServiceDirectory: eventhub
-    # Override the base matrix due to https://github.com/Azure/azure-sdk-for-python/issues/17837
-    MatrixConfigs:
-      - Name: eventhub_ci_matrix
-        Path: eng/pipelines/templates/stages/platform-matrix-no-312.json
-        Selection: sparse
-        GenerateVMJobs: true
     MatrixFilters:
       - PythonVersion=^(?!pypy3).*
     Artifacts:


### PR DESCRIPTION
Enables Python 3.12 testing and gets the eventhub pipeline green again.
