### PR TITLE
Address Breaking Release

### DIFF
--- a/eng/pipelines/templates/stages/archetype-python-release.yml
+++ b/eng/pipelines/templates/stages/archetype-python-release.yml
@@ -34,7 +34,18 @@ stages:
                 deploy:
                   steps:
                     - checkout: self
+
+                    - task: UsePythonVersion@0
+                      inputs:
+                        versionSpec: '3.12'
+
+                    - script: |
+                        set -e
+                        python -m pip install -r eng/release_requirements.txt
+                      displayName: Install Release Dependencies
+
                     - template: /eng/common/pipelines/templates/steps/retain-run.yml
+
                     - template: /eng/common/pipelines/templates/steps/set-test-pipeline-version.yml
                       parameters:
                         PackageName: "azure-template"

--- a/eng/pipelines/templates/steps/build-package-artifacts.yml
+++ b/eng/pipelines/templates/steps/build-package-artifacts.yml
@@ -34,6 +34,11 @@ parameters:
 # However, please note that this variable will not ALWAYS be set. If using `build-artifacts.yml`, ensure that this variable is set AT LEAST
 # to "linux", otherwise the primary tasks will not be run as expected. APIStub, Docs, etc are NOT run on machines that aren't linux.
 steps:
+  - task: UsePythonVersion@0
+    displayName: 'Use Python $(PythonVersion)'
+    inputs:
+      versionSpec: $(PythonVersion)
+
   - template: /eng/common/pipelines/templates/steps/set-test-pipeline-version.yml@self
     parameters:
       PackageName: "azure-template"
@@ -46,12 +51,6 @@ steps:
       echo "##vso[build.addbuildtag]Scheduled"
     displayName: 'Tag scheduled builds'
     condition: and(eq(variables['Build.SourceBranchName'], variables['DefaultBranch']), eq(variables['Build.Reason'],'Schedule'))
-
-  - task: UsePythonVersion@0
-    displayName: 'Use Python $(PythonVersion)'
-    inputs:
-      versionSpec: $(PythonVersion)
-
 
   - template: /eng/pipelines/templates/steps/use-venv.yml
     parameters:


### PR DESCRIPTION
Default agent install of python 38 is blowing up in a new interesting way.

![image](https://github.com/user-attachments/assets/a53212e7-18e3-49b5-a84a-face741e1b60)

[Example Build](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3971266&view=logs&j=3dc8fd7e-4368-5a92-293e-d53cefc8c4b3&t=352c26c2-0ff9-5c2d-4ae8-5acc0e1d472e&l=173)

The solution is to not use the default python on the machine...ever. Only due to not touching the code that it's like this.