### PR TITLE
Repair Aggregate Reports / `analyze` job

### DIFF
--- a/eng/pipelines/aggregate-reports.yml
+++ b/eng/pipelines/aggregate-reports.yml
@@ -77,33 +77,9 @@ stages:
             parameters:
               BaselineFilePath: $(Build.SourcesDirectory)\eng\python.gdnbaselines
 
-          - pwsh: |
-              azcopy copy "https://azuresdkartifacts.blob.core.windows.net/policheck/PythonPoliCheckExclusion.mdb?$(azuresdk-policheck-blob-SAS)" `
-              "$(Build.BinariesDirectory)"
-            displayName: 'Download PoliCheck Exclusion Database'
-            condition: succeededOrFailed()
-
-          - task: securedevelopmentteam.vss-secure-development-tools.build-task-policheck.PoliCheck@2
-            displayName: 'Run PoliCheck'
-            inputs:
-              targetType: F
-              targetArgument: '$(Build.SourcesDirectory)'
-              result: PoliCheck.sarif
-              optionsFC: 0
-              optionsXS: 1
-              optionsPE: 1|2|3|4
-              optionsRulesDBPath: "$(Build.BinariesDirectory)/PythonPoliCheckExclusion.mdb"
-              optionsUEPATH: "$(Build.SourcesDirectory)/eng/guardian-tools/policheck/PolicheckExclusions.xml"
-            condition: succeededOrFailed()
-
-          - task: securedevelopmentteam.vss-secure-development-tools.build-task-postanalysis.PostAnalysis@2
-            displayName: 'Post Analysis (PoliCheck)'
-            inputs:
-              GdnBreakAllTools: false
-              GdnBreakGdnToolPoliCheck: true
-              GdnBreakGdnToolPoliCheckSeverity: Warning
-            condition: succeededOrFailed()
-            continueOnError: true
+          - template: /eng/common/pipelines/templates/steps/policheck.yml
+            parameters:
+              PublishAnalysisLogs: false
 
           - task: securedevelopmentteam.vss-secure-development-tools.build-task-publishsecurityanalysislogs.PublishSecurityAnalysisLogs@3
             displayName: 'Publish Security Analysis Logs'

--- a/eng/pipelines/aggregate-reports.yml
+++ b/eng/pipelines/aggregate-reports.yml
@@ -80,6 +80,7 @@ stages:
           - template: /eng/common/pipelines/templates/steps/policheck.yml
             parameters:
               PublishAnalysisLogs: false
+              ExclusionDataBaseFileName: PythonPoliCheckExclusion.mdb
 
           - task: securedevelopmentteam.vss-secure-development-tools.build-task-publishsecurityanalysislogs.PublishSecurityAnalysisLogs@3
             displayName: 'Publish Security Analysis Logs'

--- a/eng/pipelines/aggregate-reports.yml
+++ b/eng/pipelines/aggregate-reports.yml
@@ -80,7 +80,7 @@ stages:
           - template: /eng/common/pipelines/templates/steps/policheck.yml
             parameters:
               PublishAnalysisLogs: false
-              ExclusionDataBaseFileName: PythonPoliCheckExclusion.mdb
+              ExclusionDataBaseFileName: PythonPoliCheckExclusion
 
           - task: securedevelopmentteam.vss-secure-development-tools.build-task-publishsecurityanalysislogs.PublishSecurityAnalysisLogs@3
             displayName: 'Publish Security Analysis Logs'

--- a/eng/pipelines/templates/steps/analyze_dependency.yml
+++ b/eng/pipelines/templates/steps/analyze_dependency.yml
@@ -19,12 +19,6 @@ steps:
       ScanPath: ${{ parameters.ScanPath }}
 
   - pwsh: |
-      mkdir "$(Build.ArtifactStagingDirectory)/reports"
-      Copy-Item -Path "$(Build.SourcesDirectory)/eng/common/InterdependencyGraph.html" -Destination "$(Build.ArtifactStagingDirectory)/reports/InterdependencyGraph.html"
-    displayName: 'Populate Reports Staging Folder'
-    condition: and(succeededOrFailed(),ne(variables['Skip.AnalyzeDependencies'],'true'))
-
-  - pwsh: |
       sdk_analyze_deps --verbose --out "$(Build.ArtifactStagingDirectory)/reports/dependencies.html" --dump "$(Build.ArtifactStagingDirectory)/reports"
     displayName: 'Analyze dependencies'
     condition: and(succeededOrFailed(),ne(variables['Skip.AnalyzeDependencies'],'true'))

--- a/tools/azure-sdk-tools/ci_tools/dependency_analysis.py
+++ b/tools/azure-sdk-tools/ci_tools/dependency_analysis.py
@@ -11,7 +11,10 @@ import re
 import sys
 import textwrap
 from typing import List, Set, Dict, Tuple, Any
-from collections import Sized
+try:
+    from collections import Sized
+except:
+    from collections.abc import Sized
 
 from pkg_resources import Requirement
 from packaging.specifiers import SpecifierSet, Version
@@ -312,6 +315,10 @@ def analyze_dependencies() -> None:
 
     if args.out:
         external = [k for k in dependencies if k not in packages and not k.startswith("azure")]
+
+        complete_dir = os.path.abspath(args.out)
+        report_dir = os.path.dirname(complete_dir)
+        os.makedirs(report_dir, exist_ok=True)
 
         def display_order(k):
             if k in incompatible:


### PR DESCRIPTION
- [x] Use eng/common version of policheck.
- [x] Repair analyze_dependencies upload 
- [x] Remove reference to nonexistent file blocking `analyze`

Due to a `code 128` error on checkout of the [sync-eng](https://github.com/Azure/azure-sdk-for-python/pull/36344) PR, we couldn't see the analyze error. This PR removes the ref, so it should be g2g.