### PR TITLE
Address failing `main` -- trim some deps

### DIFF
--- a/eng/ci_tools.txt
+++ b/eng/ci_tools.txt
@@ -1,7 +1,7 @@
 # requirements leveraged by ci tools
 setuptools==67.6.0; python_version >= '3.5'
 virtualenv==20.24.3
-wheel==0.37.0
+wheel==0.43.0
 packaging==23.1
 tox==4.5.0
 pathlib2==2.3.5
@@ -9,8 +9,6 @@ doc-warden==0.7.2
 beautifulsoup4==4.9.1
 pkginfo==1.9.6
 pip==24.0
-wrapt==1.12.1; python_version <= '3.10'
-wrapt==1.15.0; python_version >= '3.11'
 typing-extensions<=4.6.3
 pyproject-api<1.6
 cibuildwheel==2.16.5
@@ -22,14 +20,12 @@ coverage==7.2.5
 
 # locking packages defined as deps from azure-sdk-tools
 Jinja2==3.1.2
-MarkupSafe==2.1.3
 json-delta==2.0
 readme_renderer==42.0;
-pyopenssl==24.0.0
-python-dotenv==1.0.0; python_version > '3.7'
+python-dotenv==1.0.1
 pyyaml==6.0.1
 urllib3==2.0.7
-ConfigArgParse==1.2.3
+ConfigArgParse==1.7
 six==1.16.0
 
 # local dev packages

--- a/eng/ci_tools.txt
+++ b/eng/ci_tools.txt
@@ -1,5 +1,5 @@
 # requirements leveraged by ci tools
-setuptools==67.6.0; python_version >= '3.5'
+setuptools==70.2.0; python_version >= '3.5'
 virtualenv==20.24.3
 wheel==0.43.0
 packaging==23.1
@@ -12,6 +12,7 @@ pip==24.0
 typing-extensions<=4.6.3
 pyproject-api<1.6
 cibuildwheel==2.16.5
+importlib-metadata==8.0.0
 
 # requirements leveraged for testing
 pytest==7.3.1

--- a/eng/ci_tools.txt
+++ b/eng/ci_tools.txt
@@ -25,7 +25,6 @@ readme_renderer==42.0;
 python-dotenv==1.0.1
 pyyaml==6.0.1
 urllib3==2.0.7
-ConfigArgParse==1.7
 six==1.16.0
 
 # local dev packages

--- a/eng/conda_test_requirements.txt
+++ b/eng/conda_test_requirements.txt
@@ -8,7 +8,7 @@ trio
 typing_extensions>=3.7.2
 cryptography
 adal
-setuptools==67.6.0; python_version >= '3.5'
+setuptools==70.2.0; python_version >= '3.5'
 pytest-asyncio==0.12.0
 -e sdk/core/azure-core/tests/testserver_tests/coretestserver
 azure-mgmt-storage

--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -40,7 +40,7 @@ steps:
       ServiceDirectory: ${{ parameters.ServiceDirectory }}
 
   - pwsh: |
-      Get-Command python
+      Write-Host (Get-Command python).Source
       $ErrorActionPreference = 'Stop'
       $PSNativeCommandUseErrorActionPreference = $true
       python -m pip freeze

--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -152,7 +152,7 @@ steps:
           Write-Host "Last exit code: $LASTEXITCODE";
           exit $LASTEXITCODE;
 
-  - ${{ else }}: 
+  - ${{ else }}:
     - task: PythonScript@0
       displayName: 'Test Samples'
       condition: and(succeeded(), eq(variables['TestSamples'], 'true'))

--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -40,6 +40,7 @@ steps:
       ServiceDirectory: ${{ parameters.ServiceDirectory }}
 
   - pwsh: |
+      Get-Command python
       $ErrorActionPreference = 'Stop'
       $PSNativeCommandUseErrorActionPreference = $true
       python -m pip freeze

--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -45,8 +45,8 @@ steps:
       $PSNativeCommandUseErrorActionPreference = $true
       python -m pip freeze
       python -m pip install pip==23.2.1
-      python -m pip install setuptools==67.6.0
-      python -m pip install wheel==0.37.0
+      python -m pip install wheel==0.43.0 --force
+      python -m pip install setuptools==67.6.0 --force
       python -m pip install -r eng/ci_tools.txt
       pip --version
       pip freeze

--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -45,8 +45,8 @@ steps:
       $PSNativeCommandUseErrorActionPreference = $true
       python -m pip freeze
       python -m pip install pip==23.2.1
-      python -m pip install wheel==0.43.0 --force
-      python -m pip install setuptools==67.6.0 --force
+      python -m pip install wheel==0.43.0 --force-reinstall
+      python -m pip install setuptools==70.2.0 --force-reinstall
       python -m pip install -r eng/ci_tools.txt
       pip --version
       pip freeze

--- a/eng/regression_test_tools.txt
+++ b/eng/regression_test_tools.txt
@@ -17,14 +17,11 @@ typing-extensions<=4.6.3
 pytoml==0.1.21
 readme-renderer[md]==25.0
 json-delta==2.0
-ConfigArgParse==1.2.3
+ConfigArgParse==1.7
 six==1.14.0
 pyyaml==5.4.1
 packaging==23.1
 Jinja2==3.1.2
-MarkupSafe==2.1.3
-wrapt==1.12.1; python_version <= '3.10'
-wrapt==1.14.1; python_version >= '3.11'
 
 # Locking pylint and required packages
 pylint==1.8.4; python_version < '3.4'

--- a/eng/regression_tools.txt
+++ b/eng/regression_tools.txt
@@ -1,5 +1,5 @@
 # requirements leveraged by ci tools
-setuptools==67.6.0; python_version >= '3.5'
+setuptools==70.2.0; python_version >= '3.5'
 virtualenv==20.23.0
 wheel==0.43.0
 Jinja2==3.1.2

--- a/eng/regression_tools.txt
+++ b/eng/regression_tools.txt
@@ -1,7 +1,7 @@
 # requirements leveraged by ci tools
 setuptools==67.6.0; python_version >= '3.5'
 virtualenv==20.23.0
-wheel==0.37.0
+wheel==0.43.0
 Jinja2==3.1.2
 packaging==23.1
 tox==4.5.0
@@ -10,15 +10,12 @@ doc-warden==0.7.2
 beautifulsoup4==4.9.1
 pkginfo==1.5.0.1
 pip==20.3.3
-wrapt==1.12.1; python_version <= '3.10'
-wrapt==1.14.1; python_version >= '3.11'
-MarkupSafe==2.1.3
 typing-extensions<=4.6.3
 
 # locking packages defined as deps from azure-sdk-tools
 pytoml==0.1.21
 json-delta==2.0
-ConfigArgParse==1.2.3
+ConfigArgParse==1.7
 six==1.14.0
 pyyaml==5.4.1
 pytest==7.3.1

--- a/eng/test_tools.txt
+++ b/eng/test_tools.txt
@@ -16,5 +16,4 @@ readme_renderer==42.0;
 python-dotenv==1.0.1
 pyyaml==6.0.1
 urllib3==2.0.7
-ConfigArgParse==1.7
 six==1.16.0

--- a/eng/test_tools.txt
+++ b/eng/test_tools.txt
@@ -11,12 +11,10 @@ pyproject-api<1.6
 
 # locking packages defined as deps from azure-sdk-tools
 Jinja2==3.1.2
-MarkupSafe==2.1.3
 json-delta==2.0
 readme_renderer==42.0;
-pyopenssl==24.0.0
-python-dotenv==1.0.0; python_version > '3.7'
+python-dotenv==1.0.1
 pyyaml==6.0.1
 urllib3==2.0.7
-ConfigArgParse==1.2.3
+ConfigArgParse==1.7
 six==1.16.0

--- a/eng/tox/tox.ini
+++ b/eng/tox/tox.ini
@@ -41,7 +41,7 @@ deps =
 
 [packaging]
 pkgs =
-    wheel==0.40.0
+    wheel==0.43.0
     packaging==23.1
     urllib3==1.26.15
     tomli==2.0.1

--- a/scripts/devops_tasks/dispatch_tox.py
+++ b/scripts/devops_tasks/dispatch_tox.py
@@ -11,6 +11,7 @@
 
 import argparse
 import os
+import sys
 import logging
 from tox_harness import prep_and_run_tox
 from ci_tools.functions import discover_targeted_packages
@@ -135,4 +136,5 @@ In the case of an environment invoking `pytest`, results can be collected in a j
         logging.info("No packages collected. Exit 0.")
         exit(0)
 
+    logging.info(f"Executing prep_and_run_tox with the executable {sys.executable}.")
     prep_and_run_tox(targeted_packages, args)

--- a/scripts/devops_tasks/tox_harness.py
+++ b/scripts/devops_tasks/tox_harness.py
@@ -257,7 +257,7 @@ def prep_and_run_tox(targeted_packages: List[str], parsed_args: Namespace) -> No
         destination_tox_ini = os.path.join(package_dir, "tox.ini")
         destination_dev_req = os.path.join(package_dir, "dev_requirements.txt")
 
-        tox_execution_array = [sys.executable, "-m", "tox"]
+        tox_execution_array = [sys.executable, "-m", "tox", "-vv"]
 
         if parsed_args.tenvparallel:
             tox_execution_array.extend(["run-parallel", "-p", "all"])

--- a/scripts/devops_tasks/tox_harness.py
+++ b/scripts/devops_tasks/tox_harness.py
@@ -257,7 +257,7 @@ def prep_and_run_tox(targeted_packages: List[str], parsed_args: Namespace) -> No
         destination_tox_ini = os.path.join(package_dir, "tox.ini")
         destination_dev_req = os.path.join(package_dir, "dev_requirements.txt")
 
-        tox_execution_array = [sys.executable, "-m", "tox", "-vv"]
+        tox_execution_array = [sys.executable, "-m", "tox"]
 
         if parsed_args.tenvparallel:
             tox_execution_array.extend(["run-parallel", "-p", "all"])

--- a/sdk/core/azure-core/tests/conftest.py
+++ b/sdk/core/azure-core/tests/conftest.py
@@ -78,18 +78,16 @@ def start_testserver():
         os.environ["LANG"] = "C.UTF-8"
     cmd = "flask run -p {}".format(port)
     if os.name == "nt":  # On windows, subprocess creation works without being in the shell
-        child_process = subprocess.Popen(cmd, env=dict(os.environ), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        child_process = subprocess.Popen(cmd, env=dict(os.environ))
     else:
         # On linux, have to set shell=True
-        child_process = subprocess.Popen(cmd, shell=True, preexec_fn=os.setsid, env=dict(os.environ), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        child_process = subprocess.Popen(cmd, shell=True, preexec_fn=os.setsid, env=dict(os.environ))
     count = 5
     for _ in range(count):
         if not is_port_available(port):
             return child_process
         time.sleep(1)
-    stdout, stderr = child_process.communicate()
-    raise ValueError(f"Didn't start! Stdout: {stdout.decode()} Stderr: {stderr.decode()}")
-
+    raise ValueError(f"Didn't start!")
 
 def terminate_testserver(process):
     if os.name == "nt":

--- a/sdk/core/azure-core/tests/conftest.py
+++ b/sdk/core/azure-core/tests/conftest.py
@@ -78,16 +78,17 @@ def start_testserver():
         os.environ["LANG"] = "C.UTF-8"
     cmd = "flask run -p {}".format(port)
     if os.name == "nt":  # On windows, subprocess creation works without being in the shell
-        child_process = subprocess.Popen(cmd, env=dict(os.environ))
+        child_process = subprocess.Popen(cmd, env=dict(os.environ), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     else:
         # On linux, have to set shell=True
-        child_process = subprocess.Popen(cmd, shell=True, preexec_fn=os.setsid, env=dict(os.environ))
+        child_process = subprocess.Popen(cmd, shell=True, preexec_fn=os.setsid, env=dict(os.environ), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     count = 5
     for _ in range(count):
         if not is_port_available(port):
             return child_process
         time.sleep(1)
-    raise ValueError("Didn't start!")
+    stdout, stderr = child_process.communicate()
+    raise ValueError(f"Didn't start! Stdout: {stdout.decode()} Stderr: {stderr.decode()}")
 
 
 def terminate_testserver(process):

--- a/sdk/core/azure-core/tests/conftest.py
+++ b/sdk/core/azure-core/tests/conftest.py
@@ -89,6 +89,7 @@ def start_testserver():
         time.sleep(1)
     raise ValueError(f"Didn't start!")
 
+
 def terminate_testserver(process):
     if os.name == "nt":
         process.kill()

--- a/sdk/keyvault/azure-keyvault-certificates/dev_requirements.txt
+++ b/sdk/keyvault/azure-keyvault-certificates/dev_requirements.txt
@@ -5,3 +5,4 @@
 aiohttp>=3.0
 parameterized>=0.7.3
 python-dateutil>=2.8.0
+pyopenssl

--- a/shared_requirements.txt
+++ b/shared_requirements.txt
@@ -67,4 +67,3 @@ uamqp
 yarl
 azure-identity
 openai
-wrapt

--- a/tools/azure-sdk-tools/setup.py
+++ b/tools/azure-sdk-tools/setup.py
@@ -9,13 +9,10 @@ DEPENDENCIES = [
     "packaging",
     "wheel",
     "Jinja2",
-    "MarkupSafe",
     "json-delta>=2.0",
     # Tests
     "pytest-cov",
     "pytest>=3.5.1",
-    "readme_renderer",
-    "pyopenssl",
     "python-dotenv",
     "PyYAML",
     "urllib3",


### PR DESCRIPTION
- [x] Address failing main by trimming some additional dependencies
- [x] Add outputs to start_server in core testserver so we can see what went wrong when it fails to start

I'm quite unhappy that the venv prepend methodology isn't working as well as I'd hope on all python versions. Just seein some weirdness. Continuing to dig.