### PR TITLE
[SDK generation pipeline] Fix ApiView

### DIFF
--- a/tools/azure-sdk-tools/packaging_tools/sdk_package.py
+++ b/tools/azure-sdk-tools/packaging_tools/sdk_package.py
@@ -52,7 +52,7 @@ def main(generate_input, generate_output):
                             "/simple/"], cwd=package_path, timeout=300)
                 check_call(["apistubgen", "--pkg-path", "."], cwd=package_path, timeout=600)
                 for file in os.listdir(package_path):
-                    if "_python.json" in file:
+                    if "_python.json" in file and package_name in file:
                         package["apiViewArtifact"] = str(Path(package_path, file))
             except Exception as e:
                 _LOGGER.error(f"Fail to generate ApiView token file for {package_name}: {e}")


### PR DESCRIPTION
fixes https://github.com/Azure/azure-sdk-tools/issues/8560
typespec-python generates `apiview_mapping_python.json` which has similar name with apiview artifacts file so we need to update logic to get right apiview artifact file.
![image](https://github.com/Azure/azure-sdk-for-python/assets/70930885/5d4a6cbd-e28e-4242-b08f-e876559d4310)
