### PR TITLE
[Storage] Add crc64 support to Datalake `download_file`

### DIFF
--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_client.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_client.py
@@ -894,15 +894,25 @@ class BlobClient(StorageAccountHostsMixin, StorageEncryptionMixin):  # pylint: d
 
             This keyword argument was introduced in API version '2019-12-12'.
 
-        :keyword bool validate_content:
-            If true, calculates an MD5 hash for each chunk of the blob. The storage
-            service checks the hash of the content that has arrived with the hash
-            that was sent. This is primarily valuable for detecting bitflips on
-            the wire if using http instead of https, as https (the default), will
-            already validate. Note that this MD5 hash is not stored with the
-            blob. Also note that if enabled, the memory-efficient upload algorithm
-            will not be used because computing the MD5 hash requires buffering
-            entire blocks, and doing so defeats the purpose of the memory-efficient algorithm.
+        :keyword validate_content:
+            Enables checksum validation for the transfer.
+
+            bool - Passing a boolean is now deprecated. Will perform basic checksum validation via a pipeline
+            policy that calculates an MD5 hash for each data chunk and verifies it matches what the service sent.
+            This is primarily valuable for detecting bit-flips on the wire if using http instead of https.
+
+            "auto" - Allows the SDK to choose the best checksum algorithm to use. Currently, chooses 'crc64'.
+
+            "crc64" - This is currently the preferred choice for performance reasons and the level of validation.
+            Performs validation using Azure Storage's specific implementation of CRC64 with a custom
+            polynomial. This also uses a more sophisticated algorithm internally that may help catch
+            client-side data integrity issues.
+            NOTE: This requires the `azure-storage-extensions` package to be installed.
+
+            "md5" - Performs validation using MD5. Where available this may use a more sophisticated algorithm
+            internally that may help catch client-side data integrity issues (similar to 'crc64') but it is
+            not possible in all scenarios and may revert to the naive approach of using a pipeline policy.
+        :paramtype validate_content: Literal['auto', 'crc64', 'md5']
         :keyword lease:
             Required if the blob has an active lease. If specified, download_blob only
             succeeds if the blob's lease is active and matches this ID. Value can be a

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_blob_client_async.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_blob_client_async.py
@@ -478,15 +478,25 @@ class BlobClient(AsyncStorageAccountHostsMixin, BlobClientBase, StorageEncryptio
 
             This keyword argument was introduced in API version '2019-12-12'.
 
-        :keyword bool validate_content:
-            If true, calculates an MD5 hash for each chunk of the blob. The storage
-            service checks the hash of the content that has arrived with the hash
-            that was sent. This is primarily valuable for detecting bitflips on
-            the wire if using http instead of https, as https (the default), will
-            already validate. Note that this MD5 hash is not stored with the
-            blob. Also note that if enabled, the memory-efficient upload algorithm
-            will not be used because computing the MD5 hash requires buffering
-            entire blocks, and doing so defeats the purpose of the memory-efficient algorithm.
+        :keyword validate_content:
+            Enables checksum validation for the transfer.
+
+            bool - Passing a boolean is now deprecated. Will perform basic checksum validation via a pipeline
+            policy that calculates an MD5 hash for each data chunk and verifies it matches what the service sent.
+            This is primarily valuable for detecting bit-flips on the wire if using http instead of https.
+
+            "auto" - Allows the SDK to choose the best checksum algorithm to use. Currently, chooses 'crc64'.
+
+            "crc64" - This is currently the preferred choice for performance reasons and the level of validation.
+            Performs validation using Azure Storage's specific implementation of CRC64 with a custom
+            polynomial. This also uses a more sophisticated algorithm internally that may help catch
+            client-side data integrity issues.
+            NOTE: This requires the `azure-storage-extensions` package to be installed.
+
+            "md5" - Performs validation using MD5. Where available this may use a more sophisticated algorithm
+            internally that may help catch client-side data integrity issues (similar to 'crc64') but it is
+            not possible in all scenarios and may revert to the naive approach of using a pipeline policy.
+        :paramtype validate_content: Literal['auto', 'crc64', 'md5']
         :keyword lease:
             Required if the blob has an active lease. If specified, download_blob only
             succeeds if the blob's lease is active and matches this ID. Value can be a

--- a/sdk/storage/azure-storage-file-datalake/assets.json
+++ b/sdk/storage/azure-storage-file-datalake/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "python",
   "TagPrefix": "python/storage/azure-storage-file-datalake",
-  "Tag": "python/storage/azure-storage-file-datalake_d0c0176354"
+  "Tag": "python/storage/azure-storage-file-datalake_914a8f9400"
 }

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_data_lake_file_client.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_data_lake_file_client.py
@@ -766,8 +766,11 @@ class DataLakeFileClient(PathClient):
             process_storage_error(error)
 
     @distributed_trace
-    def download_file(self, offset=None, length=None, **kwargs):
-        # type: (Optional[int], Optional[int], Any) -> StorageStreamDownloader
+    def download_file(
+        self, offset: Optional[int] = None,
+        length: Optional[int] = None,
+        **kwargs: Any
+    ) -> StorageStreamDownloader:
         """Downloads a file to the StorageStreamDownloader. The readall() method must
         be used to read all the content, or readinto() must be used to download the file into
         a stream. Using chunks() returns an iterator which allows the user to iterate over the content in chunks.
@@ -778,6 +781,25 @@ class DataLakeFileClient(PathClient):
         :param int length:
             Number of bytes to read from the stream. This is optional, but
             should be supplied for optimal performance.
+        :keyword validate_content:
+            Enables checksum validation for the transfer.
+
+            bool - Passing a boolean is now deprecated. Will perform basic checksum validation via a pipeline
+            policy that calculates an MD5 hash for each data chunk and verifies it matches what the service sent.
+            This is primarily valuable for detecting bit-flips on the wire if using http instead of https.
+
+            "auto" - Allows the SDK to choose the best checksum algorithm to use. Currently, chooses 'crc64'.
+
+            "crc64" - This is currently the preferred choice for performance reasons and the level of validation.
+            Performs validation using Azure Storage's specific implementation of CRC64 with a custom
+            polynomial. This also uses a more sophisticated algorithm internally that may help catch
+            client-side data integrity issues.
+            NOTE: This requires the `azure-storage-extensions` package to be installed.
+
+            "md5" - Performs validation using MD5. Where available this may use a more sophisticated algorithm
+            internally that may help catch client-side data integrity issues (similar to 'crc64') but it is
+            not possible in all scenarios and may revert to the naive approach of using a pipeline policy.
+        :paramtype validate_content: Literal['auto', 'crc64', 'md5']
         :keyword lease:
             If specified, download only succeeds if the file's lease is active
             and matches this ID. Required if the file has an active lease.

--- a/sdk/storage/azure-storage-file-datalake/tests/test_content_validation_async.py
+++ b/sdk/storage/azure-storage-file-datalake/tests/test_content_validation_async.py
@@ -166,6 +166,7 @@ class TestStorageContentValidation(AsyncStorageRecordedTestCase):
 
         # Assert
         assert content == data
+        await self._teardown()
 
     @DataLakePreparer()
     @pytest.mark.parametrize('a', [True, 'md5', 'crc64'])  # a: validate_content
@@ -193,6 +194,7 @@ class TestStorageContentValidation(AsyncStorageRecordedTestCase):
         # Assert
         assert content == data
         assert content2 == data[10:1010]
+        await self._teardown()
 
     @DataLakePreparer()
     @pytest.mark.live_test_only
@@ -213,3 +215,4 @@ class TestStorageContentValidation(AsyncStorageRecordedTestCase):
 
         # Assert
         assert content == data
+        await self._teardown()

--- a/sdk/storage/azure-storage-file-datalake/tests/test_content_validation_async.py
+++ b/sdk/storage/azure-storage-file-datalake/tests/test_content_validation_async.py
@@ -14,7 +14,13 @@ from azure.storage.filedatalake.aio import (
 from devtools_testutils.aio import recorded_by_proxy_async
 from devtools_testutils.storage.aio import AsyncStorageRecordedTestCase, GenericTestProxyParametrize1
 from settings.testcase import DataLakePreparer
-from test_content_validation import assert_content_crc64, assert_content_md5, assert_structured_message
+from test_content_validation import (
+    assert_content_crc64,
+    assert_content_md5,
+    assert_content_md5_get,
+    assert_structured_message,
+    assert_structured_message_get
+)
 
 
 class TestStorageContentValidation(AsyncStorageRecordedTestCase):
@@ -139,3 +145,71 @@ class TestStorageContentValidation(AsyncStorageRecordedTestCase):
         result = await file.download_file()
         assert await result.readall() == content * len(data_list)
         await self._teardown()
+
+    @DataLakePreparer()
+    @pytest.mark.parametrize('a', [True, 'md5', 'crc64'])  # a: validate_content
+    @GenericTestProxyParametrize1()
+    @recorded_by_proxy_async
+    async def test_download_file(self, a, **kwargs):
+        datalake_storage_account_name = kwargs.pop("datalake_storage_account_name")
+        datalake_storage_account_key = kwargs.pop("datalake_storage_account_key")
+
+        await self._setup(datalake_storage_account_name, datalake_storage_account_key)
+        file = self.file_system.get_file_client(self._get_file_reference())
+        data = b'abc' * 512
+        await file.upload_data(data, overwrite=True)
+        assert_method = assert_structured_message_get if a == 'crc64' else assert_content_md5_get
+
+        # Act
+        downloader = await file.download_file(validate_content=a, raw_response_hook=assert_method)
+        content = await downloader.read()
+
+        # Assert
+        assert content == data
+
+    @DataLakePreparer()
+    @pytest.mark.parametrize('a', [True, 'md5', 'crc64'])  # a: validate_content
+    @GenericTestProxyParametrize1()
+    @recorded_by_proxy_async
+    async def test_download_file_chunks(self, a, **kwargs):
+        datalake_storage_account_name = kwargs.pop("datalake_storage_account_name")
+        datalake_storage_account_key = kwargs.pop("datalake_storage_account_key")
+
+        await self._setup(datalake_storage_account_name, datalake_storage_account_key)
+        self.file_system._config.max_single_get_size = 512
+        self.file_system._config.max_chunk_get_size = 512
+        file = self.file_system.get_file_client(self._get_file_reference())
+        data = b'abc' * 512 + b'abcde'
+        await file.upload_data(data, overwrite=True)
+        assert_method = assert_structured_message_get if a == 'crc64' else assert_content_md5_get
+
+        # Act
+        downloader = await file.download_file(validate_content=a, raw_response_hook=assert_method)
+        content = await downloader.read()
+
+        downloader2 = await file.download_file(offset=10, length=1000, validate_content=a, raw_response_hook=assert_method)
+        content2 = await downloader2.read()
+
+        # Assert
+        assert content == data
+        assert content2 == data[10:1010]
+
+    @DataLakePreparer()
+    @pytest.mark.live_test_only
+    async def test_download_file_large_chunks(self, **kwargs):
+        datalake_storage_account_name = kwargs.pop("datalake_storage_account_name")
+        datalake_storage_account_key = kwargs.pop("datalake_storage_account_key")
+
+        await self._setup(datalake_storage_account_name, datalake_storage_account_key)
+        file = self.file_system.get_file_client(self._get_file_reference())
+        # The service will use 4 MiB for structured message chunk size, so make chunk size larger
+        self.file_system._config.max_chunk_get_size = 10 * 1024 * 1024
+        data = b'abcde' * 30 * 1024 * 1024 + b'abcde'  # 150 MiB + 5
+        await file.upload_data(data, overwrite=True, max_concurrency=5)
+
+        # Act
+        downloader = await file.download_file(validate_content='crc64', max_concurrency=3)
+        content = await downloader.read()
+
+        # Assert
+        assert content == data


### PR DESCRIPTION
This changes adds crc64 support to `download_file`. Since Datalake calls into Blob for download, all that was needed was updating the documented keyword and adding tests. Also updating the docs for Blob since I forgot in the last change.