### PR TITLE
Re-enable `venv` for testing

### DIFF
--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -43,13 +43,8 @@ steps:
       Write-Host (Get-Command python).Source
       $ErrorActionPreference = 'Stop'
       $PSNativeCommandUseErrorActionPreference = $true
-      python -m pip freeze
-      python -m pip install pip==23.2.1
-      python -m pip install wheel==0.43.0 --force-reinstall
-      python -m pip install setuptools==69.2.0 --force-reinstall
-      python -m pip install -r eng/ci_tools.txt
-      pip --version
-      pip freeze
+      python -m pip install -I -r eng/ci_tools.txt
+      python -m pip freeze --all
     displayName: 'Prep Environment Linux/Mac'
 
   - ${{if eq(parameters.TestProxy, true) }}:

--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -120,7 +120,9 @@ steps:
           --toxenv="${{ parameters.ToxTestEnv }}" `
           --injected-packages="${{ parameters.InjectedPackages }}" `
           ${{ parameters.ToxEnvParallel }}
+        exit $LASTEXITCODE;
       env: ${{ parameters.EnvVars }}
+      displayName: Run Tests
 
   - ${{if eq(parameters.TestProxy, true) }}:
     - pwsh: |

--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -34,18 +34,27 @@ steps:
       versionSpec: '${{ parameters.PythonVersion }}'
 
   - template: /eng/pipelines/templates/steps/use-venv.yml
+    parameters:
+      Activate: false
 
   - template: set-dev-build.yml
     parameters:
       ServiceDirectory: ${{ parameters.ServiceDirectory }}
 
   - pwsh: |
+      if ($IsWindows) {
+        . $(VENV_LOCATION)/Scripts/Activate.ps1
+      }
+      else {
+        . $(VENV_LOCATION)/bin/Activate.ps1
+      }
       Write-Host (Get-Command python).Source
       $ErrorActionPreference = 'Stop'
       $PSNativeCommandUseErrorActionPreference = $true
       python -m pip install -I -r eng/ci_tools.txt
       python -m pip freeze --all
-    displayName: 'Prep Environment Linux/Mac'
+      Write-Host (Get-Command python).Source
+    displayName: 'Prep Environment'
 
   - ${{if eq(parameters.TestProxy, true) }}:
     - template: /eng/common/testproxy/test-proxy-tool.yml
@@ -62,6 +71,7 @@ steps:
   - template: /eng/pipelines/templates/steps/seed-virtualenv-wheels.yml
 
   - ${{ if eq('true', parameters.UseFederatedAuth) }}:
+
     - task: AzurePowerShell@5
       displayName: Run Tests (AzurePowerShell@5)
       env:
@@ -73,6 +83,13 @@ steps:
         pwsh: true
         ScriptType: InlineScript
         Inline: >-
+          if ($IsWindows) {
+            . $(VENV_LOCATION)/Scripts/Activate.ps1
+          }
+          else {
+            . $(VENV_LOCATION)/bin/Activate.ps1
+          }
+          Write-Host (Get-Command python).Source
           $account = (Get-AzContext).Account;
           $env:AZURESUBSCRIPTION_CLIENT_ID = $account.Id;
           $env:AZURESUBSCRIPTION_TENANT_ID = $account.Tenants;
@@ -90,18 +107,21 @@ steps:
           exit $LASTEXITCODE;
 
   - ${{ else }}:
-    - task: PythonScript@0
-      displayName: 'Run Tests'
-      inputs:
-        scriptPath: 'scripts/devops_tasks/dispatch_tox.py'
-        arguments: >-
-          "$(TargetingString)"
-          ${{ parameters.AdditionalTestArgs }}
-          ${{ parameters.CoverageArg }}
-          --mark_arg="${{ parameters.TestMarkArgument }}"
-          --service="${{ parameters.ServiceDirectory }}"
-          --toxenv="${{ parameters.ToxTestEnv }}"
-          --injected-packages="${{ parameters.InjectedPackages }}"
+    - pwsh: |
+        if ($IsWindows) {
+          . $(VENV_LOCATION)/Scripts/Activate.ps1
+        }
+        else {
+          . $(VENV_LOCATION)/bin/Activate.ps1
+        }
+        Write-Host (Get-Command python).Source
+        python scripts/devops_tasks/dispatch_tox.py "$(TargetingString)" `
+          ${{ parameters.AdditionalTestArgs }} `
+          ${{ parameters.CoverageArg }} `
+          --mark_arg="${{ parameters.TestMarkArgument }}" `
+          --service="${{ parameters.ServiceDirectory }}" `
+          --toxenv="${{ parameters.ToxTestEnv }}" `
+          --injected-packages="${{ parameters.InjectedPackages }}" `
           ${{ parameters.ToxEnvParallel }}
       env: ${{ parameters.EnvVars }}
 

--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -34,8 +34,6 @@ steps:
       versionSpec: '${{ parameters.PythonVersion }}'
 
   - template: /eng/pipelines/templates/steps/use-venv.yml
-    parameters:
-      Activate: false
 
   - template: set-dev-build.yml
     parameters:

--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -48,7 +48,6 @@ steps:
       else {
         . $(VENV_LOCATION)/bin/Activate.ps1
       }
-      Write-Host (Get-Command python).Source
       $ErrorActionPreference = 'Stop'
       $PSNativeCommandUseErrorActionPreference = $true
       python -m pip install -r eng/ci_tools.txt

--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -64,6 +64,8 @@ steps:
 
   - template: /eng/pipelines/templates/steps/seed-virtualenv-wheels.yml
 
+  - template: /eng/pipelines/templates/steps/use-venv.yml
+
   - ${{ if eq('true', parameters.UseFederatedAuth) }}:
     - task: AzurePowerShell@5
       displayName: Run Tests (AzurePowerShell@5)

--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -51,7 +51,7 @@ steps:
       Write-Host (Get-Command python).Source
       $ErrorActionPreference = 'Stop'
       $PSNativeCommandUseErrorActionPreference = $true
-      python -m pip install -I -r eng/ci_tools.txt
+      python -m pip install -r eng/ci_tools.txt
       python -m pip freeze --all
       Write-Host (Get-Command python).Source
     displayName: 'Prep Environment'

--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -46,7 +46,7 @@ steps:
         . $(VENV_LOCATION)/Scripts/Activate.ps1
       }
       else {
-        . $(VENV_LOCATION)/bin/Activate.ps1
+        . $(VENV_LOCATION)/bin/activate.ps1
       }
       $ErrorActionPreference = 'Stop'
       $PSNativeCommandUseErrorActionPreference = $true
@@ -86,7 +86,7 @@ steps:
             . $(VENV_LOCATION)/Scripts/Activate.ps1
           }
           else {
-            . $(VENV_LOCATION)/bin/Activate.ps1
+            . $(VENV_LOCATION)/bin/activate.ps1
           }
           Write-Host (Get-Command python).Source
           $account = (Get-AzContext).Account;
@@ -111,7 +111,7 @@ steps:
           . $(VENV_LOCATION)/Scripts/Activate.ps1
         }
         else {
-          . $(VENV_LOCATION)/bin/Activate.ps1
+          . $(VENV_LOCATION)/bin/activate.ps1
         }
         Write-Host (Get-Command python).Source
         python scripts/devops_tasks/dispatch_tox.py "$(TargetingString)" `

--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -50,7 +50,7 @@ steps:
       }
       $ErrorActionPreference = 'Stop'
       $PSNativeCommandUseErrorActionPreference = $true
-      python -m pip install -r eng/ci_tools.txt
+      python -m pip install --force -r eng/ci_tools.txt
       python -m pip freeze --all
       Write-Host (Get-Command python).Source
     displayName: 'Prep Environment'

--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -33,6 +33,8 @@ steps:
     parameters:
       versionSpec: '${{ parameters.PythonVersion }}'
 
+  - template: /eng/pipelines/templates/steps/use-venv.yml
+
   - template: set-dev-build.yml
     parameters:
       ServiceDirectory: ${{ parameters.ServiceDirectory }}
@@ -63,8 +65,6 @@ steps:
   - ${{ parameters.BeforeTestSteps }}
 
   - template: /eng/pipelines/templates/steps/seed-virtualenv-wheels.yml
-
-  - template: /eng/pipelines/templates/steps/use-venv.yml
 
   - ${{ if eq('true', parameters.UseFederatedAuth) }}:
     - task: AzurePowerShell@5

--- a/eng/pipelines/templates/steps/use-venv.yml
+++ b/eng/pipelines/templates/steps/use-venv.yml
@@ -13,10 +13,6 @@ steps:
         -RepoRoot "$(Build.SourcesDirectory)"
     displayName: Create virtual environment
 
-  - pwsh: |
-      Get-ChildItem -R $(VENV_LOCATION) | % { $_.FullName }
-    displayName: Dump Contents of Venv
-
   - ${{ if eq(parameters.Activate, true) }}:
     - pwsh: |
         $(Build.SourcesDirectory)/eng/scripts/activate-venv.ps1 `

--- a/eng/pipelines/templates/steps/use-venv.yml
+++ b/eng/pipelines/templates/steps/use-venv.yml
@@ -13,6 +13,10 @@ steps:
         -RepoRoot "$(Build.SourcesDirectory)"
     displayName: Create virtual environment
 
+  - pwsh: |
+      Get-ChildItem -R $(VENV_LOCATION) | % { $_.FullName }
+    displayName: Dump Contents of Venv
+
   - ${{ if eq(parameters.Activate, true) }}:
     - pwsh: |
         $(Build.SourcesDirectory)/eng/scripts/activate-venv.ps1 `


### PR DESCRIPTION
As mentioned in #36454 ,I would re-enable venv for test runs when I had a more elegant way of doing it.

This PR is that more elegant way, or at the very least the much less ugly version.