### PR TITLE
[Core] Update `AccessToken`

### DIFF
--- a/sdk/core/azure-core/azure/core/credentials.py
+++ b/sdk/core/azure-core/azure/core/credentials.py
@@ -3,21 +3,38 @@
 # Licensed under the MIT License. See LICENSE.txt in the project root for
 # license information.
 # -------------------------------------------------------------------------
+from dataclasses import dataclass, fields
 from typing import Any, NamedTuple, Optional
 from typing_extensions import Protocol, runtime_checkable
 
 
-class AccessToken(NamedTuple):
+@dataclass(frozen=True)
+class AccessToken:
     """Represents an OAuth access token."""
 
     token: str
+    """The token string."""
     expires_on: int
+    """The token's expiration time in Unix time."""
     refresh_on: Optional[int] = None
+    """When the token should be refreshed in Unix time."""
 
+    def __iter__(self) -> Any:
+        """Return an iterator that will yield non-None values.
 
-AccessToken.token.__doc__ = """The token string."""
-AccessToken.expires_on.__doc__ = """The token's expiration time in Unix time."""
-AccessToken.refresh_on.__doc__ = """When the token should be refreshed in Unix time."""
+        This is backwards compatible with code unpacking the token and expires_on values of AccessToken.
+
+        :return: Iterator containing the token and expires_on values.
+        :rtype: Iterator
+        """
+        # Note: `fields` returns a tuple of fields in the order they are defined in the class.
+        return (getattr(self, field.name) for field in fields(self) if getattr(self, field.name) is not None)
+
+    def __getitem__(self, index: Any) -> Any:
+        return tuple(self)[index]
+
+    def __len__(self) -> int:
+        return len(tuple(self.__iter__()))
 
 
 @runtime_checkable

--- a/sdk/core/azure-core/azure/core/pipeline/policies/_authentication.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/_authentication.py
@@ -70,11 +70,8 @@ class _BearerTokenCredentialPolicyBase:
     @property
     def _need_new_token(self) -> bool:
         now = time.time()
-        return (
-            not self._token
-            or (self._token.refresh_on is not None and self._token.refresh_on <= now)
-            or self._token.expires_on - now < 300
-        )
+        refresh_on = getattr(self._token, "refresh_on", None)
+        return not self._token or (refresh_on and refresh_on <= now) or self._token.expires_on - now < 300
 
 
 class BearerTokenCredentialPolicy(_BearerTokenCredentialPolicyBase, HTTPPolicy[HTTPRequestType, HTTPResponseType]):

--- a/sdk/core/azure-core/azure/core/pipeline/policies/_authentication_async.py
+++ b/sdk/core/azure-core/azure/core/pipeline/policies/_authentication_async.py
@@ -165,8 +165,5 @@ class AsyncBearerTokenCredentialPolicy(AsyncHTTPPolicy[HTTPRequestType, AsyncHTT
 
     def _need_new_token(self) -> bool:
         now = time.time()
-        return (
-            not self._token
-            or (self._token.refresh_on is not None and self._token.refresh_on <= now)
-            or self._token.expires_on - now < 300
-        )
+        refresh_on = getattr(self._token, "refresh_on", None)
+        return not self._token or (refresh_on and refresh_on <= now) or self._token.expires_on - now < 300


### PR DESCRIPTION
Earlier, `refresh_on` was added to `AccessToken` as an optional property. This had unintended breaking side effects. The `azure-servicebus` package recently ran into [issues](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3944865&view=logs&j=fe7804ca-eaac-501a-67e8-e2604a50cb52&t=47104e66-1805-50a2-38da-3136064464e9&l=2488) when they were unpacking the `get_token()` call:

```python
access_token, self._token_expiry_on = self._credential.get_token(self._endpoint)
```
This yielded: `ValueError: too many values to unpack (expected 2)`. 

To avoid breaking users who might be unpacking like this, this change converts `AccessToken` into a DataClass. A NamedTuple and frozen DataClass are functionally the same for our purposes, but a DataClass provides more flexibility. Here, I override the `__iter__`, `__getitem__`, and `__len__` methods to provide the same functionality as previously.

---

**Why we need `refresh_on`?**

In some cases, our current strategy of requesting a new token if it is within five minutes of expiration is not sufficient. Some customers have long-running jobs that span longer than five minutes and would like earlier refresh times to avoid authentication issues causing interruptions. In some cases, tokens can contain info on when it can/should be refreshed. We want to be able to use that info in our `BearerTokenCredentialPolicies`.

Issue: https://github.com/Azure/azure-sdk-for-python/issues/35473




