### PR TITLE
Fix for docstrings for Command.command setter and getter

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_builders/command.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_builders/command.py
@@ -394,7 +394,7 @@ class Command(BaseNode, NodeWithGroupInputMixin):
 
     @property
     def command(self) -> Optional[str]:
-        """Sets the command to be executed.
+        """The command to be executed.
 
         :rtype: Optional[str]
         """
@@ -408,7 +408,7 @@ class Command(BaseNode, NodeWithGroupInputMixin):
 
     @command.setter
     def command(self, value: str) -> None:
-        """The command to be executed.
+        """Sets the command to be executed.
 
         :param value: The command to be executed.
         :type value: str


### PR DESCRIPTION
# Description

Setter and getter docstrings were reversed.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
