### PR TITLE
[CognitiveServices] remove Search from ci post deprecation

### DIFF
--- a/sdk/cognitiveservices/azure-cognitiveservices-search-autosuggest/pyproject.toml
+++ b/sdk/cognitiveservices/azure-cognitiveservices-search-autosuggest/pyproject.toml
@@ -1,2 +1,3 @@
 [tool.azure-sdk-build]
 pylint = false
+ci_enabled = false

--- a/sdk/cognitiveservices/azure-cognitiveservices-search-customimagesearch/pyproject.toml
+++ b/sdk/cognitiveservices/azure-cognitiveservices-search-customimagesearch/pyproject.toml
@@ -1,2 +1,3 @@
 [tool.azure-sdk-build]
 pylint = false
+ci_enabled = false

--- a/sdk/cognitiveservices/azure-cognitiveservices-search-customsearch/pyproject.toml
+++ b/sdk/cognitiveservices/azure-cognitiveservices-search-customsearch/pyproject.toml
@@ -1,2 +1,3 @@
 [tool.azure-sdk-build]
 pylint = false
+ci_enabled = false

--- a/sdk/cognitiveservices/azure-cognitiveservices-search-entitysearch/pyproject.toml
+++ b/sdk/cognitiveservices/azure-cognitiveservices-search-entitysearch/pyproject.toml
@@ -1,2 +1,3 @@
 [tool.azure-sdk-build]
 pylint = false
+ci_enabled = false

--- a/sdk/cognitiveservices/azure-cognitiveservices-search-imagesearch/pyproject.toml
+++ b/sdk/cognitiveservices/azure-cognitiveservices-search-imagesearch/pyproject.toml
@@ -1,2 +1,3 @@
 [tool.azure-sdk-build]
 pylint = false
+ci_enabled = false

--- a/sdk/cognitiveservices/azure-cognitiveservices-search-newssearch/pyproject.toml
+++ b/sdk/cognitiveservices/azure-cognitiveservices-search-newssearch/pyproject.toml
@@ -1,2 +1,3 @@
 [tool.azure-sdk-build]
 pylint = false
+ci_enabled = false

--- a/sdk/cognitiveservices/azure-cognitiveservices-search-videosearch/pyproject.toml
+++ b/sdk/cognitiveservices/azure-cognitiveservices-search-videosearch/pyproject.toml
@@ -1,2 +1,3 @@
 [tool.azure-sdk-build]
 pylint = false
+ci_enabled = false

--- a/sdk/cognitiveservices/azure-cognitiveservices-search-visualsearch/pyproject.toml
+++ b/sdk/cognitiveservices/azure-cognitiveservices-search-visualsearch/pyproject.toml
@@ -1,2 +1,3 @@
 [tool.azure-sdk-build]
 pylint = false
+ci_enabled = false

--- a/sdk/cognitiveservices/azure-cognitiveservices-search-websearch/pyproject.toml
+++ b/sdk/cognitiveservices/azure-cognitiveservices-search-websearch/pyproject.toml
@@ -1,2 +1,3 @@
 [tool.azure-sdk-build]
 pylint = false
+ci_enabled = false

--- a/sdk/cognitiveservices/ci.yml
+++ b/sdk/cognitiveservices/ci.yml
@@ -29,21 +29,21 @@ extends:
     ServiceDirectory: cognitiveservices
     TestTimeoutInMinutes: 150
     Artifacts:
-    - name: azure-cognitiveservices-search-autosuggest
-      safeName: azurecognitiveservicessearchautosuggest
-    - name: azure-cognitiveservices-search-customimagesearch
-      safeName: azurecognitiveservicessearchcustomimagesearch
-    - name: azure-cognitiveservices-search-customsearch
-      safeName: azurecognitiveservicessearchcustomsearch
-    - name: azure-cognitiveservices-search-entitysearch
-      safeName: azurecognitiveservicessearchentitysearch
-    - name: azure-cognitiveservices-search-imagesearch
-      safeName: azurecognitiveservicessearchimagesearch
-    - name: azure-cognitiveservices-search-newssearch
-      safeName: azurecognitiveservicessearchnewssearch
-    - name: azure-cognitiveservices-search-videosearch
-      safeName: azurecognitiveservicessearchvideosearch
-    - name: azure-cognitiveservices-search-visualsearch
-      safeName: azurecognitiveservicessearchvisualsearch
-    - name: azure-cognitiveservices-search-websearch
-      safeName: azurecognitiveservicessearchwebsearch
+    - name: azure-cognitiveservices-knowledge-qnamaker
+      safeName: azurecognitiveservicesknowledgeqnamaker
+    - name: azure-cognitiveservices-language-luis
+      safeName: azurecognitiveserviceslanguageluis
+    - name: azure-cognitiveservices-language-spellcheck
+      safeName: azurecognitiveserviceslanguagespellcheck
+    - name: azure-cognitiveservices-personalizer
+      safeName: azurecognitiveservicespersonalizer
+    - name: azure-cognitiveservices-vision-computervision
+      safeName: azurecognitiveservicesvisioncomputervision
+    - name: azure-cognitiveservices-vision-contentmoderator
+      safeName: azurecognitiveservicesvisioncontentmoderator
+    - name: azure-cognitiveservices-vision-customvision
+      safeName: azurecognitiveservicesvisioncustomvision
+    - name: azure-cognitiveservices-vision-face
+      safeName: azurecognitiveservicesvisionface
+    - name: azure-mgmt-cognitiveservices
+      safeName: azuremgmtcognitiveservices


### PR DESCRIPTION
Removing search packages from CI after deprecating and releasing.

Adding back other artifacts to CI after removing to simplify Search releases.