### PR TITLE
Adjust deps to bypass pip install failure

### DIFF
--- a/eng/autorest_req.txt
+++ b/eng/autorest_req.txt
@@ -4,6 +4,6 @@ pytest-cov==2.8.1
 pytest-asyncio==0.12.0; python_version >= '3.5'
 isodate==0.6.0
 msrest==0.6.14
-wheel==0.34.2
+wheel==0.43.0
 GitPython==3.1.14
 aiohttp==3.6.2; python_version >= '3.6'

--- a/eng/ci_tools.txt
+++ b/eng/ci_tools.txt
@@ -9,8 +9,6 @@ doc-warden==0.7.2
 beautifulsoup4==4.9.1
 pkginfo==1.9.6
 pip==24.0
-wrapt==1.12.1; python_version <= '3.10'
-wrapt==1.15.0; python_version >= '3.11'
 typing-extensions<=4.6.3
 pyproject-api<1.6
 cibuildwheel==2.16.5
@@ -29,7 +27,6 @@ pyopenssl==24.0.0
 python-dotenv==1.0.0; python_version > '3.7'
 pyyaml==6.0.1
 urllib3==2.0.7
-ConfigArgParse==1.2.3
 six==1.16.0
 
 # local dev packages

--- a/eng/ci_tools.txt
+++ b/eng/ci_tools.txt
@@ -20,7 +20,6 @@ coverage==7.2.5
 
 # locking packages defined as deps from azure-sdk-tools
 Jinja2==3.1.2
-MarkupSafe==2.1.3
 json-delta==2.0
 readme_renderer==42.0;
 pyopenssl==24.0.0

--- a/eng/ci_tools.txt
+++ b/eng/ci_tools.txt
@@ -1,7 +1,7 @@
 # requirements leveraged by ci tools
 setuptools==67.6.0; python_version >= '3.5'
 virtualenv==20.24.3
-wheel==0.37.0
+wheel==0.43.0
 packaging==23.1
 tox==4.5.0
 pathlib2==2.3.5

--- a/eng/pipelines/templates/jobs/tests-nightly-python.yml
+++ b/eng/pipelines/templates/jobs/tests-nightly-python.yml
@@ -18,11 +18,11 @@ jobs:
       - template: /eng/pipelines/templates/steps/use-python-version.yml
         parameters:
           versionSpec: $(PythonVersion)
-        
+
       - script: |
           python -m pip freeze
           python -m pip --version
-          python -m pip install setuptools==58.3.0 wheel==0.37.0 tox==4.5.0 packaging==23.1 requests
+          python -m pip install setuptools==58.3.0 wheel==0.43.0 tox==4.5.0 packaging==23.1 requests
           python -m pip install $(Build.SourcesDirectory)/tools/azure-sdk-tools[build]
         displayName: Install Dependencies
 
@@ -67,7 +67,7 @@ jobs:
           sudo apt-get install build-essential -y
           python -m pip freeze
           python -m pip --version
-          python -m pip install setuptools==58.3.0 wheel==0.37.0 tox==4.5.0 packaging==23.1 requests
+          python -m pip install setuptools==58.3.0 wheel==0.43.0 tox==4.5.0 packaging==23.1 requests
           python -m pip install $(Build.SourcesDirectory)/tools/azure-sdk-tools[build]
         displayName: Install Dependencies
 

--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -43,7 +43,7 @@ steps:
       python -m pip freeze
       python -m pip install pip==23.2.1
       python -m pip install setuptools==67.6.0
-      python -m pip install wheel==0.37.0
+      python -m pip install wheel==0.43.0
       python -m pip install -r eng/ci_tools.txt
       pip --version
       pip freeze
@@ -150,7 +150,7 @@ steps:
           Write-Host "Last exit code: $LASTEXITCODE";
           exit $LASTEXITCODE;
 
-  - ${{ else }}: 
+  - ${{ else }}:
     - task: PythonScript@0
       displayName: 'Test Samples'
       condition: and(succeeded(), eq(variables['TestSamples'], 'true'))

--- a/eng/test_tools.txt
+++ b/eng/test_tools.txt
@@ -11,7 +11,6 @@ pyproject-api<1.6
 
 # locking packages defined as deps from azure-sdk-tools
 Jinja2==3.1.2
-MarkupSafe==2.1.3
 json-delta==2.0
 readme_renderer==42.0;
 pyopenssl==24.0.0

--- a/eng/tox/tox.ini
+++ b/eng/tox/tox.ini
@@ -41,7 +41,7 @@ deps =
 
 [packaging]
 pkgs =
-    wheel==0.40.0
+    wheel==0.43.0
     packaging==23.1
     urllib3==1.26.15
     tomli==2.0.1

--- a/tools/azure-sdk-tools/setup.py
+++ b/tools/azure-sdk-tools/setup.py
@@ -9,7 +9,6 @@ DEPENDENCIES = [
     "packaging",
     "wheel",
     "Jinja2",
-    "MarkupSafe",
     "json-delta>=2.0",
     # Tests
     "pytest-cov",


### PR DESCRIPTION
And to just straight up remove a couple deps that we literally don't use anymore.
 
1. `wrapt` usage was made obsolete with the deletion of azure-devtools and subsequent refactors
2. `markupsafe` usage was removed from our sphinx conf

These two are the primary contributors to our "builds randomly decided to start falling over" so this is just a good forcing function.  Also means I'm going to be doing a pass on all our deps as this is a good highlight.