### PR TITLE
Use platform-specific activation, pin setuptools 69.2.0

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -198,7 +198,6 @@
     "contosodataset",
     "centralus",
     "centraluseuap",
-    "corehttp",
     "creds",
     "ctoring",
     "ctxt",

--- a/eng/ci_tools.txt
+++ b/eng/ci_tools.txt
@@ -1,6 +1,6 @@
 # requirements leveraged by ci tools
-setuptools==70.2.0; python_version >= '3.5'
-virtualenv==20.24.3
+setuptools==69.2.0; python_version >= '3.5'
+virtualenv==20.25.1
 wheel==0.43.0
 packaging==23.1
 tox==4.5.0

--- a/eng/conda_test_requirements.txt
+++ b/eng/conda_test_requirements.txt
@@ -8,7 +8,7 @@ trio
 typing_extensions>=3.7.2
 cryptography
 adal
-setuptools==70.2.0; python_version >= '3.5'
+setuptools==69.2.0; python_version >= '3.5'
 pytest-asyncio==0.12.0
 -e sdk/core/azure-core/tests/testserver_tests/coretestserver
 azure-mgmt-storage

--- a/eng/pipelines/templates/steps/build-package-artifacts.yml
+++ b/eng/pipelines/templates/steps/build-package-artifacts.yml
@@ -61,7 +61,7 @@ steps:
   - bash: |
       source $(VENV_LOCATION)/bin/activate
       which python
-      python -m pip install --force -r eng\ci_tools.txt
+      python -m pip install --force -r eng/ci_tools.txt
       python -m pip freeze --all
     displayName: 'Prep Environment Linux/Mac'
     condition: and(succeeded(), or(eq(variables['Agent.OS'], 'Linux'), eq(variables['Agent.OS'], 'Darwin')))

--- a/eng/pipelines/templates/steps/build-package-artifacts.yml
+++ b/eng/pipelines/templates/steps/build-package-artifacts.yml
@@ -67,7 +67,7 @@ steps:
     condition: and(succeeded(), or(eq(variables['Agent.OS'], 'Linux'), eq(variables['Agent.OS'], 'Darwin')))
 
   - pwsh: |
-      .$(VENV_LOCATION)/Scripts/Activate.ps1
+      . $(VENV_LOCATION)/Scripts/Activate.ps1
       which python
       python -m pip install --force -r eng/ci_tools.txt
       python -m pip freeze --all

--- a/eng/pipelines/templates/steps/build-package-artifacts.yml
+++ b/eng/pipelines/templates/steps/build-package-artifacts.yml
@@ -52,14 +52,27 @@ steps:
     inputs:
       versionSpec: $(PythonVersion)
 
-  - ${{ if eq(parameters.UseVirtualEnvironment, true) }}:
-    - template: /eng/pipelines/templates/steps/use-venv.yml
 
-  - pwsh: |
+  - template: /eng/pipelines/templates/steps/use-venv.yml
+    parameters:
+      VirtualEnvironmentName: "venv"
+      Activate: false
+
+  - bash: |
+      source $(VENV_LOCATION)/bin/activate
       which python
       python -m pip install --force -r eng/ci_tools.txt
       python -m pip freeze --all
-    displayName: 'Prep Environment'
+    displayName: 'Prep Environment Linux/Mac'
+    condition: and(succeeded(), or(eq(variables['Agent.OS'], 'Linux'), eq(variables['Agent.OS'], 'Darwin')))
+
+  - pwsh: |
+      .$(VENV_LOCATION)/Scripts/Activate.ps1
+      which python
+      python -m pip install --force -r eng/ci_tools.txt
+      python -m pip freeze --all
+    displayName: 'Prep Environment Windows'
+    condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
 
   - template: set-dev-build.yml@self
     parameters:
@@ -84,10 +97,22 @@ steps:
     displayName: 'Install QEMU Dependencies'
     condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'))
 
-  - pwsh: |
+  - bash: |
+      source $(VENV_LOCATION)/bin/activate
       which python
       sdk_build -d "$(Build.ArtifactStagingDirectory)" "$(TargetingString)" --service=${{parameters.ServiceDirectory}} --inactive
-    displayName: 'Generate Packages'
+    displayName: 'Generate Packages Linux/Mac'
+    condition: and(succeeded(), or(eq(variables['Agent.OS'], 'Linux'), eq(variables['Agent.OS'], 'Darwin')))
+    timeoutInMinutes: 80
+    env:
+      CIBW_BUILD_VERBOSITY: 3
+
+  - pwsh: |
+      . $(VENV_LOCATION)/Scripts/Activate.ps1
+      which python
+      sdk_build -d "$(Build.ArtifactStagingDirectory)" "$(TargetingString)" --service=${{parameters.ServiceDirectory}} --inactive
+    displayName: 'Generate Packages Windows'
+    condition: and(succeededOrFailed(), eq(variables['Agent.OS'], 'Windows_NT'))
     timeoutInMinutes: 80
     env:
       CIBW_BUILD_VERBOSITY: 3

--- a/eng/pipelines/templates/steps/build-package-artifacts.yml
+++ b/eng/pipelines/templates/steps/build-package-artifacts.yml
@@ -61,7 +61,7 @@ steps:
   - bash: |
       source $(VENV_LOCATION)/bin/activate
       which python
-      python -m pip install --force -r eng/ci_tools.txt
+      python -m pip install --force -r eng\ci_tools.txt
       python -m pip freeze --all
     displayName: 'Prep Environment Linux/Mac'
     condition: and(succeeded(), or(eq(variables['Agent.OS'], 'Linux'), eq(variables['Agent.OS'], 'Darwin')))

--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -46,7 +46,7 @@ steps:
       python -m pip freeze
       python -m pip install pip==23.2.1
       python -m pip install wheel==0.43.0 --force-reinstall
-      python -m pip install setuptools==70.2.0 --force-reinstall
+      python -m pip install setuptools==69.2.0 --force-reinstall
       python -m pip install -r eng/ci_tools.txt
       pip --version
       pip freeze

--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -33,8 +33,6 @@ steps:
     parameters:
       versionSpec: '${{ parameters.PythonVersion }}'
 
-  - template: /eng/pipelines/templates/steps/use-venv.yml
-
   - template: set-dev-build.yml
     parameters:
       ServiceDirectory: ${{ parameters.ServiceDirectory }}
@@ -50,7 +48,7 @@ steps:
       python -m pip install -r eng/ci_tools.txt
       pip --version
       pip freeze
-    displayName: 'Prep Environment'
+    displayName: 'Prep Environment Linux/Mac'
 
   - ${{if eq(parameters.TestProxy, true) }}:
     - template: /eng/common/testproxy/test-proxy-tool.yml

--- a/eng/pipelines/templates/steps/use-venv.yml
+++ b/eng/pipelines/templates/steps/use-venv.yml
@@ -2,6 +2,9 @@ parameters:
   - name: VirtualEnvironmentName
     type: string
     default: "venv"
+  - name: Activate
+    type: boolean
+    default: true
 
 steps:
   - pwsh: |
@@ -10,8 +13,9 @@ steps:
         -RepoRoot "$(Build.SourcesDirectory)"
     displayName: Create virtual environment
 
-  - pwsh: |
-      $(Build.SourcesDirectory)/eng/scripts/activate-venv.ps1 `
-        -VenvName "${{ parameters.VirtualEnvironmentName }}" `
-        -RepoRoot "$(Build.SourcesDirectory)"
-    displayName: Use ${{ parameters.VirtualEnvironmentName }} Virtual Environment
+  - ${{ if eq(parameters.Activate, true) }}:
+    - pwsh: |
+        $(Build.SourcesDirectory)/eng/scripts/activate-venv.ps1 `
+          -VenvName "${{ parameters.VirtualEnvironmentName }}" `
+          -RepoRoot "$(Build.SourcesDirectory)"
+      displayName: Use ${{ parameters.VirtualEnvironmentName }} Virtual Environment

--- a/eng/regression_tools.txt
+++ b/eng/regression_tools.txt
@@ -1,5 +1,5 @@
 # requirements leveraged by ci tools
-setuptools==70.2.0; python_version >= '3.5'
+setuptools==69.2.0; python_version >= '3.5'
 virtualenv==20.23.0
 wheel==0.43.0
 Jinja2==3.1.2

--- a/eng/scripts/create-venv.ps1
+++ b/eng/scripts/create-venv.ps1
@@ -23,7 +23,8 @@ param(
 $venvPath = Join-Path $RepoRoot $VenvName
 if (!(Test-Path $venvPath)) {
     Write-Host "Creating virtual environment '$VenvName'."
-    python -m venv "$venvPath"
+    python -m pip install virtualenv==20.25.1
+    python -m virtualenv "$venvPath"
     Write-Host "Virtual environment '$VenvName' created."
     Write-Host "##vso[task.setvariable variable=$($VenvName)_LOCATION]$venvPath"
 }

--- a/eng/tox/tox_helper_tasks.py
+++ b/eng/tox/tox_helper_tasks.py
@@ -28,26 +28,19 @@ def unzip_sdist_to_directory(containing_folder: str) -> str:
         tars = glob.glob(os.path.join(containing_folder, "*.tar.gz"))
         return unzip_file_to_directory(tars[0], containing_folder)
 
+
 def unzip_file_to_directory(path_to_zip_file: str, extract_location: str) -> str:
     if path_to_zip_file.endswith(".zip"):
         with zipfile.ZipFile(path_to_zip_file, "r") as zip_ref:
             zip_ref.extractall(extract_location)
             extracted_dir = os.path.basename(os.path.splitext(path_to_zip_file)[0])
             return os.path.join(extract_location, extracted_dir)
-    elif path_to_zip_file.endswith(".tar.gz") or path_to_zip_file.endswith(".tgz"):
-        with tarfile.open(path_to_zip_file, "r:gz") as tar_ref:
-            tar_ref.extractall(extract_location)
-            top_level_dir = None
-            for member in tar_ref.getmembers():
-                if member.isdir():
-                    top_level_dir = member.name.split('/')[0]
-                    break
-            if top_level_dir:
-                return os.path.join(extract_location, top_level_dir)
-            else:
-                raise ValueError("Failed to determine the top-level directory in the tar.gz archive")
     else:
-        raise ValueError("Unsupported file format")
+        with tarfile.open(path_to_zip_file) as tar_ref:
+            tar_ref.extractall(extract_location)
+            extracted_dir = os.path.basename(path_to_zip_file).replace(".tar.gz", "")
+            return os.path.join(extract_location, extracted_dir)
+
 
 def move_and_rename(source_location):
     new_location = os.path.join(os.path.dirname(source_location), "unzipped")

--- a/tools/azure-sdk-tools/ci_tools/build.py
+++ b/tools/azure-sdk-tools/ci_tools/build.py
@@ -189,21 +189,3 @@ def create_package(
 
     if enable_sdist:
         run([sys.executable, "setup.py", "sdist", "-d", dist], cwd=setup_parsed.folder, check=True)
-
-        # The file normalization changes in setuptools 67.3.0 intends source distribution file names to have the
-        # formatting a whl distributions. This patch avoids that for now.
-        normalized_package_name = setup_parsed.name.replace("-", "_")
-        generated_sdist_name = os.path.join(dist, f"{normalized_package_name}-{setup_parsed.version}.tar.gz")
-        destination = generated_sdist_name.replace(normalized_package_name, setup_parsed.name)
-
-        # in cases where there is no reformatting necessary (sdk/core/corehttp is a good example)
-        # skip this effort
-        if generated_sdist_name != destination:
-            if os.path.exists(generated_sdist_name):
-                if os.path.exists(destination):
-                    os.remove(destination)
-
-                os.rename(generated_sdist_name, destination)
-            else:
-                logger.log(level=logging.ERROR, msg=f"Unable to find a source distribution for {setup_parsed.name} that could be renamed without normalization.")
-


### PR DESCRIPTION
Alright to impart context will need a bit, bear wear with me. I started doing investigatory work for workarounds to address #35204 . Obviously we want to use newer setuptools going forward, but we also don't want to break downstream.

My obvious solution is to pin setuptools to `69.2.0` (a single setuptools version before source distribution naming normalization). When I submit that PR, I hit a [very wonky issue](https://teams.microsoft.com/l/message/19:b97d98e6d22c41e0970a1150b484d935@thread.skype/1720473496159?tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&groupId=3e17dcb0-4257-4a30-b843-77f47f1d4121&parentMessageId=1720464813420&teamName=Azure%20SDK&channelName=Language%20-%20Python&createdTime=1720473496159) that had me giving `pip freeze` the sideeye.

To me, appears that pip is reporting one thing, but then _using_ another.

This was _further_ born out by [this build output](https://dev.azure.com/azure-sdk/public/_build/results?buildId=3955487&view=logs&j=3dc8fd7e-4368-5a92-293e-d53cefc8c4b3&t=3bed581a-3f65-5269-5360-1b6e11a4b6d2&l=254). [Up above](https://dev.azure.com/azure-sdk/public/_build/results?buildId=3955487&view=logs&j=3dc8fd7e-4368-5a92-293e-d53cefc8c4b3&t=1bb4b58e-f076-55c3-0dfc-a70a7c67f4bb&l=334), we report `setuptools==69.2.0` being installed, but then `build.py` reports that `setuptools 70.3.0` is being [utilized at runtime](https://dev.azure.com/azure-sdk/public/_build/results?buildId=3955487&view=logs&j=3dc8fd7e-4368-5a92-293e-d53cefc8c4b3&t=3bed581a-3f65-5269-5360-1b6e11a4b6d2&l=254):

<img width="617" alt="image" src="https://github.com/user-attachments/assets/7e447475-9b54-43a2-8f07-83d9bef65d00">

As one can see for themselves, we are reporting the expected `site-packages` AND the expected python executable. What's **not** right is the `setuptools` version. `70.3.0`. Given that pip was reporting `69.1.1`, this is disconcerting!

After a bunch more reading, I recalled that `venv` on earlier python versions ISNT a full `virtualenv` invocation. Because of that, on further examination of the executables themselves, I discovered that `venv` does NOT create new python intrepreter. It simply symlinks to the global one.

I ascertained that to get around BOTH the installation issues with setuptools, AND the improper version of setuptools being utilized during build, we should:

- [x] Create the venv using virtualenv
- [x] Activate the virtual env not by prepending the PATH and setting the necessary VIRTUAL_ENV variables, but by actually activating the task

The `build` phase is relatively uncomplicated and just activates the venv in platform-specific methodology. Let's do that. `test` will remain pre-venv until I can NOT duplicate our test invocation by double the script invocations.

This PR will absolutely ensure #35204 stops happening, but we need sync up and patch downtstream for the new setuptools sooner rather than later.
 





 
