### PR TITLE
disable tests that require local auth

### DIFF
--- a/sdk/search/azure-search-documents/tests/async_tests/test_search_indexer_client_live_async.py
+++ b/sdk/search/azure-search-documents/tests/async_tests/test_search_indexer_client_live_async.py
@@ -21,6 +21,7 @@ from search_service_preparer import SearchEnvVarPreparer, search_decorator
 
 
 class TestSearchIndexerClientTestAsync(AzureRecordedTestCase):
+    @pytest.mark.skip("fails because connection string of storage is disabled")
     @SearchEnvVarPreparer()
     @search_decorator(schema="hotel_schema.json", index_batch="hotel_small.json")
     @recorded_by_proxy_async

--- a/sdk/search/azure-search-documents/tests/test_search_indexer_client_live.py
+++ b/sdk/search/azure-search-documents/tests/test_search_indexer_client_live.py
@@ -21,6 +21,7 @@ from search_service_preparer import SearchEnvVarPreparer, search_decorator
 
 
 class TestSearchIndexerClientTest(AzureRecordedTestCase):
+    @pytest.mark.skip("fails because connection string of storage is disabled")
     @SearchEnvVarPreparer()
     @search_decorator(schema="hotel_schema.json", index_batch="hotel_small.json")
     @recorded_by_proxy


### PR DESCRIPTION
Will re-enable them when we move to test tenant.