### PR TITLE
Using federated auth for ACS tests

### DIFF
--- a/sdk/communication/azure-communication-chat/tests.yml
+++ b/sdk/communication/azure-communication-chat/tests.yml
@@ -8,10 +8,13 @@ extends:
       ServiceDirectory: communication
       MatrixReplace:
         - TestSamples=.*/true
+      UseFederatedAuth: true
       CloudConfig:
         Public:
+          ServiceConnection: azure-sdk-tests
+          SubscriptionConfigurationFilePaths:
+            - eng/common/TestResources/sub-config/AzurePublicMsft.json
           SubscriptionConfigurations:
-            - $(sub-config-azure-cloud-test-resources)
             - $(sub-config-communication-services-cloud-test-resources-common)
             - $(sub-config-communication-services-cloud-test-resources-python)
         Int:

--- a/sdk/communication/azure-communication-chat/tests.yml
+++ b/sdk/communication/azure-communication-chat/tests.yml
@@ -17,10 +17,6 @@ extends:
           SubscriptionConfigurations:
             - $(sub-config-communication-services-cloud-test-resources-common)
             - $(sub-config-communication-services-cloud-test-resources-python)
-        Int:
-            SubscriptionConfigurations:
-              - $(sub-config-communication-int-test-resources-common)
-              - $(sub-config-communication-int-test-resources-python)
-      Clouds: Public,Int
+      Clouds: Public
       TestResourceDirectories:
         - communication/test-resources/

--- a/sdk/communication/azure-communication-chat/tests/_shared/utils.py
+++ b/sdk/communication/azure-communication-chat/tests/_shared/utils.py
@@ -9,32 +9,31 @@ from typing import (  # pylint: disable=unused-import
     Tuple,
 )
 from azure.core.pipeline.policies import HttpLoggingPolicy, HeadersPolicy
+from devtools_testutils import is_live, get_credential
 
 
 def create_token_credential():
-    # type: () -> FakeTokenCredential or DefaultAzureCredential
+    # type: () -> FakeTokenCredential or get_credential
     from devtools_testutils import is_live
 
     if not is_live():
         from .fake_token_credential import FakeTokenCredential
 
         return FakeTokenCredential()
-    from azure.identity import DefaultAzureCredential
-
-    return DefaultAzureCredential()
+    
+    return get_credential()
 
 
 def async_create_token_credential():
-    # type: () -> AsyncFakeTokenCredential or DefaultAzureCredential
+    # type: () -> AsyncFakeTokenCredential or get_credential
     from devtools_testutils import is_live
 
     if not is_live():
         from .async_fake_token_credential import AsyncFakeTokenCredential
 
         return AsyncFakeTokenCredential()
-    from azure.identity.aio import DefaultAzureCredential
-
-    return DefaultAzureCredential()
+    
+    return get_credential(is_async=True)
 
 
 def get_http_logging_policy(**kwargs):

--- a/sdk/communication/azure-communication-identity/samples/identity_samples.py
+++ b/sdk/communication/azure-communication-identity/samples/identity_samples.py
@@ -28,6 +28,7 @@ from datetime import timedelta
 import os
 from azure.communication.identity._shared.utils import parse_connection_str
 from msal import PublicClientApplication
+from devtools_testutils import get_credential
 
 
 class CommunicationIdentityClientSamples(object):
@@ -53,11 +54,10 @@ class CommunicationIdentityClientSamples(object):
             and self.client_secret is not None
             and self.tenant_id is not None
         ):
-            from azure.identity import DefaultAzureCredential
-
+            
             endpoint, _ = parse_connection_str(self.connection_string)
             identity_client = CommunicationIdentityClient(
-                endpoint, DefaultAzureCredential()
+                endpoint, get_credential()
             )
         else:
             identity_client = CommunicationIdentityClient.from_connection_string(
@@ -81,11 +81,10 @@ class CommunicationIdentityClientSamples(object):
             and self.client_secret is not None
             and self.tenant_id is not None
         ):
-            from azure.identity import DefaultAzureCredential
-
+          
             endpoint, _ = parse_connection_str(self.connection_string)
             identity_client = CommunicationIdentityClient(
-                endpoint, DefaultAzureCredential()
+                endpoint, get_credential()
             )
         else:
             identity_client = CommunicationIdentityClient.from_connection_string(
@@ -112,11 +111,10 @@ class CommunicationIdentityClientSamples(object):
             and self.client_secret is not None
             and self.tenant_id is not None
         ):
-            from azure.identity import DefaultAzureCredential
-
+          
             endpoint, _ = parse_connection_str(self.connection_string)
             identity_client = CommunicationIdentityClient(
-                endpoint, DefaultAzureCredential()
+                endpoint, get_credential()
             )
         else:
             identity_client = CommunicationIdentityClient.from_connection_string(
@@ -138,11 +136,10 @@ class CommunicationIdentityClientSamples(object):
             and self.client_secret is not None
             and self.tenant_id is not None
         ):
-            from azure.identity import DefaultAzureCredential
-
+            
             endpoint, _ = parse_connection_str(self.connection_string)
             identity_client = CommunicationIdentityClient(
-                endpoint, DefaultAzureCredential()
+                endpoint, get_credential()
             )
         else:
             identity_client = CommunicationIdentityClient.from_connection_string(
@@ -163,11 +160,10 @@ class CommunicationIdentityClientSamples(object):
             and self.client_secret is not None
             and self.tenant_id is not None
         ):
-            from azure.identity import DefaultAzureCredential
-
+            
             endpoint, _ = parse_connection_str(self.connection_string)
             identity_client = CommunicationIdentityClient(
-                endpoint, DefaultAzureCredential()
+                endpoint, get_credential()
             )
         else:
             identity_client = CommunicationIdentityClient.from_connection_string(
@@ -191,11 +187,10 @@ class CommunicationIdentityClientSamples(object):
             and self.client_secret is not None
             and self.tenant_id is not None
         ):
-            from azure.identity import DefaultAzureCredential
-
+            
             endpoint, _ = parse_connection_str(self.connection_string)
             identity_client = CommunicationIdentityClient(
-                endpoint, DefaultAzureCredential()
+                endpoint, get_credential()
             )
         else:
             identity_client = CommunicationIdentityClient.from_connection_string(
@@ -217,11 +212,10 @@ class CommunicationIdentityClientSamples(object):
             and self.client_secret is not None
             and self.tenant_id is not None
         ):
-            from azure.identity import DefaultAzureCredential
-
+           
             endpoint, _ = parse_connection_str(self.connection_string)
             identity_client = CommunicationIdentityClient(
-                endpoint, DefaultAzureCredential()
+                endpoint, get_credential()
             )
         else:
             identity_client = CommunicationIdentityClient.from_connection_string(
@@ -243,11 +237,10 @@ class CommunicationIdentityClientSamples(object):
             and self.client_secret is not None
             and self.tenant_id is not None
         ):
-            from azure.identity import DefaultAzureCredential
-
+         
             endpoint, _ = parse_connection_str(self.connection_string)
             identity_client = CommunicationIdentityClient(
-                endpoint, DefaultAzureCredential()
+                endpoint, get_credential()
             )
         else:
             identity_client = CommunicationIdentityClient.from_connection_string(

--- a/sdk/communication/azure-communication-identity/tests.yml
+++ b/sdk/communication/azure-communication-identity/tests.yml
@@ -17,15 +17,7 @@ extends:
           SubscriptionConfigurations:
             - $(sub-config-communication-services-cloud-test-resources-common)
             - $(sub-config-communication-services-cloud-test-resources-python)
-        PPE:
-            SubscriptionConfigurations:
-              - $(sub-config-communication-ppe-test-resources-common)
-              - $(sub-config-communication-ppe-test-resources-python)
-        Int:
-          SubscriptionConfigurations:
-            - $(sub-config-communication-int-test-resources-common)
-            - $(sub-config-communication-int-test-resources-python)
-      Clouds: Public,PPE,Int
+      Clouds: Public
       EnvVars:
         AZURE_SKIP_LIVE_RECORDING: 'True'
         AZURE_TEST_RUN_LIVE: 'true'

--- a/sdk/communication/azure-communication-identity/tests.yml
+++ b/sdk/communication/azure-communication-identity/tests.yml
@@ -8,10 +8,13 @@ extends:
       ServiceDirectory: communication
       MatrixReplace:
         - TestSamples=.*/true
+      UseFederatedAuth: true
       CloudConfig:
         Public:
+          ServiceConnection: azure-sdk-tests
+          SubscriptionConfigurationFilePaths:
+            - eng/common/TestResources/sub-config/AzurePublicMsft.json
           SubscriptionConfigurations:
-            - $(sub-config-azure-cloud-test-resources)
             - $(sub-config-communication-services-cloud-test-resources-common)
             - $(sub-config-communication-services-cloud-test-resources-python)
         PPE:

--- a/sdk/communication/azure-communication-identity/tests/_shared/utils.py
+++ b/sdk/communication/azure-communication-identity/tests/_shared/utils.py
@@ -9,32 +9,31 @@ from typing import (  # pylint: disable=unused-import
     Tuple,
 )
 from azure.core.pipeline.policies import HttpLoggingPolicy, HeadersPolicy
+from devtools_testutils import is_live, get_credential
 
 
 def create_token_credential():
-    # type: () -> FakeTokenCredential or DefaultAzureCredential
+    # type: () -> FakeTokenCredential or get_credential
     from devtools_testutils import is_live
 
     if not is_live():
         from .fake_token_credential import FakeTokenCredential
 
         return FakeTokenCredential()
-    from azure.identity import DefaultAzureCredential
-
-    return DefaultAzureCredential()
+    
+    return get_credential()
 
 
 def async_create_token_credential():
-    # type: () -> AsyncFakeTokenCredential or DefaultAzureCredential
+    # type: () -> AsyncFakeTokenCredential or get_credential
     from devtools_testutils import is_live
 
     if not is_live():
         from .async_fake_token_credential import AsyncFakeTokenCredential
 
         return AsyncFakeTokenCredential()
-    from azure.identity.aio import DefaultAzureCredential
-
-    return DefaultAzureCredential()
+    
+    return get_credential(is_async=True)
 
 
 def get_http_logging_policy(**kwargs):

--- a/sdk/communication/azure-communication-identity/tests/test_communication_identity_client.py
+++ b/sdk/communication/azure-communication-identity/tests/test_communication_identity_client.py
@@ -7,12 +7,11 @@
 import pytest
 from datetime import timedelta
 from azure.communication.identity import CommunicationTokenScope
-from devtools_testutils import is_live, recorded_by_proxy
+from devtools_testutils import is_live, recorded_by_proxy, get_credential
 from utils import is_token_expiration_within_allowed_deviation, token_scope_scenarios
 from acs_identity_test_case import ACSIdentityTestCase
 from azure.communication.identity import CommunicationIdentityClient
 from devtools_testutils.fake_credentials import FakeTokenCredential
-from azure.identity import DefaultAzureCredential
 from _shared.utils import get_http_logging_policy
 
 
@@ -37,7 +36,7 @@ class TestClient(ACSIdentityTestCase):
         if not is_live():
             credential = FakeTokenCredential()
         else:
-            credential = DefaultAzureCredential()
+            credential = get_credential()
         return CommunicationIdentityClient(
             self.endpoint, credential, http_logging_policy=get_http_logging_policy()
         )

--- a/sdk/communication/azure-communication-identity/tests/test_communication_identity_client_async.py
+++ b/sdk/communication/azure-communication-identity/tests/test_communication_identity_client_async.py
@@ -7,14 +7,13 @@
 import pytest
 from datetime import timedelta
 from azure.communication.identity import CommunicationTokenScope
-from devtools_testutils import is_live
+from devtools_testutils import is_live, get_credential
 from devtools_testutils.aio import recorded_by_proxy_async
 from test_communication_identity_client import ArgumentPasser
 from utils import is_token_expiration_within_allowed_deviation, token_scope_scenarios
 from acs_identity_test_case import ACSIdentityTestCase
 from azure.communication.identity.aio import CommunicationIdentityClient
 from devtools_testutils.fake_credentials_async import AsyncFakeCredential
-from azure.identity.aio import DefaultAzureCredential
 from _shared.utils import get_http_logging_policy
 
 
@@ -32,7 +31,7 @@ class TestClientAsync(ACSIdentityTestCase):
         if not is_live():
             credential = AsyncFakeCredential()
         else:
-            credential = DefaultAzureCredential()
+            credential = get_credential(is_async=True)
         return CommunicationIdentityClient(
             self.endpoint, credential, http_logging_policy=get_http_logging_policy()
         )

--- a/sdk/communication/azure-communication-jobrouter/tests/_shared/utils.py
+++ b/sdk/communication/azure-communication-jobrouter/tests/_shared/utils.py
@@ -9,32 +9,31 @@ from typing import (  # pylint: disable=unused-import
     Tuple,
 )
 from azure.core.pipeline.policies import HttpLoggingPolicy, HeadersPolicy
+from devtools_testutils import is_live, get_credential
 
 
 def create_token_credential():
-    # type: () -> FakeTokenCredential or DefaultAzureCredential
+    # type: () -> FakeTokenCredential or get_credential
     from devtools_testutils import is_live
 
     if not is_live():
         from .fake_token_credential import FakeTokenCredential
 
         return FakeTokenCredential()
-    from azure.identity import DefaultAzureCredential
-
-    return DefaultAzureCredential()
+    
+    return get_credential()
 
 
 def async_create_token_credential():
-    # type: () -> AsyncFakeTokenCredential or DefaultAzureCredential
+    # type: () -> AsyncFakeTokenCredential or get_credential
     from devtools_testutils import is_live
 
     if not is_live():
         from .async_fake_token_credential import AsyncFakeTokenCredential
 
         return AsyncFakeTokenCredential()
-    from azure.identity.aio import DefaultAzureCredential
-
-    return DefaultAzureCredential()
+    
+    return get_credential(is_async=True)
 
 
 def get_http_logging_policy(**kwargs):

--- a/sdk/communication/azure-communication-rooms/tests.yml
+++ b/sdk/communication/azure-communication-rooms/tests.yml
@@ -17,12 +17,7 @@ extends:
           SubscriptionConfigurations:
             - $(sub-config-communication-services-cloud-test-resources-common)
             - $(sub-config-communication-services-cloud-test-resources-python)
-
-        PPE:
-            SubscriptionConfigurations:
-              - $(sub-config-communication-ppe-test-resources-common)
-              - $(sub-config-communication-ppe-test-resources-python)
-      Clouds: Public,PPE
+      Clouds: Public
       TestResourceDirectories:
         - communication/test-resources/
       EnvVars:

--- a/sdk/communication/azure-communication-rooms/tests.yml
+++ b/sdk/communication/azure-communication-rooms/tests.yml
@@ -8,10 +8,13 @@ extends:
       ServiceDirectory: communication
       MatrixReplace:
         - TestSamples=.*/true
+      UseFederatedAuth: true
       CloudConfig:
         Public:
+          ServiceConnection: azure-sdk-tests
+          SubscriptionConfigurationFilePaths:
+            - eng/common/TestResources/sub-config/AzurePublicMsft.json
           SubscriptionConfigurations:
-            - $(sub-config-azure-cloud-test-resources)
             - $(sub-config-communication-services-cloud-test-resources-common)
             - $(sub-config-communication-services-cloud-test-resources-python)
 

--- a/sdk/communication/azure-communication-rooms/tests/_shared/utils.py
+++ b/sdk/communication/azure-communication-rooms/tests/_shared/utils.py
@@ -9,32 +9,31 @@ from typing import (  # pylint: disable=unused-import
     Tuple,
 )
 from azure.core.pipeline.policies import HttpLoggingPolicy, HeadersPolicy
+from devtools_testutils import is_live, get_credential
 
 
 def create_token_credential():
-    # type: () -> FakeTokenCredential or DefaultAzureCredential
+    # type: () -> FakeTokenCredential or get_credential
     from devtools_testutils import is_live
 
     if not is_live():
         from .fake_token_credential import FakeTokenCredential
 
         return FakeTokenCredential()
-    from azure.identity import DefaultAzureCredential
-
-    return DefaultAzureCredential()
+    
+    return get_credential()
 
 
 def async_create_token_credential():
-    # type: () -> AsyncFakeTokenCredential or DefaultAzureCredential
+    # type: () -> AsyncFakeTokenCredential or get_credential
     from devtools_testutils import is_live
 
     if not is_live():
         from .async_fake_token_credential import AsyncFakeTokenCredential
 
         return AsyncFakeTokenCredential()
-    from azure.identity.aio import DefaultAzureCredential
-
-    return DefaultAzureCredential()
+    
+    return get_credential(is_async=True)
 
 
 def get_http_logging_policy(**kwargs):

--- a/sdk/communication/test-resources/test-resources.json
+++ b/sdk/communication/test-resources/test-resources.json
@@ -34,12 +34,6 @@
       "metadata": {
         "description": "The application client id used to run tests."
       }
-    },
-    "testApplicationSecret": {
-      "type": "String",
-      "metadata": {
-        "description": "The application client secret used to run tests."
-      }
     }
   },
   "variables": {

--- a/sdk/communication/test-resources/test-resources.json
+++ b/sdk/communication/test-resources/test-resources.json
@@ -70,10 +70,6 @@
       "type": "String",
       "value": "[parameters('testApplicationId')]"
     },
-    "AZURE_CLIENT_SECRET": {
-      "type": "String",
-      "value": "[parameters('testApplicationSecret')]"
-    },
     "COMMUNICATION_LIVETEST_DYNAMIC_CONNECTION_STRING": {
       "type": "string",
       "value": "[listKeys(resourceId('Microsoft.Communication/CommunicationServices',variables('uniqueSubDomainName')), '2023-03-31').primaryConnectionString]"

--- a/sdk/communication/tests.yml
+++ b/sdk/communication/tests.yml
@@ -25,10 +25,13 @@ extends:
       ServiceDirectory: communication
       TestResourceDirectories: ${{ parameters.TestResourceDirectories }}
       Packages: ${{ parameters.Services }}
+      UseFederatedAuth: true
       CloudConfig:
         Public:
+          ServiceConnection: azure-sdk-tests
+          SubscriptionConfigurationFilePaths:
+            - eng/common/TestResources/sub-config/AzurePublicMsft.json
           SubscriptionConfigurations:
-            - $(sub-config-azure-cloud-test-resources)
             - $(sub-config-communication-services-cloud-test-resources-common)
             - $(sub-config-communication-services-cloud-test-resources-python)
           MatrixReplace:


### PR DESCRIPTION
Changes:
In order to move away from Secret based authentication, we want to adopt FIC.
For the same azure-sdk team has added the support and we need to use service connection for our live test pipelines to access our test resources.