### PR TITLE
[Storage] STG94 GA APIView Feedback

### DIFF
--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_download.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_download.py
@@ -582,7 +582,7 @@ class StorageStreamDownloader(Generic[T]):  # pylint: disable=too-many-instance-
         ...
 
     @overload
-    def read(self, *, chars: Optional[int] = None) -> str:
+    def read(self, *, chars: Optional[int] = None) -> T:
         ...
 
     # pylint: disable-next=too-many-statements,too-many-branches

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_download_async.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_download_async.py
@@ -468,7 +468,7 @@ class StorageStreamDownloader(Generic[T]):  # pylint: disable=too-many-instance-
         ...
 
     @overload
-    def read(self, *, chars: Optional[int] = None) -> str:
+    def read(self, *, chars: Optional[int] = None) -> T:
         ...
 
     # pylint: disable-next=too-many-statements,too-many-branches


### PR DESCRIPTION
Although the feedback item was that this should be str, this is causing a MyPy issue:

```
azure\storage\blob\_download.py:602: error: Overloaded function signatures 1 and 2 overlap with incompatible return types  [overload-overlap]
azure\storage\blob\_download.py:610: error: Overloaded function implementation cannot produce return type of signature 2  [misc]
```

So we are going to revert this back to `T`, as in any practical use cases this will resolve correctly i.e. will return the correctly typed `StorageStreamDownloader`.