### PR TITLE
feat: support number Input in internal Spark

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_internal/_schema/component.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_internal/_schema/component.py
@@ -13,10 +13,10 @@ from ..._schema.job.parameterized_spark import SparkEntryClassSchema, SparkEntry
 from ..._utils._arm_id_utils import parse_name_label
 from ..._utils.utils import get_valid_dot_keys_with_wildcard
 from ...constants._common import (
-    DefaultOpenEncoding,
     LABELLED_RESOURCE_NAME,
     SOURCE_PATH_CONTEXT_KEY,
     AzureMLResourceType,
+    DefaultOpenEncoding,
 )
 from ...constants._component import NodeType as PublicNodeType
 from .._utils import yaml_safe_load_with_base_resolver
@@ -27,6 +27,7 @@ from .input_output import (
     InternalOutputPortSchema,
     InternalParameterSchema,
     InternalPrimitiveOutputSchema,
+    InternalSparkParameterSchema,
 )
 
 
@@ -186,6 +187,18 @@ class InternalSparkComponentSchema(InternalComponentSchema):
         allowed_values=PublicNodeType.SPARK,
         casing_transform=lambda x: parse_name_label(x)[0].lower(),
         pass_original=True,
+    )
+
+    # override inputs:
+    # https://componentsdk.azurewebsites.net/components/spark_component.html#differences-with-other-component-types
+    inputs = fields.Dict(
+        keys=fields.Str(),
+        values=UnionField(
+            [
+                NestedField(InternalSparkParameterSchema),
+                NestedField(InternalInputPortSchema),
+            ]
+        ),
     )
 
     environment = EnvironmentField(

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_internal/_schema/input_output.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_internal/_schema/input_output.py
@@ -22,6 +22,20 @@ SUPPORTED_INTERNAL_PARAM_TYPES = [
 ]
 
 
+SUPPORTED_INTERNAL_SPARK_PARAM_TYPES = [
+    "integer",
+    "Integer",
+    "boolean",
+    "Boolean",
+    "string",
+    "String",
+    "double",
+    "Double",
+    # remove float and add number
+    "number",
+]
+
+
 class InternalInputPortSchema(InputPortSchema):
     # skip client-side validate for type enum & support list
     type = UnionField(
@@ -64,6 +78,14 @@ class InternalPrimitiveOutputSchema(metaclass=PatchedSchemaMeta):
 class InternalParameterSchema(ParameterSchema):
     type = DumpableEnumField(
         allowed_values=SUPPORTED_INTERNAL_PARAM_TYPES,
+        required=True,
+        data_key="type",
+    )
+
+
+class InternalSparkParameterSchema(ParameterSchema):
+    type = DumpableEnumField(
+        allowed_values=SUPPORTED_INTERNAL_SPARK_PARAM_TYPES,
         required=True,
         data_key="type",
     )

--- a/sdk/ml/azure-ai-ml/tests/internal/unittests/test_component.py
+++ b/sdk/ml/azure-ai-ml/tests/internal/unittests/test_component.py
@@ -995,3 +995,20 @@ class TestComponent:
             "command": "mock.exe {inputs.mock_param1} {inputs.mock_param2} {outputs.job_info}",
             "_source": "YAML.COMPONENT",
         }
+
+    def test_spark_component_special_type(self):
+        yaml_path = "./tests/test_configs/internal/spark-component-special-type/spec.yaml"
+        component: InternalSparkComponent = load_component(source=yaml_path)
+        assert component
+        rest_object = component._to_rest_object()
+        assert rest_object.properties.component_spec["inputs"] == {
+            "file_input1": {"datastore_mode": "hdfs", "description": "The data to be read.", "type": "path"},
+            "file_input2": {"datastore_mode": "hdfs", "description": "The data to be read.", "type": "path"},
+            "number_input": {
+                "description": "The number to be used in the computation.",
+                "max": "3.0",
+                "min": "0.0",
+                "type": "number",
+            },
+            "string_input": {"description": "The string to be used in the computation.", "type": "string"},
+        }

--- a/sdk/ml/azure-ai-ml/tests/test_configs/internal/spark-component-special-type/conda.yaml
+++ b/sdk/ml/azure-ai-ml/tests/test_configs/internal/spark-component-special-type/conda.yaml
@@ -1,0 +1,6 @@
+name: component_env
+dependencies:
+  - python=3.8
+  - pip:
+    - azureml-core==1.44.0
+    - shrike==1.31.2

--- a/sdk/ml/azure-ai-ml/tests/test_configs/internal/spark-component-special-type/run.py
+++ b/sdk/ml/azure-ai-ml/tests/test_configs/internal/spark-component-special-type/run.py
@@ -1,0 +1,5 @@
+print("SystemLog: before imports")
+import shrike
+
+version = shrike.__version__
+print(f"SystemLog: shrike version is {version}")

--- a/sdk/ml/azure-ai-ml/tests/test_configs/internal/spark-component-special-type/spec.yaml
+++ b/sdk/ml/azure-ai-ml/tests/test_configs/internal/spark-component-special-type/spec.yaml
@@ -1,0 +1,44 @@
+$schema: https://componentsdk.azureedge.net/jsonschema/SparkComponent.json
+name: spark_test
+type: spark
+version: 1
+display_name: Aml Spark dataset test module
+description: Aml Spark dataset test module
+
+# Please use hdfs mode for input and output data for type path
+inputs:
+  file_input1:
+    type: path
+    datastore_mode: hdfs
+    description: The data to be read.
+  file_input2:
+    type: path
+    datastore_mode: hdfs
+    description: The data to be read.
+  number_input:
+    type: number
+    min: 0
+    max: 3
+    description: The number to be used in the computation.
+  string_input:
+    type: string
+    description: The string to be used in the computation.
+
+outputs:
+  output:
+    type: path
+    datastore_mode: hdfs
+
+entry:
+  file: entry.py # file path of the entry file relative to the code root folder
+
+pyFiles: utils.zip
+jars: scalaproj.jar
+
+args: >-
+  --file_input1 ${{inputs.file_input1}}
+  --file_input2 ${{inputs.file_input2}}
+  --output ${{outputs.output}}
+
+environment:
+  conda_file: conda.yaml


### PR DESCRIPTION
# Description

This pull request primarily introduces enhancements to the Spark component within the Azure AI ML SDK. The changes include the addition of a new schema for Spark parameters, modifications to the `InternalSparkComponentSchema` class, and the introduction of tests for these new changes.

Document for internal (v1.5) spark component input can be found [here](https://componentsdk.azurewebsites.net/components/spark_component.html#differences-with-other-component-types).

Schema and Class Modifications:

* [`sdk/ml/azure-ai-ml/azure/ai/ml/_internal/_schema/component.py`](diffhunk://#diff-ed3da6bee03a23b1851c9371e31bf39ce5c2521e7e76a124cd02350899456270L16-R19): The import order of `DefaultOpenEncoding` was changed and `InternalSparkParameterSchema` was added to the list of imports. [[1]](diffhunk://#diff-ed3da6bee03a23b1851c9371e31bf39ce5c2521e7e76a124cd02350899456270L16-R19) [[2]](diffhunk://#diff-ed3da6bee03a23b1851c9371e31bf39ce5c2521e7e76a124cd02350899456270R30)
* [`sdk/ml/azure-ai-ml/azure/ai/ml/_internal/_schema/component.py`](diffhunk://#diff-ed3da6bee03a23b1851c9371e31bf39ce5c2521e7e76a124cd02350899456270R192-R203): The `InternalSparkComponentSchema` class was modified to include a new `inputs` field that accommodates a dictionary of keys and values. This dictionary can contain instances of `InternalSparkParameterSchema` and `InternalInputPortSchema`.
* [`sdk/ml/azure-ai-ml/azure/ai/ml/_internal/_schema/input_output.py`](diffhunk://#diff-04fdad11e6675d22ee801656aa106b76a1fdb665b413611617f7a82b48b12441R25-R38): A new list of supported Spark parameter types was added and a new class `InternalSparkParameterSchema` was introduced. This class uses `DumpableEnumField` to enforce that the `type` field must be one of the supported Spark parameter types. [[1]](diffhunk://#diff-04fdad11e6675d22ee801656aa106b76a1fdb665b413611617f7a82b48b12441R25-R38) [[2]](diffhunk://#diff-04fdad11e6675d22ee801656aa106b76a1fdb665b413611617f7a82b48b12441R86-R93)

Testing:

* [`sdk/ml/azure-ai-ml/tests/internal/unittests/test_component.py`](diffhunk://#diff-8d18de2fa1b5909932550a0e021ed56bf5ff3e80855416629c90cef5747c3512R998-R1014): A new test method `test_spark_component_special_type` was added to verify the functionality of the new Spark component schema.
* `sdk/ml/azure-ai-ml/tests/test_configs/internal/spark-component-special-type/conda.yaml`, `sdk/ml/azure-ai-ml/tests/test_configs/internal/spark-component-special-type/run.py`, `sdk/ml/azure-ai-ml/tests/test_configs/internal/spark-component-special-type/spec.yaml`: These new files were added to support the new test method. They define the environment for the test, the Python script to be run, and the specifications for the Spark component, respectively. [[1]](diffhunk://#diff-2e4aec1169fd0b3044a34f3e899258225e2eacb120ce0ce76525c6ceb0c2a497R1-R6) [[2]](diffhunk://#diff-fba81fdf02cf24229afa31ef4328a3696e4b3de1711c3d4e4336ddcda6120f7aR1-R5) [[3]](diffhunk://#diff-b25a0043b2a195e750b52e970318549ea5d724f7f5e8ac609cfe3311c498198fR1-R44)

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
