### PR TITLE
Address Condition Failure

### DIFF
--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -196,7 +196,7 @@ jobs:
         - 'CoalesceBuildArtifacts'
       - ${{ else }}:
         - 'Build'
-      
+
     timeoutInMinutes: 90
 
     pool:
@@ -247,6 +247,7 @@ jobs:
         ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
           Directory: sdk/${{ parameters.ServiceDirectory }}
         CheckLinkGuidance: $true
+        Condition: succeededOrFailed()
 
     - task: DownloadPipelineArtifact@2
       condition: succeededOrFailed()

--- a/eng/pipelines/templates/steps/analyze.yml
+++ b/eng/pipelines/templates/steps/analyze.yml
@@ -27,6 +27,7 @@ steps:
 
   - task: PythonScript@0
     displayName: 'Set Tox Environment Skips'
+    condition: succeededOrFailed()
     inputs:
       scriptPath: 'scripts/devops_tasks/set_tox_environment.py'
       arguments: '"$(TargetingString)" --team-project="$(System.TeamProject)" --service="${{ parameters.ServiceDirectory }}"'
@@ -60,6 +61,7 @@ steps:
         }
       }
     displayName: Check for CRLF Line endings
+    condition: succeededOrFailed()
 
   - template: /eng/common/pipelines/templates/steps/verify-path-length.yml
     parameters:
@@ -73,7 +75,7 @@ steps:
   - template: ../steps/set-dev-build.yml
     parameters:
       ServiceDirectory: ${{ parameters.ServiceDirectory }}
-      
+
   - task: PythonScript@0
     displayName: 'Verify sdist'
     condition: and(succeededOrFailed(), ne(variables['Skip.VerifySdist'],'true'))

--- a/eng/pipelines/templates/steps/analyze.yml
+++ b/eng/pipelines/templates/steps/analyze.yml
@@ -39,6 +39,7 @@ steps:
           PackageName: ${{artifact.name}}
           ServiceName: ${{parameters.ServiceDirectory}}
           ForRelease: false
+          Condition: succeededOrFailed()
 
   - script: |
       python -m pip install "./tools/azure-sdk-tools[build]" -q -I
@@ -66,6 +67,7 @@ steps:
   - template: /eng/common/pipelines/templates/steps/verify-path-length.yml
     parameters:
       SourceDirectory: $(Build.SourcesDirectory)
+      Condition: succeededOrFailed()
 
   - template: ../steps/verify-autorest.yml
     parameters:

--- a/eng/pipelines/templates/steps/analyze_dependency.yml
+++ b/eng/pipelines/templates/steps/analyze_dependency.yml
@@ -17,6 +17,7 @@ steps:
   - template: /eng/common/pipelines/templates/steps/verify-readme.yml
     parameters:
       ScanPath: ${{ parameters.ScanPath }}
+      Condition: succeededOrFailed()
 
   - pwsh: |
       sdk_analyze_deps --verbose --out "$(Build.ArtifactStagingDirectory)/reports/dependencies.html" --dump "$(Build.ArtifactStagingDirectory)/reports"

--- a/eng/pipelines/templates/steps/build-package-artifacts.yml
+++ b/eng/pipelines/templates/steps/build-package-artifacts.yml
@@ -97,7 +97,7 @@ steps:
       twine check $(Build.ArtifactStagingDirectory)/**/*.whl
       twine check $(Build.ArtifactStagingDirectory)/**/*.tar.gz
     displayName: 'Verify Readme'
-    condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'))
+    condition: and(succeededOrFailed(), eq(variables['Agent.OS'], 'Linux'))
 
   - ${{ parameters.BeforePublishSteps }}
 

--- a/eng/pipelines/templates/steps/set-dev-build.yml
+++ b/eng/pipelines/templates/steps/set-dev-build.yml
@@ -11,6 +11,7 @@ steps:
   - template: /eng/common/pipelines/templates/steps/daily-dev-build-variable.yml
     parameters:
       ServiceDirectory: ${{ parameters.ServiceDirectory }}
+      Condition: succeededOrFailed()
 
   - pwsh: |
       python -m pip install "tools/azure-sdk-tools[build]"


### PR DESCRIPTION
@kristapratico reported this error: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3949754&view=logs&j=b70e5e73-bbb6-5567-0939-8415943fadb9&t=e3f8f308-6e5f-58aa-3a2a-fe425958de32&l=73

`SetDevVersion` variable was not set, as a link verification check caused an eng/common `daily-build-variable` template to _not_ execute as we expected.

Since no setDevVersion was present, we didn't update packages to alpha versions, which caused conflict when attempting to find packages from the `build` phase. Since the build phase didn't hit this issue, it produced the packages with alpha versioning.

Source = alpha
Test = non-alpha
= Nobody can find anything. Hence the error.

This PR uses some new `conditions` that I added to eng/common to avoid the above issue. 