### PR TITLE
[EventHubs] update perf baseline

### DIFF
--- a/sdk/eventhub/perf-tests.yml
+++ b/sdk/eventhub/perf-tests.yml
@@ -6,7 +6,7 @@ PrimaryPackage: azure-eventhub
 
 PackageVersions:
 - azure-core: 1.26.2
-  azure-eventhub: 5.11.3
+  azure-eventhub: 5.12.1
 - azure-core: source
   azure-eventhub: source
 


### PR DESCRIPTION
Updating perf baseline to 5.12.1 to include more recent fixes that improved perf.