### PR TITLE
Support credential-less fileshare datastore

### DIFF
--- a/sdk/ml/azure-ai-ml/CHANGELOG.md
+++ b/sdk/ml/azure-ai-ml/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bugs Fixed
 - Workspace update no longer broken for older workspaces due to deprecated tags.
+- Support credential-less fileshare datastore
 
 ## 1.18.0 (2024-07-09)
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_datastore/azure_storage.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_schema/_datastore/azure_storage.py
@@ -42,8 +42,8 @@ class AzureFileSchema(AzureStorageSchema):
         [
             NestedField(AccountKeySchema),
             NestedField(SasTokenSchema),
-        ],
-        required=True,
+            NestedField(NoneCredentialsSchema),
+        ]
     )
 
     @post_load

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_datastore/azure_storage.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_datastore/azure_storage.py
@@ -67,7 +67,7 @@ class AzureFileDatastore(Datastore):
         endpoint: str = _get_storage_endpoint_from_metadata(),
         protocol: str = HTTPS,
         properties: Optional[Dict] = None,
-        credentials: Union[AccountKeyConfiguration, SasTokenConfiguration],
+        credentials: Optional[Union[AccountKeyConfiguration, SasTokenConfiguration]] = None,
         **kwargs: Any
     ):
         kwargs[TYPE] = DatastoreType.AZURE_FILE

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_datastore/azure_storage.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_datastore/azure_storage.py
@@ -49,7 +49,7 @@ class AzureFileDatastore(Datastore):
     :type protocol: str
     :param properties: The asset property dictionary.
     :type properties: dict[str, str]
-    :param credentials: Credentials to use for Azure ML workspace to connect to the storage.
+    :param credentials: Credentials to use for Azure ML workspace to connect to the storage. Defaults to None.
     :type credentials: Union[~azure.ai.ml.entities.AccountKeyConfiguration,
         ~azure.ai.ml.entities.SasTokenConfiguration]
     :param kwargs: A dictionary of additional configuration parameters.


### PR DESCRIPTION
# Description

Supporting credential-less fileshare datastore creation/updation, other datastores already support it. The REST interface for fileshare datastore supports it as well, modifying the schema to support from sdk side too.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
