### PR TITLE
[ServiceBus] Call AccessToken properties instead of unpacking in AdminClient

### DIFF
--- a/sdk/servicebus/azure-servicebus/azure/servicebus/aio/management/_shared_key_policy_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/aio/management/_shared_key_policy_async.py
@@ -31,10 +31,11 @@ class AsyncServiceBusSharedKeyCredentialPolicy(SansIOHTTPPolicy):
         if (
             self._token_expiry_on + 60 <= time.time()
         ):  # Update token if it's expiring in 60 seconds
-            access_token, self._token_expiry_on = await self._credential.get_token(
+            access_token = await self._credential.get_token(
                 self._endpoint
             )
-            self._token = access_token
+            self._token_expiry_on = access_token.expires_on
+            self._token = access_token.token
 
     async def on_request(
         self, request: PipelineRequest

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/management/_shared_key_policy.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/management/_shared_key_policy.py
@@ -34,10 +34,11 @@ class ServiceBusSharedKeyCredentialPolicy(SansIOHTTPPolicy):
         if (
             self._token_expiry_on + 60 <= time.time()
         ):  # Update token if it's expiring in 60 seconds
-            access_token, self._token_expiry_on = self._credential.get_token(
+            access_token = self._credential.get_token(
                 self._endpoint
             )
-            self._token = access_token
+            self._token_expiry_on = access_token.expires_on
+            self._token = access_token.token
 
     def on_request(self, request):
         # type: (PipelineRequest) -> None


### PR DESCRIPTION
[AccessToken in azure.core has been updated to include a new property refresh_on](https://github.com/Azure/azure-sdk-for-python/pull/36183). This is [breaking the ServiceBusAdministrationClient](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3944865&view=logs&j=fe7804ca-eaac-501a-67e8-e2604a50cb52&t=47104e66-1805-50a2-38da-3136064464e9&l=2488) since we [unpack the AccessToken tuple](https://github.com/Azure/azure-sdk-for-python/blob/6112a71c8377a6c984fef1e2d2e67e49752b544f/sdk/servicebus/azure-servicebus/azure/servicebus/management/_shared_key_policy.py#L37) rather than calling individual properties as other SDKs do (ex. AccessToken(..).expires_on). 

Two values (token and expires_on) are expected but a third value (refresh_on) is not being returned. Updating so that individual properties are called on the AccessToken to fix mgmt tests.