### PR TITLE
[Storage] Fix read typehint in `_download_async.py`

### DIFF
--- a/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_download_async.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_download_async.py
@@ -464,11 +464,11 @@ class StorageStreamDownloader(Generic[T]):  # pylint: disable=too-many-instance-
             chunk_size=self._config.max_chunk_get_size)
 
     @overload
-    def read(self, size: int = -1) -> T:
+    async def read(self, size: int = -1) -> T:
         ...
 
     @overload
-    def read(self, *, chars: Optional[int] = None) -> T:
+    async def read(self, *, chars: Optional[int] = None) -> T:
         ...
 
     # pylint: disable-next=too-many-statements,too-many-branches


### PR DESCRIPTION
All the overloads for `def read` were not async 😄 