### PR TITLE
bump autorest.python 6.15.0

### DIFF
--- a/swagger_to_sdk_config_autorest.json
+++ b/swagger_to_sdk_config_autorest.json
@@ -2,12 +2,13 @@
   "meta": {
     "autorest_options": {
       "version": "3.10.2",
-      "use": ["@autorest/python@6.14.3", "@autorest/modelerfour@4.27.0"],
+      "use": ["@autorest/python@6.15.0", "@autorest/modelerfour@4.27.0"],
       "python": "",
       "sdkrel:python-sdks-folder": "./sdk/.",
       "version-tolerant": false,
       "include-x-ms-examples-original-file": true,
-      "generate-sample": true
+      "generate-sample": true,
+      "generate-test": true
     },
     "advanced_options": {
       "create_sdk_pull_requests": true,


### PR DESCRIPTION
6.15.0 add new support `--generate-test` to support test generation, so merged together with https://github.com/Azure/azure-sdk-for-python/pull/36349