### PR TITLE
Fix tagging via patch of generated source distribution file name

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -198,6 +198,7 @@
     "contosodataset",
     "centralus",
     "centraluseuap",
+    "corehttp",
     "creds",
     "ctoring",
     "ctxt",

--- a/eng/pipelines/templates/steps/build-package-artifacts.yml
+++ b/eng/pipelines/templates/steps/build-package-artifacts.yml
@@ -57,7 +57,7 @@ steps:
 
   - pwsh: |
       which python
-      python -m pip install --force -r eng\ci_tools.txt
+      python -m pip install --force -r eng/ci_tools.txt
       python -m pip freeze --all
     displayName: 'Prep Environment'
 

--- a/eng/tox/tox_helper_tasks.py
+++ b/eng/tox/tox_helper_tasks.py
@@ -28,19 +28,26 @@ def unzip_sdist_to_directory(containing_folder: str) -> str:
         tars = glob.glob(os.path.join(containing_folder, "*.tar.gz"))
         return unzip_file_to_directory(tars[0], containing_folder)
 
-
 def unzip_file_to_directory(path_to_zip_file: str, extract_location: str) -> str:
     if path_to_zip_file.endswith(".zip"):
         with zipfile.ZipFile(path_to_zip_file, "r") as zip_ref:
             zip_ref.extractall(extract_location)
             extracted_dir = os.path.basename(os.path.splitext(path_to_zip_file)[0])
             return os.path.join(extract_location, extracted_dir)
-    else:
-        with tarfile.open(path_to_zip_file) as tar_ref:
+    elif path_to_zip_file.endswith(".tar.gz") or path_to_zip_file.endswith(".tgz"):
+        with tarfile.open(path_to_zip_file, "r:gz") as tar_ref:
             tar_ref.extractall(extract_location)
-            extracted_dir = os.path.basename(path_to_zip_file).replace(".tar.gz", "")
-            return os.path.join(extract_location, extracted_dir)
-
+            top_level_dir = None
+            for member in tar_ref.getmembers():
+                if member.isdir():
+                    top_level_dir = member.name.split('/')[0]
+                    break
+            if top_level_dir:
+                return os.path.join(extract_location, top_level_dir)
+            else:
+                raise ValueError("Failed to determine the top-level directory in the tar.gz archive")
+    else:
+        raise ValueError("Unsupported file format")
 
 def move_and_rename(source_location):
     new_location = os.path.join(os.path.dirname(source_location), "unzipped")

--- a/tools/azure-sdk-tools/ci_tools/build.py
+++ b/tools/azure-sdk-tools/ci_tools/build.py
@@ -194,15 +194,16 @@ def create_package(
         # formatting a whl distributions. This patch avoids that for now.
         normalized_package_name = setup_parsed.name.replace("-", "_")
         generated_sdist_name = os.path.join(dist, f"{normalized_package_name}-{setup_parsed.version}.tar.gz")
+        destination = generated_sdist_name.replace(normalized_package_name, setup_parsed.name)
 
-        if os.path.exists(generated_sdist_name):
-            source = generated_sdist_name
-            destination = source.replace(normalized_package_name, setup_parsed.name)
+        # in cases where there is no reformatting necessary (sdk/core/corehttpp is a good example)
+        # skip this effort
+        if generated_sdist_name != destination:
+            if os.path.exists(generated_sdist_name):
+                if os.path.exists(destination):
+                    os.remove(destination)
 
-            if os.path.exists(destination):
-                os.remove(destination)
-
-            os.rename(source, destination)
-        else:
-            logger.log(level=logging.ERROR, msg=f"Unable to find a source distribution for {setup_parsed.name} that could be renamed without normalization.")
+                os.rename(generated_sdist_name, destination)
+            else:
+                logger.log(level=logging.ERROR, msg=f"Unable to find a source distribution for {setup_parsed.name} that could be renamed without normalization.")
 

--- a/tools/azure-sdk-tools/ci_tools/build.py
+++ b/tools/azure-sdk-tools/ci_tools/build.py
@@ -193,13 +193,16 @@ def create_package(
         # The file normalization changes in setuptools 67.3.0 intends source distribution file names to have the
         # formatting a whl distributions. This patch avoids that for now.
         normalized_package_name = setup_parsed.name.replace("-", "_")
-        package_for_adjustments = [f for f in os.listdir(dist) if normalized_package_name in f and f.endswith("tar.gz")]
+        generated_sdist_name = os.path.join(dist, f"{normalized_package_name}-{setup_parsed.version}.tar.gz")
 
-        if package_for_adjustments:
-            source = os.path.join(dist, package_for_adjustments[0])
+        if os.path.exists(generated_sdist_name):
+            source = generated_sdist_name
             destination = source.replace(normalized_package_name, setup_parsed.name)
+
+            if os.path.exists(destination):
+                os.remove(destination)
 
             os.rename(source, destination)
         else:
-            logger.log(level=logging.ERROR, msg=f"Unable to find a source distribution for {setup_parsed.name} that could be renamed to un-normalized title.")
+            logger.log(level=logging.ERROR, msg=f"Unable to find a source distribution for {setup_parsed.name} that could be renamed without normalization.")
 

--- a/tools/azure-sdk-tools/ci_tools/build.py
+++ b/tools/azure-sdk-tools/ci_tools/build.py
@@ -196,7 +196,7 @@ def create_package(
         generated_sdist_name = os.path.join(dist, f"{normalized_package_name}-{setup_parsed.version}.tar.gz")
         destination = generated_sdist_name.replace(normalized_package_name, setup_parsed.name)
 
-        # in cases where there is no reformatting necessary (sdk/core/corehttpp is a good example)
+        # in cases where there is no reformatting necessary (sdk/core/corehttp is a good example)
         # skip this effort
         if generated_sdist_name != destination:
             if os.path.exists(generated_sdist_name):

--- a/tools/azure-sdk-tools/ci_tools/build.py
+++ b/tools/azure-sdk-tools/ci_tools/build.py
@@ -189,3 +189,17 @@ def create_package(
 
     if enable_sdist:
         run([sys.executable, "setup.py", "sdist", "-d", dist], cwd=setup_parsed.folder, check=True)
+
+        # The file normalization changes in setuptools 67.3.0 intends source distribution file names to have the
+        # formatting a whl distributions. This patch avoids that for now.
+        normalized_package_name = setup_parsed.name.replace("-", "_")
+        package_for_adjustments = [f for f in os.listdir(dist) if normalized_package_name in f and f.endswith("tar.gz")]
+
+        if package_for_adjustments:
+            source = os.path.join(dist, package_for_adjustments[0])
+            destination = source.replace(normalized_package_name, setup_parsed.name)
+
+            os.rename(source, destination)
+        else:
+            logger.log(level=logging.ERROR, msg=f"Unable to find a source distribution for {setup_parsed.name} that could be renamed to un-normalized title.")
+


### PR DESCRIPTION
[Test Release](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3942235&view=results)

Addressing #35204 in a more permanent fashion.

FYI @weshaggard  as discussed offline.