### PR TITLE
[Storage] [STG95] Premium Files Paid Burst

### DIFF
--- a/sdk/storage/azure-storage-file-share/assets.json
+++ b/sdk/storage/azure-storage-file-share/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "python",
   "TagPrefix": "python/storage/azure-storage-file-share",
-  "Tag": "python/storage/azure-storage-file-share_d41363cb87"
+  "Tag": "python/storage/azure-storage-file-share_9f1cfd31f5"
 }

--- a/sdk/storage/azure-storage-file-share/assets.json
+++ b/sdk/storage/azure-storage-file-share/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "python",
   "TagPrefix": "python/storage/azure-storage-file-share",
-  "Tag": "python/storage/azure-storage-file-share_4a70d80d34"
+  "Tag": "python/storage/azure-storage-file-share_41f9ba38e5"
 }

--- a/sdk/storage/azure-storage-file-share/assets.json
+++ b/sdk/storage/azure-storage-file-share/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "python",
   "TagPrefix": "python/storage/azure-storage-file-share",
-  "Tag": "python/storage/azure-storage-file-share_9f1cfd31f5"
+  "Tag": "python/storage/azure-storage-file-share_4a70d80d34"
 }

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_generated/_azure_file_storage.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_generated/_azure_file_storage.py
@@ -44,7 +44,7 @@ class AzureFileStorage:  # pylint: disable=client-accepts-api-version-keyword
      URI. Default value is None.
     :type allow_source_trailing_dot: bool
     :keyword version: Specifies the version of the operation to use for this request. Default value
-     is "2024-08-04". Note that overriding this default value may result in unsupported behavior.
+     is "2024-11-04". Note that overriding this default value may result in unsupported behavior.
     :paramtype version: str
     :keyword file_range_write_from_url: Only update is supported: - Update: Writes the bytes
      downloaded from the source url into the specified range. Default value is "update". Note that

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_generated/_configuration.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_generated/_configuration.py
@@ -33,7 +33,7 @@ class AzureFileStorageConfiguration:  # pylint: disable=too-many-instance-attrib
      URI. Default value is None.
     :type allow_source_trailing_dot: bool
     :keyword version: Specifies the version of the operation to use for this request. Default value
-     is "2024-08-04". Note that overriding this default value may result in unsupported behavior.
+     is "2024-11-04". Note that overriding this default value may result in unsupported behavior.
     :paramtype version: str
     :keyword file_range_write_from_url: Only update is supported: - Update: Writes the bytes
      downloaded from the source url into the specified range. Default value is "update". Note that
@@ -49,7 +49,7 @@ class AzureFileStorageConfiguration:  # pylint: disable=too-many-instance-attrib
         allow_source_trailing_dot: Optional[bool] = None,
         **kwargs: Any
     ) -> None:
-        version: Literal["2024-08-04"] = kwargs.pop("version", "2024-08-04")
+        version: Literal["2024-11-04"] = kwargs.pop("version", "2024-11-04")
         file_range_write_from_url: Literal["update"] = kwargs.pop("file_range_write_from_url", "update")
 
         if url is None:

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_generated/aio/_azure_file_storage.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_generated/aio/_azure_file_storage.py
@@ -44,7 +44,7 @@ class AzureFileStorage:  # pylint: disable=client-accepts-api-version-keyword
      URI. Default value is None.
     :type allow_source_trailing_dot: bool
     :keyword version: Specifies the version of the operation to use for this request. Default value
-     is "2024-08-04". Note that overriding this default value may result in unsupported behavior.
+     is "2024-11-04". Note that overriding this default value may result in unsupported behavior.
     :paramtype version: str
     :keyword file_range_write_from_url: Only update is supported: - Update: Writes the bytes
      downloaded from the source url into the specified range. Default value is "update". Note that

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_generated/aio/_configuration.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_generated/aio/_configuration.py
@@ -33,7 +33,7 @@ class AzureFileStorageConfiguration:  # pylint: disable=too-many-instance-attrib
      URI. Default value is None.
     :type allow_source_trailing_dot: bool
     :keyword version: Specifies the version of the operation to use for this request. Default value
-     is "2024-08-04". Note that overriding this default value may result in unsupported behavior.
+     is "2024-11-04". Note that overriding this default value may result in unsupported behavior.
     :paramtype version: str
     :keyword file_range_write_from_url: Only update is supported: - Update: Writes the bytes
      downloaded from the source url into the specified range. Default value is "update". Note that
@@ -49,7 +49,7 @@ class AzureFileStorageConfiguration:  # pylint: disable=too-many-instance-attrib
         allow_source_trailing_dot: Optional[bool] = None,
         **kwargs: Any
     ) -> None:
-        version: Literal["2024-08-04"] = kwargs.pop("version", "2024-08-04")
+        version: Literal["2024-11-04"] = kwargs.pop("version", "2024-11-04")
         file_range_write_from_url: Literal["update"] = kwargs.pop("file_range_write_from_url", "update")
 
         if url is None:

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_generated/aio/operations/_share_operations.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_generated/aio/operations/_share_operations.py
@@ -83,6 +83,9 @@ class ShareOperations:
         enabled_protocols: Optional[str] = None,
         root_squash: Optional[Union[str, _models.ShareRootSquash]] = None,
         enable_snapshot_virtual_directory_access: Optional[bool] = None,
+        paid_bursting_enabled: Optional[bool] = None,
+        paid_bursting_max_bandwidth_mips: Optional[int] = None,
+        paid_bursting_max_iops: Optional[int] = None,
         **kwargs: Any
     ) -> None:
         """Creates a new share under the specified account. If the share with the same name already
@@ -108,6 +111,17 @@ class ShareOperations:
         :type root_squash: str or ~azure.storage.fileshare.models.ShareRootSquash
         :param enable_snapshot_virtual_directory_access: Default value is None.
         :type enable_snapshot_virtual_directory_access: bool
+        :param paid_bursting_enabled: Optional. Boolean. Default if not specified is false. This
+         property enables paid bursting. Default value is None.
+        :type paid_bursting_enabled: bool
+        :param paid_bursting_max_bandwidth_mips: Optional. Integer. Default if not specified is the
+         maximum throughput the file share can support. Current maximum for a file share is 10,340
+         MiB/sec. Default value is None.
+        :type paid_bursting_max_bandwidth_mips: int
+        :param paid_bursting_max_iops: Optional. Integer. Default if not specified is the maximum IOPS
+         the file share can support. Current maximum for a file share is 102,400 IOPS. Default value is
+         None.
+        :type paid_bursting_max_iops: int
         :return: None or the result of cls(response)
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
@@ -135,6 +149,9 @@ class ShareOperations:
             enabled_protocols=enabled_protocols,
             root_squash=root_squash,
             enable_snapshot_virtual_directory_access=enable_snapshot_virtual_directory_access,
+            paid_bursting_enabled=paid_bursting_enabled,
+            paid_bursting_max_bandwidth_mips=paid_bursting_max_bandwidth_mips,
+            paid_bursting_max_iops=paid_bursting_max_iops,
             restype=restype,
             version=self._config.version,
             headers=_headers,
@@ -272,6 +289,15 @@ class ShareOperations:
         response_headers["x-ms-root-squash"] = self._deserialize("str", response.headers.get("x-ms-root-squash"))
         response_headers["x-ms-enable-snapshot-virtual-directory-access"] = self._deserialize(
             "bool", response.headers.get("x-ms-enable-snapshot-virtual-directory-access")
+        )
+        response_headers["x-ms-share-paid-bursting-enabled"] = self._deserialize(
+            "bool", response.headers.get("x-ms-share-paid-bursting-enabled")
+        )
+        response_headers["x-ms-share-paid-bursting-max-iops"] = self._deserialize(
+            "int", response.headers.get("x-ms-share-paid-bursting-max-iops")
+        )
+        response_headers["x-ms-share-paid-bursting-max-bandwidth-mibps"] = self._deserialize(
+            "int", response.headers.get("x-ms-share-paid-bursting-max-bandwidth-mibps")
         )
 
         if cls:
@@ -1106,6 +1132,9 @@ class ShareOperations:
         access_tier: Optional[Union[str, _models.ShareAccessTier]] = None,
         root_squash: Optional[Union[str, _models.ShareRootSquash]] = None,
         enable_snapshot_virtual_directory_access: Optional[bool] = None,
+        paid_bursting_enabled: Optional[bool] = None,
+        paid_bursting_max_bandwidth_mips: Optional[int] = None,
+        paid_bursting_max_iops: Optional[int] = None,
         lease_access_conditions: Optional[_models.LeaseAccessConditions] = None,
         **kwargs: Any
     ) -> None:
@@ -1126,6 +1155,17 @@ class ShareOperations:
         :type root_squash: str or ~azure.storage.fileshare.models.ShareRootSquash
         :param enable_snapshot_virtual_directory_access: Default value is None.
         :type enable_snapshot_virtual_directory_access: bool
+        :param paid_bursting_enabled: Optional. Boolean. Default if not specified is false. This
+         property enables paid bursting. Default value is None.
+        :type paid_bursting_enabled: bool
+        :param paid_bursting_max_bandwidth_mips: Optional. Integer. Default if not specified is the
+         maximum throughput the file share can support. Current maximum for a file share is 10,340
+         MiB/sec. Default value is None.
+        :type paid_bursting_max_bandwidth_mips: int
+        :param paid_bursting_max_iops: Optional. Integer. Default if not specified is the maximum IOPS
+         the file share can support. Current maximum for a file share is 102,400 IOPS. Default value is
+         None.
+        :type paid_bursting_max_iops: int
         :param lease_access_conditions: Parameter group. Default value is None.
         :type lease_access_conditions: ~azure.storage.fileshare.models.LeaseAccessConditions
         :return: None or the result of cls(response)
@@ -1159,6 +1199,9 @@ class ShareOperations:
             lease_id=_lease_id,
             root_squash=root_squash,
             enable_snapshot_virtual_directory_access=enable_snapshot_virtual_directory_access,
+            paid_bursting_enabled=paid_bursting_enabled,
+            paid_bursting_max_bandwidth_mips=paid_bursting_max_bandwidth_mips,
+            paid_bursting_max_iops=paid_bursting_max_iops,
             restype=restype,
             comp=comp,
             version=self._config.version,

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_generated/aio/operations/_share_operations.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_generated/aio/operations/_share_operations.py
@@ -84,7 +84,7 @@ class ShareOperations:
         root_squash: Optional[Union[str, _models.ShareRootSquash]] = None,
         enable_snapshot_virtual_directory_access: Optional[bool] = None,
         paid_bursting_enabled: Optional[bool] = None,
-        paid_bursting_max_bandwidth_mips: Optional[int] = None,
+        paid_bursting_max_bandwidth_mibps: Optional[int] = None,
         paid_bursting_max_iops: Optional[int] = None,
         **kwargs: Any
     ) -> None:
@@ -114,10 +114,10 @@ class ShareOperations:
         :param paid_bursting_enabled: Optional. Boolean. Default if not specified is false. This
          property enables paid bursting. Default value is None.
         :type paid_bursting_enabled: bool
-        :param paid_bursting_max_bandwidth_mips: Optional. Integer. Default if not specified is the
+        :param paid_bursting_max_bandwidth_mibps: Optional. Integer. Default if not specified is the
          maximum throughput the file share can support. Current maximum for a file share is 10,340
          MiB/sec. Default value is None.
-        :type paid_bursting_max_bandwidth_mips: int
+        :type paid_bursting_max_bandwidth_mibps: int
         :param paid_bursting_max_iops: Optional. Integer. Default if not specified is the maximum IOPS
          the file share can support. Current maximum for a file share is 102,400 IOPS. Default value is
          None.
@@ -150,7 +150,7 @@ class ShareOperations:
             root_squash=root_squash,
             enable_snapshot_virtual_directory_access=enable_snapshot_virtual_directory_access,
             paid_bursting_enabled=paid_bursting_enabled,
-            paid_bursting_max_bandwidth_mips=paid_bursting_max_bandwidth_mips,
+            paid_bursting_max_bandwidth_mibps=paid_bursting_max_bandwidth_mibps,
             paid_bursting_max_iops=paid_bursting_max_iops,
             restype=restype,
             version=self._config.version,
@@ -1133,7 +1133,7 @@ class ShareOperations:
         root_squash: Optional[Union[str, _models.ShareRootSquash]] = None,
         enable_snapshot_virtual_directory_access: Optional[bool] = None,
         paid_bursting_enabled: Optional[bool] = None,
-        paid_bursting_max_bandwidth_mips: Optional[int] = None,
+        paid_bursting_max_bandwidth_mibps: Optional[int] = None,
         paid_bursting_max_iops: Optional[int] = None,
         lease_access_conditions: Optional[_models.LeaseAccessConditions] = None,
         **kwargs: Any
@@ -1158,10 +1158,10 @@ class ShareOperations:
         :param paid_bursting_enabled: Optional. Boolean. Default if not specified is false. This
          property enables paid bursting. Default value is None.
         :type paid_bursting_enabled: bool
-        :param paid_bursting_max_bandwidth_mips: Optional. Integer. Default if not specified is the
+        :param paid_bursting_max_bandwidth_mibps: Optional. Integer. Default if not specified is the
          maximum throughput the file share can support. Current maximum for a file share is 10,340
          MiB/sec. Default value is None.
-        :type paid_bursting_max_bandwidth_mips: int
+        :type paid_bursting_max_bandwidth_mibps: int
         :param paid_bursting_max_iops: Optional. Integer. Default if not specified is the maximum IOPS
          the file share can support. Current maximum for a file share is 102,400 IOPS. Default value is
          None.
@@ -1200,7 +1200,7 @@ class ShareOperations:
             root_squash=root_squash,
             enable_snapshot_virtual_directory_access=enable_snapshot_virtual_directory_access,
             paid_bursting_enabled=paid_bursting_enabled,
-            paid_bursting_max_bandwidth_mips=paid_bursting_max_bandwidth_mips,
+            paid_bursting_max_bandwidth_mibps=paid_bursting_max_bandwidth_mibps,
             paid_bursting_max_iops=paid_bursting_max_iops,
             restype=restype,
             comp=comp,

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_generated/models/_models_py3.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_generated/models/_models_py3.py
@@ -1241,6 +1241,12 @@ class SharePropertiesInternal(_serialization.Model):  # pylint: disable=too-many
     :vartype root_squash: str or ~azure.storage.fileshare.models.ShareRootSquash
     :ivar enable_snapshot_virtual_directory_access:
     :vartype enable_snapshot_virtual_directory_access: bool
+    :ivar paid_bursting_enabled:
+    :vartype paid_bursting_enabled: bool
+    :ivar paid_bursting_max_iops:
+    :vartype paid_bursting_max_iops: int
+    :ivar paid_bursting_max_bandwidth_mibps:
+    :vartype paid_bursting_max_bandwidth_mibps: int
     """
 
     _validation = {
@@ -1269,6 +1275,9 @@ class SharePropertiesInternal(_serialization.Model):  # pylint: disable=too-many
         "enabled_protocols": {"key": "EnabledProtocols", "type": "str"},
         "root_squash": {"key": "RootSquash", "type": "str"},
         "enable_snapshot_virtual_directory_access": {"key": "EnableSnapshotVirtualDirectoryAccess", "type": "bool"},
+        "paid_bursting_enabled": {"key": "PaidBurstingEnabled", "type": "bool"},
+        "paid_bursting_max_iops": {"key": "PaidBurstingMaxIops", "type": "int"},
+        "paid_bursting_max_bandwidth_mibps": {"key": "PaidBurstingMaxBandwidthMibps", "type": "int"},
     }
 
     def __init__(
@@ -1293,6 +1302,9 @@ class SharePropertiesInternal(_serialization.Model):  # pylint: disable=too-many
         enabled_protocols: Optional[str] = None,
         root_squash: Optional[Union[str, "_models.ShareRootSquash"]] = None,
         enable_snapshot_virtual_directory_access: Optional[bool] = None,
+        paid_bursting_enabled: Optional[bool] = None,
+        paid_bursting_max_iops: Optional[int] = None,
+        paid_bursting_max_bandwidth_mibps: Optional[int] = None,
         **kwargs: Any
     ) -> None:
         """
@@ -1337,6 +1349,12 @@ class SharePropertiesInternal(_serialization.Model):  # pylint: disable=too-many
         :paramtype root_squash: str or ~azure.storage.fileshare.models.ShareRootSquash
         :keyword enable_snapshot_virtual_directory_access:
         :paramtype enable_snapshot_virtual_directory_access: bool
+        :keyword paid_bursting_enabled:
+        :paramtype paid_bursting_enabled: bool
+        :keyword paid_bursting_max_iops:
+        :paramtype paid_bursting_max_iops: int
+        :keyword paid_bursting_max_bandwidth_mibps:
+        :paramtype paid_bursting_max_bandwidth_mibps: int
         """
         super().__init__(**kwargs)
         self.last_modified = last_modified
@@ -1358,6 +1376,9 @@ class SharePropertiesInternal(_serialization.Model):  # pylint: disable=too-many
         self.enabled_protocols = enabled_protocols
         self.root_squash = root_squash
         self.enable_snapshot_virtual_directory_access = enable_snapshot_virtual_directory_access
+        self.paid_bursting_enabled = paid_bursting_enabled
+        self.paid_bursting_max_iops = paid_bursting_max_iops
+        self.paid_bursting_max_bandwidth_mibps = paid_bursting_max_bandwidth_mibps
 
 
 class ShareProtocolSettings(_serialization.Model):

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_generated/operations/_directory_operations.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_generated/operations/_directory_operations.py
@@ -57,7 +57,7 @@ def build_create_request(
     _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
 
     restype: Literal["directory"] = kwargs.pop("restype", _params.pop("restype", "directory"))
-    version: Literal["2024-08-04"] = kwargs.pop("version", _headers.pop("x-ms-version", "2024-08-04"))
+    version: Literal["2024-11-04"] = kwargs.pop("version", _headers.pop("x-ms-version", "2024-11-04"))
     accept = _headers.pop("Accept", "application/xml")
 
     # Construct URL
@@ -110,7 +110,7 @@ def build_get_properties_request(
     _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
 
     restype: Literal["directory"] = kwargs.pop("restype", _params.pop("restype", "directory"))
-    version: Literal["2024-08-04"] = kwargs.pop("version", _headers.pop("x-ms-version", "2024-08-04"))
+    version: Literal["2024-11-04"] = kwargs.pop("version", _headers.pop("x-ms-version", "2024-11-04"))
     accept = _headers.pop("Accept", "application/xml")
 
     # Construct URL
@@ -151,7 +151,7 @@ def build_delete_request(
     _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
 
     restype: Literal["directory"] = kwargs.pop("restype", _params.pop("restype", "directory"))
-    version: Literal["2024-08-04"] = kwargs.pop("version", _headers.pop("x-ms-version", "2024-08-04"))
+    version: Literal["2024-11-04"] = kwargs.pop("version", _headers.pop("x-ms-version", "2024-11-04"))
     accept = _headers.pop("Accept", "application/xml")
 
     # Construct URL
@@ -197,7 +197,7 @@ def build_set_properties_request(
 
     restype: Literal["directory"] = kwargs.pop("restype", _params.pop("restype", "directory"))
     comp: Literal["properties"] = kwargs.pop("comp", _params.pop("comp", "properties"))
-    version: Literal["2024-08-04"] = kwargs.pop("version", _headers.pop("x-ms-version", "2024-08-04"))
+    version: Literal["2024-11-04"] = kwargs.pop("version", _headers.pop("x-ms-version", "2024-11-04"))
     accept = _headers.pop("Accept", "application/xml")
 
     # Construct URL
@@ -250,7 +250,7 @@ def build_set_metadata_request(
 
     restype: Literal["directory"] = kwargs.pop("restype", _params.pop("restype", "directory"))
     comp: Literal["metadata"] = kwargs.pop("comp", _params.pop("comp", "metadata"))
-    version: Literal["2024-08-04"] = kwargs.pop("version", _headers.pop("x-ms-version", "2024-08-04"))
+    version: Literal["2024-11-04"] = kwargs.pop("version", _headers.pop("x-ms-version", "2024-11-04"))
     accept = _headers.pop("Accept", "application/xml")
 
     # Construct URL
@@ -299,7 +299,7 @@ def build_list_files_and_directories_segment_request(  # pylint: disable=name-to
 
     restype: Literal["directory"] = kwargs.pop("restype", _params.pop("restype", "directory"))
     comp: Literal["list"] = kwargs.pop("comp", _params.pop("comp", "list"))
-    version: Literal["2024-08-04"] = kwargs.pop("version", _headers.pop("x-ms-version", "2024-08-04"))
+    version: Literal["2024-11-04"] = kwargs.pop("version", _headers.pop("x-ms-version", "2024-11-04"))
     accept = _headers.pop("Accept", "application/xml")
 
     # Construct URL
@@ -355,7 +355,7 @@ def build_list_handles_request(
     _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
 
     comp: Literal["listhandles"] = kwargs.pop("comp", _params.pop("comp", "listhandles"))
-    version: Literal["2024-08-04"] = kwargs.pop("version", _headers.pop("x-ms-version", "2024-08-04"))
+    version: Literal["2024-11-04"] = kwargs.pop("version", _headers.pop("x-ms-version", "2024-11-04"))
     accept = _headers.pop("Accept", "application/xml")
 
     # Construct URL
@@ -406,7 +406,7 @@ def build_force_close_handles_request(
     _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
 
     comp: Literal["forceclosehandles"] = kwargs.pop("comp", _params.pop("comp", "forceclosehandles"))
-    version: Literal["2024-08-04"] = kwargs.pop("version", _headers.pop("x-ms-version", "2024-08-04"))
+    version: Literal["2024-11-04"] = kwargs.pop("version", _headers.pop("x-ms-version", "2024-11-04"))
     accept = _headers.pop("Accept", "application/xml")
 
     # Construct URL
@@ -466,7 +466,7 @@ def build_rename_request(
 
     restype: Literal["directory"] = kwargs.pop("restype", _params.pop("restype", "directory"))
     comp: Literal["rename"] = kwargs.pop("comp", _params.pop("comp", "rename"))
-    version: Literal["2024-08-04"] = kwargs.pop("version", _headers.pop("x-ms-version", "2024-08-04"))
+    version: Literal["2024-11-04"] = kwargs.pop("version", _headers.pop("x-ms-version", "2024-11-04"))
     accept = _headers.pop("Accept", "application/xml")
 
     # Construct URL

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_generated/operations/_file_operations.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_generated/operations/_file_operations.py
@@ -65,7 +65,7 @@ def build_create_request(
     _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
 
     file_type_constant: Literal["file"] = kwargs.pop("file_type_constant", _headers.pop("x-ms-type", "file"))
-    version: Literal["2024-08-04"] = kwargs.pop("version", _headers.pop("x-ms-version", "2024-08-04"))
+    version: Literal["2024-11-04"] = kwargs.pop("version", _headers.pop("x-ms-version", "2024-11-04"))
     accept = _headers.pop("Accept", "application/xml")
 
     # Construct URL
@@ -136,7 +136,7 @@ def build_download_request(
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
     _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
 
-    version: Literal["2024-08-04"] = kwargs.pop("version", _headers.pop("x-ms-version", "2024-08-04"))
+    version: Literal["2024-11-04"] = kwargs.pop("version", _headers.pop("x-ms-version", "2024-11-04"))
     accept = _headers.pop("Accept", "application/xml")
 
     # Construct URL
@@ -183,7 +183,7 @@ def build_get_properties_request(
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
     _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
 
-    version: Literal["2024-08-04"] = kwargs.pop("version", _headers.pop("x-ms-version", "2024-08-04"))
+    version: Literal["2024-11-04"] = kwargs.pop("version", _headers.pop("x-ms-version", "2024-11-04"))
     accept = _headers.pop("Accept", "application/xml")
 
     # Construct URL
@@ -225,7 +225,7 @@ def build_delete_request(
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
     _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
 
-    version: Literal["2024-08-04"] = kwargs.pop("version", _headers.pop("x-ms-version", "2024-08-04"))
+    version: Literal["2024-11-04"] = kwargs.pop("version", _headers.pop("x-ms-version", "2024-11-04"))
     accept = _headers.pop("Accept", "application/xml")
 
     # Construct URL
@@ -279,7 +279,7 @@ def build_set_http_headers_request(
     _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
 
     comp: Literal["properties"] = kwargs.pop("comp", _params.pop("comp", "properties"))
-    version: Literal["2024-08-04"] = kwargs.pop("version", _headers.pop("x-ms-version", "2024-08-04"))
+    version: Literal["2024-11-04"] = kwargs.pop("version", _headers.pop("x-ms-version", "2024-11-04"))
     accept = _headers.pop("Accept", "application/xml")
 
     # Construct URL
@@ -349,7 +349,7 @@ def build_set_metadata_request(
     _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
 
     comp: Literal["metadata"] = kwargs.pop("comp", _params.pop("comp", "metadata"))
-    version: Literal["2024-08-04"] = kwargs.pop("version", _headers.pop("x-ms-version", "2024-08-04"))
+    version: Literal["2024-11-04"] = kwargs.pop("version", _headers.pop("x-ms-version", "2024-11-04"))
     accept = _headers.pop("Accept", "application/xml")
 
     # Construct URL
@@ -396,7 +396,7 @@ def build_acquire_lease_request(
 
     comp: Literal["lease"] = kwargs.pop("comp", _params.pop("comp", "lease"))
     action: Literal["acquire"] = kwargs.pop("action", _headers.pop("x-ms-lease-action", "acquire"))
-    version: Literal["2024-08-04"] = kwargs.pop("version", _headers.pop("x-ms-version", "2024-08-04"))
+    version: Literal["2024-11-04"] = kwargs.pop("version", _headers.pop("x-ms-version", "2024-11-04"))
     accept = _headers.pop("Accept", "application/xml")
 
     # Construct URL
@@ -445,7 +445,7 @@ def build_release_lease_request(
 
     comp: Literal["lease"] = kwargs.pop("comp", _params.pop("comp", "lease"))
     action: Literal["release"] = kwargs.pop("action", _headers.pop("x-ms-lease-action", "release"))
-    version: Literal["2024-08-04"] = kwargs.pop("version", _headers.pop("x-ms-version", "2024-08-04"))
+    version: Literal["2024-11-04"] = kwargs.pop("version", _headers.pop("x-ms-version", "2024-11-04"))
     accept = _headers.pop("Accept", "application/xml")
 
     # Construct URL
@@ -492,7 +492,7 @@ def build_change_lease_request(
 
     comp: Literal["lease"] = kwargs.pop("comp", _params.pop("comp", "lease"))
     action: Literal["change"] = kwargs.pop("action", _headers.pop("x-ms-lease-action", "change"))
-    version: Literal["2024-08-04"] = kwargs.pop("version", _headers.pop("x-ms-version", "2024-08-04"))
+    version: Literal["2024-11-04"] = kwargs.pop("version", _headers.pop("x-ms-version", "2024-11-04"))
     accept = _headers.pop("Accept", "application/xml")
 
     # Construct URL
@@ -540,7 +540,7 @@ def build_break_lease_request(
 
     comp: Literal["lease"] = kwargs.pop("comp", _params.pop("comp", "lease"))
     action: Literal["break"] = kwargs.pop("action", _headers.pop("x-ms-lease-action", "break"))
-    version: Literal["2024-08-04"] = kwargs.pop("version", _headers.pop("x-ms-version", "2024-08-04"))
+    version: Literal["2024-11-04"] = kwargs.pop("version", _headers.pop("x-ms-version", "2024-11-04"))
     accept = _headers.pop("Accept", "application/xml")
 
     # Construct URL
@@ -592,7 +592,7 @@ def build_upload_range_request(
 
     comp: Literal["range"] = kwargs.pop("comp", _params.pop("comp", "range"))
     content_type: Optional[str] = kwargs.pop("content_type", _headers.pop("Content-Type", None))
-    version: Literal["2024-08-04"] = kwargs.pop("version", _headers.pop("x-ms-version", "2024-08-04"))
+    version: Literal["2024-11-04"] = kwargs.pop("version", _headers.pop("x-ms-version", "2024-11-04"))
     accept = _headers.pop("Accept", "application/xml")
 
     # Construct URL
@@ -658,7 +658,7 @@ def build_upload_range_from_url_request(
     file_range_write_from_url: Literal["update"] = kwargs.pop(
         "file_range_write_from_url", _headers.pop("x-ms-write", "update")
     )
-    version: Literal["2024-08-04"] = kwargs.pop("version", _headers.pop("x-ms-version", "2024-08-04"))
+    version: Literal["2024-11-04"] = kwargs.pop("version", _headers.pop("x-ms-version", "2024-11-04"))
     accept = _headers.pop("Accept", "application/xml")
 
     # Construct URL
@@ -734,7 +734,7 @@ def build_get_range_list_request(
     _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
 
     comp: Literal["rangelist"] = kwargs.pop("comp", _params.pop("comp", "rangelist"))
-    version: Literal["2024-08-04"] = kwargs.pop("version", _headers.pop("x-ms-version", "2024-08-04"))
+    version: Literal["2024-11-04"] = kwargs.pop("version", _headers.pop("x-ms-version", "2024-11-04"))
     accept = _headers.pop("Accept", "application/xml")
 
     # Construct URL
@@ -795,7 +795,7 @@ def build_start_copy_request(
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
     _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
 
-    version: Literal["2024-08-04"] = kwargs.pop("version", _headers.pop("x-ms-version", "2024-08-04"))
+    version: Literal["2024-11-04"] = kwargs.pop("version", _headers.pop("x-ms-version", "2024-11-04"))
     accept = _headers.pop("Accept", "application/xml")
 
     # Construct URL
@@ -869,7 +869,7 @@ def build_abort_copy_request(
     copy_action_abort_constant: Literal["abort"] = kwargs.pop(
         "copy_action_abort_constant", _headers.pop("x-ms-copy-action", "abort")
     )
-    version: Literal["2024-08-04"] = kwargs.pop("version", _headers.pop("x-ms-version", "2024-08-04"))
+    version: Literal["2024-11-04"] = kwargs.pop("version", _headers.pop("x-ms-version", "2024-11-04"))
     accept = _headers.pop("Accept", "application/xml")
 
     # Construct URL
@@ -915,7 +915,7 @@ def build_list_handles_request(
     _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
 
     comp: Literal["listhandles"] = kwargs.pop("comp", _params.pop("comp", "listhandles"))
-    version: Literal["2024-08-04"] = kwargs.pop("version", _headers.pop("x-ms-version", "2024-08-04"))
+    version: Literal["2024-11-04"] = kwargs.pop("version", _headers.pop("x-ms-version", "2024-11-04"))
     accept = _headers.pop("Accept", "application/xml")
 
     # Construct URL
@@ -963,7 +963,7 @@ def build_force_close_handles_request(
     _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
 
     comp: Literal["forceclosehandles"] = kwargs.pop("comp", _params.pop("comp", "forceclosehandles"))
-    version: Literal["2024-08-04"] = kwargs.pop("version", _headers.pop("x-ms-version", "2024-08-04"))
+    version: Literal["2024-11-04"] = kwargs.pop("version", _headers.pop("x-ms-version", "2024-11-04"))
     accept = _headers.pop("Accept", "application/xml")
 
     # Construct URL
@@ -1021,7 +1021,7 @@ def build_rename_request(
     _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
 
     comp: Literal["rename"] = kwargs.pop("comp", _params.pop("comp", "rename"))
-    version: Literal["2024-08-04"] = kwargs.pop("version", _headers.pop("x-ms-version", "2024-08-04"))
+    version: Literal["2024-11-04"] = kwargs.pop("version", _headers.pop("x-ms-version", "2024-11-04"))
     accept = _headers.pop("Accept", "application/xml")
 
     # Construct URL

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_generated/operations/_service_operations.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_generated/operations/_service_operations.py
@@ -47,7 +47,7 @@ def build_set_properties_request(
     restype: Literal["service"] = kwargs.pop("restype", _params.pop("restype", "service"))
     comp: Literal["properties"] = kwargs.pop("comp", _params.pop("comp", "properties"))
     content_type: Optional[str] = kwargs.pop("content_type", _headers.pop("Content-Type", None))
-    version: Literal["2024-08-04"] = kwargs.pop("version", _headers.pop("x-ms-version", "2024-08-04"))
+    version: Literal["2024-11-04"] = kwargs.pop("version", _headers.pop("x-ms-version", "2024-11-04"))
     accept = _headers.pop("Accept", "application/xml")
 
     # Construct URL
@@ -79,7 +79,7 @@ def build_get_properties_request(url: str, *, timeout: Optional[int] = None, **k
 
     restype: Literal["service"] = kwargs.pop("restype", _params.pop("restype", "service"))
     comp: Literal["properties"] = kwargs.pop("comp", _params.pop("comp", "properties"))
-    version: Literal["2024-08-04"] = kwargs.pop("version", _headers.pop("x-ms-version", "2024-08-04"))
+    version: Literal["2024-11-04"] = kwargs.pop("version", _headers.pop("x-ms-version", "2024-11-04"))
     accept = _headers.pop("Accept", "application/xml")
 
     # Construct URL
@@ -117,7 +117,7 @@ def build_list_shares_segment_request(
     _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
 
     comp: Literal["list"] = kwargs.pop("comp", _params.pop("comp", "list"))
-    version: Literal["2024-08-04"] = kwargs.pop("version", _headers.pop("x-ms-version", "2024-08-04"))
+    version: Literal["2024-11-04"] = kwargs.pop("version", _headers.pop("x-ms-version", "2024-11-04"))
     accept = _headers.pop("Accept", "application/xml")
 
     # Construct URL

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_generated/operations/_share_operations.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_generated/operations/_share_operations.py
@@ -50,7 +50,7 @@ def build_create_request(
     root_squash: Optional[Union[str, _models.ShareRootSquash]] = None,
     enable_snapshot_virtual_directory_access: Optional[bool] = None,
     paid_bursting_enabled: Optional[bool] = None,
-    paid_bursting_max_bandwidth_mips: Optional[int] = None,
+    paid_bursting_max_bandwidth_mibps: Optional[int] = None,
     paid_bursting_max_iops: Optional[int] = None,
     **kwargs: Any
 ) -> HttpRequest:
@@ -94,9 +94,9 @@ def build_create_request(
         _headers["x-ms-share-paid-bursting-enabled"] = _SERIALIZER.header(
             "paid_bursting_enabled", paid_bursting_enabled, "bool"
         )
-    if paid_bursting_max_bandwidth_mips is not None:
+    if paid_bursting_max_bandwidth_mibps is not None:
         _headers["x-ms-share-paid-bursting-max-bandwidth-mibps"] = _SERIALIZER.header(
-            "paid_bursting_max_bandwidth_mips", paid_bursting_max_bandwidth_mips, "int"
+            "paid_bursting_max_bandwidth_mibps", paid_bursting_max_bandwidth_mibps, "int"
         )
     if paid_bursting_max_iops is not None:
         _headers["x-ms-share-paid-bursting-max-iops"] = _SERIALIZER.header(
@@ -549,7 +549,7 @@ def build_set_properties_request(
     root_squash: Optional[Union[str, _models.ShareRootSquash]] = None,
     enable_snapshot_virtual_directory_access: Optional[bool] = None,
     paid_bursting_enabled: Optional[bool] = None,
-    paid_bursting_max_bandwidth_mips: Optional[int] = None,
+    paid_bursting_max_bandwidth_mibps: Optional[int] = None,
     paid_bursting_max_iops: Optional[int] = None,
     **kwargs: Any
 ) -> HttpRequest:
@@ -593,9 +593,9 @@ def build_set_properties_request(
         _headers["x-ms-share-paid-bursting-enabled"] = _SERIALIZER.header(
             "paid_bursting_enabled", paid_bursting_enabled, "bool"
         )
-    if paid_bursting_max_bandwidth_mips is not None:
+    if paid_bursting_max_bandwidth_mibps is not None:
         _headers["x-ms-share-paid-bursting-max-bandwidth-mibps"] = _SERIALIZER.header(
-            "paid_bursting_max_bandwidth_mips", paid_bursting_max_bandwidth_mips, "int"
+            "paid_bursting_max_bandwidth_mibps", paid_bursting_max_bandwidth_mibps, "int"
         )
     if paid_bursting_max_iops is not None:
         _headers["x-ms-share-paid-bursting-max-iops"] = _SERIALIZER.header(
@@ -828,7 +828,7 @@ class ShareOperations:
         root_squash: Optional[Union[str, _models.ShareRootSquash]] = None,
         enable_snapshot_virtual_directory_access: Optional[bool] = None,
         paid_bursting_enabled: Optional[bool] = None,
-        paid_bursting_max_bandwidth_mips: Optional[int] = None,
+        paid_bursting_max_bandwidth_mibps: Optional[int] = None,
         paid_bursting_max_iops: Optional[int] = None,
         **kwargs: Any
     ) -> None:
@@ -858,10 +858,10 @@ class ShareOperations:
         :param paid_bursting_enabled: Optional. Boolean. Default if not specified is false. This
          property enables paid bursting. Default value is None.
         :type paid_bursting_enabled: bool
-        :param paid_bursting_max_bandwidth_mips: Optional. Integer. Default if not specified is the
+        :param paid_bursting_max_bandwidth_mibps: Optional. Integer. Default if not specified is the
          maximum throughput the file share can support. Current maximum for a file share is 10,340
          MiB/sec. Default value is None.
-        :type paid_bursting_max_bandwidth_mips: int
+        :type paid_bursting_max_bandwidth_mibps: int
         :param paid_bursting_max_iops: Optional. Integer. Default if not specified is the maximum IOPS
          the file share can support. Current maximum for a file share is 102,400 IOPS. Default value is
          None.
@@ -894,7 +894,7 @@ class ShareOperations:
             root_squash=root_squash,
             enable_snapshot_virtual_directory_access=enable_snapshot_virtual_directory_access,
             paid_bursting_enabled=paid_bursting_enabled,
-            paid_bursting_max_bandwidth_mips=paid_bursting_max_bandwidth_mips,
+            paid_bursting_max_bandwidth_mibps=paid_bursting_max_bandwidth_mibps,
             paid_bursting_max_iops=paid_bursting_max_iops,
             restype=restype,
             version=self._config.version,
@@ -1877,7 +1877,7 @@ class ShareOperations:
         root_squash: Optional[Union[str, _models.ShareRootSquash]] = None,
         enable_snapshot_virtual_directory_access: Optional[bool] = None,
         paid_bursting_enabled: Optional[bool] = None,
-        paid_bursting_max_bandwidth_mips: Optional[int] = None,
+        paid_bursting_max_bandwidth_mibps: Optional[int] = None,
         paid_bursting_max_iops: Optional[int] = None,
         lease_access_conditions: Optional[_models.LeaseAccessConditions] = None,
         **kwargs: Any
@@ -1902,10 +1902,10 @@ class ShareOperations:
         :param paid_bursting_enabled: Optional. Boolean. Default if not specified is false. This
          property enables paid bursting. Default value is None.
         :type paid_bursting_enabled: bool
-        :param paid_bursting_max_bandwidth_mips: Optional. Integer. Default if not specified is the
+        :param paid_bursting_max_bandwidth_mibps: Optional. Integer. Default if not specified is the
          maximum throughput the file share can support. Current maximum for a file share is 10,340
          MiB/sec. Default value is None.
-        :type paid_bursting_max_bandwidth_mips: int
+        :type paid_bursting_max_bandwidth_mibps: int
         :param paid_bursting_max_iops: Optional. Integer. Default if not specified is the maximum IOPS
          the file share can support. Current maximum for a file share is 102,400 IOPS. Default value is
          None.
@@ -1944,7 +1944,7 @@ class ShareOperations:
             root_squash=root_squash,
             enable_snapshot_virtual_directory_access=enable_snapshot_virtual_directory_access,
             paid_bursting_enabled=paid_bursting_enabled,
-            paid_bursting_max_bandwidth_mips=paid_bursting_max_bandwidth_mips,
+            paid_bursting_max_bandwidth_mibps=paid_bursting_max_bandwidth_mibps,
             paid_bursting_max_iops=paid_bursting_max_iops,
             restype=restype,
             comp=comp,

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_generated/operations/_share_operations.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_generated/operations/_share_operations.py
@@ -49,13 +49,16 @@ def build_create_request(
     enabled_protocols: Optional[str] = None,
     root_squash: Optional[Union[str, _models.ShareRootSquash]] = None,
     enable_snapshot_virtual_directory_access: Optional[bool] = None,
+    paid_bursting_enabled: Optional[bool] = None,
+    paid_bursting_max_bandwidth_mips: Optional[int] = None,
+    paid_bursting_max_iops: Optional[int] = None,
     **kwargs: Any
 ) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
     _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
 
     restype: Literal["share"] = kwargs.pop("restype", _params.pop("restype", "share"))
-    version: Literal["2024-08-04"] = kwargs.pop("version", _headers.pop("x-ms-version", "2024-08-04"))
+    version: Literal["2024-11-04"] = kwargs.pop("version", _headers.pop("x-ms-version", "2024-11-04"))
     accept = _headers.pop("Accept", "application/xml")
 
     # Construct URL
@@ -87,6 +90,18 @@ def build_create_request(
         _headers["x-ms-enable-snapshot-virtual-directory-access"] = _SERIALIZER.header(
             "enable_snapshot_virtual_directory_access", enable_snapshot_virtual_directory_access, "bool"
         )
+    if paid_bursting_enabled is not None:
+        _headers["x-ms-share-paid-bursting-enabled"] = _SERIALIZER.header(
+            "paid_bursting_enabled", paid_bursting_enabled, "bool"
+        )
+    if paid_bursting_max_bandwidth_mips is not None:
+        _headers["x-ms-share-paid-bursting-max-bandwidth-mibps"] = _SERIALIZER.header(
+            "paid_bursting_max_bandwidth_mips", paid_bursting_max_bandwidth_mips, "int"
+        )
+    if paid_bursting_max_iops is not None:
+        _headers["x-ms-share-paid-bursting-max-iops"] = _SERIALIZER.header(
+            "paid_bursting_max_iops", paid_bursting_max_iops, "int"
+        )
     _headers["Accept"] = _SERIALIZER.header("accept", accept, "str")
 
     return HttpRequest(method="PUT", url=_url, params=_params, headers=_headers, **kwargs)
@@ -104,7 +119,7 @@ def build_get_properties_request(
     _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
 
     restype: Literal["share"] = kwargs.pop("restype", _params.pop("restype", "share"))
-    version: Literal["2024-08-04"] = kwargs.pop("version", _headers.pop("x-ms-version", "2024-08-04"))
+    version: Literal["2024-11-04"] = kwargs.pop("version", _headers.pop("x-ms-version", "2024-11-04"))
     accept = _headers.pop("Accept", "application/xml")
 
     # Construct URL
@@ -144,7 +159,7 @@ def build_delete_request(
     _params = case_insensitive_dict(kwargs.pop("params", {}) or {})
 
     restype: Literal["share"] = kwargs.pop("restype", _params.pop("restype", "share"))
-    version: Literal["2024-08-04"] = kwargs.pop("version", _headers.pop("x-ms-version", "2024-08-04"))
+    version: Literal["2024-11-04"] = kwargs.pop("version", _headers.pop("x-ms-version", "2024-11-04"))
     accept = _headers.pop("Accept", "application/xml")
 
     # Construct URL
@@ -189,7 +204,7 @@ def build_acquire_lease_request(
     comp: Literal["lease"] = kwargs.pop("comp", _params.pop("comp", "lease"))
     action: Literal["acquire"] = kwargs.pop("action", _headers.pop("x-ms-lease-action", "acquire"))
     restype: Literal["share"] = kwargs.pop("restype", _params.pop("restype", "share"))
-    version: Literal["2024-08-04"] = kwargs.pop("version", _headers.pop("x-ms-version", "2024-08-04"))
+    version: Literal["2024-11-04"] = kwargs.pop("version", _headers.pop("x-ms-version", "2024-11-04"))
     accept = _headers.pop("Accept", "application/xml")
 
     # Construct URL
@@ -237,7 +252,7 @@ def build_release_lease_request(
     comp: Literal["lease"] = kwargs.pop("comp", _params.pop("comp", "lease"))
     action: Literal["release"] = kwargs.pop("action", _headers.pop("x-ms-lease-action", "release"))
     restype: Literal["share"] = kwargs.pop("restype", _params.pop("restype", "share"))
-    version: Literal["2024-08-04"] = kwargs.pop("version", _headers.pop("x-ms-version", "2024-08-04"))
+    version: Literal["2024-11-04"] = kwargs.pop("version", _headers.pop("x-ms-version", "2024-11-04"))
     accept = _headers.pop("Accept", "application/xml")
 
     # Construct URL
@@ -283,7 +298,7 @@ def build_change_lease_request(
     comp: Literal["lease"] = kwargs.pop("comp", _params.pop("comp", "lease"))
     action: Literal["change"] = kwargs.pop("action", _headers.pop("x-ms-lease-action", "change"))
     restype: Literal["share"] = kwargs.pop("restype", _params.pop("restype", "share"))
-    version: Literal["2024-08-04"] = kwargs.pop("version", _headers.pop("x-ms-version", "2024-08-04"))
+    version: Literal["2024-11-04"] = kwargs.pop("version", _headers.pop("x-ms-version", "2024-11-04"))
     accept = _headers.pop("Accept", "application/xml")
 
     # Construct URL
@@ -330,7 +345,7 @@ def build_renew_lease_request(
     comp: Literal["lease"] = kwargs.pop("comp", _params.pop("comp", "lease"))
     action: Literal["renew"] = kwargs.pop("action", _headers.pop("x-ms-lease-action", "renew"))
     restype: Literal["share"] = kwargs.pop("restype", _params.pop("restype", "share"))
-    version: Literal["2024-08-04"] = kwargs.pop("version", _headers.pop("x-ms-version", "2024-08-04"))
+    version: Literal["2024-11-04"] = kwargs.pop("version", _headers.pop("x-ms-version", "2024-11-04"))
     accept = _headers.pop("Accept", "application/xml")
 
     # Construct URL
@@ -376,7 +391,7 @@ def build_break_lease_request(
     comp: Literal["lease"] = kwargs.pop("comp", _params.pop("comp", "lease"))
     action: Literal["break"] = kwargs.pop("action", _headers.pop("x-ms-lease-action", "break"))
     restype: Literal["share"] = kwargs.pop("restype", _params.pop("restype", "share"))
-    version: Literal["2024-08-04"] = kwargs.pop("version", _headers.pop("x-ms-version", "2024-08-04"))
+    version: Literal["2024-11-04"] = kwargs.pop("version", _headers.pop("x-ms-version", "2024-11-04"))
     accept = _headers.pop("Accept", "application/xml")
 
     # Construct URL
@@ -417,7 +432,7 @@ def build_create_snapshot_request(
 
     restype: Literal["share"] = kwargs.pop("restype", _params.pop("restype", "share"))
     comp: Literal["snapshot"] = kwargs.pop("comp", _params.pop("comp", "snapshot"))
-    version: Literal["2024-08-04"] = kwargs.pop("version", _headers.pop("x-ms-version", "2024-08-04"))
+    version: Literal["2024-11-04"] = kwargs.pop("version", _headers.pop("x-ms-version", "2024-11-04"))
     accept = _headers.pop("Accept", "application/xml")
 
     # Construct URL
@@ -456,7 +471,7 @@ def build_create_permission_request(
     restype: Literal["share"] = kwargs.pop("restype", _params.pop("restype", "share"))
     comp: Literal["filepermission"] = kwargs.pop("comp", _params.pop("comp", "filepermission"))
     content_type: Optional[str] = kwargs.pop("content_type", _headers.pop("Content-Type", None))
-    version: Literal["2024-08-04"] = kwargs.pop("version", _headers.pop("x-ms-version", "2024-08-04"))
+    version: Literal["2024-11-04"] = kwargs.pop("version", _headers.pop("x-ms-version", "2024-11-04"))
     accept = _headers.pop("Accept", "application/xml")
 
     # Construct URL
@@ -497,7 +512,7 @@ def build_get_permission_request(
 
     restype: Literal["share"] = kwargs.pop("restype", _params.pop("restype", "share"))
     comp: Literal["filepermission"] = kwargs.pop("comp", _params.pop("comp", "filepermission"))
-    version: Literal["2024-08-04"] = kwargs.pop("version", _headers.pop("x-ms-version", "2024-08-04"))
+    version: Literal["2024-11-04"] = kwargs.pop("version", _headers.pop("x-ms-version", "2024-11-04"))
     accept = _headers.pop("Accept", "application/json")
 
     # Construct URL
@@ -533,6 +548,9 @@ def build_set_properties_request(
     lease_id: Optional[str] = None,
     root_squash: Optional[Union[str, _models.ShareRootSquash]] = None,
     enable_snapshot_virtual_directory_access: Optional[bool] = None,
+    paid_bursting_enabled: Optional[bool] = None,
+    paid_bursting_max_bandwidth_mips: Optional[int] = None,
+    paid_bursting_max_iops: Optional[int] = None,
     **kwargs: Any
 ) -> HttpRequest:
     _headers = case_insensitive_dict(kwargs.pop("headers", {}) or {})
@@ -540,7 +558,7 @@ def build_set_properties_request(
 
     restype: Literal["share"] = kwargs.pop("restype", _params.pop("restype", "share"))
     comp: Literal["properties"] = kwargs.pop("comp", _params.pop("comp", "properties"))
-    version: Literal["2024-08-04"] = kwargs.pop("version", _headers.pop("x-ms-version", "2024-08-04"))
+    version: Literal["2024-11-04"] = kwargs.pop("version", _headers.pop("x-ms-version", "2024-11-04"))
     accept = _headers.pop("Accept", "application/xml")
 
     # Construct URL
@@ -571,6 +589,18 @@ def build_set_properties_request(
         _headers["x-ms-enable-snapshot-virtual-directory-access"] = _SERIALIZER.header(
             "enable_snapshot_virtual_directory_access", enable_snapshot_virtual_directory_access, "bool"
         )
+    if paid_bursting_enabled is not None:
+        _headers["x-ms-share-paid-bursting-enabled"] = _SERIALIZER.header(
+            "paid_bursting_enabled", paid_bursting_enabled, "bool"
+        )
+    if paid_bursting_max_bandwidth_mips is not None:
+        _headers["x-ms-share-paid-bursting-max-bandwidth-mibps"] = _SERIALIZER.header(
+            "paid_bursting_max_bandwidth_mips", paid_bursting_max_bandwidth_mips, "int"
+        )
+    if paid_bursting_max_iops is not None:
+        _headers["x-ms-share-paid-bursting-max-iops"] = _SERIALIZER.header(
+            "paid_bursting_max_iops", paid_bursting_max_iops, "int"
+        )
     _headers["Accept"] = _SERIALIZER.header("accept", accept, "str")
 
     return HttpRequest(method="PUT", url=_url, params=_params, headers=_headers, **kwargs)
@@ -589,7 +619,7 @@ def build_set_metadata_request(
 
     restype: Literal["share"] = kwargs.pop("restype", _params.pop("restype", "share"))
     comp: Literal["metadata"] = kwargs.pop("comp", _params.pop("comp", "metadata"))
-    version: Literal["2024-08-04"] = kwargs.pop("version", _headers.pop("x-ms-version", "2024-08-04"))
+    version: Literal["2024-11-04"] = kwargs.pop("version", _headers.pop("x-ms-version", "2024-11-04"))
     accept = _headers.pop("Accept", "application/xml")
 
     # Construct URL
@@ -625,7 +655,7 @@ def build_get_access_policy_request(
 
     restype: Literal["share"] = kwargs.pop("restype", _params.pop("restype", "share"))
     comp: Literal["acl"] = kwargs.pop("comp", _params.pop("comp", "acl"))
-    version: Literal["2024-08-04"] = kwargs.pop("version", _headers.pop("x-ms-version", "2024-08-04"))
+    version: Literal["2024-11-04"] = kwargs.pop("version", _headers.pop("x-ms-version", "2024-11-04"))
     accept = _headers.pop("Accept", "application/xml")
 
     # Construct URL
@@ -660,7 +690,7 @@ def build_set_access_policy_request(
     restype: Literal["share"] = kwargs.pop("restype", _params.pop("restype", "share"))
     comp: Literal["acl"] = kwargs.pop("comp", _params.pop("comp", "acl"))
     content_type: Optional[str] = kwargs.pop("content_type", _headers.pop("Content-Type", None))
-    version: Literal["2024-08-04"] = kwargs.pop("version", _headers.pop("x-ms-version", "2024-08-04"))
+    version: Literal["2024-11-04"] = kwargs.pop("version", _headers.pop("x-ms-version", "2024-11-04"))
     accept = _headers.pop("Accept", "application/xml")
 
     # Construct URL
@@ -696,7 +726,7 @@ def build_get_statistics_request(
 
     restype: Literal["share"] = kwargs.pop("restype", _params.pop("restype", "share"))
     comp: Literal["stats"] = kwargs.pop("comp", _params.pop("comp", "stats"))
-    version: Literal["2024-08-04"] = kwargs.pop("version", _headers.pop("x-ms-version", "2024-08-04"))
+    version: Literal["2024-11-04"] = kwargs.pop("version", _headers.pop("x-ms-version", "2024-11-04"))
     accept = _headers.pop("Accept", "application/xml")
 
     # Construct URL
@@ -736,7 +766,7 @@ def build_restore_request(
 
     restype: Literal["share"] = kwargs.pop("restype", _params.pop("restype", "share"))
     comp: Literal["undelete"] = kwargs.pop("comp", _params.pop("comp", "undelete"))
-    version: Literal["2024-08-04"] = kwargs.pop("version", _headers.pop("x-ms-version", "2024-08-04"))
+    version: Literal["2024-11-04"] = kwargs.pop("version", _headers.pop("x-ms-version", "2024-11-04"))
     accept = _headers.pop("Accept", "application/xml")
 
     # Construct URL
@@ -797,6 +827,9 @@ class ShareOperations:
         enabled_protocols: Optional[str] = None,
         root_squash: Optional[Union[str, _models.ShareRootSquash]] = None,
         enable_snapshot_virtual_directory_access: Optional[bool] = None,
+        paid_bursting_enabled: Optional[bool] = None,
+        paid_bursting_max_bandwidth_mips: Optional[int] = None,
+        paid_bursting_max_iops: Optional[int] = None,
         **kwargs: Any
     ) -> None:
         """Creates a new share under the specified account. If the share with the same name already
@@ -822,6 +855,17 @@ class ShareOperations:
         :type root_squash: str or ~azure.storage.fileshare.models.ShareRootSquash
         :param enable_snapshot_virtual_directory_access: Default value is None.
         :type enable_snapshot_virtual_directory_access: bool
+        :param paid_bursting_enabled: Optional. Boolean. Default if not specified is false. This
+         property enables paid bursting. Default value is None.
+        :type paid_bursting_enabled: bool
+        :param paid_bursting_max_bandwidth_mips: Optional. Integer. Default if not specified is the
+         maximum throughput the file share can support. Current maximum for a file share is 10,340
+         MiB/sec. Default value is None.
+        :type paid_bursting_max_bandwidth_mips: int
+        :param paid_bursting_max_iops: Optional. Integer. Default if not specified is the maximum IOPS
+         the file share can support. Current maximum for a file share is 102,400 IOPS. Default value is
+         None.
+        :type paid_bursting_max_iops: int
         :return: None or the result of cls(response)
         :rtype: None
         :raises ~azure.core.exceptions.HttpResponseError:
@@ -849,6 +893,9 @@ class ShareOperations:
             enabled_protocols=enabled_protocols,
             root_squash=root_squash,
             enable_snapshot_virtual_directory_access=enable_snapshot_virtual_directory_access,
+            paid_bursting_enabled=paid_bursting_enabled,
+            paid_bursting_max_bandwidth_mips=paid_bursting_max_bandwidth_mips,
+            paid_bursting_max_iops=paid_bursting_max_iops,
             restype=restype,
             version=self._config.version,
             headers=_headers,
@@ -986,6 +1033,15 @@ class ShareOperations:
         response_headers["x-ms-root-squash"] = self._deserialize("str", response.headers.get("x-ms-root-squash"))
         response_headers["x-ms-enable-snapshot-virtual-directory-access"] = self._deserialize(
             "bool", response.headers.get("x-ms-enable-snapshot-virtual-directory-access")
+        )
+        response_headers["x-ms-share-paid-bursting-enabled"] = self._deserialize(
+            "bool", response.headers.get("x-ms-share-paid-bursting-enabled")
+        )
+        response_headers["x-ms-share-paid-bursting-max-iops"] = self._deserialize(
+            "int", response.headers.get("x-ms-share-paid-bursting-max-iops")
+        )
+        response_headers["x-ms-share-paid-bursting-max-bandwidth-mibps"] = self._deserialize(
+            "int", response.headers.get("x-ms-share-paid-bursting-max-bandwidth-mibps")
         )
 
         if cls:
@@ -1820,6 +1876,9 @@ class ShareOperations:
         access_tier: Optional[Union[str, _models.ShareAccessTier]] = None,
         root_squash: Optional[Union[str, _models.ShareRootSquash]] = None,
         enable_snapshot_virtual_directory_access: Optional[bool] = None,
+        paid_bursting_enabled: Optional[bool] = None,
+        paid_bursting_max_bandwidth_mips: Optional[int] = None,
+        paid_bursting_max_iops: Optional[int] = None,
         lease_access_conditions: Optional[_models.LeaseAccessConditions] = None,
         **kwargs: Any
     ) -> None:
@@ -1840,6 +1899,17 @@ class ShareOperations:
         :type root_squash: str or ~azure.storage.fileshare.models.ShareRootSquash
         :param enable_snapshot_virtual_directory_access: Default value is None.
         :type enable_snapshot_virtual_directory_access: bool
+        :param paid_bursting_enabled: Optional. Boolean. Default if not specified is false. This
+         property enables paid bursting. Default value is None.
+        :type paid_bursting_enabled: bool
+        :param paid_bursting_max_bandwidth_mips: Optional. Integer. Default if not specified is the
+         maximum throughput the file share can support. Current maximum for a file share is 10,340
+         MiB/sec. Default value is None.
+        :type paid_bursting_max_bandwidth_mips: int
+        :param paid_bursting_max_iops: Optional. Integer. Default if not specified is the maximum IOPS
+         the file share can support. Current maximum for a file share is 102,400 IOPS. Default value is
+         None.
+        :type paid_bursting_max_iops: int
         :param lease_access_conditions: Parameter group. Default value is None.
         :type lease_access_conditions: ~azure.storage.fileshare.models.LeaseAccessConditions
         :return: None or the result of cls(response)
@@ -1873,6 +1943,9 @@ class ShareOperations:
             lease_id=_lease_id,
             root_squash=root_squash,
             enable_snapshot_virtual_directory_access=enable_snapshot_virtual_directory_access,
+            paid_bursting_enabled=paid_bursting_enabled,
+            paid_bursting_max_bandwidth_mips=paid_bursting_max_bandwidth_mips,
+            paid_bursting_max_iops=paid_bursting_max_iops,
             restype=restype,
             comp=comp,
             version=self._config.version,

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_models.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_models.py
@@ -344,6 +344,9 @@ class ShareProperties(DictMixin):
     :ivar bool enable_snapshot_virtual_directory_access:
         Specifies whether the snapshot virtual directory should be accessible at the root of the share
         mount point when NFS is enabled. if not specified, the default is True.
+    :ivar bool paid_bursting_enabled: This property enables paid bursting.
+    :ivar int paid_bursting_max_bandwidth_mips: The maximum throughput the file share can support.
+    :ivar int paid_bursting_max_iops: The maximum IOPS the file share can support.
     """
 
     def __init__(self, **kwargs):
@@ -369,6 +372,10 @@ class ShareProperties(DictMixin):
         self.root_squash = kwargs.get('x-ms-root-squash', None)
         self.enable_snapshot_virtual_directory_access = \
             kwargs.get('x-ms-enable-snapshot-virtual-directory-access')
+        self.paid_bursting_enabled = kwargs.get('x-ms-share-paid-bursting-enabled')
+        self.paid_bursting_max_bandwidth_mips = kwargs.get('x-ms-share-paid-bursting-max-bandwidth-mibps')
+        self.paid_bursting_max_iops = kwargs.get('x-ms-share-paid-bursting-max-iops')
+
     @classmethod
     def _from_generated(cls, generated):
         props = cls()
@@ -393,7 +400,9 @@ class ShareProperties(DictMixin):
             if generated.properties.enabled_protocols else None
         props.root_squash = generated.properties.root_squash
         props.enable_snapshot_virtual_directory_access = generated.properties.enable_snapshot_virtual_directory_access
-
+        props.paid_bursting_enabled = generated.properties.paid_bursting_enabled
+        props.paid_bursting_max_bandwidth_mips = generated.properties.paid_bursting_max_bandwidth_mibps
+        props.paid_bursting_max_iops = generated.properties.paid_bursting_max_iops
         return props
 
 

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_models.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_models.py
@@ -373,7 +373,7 @@ class ShareProperties(DictMixin):
         self.enable_snapshot_virtual_directory_access = \
             kwargs.get('x-ms-enable-snapshot-virtual-directory-access')
         self.paid_bursting_enabled = kwargs.get('x-ms-share-paid-bursting-enabled')
-        self.paid_bursting_max_bandwidth_mips = kwargs.get('x-ms-share-paid-bursting-max-bandwidth-mibps')
+        self.paid_bursting_max_bandwidth_mibps = kwargs.get('x-ms-share-paid-bursting-max-bandwidth-mibps')
         self.paid_bursting_max_iops = kwargs.get('x-ms-share-paid-bursting-max-iops')
 
     @classmethod
@@ -401,7 +401,7 @@ class ShareProperties(DictMixin):
         props.root_squash = generated.properties.root_squash
         props.enable_snapshot_virtual_directory_access = generated.properties.enable_snapshot_virtual_directory_access
         props.paid_bursting_enabled = generated.properties.paid_bursting_enabled
-        props.paid_bursting_max_bandwidth_mips = generated.properties.paid_bursting_max_bandwidth_mibps
+        props.paid_bursting_max_bandwidth_mibps = generated.properties.paid_bursting_max_bandwidth_mibps
         props.paid_bursting_max_iops = generated.properties.paid_bursting_max_iops
         return props
 

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_models.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_models.py
@@ -345,7 +345,7 @@ class ShareProperties(DictMixin):
         Specifies whether the snapshot virtual directory should be accessible at the root of the share
         mount point when NFS is enabled. if not specified, the default is True.
     :ivar bool paid_bursting_enabled: This property enables paid bursting.
-    :ivar int paid_bursting_max_bandwidth_mips: The maximum throughput the file share can support.
+    :ivar int paid_bursting_max_bandwidth_mibps: The maximum throughput the file share can support in MiB/s.
     :ivar int paid_bursting_max_iops: The maximum IOPS the file share can support.
     """
 

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_share_client.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_share_client.py
@@ -377,6 +377,11 @@ class ShareClient(StorageAccountHostsMixin): # pylint: disable=too-many-public-m
         :keyword bool enable_snapshot_virtual_directory_access:
             Specifies whether the snapshot virtual directory should be accessible at the root of the share
             mount point when NFS is enabled. Default value is True.
+        :keyword bool paid_bursting_enabled: This property enables paid bursting.
+        :keyword int paid_bursting_max_bandwidth_mips: The maximum throughput the file share can support.
+            Current maximum for a file share is 10,340 MiB/sec.
+        :keyword int paid_bursting_max_iops: The maximum IOPS the file share can support.
+            Current maximum for a file share is 102,400 IOPS.
         :returns: Share-updated property dict (Etag and last modified).
         :rtype: Dict[str, Any]
 
@@ -646,6 +651,11 @@ class ShareClient(StorageAccountHostsMixin): # pylint: disable=too-many-public-m
         :keyword lease:
             Required if the share has an active lease. Value can be a ShareLeaseClient object
             or the lease ID as a string.
+        :keyword bool paid_bursting_enabled: This property enables paid bursting.
+        :keyword int paid_bursting_max_bandwidth_mips: The maximum throughput the file share can support.
+            Current maximum for a file share is 10,340 MiB/sec.
+        :keyword int paid_bursting_max_iops: The maximum IOPS the file share can support.
+            Current maximum for a file share is 102,400 IOPS.
         :returns: Share-updated property dict (Etag and last modified).
         :rtype: dict[str, Any]
 

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_share_client.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_share_client.py
@@ -378,7 +378,7 @@ class ShareClient(StorageAccountHostsMixin): # pylint: disable=too-many-public-m
             Specifies whether the snapshot virtual directory should be accessible at the root of the share
             mount point when NFS is enabled. Default value is True.
         :keyword bool paid_bursting_enabled: This property enables paid bursting.
-        :keyword int paid_bursting_max_bandwidth_mips: The maximum throughput the file share can support.
+        :keyword int paid_bursting_max_bandwidth_mipbs: The maximum throughput the file share can support.
             Current maximum for a file share is 10,340 MiB/sec.
         :keyword int paid_bursting_max_iops: The maximum IOPS the file share can support.
             Current maximum for a file share is 102,400 IOPS.
@@ -652,7 +652,7 @@ class ShareClient(StorageAccountHostsMixin): # pylint: disable=too-many-public-m
             Required if the share has an active lease. Value can be a ShareLeaseClient object
             or the lease ID as a string.
         :keyword bool paid_bursting_enabled: This property enables paid bursting.
-        :keyword int paid_bursting_max_bandwidth_mips: The maximum throughput the file share can support.
+        :keyword int paid_bursting_max_bandwidth_mibps: The maximum throughput the file share can support.
             Current maximum for a file share is 10,340 MiB/sec.
         :keyword int paid_bursting_max_iops: The maximum IOPS the file share can support.
             Current maximum for a file share is 102,400 IOPS.

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_share_client.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_share_client.py
@@ -378,10 +378,8 @@ class ShareClient(StorageAccountHostsMixin): # pylint: disable=too-many-public-m
             Specifies whether the snapshot virtual directory should be accessible at the root of the share
             mount point when NFS is enabled. Default value is True.
         :keyword bool paid_bursting_enabled: This property enables paid bursting.
-        :keyword int paid_bursting_max_bandwidth_mipbs: The maximum throughput the file share can support.
-            Current maximum for a file share is 10,340 MiB/sec.
+        :keyword int paid_bursting_max_bandwidth_mibps: The maximum throughput the file share can support in MiB/s.
         :keyword int paid_bursting_max_iops: The maximum IOPS the file share can support.
-            Current maximum for a file share is 102,400 IOPS.
         :returns: Share-updated property dict (Etag and last modified).
         :rtype: Dict[str, Any]
 
@@ -652,10 +650,8 @@ class ShareClient(StorageAccountHostsMixin): # pylint: disable=too-many-public-m
             Required if the share has an active lease. Value can be a ShareLeaseClient object
             or the lease ID as a string.
         :keyword bool paid_bursting_enabled: This property enables paid bursting.
-        :keyword int paid_bursting_max_bandwidth_mibps: The maximum throughput the file share can support.
-            Current maximum for a file share is 10,340 MiB/sec.
+        :keyword int paid_bursting_max_bandwidth_mibps: The maximum throughput the file share can support in MiB/s.
         :keyword int paid_bursting_max_iops: The maximum IOPS the file share can support.
-            Current maximum for a file share is 102,400 IOPS.
         :returns: Share-updated property dict (Etag and last modified).
         :rtype: dict[str, Any]
 

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_share_service_client.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_share_service_client.py
@@ -301,6 +301,11 @@ class ShareServiceClient(StorageAccountHostsMixin):
             This value is not tracked or validated on the client. To configure client-side network timesouts
             see `here <https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/storage/azure-storage-file-share
             #other-client--per-operation-configuration>`__.
+        :keyword bool paid_bursting_enabled: This property enables paid bursting.
+        :keyword int paid_bursting_max_bandwidth_mips: The maximum throughput the file share can support.
+            Current maximum for a file share is 10,340 MiB/sec.
+        :keyword int paid_bursting_max_iops: The maximum IOPS the file share can support.
+            Current maximum for a file share is 102,400 IOPS.
         :returns: An iterable (auto-paging) of ShareProperties.
         :rtype: ~azure.core.paging.ItemPaged[~azure.storage.fileshare.ShareProperties]
 

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_share_service_client.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_share_service_client.py
@@ -302,7 +302,7 @@ class ShareServiceClient(StorageAccountHostsMixin):
             see `here <https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/storage/azure-storage-file-share
             #other-client--per-operation-configuration>`__.
         :keyword bool paid_bursting_enabled: This property enables paid bursting.
-        :keyword int paid_bursting_max_bandwidth_mips: The maximum throughput the file share can support.
+        :keyword int paid_bursting_max_bandwidth_mibps: The maximum throughput the file share can support.
             Current maximum for a file share is 10,340 MiB/sec.
         :keyword int paid_bursting_max_iops: The maximum IOPS the file share can support.
             Current maximum for a file share is 102,400 IOPS.

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_share_service_client.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_share_service_client.py
@@ -302,10 +302,8 @@ class ShareServiceClient(StorageAccountHostsMixin):
             see `here <https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/storage/azure-storage-file-share
             #other-client--per-operation-configuration>`__.
         :keyword bool paid_bursting_enabled: This property enables paid bursting.
-        :keyword int paid_bursting_max_bandwidth_mibps: The maximum throughput the file share can support.
-            Current maximum for a file share is 10,340 MiB/sec.
+        :keyword int paid_bursting_max_bandwidth_mibps: The maximum throughput the file share can support in MiB/s.
         :keyword int paid_bursting_max_iops: The maximum IOPS the file share can support.
-            Current maximum for a file share is 102,400 IOPS.
         :returns: An iterable (auto-paging) of ShareProperties.
         :rtype: ~azure.core.paging.ItemPaged[~azure.storage.fileshare.ShareProperties]
 

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/aio/_share_client_async.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/aio/_share_client_async.py
@@ -226,6 +226,11 @@ class ShareClient(AsyncStorageAccountHostsMixin, ShareClientBase):
         :keyword bool enable_snapshot_virtual_directory_access:
             Specifies whether the snapshot virtual directory should be accessible at the root of the share
             mount point when NFS is enabled. Default value is True.
+        :keyword bool paid_bursting_enabled: This property enables paid bursting.
+        :keyword int paid_bursting_max_bandwidth_mips: The maximum throughput the file share can support.
+            Current maximum for a file share is 10,340 MiB/sec.
+        :keyword int paid_bursting_max_iops: The maximum IOPS the file share can support.
+            Current maximum for a file share is 102,400 IOPS.
         :returns: Share-updated property dict (Etag and last modified).
         :rtype: Dict[str, Any]
 
@@ -494,6 +499,11 @@ class ShareClient(AsyncStorageAccountHostsMixin, ShareClientBase):
         :keyword lease:
             Required if the share has an active lease. Value can be a ShareLeaseClient object
             or the lease ID as a string.
+        :keyword bool paid_bursting_enabled: This property enables paid bursting.
+        :keyword int paid_bursting_max_bandwidth_mips: The maximum throughput the file share can support.
+            Current maximum for a file share is 10,340 MiB/sec.
+        :keyword int paid_bursting_max_iops: The maximum IOPS the file share can support.
+            Current maximum for a file share is 102,400 IOPS.
         :returns: Share-updated property dict (Etag and last modified).
         :rtype: dict[str, Any]
 

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/aio/_share_client_async.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/aio/_share_client_async.py
@@ -227,7 +227,7 @@ class ShareClient(AsyncStorageAccountHostsMixin, ShareClientBase):
             Specifies whether the snapshot virtual directory should be accessible at the root of the share
             mount point when NFS is enabled. Default value is True.
         :keyword bool paid_bursting_enabled: This property enables paid bursting.
-        :keyword int paid_bursting_max_bandwidth_mips: The maximum throughput the file share can support.
+        :keyword int paid_bursting_max_bandwidth_mibps: The maximum throughput the file share can support.
             Current maximum for a file share is 10,340 MiB/sec.
         :keyword int paid_bursting_max_iops: The maximum IOPS the file share can support.
             Current maximum for a file share is 102,400 IOPS.
@@ -500,7 +500,7 @@ class ShareClient(AsyncStorageAccountHostsMixin, ShareClientBase):
             Required if the share has an active lease. Value can be a ShareLeaseClient object
             or the lease ID as a string.
         :keyword bool paid_bursting_enabled: This property enables paid bursting.
-        :keyword int paid_bursting_max_bandwidth_mips: The maximum throughput the file share can support.
+        :keyword int paid_bursting_max_bandwidth_mibps: The maximum throughput the file share can support.
             Current maximum for a file share is 10,340 MiB/sec.
         :keyword int paid_bursting_max_iops: The maximum IOPS the file share can support.
             Current maximum for a file share is 102,400 IOPS.

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/aio/_share_client_async.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/aio/_share_client_async.py
@@ -227,10 +227,8 @@ class ShareClient(AsyncStorageAccountHostsMixin, ShareClientBase):
             Specifies whether the snapshot virtual directory should be accessible at the root of the share
             mount point when NFS is enabled. Default value is True.
         :keyword bool paid_bursting_enabled: This property enables paid bursting.
-        :keyword int paid_bursting_max_bandwidth_mibps: The maximum throughput the file share can support.
-            Current maximum for a file share is 10,340 MiB/sec.
+        :keyword int paid_bursting_max_bandwidth_mibps: The maximum throughput the file share can support in MiB/s.
         :keyword int paid_bursting_max_iops: The maximum IOPS the file share can support.
-            Current maximum for a file share is 102,400 IOPS.
         :returns: Share-updated property dict (Etag and last modified).
         :rtype: Dict[str, Any]
 
@@ -500,10 +498,8 @@ class ShareClient(AsyncStorageAccountHostsMixin, ShareClientBase):
             Required if the share has an active lease. Value can be a ShareLeaseClient object
             or the lease ID as a string.
         :keyword bool paid_bursting_enabled: This property enables paid bursting.
-        :keyword int paid_bursting_max_bandwidth_mibps: The maximum throughput the file share can support.
-            Current maximum for a file share is 10,340 MiB/sec.
+        :keyword int paid_bursting_max_bandwidth_mibps: The maximum throughput the file share can support in MiB/s.
         :keyword int paid_bursting_max_iops: The maximum IOPS the file share can support.
-            Current maximum for a file share is 102,400 IOPS.
         :returns: Share-updated property dict (Etag and last modified).
         :rtype: dict[str, Any]
 

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/aio/_share_service_client_async.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/aio/_share_service_client_async.py
@@ -241,7 +241,7 @@ class ShareServiceClient(AsyncStorageAccountHostsMixin, ShareServiceClientBase):
             see `here <https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/storage/azure-storage-file-share
             #other-client--per-operation-configuration>`__.
         :keyword bool paid_bursting_enabled: This property enables paid bursting.
-        :keyword int paid_bursting_max_bandwidth_mips: The maximum throughput the file share can support.
+        :keyword int paid_bursting_max_bandwidth_mibps: The maximum throughput the file share can support.
             Current maximum for a file share is 10,340 MiB/sec.
         :keyword int paid_bursting_max_iops: The maximum IOPS the file share can support.
             Current maximum for a file share is 102,400 IOPS.

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/aio/_share_service_client_async.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/aio/_share_service_client_async.py
@@ -240,6 +240,11 @@ class ShareServiceClient(AsyncStorageAccountHostsMixin, ShareServiceClientBase):
             This value is not tracked or validated on the client. To configure client-side network timesouts
             see `here <https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/storage/azure-storage-file-share
             #other-client--per-operation-configuration>`__.
+        :keyword bool paid_bursting_enabled: This property enables paid bursting.
+        :keyword int paid_bursting_max_bandwidth_mips: The maximum throughput the file share can support.
+            Current maximum for a file share is 10,340 MiB/sec.
+        :keyword int paid_bursting_max_iops: The maximum IOPS the file share can support.
+            Current maximum for a file share is 102,400 IOPS.
         :returns: An iterable (auto-paging) of ShareProperties.
         :rtype: ~azure.core.async_paging.AsyncItemPaged[~azure.storage.fileshare.ShareProperties]
 

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/aio/_share_service_client_async.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/aio/_share_service_client_async.py
@@ -241,10 +241,8 @@ class ShareServiceClient(AsyncStorageAccountHostsMixin, ShareServiceClientBase):
             see `here <https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/storage/azure-storage-file-share
             #other-client--per-operation-configuration>`__.
         :keyword bool paid_bursting_enabled: This property enables paid bursting.
-        :keyword int paid_bursting_max_bandwidth_mibps: The maximum throughput the file share can support.
-            Current maximum for a file share is 10,340 MiB/sec.
+        :keyword int paid_bursting_max_bandwidth_mibps: The maximum throughput the file share can support in MiB/s.
         :keyword int paid_bursting_max_iops: The maximum IOPS the file share can support.
-            Current maximum for a file share is 102,400 IOPS.
         :returns: An iterable (auto-paging) of ShareProperties.
         :rtype: ~azure.core.async_paging.AsyncItemPaged[~azure.storage.fileshare.ShareProperties]
 

--- a/sdk/storage/azure-storage-file-share/tests/test_share.py
+++ b/sdk/storage/azure-storage-file-share/tests/test_share.py
@@ -1619,29 +1619,29 @@ class TestStorageShare(StorageRecordedTestCase):
 
         # Arrange
         self._setup(premium_storage_file_account_name, premium_storage_file_account_key)
-        max_mips = 10340
+        max_mibps = 10340
         max_iops = 102400
 
         # Act / Assert
         share = self._create_share(
             paid_bursting_enabled=True,
-            paid_bursting_max_bandwidth_mips=5000,
+            paid_bursting_max_bandwidth_mibps=5000,
             paid_bursting_max_iops=1000
         )
         share_props = share.get_share_properties()
         assert share_props.paid_bursting_enabled
-        assert share_props.paid_bursting_max_bandwidth_mips == 5000
+        assert share_props.paid_bursting_max_bandwidth_mibps == 5000
         assert share_props.paid_bursting_max_iops == 1000
 
         share.set_share_properties(
             root_squash="NoRootSquash",
             paid_bursting_enabled=True,
-            paid_bursting_max_bandwidth_mips=max_mips,
+            paid_bursting_max_bandwidth_mibps=max_mibps,
             paid_bursting_max_iops=max_iops
         )
         share_props = share.get_share_properties()
         assert share_props.paid_bursting_enabled
-        assert share_props.paid_bursting_max_bandwidth_mips == max_mips
+        assert share_props.paid_bursting_max_bandwidth_mibps == max_mibps
         assert share_props.paid_bursting_max_iops == max_iops
 
         shares = list(self.fsc.list_shares())
@@ -1649,7 +1649,7 @@ class TestStorageShare(StorageRecordedTestCase):
         assert len(shares) == 1
         assert shares[0] is not None
         assert shares[0].paid_bursting_enabled
-        assert shares[0].paid_bursting_max_bandwidth_mips == max_mips
+        assert shares[0].paid_bursting_max_bandwidth_mibps == max_mibps
         assert shares[0].paid_bursting_max_iops == max_iops
 
         self._delete_shares()

--- a/sdk/storage/azure-storage-file-share/tests/test_share_async.py
+++ b/sdk/storage/azure-storage-file-share/tests/test_share_async.py
@@ -1683,13 +1683,10 @@ class TestStorageShareAsync(AsyncStorageRecordedTestCase):
         assert share_props.paid_bursting_max_bandwidth_mibps == max_mibps
         assert share_props.paid_bursting_max_iops == max_iops
 
-        shares = None
+        shares = []
         async for share in self.fsc.list_shares():
-            if shares is None:
-                shares = []
             shares.append(share)
 
-        assert shares is not None
         assert len(shares) == 1
         assert shares[0] is not None
         assert shares[0].paid_bursting_enabled

--- a/sdk/storage/azure-storage-file-share/tests/test_share_async.py
+++ b/sdk/storage/azure-storage-file-share/tests/test_share_async.py
@@ -1658,29 +1658,29 @@ class TestStorageShareAsync(AsyncStorageRecordedTestCase):
 
         # Arrange
         self._setup(premium_storage_file_account_name, premium_storage_file_account_key)
-        max_mips = 10340
+        max_mibps = 10340
         max_iops = 102400
 
         # Act / Assert
         share = await self._create_share(
             paid_bursting_enabled=True,
-            paid_bursting_max_bandwidth_mips=5000,
+            paid_bursting_max_bandwidth_mibps=5000,
             paid_bursting_max_iops=1000
         )
         share_props = await share.get_share_properties()
         assert share_props.paid_bursting_enabled
-        assert share_props.paid_bursting_max_bandwidth_mips == 5000
+        assert share_props.paid_bursting_max_bandwidth_mibps == 5000
         assert share_props.paid_bursting_max_iops == 1000
 
         await share.set_share_properties(
             root_squash="NoRootSquash",
             paid_bursting_enabled=True,
-            paid_bursting_max_bandwidth_mips=max_mips,
+            paid_bursting_max_bandwidth_mibps=max_mibps,
             paid_bursting_max_iops=max_iops
         )
         share_props = await share.get_share_properties()
         assert share_props.paid_bursting_enabled
-        assert share_props.paid_bursting_max_bandwidth_mips == max_mips
+        assert share_props.paid_bursting_max_bandwidth_mibps == max_mibps
         assert share_props.paid_bursting_max_iops == max_iops
 
         shares = None
@@ -1693,7 +1693,7 @@ class TestStorageShareAsync(AsyncStorageRecordedTestCase):
         assert len(shares) == 1
         assert shares[0] is not None
         assert shares[0].paid_bursting_enabled
-        assert shares[0].paid_bursting_max_bandwidth_mips == max_mips
+        assert shares[0].paid_bursting_max_bandwidth_mibps == max_mibps
         assert shares[0].paid_bursting_max_iops == max_iops
 
         await self._delete_shares()


### PR DESCRIPTION
Added support for Premium File Accounts to access Paid Burst IOPS/Bandwidth. This PR's features include:

- `ShareClient`'s `create_share` is able to set `paid_bursting_enabled`, `paid_bursting_max_bandwidth_mips`, and `paid_bursting_max_iops`.
- `ShareClient`'s `set_share_properties` is able to set `paid_bursting_enabled`, `paid_bursting_max_bandwidth_mips`, and `paid_bursting_max_iops`.
- `ShareClient`'s `get_share_properties` is able to retrieve the most recent `paid_bursting_enabled`, `paid_bursting_max_bandwidth_mips`, and `paid_bursting_max_iops`.
- `ShareServiceClient`'s `list_shares` API is able to shares with `paid_bursting_enabled`, `paid_bursting_max_bandwidth_mips`, and `paid_bursting_max_iops` properties if previously defined using `create_share` or `set_share_properties`.
- Wrote tests to test all the features mentioned above and added recordings.
- Updated docs with the listed optional keywords.
