### PR TITLE
Revert "[CognitiveService] search update release date"

### DIFF
--- a/sdk/cognitiveservices/azure-cognitiveservices-search-autosuggest/CHANGELOG.md
+++ b/sdk/cognitiveservices/azure-cognitiveservices-search-autosuggest/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 0.2.1 (2024-06-27)
+## 0.2.1 (2024-06-26)
 
 ### Other Changes
 

--- a/sdk/cognitiveservices/azure-cognitiveservices-search-customimagesearch/CHANGELOG.md
+++ b/sdk/cognitiveservices/azure-cognitiveservices-search-customimagesearch/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 0.2.1 (2024-06-27)
+## 0.2.1 (2024-06-26)
 
 ### Other Changes
 

--- a/sdk/cognitiveservices/azure-cognitiveservices-search-customsearch/CHANGELOG.md
+++ b/sdk/cognitiveservices/azure-cognitiveservices-search-customsearch/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 0.3.1 (2024-06-27)
+## 0.3.1 (2024-06-26)
 
 ### Other Changes
 

--- a/sdk/cognitiveservices/azure-cognitiveservices-search-entitysearch/CHANGELOG.md
+++ b/sdk/cognitiveservices/azure-cognitiveservices-search-entitysearch/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 2.0.1 (2024-06-27)
+## 2.0.1 (2024-06-26)
 
 ### Other Changes
 

--- a/sdk/cognitiveservices/azure-cognitiveservices-search-imagesearch/CHANGELOG.md
+++ b/sdk/cognitiveservices/azure-cognitiveservices-search-imagesearch/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 2.0.1 (2024-06-27)
+## 2.0.1 (2024-06-26)
 
 ### Other Changes
 

--- a/sdk/cognitiveservices/azure-cognitiveservices-search-newssearch/CHANGELOG.md
+++ b/sdk/cognitiveservices/azure-cognitiveservices-search-newssearch/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 2.0.1 (2024-06-27)
+## 2.0.1 (2024-06-26)
 
 ### Other Changes
 

--- a/sdk/cognitiveservices/azure-cognitiveservices-search-videosearch/CHANGELOG.md
+++ b/sdk/cognitiveservices/azure-cognitiveservices-search-videosearch/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 2.0.1 (2024-06-27)
+## 2.0.1 (2024-06-26)
 
 ### Other Changes
 

--- a/sdk/cognitiveservices/azure-cognitiveservices-search-visualsearch/CHANGELOG.md
+++ b/sdk/cognitiveservices/azure-cognitiveservices-search-visualsearch/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 0.2.1 (2024-06-27)
+## 0.2.1 (2024-06-26)
 
 ### Other Changes
 

--- a/sdk/cognitiveservices/azure-cognitiveservices-search-websearch/CHANGELOG.md
+++ b/sdk/cognitiveservices/azure-cognitiveservices-search-websearch/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 2.0.1 (2024-06-27)
+## 2.0.1 (2024-06-26)
 
 ### Other Changes
 


### PR DESCRIPTION
Packages were published on pypi, even though the Publish to PyPI step failed. Reverting release date to actual date they were published.