### PR TITLE
[SDK generation pipeline] remove tsp-location.yaml when generate from swagger

### DIFF
--- a/tools/azure-sdk-tools/packaging_tools/sdk_generator.py
+++ b/tools/azure-sdk-tools/packaging_tools/sdk_generator.py
@@ -91,7 +91,7 @@ def after_multiapi_combiner(sdk_code_path: str, package_name: str, folder_name: 
         _LOGGER.info(f"do not find {toml_file}")
 
 
-def del_outdated_samples(readme: str):
+def del_outdated_files(readme: str):
     python_readme = Path(readme).parent / "readme.python.md"
     if not python_readme.exists():
         _LOGGER.info(f"do not find python configuration: {python_readme}")
@@ -102,6 +102,12 @@ def del_outdated_samples(readme: str):
     sdk_folder = extract_sdk_folder(content)
     is_multiapi = is_multiapi_package(content)
     if sdk_folder:
+        # remove tsp-location.yaml
+        tsp_location = Path(f"sdk/{sdk_folder}/tsp-location.yaml")
+        if tsp_location.exists():
+            os.remove(str(tsp_location))
+            _LOGGER.info(f"remove tsp-location.yaml: {tsp_location}")
+        # remove generated_samples
         sample_folder = Path(f"sdk/{sdk_folder}/generated_samples")
         if sample_folder.exists():
             # rdbms is generated from different swagger folder;multiapi package may don't generate every time
@@ -272,7 +278,7 @@ def main(generate_input, generate_output):
         if "resource-manager" in input_readme:
             relative_path_readme = str(Path(spec_folder, input_readme))
             update_metadata_for_multiapi_package(spec_folder, input_readme)
-            del_outdated_samples(relative_path_readme)
+            del_outdated_files(relative_path_readme)
             config = generate(
                 CONFIG_FILE,
                 sdk_folder,


### PR DESCRIPTION
When generate sdk from swagger, there is no need to keep `tsp-location.yaml` (e.g. https://github.com/Azure/azure-sdk-for-python/pull/36408/commits/8845cc4c479d1bf718c2a1a95e12f7c646130215)