### PR TITLE
re-add workspace default app insights, fix project ARM template

### DIFF
--- a/sdk/ml/azure-ai-ml/CHANGELOG.md
+++ b/sdk/ml/azure-ai-ml/CHANGELOG.md
@@ -11,7 +11,7 @@ Expose `public_ip_address` in `AmlComputeNodeInfo`, to get the public ip address
 ### Bugs Fixed
 - InputTypes exported in constants module
 - WorkspaceConnection tags are now listed as deprecated, and the erroneously-deprecated metadata field has been un-deprecated and added as a initialization field. These two fields still point to the same underlying object property, and actual API usage of this value is unchanged.
-- Workspace Create operation works without an application insights being provided.
+- Workspace Create operation works without an application insights being provided, and creates a default appIn resource for normal workspaces in that case.
 - Project create operations works in general.
 
 ### Other Changes

--- a/sdk/ml/azure-ai-ml/CHANGELOG.md
+++ b/sdk/ml/azure-ai-ml/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 1.19.0 (unreleased)
 
+### Bugs Fixed
+
+- Workspace Create operation works without an application insights being provided.
+- Project create operations works in general.
+
 ## 1.18.0 (2024-07-09)
 
 ### Features Added

--- a/sdk/ml/azure-ai-ml/CHANGELOG.md
+++ b/sdk/ml/azure-ai-ml/CHANGELOG.md
@@ -2,11 +2,6 @@
 
 ## 1.19.0 (unreleased)
 
-### Bugs Fixed
-
-- Workspace Create operation works without an application insights being provided.
-- Project create operations works in general.
-
 ## 1.18.0 (2024-07-09)
 
 ### Features Added
@@ -16,6 +11,8 @@ Expose `public_ip_address` in `AmlComputeNodeInfo`, to get the public ip address
 ### Bugs Fixed
 - InputTypes exported in constants module
 - WorkspaceConnection tags are now listed as deprecated, and the erroneously-deprecated metadata field has been un-deprecated and added as a initialization field. These two fields still point to the same underlying object property, and actual API usage of this value is unchanged.
+- Workspace Create operation works without an application insights being provided.
+- Project create operations works in general.
 
 ### Other Changes
 - WorkspaceConnections are officially GA'd and no longer experimental. But its much newer subclasses remain experimental.

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_arm_deployments/arm_templates/workspace_base.json
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_arm_deployments/arm_templates/workspace_base.json
@@ -119,10 +119,11 @@
         },
         "applicationInsightsOption": {
             "type": "string",
-            "defaultValue": "none",
+            "defaultValue": "new",
             "allowedValues": [
-                "none",
-                "existing"
+                "new",
+                "existing",
+                "none"
             ],
             "metadata": {
                 "description": "Determines whether or not new ApplicationInsights should be provisioned."
@@ -796,6 +797,34 @@
             }
         },
         {
+            "condition": "[and(variables('enablePE'), equals(parameters('applicationInsightsOption'), 'new'))]",
+            "type": "Microsoft.OperationalInsights/workspaces",
+            "tags": "[parameters('tagValues')]",
+            "apiVersion": "2020-08-01",
+            "name": "[parameters('logAnalyticsName')]",
+            "location": "[if(or(equals(toLower(parameters('applicationInsightsLocation')),'westcentralus'), equals(toLower(parameters('applicationInsightsLocation')),'eastus2euap'), equals(toLower(parameters('applicationInsightsLocation')),'centraluseuap')),'southcentralus', parameters('applicationInsightsLocation'))]",
+            "kind": "web",
+            "properties": {
+                "Application_Type": "web"
+            }
+        },
+        {
+            "condition": "[and(variables('enablePE'), equals(parameters('applicationInsightsOption'), 'new'))]",
+            "type": "Microsoft.Insights/components",
+            "tags": "[parameters('tagValues')]",
+            "apiVersion": "2020-02-02-preview",
+            "name": "[parameters('applicationInsightsName')]",
+            "location": "[if(or(equals(toLower(parameters('applicationInsightsLocation')),'westcentralus'), equals(toLower(parameters('applicationInsightsLocation')),'eastus2euap'), equals(toLower(parameters('applicationInsightsLocation')),'centraluseuap')),'southcentralus', parameters('applicationInsightsLocation'))]",
+            "kind": "web",
+            "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('logAnalyticsName'))]"
+            ],
+            "properties": {
+                "Application_Type": "web",
+                "WorkspaceResourceId": "[parameters('logAnalyticsArmId')]"
+            }
+        },
+        {
             "condition": "[variables('enablePE')]",
             "type": "Microsoft.MachineLearningServices/workspaces",
             "apiVersion": "2023-08-01-preview",
@@ -805,7 +834,8 @@
             "location": "[parameters('location')]",
             "dependsOn": [
                 "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName'))]",
-                "[resourceId('Microsoft.KeyVault/vaults', parameters('keyVaultName'))]"
+                "[resourceId('Microsoft.KeyVault/vaults', parameters('keyVaultName'))]",
+                "[resourceId('Microsoft.Insights/components', parameters('applicationInsightsName'))]"
             ],
             "identity": "[parameters('identity')]",
             "properties": {

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_arm_deployments/arm_templates/workspace_param.json
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_arm_deployments/arm_templates/workspace_param.json
@@ -39,7 +39,7 @@
         "value": ""
     },
     "applicationInsightsOption": {
-        "value": "none"
+        "value": "new"
     },
     "applicationInsightsName": {
         "value": ""

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_arm_deployments/arm_templates/workspace_project.json
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_arm_deployments/arm_templates/workspace_project.json
@@ -119,10 +119,11 @@
         },
         "applicationInsightsOption": {
             "type": "string",
-            "defaultValue": "none",
+            "defaultValue": "new",
             "allowedValues": [
-                "none",
-                "existing"
+                "new",
+                "existing",
+                "none"
             ],
             "metadata": {
                 "description": "Determines whether or not new ApplicationInsights should be provisioned."
@@ -161,7 +162,7 @@
             "type": "string",
             "defaultValue": "none",
             "allowedValues": [
-                "existing",
+                "new",
                 "none"
             ],
             "metadata": {
@@ -621,6 +622,25 @@
             ],
             "metadata": {
                 "description": "Whether to grant materialization identity permissions"
+            }
+        },
+        "allowRoleAssignmentOnRG": {
+            "type": "string",
+            "defaultValue": "true",
+            "allowedValues": [
+                "true",
+                "false"
+            ],
+            "metadata": {
+                "description": "Unused for projects, but required due to interdependency of normal and project ARM templates."
+            }
+        },
+        
+        "systemDatastoresAuthMode": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "Unused for projects, but required due to interdependency of normal and project ARM templates"
             }
         }
     },

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_workspace_operations_base.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/operations/_workspace_operations_base.py
@@ -589,6 +589,14 @@ class WorkspaceOperationsBase(ABC):
                 param["applicationInsightsResourceGroupName"],
                 group_name,
             )
+        elif workspace._kind and workspace._kind.lower() in {WorkspaceKind.HUB, WorkspaceKind.PROJECT}:
+            _set_val(param["applicationInsightsOption"], "none")
+            # Set empty values because arm templates whine over unset values.
+            _set_val(param["applicationInsightsName"], "ignoredButCantBeEmpty")
+            _set_val(
+                param["applicationInsightsResourceGroupName"],
+                "ignoredButCantBeEmpty",
+            )
         else:
             log_analytics = _generate_log_analytics(workspace.name, resources_being_deployed)
             _set_val(param["logAnalyticsName"], log_analytics)

--- a/sdk/ml/azure-ai-ml/tests/workspace/e2etests/test_workspace.py
+++ b/sdk/ml/azure-ai-ml/tests/workspace/e2etests/test_workspace.py
@@ -125,6 +125,7 @@ class TestWorkspace(AzureRecordedTestCase):
         workspace = client.workspaces.get(wps_name)
         assert isinstance(workspace, Workspace)
         assert workspace.name == wps_name
+        assert workspace.application_insights is not None
 
         param_image_build_compute = "compute"
         param_display_name = "Test display name"


### PR DESCRIPTION
Workspace, project, and hub e2e creation tests no all show the expected application insights values when created (exists for normal workspaces, does not exist for the others).

Also fixes a bug where the project template was missing some recently-added workspace template parameters (since the templates require parameter parity for some reason, even though the project template doesn't use many of the params)

Project creation still seems broken due to backend issues (creation 'fails' but still succeeds at creating the resource when the backend is examined)