### PR TITLE
update the utilized twine version to one that handles new importlib-m…

### DIFF
--- a/eng/pipelines/templates/steps/build-package-artifacts.yml
+++ b/eng/pipelines/templates/steps/build-package-artifacts.yml
@@ -115,7 +115,7 @@ steps:
       CIBW_BUILD_VERBOSITY: 3
 
   - script: |
-      pip install twine==4.0.2 importlib-metadata==7.2.1
+      pip install -r eng/release_requirements.txt
       twine check $(Build.ArtifactStagingDirectory)/**/*.whl
       twine check $(Build.ArtifactStagingDirectory)/**/*.tar.gz
     displayName: 'Verify Readme'

--- a/eng/release_requirements.txt
+++ b/eng/release_requirements.txt
@@ -1,3 +1,2 @@
-twine==4.0.2; python_version >= '3.6'
-importlib-metadata==7.2.1
+twine==5.1.1
 tools/azure-sdk-tools


### PR DESCRIPTION
[Example successful build and release](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3920641&view=results#SourceCard)

fyi @pvaneck as you mentioned that `twine` had resolved this yesterday. Confirmed!