### PR TITLE
[Storage] [Typing] [File Share] Resolved `_file_client.py` and `_file_client_async.py` `mypy` errors

### DIFF
--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_file_client_helpers.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_file_client_helpers.py
@@ -6,7 +6,7 @@
 # pylint: disable=docstring-keyword-should-match-keyword-only
 
 from typing import (
-    Any, Dict, Optional, Tuple, Union,
+    Any, Dict, List, Optional, Tuple, Union,
     TYPE_CHECKING
 )
 from urllib.parse import quote, unquote, urlparse
@@ -57,7 +57,13 @@ def _from_file_url(
     return account_url, share_name, file_path, snapshot
 
 
-def _format_url(scheme: str, hostname: str, share_name: str, file_path: str, query_str: str) -> str:
+def _format_url(
+    scheme: str,
+    hostname: str,
+    share_name: Union[str, bytes],
+    file_path: List[str],
+    query_str: str
+) -> str:
     if isinstance(share_name, str):
         share_name = share_name.encode('UTF-8')
     return (f"{scheme}://{hostname}/{quote(share_name)}"
@@ -105,7 +111,7 @@ def _upload_range_from_url_options(
 
 
 def _get_ranges_options(
-    snapshot: str,
+    snapshot: Optional[str],
     offset: Optional[int] = None,
     length: Optional[int] = None,
     previous_sharesnapshot: Optional[Union[str, Dict[str, Any]]] = None,

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_lease.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_lease.py
@@ -7,8 +7,8 @@
 
 import uuid
 
-from typing import (  # pylint: disable=unused-import
-    Union, Optional, Any, TypeVar, TYPE_CHECKING
+from typing import (
+    Union, Optional, Any, TYPE_CHECKING
 )
 
 from azure.core.tracing.decorator import distributed_trace
@@ -19,8 +19,7 @@ from ._generated.operations import FileOperations, ShareOperations
 
 if TYPE_CHECKING:
     from datetime import datetime
-    ShareFileClient = TypeVar("ShareFileClient")
-    ShareClient = TypeVar("ShareClient")
+    from azure.storage.fileshare import ShareClient, ShareFileClient
 
 
 class ShareLeaseClient(object):  # pylint: disable=client-accepts-api-version-keyword
@@ -46,10 +45,10 @@ class ShareLeaseClient(object):  # pylint: disable=client-accepts-api-version-ke
         A string representing the lease ID of an existing lease. This value does not
         need to be specified in order to acquire a new lease, or break one.
     """
-    def __init__(
-            self, client, lease_id=None
-    ):  # pylint: disable=missing-client-constructor-parameter-credential,missing-client-constructor-parameter-kwargs
-        # type: (Union[ShareFileClient, ShareClient], Optional[str]) -> None
+    def __init__(  # pylint: disable=missing-client-constructor-parameter-credential,missing-client-constructor-parameter-kwargs
+        self, client: Union["ShareFileClient", "ShareClient"],
+        lease_id: Optional[str] = None
+    ) -> None:
         self.id = lease_id or str(uuid.uuid4())
         self.last_modified = None
         self.etag = None
@@ -65,12 +64,11 @@ class ShareLeaseClient(object):  # pylint: disable=client-accepts-api-version-ke
     def __enter__(self):
         return self
 
-    def __exit__(self, *args):
+    def __exit__(self, *args: Any):
         self.release()
 
     @distributed_trace
-    def acquire(self, **kwargs):
-        # type: (**Any) -> None
+    def acquire(self, **kwargs: Any) -> None:
         """Requests a new lease. This operation establishes and manages a lock on a
         file or share for write and delete operations. If the file or share does not have an active lease,
         the File or Share service creates a lease on the file or share. If the file has an active lease,
@@ -106,13 +104,12 @@ class ShareLeaseClient(object):  # pylint: disable=client-accepts-api-version-ke
                 **kwargs)
         except HttpResponseError as error:
             process_storage_error(error)
-        self.id = response.get('lease_id')  # type: str
-        self.last_modified = response.get('last_modified')   # type: datetime
-        self.etag = response.get('etag')  # type: str
+        self.id = response.get('lease_id')
+        self.last_modified = response.get('last_modified')
+        self.etag = response.get('etag')
 
     @distributed_trace
-    def renew(self, **kwargs):
-        # type: (Any) -> None
+    def renew(self, **kwargs: Any) -> None:
         """Renews the share lease.
 
         The share lease can be renewed if the lease ID specified in the
@@ -142,13 +139,12 @@ class ShareLeaseClient(object):  # pylint: disable=client-accepts-api-version-ke
                 **kwargs)
         except HttpResponseError as error:
             process_storage_error(error)
-        self.etag = response.get('etag')  # type: str
-        self.id = response.get('lease_id')  # type: str
-        self.last_modified = response.get('last_modified')   # type: datetime
+        self.etag = response.get('etag')
+        self.id = response.get('lease_id')
+        self.last_modified = response.get('last_modified')
 
     @distributed_trace
-    def release(self, **kwargs):
-        # type: (Any) -> None
+    def release(self, **kwargs: Any) -> None:
         """Releases the lease. The lease may be released if the lease ID specified on the request matches
         that associated with the share or file. Releasing the lease allows another client to immediately acquire
         the lease for the share or file as soon as the release is complete.
@@ -171,13 +167,12 @@ class ShareLeaseClient(object):  # pylint: disable=client-accepts-api-version-ke
                 **kwargs)
         except HttpResponseError as error:
             process_storage_error(error)
-        self.etag = response.get('etag')  # type: str
-        self.id = response.get('lease_id')  # type: str
-        self.last_modified = response.get('last_modified')   # type: datetime
+        self.etag = response.get('etag')
+        self.id = response.get('lease_id')
+        self.last_modified = response.get('last_modified')
 
     @distributed_trace
-    def change(self, proposed_lease_id, **kwargs):
-        # type: (str, Any) -> None
+    def change(self, proposed_lease_id: str, **kwargs: Any) -> None:
         """ Changes the lease ID of an active lease. A change must include the current lease ID in x-ms-lease-id and
         a new lease ID in x-ms-proposed-lease-id.
 
@@ -203,13 +198,12 @@ class ShareLeaseClient(object):  # pylint: disable=client-accepts-api-version-ke
                 **kwargs)
         except HttpResponseError as error:
             process_storage_error(error)
-        self.etag = response.get('etag')  # type: str
-        self.id = response.get('lease_id')  # type: str
-        self.last_modified = response.get('last_modified')   # type: datetime
+        self.etag = response.get('etag')
+        self.id = response.get('lease_id')
+        self.last_modified = response.get('last_modified')
 
     @distributed_trace
-    def break_lease(self, **kwargs):
-        # type: (Any) -> int
+    def break_lease(self, **kwargs: Any) -> int:
         """Force breaks the lease if the file or share has an active lease. Any authorized request can break the lease;
         the request is not required to specify a matching lease ID. An infinite lease breaks immediately.
 

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/aio/_lease_async.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/aio/_lease_async.py
@@ -5,6 +5,8 @@
 # --------------------------------------------------------------------------
 # pylint: disable=invalid-overridden-method, docstring-keyword-should-match-keyword-only
 
+import uuid
+
 from typing import (  # pylint: disable=unused-import
     Union, Optional, Any, IO, Iterable, AnyStr, Dict, List, Tuple,
     TypeVar, TYPE_CHECKING
@@ -15,15 +17,13 @@ from azure.core.tracing.decorator_async import distributed_trace_async
 
 from .._shared.response_handlers import return_response_headers, process_storage_error
 from .._generated.aio.operations import FileOperations, ShareOperations
-from .._lease import ShareLeaseClient as LeaseClientBase
 
 if TYPE_CHECKING:
     from datetime import datetime
-    ShareFileClient = TypeVar("ShareFileClient")
-    ShareClient = TypeVar("ShareClient")
+    from azure.storage.fileshare.aio import ShareClient, ShareFileClient
 
 
-class ShareLeaseClient(LeaseClientBase):
+class ShareLeaseClient:  # pylint: disable=client-accepts-api-version-keyword
     """Creates a new ShareLeaseClient.
 
     This client provides lease operations on a ShareClient or ShareFileClient.
@@ -46,22 +46,36 @@ class ShareLeaseClient(LeaseClientBase):
         A string representing the lease ID of an existing lease. This value does not
         need to be specified in order to acquire a new lease, or break one.
     """
+    def __init__(  # pylint: disable=missing-client-constructor-parameter-credential,missing-client-constructor-parameter-kwargs
+        self, client: Union["ShareFileClient", "ShareClient"],
+        lease_id: Optional[str] = None
+    ) -> None:
+        self.id = lease_id or str(uuid.uuid4())
+        self.last_modified = None
+        self.etag = None
+        if hasattr(client, 'file_name'):
+            self._client = client._client.file  # type: ignore # pylint: disable=protected-access
+            self._snapshot = None
+        elif hasattr(client, 'share_name'):
+            self._client = client._client.share
+            self._snapshot = client.snapshot
+        else:
+            raise TypeError("Lease must use ShareFileClient or ShareClient.")
 
     def __enter__(self):
         raise TypeError("Async lease must use 'async with'.")
 
-    def __exit__(self, *args):
+    def __exit__(self, *args: Any):
         self.release()
 
     async def __aenter__(self):
         return self
 
-    async def __aexit__(self, *args):
+    async def __aexit__(self, *args: Any):
         await self.release()
 
     @distributed_trace_async
-    async def acquire(self, **kwargs):
-        # type: (**Any) -> None
+    async def acquire(self, **kwargs: Any) -> None:
         """Requests a new lease. This operation establishes and manages a lock on a
         file or share for write and delete operations. If the file or share does not have an active lease,
         the File or Share service creates a lease on the file or share. If the file has an active lease,
@@ -97,13 +111,12 @@ class ShareLeaseClient(LeaseClientBase):
                 **kwargs)
         except HttpResponseError as error:
             process_storage_error(error)
-        self.id = response.get('lease_id')  # type: str
-        self.last_modified = response.get('last_modified')   # type: datetime
-        self.etag = response.get('etag')  # type: str
+        self.id = response.get('lease_id')
+        self.last_modified = response.get('last_modified')
+        self.etag = response.get('etag')
 
     @distributed_trace_async
-    async def renew(self, **kwargs):
-        # type: (Any) -> None
+    async def renew(self, **kwargs: Any) -> None:
         """Renews the share lease.
 
         The share lease can be renewed if the lease ID specified in the
@@ -133,13 +146,12 @@ class ShareLeaseClient(LeaseClientBase):
                 **kwargs)
         except HttpResponseError as error:
             process_storage_error(error)
-        self.etag = response.get('etag')  # type: str
-        self.id = response.get('lease_id')  # type: str
-        self.last_modified = response.get('last_modified')   # type: datetime
+        self.etag = response.get('etag')
+        self.id = response.get('lease_id')
+        self.last_modified = response.get('last_modified')
 
     @distributed_trace_async
-    async def release(self, **kwargs):
-        # type: (Any) -> None
+    async def release(self, **kwargs: Any) -> None:
         """Releases the lease. The lease may be released if the lease ID specified on the request matches
         that associated with the share or file. Releasing the lease allows another client to immediately acquire
         the lease for the share or file as soon as the release is complete.
@@ -162,13 +174,12 @@ class ShareLeaseClient(LeaseClientBase):
                 **kwargs)
         except HttpResponseError as error:
             process_storage_error(error)
-        self.etag = response.get('etag')  # type: str
-        self.id = response.get('lease_id')  # type: str
-        self.last_modified = response.get('last_modified')   # type: datetime
+        self.etag = response.get('etag')
+        self.id = response.get('lease_id')
+        self.last_modified = response.get('last_modified')
 
     @distributed_trace_async
-    async def change(self, proposed_lease_id, **kwargs):
-        # type: (str, Any) -> None
+    async def change(self, proposed_lease_id: str, **kwargs: Any) -> None:
         """ Changes the lease ID of an active lease. A change must include the current lease ID in x-ms-lease-id and
         a new lease ID in x-ms-proposed-lease-id.
 
@@ -194,13 +205,12 @@ class ShareLeaseClient(LeaseClientBase):
                 **kwargs)
         except HttpResponseError as error:
             process_storage_error(error)
-        self.etag = response.get('etag')  # type: str
-        self.id = response.get('lease_id')  # type: str
-        self.last_modified = response.get('last_modified')   # type: datetime
+        self.etag = response.get('etag')
+        self.id = response.get('lease_id')
+        self.last_modified = response.get('last_modified')
 
     @distributed_trace_async
-    async def break_lease(self, **kwargs):
-        # type: (Any) -> int
+    async def break_lease(self, **kwargs: Any) -> int:
         """Force breaks the lease if the file or share has an active lease. Any authorized request can break the lease;
         the request is not required to specify a matching lease ID. An infinite lease breaks immediately.
 
@@ -246,4 +256,4 @@ class ShareLeaseClient(LeaseClientBase):
                 **kwargs)
         except HttpResponseError as error:
             process_storage_error(error)
-        return response.get('lease_time') # type: ignore
+        return response.get('lease_time')  # type: ignore


### PR DESCRIPTION
🧙

There was a few changes made to `_lease.py` and `_lease_async.py` which originated from `_file_client.py` and async. The remaining errors will be fixed in a separate PR.

The positional and non-positional arguments in `_upload_file_helper` have been shifted due to default arguments and types. The return type here is technically `Dict[str, Any]` since that is what `upload_file` expects, so no cast is needed in `upload_file`.