### PR TITLE
[Storage] Testing for Oauth Custom Audience Intermittent Failures

### DIFF
--- a/tools/azure-sdk-tools/devtools_testutils/azure_recorded_testcase.py
+++ b/tools/azure-sdk-tools/devtools_testutils/azure_recorded_testcase.py
@@ -271,11 +271,11 @@ def get_credential(**kwargs):
                 **kwargs
             )
         # This is for testing purposes only, to ensure that the AzurePipelinesCredential is used when available
-        # else:
-        #     raise ValueError(
-        #         "Environment variables not set for service principal authentication. "
-        #         f"service_connection_id: {service_connection_id}, client_id: {client_id}, tenant_id: {tenant_id}, system_access_token: {system_access_token}"
-        #     )
+        else:
+            raise ValueError(
+                "Environment variables not set for service principal authentication. "
+                f"service_connection_id: {service_connection_id}, client_id: {client_id}, tenant_id: {tenant_id}, system_access_token: {system_access_token}"
+            )
         # Fall back to DefaultAzureCredential
         from azure.identity import DefaultAzureCredential
         if is_async:


### PR DESCRIPTION
We are currently facing some issues with some Live tests falling back on `DefaultAzureCredential` rather than `AzurePipelinesCredential`
https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3962010&view=logs&j=8c7316b5-97ce-51d1-dc98-ee9903aaafda&t=1af13c7a-10b9-5ea0-4c43-fb6f4ca97f87&l=3561
https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3962010&view=ms.vss-test-web.build-test-results-tab


Putting this up to uncomment some code that should help us identify the root cause.