### PR TITLE
[Storage] Adjust dev_requirements and tests.yml

### DIFF
--- a/sdk/storage/azure-storage-blob-changefeed/dev_requirements.txt
+++ b/sdk/storage/azure-storage-blob-changefeed/dev_requirements.txt
@@ -1,4 +1,5 @@
 -e ../../../tools/azure-sdk-tools
-../azure-storage-blob
+-e ../../core/azure-core
 -e ../../identity/azure-identity
+-e ../azure-storage-blob
 aiohttp>=3.0

--- a/sdk/storage/azure-storage-blob/dev_requirements.txt
+++ b/sdk/storage/azure-storage-blob/dev_requirements.txt
@@ -1,5 +1,5 @@
 -e ../../../tools/azure-sdk-tools
-../../core/azure-core
-azure-identity
+-e ../../core/azure-core
+-e ../../identity/azure-identity
 azure-mgmt-storage==20.1.0
 aiohttp>=3.0

--- a/sdk/storage/azure-storage-file-datalake/dev_requirements.txt
+++ b/sdk/storage/azure-storage-file-datalake/dev_requirements.txt
@@ -1,6 +1,5 @@
 -e ../../../tools/azure-sdk-tools
-../../core/azure-core
-../azure-storage-blob
+-e ../../core/azure-core
 -e ../../identity/azure-identity
+-e ../azure-storage-blob
 aiohttp>=3.0
-adal

--- a/sdk/storage/azure-storage-file-share/dev_requirements.txt
+++ b/sdk/storage/azure-storage-file-share/dev_requirements.txt
@@ -1,5 +1,5 @@
 -e ../../../tools/azure-sdk-tools
-../../core/azure-core
-azure-identity
+-e ../../core/azure-core
+-e ../../identity/azure-identity
 -e ../azure-storage-blob
 aiohttp>=3.0

--- a/sdk/storage/azure-storage-queue/dev_requirements.txt
+++ b/sdk/storage/azure-storage-queue/dev_requirements.txt
@@ -1,5 +1,5 @@
 -e ../../../tools/azure-sdk-tools
-../../core/azure-core
-azure-identity
+-e ../../core/azure-core
+-e ../../identity/azure-identity
 azure-mgmt-storage==20.1.0
 aiohttp>=3.0

--- a/sdk/storage/tests.yml
+++ b/sdk/storage/tests.yml
@@ -5,10 +5,9 @@ parameters:
     type: object
     default:
       - azure-storage-blob
-      - azure-storage-blob-changefeed
-      - azure-storage-queue
       - azure-storage-file-datalake
       - azure-storage-file-share
+      - azure-storage-queue
 
 extends:
     template: /eng/pipelines/templates/stages/archetype-sdk-tests.yml
@@ -31,7 +30,6 @@ extends:
             Selection: sparse
             GenerateVMJobs: true
       EnvVars:
-        TEST_MODE: 'RunLiveNoRecord'
         AZURE_SKIP_LIVE_RECORDING: 'True'
         AZURE_TEST_RUN_LIVE: 'true'
         AZURE_SUBSCRIPTION_ID: $(azure-subscription-id)


### PR DESCRIPTION
This change includes minor adjustments to all of our `dev_requirements` files to bring them in line with each in terms what packages are installed and where interactive mode is used.

Also removes `azure-storage-blob-changefeed` from our tests.yml as all changedfeed tests are currently playback only so it doesn't make sense to run the Live test pipeline on that package. This should save some Storage account resources.