### PR TITLE
[ServiceBus] trigger ci on core pr

### DIFF
--- a/sdk/servicebus/ci.yml
+++ b/sdk/servicebus/ci.yml
@@ -23,6 +23,7 @@ pr:
   paths:
     include:
     - sdk/servicebus/
+    - sdk/core/
 
 extends:
   template: ../../eng/pipelines/templates/stages/archetype-sdk-client.yml

--- a/sdk/servicebus/ci.yml
+++ b/sdk/servicebus/ci.yml
@@ -10,6 +10,7 @@ trigger:
   paths:
     include:
     - sdk/servicebus/
+    - sdk/core/
 
 pr:
   branches:


### PR DESCRIPTION
We should trigger SB CI on azure-core tests, since SBAdminClient is HTTP based.