### PR TITLE
[SB] Fix Scope URI for Management Client

### DIFF
--- a/sdk/servicebus/azure-servicebus/azure/servicebus/aio/management/_management_client_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/aio/management/_management_client_async.py
@@ -231,6 +231,10 @@ class ServiceBusAdministrationClient:  # pylint:disable=too-many-public-methods
         kwargs["headers"] = kwargs.get("headers", {})
 
         async def _populate_header_within_kwargs(uri, header):
+            if not isinstance(
+                self._credential,
+                ServiceBusSharedKeyCredential):
+                uri = JWT_TOKEN_SCOPE
             token = (await self._credential.get_token(uri)).token
             if not isinstance(
                 self._credential,

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/management/_management_client.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/management/_management_client.py
@@ -229,6 +229,10 @@ class ServiceBusAdministrationClient:  # pylint:disable=too-many-public-methods
         kwargs["headers"] = kwargs.get("headers", {})
 
         def _populate_header_within_kwargs(uri, header):
+            if not isinstance(
+                self._credential,
+                ServiceBusSharedKeyCredential):
+                uri = JWT_TOKEN_SCOPE
             token = self._credential.get_token(uri).token
             if not isinstance(
                 self._credential,

--- a/sdk/servicebus/azure-servicebus/samples/async_samples/auto_lock_renew_async.py
+++ b/sdk/servicebus/azure-servicebus/samples/async_samples/auto_lock_renew_async.py
@@ -21,14 +21,17 @@ import asyncio
 from azure.servicebus import ServiceBusMessage
 from azure.servicebus.aio import ServiceBusClient, AutoLockRenewer
 from azure.servicebus.exceptions import ServiceBusError
+from azure.identity.aio import DefaultAzureCredential
 
-CONNECTION_STR = os.environ['SERVICEBUS_CONNECTION_STR']
+FULLY_QUALIFIED_NAMESPACE = os.environ['SERVICEBUS_FULLY_QUALIFIED_NAMESPACE']
 QUEUE_NAME = os.environ["SERVICEBUS_QUEUE_NAME"]
 SESSION_QUEUE_NAME = os.environ['SERVICEBUS_SESSION_QUEUE_NAME']
 
 
+
 async def renew_lock_on_message_received_from_non_sessionful_entity():
-    servicebus_client = ServiceBusClient.from_connection_string(conn_str=CONNECTION_STR)
+    credential = DefaultAzureCredential()
+    servicebus_client = ServiceBusClient(FULLY_QUALIFIED_NAMESPACE, credential)
 
     async with servicebus_client:
         async with servicebus_client.get_queue_sender(queue_name=QUEUE_NAME) as sender:
@@ -57,7 +60,8 @@ async def renew_lock_on_message_received_from_non_sessionful_entity():
 
 
 async def renew_lock_on_session_of_the_sessionful_entity():
-    servicebus_client = ServiceBusClient.from_connection_string(conn_str=CONNECTION_STR)
+    credential = DefaultAzureCredential()
+    servicebus_client = ServiceBusClient(FULLY_QUALIFIED_NAMESPACE, credential)
 
     async with servicebus_client:
 
@@ -86,7 +90,8 @@ async def renew_lock_on_session_of_the_sessionful_entity():
 
 
 async def renew_lock_with_lock_renewal_failure_callback():
-    servicebus_client = ServiceBusClient.from_connection_string(conn_str=CONNECTION_STR)
+    credential = DefaultAzureCredential()
+    servicebus_client = ServiceBusClient(FULLY_QUALIFIED_NAMESPACE, credential)
 
     async with servicebus_client:
         async with servicebus_client.get_queue_sender(queue_name=QUEUE_NAME) as sender:

--- a/sdk/servicebus/azure-servicebus/samples/async_samples/connection_to_custom_endpoint_address_async.py
+++ b/sdk/servicebus/azure-servicebus/samples/async_samples/connection_to_custom_endpoint_address_async.py
@@ -13,9 +13,10 @@ import os
 import asyncio
 from azure.servicebus import ServiceBusMessage
 from azure.servicebus.aio import ServiceBusClient
+from azure.identity.aio import DefaultAzureCredential
 
 
-CONNECTION_STR = os.environ['SERVICEBUS_CONNECTION_STR']
+FULLY_QUALIFIED_NAMESPACE = os.environ['SERVICEBUS_FULLY_QUALIFIED_NAMESPACE']
 QUEUE_NAME = os.environ["SERVICEBUS_QUEUE_NAME"]
 # The custom endpoint address to use for establishing a connection to the Service Bus service,
 # allowing network requests to be routed through any application gateways
@@ -31,8 +32,10 @@ async def send_single_message(sender):
     await sender.send_messages(message)
 
 async def main():
-    servicebus_client = ServiceBusClient.from_connection_string(
-    conn_str=CONNECTION_STR, 
+    credential = DefaultAzureCredential()
+    servicebus_client = ServiceBusClient(
+    FULLY_QUALIFIED_NAMESPACE,
+    credential,
     custom_endpoint_address=CUSTOM_ENDPOINT_ADDRESS, 
     connection_verify=CUSTOM_CA_BUNDLE_PATH
     )

--- a/sdk/servicebus/azure-servicebus/samples/async_samples/deadletter_messages_and_correct_async.py
+++ b/sdk/servicebus/azure-servicebus/samples/async_samples/deadletter_messages_and_correct_async.py
@@ -17,9 +17,10 @@ import os
 import asyncio
 from azure.servicebus import ServiceBusMessage, ServiceBusSubQueue
 from azure.servicebus.aio import ServiceBusClient
+from azure.identity.aio import DefaultAzureCredential
 
 
-CONNECTION_STR = os.environ['SERVICEBUS_CONNECTION_STR']
+FULLY_QUALIFIED_NAMESPACE = os.environ['SERVICEBUS_FULLY_QUALIFIED_NAMESPACE']
 QUEUE_NAME = os.environ["SERVICEBUS_QUEUE_NAME"]
 
 async def send_messages(servicebus_client, num_messages):
@@ -93,7 +94,8 @@ async def fix_deadletters(servicebus_client):
                 await receiver.complete_message(msg)
 
 async def main():
-    servicebus_client = ServiceBusClient.from_connection_string(conn_str=CONNECTION_STR)
+    credential = DefaultAzureCredential()
+    servicebus_client = ServiceBusClient(FULLY_QUALIFIED_NAMESPACE, credential)
     receiver = servicebus_client.get_queue_receiver(queue_name=QUEUE_NAME)
     dlq_receiver = servicebus_client.get_queue_receiver(queue_name=QUEUE_NAME, 
                                                         sub_queue=ServiceBusSubQueue.DEAD_LETTER)

--- a/sdk/servicebus/azure-servicebus/samples/async_samples/mgmt_queue_async.py
+++ b/sdk/servicebus/azure-servicebus/samples/async_samples/mgmt_queue_async.py
@@ -18,8 +18,9 @@ import os
 import asyncio
 import uuid
 from azure.servicebus.aio.management import ServiceBusAdministrationClient
+from azure.identity.aio import DefaultAzureCredential
 
-CONNECTION_STR = os.environ['SERVICEBUS_CONNECTION_STR']
+FULLY_QUALIFIED_NAMESPACE = os.environ['SERVICEBUS_FULLY_QUALIFIED_NAMESPACE']
 QUEUE_NAME = "sb_mgmt_queue" + str(uuid.uuid4())
 
 
@@ -79,7 +80,8 @@ async def get_queue_runtime_properties(servicebus_mgmt_client):
 
 
 async def main():
-    async with ServiceBusAdministrationClient.from_connection_string(CONNECTION_STR) as servicebus_mgmt_client:
+    credential = DefaultAzureCredential()
+    async with ServiceBusAdministrationClient(FULLY_QUALIFIED_NAMESPACE, credential) as servicebus_mgmt_client:
         await create_queue(servicebus_mgmt_client)
         await list_queues(servicebus_mgmt_client)
         await get_and_update_queue(servicebus_mgmt_client)

--- a/sdk/servicebus/azure-servicebus/samples/async_samples/mgmt_rule_async.py
+++ b/sdk/servicebus/azure-servicebus/samples/async_samples/mgmt_rule_async.py
@@ -20,8 +20,9 @@ import asyncio
 import uuid
 from azure.servicebus.management import SqlRuleFilter
 from azure.servicebus.aio.management import ServiceBusAdministrationClient
+from azure.identity.aio import DefaultAzureCredential
 
-CONNECTION_STR = os.environ['SERVICEBUS_CONNECTION_STR']
+FULLY_QUALIFIED_NAMESPACE = os.environ['SERVICEBUS_FULLY_QUALIFIED_NAMESPACE']
 TOPIC_NAME = os.environ['SERVICEBUS_TOPIC_NAME']
 SUBSCRIPTION_NAME = os.environ['SERVICEBUS_SUBSCRIPTION_NAME']
 RULE_NAME = "sb_mgmt_rule" + str(uuid.uuid4())
@@ -97,7 +98,8 @@ async def get_and_update_rule(servicebus_mgmt_client):
 
 
 async def main():
-    async with ServiceBusAdministrationClient.from_connection_string(CONNECTION_STR) as servicebus_mgmt_client:
+    credential = DefaultAzureCredential()
+    async with ServiceBusAdministrationClient(FULLY_QUALIFIED_NAMESPACE, credential) as servicebus_mgmt_client:
         await create_rule(servicebus_mgmt_client)
         await list_rules(servicebus_mgmt_client)
         await get_and_update_rule(servicebus_mgmt_client)

--- a/sdk/servicebus/azure-servicebus/samples/async_samples/mgmt_subscription_async.py
+++ b/sdk/servicebus/azure-servicebus/samples/async_samples/mgmt_subscription_async.py
@@ -18,8 +18,9 @@ import os
 import asyncio
 import uuid
 from azure.servicebus.aio.management import ServiceBusAdministrationClient
+from azure.identity.aio import DefaultAzureCredential
 
-CONNECTION_STR = os.environ['SERVICEBUS_CONNECTION_STR']
+FULLY_QUALIFIED_NAMESPACE = os.environ['SERVICEBUS_FULLY_QUALIFIED_NAMESPACE']
 TOPIC_NAME = os.environ['SERVICEBUS_TOPIC_NAME']
 SUBSCRIPTION_NAME = "sb_mgmt_sub" + str(uuid.uuid4())
 
@@ -68,7 +69,8 @@ async def get_subscription_runtime_properties(servicebus_mgmt_client):
     print("")
 
 async def main():
-    async with ServiceBusAdministrationClient.from_connection_string(CONNECTION_STR) as servicebus_mgmt_client:
+    credential = DefaultAzureCredential()
+    async with ServiceBusAdministrationClient(FULLY_QUALIFIED_NAMESPACE, credential) as servicebus_mgmt_client:
         await create_subscription(servicebus_mgmt_client)
         await list_subscriptions(servicebus_mgmt_client)
         await get_and_update_subscription(servicebus_mgmt_client)

--- a/sdk/servicebus/azure-servicebus/samples/async_samples/mgmt_topic_async.py
+++ b/sdk/servicebus/azure-servicebus/samples/async_samples/mgmt_topic_async.py
@@ -19,8 +19,9 @@ import asyncio
 import uuid
 import datetime
 from azure.servicebus.aio.management import ServiceBusAdministrationClient
+from azure.identity.aio import DefaultAzureCredential
 
-CONNECTION_STR = os.environ['SERVICEBUS_CONNECTION_STR']
+FULLY_QUALIFIED_NAMESPACE = os.environ['SERVICEBUS_FULLY_QUALIFIED_NAMESPACE']
 TOPIC_NAME = "sb_mgmt_topic" + str(uuid.uuid4())
 
 
@@ -72,7 +73,8 @@ async def get_topic_runtime_properties(servicebus_mgmt_client):
 
 
 async def main():
-    async with ServiceBusAdministrationClient.from_connection_string(CONNECTION_STR) as servicebus_mgmt_client:
+    credential = DefaultAzureCredential()
+    async with ServiceBusAdministrationClient(FULLY_QUALIFIED_NAMESPACE, credential) as servicebus_mgmt_client:
         await create_topic(servicebus_mgmt_client)
         await list_topics(servicebus_mgmt_client)
         await get_and_update_topic(servicebus_mgmt_client)

--- a/sdk/servicebus/azure-servicebus/samples/async_samples/proxy_async.py
+++ b/sdk/servicebus/azure-servicebus/samples/async_samples/proxy_async.py
@@ -13,8 +13,9 @@ import os
 import asyncio
 from azure.servicebus import ServiceBusMessage
 from azure.servicebus.aio import ServiceBusClient
+from azure.identity.aio import DefaultAzureCredential
 
-CONNECTION_STR = os.environ['SERVICEBUS_CONNECTION_STR']
+FULLY_QUALIFIED_NAMESPACE = os.environ['SERVICEBUS_FULLY_QUALIFIED_NAMESPACE']
 QUEUE_NAME = os.environ["SERVICEBUS_QUEUE_NAME"]
 
 
@@ -32,8 +33,10 @@ async def send_single_message(sender):
 
 
 async def main():
-    servicebus_client = ServiceBusClient.from_connection_string(
-        conn_str=CONNECTION_STR,
+    credential = DefaultAzureCredential()
+    servicebus_client = ServiceBusClient(
+        FULLY_QUALIFIED_NAMESPACE,
+        credential,
         http_proxy=HTTP_PROXY
     )
 

--- a/sdk/servicebus/azure-servicebus/samples/async_samples/receive_deadlettered_messages_async.py
+++ b/sdk/servicebus/azure-servicebus/samples/async_samples/receive_deadlettered_messages_async.py
@@ -13,14 +13,16 @@ import os
 import asyncio
 from azure.servicebus import ServiceBusMessage, ServiceBusSubQueue
 from azure.servicebus.aio import ServiceBusClient
+from azure.identity.aio import DefaultAzureCredential
 
 
-CONNECTION_STR = os.environ['SERVICEBUS_CONNECTION_STR']
+FULLY_QUALIFIED_NAMESPACE = os.environ['SERVICEBUS_FULLY_QUALIFIED_NAMESPACE']
 QUEUE_NAME = os.environ["SERVICEBUS_QUEUE_NAME"]
 
 
 async def main():
-    servicebus_client = ServiceBusClient.from_connection_string(conn_str=CONNECTION_STR)
+    credential = DefaultAzureCredential()
+    servicebus_client = ServiceBusClient(FULLY_QUALIFIED_NAMESPACE, credential)
 
     async with servicebus_client:
         sender = servicebus_client.get_queue_sender(queue_name=QUEUE_NAME)

--- a/sdk/servicebus/azure-servicebus/samples/async_samples/receive_deferred_message_queue_async.py
+++ b/sdk/servicebus/azure-servicebus/samples/async_samples/receive_deferred_message_queue_async.py
@@ -13,14 +13,16 @@ import os
 import asyncio
 from azure.servicebus import ServiceBusMessage
 from azure.servicebus.aio import ServiceBusClient
+from azure.identity.aio import DefaultAzureCredential
 
 
-CONNECTION_STR = os.environ['SERVICEBUS_CONNECTION_STR']
+FULLY_QUALIFIED_NAMESPACE = os.environ['SERVICEBUS_FULLY_QUALIFIED_NAMESPACE']
 QUEUE_NAME = os.environ["SERVICEBUS_QUEUE_NAME"]
 
 
 async def main():
-    servicebus_client = ServiceBusClient.from_connection_string(conn_str=CONNECTION_STR)
+    credential = DefaultAzureCredential()
+    servicebus_client = ServiceBusClient(FULLY_QUALIFIED_NAMESPACE, credential)
 
     async with servicebus_client:
         sender = servicebus_client.get_queue_sender(queue_name=QUEUE_NAME)

--- a/sdk/servicebus/azure-servicebus/samples/async_samples/receive_iterator_queue_async.py
+++ b/sdk/servicebus/azure-servicebus/samples/async_samples/receive_iterator_queue_async.py
@@ -12,13 +12,15 @@ Example to show iterator receiving from a Service Bus Queue asynchronously.
 import os
 import asyncio
 from azure.servicebus.aio import ServiceBusClient
+from azure.identity.aio import DefaultAzureCredential
 
-CONNECTION_STR = os.environ['SERVICEBUS_CONNECTION_STR']
+FULLY_QUALIFIED_NAMESPACE = os.environ['SERVICEBUS_FULLY_QUALIFIED_NAMESPACE']
 QUEUE_NAME = os.environ["SERVICEBUS_QUEUE_NAME"]
 
 
 async def main():
-    servicebus_client = ServiceBusClient.from_connection_string(conn_str=CONNECTION_STR)
+    credential = DefaultAzureCredential()
+    servicebus_client = ServiceBusClient(FULLY_QUALIFIED_NAMESPACE, credential)
 
     async with servicebus_client:
         receiver = servicebus_client.get_queue_receiver(queue_name=QUEUE_NAME)

--- a/sdk/servicebus/azure-servicebus/samples/async_samples/receive_peek_async.py
+++ b/sdk/servicebus/azure-servicebus/samples/async_samples/receive_peek_async.py
@@ -12,13 +12,15 @@ Example to show browsing messages currently pending in the queue asynchronously.
 import os
 import asyncio
 from azure.servicebus.aio import ServiceBusClient
+from azure.identity.aio import DefaultAzureCredential
 
-CONNECTION_STR = os.environ['SERVICEBUS_CONNECTION_STR']
+FULLY_QUALIFIED_NAMESPACE = os.environ['SERVICEBUS_FULLY_QUALIFIED_NAMESPACE']
 QUEUE_NAME = os.environ["SERVICEBUS_QUEUE_NAME"]
 
 
 async def main():
-    servicebus_client = ServiceBusClient.from_connection_string(conn_str=CONNECTION_STR)
+    credential = DefaultAzureCredential()
+    servicebus_client = ServiceBusClient(FULLY_QUALIFIED_NAMESPACE, credential)
 
     async with servicebus_client:
         receiver = servicebus_client.get_queue_receiver(queue_name=QUEUE_NAME)

--- a/sdk/servicebus/azure-servicebus/samples/async_samples/receive_queue_async.py
+++ b/sdk/servicebus/azure-servicebus/samples/async_samples/receive_queue_async.py
@@ -12,13 +12,15 @@ Example to show receiving batch messages from a Service Bus Queue asynchronously
 import os
 import asyncio
 from azure.servicebus.aio import ServiceBusClient
+from azure.identity.aio import DefaultAzureCredential
 
-CONNECTION_STR = os.environ['SERVICEBUS_CONNECTION_STR']
+FULLY_QUALIFIED_NAMESPACE = os.environ['SERVICEBUS_FULLY_QUALIFIED_NAMESPACE']
 QUEUE_NAME = os.environ["SERVICEBUS_QUEUE_NAME"]
 
 
 async def main():
-    servicebus_client = ServiceBusClient.from_connection_string(conn_str=CONNECTION_STR)
+    credential = DefaultAzureCredential()
+    servicebus_client = ServiceBusClient(FULLY_QUALIFIED_NAMESPACE, credential)
 
     async with servicebus_client:
         receiver = servicebus_client.get_queue_receiver(queue_name=QUEUE_NAME)

--- a/sdk/servicebus/azure-servicebus/samples/async_samples/receive_subscription_async.py
+++ b/sdk/servicebus/azure-servicebus/samples/async_samples/receive_subscription_async.py
@@ -12,14 +12,16 @@ Example to show receiving batch messages from a Service Bus Subscription under s
 import os
 import asyncio
 from azure.servicebus.aio import ServiceBusClient
+from azure.identity.aio import DefaultAzureCredential
 
-CONNECTION_STR = os.environ['SERVICEBUS_CONNECTION_STR']
+FULLY_QUALIFIED_NAMESPACE = os.environ['SERVICEBUS_FULLY_QUALIFIED_NAMESPACE']
 TOPIC_NAME = os.environ["SERVICEBUS_TOPIC_NAME"]
 SUBSCRIPTION_NAME = os.environ["SERVICEBUS_SUBSCRIPTION_NAME"]
 
 
 async def main():
-    servicebus_client = ServiceBusClient.from_connection_string(conn_str=CONNECTION_STR)
+    credential = DefaultAzureCredential()
+    servicebus_client = ServiceBusClient(FULLY_QUALIFIED_NAMESPACE, credential)
 
     async with servicebus_client:
         receiver = servicebus_client.get_subscription_receiver(

--- a/sdk/servicebus/azure-servicebus/samples/async_samples/schedule_messages_and_cancellation_async.py
+++ b/sdk/servicebus/azure-servicebus/samples/async_samples/schedule_messages_and_cancellation_async.py
@@ -14,8 +14,9 @@ import asyncio
 import datetime
 from azure.servicebus.aio import ServiceBusClient
 from azure.servicebus import ServiceBusMessage
+from azure.identity.aio import DefaultAzureCredential
 
-CONNECTION_STR = os.environ['SERVICEBUS_CONNECTION_STR']
+FULLY_QUALIFIED_NAMESPACE = os.environ["SERVICEBUS_FULLY_QUALIFIED_NAMESPACE"]
 QUEUE_NAME = os.environ["SERVICEBUS_QUEUE_NAME"]
 
 
@@ -37,7 +38,8 @@ async def schedule_multiple_messages(sender):
 
 
 async def main():
-    servicebus_client = ServiceBusClient.from_connection_string(conn_str=CONNECTION_STR, logging_enable=True)
+    credential = DefaultAzureCredential()
+    servicebus_client = ServiceBusClient(FULLY_QUALIFIED_NAMESPACE, credential, logging_enable=True)
     async with servicebus_client:
         sender = servicebus_client.get_queue_sender(queue_name=QUEUE_NAME)
         async with sender:

--- a/sdk/servicebus/azure-servicebus/samples/async_samples/schedule_topic_messages_and_cancellation_async.py
+++ b/sdk/servicebus/azure-servicebus/samples/async_samples/schedule_topic_messages_and_cancellation_async.py
@@ -14,8 +14,9 @@ import asyncio
 import datetime
 from azure.servicebus.aio import ServiceBusClient
 from azure.servicebus import ServiceBusMessage
+from azure.identity.aio import DefaultAzureCredential
 
-CONNECTION_STR = os.environ["SERVICEBUS_CONNECTION_STR"]
+FULLY_QUALIFIED_NAMESPACE = os.environ["SERVICEBUS_FULLY_QUALIFIED_NAMESPACE"]
 TOPIC_NAME = os.environ["SERVICEBUS_TOPIC_NAME"]
 
 
@@ -39,8 +40,9 @@ async def schedule_multiple_messages(sender):
 
 
 async def main():
-    servicebus_client = ServiceBusClient.from_connection_string(
-        conn_str=CONNECTION_STR, logging_enable=True
+    credential = DefaultAzureCredential()
+    servicebus_client = ServiceBusClient(
+        FULLY_QUALIFIED_NAMESPACE, credential, logging_enable=True
     )
     async with servicebus_client:
         sender = servicebus_client.get_topic_sender(topic_name=TOPIC_NAME)

--- a/sdk/servicebus/azure-servicebus/samples/async_samples/send_and_receive_amqp_annotated_message_async.py
+++ b/sdk/servicebus/azure-servicebus/samples/async_samples/send_and_receive_amqp_annotated_message_async.py
@@ -13,8 +13,9 @@ import os
 import asyncio
 from azure.servicebus.amqp import AmqpAnnotatedMessage, AmqpMessageBodyType, AmqpMessageProperties, AmqpMessageHeader
 from azure.servicebus.aio import ServiceBusClient
+from azure.identity.aio import DefaultAzureCredential
 
-CONNECTION_STR = os.environ['SERVICEBUS_CONNECTION_STR']
+FULLY_QUALIFIED_NAMESPACE = os.environ['SERVICEBUS_FULLY_QUALIFIED_NAMESPACE']
 QUEUE_NAME = os.environ["SERVICEBUS_QUEUE_NAME"]
 
 
@@ -79,7 +80,8 @@ async def receive_and_parse_message(receiver):
 
 
 async def main():
-    servicebus_client = ServiceBusClient.from_connection_string(conn_str=CONNECTION_STR)
+    credential = DefaultAzureCredential()
+    servicebus_client = ServiceBusClient(FULLY_QUALIFIED_NAMESPACE, credential)
 
     async with servicebus_client:
         sender = servicebus_client.get_queue_sender(queue_name=QUEUE_NAME)

--- a/sdk/servicebus/azure-servicebus/samples/async_samples/send_queue_async.py
+++ b/sdk/servicebus/azure-servicebus/samples/async_samples/send_queue_async.py
@@ -13,8 +13,9 @@ import os
 import asyncio
 from azure.servicebus import ServiceBusMessage
 from azure.servicebus.aio import ServiceBusClient
+from azure.identity.aio import DefaultAzureCredential
 
-CONNECTION_STR = os.environ['SERVICEBUS_CONNECTION_STR']
+FULLY_QUALIFIED_NAMESPACE = os.environ['SERVICEBUS_FULLY_QUALIFIED_NAMESPACE']
 QUEUE_NAME = os.environ["SERVICEBUS_QUEUE_NAME"]
 
 
@@ -41,7 +42,8 @@ async def send_batch_message(sender):
 
 
 async def main():
-    servicebus_client = ServiceBusClient.from_connection_string(conn_str=CONNECTION_STR)
+    credential = DefaultAzureCredential()
+    servicebus_client = ServiceBusClient(FULLY_QUALIFIED_NAMESPACE, credential)
 
     async with servicebus_client:
         sender = servicebus_client.get_queue_sender(queue_name=QUEUE_NAME)

--- a/sdk/servicebus/azure-servicebus/samples/async_samples/send_topic_async.py
+++ b/sdk/servicebus/azure-servicebus/samples/async_samples/send_topic_async.py
@@ -13,8 +13,9 @@ import os
 import asyncio
 from azure.servicebus import ServiceBusMessage
 from azure.servicebus.aio import ServiceBusClient
+from azure.identity.aio import DefaultAzureCredential
 
-CONNECTION_STR = os.environ['SERVICEBUS_CONNECTION_STR']
+FULLY_QUALIFIED_NAMESPACE = os.environ['SERVICEBUS_FULLY_QUALIFIED_NAMESPACE']
 TOPIC_NAME = os.environ["SERVICEBUS_TOPIC_NAME"]
 
 
@@ -41,7 +42,8 @@ async def send_batch_message(sender):
 
 
 async def main():
-    servicebus_client = ServiceBusClient.from_connection_string(conn_str=CONNECTION_STR, logging_enable=True)
+    credential = DefaultAzureCredential()
+    servicebus_client = ServiceBusClient(FULLY_QUALIFIED_NAMESPACE, credential, logging_enable=True)
 
     async with servicebus_client:
         sender = servicebus_client.get_topic_sender(topic_name=TOPIC_NAME)

--- a/sdk/servicebus/azure-servicebus/samples/async_samples/session_pool_receive_async.py
+++ b/sdk/servicebus/azure-servicebus/samples/async_samples/session_pool_receive_async.py
@@ -11,9 +11,10 @@ import uuid
 from azure.servicebus.aio import ServiceBusClient, AutoLockRenewer
 from azure.servicebus import ServiceBusMessage, NEXT_AVAILABLE_SESSION
 from azure.servicebus.exceptions import OperationTimeoutError
+from azure.identity.aio import DefaultAzureCredential
 
 
-CONNECTION_STR = os.environ['SERVICEBUS_CONNECTION_STR']
+FULLY_QUALIFIED_NAMESPACE = os.environ['SERVICEBUS_FULLY_QUALIFIED_NAMESPACE']
 # Note: This must be a session-enabled queue.
 SESSION_QUEUE_NAME = os.environ["SERVICEBUS_SESSION_QUEUE_NAME"]
 
@@ -51,7 +52,8 @@ async def sample_session_send_receive_with_pool_async(connection_string, queue_n
 
     concurrent_receivers = 5
     sessions = [str(uuid.uuid4()) for i in range(concurrent_receivers)]
-    client = ServiceBusClient.from_connection_string(connection_string)
+    credential = DefaultAzureCredential()
+    client = ServiceBusClient(FULLY_QUALIFIED_NAMESPACE, credential)
 
     for session_id in sessions:
         async with client.get_queue_sender(queue_name) as sender:

--- a/sdk/servicebus/azure-servicebus/samples/async_samples/session_send_receive_async.py
+++ b/sdk/servicebus/azure-servicebus/samples/async_samples/session_send_receive_async.py
@@ -13,10 +13,11 @@ import os
 import asyncio
 from azure.servicebus import ServiceBusMessage
 from azure.servicebus.aio import ServiceBusClient
+from azure.identity.aio import DefaultAzureCredential
 
-CONNECTION_STR = os.environ['SERVICEBUS_CONNECTION_STR']
 SESSION_QUEUE_NAME = os.environ["SERVICEBUS_SESSION_QUEUE_NAME"]
 SESSION_ID = os.environ['SERVICEBUS_SESSION_ID']
+FULLY_QUALIFIED_NAMESPACE = os.environ['SERVICEBUS_FULLY_QUALIFIED_NAMESPACE']
 
 
 async def send_single_message(sender):
@@ -55,7 +56,8 @@ async def receive_batch_messages(receiver):
 
 
 async def main():
-    servicebus_client = ServiceBusClient.from_connection_string(conn_str=CONNECTION_STR)
+    credential = DefaultAzureCredential()
+    servicebus_client = ServiceBusClient(FULLY_QUALIFIED_NAMESPACE, credential)
 
     async with servicebus_client:
         sender = servicebus_client.get_queue_sender(queue_name=SESSION_QUEUE_NAME)

--- a/sdk/servicebus/azure-servicebus/samples/async_samples/topic_subscription_with_rule_operations_async.py
+++ b/sdk/servicebus/azure-servicebus/samples/async_samples/topic_subscription_with_rule_operations_async.py
@@ -22,9 +22,10 @@ from azure.servicebus.management import (
 )
 from azure.servicebus.aio import ServiceBusClient
 from azure.servicebus import ServiceBusMessage
+from azure.identity.aio import DefaultAzureCredential
 
-CONNECTION_STR = os.environ['SERVICEBUS_CONNECTION_STR']
 TOPIC_NAME = os.environ['SERVICEBUS_TOPIC_NAME']
+FULLY_QUALIFIED_NAMESPACE = os.environ['SERVICEBUS_FULLY_QUALIFIED_NAMESPACE']
 ALL_MSGS_SUBSCRIPTION_NAME = 'sb-allmsgs-sub'
 SQL_FILTER_ONLY_SUBSCRIPTION_NAME = 'sb-sqlfilteronly-sub'
 SQL_FILTER_WITH_ACTION_SUBSCRIPTION_NAME = 'sb-sqlfilteraction-sub'
@@ -141,8 +142,9 @@ async def delete_subscription(servicebus_mgmt_client, subscription_name):
     print("Subscription {} is deleted.".format(subscription_name))
 
 async def main():
-    servicebus_mgmt_client = ServiceBusAdministrationClient.from_connection_string(CONNECTION_STR)
-    servicebus_client = ServiceBusClient.from_connection_string(conn_str=CONNECTION_STR)
+    credential = DefaultAzureCredential()
+    servicebus_mgmt_client = ServiceBusAdministrationClient(FULLY_QUALIFIED_NAMESPACE, credential)
+    servicebus_client = ServiceBusClient(FULLY_QUALIFIED_NAMESPACE, credential)
 
     # Create subscriptions.
     await create_subscription(servicebus_mgmt_client, ALL_MSGS_SUBSCRIPTION_NAME)

--- a/sdk/servicebus/azure-servicebus/samples/sync_samples/auto_lock_renew.py
+++ b/sdk/servicebus/azure-servicebus/samples/sync_samples/auto_lock_renew.py
@@ -20,14 +20,16 @@ import time
 
 from azure.servicebus import ServiceBusClient, AutoLockRenewer, ServiceBusMessage
 from azure.servicebus.exceptions import ServiceBusError
+from azure.identity import DefaultAzureCredential
 
-CONNECTION_STR = os.environ['SERVICEBUS_CONNECTION_STR']
+FULLY_QUALIFIED_NAMESPACE = os.environ['SERVICEBUS_FULLY_QUALIFIED_NAMESPACE']
 QUEUE_NAME = os.environ["SERVICEBUS_QUEUE_NAME"]
 SESSION_QUEUE_NAME = os.environ['SERVICEBUS_SESSION_QUEUE_NAME']
 
 
 def renew_lock_on_message_received_from_non_sessionful_entity():
-    servicebus_client = ServiceBusClient.from_connection_string(conn_str=CONNECTION_STR)
+    credential = DefaultAzureCredential()
+    servicebus_client = ServiceBusClient(FULLY_QUALIFIED_NAMESPACE, credential)
 
     with servicebus_client:
         with servicebus_client.get_queue_sender(queue_name=QUEUE_NAME) as sender:
@@ -56,7 +58,8 @@ def renew_lock_on_message_received_from_non_sessionful_entity():
 
 
 def renew_lock_on_session_of_the_sessionful_entity():
-    servicebus_client = ServiceBusClient.from_connection_string(conn_str=CONNECTION_STR)
+    credential = DefaultAzureCredential()
+    servicebus_client = ServiceBusClient(FULLY_QUALIFIED_NAMESPACE, credential)
 
     with servicebus_client:
 
@@ -89,7 +92,8 @@ def renew_lock_on_session_of_the_sessionful_entity():
 
 
 def renew_lock_with_lock_renewal_failure_callback():
-    servicebus_client = ServiceBusClient.from_connection_string(conn_str=CONNECTION_STR)
+    credential = DefaultAzureCredential()
+    servicebus_client = ServiceBusClient(FULLY_QUALIFIED_NAMESPACE, credential)
 
     with servicebus_client:
         with servicebus_client.get_queue_sender(queue_name=QUEUE_NAME) as sender:

--- a/sdk/servicebus/azure-servicebus/samples/sync_samples/connection_to_custom_endpoint_address.py
+++ b/sdk/servicebus/azure-servicebus/samples/sync_samples/connection_to_custom_endpoint_address.py
@@ -11,9 +11,10 @@ Examples to show how to create async EventHubProducerClient and EventHubConsumer
 
 import os
 from azure.servicebus import ServiceBusClient, ServiceBusMessage
+from azure.identity import DefaultAzureCredential
 
 
-CONNECTION_STR = os.environ['SERVICEBUS_CONNECTION_STR']
+FULLY_QUALIFIED_NAMESPACE = os.environ['SERVICEBUS_FULLY_QUALIFIED_NAMESPACE']
 QUEUE_NAME = os.environ["SERVICEBUS_QUEUE_NAME"]
 # The custom endpoint address to use for establishing a connection to the Service Bus service,
 # allowing network requests to be routed through any application gateways
@@ -28,8 +29,10 @@ def send_single_message(sender):
     message = ServiceBusMessage("Single Message")
     sender.send_messages(message)
 
-servicebus_client = ServiceBusClient.from_connection_string(
-    conn_str=CONNECTION_STR, 
+credential = DefaultAzureCredential()
+servicebus_client = ServiceBusClient(
+    FULLY_QUALIFIED_NAMESPACE,
+    credential,
     logging_enable=True, 
     custom_endpoint_address=CUSTOM_ENDPOINT_ADDRESS, 
     connection_verify=CUSTOM_CA_BUNDLE_PATH

--- a/sdk/servicebus/azure-servicebus/samples/sync_samples/deadletter_messages_and_correct.py
+++ b/sdk/servicebus/azure-servicebus/samples/sync_samples/deadletter_messages_and_correct.py
@@ -15,9 +15,10 @@ to the sample `receive_deadlettered_messages.py`.
 
 import os
 from azure.servicebus import ServiceBusMessage, ServiceBusSubQueue, ServiceBusClient
+from azure.identity import DefaultAzureCredential
 
 
-CONNECTION_STR = os.environ['SERVICEBUS_CONNECTION_STR']
+FULLY_QUALIFIED_NAMESPACE = os.environ['SERVICEBUS_FULLY_QUALIFIED_NAMESPACE']
 QUEUE_NAME = os.environ["SERVICEBUS_QUEUE_NAME"]
 
 def send_messages(servicebus_client, num_messages):
@@ -91,7 +92,8 @@ def fix_deadletters(servicebus_client):
                 receiver.complete_message(msg)
 
 if __name__=="__main__":
-    servicebus_client = ServiceBusClient.from_connection_string(conn_str=CONNECTION_STR)
+    credential = DefaultAzureCredential
+    servicebus_client = ServiceBusClient(FULLY_QUALIFIED_NAMESPACE, credential)
     receiver = servicebus_client.get_queue_receiver(queue_name=QUEUE_NAME)
     dlq_receiver = servicebus_client.get_queue_receiver(queue_name=QUEUE_NAME, 
                                                         sub_queue=ServiceBusSubQueue.DEAD_LETTER)

--- a/sdk/servicebus/azure-servicebus/samples/sync_samples/failure_and_recovery.py
+++ b/sdk/servicebus/azure-servicebus/samples/sync_samples/failure_and_recovery.py
@@ -26,8 +26,9 @@ from azure.servicebus.exceptions import (
     MessageLockLostError,
     MessageNotFoundError
 )
+from azure.identity import DefaultAzureCredential
 
-CONNECTION_STR = os.environ['SERVICEBUS_CONNECTION_STR']
+FULLY_QUALIFIED_NAMESPACE = os.environ['SERVICEBUS_FULLY_QUALIFIED_NAMESPACE']
 QUEUE_NAME = os.environ["SERVICEBUS_QUEUE_NAME"]
 
 def send_batch_messages(sender):
@@ -113,7 +114,8 @@ def receive_messages(receiver):
 
 
 def send_and_receive_defensively():
-    servicebus_client = ServiceBusClient.from_connection_string(conn_str=CONNECTION_STR, logging_enable=True)
+    credential = DefaultAzureCredential()
+    servicebus_client = ServiceBusClient(FULLY_QUALIFIED_NAMESPACE, credential, logging_enable=True)
 
     for _ in range(3): # Connection retries.
         try:

--- a/sdk/servicebus/azure-servicebus/samples/sync_samples/mgmt_queue.py
+++ b/sdk/servicebus/azure-servicebus/samples/sync_samples/mgmt_queue.py
@@ -17,8 +17,9 @@ Example to show managing queue entities under a ServiceBus Namespace, including
 import os
 import uuid
 from azure.servicebus.management import ServiceBusAdministrationClient
+from azure.identity import DefaultAzureCredential
 
-CONNECTION_STR = os.environ['SERVICEBUS_CONNECTION_STR']
+FULLY_QUALIFIED_NAMESPACE = os.environ['SERVICEBUS_FULLY_QUALIFIED_NAMESPACE']
 QUEUE_NAME = "sb_mgmt_queue" + str(uuid.uuid4())
 
 
@@ -77,7 +78,8 @@ def get_queue_runtime_properties(servicebus_mgmt_client):
     print("")
 
 
-with ServiceBusAdministrationClient.from_connection_string(CONNECTION_STR) as servicebus_mgmt_client:
+credential = DefaultAzureCredential()
+with ServiceBusAdministrationClient(FULLY_QUALIFIED_NAMESPACE, credential) as servicebus_mgmt_client:
     create_queue(servicebus_mgmt_client)
     list_queues(servicebus_mgmt_client)
     get_and_update_queue(servicebus_mgmt_client)

--- a/sdk/servicebus/azure-servicebus/samples/sync_samples/mgmt_rule.py
+++ b/sdk/servicebus/azure-servicebus/samples/sync_samples/mgmt_rule.py
@@ -21,8 +21,9 @@ from azure.servicebus.management import (
     ServiceBusAdministrationClient,
     SqlRuleFilter
 )
+from azure.identity import DefaultAzureCredential
 
-CONNECTION_STR = os.environ['SERVICEBUS_CONNECTION_STR']
+FULLY_QUALIFIED_NAMESPACE = os.environ['SERVICEBUS_FULLY_QUALIFIED_NAMESPACE']
 TOPIC_NAME = os.environ['SERVICEBUS_TOPIC_NAME']
 SUBSCRIPTION_NAME = os.environ['SERVICEBUS_SUBSCRIPTION_NAME']
 RULE_NAME = "sb_mgmt_rule" + str(uuid.uuid4())
@@ -97,7 +98,8 @@ def get_and_update_rule(servicebus_mgmt_client):
     )
 
 
-with ServiceBusAdministrationClient.from_connection_string(CONNECTION_STR) as servicebus_mgmt_client:
+credential = DefaultAzureCredential()
+with ServiceBusAdministrationClient(FULLY_QUALIFIED_NAMESPACE, credential) as servicebus_mgmt_client:
     create_rule(servicebus_mgmt_client)
     list_rules(servicebus_mgmt_client)
     get_and_update_rule(servicebus_mgmt_client)

--- a/sdk/servicebus/azure-servicebus/samples/sync_samples/mgmt_subscription.py
+++ b/sdk/servicebus/azure-servicebus/samples/sync_samples/mgmt_subscription.py
@@ -17,8 +17,9 @@ Example to show managing subscription entities under a ServiceBus Namespace, inc
 import os
 import uuid
 from azure.servicebus.management import ServiceBusAdministrationClient
+from azure.identity import DefaultAzureCredential
 
-CONNECTION_STR = os.environ['SERVICEBUS_CONNECTION_STR']
+FULLY_QUALIFIED_NAMESPACE = os.environ['SERVICEBUS_FULLY_QUALIFIED_NAMESPACE']
 TOPIC_NAME = os.environ['SERVICEBUS_TOPIC_NAME']
 SUBSCRIPTION_NAME = "sb_mgmt_sub" + str(uuid.uuid4())
 
@@ -68,7 +69,8 @@ def get_subscription_runtime_properties(servicebus_mgmt_client):
     print("")
 
 
-with ServiceBusAdministrationClient.from_connection_string(CONNECTION_STR) as servicebus_mgmt_client:
+credential = DefaultAzureCredential()
+with ServiceBusAdministrationClient(FULLY_QUALIFIED_NAMESPACE, credential) as servicebus_mgmt_client:
     create_subscription(servicebus_mgmt_client)
     list_subscriptions(servicebus_mgmt_client)
     get_and_update_subscription(servicebus_mgmt_client)

--- a/sdk/servicebus/azure-servicebus/samples/sync_samples/mgmt_topic.py
+++ b/sdk/servicebus/azure-servicebus/samples/sync_samples/mgmt_topic.py
@@ -18,8 +18,9 @@ import os
 import uuid
 import datetime
 from azure.servicebus.management import ServiceBusAdministrationClient
+from azure.identity import DefaultAzureCredential
 
-CONNECTION_STR = os.environ['SERVICEBUS_CONNECTION_STR']
+FULLY_QUALIFIED_NAMESPACE = os.environ['SERVICEBUS_FULLY_QUALIFIED_NAMESPACE']
 TOPIC_NAME = "sb_mgmt_topic" + str(uuid.uuid4())
 
 
@@ -71,7 +72,8 @@ def get_topic_runtime_properties(servicebus_mgmt_client):
     print("")
 
 
-with ServiceBusAdministrationClient.from_connection_string(CONNECTION_STR) as servicebus_mgmt_client:
+credential = DefaultAzureCredential()
+with ServiceBusAdministrationClient(FULLY_QUALIFIED_NAMESPACE, credential) as servicebus_mgmt_client:
     create_topic(servicebus_mgmt_client)
     list_topics(servicebus_mgmt_client)
     get_and_update_topic(servicebus_mgmt_client)

--- a/sdk/servicebus/azure-servicebus/samples/sync_samples/proxy.py
+++ b/sdk/servicebus/azure-servicebus/samples/sync_samples/proxy.py
@@ -11,8 +11,9 @@ Example to show sending message through http proxy to a Service Bus Queue.
 
 import os
 from azure.servicebus import ServiceBusClient, ServiceBusMessage
+from azure.identity import DefaultAzureCredential
 
-CONNECTION_STR = os.environ['SERVICEBUS_CONNECTION_STR']
+FULLY_QUALIFIED_NAMESPACE = os.environ['SERVICEBUS_FULLY_QUALIFIED_NAMESPACE']
 QUEUE_NAME = os.environ["SERVICEBUS_QUEUE_NAME"]
 
 
@@ -29,8 +30,10 @@ def send_single_message(sender):
     sender.send_messages(message)
 
 
-servicebus_client = ServiceBusClient.from_connection_string(
-    conn_str=CONNECTION_STR,
+credential = DefaultAzureCredential()
+servicebus_client = ServiceBusClient(
+    FULLY_QUALIFIED_NAMESPACE,
+    credential,
     http_proxy=HTTP_PROXY
 )
 

--- a/sdk/servicebus/azure-servicebus/samples/sync_samples/receive_deadlettered_messages.py
+++ b/sdk/servicebus/azure-servicebus/samples/sync_samples/receive_deadlettered_messages.py
@@ -11,11 +11,13 @@ Example to show receiving dead-lettered messages from a Service Bus Queue.
 
 import os
 from azure.servicebus import ServiceBusClient, ServiceBusMessage, ServiceBusSubQueue
+from azure.identity import DefaultAzureCredential
 
-CONNECTION_STR = os.environ['SERVICEBUS_CONNECTION_STR']
+FULLY_QUALIFIED_NAMESPACE = os.environ["SERVICEBUS_FULLY_QUALIFIED_NAMESPACE"]
 QUEUE_NAME = os.environ["SERVICEBUS_QUEUE_NAME"]
 
-servicebus_client = ServiceBusClient.from_connection_string(conn_str=CONNECTION_STR)
+credential = DefaultAzureCredential()
+servicebus_client = ServiceBusClient(FULLY_QUALIFIED_NAMESPACE, credential)
 
 with servicebus_client:
     sender = servicebus_client.get_queue_sender(queue_name=QUEUE_NAME)

--- a/sdk/servicebus/azure-servicebus/samples/sync_samples/receive_deferred_message_queue.py
+++ b/sdk/servicebus/azure-servicebus/samples/sync_samples/receive_deferred_message_queue.py
@@ -12,11 +12,13 @@ Example to show receiving deferred message from a Service Bus Queue.
 import os
 from typing import List
 from azure.servicebus import ServiceBusMessage, ServiceBusClient
+from azure.identity import DefaultAzureCredential
 
-CONNECTION_STR = os.environ['SERVICEBUS_CONNECTION_STR']
+FULLY_QUALIFIED_NAMESPACE = os.environ["SERVICEBUS_FULLY_QUALIFIED_NAMESPACE"]
 QUEUE_NAME = os.environ["SERVICEBUS_QUEUE_NAME"]
 
-servicebus_client = ServiceBusClient.from_connection_string(conn_str=CONNECTION_STR)
+credential = DefaultAzureCredential()
+servicebus_client = ServiceBusClient(FULLY_QUALIFIED_NAMESPACE, credential)
 
 with servicebus_client:
     sender = servicebus_client.get_queue_sender(queue_name=QUEUE_NAME)

--- a/sdk/servicebus/azure-servicebus/samples/sync_samples/receive_iterator_queue.py
+++ b/sdk/servicebus/azure-servicebus/samples/sync_samples/receive_iterator_queue.py
@@ -11,11 +11,13 @@ Example to show iterator receiving from a Service Bus Queue.
 
 import os
 from azure.servicebus import ServiceBusClient
+from azure.identity import DefaultAzureCredential
 
-CONNECTION_STR = os.environ['SERVICEBUS_CONNECTION_STR']
+FULLY_QUALIFIED_NAMESPACE = os.environ["SERVICEBUS_FULLY_QUALIFIED_NAMESPACE"]
 QUEUE_NAME = os.environ["SERVICEBUS_QUEUE_NAME"]
 
-servicebus_client = ServiceBusClient.from_connection_string(conn_str=CONNECTION_STR)
+credential = DefaultAzureCredential()
+servicebus_client = ServiceBusClient(FULLY_QUALIFIED_NAMESPACE, credential)
 
 with servicebus_client:
     receiver = servicebus_client.get_queue_receiver(queue_name=QUEUE_NAME)

--- a/sdk/servicebus/azure-servicebus/samples/sync_samples/receive_peek.py
+++ b/sdk/servicebus/azure-servicebus/samples/sync_samples/receive_peek.py
@@ -11,11 +11,13 @@ Example to show browsing messages currently pending in the queue.
 
 import os
 from azure.servicebus import ServiceBusClient
+from azure.identity import DefaultAzureCredential
 
-CONNECTION_STR = os.environ['SERVICEBUS_CONNECTION_STR']
+FULLY_QUALIFIED_NAMESPACE = os.environ["SERVICEBUS_FULLY_QUALIFIED_NAMESPACE"]
 QUEUE_NAME = os.environ["SERVICEBUS_QUEUE_NAME"]
 
-servicebus_client = ServiceBusClient.from_connection_string(conn_str=CONNECTION_STR)
+credential = DefaultAzureCredential()
+servicebus_client = ServiceBusClient(FULLY_QUALIFIED_NAMESPACE, credential)
 
 with servicebus_client:
     receiver = servicebus_client.get_queue_receiver(queue_name=QUEUE_NAME)

--- a/sdk/servicebus/azure-servicebus/samples/sync_samples/receive_queue.py
+++ b/sdk/servicebus/azure-servicebus/samples/sync_samples/receive_queue.py
@@ -11,11 +11,13 @@ Example to show receiving batch messages from a Service Bus Queue.
 
 import os
 from azure.servicebus import ServiceBusClient
+from azure.identity import DefaultAzureCredential
 
-CONNECTION_STR = os.environ['SERVICEBUS_CONNECTION_STR']
+FULLY_QUALIFIED_NAMESPACE = os.environ["SERVICEBUS_FULLY_QUALIFIED_NAMESPACE"]
 QUEUE_NAME = os.environ["SERVICEBUS_QUEUE_NAME"]
 
-servicebus_client = ServiceBusClient.from_connection_string(conn_str=CONNECTION_STR)
+credential = DefaultAzureCredential()
+servicebus_client = ServiceBusClient(FULLY_QUALIFIED_NAMESPACE, credential)
 
 with servicebus_client:
     receiver = servicebus_client.get_queue_receiver(queue_name=QUEUE_NAME)

--- a/sdk/servicebus/azure-servicebus/samples/sync_samples/receive_subscription.py
+++ b/sdk/servicebus/azure-servicebus/samples/sync_samples/receive_subscription.py
@@ -11,13 +11,15 @@ Example to show receiving batch messages from a Service Bus Subscription under s
 
 import os
 from azure.servicebus import ServiceBusClient
+from azure.identity import DefaultAzureCredential
 
 
-CONNECTION_STR = os.environ['SERVICEBUS_CONNECTION_STR']
+FULLY_QUALIFIED_NAMESPACE = os.environ["SERVICEBUS_FULLY_QUALIFIED_NAMESPACE"]
 TOPIC_NAME = os.environ["SERVICEBUS_TOPIC_NAME"]
 SUBSCRIPTION_NAME = os.environ["SERVICEBUS_SUBSCRIPTION_NAME"]
 
-servicebus_client = ServiceBusClient.from_connection_string(conn_str=CONNECTION_STR)
+credential = DefaultAzureCredential()
+servicebus_client = ServiceBusClient(FULLY_QUALIFIED_NAMESPACE, credential)
 with servicebus_client:
     receiver = servicebus_client.get_subscription_receiver(
         topic_name=TOPIC_NAME,

--- a/sdk/servicebus/azure-servicebus/samples/sync_samples/schedule_messages_and_cancellation.py
+++ b/sdk/servicebus/azure-servicebus/samples/sync_samples/schedule_messages_and_cancellation.py
@@ -12,8 +12,9 @@ Example to show scheduling messages to and cancelling messages from a Service Bu
 import os
 import datetime
 from azure.servicebus import ServiceBusClient, ServiceBusMessage
+from azure.identity import DefaultAzureCredential
 
-CONNECTION_STR = os.environ['SERVICEBUS_CONNECTION_STR']
+FULLY_QUALIFIED_NAMESPACE = os.environ["SERVICEBUS_FULLY_QUALIFIED_NAMESPACE"]
 QUEUE_NAME = os.environ["SERVICEBUS_QUEUE_NAME"]
 
 
@@ -33,8 +34,8 @@ def schedule_multiple_messages(sender):
     sequence_numbers = sender.schedule_messages(messages_to_schedule, scheduled_time_utc)
     return sequence_numbers
 
-
-servicebus_client = ServiceBusClient.from_connection_string(conn_str=CONNECTION_STR, logging_enable=True)
+credential = DefaultAzureCredential()
+servicebus_client = ServiceBusClient(FULLY_QUALIFIED_NAMESPACE, credential, logging_enable=True)
 with servicebus_client:
     sender = servicebus_client.get_queue_sender(queue_name=QUEUE_NAME)
     with sender:

--- a/sdk/servicebus/azure-servicebus/samples/sync_samples/schedule_topic_messages_and_cancellation.py
+++ b/sdk/servicebus/azure-servicebus/samples/sync_samples/schedule_topic_messages_and_cancellation.py
@@ -12,8 +12,9 @@ Example to show scheduling messages to and cancelling messages from a Service Bu
 import os
 import datetime
 from azure.servicebus import ServiceBusClient, ServiceBusMessage
+from azure.identity import DefaultAzureCredential
 
-CONNECTION_STR = os.environ["SERVICEBUS_CONNECTION_STR"]
+FULLY_QUALIFIED_NAMESPACE = os.environ['SERVICEBUS_FULLY_QUALIFIED_NAMESPACE']
 TOPIC_NAME = os.environ["SERVICEBUS_TOPIC_NAME"]
 
 
@@ -37,8 +38,9 @@ def schedule_multiple_messages(sender):
 
 
 def main():
-    servicebus_client = ServiceBusClient.from_connection_string(
-        conn_str=CONNECTION_STR, logging_enable=True
+    credential = DefaultAzureCredential()
+    servicebus_client = ServiceBusClient(
+        FULLY_QUALIFIED_NAMESPACE, credential, logging_enable=True
     )
     with servicebus_client:
         sender = servicebus_client.get_topic_sender(topic_name=TOPIC_NAME)

--- a/sdk/servicebus/azure-servicebus/samples/sync_samples/send_and_receive_amqp_annotated_message.py
+++ b/sdk/servicebus/azure-servicebus/samples/sync_samples/send_and_receive_amqp_annotated_message.py
@@ -12,9 +12,10 @@ Example to show sending, receiving and parsing amqp annotated message(s) to a Se
 import os
 from azure.servicebus import ServiceBusClient
 from azure.servicebus.amqp import AmqpAnnotatedMessage, AmqpMessageBodyType
+from azure.identity.aio import DefaultAzureCredential
 
 
-CONNECTION_STR = os.environ['SERVICEBUS_CONNECTION_STR']
+FULLY_QUALIFIED_NAMESPACE = os.environ["SERVICEBUS_FULLY_QUALIFIED_NAMESPACE"]
 QUEUE_NAME = os.environ["SERVICEBUS_QUEUE_NAME"]
 
 
@@ -78,7 +79,8 @@ def receive_and_parse_message(receiver):
         receiver.complete_message(message)
 
 
-servicebus_client = ServiceBusClient.from_connection_string(conn_str=CONNECTION_STR)
+credential = DefaultAzureCredential()
+servicebus_client = ServiceBusClient(FULLY_QUALIFIED_NAMESPACE, credential)
 with servicebus_client:
     sender = servicebus_client.get_queue_sender(queue_name=QUEUE_NAME)
     receiver = servicebus_client.get_queue_receiver(queue_name=QUEUE_NAME, max_wait_time=10)

--- a/sdk/servicebus/azure-servicebus/samples/sync_samples/send_queue.py
+++ b/sdk/servicebus/azure-servicebus/samples/sync_samples/send_queue.py
@@ -11,9 +11,10 @@ Example to show sending message(s) to a Service Bus Queue.
 
 import os
 from azure.servicebus import ServiceBusClient, ServiceBusMessage
+from azure.identity import DefaultAzureCredential
 
 
-CONNECTION_STR = os.environ['SERVICEBUS_CONNECTION_STR']
+FULLY_QUALIFIED_NAMESPACE = os.environ['SERVICEBUS_FULLY_QUALIFIED_NAMESPACE']
 QUEUE_NAME = os.environ["SERVICEBUS_QUEUE_NAME"]
 
 
@@ -39,7 +40,8 @@ def send_batch_message(sender):
     sender.send_messages(batch_message)
 
 
-servicebus_client = ServiceBusClient.from_connection_string(conn_str=CONNECTION_STR, logging_enable=True)
+credential = DefaultAzureCredential()
+servicebus_client = ServiceBusClient(FULLY_QUALIFIED_NAMESPACE, credential, logging_enable=True)
 with servicebus_client:
     sender = servicebus_client.get_queue_sender(queue_name=QUEUE_NAME)
     with sender:

--- a/sdk/servicebus/azure-servicebus/samples/sync_samples/send_topic.py
+++ b/sdk/servicebus/azure-servicebus/samples/sync_samples/send_topic.py
@@ -11,8 +11,9 @@ Example to show sending message(s) to a Service Bus Topic.
 
 import os
 from azure.servicebus import ServiceBusClient, ServiceBusMessage
+from azure.identity import DefaultAzureCredential
 
-CONNECTION_STR = os.environ['SERVICEBUS_CONNECTION_STR']
+FULLY_QUALIFIED_NAMESPACE = os.environ['SERVICEBUS_FULLY_QUALIFIED_NAMESPACE']
 TOPIC_NAME = os.environ["SERVICEBUS_TOPIC_NAME"]
 
 
@@ -38,7 +39,8 @@ def send_batch_message(sender):
     sender.send_messages(batch_message)
 
 
-servicebus_client = ServiceBusClient.from_connection_string(conn_str=CONNECTION_STR, logging_enable=True)
+credential = DefaultAzureCredential()
+servicebus_client = ServiceBusClient(FULLY_QUALIFIED_NAMESPACE, credential, logging_enable=True)
 with servicebus_client:
     sender = servicebus_client.get_topic_sender(topic_name=TOPIC_NAME)
     with sender:

--- a/sdk/servicebus/azure-servicebus/samples/sync_samples/session_pool_receive.py
+++ b/sdk/servicebus/azure-servicebus/samples/sync_samples/session_pool_receive.py
@@ -11,8 +11,9 @@ from typing import List
 
 from azure.servicebus import ServiceBusClient, ServiceBusMessage, AutoLockRenewer, NEXT_AVAILABLE_SESSION
 from azure.servicebus.exceptions import OperationTimeoutError
+from azure.identity import DefaultAzureCredential
 
-CONNECTION_STR = os.environ['SERVICEBUS_CONNECTION_STR']
+FULLY_QUALIFIED_NAMESPACE = os.environ['SERVICEBUS_FULLY_QUALIFIED_NAMESPACE']
 # Note: This must be a session-enabled queue.
 SESSION_QUEUE_NAME = os.environ["SERVICEBUS_SESSION_QUEUE_NAME"]
 
@@ -46,11 +47,12 @@ def message_processing(sb_client, queue_name, messages):
             return
 
 
-def sample_session_send_receive_with_pool(connection_string, queue_name):
+def sample_session_send_receive_with_pool(fully_qualified_namespace, queue_name):
 
     concurrent_receivers = 5
     sessions = [str(uuid.uuid4()) for i in range(2 * concurrent_receivers)]
-    with ServiceBusClient.from_connection_string(connection_string) as client:
+    credential = DefaultAzureCredential()
+    with ServiceBusClient(fully_qualified_namespace, credential) as client:
     
         with client.get_queue_sender(queue_name) as sender:
             for session_id in sessions:
@@ -69,4 +71,4 @@ def sample_session_send_receive_with_pool(connection_string, queue_name):
 
 
 if __name__ == '__main__':
-    sample_session_send_receive_with_pool(CONNECTION_STR, SESSION_QUEUE_NAME)
+    sample_session_send_receive_with_pool(FULLY_QUALIFIED_NAMESPACE, SESSION_QUEUE_NAME)

--- a/sdk/servicebus/azure-servicebus/samples/sync_samples/session_send_receive.py
+++ b/sdk/servicebus/azure-servicebus/samples/sync_samples/session_send_receive.py
@@ -11,8 +11,9 @@ Example to show sending message(s) to and receiving messages from a Service Bus 
 
 import os
 from azure.servicebus import ServiceBusClient, ServiceBusMessage
+from azure.identity import DefaultAzureCredential
 
-CONNECTION_STR = os.environ['SERVICEBUS_CONNECTION_STR']
+FULLY_QUALIFIED_NAMESPACE = os.environ['SERVICEBUS_FULLY_QUALIFIED_NAMESPACE']
 SESSION_QUEUE_NAME = os.environ["SERVICEBUS_SESSION_QUEUE_NAME"]
 SESSION_ID = os.environ['SERVICEBUS_SESSION_ID']
 
@@ -53,7 +54,8 @@ def receive_batch_message(receiver):
 
 
 if __name__ == '__main__':
-    servicebus_client = ServiceBusClient.from_connection_string(conn_str=CONNECTION_STR, logging_enable=True)
+    credential = DefaultAzureCredential()
+    servicebus_client = ServiceBusClient(FULLY_QUALIFIED_NAMESPACE, credential, logging_enable=True)
     with servicebus_client:
         sender = servicebus_client.get_queue_sender(queue_name=SESSION_QUEUE_NAME)
         with sender:

--- a/sdk/servicebus/azure-servicebus/samples/sync_samples/topic_subscription_with_rule_operations.py
+++ b/sdk/servicebus/azure-servicebus/samples/sync_samples/topic_subscription_with_rule_operations.py
@@ -20,8 +20,9 @@ from azure.servicebus.management import (
     CorrelationRuleFilter
 )
 from azure.servicebus import ServiceBusMessage, ServiceBusClient
+from azure.identity import DefaultAzureCredential
 
-CONNECTION_STR = os.environ['SERVICEBUS_CONNECTION_STR']
+FULLY_QUALIFIED_NAMESPACE = os.environ['SERVICEBUS_FULLY_QUALIFIED_NAMESPACE']
 TOPIC_NAME = os.environ['SERVICEBUS_TOPIC_NAME']
 ALL_MSGS_SUBSCRIPTION_NAME = 'sb-allmsgs-sub'
 SQL_FILTER_ONLY_SUBSCRIPTION_NAME = 'sb-sqlfilteronly-sub'
@@ -88,7 +89,8 @@ def create_rule_with_filter(servicebus_mgmt_client, subscription_name, filter_na
         pass
 
 def send_messages():
-    servicebus_client = ServiceBusClient.from_connection_string(CONNECTION_STR)
+    credential = DefaultAzureCredential()
+    servicebus_client = ServiceBusClient(FULLY_QUALIFIED_NAMESPACE, credential)
     print("====================== Sending messages to topic ======================")
     msgs_to_send = []
     with servicebus_client.get_topic_sender(topic_name=TOPIC_NAME) as sender:
@@ -139,8 +141,9 @@ def delete_subscription(servicebus_mgmt_client, subscription_name):
     print("Subscription {} is deleted.".format(subscription_name))
 
 if __name__=="__main__":
-    servicebus_mgmt_client = ServiceBusAdministrationClient.from_connection_string(CONNECTION_STR)
-    servicebus_client = ServiceBusClient.from_connection_string(conn_str=CONNECTION_STR)
+    credential = DefaultAzureCredential()
+    servicebus_mgmt_client = ServiceBusAdministrationClient(FULLY_QUALIFIED_NAMESPACE, credential)
+    servicebus_client = ServiceBusClient(FULLY_QUALIFIED_NAMESPACE, credential)
 
     # Create subscriptions.
     create_subscription(servicebus_mgmt_client, ALL_MSGS_SUBSCRIPTION_NAME)

--- a/sdk/servicebus/azure-servicebus/tests/async_tests/test_queues_async.py
+++ b/sdk/servicebus/azure-servicebus/tests/async_tests/test_queues_async.py
@@ -1784,7 +1784,8 @@ class TestServiceBusQueueAsync(AzureMgmtRecordedTestCase):
 
     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
     def test_queue_message_http_proxy_setting(self, uamqp_transport):
-        mock_conn_str = "Endpoint=sb://mock.servicebus.windows.net/;SharedAccessKeyName=mock;SharedAccessKey=mock"
+        mock_fully_qualified_namespace = "mock_namespace"
+        credential = get_credential(is_async=True)
         http_proxy = {
             'proxy_hostname': '127.0.0.1',
             'proxy_port': 8899,
@@ -1792,7 +1793,7 @@ class TestServiceBusQueueAsync(AzureMgmtRecordedTestCase):
             'password': '123456'
         }
 
-        sb_client = ServiceBusClient(mock_conn_str, http_proxy=http_proxy, uamqp_transport=uamqp_transport)
+        sb_client = ServiceBusClient(mock_fully_qualified_namespace, credential, http_proxy=http_proxy, uamqp_transport=uamqp_transport)
         assert sb_client._config.http_proxy == http_proxy
         assert sb_client._config.transport_type == TransportType.AmqpOverWebsocket
 
@@ -2448,9 +2449,7 @@ class TestServiceBusQueueAsync(AzureMgmtRecordedTestCase):
     async def test_async_send_message_no_body(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_namespace=None, servicebus_queue=None, **kwargs):
         fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
         credential = get_credential(is_async=True)
-        async with ServiceBusClient(
-            servicebus_namespace_connection_string) as sb_client:
-
+        async with ServiceBusClient(fully_qualified_namespace, credential) as sb_client:
             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
                 await sender.send_messages(ServiceBusMessage(body=None))
 

--- a/sdk/servicebus/azure-servicebus/tests/async_tests/test_queues_async.py
+++ b/sdk/servicebus/azure-servicebus/tests/async_tests/test_queues_async.py
@@ -1,2835 +1,2958 @@
-# #-------------------------------------------------------------------------
-# # Copyright (c) Microsoft Corporation. All rights reserved.
-# # Licensed under the MIT License. See License.txt in the project root for
-# # license information.
-# #--------------------------------------------------------------------------
+#-------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+#--------------------------------------------------------------------------
 
-# import asyncio
-# import json
-# import logging
-# import sys
-# import os
-# import types
-# import pytest
-# import time
-# import uuid
-# import pickle
-# from datetime import datetime, timedelta
+import asyncio
+import json
+import logging
+import sys
+import os
+import types
+import pytest
+import time
+import uuid
+import pickle
+from datetime import datetime, timedelta
 
-# try:
-#     import uamqp
-#     from azure.servicebus.aio._transport._uamqp_transport_async import UamqpTransportAsync
-# except ImportError:
-#     uamqp = None
+try:
+    import uamqp
+    from azure.servicebus.aio._transport._uamqp_transport_async import UamqpTransportAsync
+except ImportError:
+    uamqp = None
 
-# try:
-#     from azure.servicebus.aio._transport._pyamqp_transport_async import PyamqpTransportAsync
-# except:
-#     PyamqpTransportAsync = None
-# from azure.servicebus.aio import (
-#     ServiceBusClient,
-#     AutoLockRenewer
-# )
-# from azure.servicebus import (
-#     ServiceBusMessage,
-#     ServiceBusMessageBatch,
-#     ServiceBusReceivedMessage,
-#     TransportType,
-#     ServiceBusReceiveMode,
-#     ServiceBusSubQueue,
-#     ServiceBusMessageState
-# )
-# from azure.servicebus.amqp import (
-#     AmqpMessageHeader,
-#     AmqpMessageBodyType,
-#     AmqpAnnotatedMessage,
-#     AmqpMessageProperties,
-# )
-# from azure.servicebus._pyamqp.message import Message
-# from azure.servicebus._pyamqp import error, management_operation
-# from azure.servicebus._pyamqp.aio import AMQPClientAsync, ReceiveClientAsync, _management_operation_async
-# from azure.servicebus._common.constants import ServiceBusReceiveMode, ServiceBusSubQueue
-# from azure.servicebus._common.utils import utc_now
-# from azure.servicebus.management._models import DictMixin
-# from azure.servicebus.exceptions import (
-#     ServiceBusConnectionError,
-#     ServiceBusError,
-#     MessageLockLostError,
-#     MessageAlreadySettled,
-#     AutoLockRenewTimeout,
-#     MessageSizeExceededError,
-#     OperationTimeoutError
-# )
-# from devtools_testutils import AzureMgmtRecordedTestCase, AzureRecordedTestCase
-# from tests.servicebus_preparer import (
-#     CachedServiceBusNamespacePreparer,
-#     CachedServiceBusQueuePreparer,
-#     ServiceBusQueuePreparer,
-#     CachedServiceBusResourceGroupPreparer
-# )
-# from tests.utilities import get_logger, print_message, sleep_until_expired
-# from mocks_async import MockReceivedMessage, MockReceiver
-# from tests.utilities import get_logger, print_message, sleep_until_expired, uamqp_transport as get_uamqp_transport, ArgPasserAsync
+try:
+    from azure.servicebus.aio._transport._pyamqp_transport_async import PyamqpTransportAsync
+except:
+    PyamqpTransportAsync = None
+from azure.servicebus.aio import (
+    ServiceBusClient,
+    AutoLockRenewer
+)
+from azure.servicebus import (
+    ServiceBusMessage,
+    ServiceBusMessageBatch,
+    ServiceBusReceivedMessage,
+    TransportType,
+    ServiceBusReceiveMode,
+    ServiceBusSubQueue,
+    ServiceBusMessageState
+)
+from azure.servicebus.amqp import (
+    AmqpMessageHeader,
+    AmqpMessageBodyType,
+    AmqpAnnotatedMessage,
+    AmqpMessageProperties,
+)
+from azure.servicebus._pyamqp.message import Message
+from azure.servicebus._pyamqp import error, management_operation
+from azure.servicebus._pyamqp.aio import AMQPClientAsync, ReceiveClientAsync, _management_operation_async
+from azure.servicebus._common.constants import ServiceBusReceiveMode, ServiceBusSubQueue
+from azure.servicebus._common.utils import utc_now
+from azure.servicebus.management._models import DictMixin
+from azure.servicebus.exceptions import (
+    ServiceBusConnectionError,
+    ServiceBusError,
+    MessageLockLostError,
+    MessageAlreadySettled,
+    AutoLockRenewTimeout,
+    MessageSizeExceededError,
+    OperationTimeoutError
+)
+from devtools_testutils import AzureMgmtRecordedTestCase, AzureRecordedTestCase, get_credential
+from tests.servicebus_preparer import (
+    SERVICEBUS_ENDPOINT_SUFFIX,
+    CachedServiceBusNamespacePreparer,
+    CachedServiceBusQueuePreparer,
+    ServiceBusQueuePreparer,
+    CachedServiceBusResourceGroupPreparer
+)
+from tests.utilities import get_logger, print_message, sleep_until_expired
+from mocks_async import MockReceivedMessage, MockReceiver
+from tests.utilities import get_logger, print_message, sleep_until_expired, uamqp_transport as get_uamqp_transport, ArgPasserAsync
 
-# uamqp_transport_params, uamqp_transport_ids = get_uamqp_transport()
+uamqp_transport_params, uamqp_transport_ids = get_uamqp_transport()
 
-# _logger = get_logger(logging.DEBUG)
+_logger = get_logger(logging.DEBUG)
 
 
-# class TestServiceBusQueueAsync(AzureMgmtRecordedTestCase):
+class TestServiceBusQueueAsync(AzureMgmtRecordedTestCase):
 
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True, lock_duration='PT10S')
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_async_queue_by_queue_client_conn_str_receive_handler_peeklock(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         async with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True, lock_duration='PT10S')
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_async_queue_by_queue_client_conn_str_receive_handler_peeklock(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential(is_async=True)
+        async with ServiceBusClient(
+            fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-#             sender = sb_client.get_queue_sender(servicebus_queue.name)
-#             async with sender:
-#                 for i in range(10):
-#                     message = ServiceBusMessage("Handler message no. {}".format(i))
-#                     await sender.send_messages(message, timeout=5)
+            sender = sb_client.get_queue_sender(servicebus_queue.name)
+            async with sender:
+                for i in range(10):
+                    message = ServiceBusMessage("Handler message no. {}".format(i))
+                    await sender.send_messages(message, timeout=5)
 
-#                 # Test that noop empty send works properly.
-#                 await sender.send_messages([])
-#                 await sender.send_messages(ServiceBusMessageBatch())
-#                 assert len(await sender.schedule_messages([], utc_now())) == 0
-#                 await sender.cancel_scheduled_messages([])
+                # Test that noop empty send works properly.
+                await sender.send_messages([])
+                await sender.send_messages(ServiceBusMessageBatch())
+                assert len(await sender.schedule_messages([], utc_now())) == 0
+                await sender.cancel_scheduled_messages([])
 
-#             # Then test expected failure modes.
-#             with pytest.raises(ValueError):
-#                 async with sender:
-#                     raise AssertionError("Should raise ValueError")
-#             with pytest.raises(ValueError):
-#                 await sender.send_messages(ServiceBusMessage('msg'))
-#             with pytest.raises(ValueError):
-#                 await sender.schedule_messages(ServiceBusMessage('msg'), utc_now())
-#             with pytest.raises(ValueError):
-#                 await sender.cancel_scheduled_messages([1, 2, 3])
+            # Then test expected failure modes.
+            with pytest.raises(ValueError):
+                async with sender:
+                    raise AssertionError("Should raise ValueError")
+            with pytest.raises(ValueError):
+                await sender.send_messages(ServiceBusMessage('msg'))
+            with pytest.raises(ValueError):
+                await sender.schedule_messages(ServiceBusMessage('msg'), utc_now())
+            with pytest.raises(ValueError):
+                await sender.cancel_scheduled_messages([1, 2, 3])
 
-#             with pytest.raises(ServiceBusError):
-#                 await (sb_client.get_queue_receiver(servicebus_queue.name, session_id="test", max_wait_time=5))._open_with_retry()
+            with pytest.raises(ServiceBusError):
+                await (sb_client.get_queue_receiver(servicebus_queue.name, session_id="test", max_wait_time=5))._open_with_retry()
 
-#             with pytest.raises(ValueError):
-#                 sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=0)
+            with pytest.raises(ValueError):
+                sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=0)
 
-#             receiver = sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5)
-#             async with receiver:
-#                 assert len(await receiver.receive_deferred_messages([])) == 0
-#                 with pytest.raises(ValueError):
-#                     await receiver.receive_messages(max_wait_time=0)
+            receiver = sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5)
+            async with receiver:
+                assert len(await receiver.receive_deferred_messages([])) == 0
+                with pytest.raises(ValueError):
+                    await receiver.receive_messages(max_wait_time=0)
 
-#                 count = 0
-#                 async for message in receiver:
-#                     print_message(_logger, message)
-#                     count += 1
-#                     await receiver.complete_message(message)
+                count = 0
+                async for message in receiver:
+                    print_message(_logger, message)
+                    count += 1
+                    await receiver.complete_message(message)
 
-#             assert count == 10
+            assert count == 10
 
-#             with pytest.raises(ValueError):
-#                 await receiver.receive_messages()
-#             with pytest.raises(ValueError):
-#                 async with receiver:
-#                     raise AssertionError("Should raise ValueError")
-#             with pytest.raises(ValueError):
-#                 await receiver.receive_deferred_messages([1, 2, 3])
-#             with pytest.raises(ValueError):
-#                 await receiver.peek_messages()
-
-    
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True, lock_duration='PT10S')
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_async_queue_by_queue_client_conn_str_receive_handler_release_messages(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         async with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-
-#             async def sub_test_releasing_messages():
-#                 # test releasing messages when prefetch is 1 and link credits are issue dynamically
-#                 receiver = sb_client.get_queue_receiver(servicebus_queue.name)
-#                 sender = sb_client.get_queue_sender(servicebus_queue.name)
-#                 async with sender, receiver:
-#                     # send 10 msgs to queue first
-#                     await sender.send_messages([ServiceBusMessage('test') for _ in range(5)])
-
-#                     received_msgs = []
-#                     # the amount of messages returned by receive call is not stable, especially in live tests
-#                     # of different os platforms, this is why a while loop is used here to receive the specific
-#                     # amount of message we want to receive
-#                     while len(received_msgs) < 5:
-#                         # issue link credits more than 5, client should consume 5 msgs from the service in total,
-#                         # leaving the extra credits on the wire
-#                         for msg in (await receiver.receive_messages(max_message_count=10, max_wait_time=10)):
-#                             await receiver.complete_message(msg)
-#                             received_msgs.append(received_msgs)
-#                     assert len(received_msgs) == 5
-
-#                     # send 5 more messages, those messages would arrive at the client while the program is sleeping
-#                     await sender.send_messages([ServiceBusMessage('test') for _ in range(5)])
-#                     await asyncio.sleep(15)  # sleep > message expiration time
-
-#                     target_msgs_count = 5
-#                     received_msgs = []
-#                     while len(received_msgs) < target_msgs_count:
-#                         # issue 10 link credits, client should consume 5 msgs from the service, leaving no link credits
-#                         for msg in (await receiver.receive_messages(max_message_count=target_msgs_count - len(received_msgs),
-#                                                              max_wait_time=10)):
-#                             assert msg.delivery_count == 0  # release would not increase delivery count
-#                             await receiver.complete_message(msg)
-#                             received_msgs.append(msg)
-#                     assert len(received_msgs) == 5
-
-#             async def sub_test_releasing_messages_iterator():
-#                 # test nested iterator scenario
-#                 receiver = sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10)
-#                 sender = sb_client.get_queue_sender(servicebus_queue.name)
-#                 async with sender, receiver:
-#                     # send 5 msgs to queue first
-#                     await sender.send_messages([ServiceBusMessage('test') for _ in range(5)])
-#                     first_time = True
-#                     iterator_recv_cnt = 0
-
-#                     # case: iterator + receive batch
-#                     async for msg in receiver:
-#                         assert msg.delivery_count == 0  # release would not increase delivery count
-#                         await receiver.complete_message(msg)
-#                         iterator_recv_cnt += 1
-#                         if first_time:  # for the first time, we call nested receive message call
-#                             received_msgs = []
-
-#                             while len(received_msgs) < 4:  # there supposed to be 5 msgs in the queue
-#                                 # we issue 10 link credits, leaving more credits on the wire
-#                                 for sub_msg in (await receiver.receive_messages(max_message_count=10, max_wait_time=10)):
-#                                     assert sub_msg.delivery_count == 0
-#                                     await receiver.complete_message(sub_msg)
-#                                     received_msgs.append(sub_msg)
-#                             assert len(received_msgs) == 4
-#                             await sender.send_messages([ServiceBusMessage('test') for _ in range(10)])
-#                             await asyncio.sleep(15)  # sleep > message expiration time
-
-#                             received_msgs = []
-#                             target_msgs_count = 5  # we want to receive 5 with the receive message call
-#                             while len(received_msgs) < target_msgs_count:
-#                                 for sub_msg in (await receiver.receive_messages(
-#                                         max_message_count=target_msgs_count - len(received_msgs), max_wait_time=5)):
-#                                     assert sub_msg.delivery_count == 0  # release would not increase delivery count
-#                                     await receiver.complete_message(sub_msg)
-#                                     received_msgs.append(sub_msg)
-#                             assert len(received_msgs) == target_msgs_count
-#                             first_time = False
-#                     assert iterator_recv_cnt == 6  # 1 before nested receive message call + 5 after nested receive message call
-
-#                     # case: iterator + iterator case
-#                     await sender.send_messages([ServiceBusMessage('test') for _ in range(10)])
-#                     outter_recv_cnt = 0
-#                     inner_recv_cnt = 0
-#                     async for msg in receiver:
-#                         assert msg.delivery_count == 0
-#                         outter_recv_cnt += 1
-#                         await receiver.complete_message(msg)
-#                         async for sub_msg in receiver:
-#                             assert sub_msg.delivery_count == 0
-#                             inner_recv_cnt += 1
-#                             await receiver.complete_message(sub_msg)
-#                             if inner_recv_cnt == 5:
-#                                 await asyncio.sleep(15)  # innner finish receiving first 5 messages then sleep until lock expiration
-#                                 break
-#                     assert outter_recv_cnt == 1
-#                     outter_recv_cnt = 0
-#                     async for msg in receiver:
-#                         assert msg.delivery_count == 0
-#                         outter_recv_cnt += 1
-#                         await receiver.complete_message(msg)
-#                     assert outter_recv_cnt == 4
-
-#             async def sub_test_non_releasing_messages():
-#                 # test not releasing messages when prefetch is not 1
-#                 receiver = sb_client.get_queue_receiver(servicebus_queue.name)
-#                 sender = sb_client.get_queue_sender(servicebus_queue.name)
-
-#                 if uamqp_transport:
-#                     def _hack_disable_receive_context_message_received(self, message):
-#                         # pylint: disable=protected-access
-#                         self._handler._was_message_received = True
-#                         self._handler._received_messages.put(message)
-#                 else:
-#                     def _hack_disable_receive_context_message_received(self, frame, message):
-#                         # pylint: disable=protected-access
-#                         self._handler._last_activity_timestamp = time.time()
-#                         self._handler._received_messages.put((frame, message))
-
-#                 async with sender, receiver:
-#                     # send 5 msgs to queue first
-#                     await sender.send_messages([ServiceBusMessage('test') for _ in range(5)])
-#                     if uamqp_transport:
-#                         receiver._handler.message_handler.on_message_received = types.MethodType(
-#                             _hack_disable_receive_context_message_received, receiver)
-#                     else:
-#                         receiver._handler._link._on_transfer = types.MethodType(
-#                             _hack_disable_receive_context_message_received, receiver)
-#                     received_msgs = []
-#                     while len(received_msgs) < 5:
-#                         # issue 10 link credits, client should consume 5 msgs from the service
-#                         # leaving 5 credits on the wire
-#                         for msg in (await receiver.receive_messages(max_message_count=10, max_wait_time=10)):
-#                             await receiver.complete_message(msg)
-#                             received_msgs.append(msg)
-#                     assert len(received_msgs) == 5
-
-#                     # send 5 more messages, those messages would arrive at the client while the program is sleeping
-#                     await sender.send_messages([ServiceBusMessage('test') for _ in range(5)])
-#                     await asyncio.sleep(15)  # sleep > message expiration time
-
-#                     # issue 5 link credits, client should consume 5 msgs from the internal buffer which is already lock expired
-#                     target_msgs_count = 5
-#                     received_msgs = []
-#                     while len(received_msgs) < target_msgs_count:
-#                         received_msgs.extend((await receiver.receive_messages(max_message_count=5, max_wait_time=10)))
-#                     assert len(received_msgs) == 5
-#                     for msg in received_msgs:
-#                         assert msg.delivery_count == 0
-#                         with pytest.raises(ServiceBusError):
-#                             await receiver.complete_message(msg)
-
-#                     # re-received message with delivery count increased
-#                     target_msgs_count = 5
-#                     received_msgs = []
-#                     while len(received_msgs) < target_msgs_count:
-#                         received_msgs.extend((await receiver.receive_messages(max_message_count=5, max_wait_time=10)))
-#                     assert len(received_msgs) == 5
-#                     for msg in received_msgs:
-#                         assert msg.delivery_count > 0
-#                         await receiver.complete_message(msg)
-
-#             await sub_test_releasing_messages()
-#             await sub_test_releasing_messages_iterator()
-#             await sub_test_non_releasing_messages()
+            with pytest.raises(ValueError):
+                await receiver.receive_messages()
+            with pytest.raises(ValueError):
+                async with receiver:
+                    raise AssertionError("Should raise ValueError")
+            with pytest.raises(ValueError):
+                await receiver.receive_deferred_messages([1, 2, 3])
+            with pytest.raises(ValueError):
+                await receiver.peek_messages()
 
     
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_async_queue_by_queue_client_send_multiple_messages(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         async with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-#             sender = sb_client.get_queue_sender(servicebus_queue.name)
-#             async with sender:
-#                 messages = []
-#                 for i in range(10):
-#                     message = ServiceBusMessage("Handler message no. {}".format(i))
-#                     messages.append(message)
-#                 await sender.send_messages(messages)
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True, lock_duration='PT10S')
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_async_queue_by_queue_client_conn_str_receive_handler_release_messages(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential(is_async=True)
+        async with ServiceBusClient(
+            fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-#             with pytest.raises(ValueError):
-#                 async with sender:
-#                     raise AssertionError("Should raise ValueError")
-#             with pytest.raises(ValueError):
-#                 await sender.send_messages(ServiceBusMessage('msg'))
-#             with pytest.raises(ValueError):
-#                 await sender.schedule_messages(ServiceBusMessage('msg'), utc_now())
-#             with pytest.raises(ValueError):
-#                 await sender.cancel_scheduled_messages([1, 2, 3])
+            async def sub_test_releasing_messages():
+                # test releasing messages when prefetch is 1 and link credits are issue dynamically
+                receiver = sb_client.get_queue_receiver(servicebus_queue.name)
+                sender = sb_client.get_queue_sender(servicebus_queue.name)
+                async with sender, receiver:
+                    # send 10 msgs to queue first
+                    await sender.send_messages([ServiceBusMessage('test') for _ in range(5)])
 
-#             receiver = sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5)
-#             count = 0
-#             async for message in receiver:
-#                 print_message(_logger, message)
-#                 count += 1
-#                 await receiver.complete_message(message)
+                    received_msgs = []
+                    # the amount of messages returned by receive call is not stable, especially in live tests
+                    # of different os platforms, this is why a while loop is used here to receive the specific
+                    # amount of message we want to receive
+                    while len(received_msgs) < 5:
+                        # issue link credits more than 5, client should consume 5 msgs from the service in total,
+                        # leaving the extra credits on the wire
+                        for msg in (await receiver.receive_messages(max_message_count=10, max_wait_time=10)):
+                            await receiver.complete_message(msg)
+                            received_msgs.append(received_msgs)
+                    assert len(received_msgs) == 5
 
-#             assert count == 10
+                    # send 5 more messages, those messages would arrive at the client while the program is sleeping
+                    await sender.send_messages([ServiceBusMessage('test') for _ in range(5)])
+                    await asyncio.sleep(15)  # sleep > message expiration time
 
-#             await receiver.close()
+                    target_msgs_count = 5
+                    received_msgs = []
+                    while len(received_msgs) < target_msgs_count:
+                        # issue 10 link credits, client should consume 5 msgs from the service, leaving no link credits
+                        for msg in (await receiver.receive_messages(max_message_count=target_msgs_count - len(received_msgs),
+                                                             max_wait_time=10)):
+                            assert msg.delivery_count == 0  # release would not increase delivery count
+                            await receiver.complete_message(msg)
+                            received_msgs.append(msg)
+                    assert len(received_msgs) == 5
 
-#             with pytest.raises(ValueError):
-#                 await receiver.receive_messages()
-#             with pytest.raises(ValueError):
-#                 async with receiver:
-#                     raise AssertionError("Should raise ValueError")
-#             with pytest.raises(ValueError):
-#                 await receiver.receive_deferred_messages([1, 2, 3])
-#             with pytest.raises(ValueError):
-#                 await receiver.peek_messages()
+            async def sub_test_releasing_messages_iterator():
+                # test nested iterator scenario
+                receiver = sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10)
+                sender = sb_client.get_queue_sender(servicebus_queue.name)
+                async with sender, receiver:
+                    # send 5 msgs to queue first
+                    await sender.send_messages([ServiceBusMessage('test') for _ in range(5)])
+                    first_time = True
+                    iterator_recv_cnt = 0
 
-#             sender = sb_client.get_queue_sender(servicebus_queue.name)
-#             receiver = sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5)
-#             async with sender, receiver:
-#                 # send previously unpicklable message
-#                 msg = {
-#                     "body":"W1tdLCB7ImlucHV0X2lkIjogNH0sIHsiY2FsbGJhY2tzIjogbnVsbCwgImVycmJhY2tzIjogbnVsbCwgImNoYWluIjogbnVsbCwgImNob3JkIjogbnVsbH1d",
-#                     "content-encoding":"utf-8",
-#                     "content-type":"application/json",
-#                     "headers":{
-#                         "lang":"py",
-#                         "task":"tasks.example_task",
-#                         "id":"7c66557d-e4bc-437f-b021-b66dcc39dfdf",
-#                         "shadow":None,
-#                         "eta":"2021-10-07T02:30:23.764066+00:00",
-#                         "expires":None,
-#                         "group":None,
-#                         "group_index":None,
-#                         "retries":1,
-#                         "timelimit":[
-#                             None,
-#                             None
-#                         ],
-#                         "root_id":"7c66557d-e4bc-437f-b021-b66dcc39dfdf",
-#                         "parent_id":"7c66557d-e4bc-437f-b021-b66dcc39dfdf",
-#                         "argsrepr":"()",
-#                         "kwargsrepr":"{'input_id': 4}",
-#                         "origin":"gen36@94713e01a9c0",
-#                         "ignore_result":1,
-#                         "x_correlator":"44a1978d-c869-4173-afe4-da741f0edfb9"
-#                     },
-#                     "properties":{
-#                         "correlation_id":"7c66557d-e4bc-437f-b021-b66dcc39dfdf",
-#                         "reply_to":"7b9a3672-2fed-3e9b-8bfd-23ae2397d9ad",
-#                         "origin":"gen68@c33d4eef123a",
-#                         "delivery_mode":2,
-#                         "delivery_info":{
-#                             "exchange":"",
-#                             "routing_key":"celery_task_queue"
-#                         },
-#                         "priority":0,
-#                         "body_encoding":"base64",
-#                         "delivery_tag":"dc83ddb6-8cdc-4413-b88a-06c56cbde90d"
-#                     }
-#                 }
-#                 await sender.send_messages(ServiceBusMessage(json.dumps(msg)))
-#                 messages = await receiver.receive_messages(max_wait_time=10, max_message_count=1)
-#                 if not uamqp_transport:
-#                     pickled = pickle.loads(pickle.dumps(messages[0]))
-#                     assert json.loads(str(pickled)) == json.loads(str(messages[0]))
-#                     await receiver.complete_message(pickled)
-#                 else:
-#                     with pytest.raises(TypeError):
-#                         pickled = pickle.loads(pickle.dumps(messages[0]))
-#                     await receiver.complete_message(messages[0])
-    
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer()
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_github_issue_7079_async(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         async with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-    
-#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 for i in range(5):
-#                     await sender.send_messages(ServiceBusMessage("ServiceBusMessage {}".format(i)))
-#             async with sb_client.get_queue_receiver(servicebus_queue.name, receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE, max_wait_time=5) as messages:
-#                 batch = await messages.receive_messages()
-#                 count = len(batch)
-#                 async for message in messages:
-#                    _logger.debug(message)
-#                    count += 1
-#                 assert count == 5
+                    # case: iterator + receive batch
+                    async for msg in receiver:
+                        assert msg.delivery_count == 0  # release would not increase delivery count
+                        await receiver.complete_message(msg)
+                        iterator_recv_cnt += 1
+                        if first_time:  # for the first time, we call nested receive message call
+                            received_msgs = []
 
-    
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer()
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @CachedServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_github_issue_6178_async(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         async with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+                            while len(received_msgs) < 4:  # there supposed to be 5 msgs in the queue
+                                # we issue 10 link credits, leaving more credits on the wire
+                                for sub_msg in (await receiver.receive_messages(max_message_count=10, max_wait_time=10)):
+                                    assert sub_msg.delivery_count == 0
+                                    await receiver.complete_message(sub_msg)
+                                    received_msgs.append(sub_msg)
+                            assert len(received_msgs) == 4
+                            await sender.send_messages([ServiceBusMessage('test') for _ in range(10)])
+                            await asyncio.sleep(15)  # sleep > message expiration time
 
-#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 for i in range(3):
-#                     await sender.send_messages(ServiceBusMessage("Message {}".format(i)))
-#             async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=60) as receiver:
-#                 async for message in receiver:
-#                     _logger.debug(message)
-#                     _logger.debug(message.sequence_number)
-#                     _logger.debug(message.enqueued_time_utc)
-#                     _logger.debug(message._lock_expired)
-#                     await receiver.complete_message(message)
-#                     await asyncio.sleep(40)
+                            received_msgs = []
+                            target_msgs_count = 5  # we want to receive 5 with the receive message call
+                            while len(received_msgs) < target_msgs_count:
+                                for sub_msg in (await receiver.receive_messages(
+                                        max_message_count=target_msgs_count - len(received_msgs), max_wait_time=5)):
+                                    assert sub_msg.delivery_count == 0  # release would not increase delivery count
+                                    await receiver.complete_message(sub_msg)
+                                    received_msgs.append(sub_msg)
+                            assert len(received_msgs) == target_msgs_count
+                            first_time = False
+                    assert iterator_recv_cnt == 6  # 1 before nested receive message call + 5 after nested receive message call
 
-    
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True, lock_duration='PT10S')
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_async_queue_by_queue_client_conn_str_receive_handler_receiveanddelete(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         async with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+                    # case: iterator + iterator case
+                    await sender.send_messages([ServiceBusMessage('test') for _ in range(10)])
+                    outter_recv_cnt = 0
+                    inner_recv_cnt = 0
+                    async for msg in receiver:
+                        assert msg.delivery_count == 0
+                        outter_recv_cnt += 1
+                        await receiver.complete_message(msg)
+                        async for sub_msg in receiver:
+                            assert sub_msg.delivery_count == 0
+                            inner_recv_cnt += 1
+                            await receiver.complete_message(sub_msg)
+                            if inner_recv_cnt == 5:
+                                await asyncio.sleep(15)  # innner finish receiving first 5 messages then sleep until lock expiration
+                                break
+                    assert outter_recv_cnt == 1
+                    outter_recv_cnt = 0
+                    async for msg in receiver:
+                        assert msg.delivery_count == 0
+                        outter_recv_cnt += 1
+                        await receiver.complete_message(msg)
+                    assert outter_recv_cnt == 4
 
-#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 for i in range(10):
-#                     message = ServiceBusMessage("Handler message no. {}".format(i))
-#                     await sender.send_messages(message)
+            async def sub_test_non_releasing_messages():
+                # test not releasing messages when prefetch is not 1
+                receiver = sb_client.get_queue_receiver(servicebus_queue.name)
+                sender = sb_client.get_queue_sender(servicebus_queue.name)
 
-#             messages = []
-#             async with sb_client.get_queue_receiver(servicebus_queue.name, receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE, max_wait_time=8) as receiver:
-#                 async for message in receiver:
-#                     messages.append(message)
-#                     with pytest.raises(ValueError):
-#                         await receiver.complete_message(message)
-#                     with pytest.raises(ValueError): # RECEIVE_AND_DELETE messages cannot be lock renewed.
-#                         renewer = AutoLockRenewer()
-#                         renewer.register(receiver, message)
+                if uamqp_transport:
+                    def _hack_disable_receive_context_message_received(self, message):
+                        # pylint: disable=protected-access
+                        self._handler._was_message_received = True
+                        self._handler._received_messages.put(message)
+                else:
+                    def _hack_disable_receive_context_message_received(self, frame, message):
+                        # pylint: disable=protected-access
+                        self._handler._last_activity_timestamp = time.time()
+                        self._handler._received_messages.put((frame, message))
 
-#             assert not receiver._running
-#             assert len(messages) == 10
-#             time.sleep(10)
+                async with sender, receiver:
+                    # send 5 msgs to queue first
+                    await sender.send_messages([ServiceBusMessage('test') for _ in range(5)])
+                    if uamqp_transport:
+                        receiver._handler.message_handler.on_message_received = types.MethodType(
+                            _hack_disable_receive_context_message_received, receiver)
+                    else:
+                        receiver._handler._link._on_transfer = types.MethodType(
+                            _hack_disable_receive_context_message_received, receiver)
+                    received_msgs = []
+                    while len(received_msgs) < 5:
+                        # issue 10 link credits, client should consume 5 msgs from the service
+                        # leaving 5 credits on the wire
+                        for msg in (await receiver.receive_messages(max_message_count=10, max_wait_time=10)):
+                            await receiver.complete_message(msg)
+                            received_msgs.append(msg)
+                    assert len(received_msgs) == 5
 
-#             messages = []
-#             async with sb_client.get_queue_receiver(servicebus_queue.name, receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE, max_wait_time=5) as receiver:
-#                 async for message in receiver:
-#                     messages.append(message)
-#                 assert len(messages) == 0
+                    # send 5 more messages, those messages would arrive at the client while the program is sleeping
+                    await sender.send_messages([ServiceBusMessage('test') for _ in range(5)])
+                    await asyncio.sleep(15)  # sleep > message expiration time
 
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True, lock_duration='PT10S')
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_async_queue_by_queue_client_conn_str_receive_handler_receiveanddelete_prefetch(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         async with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+                    # issue 5 link credits, client should consume 5 msgs from the internal buffer which is already lock expired
+                    target_msgs_count = 5
+                    received_msgs = []
+                    while len(received_msgs) < target_msgs_count:
+                        received_msgs.extend((await receiver.receive_messages(max_message_count=5, max_wait_time=10)))
+                    assert len(received_msgs) == 5
+                    for msg in received_msgs:
+                        assert msg.delivery_count == 0
+                        with pytest.raises(ServiceBusError):
+                            await receiver.complete_message(msg)
 
-#             # send 10 messages
-#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 for i in range(10):
-#                     message = ServiceBusMessage("Handler message no. {}".format(i))
-#                     await sender.send_messages(message)
+                    # re-received message with delivery count increased
+                    target_msgs_count = 5
+                    received_msgs = []
+                    while len(received_msgs) < target_msgs_count:
+                        received_msgs.extend((await receiver.receive_messages(max_message_count=5, max_wait_time=10)))
+                    assert len(received_msgs) == 5
+                    for msg in received_msgs:
+                        assert msg.delivery_count > 0
+                        await receiver.complete_message(msg)
 
-#             # check peek_messages returns correctly, with default prefetch_count = 0
-#             messages = []
-#             async with sb_client.get_queue_receiver(servicebus_queue.name,
-#                                                 receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE,
-#                                                 max_wait_time=10) as receiver:
-#                 # peek messages checks current state of queue, which should return 10
-#                 # since none were prefetched, added to internal buffer, and deleted on receive
-#                 peeked_msgs = await receiver.peek_messages(max_message_count=10, timeout=10)
-#                 assert len(peeked_msgs) == 10
-
-#                 # iterator receives and deletes each message from SB queue
-#                 async for msg in receiver:
-#                     messages.append(msg)
-#                 assert len(messages) == 10
-
-#                 # queue should be empty now
-#                 peeked_msgs = await receiver.peek_messages(max_message_count=10, timeout=10)
-#                 assert len(peeked_msgs) == 0
-
-#             # send 10 messages
-#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 for i in range(10):
-#                     message = ServiceBusMessage("Handler message no. {}".format(i))
-#                     await sender.send_messages(message)
-
-#             # check peek_messages returns correctly, with default prefetch_count > 0
-#             messages = []
-#             # prefetch 1 message from SB queue when receive is called and not on open
-#             async with sb_client.get_queue_receiver(servicebus_queue.name,
-#                                             receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE,
-#                                             prefetch_count=1,
-#                                             max_wait_time=30) as receiver:
-#                 # peek messages checks current state of SB queue, and returns 10
-#                 peeked_msgs = await receiver.peek_messages(max_message_count=10, timeout=10)
-#                 assert len(peeked_msgs) == 10
-
-#                 # receive 3 messages
-#                 recvd_msgs = await receiver.receive_messages(max_message_count=3, max_wait_time=10)
-#                 assert len(recvd_msgs) == 3
-
-#                 # receive rest of messages in queue
-#                 async for msg in receiver:
-#                     messages.append(msg)
-#                 assert len(messages) == 7
-
-#                 # queue should be empty now
-#                 peeked_msgs = await receiver.peek_messages(max_message_count=10, timeout=10)
-#                 assert len(peeked_msgs) == 0
-
-
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_async_queue_by_queue_client_conn_str_receive_handler_with_stop(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         async with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-
-#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 for i in range(10):
-#                     message = ServiceBusMessage("Stop message no. {}".format(i))
-#                     await sender.send_messages(message)
-
-#             messages = []
-#             receiver = sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5, prefetch_count=0) 
-#             async with receiver:
-#                 async for message in receiver:
-#                     messages.append(message)
-#                     await receiver.complete_message(message)
-#                     if len(messages) >= 5:
-#                         break
-
-#                 assert receiver._running
-#                 assert len(messages) == 5
-
-#                 async for message in receiver:
-#                     messages.append(message)
-#                     await receiver.complete_message(message)
-#                     if len(messages) >= 5:
-#                         break
-
-#             assert not receiver._running
-#             assert len(messages) == 6
+            await sub_test_releasing_messages()
+            await sub_test_releasing_messages_iterator()
+            await sub_test_non_releasing_messages()
 
     
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_async_queue_by_servicebus_client_iter_messages_simple(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         async with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_async_queue_by_queue_client_send_multiple_messages(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential(is_async=True)
+        async with ServiceBusClient(
+            fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+            sender = sb_client.get_queue_sender(servicebus_queue.name)
+            async with sender:
+                messages = []
+                for i in range(10):
+                    message = ServiceBusMessage("Handler message no. {}".format(i))
+                    messages.append(message)
+                await sender.send_messages(messages)
 
-#             async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10, receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
+            with pytest.raises(ValueError):
+                async with sender:
+                    raise AssertionError("Should raise ValueError")
+            with pytest.raises(ValueError):
+                await sender.send_messages(ServiceBusMessage('msg'))
+            with pytest.raises(ValueError):
+                await sender.schedule_messages(ServiceBusMessage('msg'), utc_now())
+            with pytest.raises(ValueError):
+                await sender.cancel_scheduled_messages([1, 2, 3])
 
-#                 async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                     for i in range(10):
-#                         message = ServiceBusMessage("Iter message no. {}".format(i))
-#                         await sender.send_messages(message)
+            receiver = sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5)
+            count = 0
+            async for message in receiver:
+                print_message(_logger, message)
+                count += 1
+                await receiver.complete_message(message)
 
-#                 count = 0
-#                 async for message in receiver:
-#                     print_message(_logger, message)
-#                     await receiver.complete_message(message)
-#                     with pytest.raises(MessageAlreadySettled):
-#                         await receiver.complete_message(message)
-#                     with pytest.raises(MessageAlreadySettled):
-#                         await receiver.renew_message_lock(message)
-#                     count += 1
+            assert count == 10
 
-#                 with pytest.raises(StopAsyncIteration):
-#                     await receiver.__anext__()
+            await receiver.close()
 
-#             assert count == 10
+            with pytest.raises(ValueError):
+                await receiver.receive_messages()
+            with pytest.raises(ValueError):
+                async with receiver:
+                    raise AssertionError("Should raise ValueError")
+            with pytest.raises(ValueError):
+                await receiver.receive_deferred_messages([1, 2, 3])
+            with pytest.raises(ValueError):
+                await receiver.peek_messages()
+
+            sender = sb_client.get_queue_sender(servicebus_queue.name)
+            receiver = sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5)
+            async with sender, receiver:
+                # send previously unpicklable message
+                msg = {
+                    "body":"W1tdLCB7ImlucHV0X2lkIjogNH0sIHsiY2FsbGJhY2tzIjogbnVsbCwgImVycmJhY2tzIjogbnVsbCwgImNoYWluIjogbnVsbCwgImNob3JkIjogbnVsbH1d",
+                    "content-encoding":"utf-8",
+                    "content-type":"application/json",
+                    "headers":{
+                        "lang":"py",
+                        "task":"tasks.example_task",
+                        "id":"7c66557d-e4bc-437f-b021-b66dcc39dfdf",
+                        "shadow":None,
+                        "eta":"2021-10-07T02:30:23.764066+00:00",
+                        "expires":None,
+                        "group":None,
+                        "group_index":None,
+                        "retries":1,
+                        "timelimit":[
+                            None,
+                            None
+                        ],
+                        "root_id":"7c66557d-e4bc-437f-b021-b66dcc39dfdf",
+                        "parent_id":"7c66557d-e4bc-437f-b021-b66dcc39dfdf",
+                        "argsrepr":"()",
+                        "kwargsrepr":"{'input_id': 4}",
+                        "origin":"gen36@94713e01a9c0",
+                        "ignore_result":1,
+                        "x_correlator":"44a1978d-c869-4173-afe4-da741f0edfb9"
+                    },
+                    "properties":{
+                        "correlation_id":"7c66557d-e4bc-437f-b021-b66dcc39dfdf",
+                        "reply_to":"7b9a3672-2fed-3e9b-8bfd-23ae2397d9ad",
+                        "origin":"gen68@c33d4eef123a",
+                        "delivery_mode":2,
+                        "delivery_info":{
+                            "exchange":"",
+                            "routing_key":"celery_task_queue"
+                        },
+                        "priority":0,
+                        "body_encoding":"base64",
+                        "delivery_tag":"dc83ddb6-8cdc-4413-b88a-06c56cbde90d"
+                    }
+                }
+                await sender.send_messages(ServiceBusMessage(json.dumps(msg)))
+                messages = await receiver.receive_messages(max_wait_time=10, max_message_count=1)
+                if not uamqp_transport:
+                    pickled = pickle.loads(pickle.dumps(messages[0]))
+                    assert json.loads(str(pickled)) == json.loads(str(messages[0]))
+                    await receiver.complete_message(pickled)
+                else:
+                    with pytest.raises(TypeError):
+                        pickled = pickle.loads(pickle.dumps(messages[0]))
+                    await receiver.complete_message(messages[0])
+    
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer()
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_github_issue_7079_async(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential(is_async=True)
+        async with ServiceBusClient(
+            fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+    
+            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                for i in range(5):
+                    await sender.send_messages(ServiceBusMessage("ServiceBusMessage {}".format(i)))
+            async with sb_client.get_queue_receiver(servicebus_queue.name, receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE, max_wait_time=5) as messages:
+                batch = await messages.receive_messages()
+                count = len(batch)
+                async for message in messages:
+                   _logger.debug(message)
+                   count += 1
+                assert count == 5
 
     
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_async_queue_by_servicebus_conn_str_client_iter_messages_with_abandon(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         async with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer()
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @CachedServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_github_issue_6178_async(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential(is_async=True)
+        async with ServiceBusClient(
+            fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-#             async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10, receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
-
-#                 async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                     for i in range(10):
-#                         message = ServiceBusMessage("Abandoned message no. {}".format(i))
-#                         await sender.send_messages(message)
-
-#                 count = 0
-#                 async for message in receiver:
-#                     print_message(_logger, message)
-#                     if not message.delivery_count:
-#                         count += 1
-#                         await receiver.abandon_message(message)
-#                     else:
-#                         assert message.delivery_count == 1
-#                         await receiver.complete_message(message)
-
-#             assert count == 10
-
-#             async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10, receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
-#                 count = 0
-#                 async for message in receiver:
-#                     print_message(_logger, message)
-#                     await receiver.complete_message(message)
-#                     count += 1
-#             assert count == 0
+            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                for i in range(3):
+                    await sender.send_messages(ServiceBusMessage("Message {}".format(i)))
+            async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=60) as receiver:
+                async for message in receiver:
+                    _logger.debug(message)
+                    _logger.debug(message.sequence_number)
+                    _logger.debug(message.enqueued_time_utc)
+                    _logger.debug(message._lock_expired)
+                    await receiver.complete_message(message)
+                    await asyncio.sleep(40)
 
     
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_async_queue_by_servicebus_client_iter_messages_with_defer(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         async with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True, lock_duration='PT10S')
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_async_queue_by_queue_client_conn_str_receive_handler_receiveanddelete(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential(is_async=True)
+        async with ServiceBusClient(
+            fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-#             deferred_messages = []
-#             async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10, receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
+            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                for i in range(10):
+                    message = ServiceBusMessage("Handler message no. {}".format(i))
+                    await sender.send_messages(message)
 
-#                 async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                     for i in range(10):
-#                         message = ServiceBusMessage("Deferred message no. {}".format(i))
-#                         await sender.send_messages(message)
+            messages = []
+            async with sb_client.get_queue_receiver(servicebus_queue.name, receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE, max_wait_time=8) as receiver:
+                async for message in receiver:
+                    messages.append(message)
+                    with pytest.raises(ValueError):
+                        await receiver.complete_message(message)
+                    with pytest.raises(ValueError): # RECEIVE_AND_DELETE messages cannot be lock renewed.
+                        renewer = AutoLockRenewer()
+                        renewer.register(receiver, message)
 
-#                 count = 0
-#                 async for message in receiver:
-#                     deferred_messages.append(message.sequence_number)
-#                     print_message(_logger, message)
-#                     count += 1
-#                     await receiver.defer_message(message)
+            assert not receiver._running
+            assert len(messages) == 10
+            time.sleep(10)
 
-#             assert count == 10
-#             async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10, receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
-#                 count = 0
-#                 async for message in receiver:
-#                     print_message(_logger, message)
-#                     await receiver.complete_message(message)
-#                     count += 1
-#             assert count == 0
+            messages = []
+            async with sb_client.get_queue_receiver(servicebus_queue.name, receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE, max_wait_time=5) as receiver:
+                async for message in receiver:
+                    messages.append(message)
+                assert len(messages) == 0
 
-    
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_async_queue_by_servicebus_client_iter_messages_with_retrieve_deferred_client(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         async with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True, lock_duration='PT10S')
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_async_queue_by_queue_client_conn_str_receive_handler_receiveanddelete_prefetch(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential(is_async=True)
+        async with ServiceBusClient(
+            fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-#             deferred_messages = []
-#             async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10, receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
+            # send 10 messages
+            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                for i in range(10):
+                    message = ServiceBusMessage("Handler message no. {}".format(i))
+                    await sender.send_messages(message)
 
-#                 async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                     for i in range(10):
-#                         message = ServiceBusMessage("Deferred message no. {}".format(i))
-#                         await sender.send_messages(message)
+            # check peek_messages returns correctly, with default prefetch_count = 0
+            messages = []
+            async with sb_client.get_queue_receiver(servicebus_queue.name,
+                                                receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE,
+                                                max_wait_time=10) as receiver:
+                # peek messages checks current state of queue, which should return 10
+                # since none were prefetched, added to internal buffer, and deleted on receive
+                peeked_msgs = await receiver.peek_messages(max_message_count=10, timeout=10)
+                assert len(peeked_msgs) == 10
 
-#                 count = 0
-#                 async for message in receiver:
-#                     deferred_messages.append(message.sequence_number)
-#                     print_message(_logger, message)
-#                     count += 1
-#                     await receiver.defer_message(message)
+                # iterator receives and deletes each message from SB queue
+                async for msg in receiver:
+                    messages.append(msg)
+                assert len(messages) == 10
 
-#                 assert count == 10
+                # queue should be empty now
+                peeked_msgs = await receiver.peek_messages(max_message_count=10, timeout=10)
+                assert len(peeked_msgs) == 0
 
-#                 deferred = await receiver.receive_deferred_messages(deferred_messages, timeout=10)
-#                 assert len(deferred) == 10
-#                 for message in deferred:
-#                     assert isinstance(message, ServiceBusReceivedMessage)
-#                     await receiver.complete_message(message)
+            # send 10 messages
+            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                for i in range(10):
+                    message = ServiceBusMessage("Handler message no. {}".format(i))
+                    await sender.send_messages(message)
 
-#                 with pytest.raises(ServiceBusError):
-#                     await receiver.receive_deferred_messages(deferred_messages)
+            # check peek_messages returns correctly, with default prefetch_count > 0
+            messages = []
+            # prefetch 1 message from SB queue when receive is called and not on open
+            async with sb_client.get_queue_receiver(servicebus_queue.name,
+                                            receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE,
+                                            prefetch_count=1,
+                                            max_wait_time=30) as receiver:
+                # peek messages checks current state of SB queue, and returns 10
+                peeked_msgs = await receiver.peek_messages(max_message_count=10, timeout=10)
+                assert len(peeked_msgs) == 10
 
-    
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_async_queue_by_servicebus_client_iter_messages_with_retrieve_deferred_receiver_complete(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         async with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+                # receive 3 messages
+                recvd_msgs = await receiver.receive_messages(max_message_count=3, max_wait_time=10)
+                assert len(recvd_msgs) == 3
 
-#             deferred_messages = []
-#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 for message in [ServiceBusMessage("Deferred message no. {}".format(i)) for i in range(10)]:
-#                     results = await sender.send_messages(message)
+                # receive rest of messages in queue
+                async for msg in receiver:
+                    messages.append(msg)
+                assert len(messages) == 7
 
-#             async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5, receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
-#                 count = 0
-#                 async for message in receiver:
-#                     deferred_messages.append(message.sequence_number)
-#                     print_message(_logger, message)
-#                     count += 1
-#                     await receiver.defer_message(message)
-#             assert count == 10
+                # queue should be empty now
+                peeked_msgs = await receiver.peek_messages(max_message_count=10, timeout=10)
+                assert len(peeked_msgs) == 0
 
-#             async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5) as receiver:
-#                 with pytest.raises(ValueError):
-#                     await receiver.receive_deferred_messages(deferred_messages, timeout=0)
-#                 deferred = await receiver.receive_deferred_messages(deferred_messages)
-#                 assert len(deferred) == 10
-#                 for message in deferred:
-#                     assert isinstance(message, ServiceBusReceivedMessage)
-#                     assert message.lock_token
-#                     assert message.locked_until_utc
-#                     assert message._receiver
-#                     await receiver.renew_message_lock(message)
-#                     await receiver.complete_message(message)
 
-    
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_async_queue_by_servicebus_client_iter_messages_with_retrieve_deferred_receiver_deadletter(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         async with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_async_queue_by_queue_client_conn_str_receive_handler_with_stop(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential(is_async=True)
+        async with ServiceBusClient(
+            fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-#             deferred_messages = []
-#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 for message in [ServiceBusMessage("Deferred message no. {}".format(i)) for i in range(10)]:
-#                     results = await sender.send_messages(message)
+            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                for i in range(10):
+                    message = ServiceBusMessage("Stop message no. {}".format(i))
+                    await sender.send_messages(message)
 
-#             async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10, receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
-#                 count = 0
-#                 async for message in receiver:
-#                     deferred_messages.append(message.sequence_number)
-#                     print_message(_logger, message)
-#                     count += 1
-#                     await receiver.defer_message(message)
+            messages = []
+            receiver = sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5, prefetch_count=0) 
+            async with receiver:
+                async for message in receiver:
+                    messages.append(message)
+                    await receiver.complete_message(message)
+                    if len(messages) >= 5:
+                        break
 
-#             assert count == 10
+                assert receiver._running
+                assert len(messages) == 5
 
-#             async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10) as receiver:
-#                 deferred = await receiver.receive_deferred_messages(deferred_messages, timeout=None)
-#                 assert len(deferred) == 10
-#                 for message in deferred:
-#                     assert isinstance(message, ServiceBusReceivedMessage)
-#                     await receiver.dead_letter_message(message, reason="Testing reason", error_description="Testing description")
+                async for message in receiver:
+                    messages.append(message)
+                    await receiver.complete_message(message)
+                    if len(messages) >= 5:
+                        break
 
-#             count = 0
-#             async with sb_client.get_queue_receiver(servicebus_queue.name, 
-#                                                     sub_queue = ServiceBusSubQueue.DEAD_LETTER,
-#                                                     max_wait_time=10) as receiver:
-#                 async for message in receiver:
-#                     count += 1
-#                     print_message(_logger, message)
-#                     assert message.dead_letter_reason == 'Testing reason'
-#                     assert message.dead_letter_error_description == 'Testing description'
-#                     assert message.application_properties[b'DeadLetterReason'] == b'Testing reason'
-#                     assert message.application_properties[b'DeadLetterErrorDescription'] == b'Testing description'
-#                     await receiver.complete_message(message)
-#             assert count == 10
+            assert not receiver._running
+            assert len(messages) == 6
 
     
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_async_queue_by_servicebus_client_iter_messages_with_retrieve_deferred_receiver_deletemode(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         async with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_async_queue_by_servicebus_client_iter_messages_simple(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential(is_async=True)
+        async with ServiceBusClient(
+            fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-#             deferred_messages = []
-#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 for message in [ServiceBusMessage("Deferred message no. {}".format(i)) for i in range(10)]:
-#                     results = await sender.send_messages(message)
+            async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10, receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
 
-#             count = 0
-#             async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10) as receiver:
-#                 async for message in receiver:
-#                     deferred_messages.append(message.sequence_number)
-#                     print_message(_logger, message)
-#                     count += 1
-#                     await receiver.defer_message(message)
+                async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                    for i in range(10):
+                        message = ServiceBusMessage("Iter message no. {}".format(i))
+                        await sender.send_messages(message)
 
-#             assert count == 10
-#             async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10, receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE.value) as receiver:
-#                 deferred = await receiver.receive_deferred_messages(deferred_messages)
-#                 assert len(deferred) == 10
-#                 for message in deferred:
-#                     assert isinstance(message, ServiceBusReceivedMessage)
-#                     with pytest.raises(ValueError):
-#                         await receiver.complete_message(message)
-#                 with pytest.raises(ServiceBusError):
-#                     deferred = await receiver.receive_deferred_messages(deferred_messages)
+                count = 0
+                async for message in receiver:
+                    print_message(_logger, message)
+                    await receiver.complete_message(message)
+                    with pytest.raises(MessageAlreadySettled):
+                        await receiver.complete_message(message)
+                    with pytest.raises(MessageAlreadySettled):
+                        await receiver.renew_message_lock(message)
+                    count += 1
 
-    
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_async_queue_by_servicebus_client_iter_messages_with_retrieve_deferred_not_found(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         async with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+                with pytest.raises(StopAsyncIteration):
+                    await receiver.__anext__()
 
-#             deferred_messages = []
-#             async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10, receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
-
-#                 async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                     for i in range(3):
-#                         message = ServiceBusMessage("Deferred message no. {}".format(i))
-#                         await sender.send_messages(message)
-
-#                 count = 0
-#                 async for message in receiver:
-#                     deferred_messages.append(message.sequence_number)
-#                     print_message(_logger, message)
-#                     count += 1
-#                     await receiver.defer_message(message)
-
-#             assert count == 3
-
-#             async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10, receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
-#                 with pytest.raises(ServiceBusError):
-#                     deferred = await receiver.receive_deferred_messages([3, 4])
-
-#                 with pytest.raises(ServiceBusError):
-#                     deferred = await receiver.receive_deferred_messages([5, 6, 7])
+            assert count == 10
 
     
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_async_queue_by_servicebus_client_receive_batch_with_deadletter(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         async with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_async_queue_by_servicebus_conn_str_client_iter_messages_with_abandon(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential(is_async=True)
+        async with ServiceBusClient(
+            fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-#             async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10, receive_mode=ServiceBusReceiveMode.PEEK_LOCK, prefetch_count=10) as receiver:
+            async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10, receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
 
-#                 async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                     for i in range(10):
-#                         message = ServiceBusMessage("Dead lettered message no. {}".format(i))
-#                         await sender.send_messages(message)
+                async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                    for i in range(10):
+                        message = ServiceBusMessage("Abandoned message no. {}".format(i))
+                        await sender.send_messages(message)
 
-#                 count = 0
-#                 messages = await receiver.receive_messages()
-#                 while messages:
-#                     for message in messages:
-#                         print_message(_logger, message)
-#                         count += 1
-#                         await receiver.dead_letter_message(message, reason="Testing reason", error_description="Testing description")
-#                     messages = await receiver.receive_messages()
+                count = 0
+                async for message in receiver:
+                    print_message(_logger, message)
+                    if not message.delivery_count:
+                        count += 1
+                        await receiver.abandon_message(message)
+                    else:
+                        assert message.delivery_count == 1
+                        await receiver.complete_message(message)
 
-#             assert count == 10
+            assert count == 10
 
-#             async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10, receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
-#                 count = 0
-#                 async for message in receiver:
-#                     print_message(_logger, message)
-#                     await receiver.complete_message(message)
-#                     count += 1
-#             assert count == 0
-
-#             async with sb_client.get_queue_receiver(
-#                     servicebus_queue.name,
-#                     sub_queue = ServiceBusSubQueue.DEAD_LETTER.value,
-#                     max_wait_time=10,
-#                     mode=ServiceBusReceiveMode.PEEK_LOCK) as dl_receiver:
-#                 count = 0
-#                 async for message in dl_receiver:
-#                     await dl_receiver.complete_message(message)
-#                     count += 1
-#                     assert message.dead_letter_reason == 'Testing reason'
-#                     assert message.dead_letter_error_description == 'Testing description'
-#                     assert message.application_properties[b'DeadLetterReason'] == b'Testing reason'
-#                     assert message.application_properties[b'DeadLetterErrorDescription'] == b'Testing description'
-#                 assert count == 10
+            async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10, receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
+                count = 0
+                async for message in receiver:
+                    print_message(_logger, message)
+                    await receiver.complete_message(message)
+                    count += 1
+            assert count == 0
 
     
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_async_queue_by_servicebus_client_receive_batch_with_retrieve_deadletter(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         async with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_async_queue_by_servicebus_client_iter_messages_with_defer(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential(is_async=True)
+        async with ServiceBusClient(
+            fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-#             async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5, receive_mode=ServiceBusReceiveMode.PEEK_LOCK, prefetch_count=10) as receiver:
+            deferred_messages = []
+            async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10, receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
 
-#                 async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                     for i in range(10):
-#                         message = ServiceBusMessage("Dead lettered message no. {}".format(i))
-#                         await sender.send_messages(message)
+                async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                    for i in range(10):
+                        message = ServiceBusMessage("Deferred message no. {}".format(i))
+                        await sender.send_messages(message)
 
-#                 count = 0
-#                 messages = await receiver.receive_messages()
-#                 while messages:
-#                     for message in messages:
-#                         print_message(_logger, message)
-#                         await receiver.dead_letter_message(message, reason="Testing reason", error_description="Testing description")
-#                         count += 1
-#                     messages = await receiver.receive_messages()
+                count = 0
+                async for message in receiver:
+                    deferred_messages.append(message.sequence_number)
+                    print_message(_logger, message)
+                    count += 1
+                    await receiver.defer_message(message)
 
-#             assert count == 10
+            assert count == 10
+            async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10, receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
+                count = 0
+                async for message in receiver:
+                    print_message(_logger, message)
+                    await receiver.complete_message(message)
+                    count += 1
+            assert count == 0
 
-#             async with sb_client.get_queue_receiver(
-#                 servicebus_queue.name,
-#                 sub_queue = ServiceBusSubQueue.DEAD_LETTER,
-#                 max_wait_time=5,
-#                 receive_mode=ServiceBusReceiveMode.PEEK_LOCK
-#             ) as receiver:
-#                 count = 0
-#                 async for message in receiver:
-#                     print_message(_logger, message)
-#                     assert message.dead_letter_reason == 'Testing reason'
-#                     assert message.dead_letter_error_description == 'Testing description'
-#                     assert message.application_properties[b'DeadLetterReason'] == b'Testing reason'
-#                     assert message.application_properties[b'DeadLetterErrorDescription'] == b'Testing description'
-#                     await receiver.complete_message(message)
-#                     count += 1
-#             assert count == 10
+    
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_async_queue_by_servicebus_client_iter_messages_with_retrieve_deferred_client(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential(is_async=True)
+        async with ServiceBusClient(
+            fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_async_queue_by_servicebus_client_session_fail(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         async with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+            deferred_messages = []
+            async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10, receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
 
-#             with pytest.raises(ServiceBusError):
-#                 await sb_client.get_queue_receiver(servicebus_queue.name, session_id="test")._open_with_retry()
+                async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                    for i in range(10):
+                        message = ServiceBusMessage("Deferred message no. {}".format(i))
+                        await sender.send_messages(message)
 
-#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 await sender.send_messages(ServiceBusMessage("test session sender", session_id="test"))
+                count = 0
+                async for message in receiver:
+                    deferred_messages.append(message.sequence_number)
+                    print_message(_logger, message)
+                    count += 1
+                    await receiver.defer_message(message)
 
-#             async with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
-#                 messages = await receiver.receive_messages()
-#                 for message in messages:
-#                     assert str(message) == "test session sender"
-#                     await receiver.complete_message(message)
+                assert count == 10
+
+                deferred = await receiver.receive_deferred_messages(deferred_messages, timeout=10)
+                assert len(deferred) == 10
+                for message in deferred:
+                    assert isinstance(message, ServiceBusReceivedMessage)
+                    await receiver.complete_message(message)
+
+                with pytest.raises(ServiceBusError):
+                    await receiver.receive_deferred_messages(deferred_messages)
+
+    
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_async_queue_by_servicebus_client_iter_messages_with_retrieve_deferred_receiver_complete(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential(is_async=True)
+        async with ServiceBusClient(
+            fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+
+            deferred_messages = []
+            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                for message in [ServiceBusMessage("Deferred message no. {}".format(i)) for i in range(10)]:
+                    results = await sender.send_messages(message)
+
+            async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5, receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
+                count = 0
+                async for message in receiver:
+                    deferred_messages.append(message.sequence_number)
+                    print_message(_logger, message)
+                    count += 1
+                    await receiver.defer_message(message)
+            assert count == 10
+
+            async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5) as receiver:
+                with pytest.raises(ValueError):
+                    await receiver.receive_deferred_messages(deferred_messages, timeout=0)
+                deferred = await receiver.receive_deferred_messages(deferred_messages)
+                assert len(deferred) == 10
+                for message in deferred:
+                    assert isinstance(message, ServiceBusReceivedMessage)
+                    assert message.lock_token
+                    assert message.locked_until_utc
+                    assert message._receiver
+                    await receiver.renew_message_lock(message)
+                    await receiver.complete_message(message)
+
+    
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_async_queue_by_servicebus_client_iter_messages_with_retrieve_deferred_receiver_deadletter(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential(is_async=True)
+        async with ServiceBusClient(
+            fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+
+            deferred_messages = []
+            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                for message in [ServiceBusMessage("Deferred message no. {}".format(i)) for i in range(10)]:
+                    results = await sender.send_messages(message)
+
+            async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10, receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
+                count = 0
+                async for message in receiver:
+                    deferred_messages.append(message.sequence_number)
+                    print_message(_logger, message)
+                    count += 1
+                    await receiver.defer_message(message)
+
+            assert count == 10
+
+            async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10) as receiver:
+                deferred = await receiver.receive_deferred_messages(deferred_messages, timeout=None)
+                assert len(deferred) == 10
+                for message in deferred:
+                    assert isinstance(message, ServiceBusReceivedMessage)
+                    await receiver.dead_letter_message(message, reason="Testing reason", error_description="Testing description")
+
+            count = 0
+            async with sb_client.get_queue_receiver(servicebus_queue.name, 
+                                                    sub_queue = ServiceBusSubQueue.DEAD_LETTER,
+                                                    max_wait_time=10) as receiver:
+                async for message in receiver:
+                    count += 1
+                    print_message(_logger, message)
+                    assert message.dead_letter_reason == 'Testing reason'
+                    assert message.dead_letter_error_description == 'Testing description'
+                    assert message.application_properties[b'DeadLetterReason'] == b'Testing reason'
+                    assert message.application_properties[b'DeadLetterErrorDescription'] == b'Testing description'
+                    await receiver.complete_message(message)
+            assert count == 10
+
+    
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_async_queue_by_servicebus_client_iter_messages_with_retrieve_deferred_receiver_deletemode(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential(is_async=True)
+        async with ServiceBusClient(
+            fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+
+            deferred_messages = []
+            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                for message in [ServiceBusMessage("Deferred message no. {}".format(i)) for i in range(10)]:
+                    results = await sender.send_messages(message)
+
+            count = 0
+            async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10) as receiver:
+                async for message in receiver:
+                    deferred_messages.append(message.sequence_number)
+                    print_message(_logger, message)
+                    count += 1
+                    await receiver.defer_message(message)
+
+            assert count == 10
+            async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10, receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE.value) as receiver:
+                deferred = await receiver.receive_deferred_messages(deferred_messages)
+                assert len(deferred) == 10
+                for message in deferred:
+                    assert isinstance(message, ServiceBusReceivedMessage)
+                    with pytest.raises(ValueError):
+                        await receiver.complete_message(message)
+                with pytest.raises(ServiceBusError):
+                    deferred = await receiver.receive_deferred_messages(deferred_messages)
+
+    
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_async_queue_by_servicebus_client_iter_messages_with_retrieve_deferred_not_found(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential(is_async=True)
+        async with ServiceBusClient(
+            fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+
+            deferred_messages = []
+            async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10, receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
+
+                async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                    for i in range(3):
+                        message = ServiceBusMessage("Deferred message no. {}".format(i))
+                        await sender.send_messages(message)
+
+                count = 0
+                async for message in receiver:
+                    deferred_messages.append(message.sequence_number)
+                    print_message(_logger, message)
+                    count += 1
+                    await receiver.defer_message(message)
+
+            assert count == 3
+
+            async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10, receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
+                with pytest.raises(ServiceBusError):
+                    deferred = await receiver.receive_deferred_messages([3, 4])
+
+                with pytest.raises(ServiceBusError):
+                    deferred = await receiver.receive_deferred_messages([5, 6, 7])
+
+    
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_async_queue_by_servicebus_client_receive_batch_with_deadletter(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential(is_async=True)
+        async with ServiceBusClient(
+            fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+
+            async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10, receive_mode=ServiceBusReceiveMode.PEEK_LOCK, prefetch_count=10) as receiver:
+
+                async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                    for i in range(10):
+                        message = ServiceBusMessage("Dead lettered message no. {}".format(i))
+                        await sender.send_messages(message)
+
+                count = 0
+                messages = await receiver.receive_messages()
+                while messages:
+                    for message in messages:
+                        print_message(_logger, message)
+                        count += 1
+                        await receiver.dead_letter_message(message, reason="Testing reason", error_description="Testing description")
+                    messages = await receiver.receive_messages()
+
+            assert count == 10
+
+            async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10, receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
+                count = 0
+                async for message in receiver:
+                    print_message(_logger, message)
+                    await receiver.complete_message(message)
+                    count += 1
+            assert count == 0
+
+            async with sb_client.get_queue_receiver(
+                    servicebus_queue.name,
+                    sub_queue = ServiceBusSubQueue.DEAD_LETTER.value,
+                    max_wait_time=10,
+                    mode=ServiceBusReceiveMode.PEEK_LOCK) as dl_receiver:
+                count = 0
+                async for message in dl_receiver:
+                    await dl_receiver.complete_message(message)
+                    count += 1
+                    assert message.dead_letter_reason == 'Testing reason'
+                    assert message.dead_letter_error_description == 'Testing description'
+                    assert message.application_properties[b'DeadLetterReason'] == b'Testing reason'
+                    assert message.application_properties[b'DeadLetterErrorDescription'] == b'Testing description'
+                assert count == 10
+
+    
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_async_queue_by_servicebus_client_receive_batch_with_retrieve_deadletter(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential(is_async=True)
+        async with ServiceBusClient(
+            fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+
+            async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5, receive_mode=ServiceBusReceiveMode.PEEK_LOCK, prefetch_count=10) as receiver:
+
+                async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                    for i in range(10):
+                        message = ServiceBusMessage("Dead lettered message no. {}".format(i))
+                        await sender.send_messages(message)
+
+                count = 0
+                messages = await receiver.receive_messages()
+                while messages:
+                    for message in messages:
+                        print_message(_logger, message)
+                        await receiver.dead_letter_message(message, reason="Testing reason", error_description="Testing description")
+                        count += 1
+                    messages = await receiver.receive_messages()
+
+            assert count == 10
+
+            async with sb_client.get_queue_receiver(
+                servicebus_queue.name,
+                sub_queue = ServiceBusSubQueue.DEAD_LETTER,
+                max_wait_time=5,
+                receive_mode=ServiceBusReceiveMode.PEEK_LOCK
+            ) as receiver:
+                count = 0
+                async for message in receiver:
+                    print_message(_logger, message)
+                    assert message.dead_letter_reason == 'Testing reason'
+                    assert message.dead_letter_error_description == 'Testing description'
+                    assert message.application_properties[b'DeadLetterReason'] == b'Testing reason'
+                    assert message.application_properties[b'DeadLetterErrorDescription'] == b'Testing description'
+                    await receiver.complete_message(message)
+                    count += 1
+            assert count == 10
+
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_async_queue_by_servicebus_client_session_fail(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential(is_async=True)
+        async with ServiceBusClient(
+            fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+
+            with pytest.raises(ServiceBusError):
+                await sb_client.get_queue_receiver(servicebus_queue.name, session_id="test")._open_with_retry()
+
+            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                await sender.send_messages(ServiceBusMessage("test session sender", session_id="test"))
+
+            async with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
+                messages = await receiver.receive_messages()
+                for message in messages:
+                    assert str(message) == "test session sender"
+                    await receiver.complete_message(message)
  
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_async_queue_by_servicebus_client_browse_messages_client(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         async with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_async_queue_by_servicebus_client_browse_messages_client(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential(is_async=True)
+        async with ServiceBusClient(
+            fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 for i in range(5):
-#                     message = ServiceBusMessage("Test message no. {}".format(i))
-#                     await sender.send_messages(message)
+            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                for i in range(5):
+                    message = ServiceBusMessage("Test message no. {}".format(i))
+                    await sender.send_messages(message)
 
-#             async with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
-#                 messages = await receiver.peek_messages(5)
-#                 assert len(messages) == 5
-#                 assert all(isinstance(m, ServiceBusReceivedMessage) for m in messages)
-#                 for message in messages:
-#                     print_message(_logger, message)
-#                     with pytest.raises(ValueError):
-#                         await receiver.complete_message(message)
+            async with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
+                messages = await receiver.peek_messages(5)
+                assert len(messages) == 5
+                assert all(isinstance(m, ServiceBusReceivedMessage) for m in messages)
+                for message in messages:
+                    print_message(_logger, message)
+                    with pytest.raises(ValueError):
+                        await receiver.complete_message(message)
 
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_async_queue_by_servicebus_client_browse_messages_with_receiver(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         async with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_async_queue_by_servicebus_client_browse_messages_with_receiver(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential(is_async=True)
+        async with ServiceBusClient(
+            fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-#             async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5, receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
-#                 async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                     for i in range(5):
-#                         message = ServiceBusMessage("Test message no. {}".format(i))
-#                         await sender.send_messages(message)
+            async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5, receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
+                async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                    for i in range(5):
+                        message = ServiceBusMessage("Test message no. {}".format(i))
+                        await sender.send_messages(message)
 
-#                 messages = await receiver.peek_messages(5, timeout=5)
-#                 assert len(messages) > 0
-#                 assert all(isinstance(m, ServiceBusReceivedMessage) for m in messages)
-#                 for message in messages:
-#                     print_message(_logger, message)
-#                     with pytest.raises(ValueError):
-#                         await receiver.complete_message(message)
+                messages = await receiver.peek_messages(5, timeout=5)
+                assert len(messages) > 0
+                assert all(isinstance(m, ServiceBusReceivedMessage) for m in messages)
+                for message in messages:
+                    print_message(_logger, message)
+                    with pytest.raises(ValueError):
+                        await receiver.complete_message(message)
 
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_async_queue_by_servicebus_client_browse_empty_messages(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         async with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_async_queue_by_servicebus_client_browse_empty_messages(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential(is_async=True)
+        async with ServiceBusClient(
+            fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-#             async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5, receive_mode=ServiceBusReceiveMode.PEEK_LOCK, prefetch_count=10) as receiver:
-#                 messages = await receiver.peek_messages(10)
-#                 assert len(messages) == 0
+            async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5, receive_mode=ServiceBusReceiveMode.PEEK_LOCK, prefetch_count=10) as receiver:
+                messages = await receiver.peek_messages(10)
+                assert len(messages) == 0
 
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_async_queue_by_servicebus_client_renew_message_locks(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         async with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_async_queue_by_servicebus_client_renew_message_locks(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential(is_async=True)
+        async with ServiceBusClient(
+            fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-#             messages = []
-#             locks = 3
-#             async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5, receive_mode=ServiceBusReceiveMode.PEEK_LOCK, prefetch_count=10) as receiver:
-#                 async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                     for i in range(locks):
-#                         message = ServiceBusMessage("Test message no. {}".format(i))
-#                         await sender.send_messages(message)
+            messages = []
+            locks = 3
+            async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5, receive_mode=ServiceBusReceiveMode.PEEK_LOCK, prefetch_count=10) as receiver:
+                async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                    for i in range(locks):
+                        message = ServiceBusMessage("Test message no. {}".format(i))
+                        await sender.send_messages(message)
 
-#                 messages.extend(await receiver.receive_messages())
-#                 recv = True
-#                 while recv:
-#                     recv = await receiver.receive_messages()
-#                     messages.extend(recv)
+                messages.extend(await receiver.receive_messages())
+                recv = True
+                while recv:
+                    recv = await receiver.receive_messages()
+                    messages.extend(recv)
 
-#                 try:
-#                     with pytest.raises(AttributeError):
-#                         assert not message._lock_expired
-#                     for message in messages:
-#                         time.sleep(5)
-#                         initial_expiry = message.locked_until_utc
-#                         await receiver.renew_message_lock(message)
-#                         assert (message.locked_until_utc - initial_expiry) >= timedelta(seconds=5)
-#                 finally:
-#                     await receiver.complete_message(messages[0])
-#                     await receiver.complete_message(messages[1])
-#                     sleep_until_expired(messages[2])
-#                     with pytest.raises(MessageLockLostError):
-#                         await receiver.complete_message(messages[2])
-
-    
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True, lock_duration='PT5S')
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_async_queue_by_queue_client_conn_str_receive_handler_with_autolockrenew(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         async with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-
-#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 for i in range(10):
-#                     message = ServiceBusMessage("{}".format(i))
-#                     await sender.send_messages(message)
-
-#             # issue https://github.com/Azure/azure-sdk-for-python/issues/19642
-#             empty_renewer = AutoLockRenewer()
-#             async with empty_renewer:
-#                 pass
-
-#             renewer = AutoLockRenewer()
-#             messages = []
-#             async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5, receive_mode=ServiceBusReceiveMode.PEEK_LOCK, prefetch_count=10) as receiver:
-#                 async for message in receiver:
-#                     if not messages:
-#                         messages.append(message)
-#                         assert not message._lock_expired
-#                         renewer.register(receiver, message, max_lock_renewal_duration=10)
-#                         print("Registered lock renew thread", message.locked_until_utc, utc_now())
-#                         await asyncio.sleep(10)
-#                         print("Finished first sleep", message.locked_until_utc)
-#                         assert not message._lock_expired
-#                         await asyncio.sleep(15) #generate autolockrenewtimeout error by going one iteration past.
-#                         sleep_until_expired(message)
-#                         print("Finished second sleep", message.locked_until_utc, utc_now())
-#                         assert message._lock_expired
-#                         try:
-#                             await receiver.complete_message(message)
-#                             raise AssertionError("Didn't raise MessageLockLostError")
-#                         except MessageLockLostError as e:
-#                             assert isinstance(e.inner_exception, AutoLockRenewTimeout)
-#                     else:
-#                         if message._lock_expired:
-#                             print("Remaining messages", message.locked_until_utc, utc_now())
-#                             assert message._lock_expired
-#                             with pytest.raises(MessageLockLostError):
-#                                 await receiver.complete_message(message)
-#                         else:
-#                             assert message.delivery_count >= 1
-#                             print("Remaining messages", message.locked_until_utc, utc_now())
-#                             messages.append(message)
-#                             await receiver.complete_message(message)
-#             await renewer.close()
-#             assert len(messages) == 11
+                try:
+                    with pytest.raises(AttributeError):
+                        assert not message._lock_expired
+                    for message in messages:
+                        time.sleep(5)
+                        initial_expiry = message.locked_until_utc
+                        await receiver.renew_message_lock(message)
+                        assert (message.locked_until_utc - initial_expiry) >= timedelta(seconds=5)
+                finally:
+                    await receiver.complete_message(messages[0])
+                    await receiver.complete_message(messages[1])
+                    sleep_until_expired(messages[2])
+                    with pytest.raises(MessageLockLostError):
+                        await receiver.complete_message(messages[2])
 
     
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True, lock_duration='PT5S')
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_async_queue_by_queue_client_conn_str_receive_handler_with_auto_autolockrenew(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         async with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True, lock_duration='PT5S')
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_async_queue_by_queue_client_conn_str_receive_handler_with_autolockrenew(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential(is_async=True)
+        async with ServiceBusClient(
+            fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 # The 10 iterations is "important" because it gives time for the timed out message to be received again.
-#                 for i in range(10):
-#                     message = ServiceBusMessage("{}".format(i))
-#                     await sender.send_messages(message)
+            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                for i in range(10):
+                    message = ServiceBusMessage("{}".format(i))
+                    await sender.send_messages(message)
 
-#             renewer = AutoLockRenewer(max_lock_renewal_duration=10)
-#             messages = []
-#             async with sb_client.get_queue_receiver(servicebus_queue.name,
-#                                                     max_wait_time=5,
-#                                                     receive_mode=ServiceBusReceiveMode.PEEK_LOCK,
-#                                                     prefetch_count=10,
-#                                                     auto_lock_renewer=renewer) as receiver:
-#                 async for message in receiver:
-#                     if not messages:
-#                         messages.append(message)
-#                         assert not message._lock_expired
-#                         print("Registered lock renew thread", message.locked_until_utc, utc_now())
-#                         await asyncio.sleep(10)
-#                         print("Finished first sleep", message.locked_until_utc)
-#                         assert not message._lock_expired
-#                         await asyncio.sleep(15) #generate autolockrenewtimeout error by going one iteration past.
-#                         sleep_until_expired(message)
-#                         print("Finished second sleep", message.locked_until_utc, utc_now())
-#                         assert message._lock_expired
-#                         try:
-#                             await receiver.complete_message(message)
-#                             raise AssertionError("Didn't raise MessageLockLostError")
-#                         except MessageLockLostError as e:
-#                             assert isinstance(e.inner_exception, AutoLockRenewTimeout)
-#                     else:
-#                         if message._lock_expired:
-#                             print("Remaining messages", message.locked_until_utc, utc_now())
-#                             assert message._lock_expired
-#                             with pytest.raises(MessageLockLostError):
-#                                 await receiver.complete_message(message)
-#                         else:
-#                             assert message.delivery_count >= 1
-#                             print("Remaining messages", message.locked_until_utc, utc_now())
-#                             messages.append(message)
-#                             await receiver.complete_message(message)
-#             await renewer.close()
-#             assert len(messages) == 11
+            # issue https://github.com/Azure/azure-sdk-for-python/issues/19642
+            empty_renewer = AutoLockRenewer()
+            async with empty_renewer:
+                pass
 
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_async_queue_by_servicebus_client_fail_send_messages(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         async with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+            renewer = AutoLockRenewer()
+            messages = []
+            async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5, receive_mode=ServiceBusReceiveMode.PEEK_LOCK, prefetch_count=10) as receiver:
+                async for message in receiver:
+                    if not messages:
+                        messages.append(message)
+                        assert not message._lock_expired
+                        renewer.register(receiver, message, max_lock_renewal_duration=10)
+                        print("Registered lock renew thread", message.locked_until_utc, utc_now())
+                        await asyncio.sleep(10)
+                        print("Finished first sleep", message.locked_until_utc)
+                        assert not message._lock_expired
+                        await asyncio.sleep(15) #generate autolockrenewtimeout error by going one iteration past.
+                        sleep_until_expired(message)
+                        print("Finished second sleep", message.locked_until_utc, utc_now())
+                        assert message._lock_expired
+                        try:
+                            await receiver.complete_message(message)
+                            raise AssertionError("Didn't raise MessageLockLostError")
+                        except MessageLockLostError as e:
+                            assert isinstance(e.inner_exception, AutoLockRenewTimeout)
+                    else:
+                        if message._lock_expired:
+                            print("Remaining messages", message.locked_until_utc, utc_now())
+                            assert message._lock_expired
+                            with pytest.raises(MessageLockLostError):
+                                await receiver.complete_message(message)
+                        else:
+                            assert message.delivery_count >= 1
+                            print("Remaining messages", message.locked_until_utc, utc_now())
+                            messages.append(message)
+                            await receiver.complete_message(message)
+            await renewer.close()
+            assert len(messages) == 11
 
-#             too_large = "A" * 1024 * 256
+    
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True, lock_duration='PT5S')
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_async_queue_by_queue_client_conn_str_receive_handler_with_auto_autolockrenew(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential(is_async=True)
+        async with ServiceBusClient(
+            fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+
+            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                # The 10 iterations is "important" because it gives time for the timed out message to be received again.
+                for i in range(10):
+                    message = ServiceBusMessage("{}".format(i))
+                    await sender.send_messages(message)
+
+            renewer = AutoLockRenewer(max_lock_renewal_duration=10)
+            messages = []
+            async with sb_client.get_queue_receiver(servicebus_queue.name,
+                                                    max_wait_time=5,
+                                                    receive_mode=ServiceBusReceiveMode.PEEK_LOCK,
+                                                    prefetch_count=10,
+                                                    auto_lock_renewer=renewer) as receiver:
+                async for message in receiver:
+                    if not messages:
+                        messages.append(message)
+                        assert not message._lock_expired
+                        print("Registered lock renew thread", message.locked_until_utc, utc_now())
+                        await asyncio.sleep(10)
+                        print("Finished first sleep", message.locked_until_utc)
+                        assert not message._lock_expired
+                        await asyncio.sleep(15) #generate autolockrenewtimeout error by going one iteration past.
+                        sleep_until_expired(message)
+                        print("Finished second sleep", message.locked_until_utc, utc_now())
+                        assert message._lock_expired
+                        try:
+                            await receiver.complete_message(message)
+                            raise AssertionError("Didn't raise MessageLockLostError")
+                        except MessageLockLostError as e:
+                            assert isinstance(e.inner_exception, AutoLockRenewTimeout)
+                    else:
+                        if message._lock_expired:
+                            print("Remaining messages", message.locked_until_utc, utc_now())
+                            assert message._lock_expired
+                            with pytest.raises(MessageLockLostError):
+                                await receiver.complete_message(message)
+                        else:
+                            assert message.delivery_count >= 1
+                            print("Remaining messages", message.locked_until_utc, utc_now())
+                            messages.append(message)
+                            await receiver.complete_message(message)
+            await renewer.close()
+            assert len(messages) == 11
+
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_async_queue_by_servicebus_client_fail_send_messages(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential(is_async=True)
+        async with ServiceBusClient(
+            fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+
+            too_large = "A" * 1024 * 256
             
-#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 with pytest.raises(MessageSizeExceededError):
-#                     await sender.send_messages(ServiceBusMessage(too_large))
+            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                with pytest.raises(MessageSizeExceededError):
+                    await sender.send_messages(ServiceBusMessage(too_large))
                     
-#                 half_too_large = "A" * int((1024 * 256) / 2)
-#                 with pytest.raises(MessageSizeExceededError):
-#                     await sender.send_messages([ServiceBusMessage(half_too_large), ServiceBusMessage(half_too_large)])
+                half_too_large = "A" * int((1024 * 256) / 2)
+                with pytest.raises(MessageSizeExceededError):
+                    await sender.send_messages([ServiceBusMessage(half_too_large), ServiceBusMessage(half_too_large)])
 
     
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_async_queue_message_time_to_live(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         async with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_async_queue_message_time_to_live(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential(is_async=True)
+        async with ServiceBusClient(
+            fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 content = str(uuid.uuid4())
-#                 message_id = uuid.uuid4()
-#                 message = ServiceBusMessage(content)
-#                 message.time_to_live = timedelta(seconds=15)
-#                 await sender.send_messages(message)
+            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                content = str(uuid.uuid4())
+                message_id = uuid.uuid4()
+                message = ServiceBusMessage(content)
+                message.time_to_live = timedelta(seconds=15)
+                await sender.send_messages(message)
 
-#             time.sleep(15)
-#             async with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
-#                 messages = await receiver.receive_messages(max_wait_time=10)
-#             assert not messages
+            time.sleep(15)
+            async with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
+                messages = await receiver.receive_messages(max_wait_time=10)
+            assert not messages
 
-#             async with sb_client.get_queue_receiver(servicebus_queue.name, 
-#                                                     sub_queue = ServiceBusSubQueue.DEAD_LETTER,
-#                                                     max_wait_time=5, 
-#                                                     receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
-#                 count = 0
-#                 async for message in receiver:
-#                     print_message(_logger, message)
-#                     await receiver.complete_message(message)
-#                     count += 1
-#                 assert count == 1
-
-    
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_duplicate_detection=True, dead_lettering_on_message_expiration=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_async_queue_message_duplicate_detection(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         async with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-
-#             message_id = uuid.uuid4()
-
-#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 for i in range(5):
-#                     message = ServiceBusMessage(str(i))
-#                     message.message_id = message_id
-#                     await sender.send_messages(message)
-
-#             async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5) as receiver:
-#                 count = 0
-#                 async for message in receiver:
-#                     print_message(_logger, message)
-#                     assert message.message_id == message_id
-#                     await receiver.complete_message(message)
-#                     count += 1
-#                 assert count == 1
-
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_async_queue_message_connection_closed(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         async with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-
-#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 content = str(uuid.uuid4())
-#                 message = ServiceBusMessage(content)
-#                 await sender.send_messages(message)
-
-#             async with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
-#                 messages = await receiver.receive_messages(max_wait_time=10)
-#                 assert len(messages) == 1
-
-#             with pytest.raises(ValueError):
-#                 await receiver.complete_message(messages[0])
-
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_async_queue_message_expiry(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         async with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-
-#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 content = str(uuid.uuid4())
-#                 message = ServiceBusMessage(content)
-#                 await sender.send_messages(message)
-
-#             async with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
-#                 messages = await receiver.receive_messages(max_wait_time=10)
-#                 assert len(messages) == 1
-#                 time.sleep(60)
-#                 assert messages[0]._lock_expired
-#                 with pytest.raises(MessageLockLostError):
-#                     await receiver.complete_message(messages[0])
-#                 with pytest.raises(MessageLockLostError):
-#                     await receiver.renew_message_lock(messages[0])
-
-#             async with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
-#                 messages = await receiver.receive_messages(max_wait_time=30)
-#                 assert len(messages) == 1
-#                 print_message(_logger, messages[0])
-#                 assert messages[0].delivery_count > 0
-#                 await receiver.complete_message(messages[0])
-
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_async_queue_message_lock_renew(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         async with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-            
-#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 content = str(uuid.uuid4())
-#                 message = ServiceBusMessage(content)
-#                 await sender.send_messages(message)
-            
-#             async with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
-#                 messages = await receiver.receive_messages(max_wait_time=10)
-#                 assert len(messages) == 1
-#                 time.sleep(15)
-#                 await receiver.renew_message_lock(messages[0], timeout=5)
-#                 time.sleep(15)
-#                 await receiver.renew_message_lock(messages[0])
-#                 time.sleep(15)
-#                 assert not messages[0]._lock_expired
-#                 await receiver.complete_message(messages[0])
-            
-#             async with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
-#                 messages = await receiver.receive_messages(max_wait_time=10)
-#                 assert len(messages) == 0
-
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True, lock_duration='PT10S')
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_async_queue_message_receive_and_delete(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         if uamqp:
-#             transport_type = uamqp.constants.TransportType.Amqp
-#         else:
-#             transport_type = TransportType.Amqp
-#         async with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string,
-#             transport_type=transport_type,
-#             logging_enable=False,
-#             uamqp_transport=uamqp_transport
-#         ) as sb_client:
-
-#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 message = ServiceBusMessage("Receive and delete test")
-#                 await sender.send_messages(message)
-
-#             async with sb_client.get_queue_receiver(servicebus_queue.name, receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE) as receiver:
-#                 messages = await receiver.receive_messages(max_wait_time=10)
-#                 assert len(messages) == 1
-#                 message = messages[0]
-#                 print_message(_logger, message)
-#                 with pytest.raises(ValueError):
-#                     await receiver.complete_message(message)
-#                 with pytest.raises(ValueError):
-#                     await receiver.abandon_message(message)
-#                 with pytest.raises(ValueError):
-#                     await receiver.defer_message(message)
-#                 with pytest.raises(ValueError):
-#                     await receiver.dead_letter_message(message)
-#                 with pytest.raises(ValueError):
-#                     await receiver.renew_message_lock(message)
-
-#             time.sleep(10)
-#             async with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
-#                 messages = await receiver.receive_messages(max_wait_time=10)
-#                 for m in messages:
-#                     print_message(_logger, m)
-#                 assert len(messages) == 0
-
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_async_queue_message_batch(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         async with ServiceBusClient.from_connection_string(
-#                 servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-
-#             def message_content():
-#                 for i in range(5):
-#                     message = ServiceBusMessage("ServiceBusMessage no. {}".format(i))
-#                     message.application_properties = {'key': 'value'}
-#                     message.subject = 'label'
-#                     message.content_type = 'application/text'
-#                     message.correlation_id = 'cid'
-#                     message.message_id = str(i)
-#                     message.to = 'to'
-#                     message.reply_to = 'reply_to'
-#                     message.time_to_live = timedelta(seconds=60)
-#                     assert message.raw_amqp_message.properties.absolute_expiry_time == message.raw_amqp_message.properties.creation_time + message.raw_amqp_message.header.time_to_live
-
-#                     yield message
-
-#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 # sending manually created message batch (with default pyamqp) should work for both uamqp/pyamqp
-#                 message = ServiceBusMessageBatch()
-#                 for each in message_content():
-#                     message.add_message(each)
-#                 await sender.send_messages(message)
-
-#             async with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
-#                 messages = await receiver.receive_messages(max_wait_time=10)
-#                 recv = True
-#                 while recv:
-#                     recv = await receiver.receive_messages(max_wait_time=10)
-#                     messages.extend(recv)
-
-#                 assert len(messages) == 5
-#                 count = 0
-#                 for message in messages:
-#                     assert message.delivery_count == 0
-#                     assert message.application_properties
-#                     assert message.application_properties[b'key'] == b'value'
-#                     assert message.subject == 'label'
-#                     assert message.content_type == 'application/text'
-#                     assert message.correlation_id == 'cid'
-#                     assert message.message_id == str(count)
-#                     assert message.to == 'to'
-#                     assert message.reply_to == 'reply_to'
-#                     assert message.sequence_number
-#                     assert message.enqueued_time_utc
-#                     assert message.expires_at_utc == (message.enqueued_time_utc + timedelta(seconds=60))
-#                     print_message(_logger, message)
-#                     await receiver.complete_message(message)
-#                     count += 1
-
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_async_queue_schedule_message(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         async with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-
-#             scheduled_enqueue_time = (utc_now() + timedelta(minutes=2)).replace(microsecond=0)
-#             async with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
-#                 async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                     content = str(uuid.uuid4())
-#                     message_id = uuid.uuid4()
-#                     message = ServiceBusMessage(content)
-#                     message.message_id = message_id
-#                     message.scheduled_enqueue_time_utc = scheduled_enqueue_time
-#                     await sender.send_messages(message)
-
-#                 messages = await receiver.receive_messages(max_wait_time=120)
-#                 if messages:
-#                     try:
-#                         data = str(messages[0])
-#                         assert data == content
-#                         assert messages[0].message_id == message_id
-#                         assert messages[0].scheduled_enqueue_time_utc == scheduled_enqueue_time
-#                         assert messages[0].scheduled_enqueue_time_utc <= messages[0].enqueued_time_utc.replace(microsecond=0)
-#                         assert len(messages) == 1
-#                     finally:
-#                         for message in messages:
-#                             await receiver.complete_message(message)
-#                 else:
-#                     raise Exception("Failed to receive scheduled message.")
+            async with sb_client.get_queue_receiver(servicebus_queue.name, 
+                                                    sub_queue = ServiceBusSubQueue.DEAD_LETTER,
+                                                    max_wait_time=5, 
+                                                    receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
+                count = 0
+                async for message in receiver:
+                    print_message(_logger, message)
+                    await receiver.complete_message(message)
+                    count += 1
+                assert count == 1
 
     
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_async_queue_schedule_multiple_messages(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         async with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-#             scheduled_enqueue_time = (utc_now() + timedelta(minutes=2)).replace(microsecond=0)
-#             messages = []
-#             receiver = sb_client.get_queue_receiver(servicebus_queue.name, prefetch_count=20, max_wait_time=5)
-#             sender = sb_client.get_queue_sender(servicebus_queue.name)
-#             async with sender, receiver:
-#                 content = str(uuid.uuid4())
-#                 message_id_a = uuid.uuid4()
-#                 message_a = ServiceBusMessage(content)
-#                 message_a.message_id = message_id_a
-#                 message_id_b = uuid.uuid4()
-#                 message_b = ServiceBusMessage(content)
-#                 message_b.message_id = message_id_b
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_duplicate_detection=True, dead_lettering_on_message_expiration=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_async_queue_message_duplicate_detection(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential(is_async=True)
+        async with ServiceBusClient(
+            fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-#                 await sender.send_messages([message_a, message_b])
+            message_id = uuid.uuid4()
 
-#                 received_messages = []
-#                 async for message in receiver:
-#                     received_messages.append(message)
-#                     await receiver.complete_message(message)
+            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                for i in range(5):
+                    message = ServiceBusMessage(str(i))
+                    message.message_id = message_id
+                    await sender.send_messages(message)
 
-#                 tokens = await sender.schedule_messages(received_messages, scheduled_enqueue_time, timeout=5)
-#                 assert len(tokens) == 2
+            async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5) as receiver:
+                count = 0
+                async for message in receiver:
+                    print_message(_logger, message)
+                    assert message.message_id == message_id
+                    await receiver.complete_message(message)
+                    count += 1
+                assert count == 1
 
-#                 messages = await receiver.receive_messages(max_wait_time=120)
-#                 recv = await receiver.receive_messages(max_wait_time=5)
-#                 messages.extend(recv)
-#                 if messages:
-#                     try:
-#                         data = str(messages[0])
-#                         assert data == content
-#                         assert messages[0].message_id in (message_id_a, message_id_b)
-#                         assert messages[0].scheduled_enqueue_time_utc == scheduled_enqueue_time
-#                         assert messages[0].scheduled_enqueue_time_utc <= messages[0].enqueued_time_utc.replace(microsecond=0)
-#                         assert len(messages) == 2
-#                     finally:
-#                         for message in messages:
-#                             await receiver.complete_message(message)
-#                         if not uamqp_transport:
-#                             pickled = pickle.loads(pickle.dumps(messages[0]))
-#                             assert pickled.message_id == messages[0].message_id
-#                             assert pickled.scheduled_enqueue_time_utc == messages[0].scheduled_enqueue_time_utc
-#                             assert pickled.scheduled_enqueue_time_utc <= pickled.enqueued_time_utc.replace(microsecond=0)
-#                 else:
-#                     raise Exception("Failed to receive scheduled message.")
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_async_queue_message_connection_closed(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential(is_async=True)
+        async with ServiceBusClient(
+            fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_async_queue_cancel_scheduled_messages(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         async with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                content = str(uuid.uuid4())
+                message = ServiceBusMessage(content)
+                await sender.send_messages(message)
 
-#             enqueue_time = (utc_now() + timedelta(minutes=2)).replace(microsecond=0)
-#             async with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
-#                 async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                     message_a = ServiceBusMessage("Test scheduled message")
-#                     message_b = ServiceBusMessage("Test scheduled message")
-#                     tokens = await sender.schedule_messages([message_a, message_b], enqueue_time)
-#                     assert len(tokens) == 2
+            async with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
+                messages = await receiver.receive_messages(max_wait_time=10)
+                assert len(messages) == 1
 
-#                     await sender.cancel_scheduled_messages(tokens, timeout=None)
+            with pytest.raises(ValueError):
+                await receiver.complete_message(messages[0])
 
-#                 messages = await receiver.receive_messages(max_wait_time=120)
-#                 assert len(messages) == 0
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_async_queue_message_expiry(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential(is_async=True)
+        async with ServiceBusClient(
+            fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_queue_message_amqp_over_websocket(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         async with ServiceBusClient.from_connection_string(
-#                 servicebus_namespace_connection_string,
-#                 transport_type=TransportType.AmqpOverWebsocket,
-#                 logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                content = str(uuid.uuid4())
+                message = ServiceBusMessage(content)
+                await sender.send_messages(message)
 
-#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 assert sender._config.transport_type == TransportType.AmqpOverWebsocket
-#                 message = ServiceBusMessage("Test")
-#                 await sender.send_messages(message)
+            async with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
+                messages = await receiver.receive_messages(max_wait_time=10)
+                assert len(messages) == 1
+                time.sleep(60)
+                assert messages[0]._lock_expired
+                with pytest.raises(MessageLockLostError):
+                    await receiver.complete_message(messages[0])
+                with pytest.raises(MessageLockLostError):
+                    await receiver.renew_message_lock(messages[0])
 
-#             async with sb_client.get_queue_receiver(servicebus_queue.name, receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE) as receiver:
-#                 assert receiver._config.transport_type == TransportType.AmqpOverWebsocket
-#                 messages = await receiver.receive_messages(max_wait_time=5)
-#                 assert len(messages) == 1
+            async with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
+                messages = await receiver.receive_messages(max_wait_time=30)
+                assert len(messages) == 1
+                print_message(_logger, messages[0])
+                assert messages[0].delivery_count > 0
+                await receiver.complete_message(messages[0])
 
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     def test_queue_message_http_proxy_setting(self, uamqp_transport):
-#         mock_conn_str = "Endpoint=sb://mock.servicebus.windows.net/;SharedAccessKeyName=mock;SharedAccessKey=mock"
-#         http_proxy = {
-#             'proxy_hostname': '127.0.0.1',
-#             'proxy_port': 8899,
-#             'username': 'admin',
-#             'password': '123456'
-#         }
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_async_queue_message_lock_renew(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential(is_async=True)
+        async with ServiceBusClient(
+            fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+            
+            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                content = str(uuid.uuid4())
+                message = ServiceBusMessage(content)
+                await sender.send_messages(message)
+            
+            async with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
+                messages = await receiver.receive_messages(max_wait_time=10)
+                assert len(messages) == 1
+                time.sleep(15)
+                await receiver.renew_message_lock(messages[0], timeout=5)
+                time.sleep(15)
+                await receiver.renew_message_lock(messages[0])
+                time.sleep(15)
+                assert not messages[0]._lock_expired
+                await receiver.complete_message(messages[0])
+            
+            async with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
+                messages = await receiver.receive_messages(max_wait_time=10)
+                assert len(messages) == 0
 
-#         sb_client = ServiceBusClient.from_connection_string(mock_conn_str, http_proxy=http_proxy, uamqp_transport=uamqp_transport)
-#         assert sb_client._config.http_proxy == http_proxy
-#         assert sb_client._config.transport_type == TransportType.AmqpOverWebsocket
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True, lock_duration='PT10S')
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_async_queue_message_receive_and_delete(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        if uamqp:
+            transport_type = uamqp.constants.TransportType.Amqp
+        else:
+            transport_type = TransportType.Amqp
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential(is_async=True)
+        async with ServiceBusClient(
+            fully_qualified_namespace, credential,
+            transport_type=transport_type,
+            logging_enable=False,
+            uamqp_transport=uamqp_transport
+        ) as sb_client:
 
-#         sender = sb_client.get_queue_sender(queue_name="mock")
-#         assert sender._config.http_proxy == http_proxy
-#         assert sender._config.transport_type == TransportType.AmqpOverWebsocket
+            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                message = ServiceBusMessage("Receive and delete test")
+                await sender.send_messages(message)
 
-#         receiver = sb_client.get_queue_receiver(queue_name="mock")
-#         assert receiver._config.http_proxy == http_proxy
-#         assert receiver._config.transport_type == TransportType.AmqpOverWebsocket
+            async with sb_client.get_queue_receiver(servicebus_queue.name, receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE) as receiver:
+                messages = await receiver.receive_messages(max_wait_time=10)
+                assert len(messages) == 1
+                message = messages[0]
+                print_message(_logger, message)
+                with pytest.raises(ValueError):
+                    await receiver.complete_message(message)
+                with pytest.raises(ValueError):
+                    await receiver.abandon_message(message)
+                with pytest.raises(ValueError):
+                    await receiver.defer_message(message)
+                with pytest.raises(ValueError):
+                    await receiver.dead_letter_message(message)
+                with pytest.raises(ValueError):
+                    await receiver.renew_message_lock(message)
 
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_queue_message_settle_through_mgmt_link_due_to_broken_receiver_link(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         async with ServiceBusClient.from_connection_string(
-#                 servicebus_namespace_connection_string,
-#                 logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+            time.sleep(10)
+            async with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
+                messages = await receiver.receive_messages(max_wait_time=10)
+                for m in messages:
+                    print_message(_logger, m)
+                assert len(messages) == 0
 
-#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 message = ServiceBusMessage("Test")
-#                 await sender.send_messages(message)
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_async_queue_message_batch(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential(is_async=True)
+        async with ServiceBusClient(
+                fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-#             async with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
-#                 messages = await receiver.receive_messages(max_wait_time=5)
-#                 # destroy the underlying receiver link
-#                 if uamqp_transport:
-#                     await receiver._handler.message_handler.destroy_async()
-#                 else:
-#                     await receiver._handler._link.detach()
-#                 assert len(messages) == 1
-#                 await receiver.complete_message(messages[0])
+            def message_content():
+                for i in range(5):
+                    message = ServiceBusMessage("ServiceBusMessage no. {}".format(i))
+                    message.application_properties = {'key': 'value'}
+                    message.subject = 'label'
+                    message.content_type = 'application/text'
+                    message.correlation_id = 'cid'
+                    message.message_id = str(i)
+                    message.to = 'to'
+                    message.reply_to = 'reply_to'
+                    message.time_to_live = timedelta(seconds=60)
+                    assert message.raw_amqp_message.properties.absolute_expiry_time == message.raw_amqp_message.properties.creation_time + message.raw_amqp_message.header.time_to_live
 
-#     @pytest.mark.skip('hard to test')
-#     @AzureRecordedTestCase.await_prepared_test
-#     async def test_async_queue_mock_auto_lock_renew_callback(self):
-#         # A warning to future devs: If the renew period override heuristic in registration
-#         # ever changes, it may break this (since it adjusts renew period if it is not short enough)
+                    yield message
 
-#         results = []
-#         errors = []
-#         async def callback_mock(renewable, error):
-#             results.append(renewable)
-#             if error:
-#                 errors.append(error)
+            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                # sending manually created message batch (with default pyamqp) should work for both uamqp/pyamqp
+                message = ServiceBusMessageBatch()
+                for each in message_content():
+                    message.add_message(each)
+                await sender.send_messages(message)
 
-#         receiver = MockReceiver()
-#         auto_lock_renew = AutoLockRenewer()
-#         with pytest.raises(TypeError):
-#             auto_lock_renew.register(receiver, renewable=Exception())  # an arbitrary invalid type.
+            async with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
+                messages = await receiver.receive_messages(max_wait_time=10)
+                recv = True
+                while recv:
+                    recv = await receiver.receive_messages(max_wait_time=10)
+                    messages.extend(recv)
 
-#         auto_lock_renew = AutoLockRenewer()
-#         auto_lock_renew._renew_period = 1  # So we can run the test fast.
-#         async with auto_lock_renew:  # Check that it is called when the object expires for any reason (silent renew failure)
-#             message = MockReceivedMessage(prevent_renew_lock=True)
-#             auto_lock_renew.register(receiver, renewable=message, on_lock_renew_failure=callback_mock)
-#             await asyncio.sleep(3)
-#             assert len(results) == 1 and results[-1]._lock_expired == True
-#             assert not errors
+                assert len(messages) == 5
+                count = 0
+                for message in messages:
+                    assert message.delivery_count == 0
+                    assert message.application_properties
+                    assert message.application_properties[b'key'] == b'value'
+                    assert message.subject == 'label'
+                    assert message.content_type == 'application/text'
+                    assert message.correlation_id == 'cid'
+                    assert message.message_id == str(count)
+                    assert message.to == 'to'
+                    assert message.reply_to == 'reply_to'
+                    assert message.sequence_number
+                    assert message.enqueued_time_utc
+                    assert message.expires_at_utc == (message.enqueued_time_utc + timedelta(seconds=60))
+                    print_message(_logger, message)
+                    await receiver.complete_message(message)
+                    count += 1
 
-#         del results[:]
-#         del errors[:]
-#         auto_lock_renew = AutoLockRenewer()
-#         auto_lock_renew._renew_period = 1
-#         async with auto_lock_renew:  # Check that in normal operation it does not get called
-#             auto_lock_renew.register(receiver, renewable=MockReceivedMessage(), on_lock_renew_failure=callback_mock)
-#             await asyncio.sleep(3)
-#             assert not results
-#             assert not errors
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_async_queue_schedule_message(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential(is_async=True)
+        async with ServiceBusClient(
+            fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-#         del results[:]
-#         del errors[:]
-#         auto_lock_renew = AutoLockRenewer()
-#         auto_lock_renew._renew_period = 1
-#         async with auto_lock_renew:  # Check that when a message is settled, it will not get called even after expiry
-#             message = MockReceivedMessage(prevent_renew_lock=True)
-#             auto_lock_renew.register(receiver, renewable=message, on_lock_renew_failure=callback_mock)
-#             message._settled = True
-#             await asyncio.sleep(3)
-#             assert not results
-#             assert not errors
+            scheduled_enqueue_time = (utc_now() + timedelta(minutes=2)).replace(microsecond=0)
+            async with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
+                async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                    content = str(uuid.uuid4())
+                    message_id = uuid.uuid4()
+                    message = ServiceBusMessage(content)
+                    message.message_id = message_id
+                    message.scheduled_enqueue_time_utc = scheduled_enqueue_time
+                    await sender.send_messages(message)
 
-#         del results[:]
-#         del errors[:]
-#         auto_lock_renew = AutoLockRenewer()
-#         auto_lock_renew._renew_period = 1
-#         async with auto_lock_renew: # Check that it is called when there is an overt renew failure
-#             message = MockReceivedMessage(exception_on_renew_lock=True)
-#             auto_lock_renew.register(receiver, renewable=message, on_lock_renew_failure=callback_mock)
-#             await asyncio.sleep(3)
-#             assert len(results) == 1 and results[-1]._lock_expired == True
-#             assert errors[-1]
+                messages = await receiver.receive_messages(max_wait_time=120)
+                if messages:
+                    try:
+                        data = str(messages[0])
+                        assert data == content
+                        assert messages[0].message_id == message_id
+                        assert messages[0].scheduled_enqueue_time_utc == scheduled_enqueue_time
+                        assert messages[0].scheduled_enqueue_time_utc <= messages[0].enqueued_time_utc.replace(microsecond=0)
+                        assert len(messages) == 1
+                    finally:
+                        for message in messages:
+                            await receiver.complete_message(message)
+                else:
+                    raise Exception("Failed to receive scheduled message.")
 
-#         del results[:]
-#         del errors[:]
-#         auto_lock_renew = AutoLockRenewer()
-#         auto_lock_renew._renew_period = 1
-#         async with auto_lock_renew:  # Check that it is not called when the renewer is shutdown
-#             message = MockReceivedMessage(prevent_renew_lock=True)
-#             auto_lock_renew.register(receiver, renewable=message, on_lock_renew_failure=callback_mock)
-#             await auto_lock_renew.close()
-#             await asyncio.sleep(3)
-#             assert not results
-#             assert not errors
+    
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_async_queue_schedule_multiple_messages(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential(is_async=True)
+        async with ServiceBusClient(
+            fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+            scheduled_enqueue_time = (utc_now() + timedelta(minutes=2)).replace(microsecond=0)
+            messages = []
+            receiver = sb_client.get_queue_receiver(servicebus_queue.name, prefetch_count=20, max_wait_time=5)
+            sender = sb_client.get_queue_sender(servicebus_queue.name)
+            async with sender, receiver:
+                content = str(uuid.uuid4())
+                message_id_a = uuid.uuid4()
+                message_a = ServiceBusMessage(content)
+                message_a.message_id = message_id_a
+                message_id_b = uuid.uuid4()
+                message_b = ServiceBusMessage(content)
+                message_b.message_id = message_id_b
 
-#         del results[:]
-#         del errors[:]
-#         auto_lock_renew = AutoLockRenewer()
-#         auto_lock_renew._renew_period = 1
-#         async with auto_lock_renew:  # Check that it is not called when the receiver is shutdown
-#             message = MockReceivedMessage(prevent_renew_lock=True)
-#             auto_lock_renew.register(receiver, renewable=message, on_lock_renew_failure=callback_mock)
-#             message._receiver._running = False
-#             await asyncio.sleep(3)
-#             assert not results
-#             assert not errors
+                await sender.send_messages([message_a, message_b])
 
-#     @AzureRecordedTestCase.await_prepared_test
-#     async def test_async_queue_mock_no_reusing_auto_lock_renew(self):
-#         auto_lock_renew = AutoLockRenewer()
-#         auto_lock_renew._renew_period = 1
+                received_messages = []
+                async for message in receiver:
+                    received_messages.append(message)
+                    await receiver.complete_message(message)
 
-#         receiver = MockReceiver()
-#         async with auto_lock_renew:
-#             auto_lock_renew.register(receiver, renewable=MockReceivedMessage())
-#             await asyncio.sleep(3)
+                tokens = await sender.schedule_messages(received_messages, scheduled_enqueue_time, timeout=5)
+                assert len(tokens) == 2
 
-#         with pytest.raises(ServiceBusError):
-#             async with auto_lock_renew:
-#                 pass
+                messages = await receiver.receive_messages(max_wait_time=120)
+                recv = await receiver.receive_messages(max_wait_time=5)
+                messages.extend(recv)
+                if messages:
+                    try:
+                        data = str(messages[0])
+                        assert data == content
+                        assert messages[0].message_id in (message_id_a, message_id_b)
+                        assert messages[0].scheduled_enqueue_time_utc == scheduled_enqueue_time
+                        assert messages[0].scheduled_enqueue_time_utc <= messages[0].enqueued_time_utc.replace(microsecond=0)
+                        assert len(messages) == 2
+                    finally:
+                        for message in messages:
+                            await receiver.complete_message(message)
+                        if not uamqp_transport:
+                            pickled = pickle.loads(pickle.dumps(messages[0]))
+                            assert pickled.message_id == messages[0].message_id
+                            assert pickled.scheduled_enqueue_time_utc == messages[0].scheduled_enqueue_time_utc
+                            assert pickled.scheduled_enqueue_time_utc <= pickled.enqueued_time_utc.replace(microsecond=0)
+                else:
+                    raise Exception("Failed to receive scheduled message.")
 
-#         with pytest.raises(ServiceBusError):
-#             auto_lock_renew.register(receiver, renewable=MockReceivedMessage())
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_async_queue_cancel_scheduled_messages(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential(is_async=True)
+        async with ServiceBusClient(
+            fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-#         auto_lock_renew = AutoLockRenewer()
-#         auto_lock_renew._renew_period = 1
+            enqueue_time = (utc_now() + timedelta(minutes=2)).replace(microsecond=0)
+            async with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
+                async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                    message_a = ServiceBusMessage("Test scheduled message")
+                    message_b = ServiceBusMessage("Test scheduled message")
+                    tokens = await sender.schedule_messages([message_a, message_b], enqueue_time)
+                    assert len(tokens) == 2
 
-#         auto_lock_renew.register(receiver, renewable=MockReceivedMessage())
-#         time.sleep(3)
+                    await sender.cancel_scheduled_messages(tokens, timeout=None)
 
-#         await auto_lock_renew.close()
+                messages = await receiver.receive_messages(max_wait_time=120)
+                assert len(messages) == 0
 
-#         with pytest.raises(ServiceBusError):
-#             async with auto_lock_renew:
-#                 pass
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_queue_message_amqp_over_websocket(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential(is_async=True)
+        async with ServiceBusClient(
+                fully_qualified_namespace, credential,
+                transport_type=TransportType.AmqpOverWebsocket,
+                logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-#         with pytest.raises(ServiceBusError):
-#             auto_lock_renew.register(receiver, renewable=MockReceivedMessage())
+            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                assert sender._config.transport_type == TransportType.AmqpOverWebsocket
+                message = ServiceBusMessage("Test")
+                await sender.send_messages(message)
 
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @CachedServiceBusQueuePreparer(name_prefix='servicebustest')
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_queue_receiver_invalid_autolockrenew_mode(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+            async with sb_client.get_queue_receiver(servicebus_queue.name, receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE) as receiver:
+                assert receiver._config.transport_type == TransportType.AmqpOverWebsocket
+                messages = await receiver.receive_messages(max_wait_time=5)
+                assert len(messages) == 1
+
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    def test_queue_message_http_proxy_setting(self, uamqp_transport):
+        mock_conn_str = "Endpoint=sb://mock.servicebus.windows.net/;SharedAccessKeyName=mock;SharedAccessKey=mock"
+        http_proxy = {
+            'proxy_hostname': '127.0.0.1',
+            'proxy_port': 8899,
+            'username': 'admin',
+            'password': '123456'
+        }
+
+        sb_client = ServiceBusClient(mock_conn_str, http_proxy=http_proxy, uamqp_transport=uamqp_transport)
+        assert sb_client._config.http_proxy == http_proxy
+        assert sb_client._config.transport_type == TransportType.AmqpOverWebsocket
+
+        sender = sb_client.get_queue_sender(queue_name="mock")
+        assert sender._config.http_proxy == http_proxy
+        assert sender._config.transport_type == TransportType.AmqpOverWebsocket
+
+        receiver = sb_client.get_queue_receiver(queue_name="mock")
+        assert receiver._config.http_proxy == http_proxy
+        assert receiver._config.transport_type == TransportType.AmqpOverWebsocket
+
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_queue_message_settle_through_mgmt_link_due_to_broken_receiver_link(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential(is_async=True)
+        async with ServiceBusClient(
+                fully_qualified_namespace, credential,
+                logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+
+            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                message = ServiceBusMessage("Test")
+                await sender.send_messages(message)
+
+            async with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
+                messages = await receiver.receive_messages(max_wait_time=5)
+                # destroy the underlying receiver link
+                if uamqp_transport:
+                    await receiver._handler.message_handler.destroy_async()
+                else:
+                    await receiver._handler._link.detach()
+                assert len(messages) == 1
+                await receiver.complete_message(messages[0])
+
+    @pytest.mark.skip('hard to test')
+    @AzureRecordedTestCase.await_prepared_test
+    async def test_async_queue_mock_auto_lock_renew_callback(self):
+        # A warning to future devs: If the renew period override heuristic in registration
+        # ever changes, it may break this (since it adjusts renew period if it is not short enough)
+
+        results = []
+        errors = []
+        async def callback_mock(renewable, error):
+            results.append(renewable)
+            if error:
+                errors.append(error)
+
+        receiver = MockReceiver()
+        auto_lock_renew = AutoLockRenewer()
+        with pytest.raises(TypeError):
+            auto_lock_renew.register(receiver, renewable=Exception())  # an arbitrary invalid type.
+
+        auto_lock_renew = AutoLockRenewer()
+        auto_lock_renew._renew_period = 1  # So we can run the test fast.
+        async with auto_lock_renew:  # Check that it is called when the object expires for any reason (silent renew failure)
+            message = MockReceivedMessage(prevent_renew_lock=True)
+            auto_lock_renew.register(receiver, renewable=message, on_lock_renew_failure=callback_mock)
+            await asyncio.sleep(3)
+            assert len(results) == 1 and results[-1]._lock_expired == True
+            assert not errors
+
+        del results[:]
+        del errors[:]
+        auto_lock_renew = AutoLockRenewer()
+        auto_lock_renew._renew_period = 1
+        async with auto_lock_renew:  # Check that in normal operation it does not get called
+            auto_lock_renew.register(receiver, renewable=MockReceivedMessage(), on_lock_renew_failure=callback_mock)
+            await asyncio.sleep(3)
+            assert not results
+            assert not errors
+
+        del results[:]
+        del errors[:]
+        auto_lock_renew = AutoLockRenewer()
+        auto_lock_renew._renew_period = 1
+        async with auto_lock_renew:  # Check that when a message is settled, it will not get called even after expiry
+            message = MockReceivedMessage(prevent_renew_lock=True)
+            auto_lock_renew.register(receiver, renewable=message, on_lock_renew_failure=callback_mock)
+            message._settled = True
+            await asyncio.sleep(3)
+            assert not results
+            assert not errors
+
+        del results[:]
+        del errors[:]
+        auto_lock_renew = AutoLockRenewer()
+        auto_lock_renew._renew_period = 1
+        async with auto_lock_renew: # Check that it is called when there is an overt renew failure
+            message = MockReceivedMessage(exception_on_renew_lock=True)
+            auto_lock_renew.register(receiver, renewable=message, on_lock_renew_failure=callback_mock)
+            await asyncio.sleep(3)
+            assert len(results) == 1 and results[-1]._lock_expired == True
+            assert errors[-1]
+
+        del results[:]
+        del errors[:]
+        auto_lock_renew = AutoLockRenewer()
+        auto_lock_renew._renew_period = 1
+        async with auto_lock_renew:  # Check that it is not called when the renewer is shutdown
+            message = MockReceivedMessage(prevent_renew_lock=True)
+            auto_lock_renew.register(receiver, renewable=message, on_lock_renew_failure=callback_mock)
+            await auto_lock_renew.close()
+            await asyncio.sleep(3)
+            assert not results
+            assert not errors
+
+        del results[:]
+        del errors[:]
+        auto_lock_renew = AutoLockRenewer()
+        auto_lock_renew._renew_period = 1
+        async with auto_lock_renew:  # Check that it is not called when the receiver is shutdown
+            message = MockReceivedMessage(prevent_renew_lock=True)
+            auto_lock_renew.register(receiver, renewable=message, on_lock_renew_failure=callback_mock)
+            message._receiver._running = False
+            await asyncio.sleep(3)
+            assert not results
+            assert not errors
+
+    @AzureRecordedTestCase.await_prepared_test
+    async def test_async_queue_mock_no_reusing_auto_lock_renew(self):
+        auto_lock_renew = AutoLockRenewer()
+        auto_lock_renew._renew_period = 1
+
+        receiver = MockReceiver()
+        async with auto_lock_renew:
+            auto_lock_renew.register(receiver, renewable=MockReceivedMessage())
+            await asyncio.sleep(3)
+
+        with pytest.raises(ServiceBusError):
+            async with auto_lock_renew:
+                pass
+
+        with pytest.raises(ServiceBusError):
+            auto_lock_renew.register(receiver, renewable=MockReceivedMessage())
+
+        auto_lock_renew = AutoLockRenewer()
+        auto_lock_renew._renew_period = 1
+
+        auto_lock_renew.register(receiver, renewable=MockReceivedMessage())
+        time.sleep(3)
+
+        await auto_lock_renew.close()
+
+        with pytest.raises(ServiceBusError):
+            async with auto_lock_renew:
+                pass
+
+        with pytest.raises(ServiceBusError):
+            auto_lock_renew.register(receiver, renewable=MockReceivedMessage())
+
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @CachedServiceBusQueuePreparer(name_prefix='servicebustest')
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_queue_receiver_invalid_autolockrenew_mode(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_namespace=None, servicebus_queue=None, **kwargs):
         
-#         async with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-#             with pytest.raises(ValueError):
-#                 async with sb_client.get_queue_receiver(servicebus_queue.name, 
-#                                                   receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE,
-#                                                   auto_lock_renewer=AutoLockRenewer()) as receiver:
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential(is_async=True)
+        async with ServiceBusClient(
+            fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+            with pytest.raises(ValueError):
+                async with sb_client.get_queue_receiver(servicebus_queue.name, 
+                                                  receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE,
+                                                  auto_lock_renewer=AutoLockRenewer()) as receiver:
                 
-#                     raise Exception("Should not get here, should fail fast because RECEIVE_AND_DELETE messages cannot be autorenewed.")
+                    raise Exception("Should not get here, should fail fast because RECEIVE_AND_DELETE messages cannot be autorenewed.")
 
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_async_queue_receive_batch_without_setting_prefetch(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         async with ServiceBusClient.from_connection_string(
-#                 servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_async_queue_receive_batch_without_setting_prefetch(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential(is_async=True)
+        async with ServiceBusClient(
+                fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-#             def message_content():
-#                 for i in range(20):
-#                     yield ServiceBusMessage(
-#                         body=f"ServiceBusMessage no. {i}",
-#                         subject='1st'
-#                     )
+            def message_content():
+                for i in range(20):
+                    yield ServiceBusMessage(
+                        body=f"ServiceBusMessage no. {i}",
+                        subject='1st'
+                    )
 
-#             sender = sb_client.get_queue_sender(servicebus_queue.name)
-#             receiver = sb_client.get_queue_receiver(servicebus_queue.name)
+            sender = sb_client.get_queue_sender(servicebus_queue.name)
+            receiver = sb_client.get_queue_receiver(servicebus_queue.name)
 
-#             async with sender, receiver:
-#                 message = ServiceBusMessageBatch()
-#                 for each in message_content():
-#                     message.add_message(each)
-#                 await sender.send_messages(message)
+            async with sender, receiver:
+                message = ServiceBusMessageBatch()
+                for each in message_content():
+                    message.add_message(each)
+                await sender.send_messages(message)
 
-#                 receive_counter = 0
-#                 message_1st_received_cnt = 0
-#                 message_2nd_received_cnt = 0
-#                 while message_1st_received_cnt < 20 or message_2nd_received_cnt < 20:
-#                     messages = []
-#                     batch = await receiver.receive_messages(max_message_count=20, max_wait_time=5)
-#                     while batch:
-#                         messages += batch
-#                         batch = await receiver.receive_messages(max_message_count=20, max_wait_time=5)
-#                     if not messages:
-#                         break
-#                     receive_counter += 1
-#                     for message in messages:
-#                         print_message(_logger, message)
-#                         if message.subject == '1st':
-#                             message_1st_received_cnt += 1
-#                             await receiver.complete_message(message)
-#                             message.subject = '2nd'
-#                             await sender.send_messages(message)  # resending received message
-#                         elif message.subject == '2nd':
-#                             message_2nd_received_cnt += 1
-#                             await receiver.complete_message(message)
+                receive_counter = 0
+                message_1st_received_cnt = 0
+                message_2nd_received_cnt = 0
+                while message_1st_received_cnt < 20 or message_2nd_received_cnt < 20:
+                    messages = []
+                    batch = await receiver.receive_messages(max_message_count=20, max_wait_time=5)
+                    while batch:
+                        messages += batch
+                        batch = await receiver.receive_messages(max_message_count=20, max_wait_time=5)
+                    if not messages:
+                        break
+                    receive_counter += 1
+                    for message in messages:
+                        print_message(_logger, message)
+                        if message.subject == '1st':
+                            message_1st_received_cnt += 1
+                            await receiver.complete_message(message)
+                            message.subject = '2nd'
+                            await sender.send_messages(message)  # resending received message
+                        elif message.subject == '2nd':
+                            message_2nd_received_cnt += 1
+                            await receiver.complete_message(message)
 
-#                 assert message_1st_received_cnt == 20 and message_2nd_received_cnt == 20
-#                 # Network/server might be unstable making flow control ineffective in the leading rounds of connection iteration
-#                 assert receive_counter < 10  # Dynamic link credit issuing come info effect
+                assert message_1st_received_cnt == 20 and message_2nd_received_cnt == 20
+                # Network/server might be unstable making flow control ineffective in the leading rounds of connection iteration
+                assert receive_counter < 10  # Dynamic link credit issuing come info effect
 
     
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_async_queue_receiver_alive_after_timeout(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         async with ServiceBusClient.from_connection_string(
-#                 servicebus_namespace_connection_string,
-#                 logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_async_queue_receiver_alive_after_timeout(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential(is_async=True)
+        async with ServiceBusClient(
+                fully_qualified_namespace, credential,
+                logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 message = ServiceBusMessage("0")
-#                 message_1 = ServiceBusMessage("1")
-#                 await sender.send_messages([message, message_1])
+            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                message = ServiceBusMessage("0")
+                message_1 = ServiceBusMessage("1")
+                await sender.send_messages([message, message_1])
 
-#                 messages = []
-#                 async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10) as receiver:
+                messages = []
+                async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10) as receiver:
                     
-#                     async for message in receiver:
-#                         messages.append(message)
-#                         break
+                    async for message in receiver:
+                        messages.append(message)
+                        break
 
-#                     async for message in receiver:
-#                         messages.append(message)
+                    async for message in receiver:
+                        messages.append(message)
 
-#                     for message in messages:
-#                         await receiver.complete_message(message)
+                    for message in messages:
+                        await receiver.complete_message(message)
 
-#                     assert len(messages) == 2
-#                     assert str(messages[0]) == "0"
-#                     assert str(messages[1]) == "1"
+                    assert len(messages) == 2
+                    assert str(messages[0]) == "0"
+                    assert str(messages[1]) == "1"
 
-#                     message_2 = ServiceBusMessage("2")
-#                     message_3 = ServiceBusMessage("3")
-#                     await sender.send_messages([message_2, message_3])
+                    message_2 = ServiceBusMessage("2")
+                    message_3 = ServiceBusMessage("3")
+                    await sender.send_messages([message_2, message_3])
 
-#                     async for message in receiver:
-#                         messages.append(message)
-#                         async for message in receiver:
-#                             messages.append(message)
+                    async for message in receiver:
+                        messages.append(message)
+                        async for message in receiver:
+                            messages.append(message)
 
-#                     assert len(messages) == 4
-#                     assert str(messages[2]) == "2"
-#                     assert str(messages[3]) == "3"
+                    assert len(messages) == 4
+                    assert str(messages[2]) == "2"
+                    assert str(messages[3]) == "3"
 
-#                     for message in messages[2:]:
-#                         await receiver.complete_message(message)
+                    for message in messages[2:]:
+                        await receiver.complete_message(message)
 
-#                     messages = await receiver.receive_messages()
-#                     assert not messages
-
-    
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True, lock_duration='PT5M')
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_queue_receive_keep_conn_alive_async(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         async with ServiceBusClient.from_connection_string(
-#                 servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-
-#             sender = sb_client.get_queue_sender(servicebus_queue.name)
-#             receiver = sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5)
-
-#             async with sender, receiver:
-#                 await sender.send_messages([ServiceBusMessage("message1"), ServiceBusMessage("message2")])
-
-#                 messages = []
-#                 async for message in receiver:
-#                     messages.append(message)
-
-#                 receiver_handler = receiver._handler
-#                 assert len(messages) == 2
-#                 await asyncio.sleep(4 * 60 + 5)  # 240s is the service defined connection idle timeout
-#                 await receiver.renew_message_lock(messages[0])  # check mgmt link operation
-#                 await receiver.complete_message(messages[0])
-#                 await receiver.complete_message(messages[1])  # check receiver link operation
-
-#                 await asyncio.sleep(60)  # sleep another one minute to ensure we pass the lock_duration time
-#                 messages = []
-#                 async for message in receiver:
-#                     messages.append(message)
-
-#                 assert len(messages) == 0  # make sure messages are removed from the queue
-#                 assert receiver_handler == receiver._handler  # make sure no reconnection happened
-    
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest')
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_async_queue_send_twice(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         if uamqp:
-#             transport_type = uamqp.constants.TransportType.AmqpOverWebsocket
-#         else:
-#             transport_type = TransportType.AmqpOverWebsocket
-#         async with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False,
-#             transport_type=transport_type, uamqp_transport=uamqp_transport) as sb_client:
-
-#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 message = ServiceBusMessage("ServiceBusMessage")
-#                 message2 = ServiceBusMessage("Message2")
-#                 # first test batch message resending.
-#                 batch_message = await sender.create_message_batch()
-#                 batch_message._from_list([message, message2])  # pylint: disable=protected-access
-#                 await sender.send_messages(batch_message)
-#                 await sender.send_messages(batch_message)
-#                 messages = []
-#                 async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=20) as receiver:
-#                     async for message in receiver:
-#                         messages.append(message)
-#                         await receiver.complete_message(message)
-#                     assert len(messages) == 4
-#                 # then normal message resending
-#                 await sender.send_messages(message)
-#                 await sender.send_messages(message)
-#                 expected_count = 2
-#                 if not uamqp_transport:
-#                     # pyamqp re-send received pickled message
-#                     pickled_recvd = pickle.loads(pickle.dumps(messages[0]))
-#                     await sender.send_messages(pickled_recvd)
-#                     expected_count = 3
-#             messages = []
-#             async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=20) as receiver:
-#                 # pyamqp receiver should be picklable
-#                 async for message in receiver:
-#                     messages.append(message)
-#                     await receiver.complete_message(message)
-#                 assert len(messages) == expected_count
-
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @CachedServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_async_queue_send_timeout(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         async def _hack_amqp_sender_run_async(self, **kwargs):
-#             time.sleep(6)  # sleep until timeout
-#             if uamqp_transport:
-#                 await self.message_handler.work_async()
-#                 self._waiting_messages = 0
-#                 self._pending_messages = self._filter_pending()
-#                 if self._backoff and not self._waiting_messages:
-#                     _logger.info("Client told to backoff - sleeping for %r seconds", self._backoff)
-#                     await self._connection.sleep_async(self._backoff)
-#                     self._backoff = 0
-#                 await self._connection.work_async()
-#             else:
-#                 try:
-#                     await self._link.update_pending_deliveries()
-#                     await self._connection.listen(wait=self._socket_timeout, **kwargs)
-#                 except ValueError:
-#                     self._shutdown = True
-#                     return False
-#             return True
-
-#         async with ServiceBusClient.from_connection_string(
-#                 servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 # this one doesn't need to reset the method, as it's hacking the method on the instance
-#                 sender._handler._client_run_async = types.MethodType(_hack_amqp_sender_run_async, sender._handler)
-#                 with pytest.raises(OperationTimeoutError):
-#                     await sender.send_messages(ServiceBusMessage("body"), timeout=5)
-
-#         if not uamqp_transport:
-#             # Amqp
-#             async with ServiceBusClient.from_connection_string(
-#                 servicebus_namespace_connection_string,
-#                 uamqp_transport=uamqp_transport
-#             ) as sb_client:
-#                 async with sb_client.get_queue_sender(servicebus_queue.name, socket_timeout=1.0) as sender:
-#                     payload = "A" * 250 * 1024
-#                     await sender.send_messages(ServiceBusMessage(payload))
-
-#             if uamqp:
-#                 transport_type = uamqp.constants.TransportType.AmqpOverWebsocket
-#             else:
-#                 transport_type = TransportType.AmqpOverWebsocket
-#             # AmqpOverWebsocket
-#             async with ServiceBusClient.from_connection_string(
-#                 servicebus_namespace_connection_string,
-#                 transport_type=transport_type,
-#                 uamqp_transport=uamqp_transport
-#             ) as sb_client:
-#                 async with sb_client.get_queue_sender(servicebus_queue.name, socket_timeout=1.2) as sender:
-#                     payload = "A" * 250 * 1024
-#                     await sender.send_messages(ServiceBusMessage(payload))
-
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_async_queue_send_large_message_receive(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-
-#         async with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string,
-#             uamqp_transport=uamqp_transport
-#         ) as sb_client:
-#             async with sb_client.get_queue_sender(servicebus_queue.name, socket_timeout=1.0) as sender:
-#                 payload = "A" * 250 * 1024
-#                 await sender.send_messages(ServiceBusMessage(payload))
-
-#         if uamqp:
-#             transport_type = uamqp.constants.TransportType.AmqpOverWebsocket
-#         else:
-#             transport_type = TransportType.AmqpOverWebsocket
-#         # AmqpOverWebsocket
-#         async with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string,
-#             transport_type=transport_type,
-#             uamqp_transport=uamqp_transport
-#         ) as sb_client:
-#             async with sb_client.get_queue_sender(servicebus_queue.name, socket_timeout=1.2) as sender:
-#                 payload = "A" * 250 * 1024
-#                 await sender.send_messages(ServiceBusMessage(payload))
-
-#         # ReceiveMessages
-#         async with ServiceBusClient.from_connection_string(
-#                 servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-#             async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5) as receiver:
-#                 messages = await receiver.receive_messages(max_message_count=5, max_wait_time=5)
-#                 for message in messages:
-#                     if not uamqp_transport:
-#                         assert message._delivery_id is not None
-#                         assert message._message.data[0].decode("utf-8")  == "A" * 250 * 1024
-#                     await receiver.complete_message(message)  # complete messages 
-
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @CachedServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_async_queue_mgmt_operation_timeout(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         if uamqp_transport:
-#             async def hack_mgmt_execute_async(self, operation, op_type, message, timeout=0):
-#                 start_time = self._counter.get_current_ms()
-#                 operation_id = str(uuid.uuid4())
-#                 self._responses[operation_id] = None
-
-#                 await asyncio.sleep(6)  # sleep until timeout
-#                 while not self._responses[operation_id] and not self.mgmt_error:
-#                     if timeout > 0:
-#                         now = self._counter.get_current_ms()
-#                         if (now - start_time) >= timeout:
-#                             raise uamqp.compat.TimeoutException("Failed to receive mgmt response in {}ms".format(timeout))
-#                     await self.connection.work_async()
-#                 if self.mgmt_error:
-#                     raise self.mgmt_error
-#                 response = self._responses.pop(operation_id)
-#                 return response
-
-#             original_execute_method = uamqp.async_ops.mgmt_operation_async.MgmtOperationAsync.execute_async
-#             # hack the mgmt method on the class, not on an instance, so it needs reset
-#         else:
-#             async def hack_mgmt_execute_async(self, message, operation=None, operation_type=None, timeout=0):
-#                 start_time = time.time()
-#                 operation_id = str(uuid.uuid4())
-#                 self._responses[operation_id] = None
-#                 self._mgmt_error = None
-
-#                 await asyncio.sleep(6)  # sleep until timeout
-#                 while not self._responses[operation_id] and not self._mgmt_error:
-#                     if timeout and timeout > 0:
-#                         now = time.time()
-#                         if (now - start_time) >= timeout:
-#                             raise TimeoutError("Failed to receive mgmt response in {}ms".format(timeout))
-#                     await self.connection.listen()
-#                 if self._mgmt_error:
-#                     self._responses.pop(operation_id)
-#                     raise self._mgmt_error
-#                 response = self._responses.pop(operation_id)
-#                 return response
-
-#             original_execute_method = _management_operation_async.ManagementOperation.execute
-#             # hack the mgmt method on the class, not on an instance, so it needs reset
-#         try:
-#             if uamqp_transport:
-#                 uamqp.async_ops.mgmt_operation_async.MgmtOperationAsync.execute_async = hack_mgmt_execute_async
-#             else:
-#                 _management_operation_async.ManagementOperation.execute = hack_mgmt_execute_async
-#             async with ServiceBusClient.from_connection_string(
-#                     servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-#                 async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                     with pytest.raises(OperationTimeoutError):
-#                         scheduled_time_utc = utc_now() + timedelta(seconds=30)
-#                         await sender.schedule_messages(ServiceBusMessage("ServiceBusMessage to be scheduled"), scheduled_time_utc, timeout=5)
-#         finally:
-#             # must reset the mgmt execute method, otherwise other test cases would use the hacked execute method, leading to timeout error
-#             if uamqp_transport:
-#                 uamqp.async_ops.mgmt_operation_async.MgmtOperationAsync.execute_async = original_execute_method
-#             else:
-#                 _management_operation_async.ManagementOperation.execute = original_execute_method
-
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @CachedServiceBusQueuePreparer(name_prefix='servicebustest', lock_duration='PT10S')
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_async_queue_operation_negative(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         if uamqp_transport:
-#             def _hack_amqp_message_complete(cls):
-#                 raise RuntimeError()
-
-#             def _hack_amqp_mgmt_request(cls, message, operation, op_type=None, node=None, callback=None, **kwargs):
-#                 raise uamqp.errors.AMQPConnectionError()
-
-#             def _hack_sb_receiver_settle_message(self, message, settle_operation, dead_letter_reason=None, dead_letter_error_description=None):
-#                 raise uamqp.errors.AMQPError()
-#         else:
-#             async def _hack_amqp_message_complete(cls, _, settlement):
-#                 if settlement == 'completed':
-#                     raise RuntimeError()
-
-#             async def _hack_amqp_mgmt_request(cls, message, operation, op_type=None, node=None, callback=None, **kwargs):
-#                 raise error.AMQPConnectionError(error.ErrorCondition.ConnectionCloseForced)
-
-#             async def _hack_sb_receiver_settle_message(self, message, settle_operation, dead_letter_reason=None, dead_letter_error_description=None):
-#                 raise error.AMQPException(error.ErrorCondition.ClientError)
-
-#         async with ServiceBusClient.from_connection_string(
-#                 servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-#             sender = sb_client.get_queue_sender(servicebus_queue.name)
-#             receiver = sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10)
-#             if not uamqp_transport:
-#                 original_settlement = ReceiveClientAsync.settle_messages_async
-#             try:
-#                 async with sender, receiver:
-#                     # negative settlement via receiver link
-#                     await sender.send_messages(ServiceBusMessage("body"), timeout=5)
-#                     message = (await receiver.receive_messages(max_wait_time=10))[0]
-#                     if uamqp_transport:
-#                         message._message.accept = types.MethodType(_hack_amqp_message_complete, message._message)
-#                     else:
-#                         ReceiveClientAsync.settle_messages_async = types.MethodType(_hack_amqp_message_complete, receiver._handler)
-#                     await receiver.complete_message(message)  # settle via mgmt link
-
-#                     if uamqp_transport:
-#                         amqp_client = uamqp.AMQPClientAsync
-#                     else:
-#                         amqp_client = AMQPClientAsync
-
-#                     origin_amqp_client_mgmt_request_method = amqp_client.mgmt_request_async
-#                     try:
-#                         amqp_client.mgmt_request_async = _hack_amqp_mgmt_request
-#                         with pytest.raises(ServiceBusConnectionError):
-#                             receiver._handler.mgmt_request_async = types.MethodType(_hack_amqp_mgmt_request, receiver._handler)
-#                             await receiver.peek_messages()
-#                     finally:
-#                         amqp_client.mgmt_request_async = origin_amqp_client_mgmt_request_method
-
-#                     await sender.send_messages(ServiceBusMessage("body"), timeout=5)
-
-#                     message = (await receiver.receive_messages(max_wait_time=10))[0]
-#                     origin_sb_receiver_settle_message_method = receiver._settle_message
-#                     receiver._settle_message = types.MethodType(_hack_sb_receiver_settle_message, receiver)
-#                     with pytest.raises(ServiceBusError):
-#                         await receiver.complete_message(message)
-
-#                     receiver._settle_message = origin_sb_receiver_settle_message_method
-#                     message = (await receiver.receive_messages(max_wait_time=10))[0]
-#                     await receiver.complete_message(message)
-#             finally:
-#                 if not uamqp_transport:
-#                     ReceiveClientAsync.settle_messages_async = original_settlement
+                    messages = await receiver.receive_messages()
+                    assert not messages
 
     
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_async_send_message_no_body(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         async with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string) as sb_client:
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True, lock_duration='PT5M')
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_queue_receive_keep_conn_alive_async(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential(is_async=True)
+        async with ServiceBusClient(
+                fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 await sender.send_messages(ServiceBusMessage(body=None))
+            sender = sb_client.get_queue_sender(servicebus_queue.name)
+            receiver = sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5)
 
-#             async with sb_client.get_queue_receiver(servicebus_queue.name,  
-#                                             max_wait_time=10) as receiver:
-#                 message = await receiver.__anext__()
-#                 assert message.body is None
-#                 await receiver.complete_message(message)
+            async with sender, receiver:
+                await sender.send_messages([ServiceBusMessage("message1"), ServiceBusMessage("message2")])
 
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @CachedServiceBusQueuePreparer(name_prefix='servicebustest')
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_async_queue_by_servicebus_client_enum_case_sensitivity(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         # Note: This test is currently intended to enforce case-sensitivity.  If we eventually upgrade to the Fancy Enums being used with new autorest,
-#         # we may want to tweak this.
-#         async with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-#             async with sb_client.get_queue_receiver(servicebus_queue.name, 
-#                                               receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE.value, 
-#                                               max_wait_time=5) as receiver:
-#                 pass
-#             with pytest.raises(ValueError):
-#                 async with sb_client.get_queue_receiver(servicebus_queue.name, 
-#                                                   receive_mode=str.upper(ServiceBusReceiveMode.RECEIVE_AND_DELETE.value),
-#                                                   max_wait_time=5) as receiver:
-#                     raise Exception("Should not get here, should be case sensitive.")
-#             async with sb_client.get_queue_receiver(servicebus_queue.name, 
-#                                               sub_queue=ServiceBusSubQueue.DEAD_LETTER.value,
-#                                               max_wait_time=5) as receiver:
-#                 pass
-#             with pytest.raises(ValueError):
-#                 async with sb_client.get_queue_receiver(servicebus_queue.name, 
-#                                                   sub_queue=str.upper(ServiceBusSubQueue.DEAD_LETTER.value),
-#                                                   max_wait_time=5) as receiver:
-#                     raise Exception("Should not get here, should be case sensitive.")
+                messages = []
+                async for message in receiver:
+                    messages.append(message)
+
+                receiver_handler = receiver._handler
+                assert len(messages) == 2
+                await asyncio.sleep(4 * 60 + 5)  # 240s is the service defined connection idle timeout
+                await receiver.renew_message_lock(messages[0])  # check mgmt link operation
+                await receiver.complete_message(messages[0])
+                await receiver.complete_message(messages[1])  # check receiver link operation
+
+                await asyncio.sleep(60)  # sleep another one minute to ensure we pass the lock_duration time
+                messages = []
+                async for message in receiver:
+                    messages.append(message)
+
+                assert len(messages) == 0  # make sure messages are removed from the queue
+                assert receiver_handler == receiver._handler  # make sure no reconnection happened
+    
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest')
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_async_queue_send_twice(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        if uamqp:
+            transport_type = uamqp.constants.TransportType.AmqpOverWebsocket
+        else:
+            transport_type = TransportType.AmqpOverWebsocket
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential(is_async=True)
+        async with ServiceBusClient(
+            fully_qualified_namespace, credential, logging_enable=False,
+            transport_type=transport_type, uamqp_transport=uamqp_transport) as sb_client:
+
+            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                message = ServiceBusMessage("ServiceBusMessage")
+                message2 = ServiceBusMessage("Message2")
+                # first test batch message resending.
+                batch_message = await sender.create_message_batch()
+                batch_message._from_list([message, message2])  # pylint: disable=protected-access
+                await sender.send_messages(batch_message)
+                await sender.send_messages(batch_message)
+                messages = []
+                async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=20) as receiver:
+                    async for message in receiver:
+                        messages.append(message)
+                        await receiver.complete_message(message)
+                    assert len(messages) == 4
+                # then normal message resending
+                await sender.send_messages(message)
+                await sender.send_messages(message)
+                expected_count = 2
+                if not uamqp_transport:
+                    # pyamqp re-send received pickled message
+                    pickled_recvd = pickle.loads(pickle.dumps(messages[0]))
+                    await sender.send_messages(pickled_recvd)
+                    expected_count = 3
+            messages = []
+            async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=20) as receiver:
+                # pyamqp receiver should be picklable
+                async for message in receiver:
+                    messages.append(message)
+                    await receiver.complete_message(message)
+                assert len(messages) == expected_count
+
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @CachedServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_async_queue_send_timeout(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        async def _hack_amqp_sender_run_async(self, **kwargs):
+            time.sleep(6)  # sleep until timeout
+            if uamqp_transport:
+                await self.message_handler.work_async()
+                self._waiting_messages = 0
+                self._pending_messages = self._filter_pending()
+                if self._backoff and not self._waiting_messages:
+                    _logger.info("Client told to backoff - sleeping for %r seconds", self._backoff)
+                    await self._connection.sleep_async(self._backoff)
+                    self._backoff = 0
+                await self._connection.work_async()
+            else:
+                try:
+                    await self._link.update_pending_deliveries()
+                    await self._connection.listen(wait=self._socket_timeout, **kwargs)
+                except ValueError:
+                    self._shutdown = True
+                    return False
+            return True
+
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential(is_async=True)
+        async with ServiceBusClient(
+                fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                # this one doesn't need to reset the method, as it's hacking the method on the instance
+                sender._handler._client_run_async = types.MethodType(_hack_amqp_sender_run_async, sender._handler)
+                with pytest.raises(OperationTimeoutError):
+                    await sender.send_messages(ServiceBusMessage("body"), timeout=5)
+
+        if not uamqp_transport:
+            # Amqp
+            async with ServiceBusClient(
+                fully_qualified_namespace,
+                credential,
+                uamqp_transport=uamqp_transport
+            ) as sb_client:
+                async with sb_client.get_queue_sender(servicebus_queue.name, socket_timeout=1.0) as sender:
+                    payload = "A" * 250 * 1024
+                    await sender.send_messages(ServiceBusMessage(payload))
+
+            if uamqp:
+                transport_type = uamqp.constants.TransportType.AmqpOverWebsocket
+            else:
+                transport_type = TransportType.AmqpOverWebsocket
+            # AmqpOverWebsocket
+            async with ServiceBusClient(
+                fully_qualified_namespace,
+                credential,
+                transport_type=transport_type,
+                uamqp_transport=uamqp_transport
+            ) as sb_client:
+                async with sb_client.get_queue_sender(servicebus_queue.name, socket_timeout=1.2) as sender:
+                    payload = "A" * 250 * 1024
+                    await sender.send_messages(ServiceBusMessage(payload))
+
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_async_queue_send_large_message_receive(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential(is_async=True)
+        async with ServiceBusClient(
+            fully_qualified_namespace, credential,
+            uamqp_transport=uamqp_transport
+        ) as sb_client:
+            async with sb_client.get_queue_sender(servicebus_queue.name, socket_timeout=1.0) as sender:
+                payload = "A" * 250 * 1024
+                await sender.send_messages(ServiceBusMessage(payload))
+
+        if uamqp:
+            transport_type = uamqp.constants.TransportType.AmqpOverWebsocket
+        else:
+            transport_type = TransportType.AmqpOverWebsocket
+        # AmqpOverWebsocket
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential(is_async=True)
+        async with ServiceBusClient(
+            fully_qualified_namespace, credential,
+            transport_type=transport_type,
+            uamqp_transport=uamqp_transport
+        ) as sb_client:
+            async with sb_client.get_queue_sender(servicebus_queue.name, socket_timeout=1.2) as sender:
+                payload = "A" * 250 * 1024
+                await sender.send_messages(ServiceBusMessage(payload))
+
+        # ReceiveMessages
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential(is_async=True)
+        async with ServiceBusClient(
+                fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+            async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5) as receiver:
+                messages = await receiver.receive_messages(max_message_count=5, max_wait_time=5)
+                for message in messages:
+                    if not uamqp_transport:
+                        assert message._delivery_id is not None
+                        assert message._message.data[0].decode("utf-8")  == "A" * 250 * 1024
+                    await receiver.complete_message(message)  # complete messages 
+
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @CachedServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_async_queue_mgmt_operation_timeout(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        if uamqp_transport:
+            async def hack_mgmt_execute_async(self, operation, op_type, message, timeout=0):
+                start_time = self._counter.get_current_ms()
+                operation_id = str(uuid.uuid4())
+                self._responses[operation_id] = None
+
+                await asyncio.sleep(6)  # sleep until timeout
+                while not self._responses[operation_id] and not self.mgmt_error:
+                    if timeout > 0:
+                        now = self._counter.get_current_ms()
+                        if (now - start_time) >= timeout:
+                            raise uamqp.compat.TimeoutException("Failed to receive mgmt response in {}ms".format(timeout))
+                    await self.connection.work_async()
+                if self.mgmt_error:
+                    raise self.mgmt_error
+                response = self._responses.pop(operation_id)
+                return response
+
+            original_execute_method = uamqp.async_ops.mgmt_operation_async.MgmtOperationAsync.execute_async
+            # hack the mgmt method on the class, not on an instance, so it needs reset
+        else:
+            async def hack_mgmt_execute_async(self, message, operation=None, operation_type=None, timeout=0):
+                start_time = time.time()
+                operation_id = str(uuid.uuid4())
+                self._responses[operation_id] = None
+                self._mgmt_error = None
+
+                await asyncio.sleep(6)  # sleep until timeout
+                while not self._responses[operation_id] and not self._mgmt_error:
+                    if timeout and timeout > 0:
+                        now = time.time()
+                        if (now - start_time) >= timeout:
+                            raise TimeoutError("Failed to receive mgmt response in {}ms".format(timeout))
+                    await self.connection.listen()
+                if self._mgmt_error:
+                    self._responses.pop(operation_id)
+                    raise self._mgmt_error
+                response = self._responses.pop(operation_id)
+                return response
+
+            original_execute_method = _management_operation_async.ManagementOperation.execute
+            # hack the mgmt method on the class, not on an instance, so it needs reset
+        try:
+            if uamqp_transport:
+                uamqp.async_ops.mgmt_operation_async.MgmtOperationAsync.execute_async = hack_mgmt_execute_async
+            else:
+                _management_operation_async.ManagementOperation.execute = hack_mgmt_execute_async
+            fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+            credential = get_credential(is_async=True)
+            async with ServiceBusClient(
+                    fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+                async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                    with pytest.raises(OperationTimeoutError):
+                        scheduled_time_utc = utc_now() + timedelta(seconds=30)
+                        await sender.schedule_messages(ServiceBusMessage("ServiceBusMessage to be scheduled"), scheduled_time_utc, timeout=5)
+        finally:
+            # must reset the mgmt execute method, otherwise other test cases would use the hacked execute method, leading to timeout error
+            if uamqp_transport:
+                uamqp.async_ops.mgmt_operation_async.MgmtOperationAsync.execute_async = original_execute_method
+            else:
+                _management_operation_async.ManagementOperation.execute = original_execute_method
+
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @CachedServiceBusQueuePreparer(name_prefix='servicebustest', lock_duration='PT10S')
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_async_queue_operation_negative(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        if uamqp_transport:
+            def _hack_amqp_message_complete(cls):
+                raise RuntimeError()
+
+            def _hack_amqp_mgmt_request(cls, message, operation, op_type=None, node=None, callback=None, **kwargs):
+                raise uamqp.errors.AMQPConnectionError()
+
+            def _hack_sb_receiver_settle_message(self, message, settle_operation, dead_letter_reason=None, dead_letter_error_description=None):
+                raise uamqp.errors.AMQPError()
+        else:
+            async def _hack_amqp_message_complete(cls, _, settlement):
+                if settlement == 'completed':
+                    raise RuntimeError()
+
+            async def _hack_amqp_mgmt_request(cls, message, operation, op_type=None, node=None, callback=None, **kwargs):
+                raise error.AMQPConnectionError(error.ErrorCondition.ConnectionCloseForced)
+
+            async def _hack_sb_receiver_settle_message(self, message, settle_operation, dead_letter_reason=None, dead_letter_error_description=None):
+                raise error.AMQPException(error.ErrorCondition.ClientError)
+
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential(is_async=True)
+        async with ServiceBusClient(
+                fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+            sender = sb_client.get_queue_sender(servicebus_queue.name)
+            receiver = sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10)
+            if not uamqp_transport:
+                original_settlement = ReceiveClientAsync.settle_messages_async
+            try:
+                async with sender, receiver:
+                    # negative settlement via receiver link
+                    await sender.send_messages(ServiceBusMessage("body"), timeout=5)
+                    message = (await receiver.receive_messages(max_wait_time=10))[0]
+                    if uamqp_transport:
+                        message._message.accept = types.MethodType(_hack_amqp_message_complete, message._message)
+                    else:
+                        ReceiveClientAsync.settle_messages_async = types.MethodType(_hack_amqp_message_complete, receiver._handler)
+                    await receiver.complete_message(message)  # settle via mgmt link
+
+                    if uamqp_transport:
+                        amqp_client = uamqp.AMQPClientAsync
+                    else:
+                        amqp_client = AMQPClientAsync
+
+                    origin_amqp_client_mgmt_request_method = amqp_client.mgmt_request_async
+                    try:
+                        amqp_client.mgmt_request_async = _hack_amqp_mgmt_request
+                        with pytest.raises(ServiceBusConnectionError):
+                            receiver._handler.mgmt_request_async = types.MethodType(_hack_amqp_mgmt_request, receiver._handler)
+                            await receiver.peek_messages()
+                    finally:
+                        amqp_client.mgmt_request_async = origin_amqp_client_mgmt_request_method
+
+                    await sender.send_messages(ServiceBusMessage("body"), timeout=5)
+
+                    message = (await receiver.receive_messages(max_wait_time=10))[0]
+                    origin_sb_receiver_settle_message_method = receiver._settle_message
+                    receiver._settle_message = types.MethodType(_hack_sb_receiver_settle_message, receiver)
+                    with pytest.raises(ServiceBusError):
+                        await receiver.complete_message(message)
+
+                    receiver._settle_message = origin_sb_receiver_settle_message_method
+                    message = (await receiver.receive_messages(max_wait_time=10))[0]
+                    await receiver.complete_message(message)
+            finally:
+                if not uamqp_transport:
+                    ReceiveClientAsync.settle_messages_async = original_settlement
+
+    
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_async_send_message_no_body(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential(is_async=True)
+        async with ServiceBusClient(
+            servicebus_namespace_connection_string) as sb_client:
+
+            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                await sender.send_messages(ServiceBusMessage(body=None))
+
+            async with sb_client.get_queue_receiver(servicebus_queue.name,  
+                                            max_wait_time=10) as receiver:
+                message = await receiver.__anext__()
+                assert message.body is None
+                await receiver.complete_message(message)
+
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @CachedServiceBusQueuePreparer(name_prefix='servicebustest')
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_async_queue_by_servicebus_client_enum_case_sensitivity(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        # Note: This test is currently intended to enforce case-sensitivity.  If we eventually upgrade to the Fancy Enums being used with new autorest,
+        # we may want to tweak this.
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential(is_async=True)
+        async with ServiceBusClient(
+            fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+            async with sb_client.get_queue_receiver(servicebus_queue.name, 
+                                              receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE.value, 
+                                              max_wait_time=5) as receiver:
+                pass
+            with pytest.raises(ValueError):
+                async with sb_client.get_queue_receiver(servicebus_queue.name, 
+                                                  receive_mode=str.upper(ServiceBusReceiveMode.RECEIVE_AND_DELETE.value),
+                                                  max_wait_time=5) as receiver:
+                    raise Exception("Should not get here, should be case sensitive.")
+            async with sb_client.get_queue_receiver(servicebus_queue.name, 
+                                              sub_queue=ServiceBusSubQueue.DEAD_LETTER.value,
+                                              max_wait_time=5) as receiver:
+                pass
+            with pytest.raises(ValueError):
+                async with sb_client.get_queue_receiver(servicebus_queue.name, 
+                                                  sub_queue=str.upper(ServiceBusSubQueue.DEAD_LETTER.value),
+                                                  max_wait_time=5) as receiver:
+                    raise Exception("Should not get here, should be case sensitive.")
 
       
-#     @pytest.mark.asyncio          
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest')
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_queue_async_send_dict_messages(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         async with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+    @pytest.mark.asyncio          
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest')
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_queue_async_send_dict_messages(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential(is_async=True)
+        async with ServiceBusClient(
+            fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
 
-#                 message_dict = {"body": "Message"}
-#                 message2_dict = {"body": "Message2"}
-#                 list_message_dicts = [message_dict, message2_dict]
+                message_dict = {"body": "Message"}
+                message2_dict = {"body": "Message2"}
+                list_message_dicts = [message_dict, message2_dict]
 
-#                 # send single dict
-#                 await sender.send_messages(message_dict)
+                # send single dict
+                await sender.send_messages(message_dict)
 
-#                 # send list of dicts
-#                 await sender.send_messages(list_message_dicts)
+                # send list of dicts
+                await sender.send_messages(list_message_dicts)
 
-#                 # create and send BatchMessage with dicts
-#                 batch_message = await sender.create_message_batch()
-#                 batch_message._from_list(list_message_dicts)  # pylint: disable=protected-access
-#                 batch_message.add_message(message_dict)
-#                 await sender.send_messages(batch_message)
+                # create and send BatchMessage with dicts
+                batch_message = await sender.create_message_batch()
+                batch_message._from_list(list_message_dicts)  # pylint: disable=protected-access
+                batch_message.add_message(message_dict)
+                await sender.send_messages(batch_message)
 
-#                 received_messages = []
-#                 async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5) as receiver:
-#                     async for message in receiver:
-#                         received_messages.append(message)
-#                 assert len(received_messages) == 6
+                received_messages = []
+                async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5) as receiver:
+                    async for message in receiver:
+                        received_messages.append(message)
+                assert len(received_messages) == 6
 
-#                 batch_message = await sender.create_message_batch(max_size_in_bytes=73)
-#                 for _ in range(2):
-#                     try:
-#                         batch_message.add_message(message_dict)
-#                     except ValueError:
-#                         break
-#                 await sender.send_messages(batch_message)
-#                 received_messages = []
-#                 async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5) as receiver:
-#                     async for message in receiver:
-#                         received_messages.append(message)
-#                 assert len(received_messages) == 1
+                batch_message = await sender.create_message_batch(max_size_in_bytes=73)
+                for _ in range(2):
+                    try:
+                        batch_message.add_message(message_dict)
+                    except ValueError:
+                        break
+                await sender.send_messages(batch_message)
+                received_messages = []
+                async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5) as receiver:
+                    async for message in receiver:
+                        received_messages.append(message)
+                assert len(received_messages) == 1
 
     
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest')
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_queue_async_send_mapping_messages(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         class MappingMessage(DictMixin):
-#             def __init__(self, content):
-#                 self.body = content
-#                 self.message_id = 'foo'
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest')
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_queue_async_send_mapping_messages(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        class MappingMessage(DictMixin):
+            def __init__(self, content):
+                self.body = content
+                self.message_id = 'foo'
         
-#         class BadMappingMessage(DictMixin):
-#             def __init__(self):
-#                 self.message_id = 'foo'
+        class BadMappingMessage(DictMixin):
+            def __init__(self):
+                self.message_id = 'foo'
 
-#         async with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential(is_async=True)
+        async with ServiceBusClient(
+            fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
 
-#                 message_dict = MappingMessage("Message")
-#                 message2_dict = MappingMessage("Message2")
-#                 message3_dict = BadMappingMessage()
-#                 list_message_dicts = [message_dict, message2_dict]
+                message_dict = MappingMessage("Message")
+                message2_dict = MappingMessage("Message2")
+                message3_dict = BadMappingMessage()
+                list_message_dicts = [message_dict, message2_dict]
 
-#                 # send single dict
-#                 await sender.send_messages(message_dict)
+                # send single dict
+                await sender.send_messages(message_dict)
 
-#                 # send list of dicts
-#                 await sender.send_messages(list_message_dicts)
+                # send list of dicts
+                await sender.send_messages(list_message_dicts)
 
-#                 # send bad dict
-#                 with pytest.raises(TypeError):
-#                     await sender.send_messages(message3_dict)
+                # send bad dict
+                with pytest.raises(TypeError):
+                    await sender.send_messages(message3_dict)
 
-#                 # create and send BatchMessage with dicts
-#                 batch_message = await sender.create_message_batch()
-#                 batch_message._from_list(list_message_dicts)  # pylint: disable=protected-access
-#                 batch_message.add_message(message_dict)
-#                 await sender.send_messages(batch_message)
+                # create and send BatchMessage with dicts
+                batch_message = await sender.create_message_batch()
+                batch_message._from_list(list_message_dicts)  # pylint: disable=protected-access
+                batch_message.add_message(message_dict)
+                await sender.send_messages(batch_message)
 
-#                 received_messages = []
-#                 async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5) as receiver:
-#                     async for message in receiver:
-#                         received_messages.append(message)
-#                 assert len(received_messages) == 6
+                received_messages = []
+                async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5) as receiver:
+                    async for message in receiver:
+                        received_messages.append(message)
+                assert len(received_messages) == 6
 
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest')
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_queue_async_send_dict_messages_error_badly_formatted_dicts(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         async with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest')
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_queue_async_send_dict_messages_error_badly_formatted_dicts(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential(is_async=True)
+        async with ServiceBusClient(
+            fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
 
-#                 message_dict = {"bad_key": "Message"}
-#                 message2_dict = {"bad_key": "Message2"}
-#                 list_message_dicts = [message_dict, message2_dict]
+                message_dict = {"bad_key": "Message"}
+                message2_dict = {"bad_key": "Message2"}
+                list_message_dicts = [message_dict, message2_dict]
 
-#                 # send single dict
-#                 with pytest.raises(TypeError):
-#                     await sender.send_messages(message_dict)
+                # send single dict
+                with pytest.raises(TypeError):
+                    await sender.send_messages(message_dict)
 
-#                 # send list of dicts
-#                 with pytest.raises(TypeError):
-#                     await sender.send_messages(list_message_dicts)
+                # send list of dicts
+                with pytest.raises(TypeError):
+                    await sender.send_messages(list_message_dicts)
 
-#                 # create and send BatchMessage with dicts
-#                 batch_message = await sender.create_message_batch()
-#                 with pytest.raises(TypeError):
-#                     batch_message._from_list(list_message_dicts)  # pylint: disable=protected-access
+                # create and send BatchMessage with dicts
+                batch_message = await sender.create_message_batch()
+                with pytest.raises(TypeError):
+                    batch_message._from_list(list_message_dicts)  # pylint: disable=protected-access
 
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_queue_async_send_dict_messages_scheduled(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_queue_async_send_dict_messages_scheduled(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_namespace=None, servicebus_queue=None, **kwargs):
         
-#         async with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-#             content = "Test scheduled message"
-#             message_id = uuid.uuid4()
-#             message_id2 = uuid.uuid4()
-#             scheduled_enqueue_time = (utc_now() + timedelta(minutes=0.05)).replace(microsecond=0)
-#             message_dict = {"message_id": message_id, "body": content}
-#             message2_dict = {"message_id": message_id2, "body": content}
-#             list_message_dicts = [message_dict, message2_dict]
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential(is_async=True)
+        async with ServiceBusClient(
+            fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+            content = "Test scheduled message"
+            message_id = uuid.uuid4()
+            message_id2 = uuid.uuid4()
+            scheduled_enqueue_time = (utc_now() + timedelta(minutes=0.05)).replace(microsecond=0)
+            message_dict = {"message_id": message_id, "body": content}
+            message2_dict = {"message_id": message_id2, "body": content}
+            list_message_dicts = [message_dict, message2_dict]
             
-#             # send single dict
-#             async with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
-#                 async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                     tokens = await sender.schedule_messages(message_dict, scheduled_enqueue_time)
-#                     assert len(tokens) == 1
+            # send single dict
+            async with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
+                async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                    tokens = await sender.schedule_messages(message_dict, scheduled_enqueue_time)
+                    assert len(tokens) == 1
     
-#                 messages = await receiver.receive_messages(max_wait_time=20)
-#                 if messages:
-#                     try:
-#                         data = str(messages[0])
-#                         assert data == content
-#                         assert messages[0].message_id == message_id
-#                         assert messages[0].scheduled_enqueue_time_utc == scheduled_enqueue_time
-#                         assert messages[0].scheduled_enqueue_time_utc <= messages[0].enqueued_time_utc.replace(microsecond=0)
-#                         assert len(messages) == 1
-#                     finally:
-#                         for m in messages:
-#                             await receiver.complete_message(m)
-#                 else:
-#                     raise Exception("Failed to receive schdeduled message.")
+                messages = await receiver.receive_messages(max_wait_time=20)
+                if messages:
+                    try:
+                        data = str(messages[0])
+                        assert data == content
+                        assert messages[0].message_id == message_id
+                        assert messages[0].scheduled_enqueue_time_utc == scheduled_enqueue_time
+                        assert messages[0].scheduled_enqueue_time_utc <= messages[0].enqueued_time_utc.replace(microsecond=0)
+                        assert len(messages) == 1
+                    finally:
+                        for m in messages:
+                            await receiver.complete_message(m)
+                else:
+                    raise Exception("Failed to receive schdeduled message.")
 
-#             # send list of dicts
-#             async with sb_client.get_queue_receiver(servicebus_queue.name, prefetch_count=20) as receiver:
-#                 async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                     tokens = await sender.schedule_messages(list_message_dicts, scheduled_enqueue_time)
-#                     assert len(tokens) == 2
+            # send list of dicts
+            async with sb_client.get_queue_receiver(servicebus_queue.name, prefetch_count=20) as receiver:
+                async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                    tokens = await sender.schedule_messages(list_message_dicts, scheduled_enqueue_time)
+                    assert len(tokens) == 2
     
-#                 messages = await receiver.receive_messages(max_wait_time=20)
-#                 messages.extend(await receiver.receive_messages(max_wait_time=5))
-#                 if messages:
-#                     try:
-#                         data = str(messages[0])
-#                         print(messages)
-#                         assert data == content
-#                         assert messages[0].message_id == message_id
-#                         assert messages[0].scheduled_enqueue_time_utc == scheduled_enqueue_time
-#                         assert messages[0].scheduled_enqueue_time_utc <= messages[0].enqueued_time_utc.replace(microsecond=0)
-#                         assert len(messages) == 2
-#                     finally:
-#                         for m in messages:
-#                             await receiver.complete_message(m)
-#                 else:
-#                     raise Exception("Failed to receive schdeduled message.")
+                messages = await receiver.receive_messages(max_wait_time=20)
+                messages.extend(await receiver.receive_messages(max_wait_time=5))
+                if messages:
+                    try:
+                        data = str(messages[0])
+                        print(messages)
+                        assert data == content
+                        assert messages[0].message_id == message_id
+                        assert messages[0].scheduled_enqueue_time_utc == scheduled_enqueue_time
+                        assert messages[0].scheduled_enqueue_time_utc <= messages[0].enqueued_time_utc.replace(microsecond=0)
+                        assert len(messages) == 2
+                    finally:
+                        for m in messages:
+                            await receiver.complete_message(m)
+                else:
+                    raise Exception("Failed to receive schdeduled message.")
 
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_queue_async_send_dict_messages_scheduled_error_badly_formatted_dicts(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_queue_async_send_dict_messages_scheduled_error_badly_formatted_dicts(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_namespace=None, servicebus_queue=None, **kwargs):
         
-#         async with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-#             content = "Test scheduled message"
-#             message_id = uuid.uuid4()
-#             message_id2 = uuid.uuid4()
-#             scheduled_enqueue_time = (utc_now() + timedelta(minutes=0.1)).replace(microsecond=0)
-#             async with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
-#                 async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                     message_dict = {"message_id": message_id, "bad_key": content}
-#                     message2_dict = {"message_id": message_id2, "bad_key": content}
-#                     list_message_dicts = [message_dict, message2_dict]
-#                     with pytest.raises(TypeError):
-#                         await sender.schedule_messages(message_dict, scheduled_enqueue_time)
-#                     with pytest.raises(TypeError):
-#                         await sender.schedule_messages(list_message_dicts, scheduled_enqueue_time)
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential(is_async=True)
+        async with ServiceBusClient(
+            fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+            content = "Test scheduled message"
+            message_id = uuid.uuid4()
+            message_id2 = uuid.uuid4()
+            scheduled_enqueue_time = (utc_now() + timedelta(minutes=0.1)).replace(microsecond=0)
+            async with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
+                async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                    message_dict = {"message_id": message_id, "bad_key": content}
+                    message2_dict = {"message_id": message_id2, "bad_key": content}
+                    list_message_dicts = [message_dict, message2_dict]
+                    with pytest.raises(TypeError):
+                        await sender.schedule_messages(message_dict, scheduled_enqueue_time)
+                    with pytest.raises(TypeError):
+                        await sender.schedule_messages(list_message_dicts, scheduled_enqueue_time)
 
     
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_queue_async_receive_iterator_resume_after_link_detach(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_queue_async_receive_iterator_resume_after_link_detach(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_namespace=None, servicebus_queue=None, **kwargs):
 
-#         async def hack_iter_next_mock_error(self, wait_time=None):
-#             try:
-#                 self._receive_context.set()
-#                 await self._open()
-#                 # when trying to receive the second message (execution_times is 1), raising LinkDetach error to mock 10 mins idle timeout
-#                 if self.execution_times == 1:
-#                     if uamqp_transport:
-#                         from uamqp.errors import LinkDetach
-#                         from uamqp.constants import ErrorCodes
-#                         error = LinkDetach
-#                         error_condition = ErrorCodes
-#                     else:
-#                         from azure.servicebus._pyamqp.error import ErrorCondition, AMQPLinkError
-#                         error = AMQPLinkError
-#                         error_condition = ErrorCondition
-#                     self.execution_times += 1
-#                     self.error_raised = True
-#                     raise error(error_condition.LinkDetachForced)
-#                 else:
-#                     self.execution_times += 1
-#                 if not self._message_iter:
-#                     if uamqp_transport:
-#                         self._message_iter = self._handler.receive_messages_iter_async()
-#                     else:
-#                         self._message_iter = await self._handler.receive_messages_iter_async(timeout=wait_time)
-#                 amqp_message = await self._message_iter.__anext__()
-#                 message = self._build_received_message(amqp_message)
-#                 return message
-#             finally:
-#                 self._receive_context.clear()
+        async def hack_iter_next_mock_error(self, wait_time=None):
+            try:
+                self._receive_context.set()
+                await self._open()
+                # when trying to receive the second message (execution_times is 1), raising LinkDetach error to mock 10 mins idle timeout
+                if self.execution_times == 1:
+                    if uamqp_transport:
+                        from uamqp.errors import LinkDetach
+                        from uamqp.constants import ErrorCodes
+                        error = LinkDetach
+                        error_condition = ErrorCodes
+                    else:
+                        from azure.servicebus._pyamqp.error import ErrorCondition, AMQPLinkError
+                        error = AMQPLinkError
+                        error_condition = ErrorCondition
+                    self.execution_times += 1
+                    self.error_raised = True
+                    raise error(error_condition.LinkDetachForced)
+                else:
+                    self.execution_times += 1
+                if not self._message_iter:
+                    if uamqp_transport:
+                        self._message_iter = self._handler.receive_messages_iter_async()
+                    else:
+                        self._message_iter = await self._handler.receive_messages_iter_async(timeout=wait_time)
+                amqp_message = await self._message_iter.__anext__()
+                message = self._build_received_message(amqp_message)
+                return message
+            finally:
+                self._receive_context.clear()
 
-#         async with ServiceBusClient.from_connection_string(
-#                 servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 await sender.send_messages(
-#                     [ServiceBusMessage("test1"), ServiceBusMessage("test2"), ServiceBusMessage("test3")]
-#                 )
-#             async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10) as receiver:
-#                 receiver.execution_times = 0
-#                 receiver.error_raised = False
-#                 receiver._iter_next = types.MethodType(hack_iter_next_mock_error, receiver)
-#                 res = []
-#                 async for msg in receiver:
-#                     await receiver.complete_message(msg)
-#                     res.append(msg)
-#                 assert len(res) == 3
-#                 assert receiver.error_raised
-#                 assert receiver.execution_times >= 4  # at least 1 failure and 3 successful receiving iterator
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential(is_async=True)
+        async with ServiceBusClient(
+                fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                await sender.send_messages(
+                    [ServiceBusMessage("test1"), ServiceBusMessage("test2"), ServiceBusMessage("test3")]
+                )
+            async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10) as receiver:
+                receiver.execution_times = 0
+                receiver.error_raised = False
+                receiver._iter_next = types.MethodType(hack_iter_next_mock_error, receiver)
+                res = []
+                async for msg in receiver:
+                    await receiver.complete_message(msg)
+                    res.append(msg)
+                assert len(res) == 3
+                assert receiver.error_raised
+                assert receiver.execution_times >= 4  # at least 1 failure and 3 successful receiving iterator
 
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_queue_async_send_amqp_annotated_message(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_queue_async_send_amqp_annotated_message(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_namespace=None, servicebus_queue=None, **kwargs):
 
-#         async with ServiceBusClient.from_connection_string(
-#                 servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-#             sequence_body = [b'message', 123.456, True]
-#             footer = {'footer_key': 'footer_value'}
-#             prop = {"subject": "sequence"}
-#             seq_app_prop = {"body_type": "sequence"}
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential(is_async=True)
+        async with ServiceBusClient(
+                fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+            sequence_body = [b'message', 123.456, True]
+            footer = {'footer_key': 'footer_value'}
+            prop = {"subject": "sequence"}
+            seq_app_prop = {"body_type": "sequence"}
 
-#             sequence_message = AmqpAnnotatedMessage(
-#                 sequence_body=sequence_body,
-#                 footer=footer,
-#                 properties=prop,
-#                 application_properties=seq_app_prop
-#             )
+            sequence_message = AmqpAnnotatedMessage(
+                sequence_body=sequence_body,
+                footer=footer,
+                properties=prop,
+                application_properties=seq_app_prop
+            )
 
-#             value_body = {b"key": [-123, b'data', False]}
-#             header = {"priority": 10}
-#             anno = {"ann_key": "ann_value"}
-#             value_app_prop = {"body_type": "value"}
+            value_body = {b"key": [-123, b'data', False]}
+            header = {"priority": 10}
+            anno = {"ann_key": "ann_value"}
+            value_app_prop = {"body_type": "value"}
 
-#             value_message = AmqpAnnotatedMessage(
-#                 value_body=value_body,
-#                 header=header,
-#                 annotations=anno,
-#                 application_properties=value_app_prop
-#             )
+            value_message = AmqpAnnotatedMessage(
+                value_body=value_body,
+                header=header,
+                annotations=anno,
+                application_properties=value_app_prop
+            )
 
-#             data_body = [b'aa', b'bb', b'cc']
-#             data_app_prop = {"body_type": "data"}
-#             del_anno = {"delann_key": "delann_value"}
-#             data_message = AmqpAnnotatedMessage(
-#                 data_body=data_body,
-#                 delivery_annotations=del_anno,
-#                 application_properties=data_app_prop
-#             )
+            data_body = [b'aa', b'bb', b'cc']
+            data_app_prop = {"body_type": "data"}
+            del_anno = {"delann_key": "delann_value"}
+            data_message = AmqpAnnotatedMessage(
+                data_body=data_body,
+                delivery_annotations=del_anno,
+                application_properties=data_app_prop
+            )
 
-#             content = "normalmessage"
-#             dict_message = {"body": content}
-#             sb_message = ServiceBusMessage(body=content)
-#             message_with_ttl = AmqpAnnotatedMessage(data_body=data_body, header=AmqpMessageHeader(time_to_live=60000))
-#             if uamqp_transport:
-#                 amqp_transport = UamqpTransportAsync
-#             else:
-#                 amqp_transport = PyamqpTransportAsync
-#             amqp_with_ttl = amqp_transport.to_outgoing_amqp_message(message_with_ttl)
-#             assert amqp_with_ttl.properties.absolute_expiry_time == amqp_with_ttl.properties.creation_time + amqp_with_ttl.header.ttl
+            content = "normalmessage"
+            dict_message = {"body": content}
+            sb_message = ServiceBusMessage(body=content)
+            message_with_ttl = AmqpAnnotatedMessage(data_body=data_body, header=AmqpMessageHeader(time_to_live=60000))
+            if uamqp_transport:
+                amqp_transport = UamqpTransportAsync
+            else:
+                amqp_transport = PyamqpTransportAsync
+            amqp_with_ttl = amqp_transport.to_outgoing_amqp_message(message_with_ttl)
+            assert amqp_with_ttl.properties.absolute_expiry_time == amqp_with_ttl.properties.creation_time + amqp_with_ttl.header.ttl
 
-#             recv_data_msg = recv_sequence_msg = recv_value_msg = normal_msg = 0
-#             async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10) as receiver:
-#                 async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                     batch = await sender.create_message_batch()
-#                     batch.add_message(data_message)
-#                     batch.add_message(value_message)
-#                     batch.add_message(sequence_message)
-#                     batch.add_message(dict_message)
-#                     batch.add_message(sb_message)
+            recv_data_msg = recv_sequence_msg = recv_value_msg = normal_msg = 0
+            async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10) as receiver:
+                async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                    batch = await sender.create_message_batch()
+                    batch.add_message(data_message)
+                    batch.add_message(value_message)
+                    batch.add_message(sequence_message)
+                    batch.add_message(dict_message)
+                    batch.add_message(sb_message)
 
-#                     await sender.send_messages(batch)
-#                     await sender.send_messages([data_message, value_message, sequence_message, dict_message, sb_message])
-#                     await sender.send_messages(data_message)
-#                     await sender.send_messages(value_message)
-#                     await sender.send_messages(sequence_message)
+                    await sender.send_messages(batch)
+                    await sender.send_messages([data_message, value_message, sequence_message, dict_message, sb_message])
+                    await sender.send_messages(data_message)
+                    await sender.send_messages(value_message)
+                    await sender.send_messages(sequence_message)
 
-#                     async for message in receiver:
-#                         raw_amqp_message = message.raw_amqp_message
-#                         if raw_amqp_message.body_type == AmqpMessageBodyType.DATA:
-#                             if raw_amqp_message.application_properties and raw_amqp_message.application_properties.get(b'body_type') == b'data':
-#                                 body = [data for data in raw_amqp_message.body]
-#                                 assert data_body == body
-#                                 assert raw_amqp_message.delivery_annotations[b'delann_key'] == b'delann_value'
-#                                 assert raw_amqp_message.application_properties[b'body_type'] == b'data'
-#                                 recv_data_msg += 1
-#                             else:
-#                                 assert str(message) == content
-#                                 normal_msg += 1
-#                         elif raw_amqp_message.body_type == AmqpMessageBodyType.SEQUENCE:
-#                             body = [sequence for sequence in raw_amqp_message.body]
-#                             assert [sequence_body] == body
-#                             assert raw_amqp_message.footer[b'footer_key'] == b'footer_value'
-#                             assert raw_amqp_message.properties.subject == b'sequence'
-#                             assert raw_amqp_message.application_properties[b'body_type'] == b'sequence'
-#                             recv_sequence_msg += 1
-#                         elif raw_amqp_message.body_type == AmqpMessageBodyType.VALUE:
-#                             assert raw_amqp_message.body == value_body
-#                             assert raw_amqp_message.header.priority == 10
-#                             assert raw_amqp_message.annotations[b'ann_key'] == b'ann_value'
-#                             assert raw_amqp_message.application_properties[b'body_type'] == b'value'
-#                             recv_value_msg += 1
-#                         await receiver.complete_message(message)
+                    async for message in receiver:
+                        raw_amqp_message = message.raw_amqp_message
+                        if raw_amqp_message.body_type == AmqpMessageBodyType.DATA:
+                            if raw_amqp_message.application_properties and raw_amqp_message.application_properties.get(b'body_type') == b'data':
+                                body = [data for data in raw_amqp_message.body]
+                                assert data_body == body
+                                assert raw_amqp_message.delivery_annotations[b'delann_key'] == b'delann_value'
+                                assert raw_amqp_message.application_properties[b'body_type'] == b'data'
+                                recv_data_msg += 1
+                            else:
+                                assert str(message) == content
+                                normal_msg += 1
+                        elif raw_amqp_message.body_type == AmqpMessageBodyType.SEQUENCE:
+                            body = [sequence for sequence in raw_amqp_message.body]
+                            assert [sequence_body] == body
+                            assert raw_amqp_message.footer[b'footer_key'] == b'footer_value'
+                            assert raw_amqp_message.properties.subject == b'sequence'
+                            assert raw_amqp_message.application_properties[b'body_type'] == b'sequence'
+                            recv_sequence_msg += 1
+                        elif raw_amqp_message.body_type == AmqpMessageBodyType.VALUE:
+                            assert raw_amqp_message.body == value_body
+                            assert raw_amqp_message.header.priority == 10
+                            assert raw_amqp_message.annotations[b'ann_key'] == b'ann_value'
+                            assert raw_amqp_message.application_properties[b'body_type'] == b'value'
+                            recv_value_msg += 1
+                        await receiver.complete_message(message)
 
-#                     assert recv_data_msg == 3
-#                     assert recv_sequence_msg == 3
-#                     assert recv_value_msg == 3
-#                     assert normal_msg == 4
+                    assert recv_data_msg == 3
+                    assert recv_sequence_msg == 3
+                    assert recv_value_msg == 3
+                    assert normal_msg == 4
 
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_state_scheduled_async(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         async with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, uamqp_transport=uamqp_transport) as sb_client:
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_state_scheduled_async(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential(is_async=True)
+        async with ServiceBusClient(
+            fully_qualified_namespace, credential, uamqp_transport=uamqp_transport) as sb_client:
 
-#             sender = sb_client.get_queue_sender(servicebus_queue.name)
-#             async with sender:
-#                 for i in range(10):
-#                     message = ServiceBusMessage("message no. {}".format(i))
-#                     scheduled_time_utc = datetime.utcnow() + timedelta(seconds=30)
-#                     sequence_number = await sender.schedule_messages(message, scheduled_time_utc)
+            sender = sb_client.get_queue_sender(servicebus_queue.name)
+            async with sender:
+                for i in range(10):
+                    message = ServiceBusMessage("message no. {}".format(i))
+                    scheduled_time_utc = datetime.utcnow() + timedelta(seconds=30)
+                    sequence_number = await sender.schedule_messages(message, scheduled_time_utc)
 
-#             receiver = sb_client.get_queue_receiver(servicebus_queue.name)
-#             async with receiver:
-#                 messages = await receiver.peek_messages()
-#                 for msg in messages:
-#                     assert msg.state == ServiceBusMessageState.SCHEDULED
+            receiver = sb_client.get_queue_receiver(servicebus_queue.name)
+            async with receiver:
+                messages = await receiver.peek_messages()
+                for msg in messages:
+                    assert msg.state == ServiceBusMessageState.SCHEDULED
 
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_state_deferred_async(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         async with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, uamqp_transport=uamqp_transport) as sb_client:
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_state_deferred_async(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential(is_async=True)
+        async with ServiceBusClient(
+            fully_qualified_namespace, credential, uamqp_transport=uamqp_transport) as sb_client:
 
-#             sender = sb_client.get_queue_sender(servicebus_queue.name)
-#             async with sender:
-#                 for i in range(10):
-#                     message = ServiceBusMessage("message no. {}".format(i))
-#                     await sender.send_messages(message)
+            sender = sb_client.get_queue_sender(servicebus_queue.name)
+            async with sender:
+                for i in range(10):
+                    message = ServiceBusMessage("message no. {}".format(i))
+                    await sender.send_messages(message)
 
-#             receiver = sb_client.get_queue_receiver(servicebus_queue.name)
-#             deferred_messages = []
-#             async with receiver:
-#                 received_msgs = await receiver.receive_messages()
-#                 for message in received_msgs:
-#                     assert message.state == ServiceBusMessageState.ACTIVE
-#                     deferred_messages.append(message.sequence_number)
-#                     await receiver.defer_message(message)
-#                 await asyncio.sleep(5)
-#                 if deferred_messages:
-#                     received_deferred_msg = await receiver.receive_deferred_messages(
-#                         sequence_numbers=deferred_messages
-#                         )                
-#                 for message in received_deferred_msg:
-#                     assert message.state == ServiceBusMessageState.DEFERRED
+            receiver = sb_client.get_queue_receiver(servicebus_queue.name)
+            deferred_messages = []
+            async with receiver:
+                received_msgs = await receiver.receive_messages()
+                for message in received_msgs:
+                    assert message.state == ServiceBusMessageState.ACTIVE
+                    deferred_messages.append(message.sequence_number)
+                    await receiver.defer_message(message)
+                await asyncio.sleep(5)
+                if deferred_messages:
+                    received_deferred_msg = await receiver.receive_deferred_messages(
+                        sequence_numbers=deferred_messages
+                        )                
+                for message in received_deferred_msg:
+                    assert message.state == ServiceBusMessageState.DEFERRED

--- a/sdk/servicebus/azure-servicebus/tests/async_tests/test_queues_async.py
+++ b/sdk/servicebus/azure-servicebus/tests/async_tests/test_queues_async.py
@@ -1,2835 +1,2835 @@
-#-------------------------------------------------------------------------
-# Copyright (c) Microsoft Corporation. All rights reserved.
-# Licensed under the MIT License. See License.txt in the project root for
-# license information.
-#--------------------------------------------------------------------------
+# #-------------------------------------------------------------------------
+# # Copyright (c) Microsoft Corporation. All rights reserved.
+# # Licensed under the MIT License. See License.txt in the project root for
+# # license information.
+# #--------------------------------------------------------------------------
 
-import asyncio
-import json
-import logging
-import sys
-import os
-import types
-import pytest
-import time
-import uuid
-import pickle
-from datetime import datetime, timedelta
+# import asyncio
+# import json
+# import logging
+# import sys
+# import os
+# import types
+# import pytest
+# import time
+# import uuid
+# import pickle
+# from datetime import datetime, timedelta
 
-try:
-    import uamqp
-    from azure.servicebus.aio._transport._uamqp_transport_async import UamqpTransportAsync
-except ImportError:
-    uamqp = None
+# try:
+#     import uamqp
+#     from azure.servicebus.aio._transport._uamqp_transport_async import UamqpTransportAsync
+# except ImportError:
+#     uamqp = None
 
-try:
-    from azure.servicebus.aio._transport._pyamqp_transport_async import PyamqpTransportAsync
-except:
-    PyamqpTransportAsync = None
-from azure.servicebus.aio import (
-    ServiceBusClient,
-    AutoLockRenewer
-)
-from azure.servicebus import (
-    ServiceBusMessage,
-    ServiceBusMessageBatch,
-    ServiceBusReceivedMessage,
-    TransportType,
-    ServiceBusReceiveMode,
-    ServiceBusSubQueue,
-    ServiceBusMessageState
-)
-from azure.servicebus.amqp import (
-    AmqpMessageHeader,
-    AmqpMessageBodyType,
-    AmqpAnnotatedMessage,
-    AmqpMessageProperties,
-)
-from azure.servicebus._pyamqp.message import Message
-from azure.servicebus._pyamqp import error, management_operation
-from azure.servicebus._pyamqp.aio import AMQPClientAsync, ReceiveClientAsync, _management_operation_async
-from azure.servicebus._common.constants import ServiceBusReceiveMode, ServiceBusSubQueue
-from azure.servicebus._common.utils import utc_now
-from azure.servicebus.management._models import DictMixin
-from azure.servicebus.exceptions import (
-    ServiceBusConnectionError,
-    ServiceBusError,
-    MessageLockLostError,
-    MessageAlreadySettled,
-    AutoLockRenewTimeout,
-    MessageSizeExceededError,
-    OperationTimeoutError
-)
-from devtools_testutils import AzureMgmtRecordedTestCase, AzureRecordedTestCase
-from tests.servicebus_preparer import (
-    CachedServiceBusNamespacePreparer,
-    CachedServiceBusQueuePreparer,
-    ServiceBusQueuePreparer,
-    CachedServiceBusResourceGroupPreparer
-)
-from tests.utilities import get_logger, print_message, sleep_until_expired
-from mocks_async import MockReceivedMessage, MockReceiver
-from tests.utilities import get_logger, print_message, sleep_until_expired, uamqp_transport as get_uamqp_transport, ArgPasserAsync
+# try:
+#     from azure.servicebus.aio._transport._pyamqp_transport_async import PyamqpTransportAsync
+# except:
+#     PyamqpTransportAsync = None
+# from azure.servicebus.aio import (
+#     ServiceBusClient,
+#     AutoLockRenewer
+# )
+# from azure.servicebus import (
+#     ServiceBusMessage,
+#     ServiceBusMessageBatch,
+#     ServiceBusReceivedMessage,
+#     TransportType,
+#     ServiceBusReceiveMode,
+#     ServiceBusSubQueue,
+#     ServiceBusMessageState
+# )
+# from azure.servicebus.amqp import (
+#     AmqpMessageHeader,
+#     AmqpMessageBodyType,
+#     AmqpAnnotatedMessage,
+#     AmqpMessageProperties,
+# )
+# from azure.servicebus._pyamqp.message import Message
+# from azure.servicebus._pyamqp import error, management_operation
+# from azure.servicebus._pyamqp.aio import AMQPClientAsync, ReceiveClientAsync, _management_operation_async
+# from azure.servicebus._common.constants import ServiceBusReceiveMode, ServiceBusSubQueue
+# from azure.servicebus._common.utils import utc_now
+# from azure.servicebus.management._models import DictMixin
+# from azure.servicebus.exceptions import (
+#     ServiceBusConnectionError,
+#     ServiceBusError,
+#     MessageLockLostError,
+#     MessageAlreadySettled,
+#     AutoLockRenewTimeout,
+#     MessageSizeExceededError,
+#     OperationTimeoutError
+# )
+# from devtools_testutils import AzureMgmtRecordedTestCase, AzureRecordedTestCase
+# from tests.servicebus_preparer import (
+#     CachedServiceBusNamespacePreparer,
+#     CachedServiceBusQueuePreparer,
+#     ServiceBusQueuePreparer,
+#     CachedServiceBusResourceGroupPreparer
+# )
+# from tests.utilities import get_logger, print_message, sleep_until_expired
+# from mocks_async import MockReceivedMessage, MockReceiver
+# from tests.utilities import get_logger, print_message, sleep_until_expired, uamqp_transport as get_uamqp_transport, ArgPasserAsync
 
-uamqp_transport_params, uamqp_transport_ids = get_uamqp_transport()
+# uamqp_transport_params, uamqp_transport_ids = get_uamqp_transport()
 
-_logger = get_logger(logging.DEBUG)
+# _logger = get_logger(logging.DEBUG)
 
 
-class TestServiceBusQueueAsync(AzureMgmtRecordedTestCase):
+# class TestServiceBusQueueAsync(AzureMgmtRecordedTestCase):
 
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True, lock_duration='PT10S')
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_async_queue_by_queue_client_conn_str_receive_handler_peeklock(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        async with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True, lock_duration='PT10S')
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_async_queue_by_queue_client_conn_str_receive_handler_peeklock(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         async with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-            sender = sb_client.get_queue_sender(servicebus_queue.name)
-            async with sender:
-                for i in range(10):
-                    message = ServiceBusMessage("Handler message no. {}".format(i))
-                    await sender.send_messages(message, timeout=5)
+#             sender = sb_client.get_queue_sender(servicebus_queue.name)
+#             async with sender:
+#                 for i in range(10):
+#                     message = ServiceBusMessage("Handler message no. {}".format(i))
+#                     await sender.send_messages(message, timeout=5)
 
-                # Test that noop empty send works properly.
-                await sender.send_messages([])
-                await sender.send_messages(ServiceBusMessageBatch())
-                assert len(await sender.schedule_messages([], utc_now())) == 0
-                await sender.cancel_scheduled_messages([])
+#                 # Test that noop empty send works properly.
+#                 await sender.send_messages([])
+#                 await sender.send_messages(ServiceBusMessageBatch())
+#                 assert len(await sender.schedule_messages([], utc_now())) == 0
+#                 await sender.cancel_scheduled_messages([])
 
-            # Then test expected failure modes.
-            with pytest.raises(ValueError):
-                async with sender:
-                    raise AssertionError("Should raise ValueError")
-            with pytest.raises(ValueError):
-                await sender.send_messages(ServiceBusMessage('msg'))
-            with pytest.raises(ValueError):
-                await sender.schedule_messages(ServiceBusMessage('msg'), utc_now())
-            with pytest.raises(ValueError):
-                await sender.cancel_scheduled_messages([1, 2, 3])
+#             # Then test expected failure modes.
+#             with pytest.raises(ValueError):
+#                 async with sender:
+#                     raise AssertionError("Should raise ValueError")
+#             with pytest.raises(ValueError):
+#                 await sender.send_messages(ServiceBusMessage('msg'))
+#             with pytest.raises(ValueError):
+#                 await sender.schedule_messages(ServiceBusMessage('msg'), utc_now())
+#             with pytest.raises(ValueError):
+#                 await sender.cancel_scheduled_messages([1, 2, 3])
 
-            with pytest.raises(ServiceBusError):
-                await (sb_client.get_queue_receiver(servicebus_queue.name, session_id="test", max_wait_time=5))._open_with_retry()
+#             with pytest.raises(ServiceBusError):
+#                 await (sb_client.get_queue_receiver(servicebus_queue.name, session_id="test", max_wait_time=5))._open_with_retry()
 
-            with pytest.raises(ValueError):
-                sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=0)
+#             with pytest.raises(ValueError):
+#                 sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=0)
 
-            receiver = sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5)
-            async with receiver:
-                assert len(await receiver.receive_deferred_messages([])) == 0
-                with pytest.raises(ValueError):
-                    await receiver.receive_messages(max_wait_time=0)
+#             receiver = sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5)
+#             async with receiver:
+#                 assert len(await receiver.receive_deferred_messages([])) == 0
+#                 with pytest.raises(ValueError):
+#                     await receiver.receive_messages(max_wait_time=0)
 
-                count = 0
-                async for message in receiver:
-                    print_message(_logger, message)
-                    count += 1
-                    await receiver.complete_message(message)
+#                 count = 0
+#                 async for message in receiver:
+#                     print_message(_logger, message)
+#                     count += 1
+#                     await receiver.complete_message(message)
 
-            assert count == 10
+#             assert count == 10
 
-            with pytest.raises(ValueError):
-                await receiver.receive_messages()
-            with pytest.raises(ValueError):
-                async with receiver:
-                    raise AssertionError("Should raise ValueError")
-            with pytest.raises(ValueError):
-                await receiver.receive_deferred_messages([1, 2, 3])
-            with pytest.raises(ValueError):
-                await receiver.peek_messages()
-
-    
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True, lock_duration='PT10S')
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_async_queue_by_queue_client_conn_str_receive_handler_release_messages(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        async with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-
-            async def sub_test_releasing_messages():
-                # test releasing messages when prefetch is 1 and link credits are issue dynamically
-                receiver = sb_client.get_queue_receiver(servicebus_queue.name)
-                sender = sb_client.get_queue_sender(servicebus_queue.name)
-                async with sender, receiver:
-                    # send 10 msgs to queue first
-                    await sender.send_messages([ServiceBusMessage('test') for _ in range(5)])
-
-                    received_msgs = []
-                    # the amount of messages returned by receive call is not stable, especially in live tests
-                    # of different os platforms, this is why a while loop is used here to receive the specific
-                    # amount of message we want to receive
-                    while len(received_msgs) < 5:
-                        # issue link credits more than 5, client should consume 5 msgs from the service in total,
-                        # leaving the extra credits on the wire
-                        for msg in (await receiver.receive_messages(max_message_count=10, max_wait_time=10)):
-                            await receiver.complete_message(msg)
-                            received_msgs.append(received_msgs)
-                    assert len(received_msgs) == 5
-
-                    # send 5 more messages, those messages would arrive at the client while the program is sleeping
-                    await sender.send_messages([ServiceBusMessage('test') for _ in range(5)])
-                    await asyncio.sleep(15)  # sleep > message expiration time
-
-                    target_msgs_count = 5
-                    received_msgs = []
-                    while len(received_msgs) < target_msgs_count:
-                        # issue 10 link credits, client should consume 5 msgs from the service, leaving no link credits
-                        for msg in (await receiver.receive_messages(max_message_count=target_msgs_count - len(received_msgs),
-                                                             max_wait_time=10)):
-                            assert msg.delivery_count == 0  # release would not increase delivery count
-                            await receiver.complete_message(msg)
-                            received_msgs.append(msg)
-                    assert len(received_msgs) == 5
-
-            async def sub_test_releasing_messages_iterator():
-                # test nested iterator scenario
-                receiver = sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10)
-                sender = sb_client.get_queue_sender(servicebus_queue.name)
-                async with sender, receiver:
-                    # send 5 msgs to queue first
-                    await sender.send_messages([ServiceBusMessage('test') for _ in range(5)])
-                    first_time = True
-                    iterator_recv_cnt = 0
-
-                    # case: iterator + receive batch
-                    async for msg in receiver:
-                        assert msg.delivery_count == 0  # release would not increase delivery count
-                        await receiver.complete_message(msg)
-                        iterator_recv_cnt += 1
-                        if first_time:  # for the first time, we call nested receive message call
-                            received_msgs = []
-
-                            while len(received_msgs) < 4:  # there supposed to be 5 msgs in the queue
-                                # we issue 10 link credits, leaving more credits on the wire
-                                for sub_msg in (await receiver.receive_messages(max_message_count=10, max_wait_time=10)):
-                                    assert sub_msg.delivery_count == 0
-                                    await receiver.complete_message(sub_msg)
-                                    received_msgs.append(sub_msg)
-                            assert len(received_msgs) == 4
-                            await sender.send_messages([ServiceBusMessage('test') for _ in range(10)])
-                            await asyncio.sleep(15)  # sleep > message expiration time
-
-                            received_msgs = []
-                            target_msgs_count = 5  # we want to receive 5 with the receive message call
-                            while len(received_msgs) < target_msgs_count:
-                                for sub_msg in (await receiver.receive_messages(
-                                        max_message_count=target_msgs_count - len(received_msgs), max_wait_time=5)):
-                                    assert sub_msg.delivery_count == 0  # release would not increase delivery count
-                                    await receiver.complete_message(sub_msg)
-                                    received_msgs.append(sub_msg)
-                            assert len(received_msgs) == target_msgs_count
-                            first_time = False
-                    assert iterator_recv_cnt == 6  # 1 before nested receive message call + 5 after nested receive message call
-
-                    # case: iterator + iterator case
-                    await sender.send_messages([ServiceBusMessage('test') for _ in range(10)])
-                    outter_recv_cnt = 0
-                    inner_recv_cnt = 0
-                    async for msg in receiver:
-                        assert msg.delivery_count == 0
-                        outter_recv_cnt += 1
-                        await receiver.complete_message(msg)
-                        async for sub_msg in receiver:
-                            assert sub_msg.delivery_count == 0
-                            inner_recv_cnt += 1
-                            await receiver.complete_message(sub_msg)
-                            if inner_recv_cnt == 5:
-                                await asyncio.sleep(15)  # innner finish receiving first 5 messages then sleep until lock expiration
-                                break
-                    assert outter_recv_cnt == 1
-                    outter_recv_cnt = 0
-                    async for msg in receiver:
-                        assert msg.delivery_count == 0
-                        outter_recv_cnt += 1
-                        await receiver.complete_message(msg)
-                    assert outter_recv_cnt == 4
-
-            async def sub_test_non_releasing_messages():
-                # test not releasing messages when prefetch is not 1
-                receiver = sb_client.get_queue_receiver(servicebus_queue.name)
-                sender = sb_client.get_queue_sender(servicebus_queue.name)
-
-                if uamqp_transport:
-                    def _hack_disable_receive_context_message_received(self, message):
-                        # pylint: disable=protected-access
-                        self._handler._was_message_received = True
-                        self._handler._received_messages.put(message)
-                else:
-                    def _hack_disable_receive_context_message_received(self, frame, message):
-                        # pylint: disable=protected-access
-                        self._handler._last_activity_timestamp = time.time()
-                        self._handler._received_messages.put((frame, message))
-
-                async with sender, receiver:
-                    # send 5 msgs to queue first
-                    await sender.send_messages([ServiceBusMessage('test') for _ in range(5)])
-                    if uamqp_transport:
-                        receiver._handler.message_handler.on_message_received = types.MethodType(
-                            _hack_disable_receive_context_message_received, receiver)
-                    else:
-                        receiver._handler._link._on_transfer = types.MethodType(
-                            _hack_disable_receive_context_message_received, receiver)
-                    received_msgs = []
-                    while len(received_msgs) < 5:
-                        # issue 10 link credits, client should consume 5 msgs from the service
-                        # leaving 5 credits on the wire
-                        for msg in (await receiver.receive_messages(max_message_count=10, max_wait_time=10)):
-                            await receiver.complete_message(msg)
-                            received_msgs.append(msg)
-                    assert len(received_msgs) == 5
-
-                    # send 5 more messages, those messages would arrive at the client while the program is sleeping
-                    await sender.send_messages([ServiceBusMessage('test') for _ in range(5)])
-                    await asyncio.sleep(15)  # sleep > message expiration time
-
-                    # issue 5 link credits, client should consume 5 msgs from the internal buffer which is already lock expired
-                    target_msgs_count = 5
-                    received_msgs = []
-                    while len(received_msgs) < target_msgs_count:
-                        received_msgs.extend((await receiver.receive_messages(max_message_count=5, max_wait_time=10)))
-                    assert len(received_msgs) == 5
-                    for msg in received_msgs:
-                        assert msg.delivery_count == 0
-                        with pytest.raises(ServiceBusError):
-                            await receiver.complete_message(msg)
-
-                    # re-received message with delivery count increased
-                    target_msgs_count = 5
-                    received_msgs = []
-                    while len(received_msgs) < target_msgs_count:
-                        received_msgs.extend((await receiver.receive_messages(max_message_count=5, max_wait_time=10)))
-                    assert len(received_msgs) == 5
-                    for msg in received_msgs:
-                        assert msg.delivery_count > 0
-                        await receiver.complete_message(msg)
-
-            await sub_test_releasing_messages()
-            await sub_test_releasing_messages_iterator()
-            await sub_test_non_releasing_messages()
+#             with pytest.raises(ValueError):
+#                 await receiver.receive_messages()
+#             with pytest.raises(ValueError):
+#                 async with receiver:
+#                     raise AssertionError("Should raise ValueError")
+#             with pytest.raises(ValueError):
+#                 await receiver.receive_deferred_messages([1, 2, 3])
+#             with pytest.raises(ValueError):
+#                 await receiver.peek_messages()
 
     
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_async_queue_by_queue_client_send_multiple_messages(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        async with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-            sender = sb_client.get_queue_sender(servicebus_queue.name)
-            async with sender:
-                messages = []
-                for i in range(10):
-                    message = ServiceBusMessage("Handler message no. {}".format(i))
-                    messages.append(message)
-                await sender.send_messages(messages)
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True, lock_duration='PT10S')
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_async_queue_by_queue_client_conn_str_receive_handler_release_messages(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         async with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-            with pytest.raises(ValueError):
-                async with sender:
-                    raise AssertionError("Should raise ValueError")
-            with pytest.raises(ValueError):
-                await sender.send_messages(ServiceBusMessage('msg'))
-            with pytest.raises(ValueError):
-                await sender.schedule_messages(ServiceBusMessage('msg'), utc_now())
-            with pytest.raises(ValueError):
-                await sender.cancel_scheduled_messages([1, 2, 3])
+#             async def sub_test_releasing_messages():
+#                 # test releasing messages when prefetch is 1 and link credits are issue dynamically
+#                 receiver = sb_client.get_queue_receiver(servicebus_queue.name)
+#                 sender = sb_client.get_queue_sender(servicebus_queue.name)
+#                 async with sender, receiver:
+#                     # send 10 msgs to queue first
+#                     await sender.send_messages([ServiceBusMessage('test') for _ in range(5)])
 
-            receiver = sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5)
-            count = 0
-            async for message in receiver:
-                print_message(_logger, message)
-                count += 1
-                await receiver.complete_message(message)
+#                     received_msgs = []
+#                     # the amount of messages returned by receive call is not stable, especially in live tests
+#                     # of different os platforms, this is why a while loop is used here to receive the specific
+#                     # amount of message we want to receive
+#                     while len(received_msgs) < 5:
+#                         # issue link credits more than 5, client should consume 5 msgs from the service in total,
+#                         # leaving the extra credits on the wire
+#                         for msg in (await receiver.receive_messages(max_message_count=10, max_wait_time=10)):
+#                             await receiver.complete_message(msg)
+#                             received_msgs.append(received_msgs)
+#                     assert len(received_msgs) == 5
 
-            assert count == 10
+#                     # send 5 more messages, those messages would arrive at the client while the program is sleeping
+#                     await sender.send_messages([ServiceBusMessage('test') for _ in range(5)])
+#                     await asyncio.sleep(15)  # sleep > message expiration time
 
-            await receiver.close()
+#                     target_msgs_count = 5
+#                     received_msgs = []
+#                     while len(received_msgs) < target_msgs_count:
+#                         # issue 10 link credits, client should consume 5 msgs from the service, leaving no link credits
+#                         for msg in (await receiver.receive_messages(max_message_count=target_msgs_count - len(received_msgs),
+#                                                              max_wait_time=10)):
+#                             assert msg.delivery_count == 0  # release would not increase delivery count
+#                             await receiver.complete_message(msg)
+#                             received_msgs.append(msg)
+#                     assert len(received_msgs) == 5
 
-            with pytest.raises(ValueError):
-                await receiver.receive_messages()
-            with pytest.raises(ValueError):
-                async with receiver:
-                    raise AssertionError("Should raise ValueError")
-            with pytest.raises(ValueError):
-                await receiver.receive_deferred_messages([1, 2, 3])
-            with pytest.raises(ValueError):
-                await receiver.peek_messages()
+#             async def sub_test_releasing_messages_iterator():
+#                 # test nested iterator scenario
+#                 receiver = sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10)
+#                 sender = sb_client.get_queue_sender(servicebus_queue.name)
+#                 async with sender, receiver:
+#                     # send 5 msgs to queue first
+#                     await sender.send_messages([ServiceBusMessage('test') for _ in range(5)])
+#                     first_time = True
+#                     iterator_recv_cnt = 0
 
-            sender = sb_client.get_queue_sender(servicebus_queue.name)
-            receiver = sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5)
-            async with sender, receiver:
-                # send previously unpicklable message
-                msg = {
-                    "body":"W1tdLCB7ImlucHV0X2lkIjogNH0sIHsiY2FsbGJhY2tzIjogbnVsbCwgImVycmJhY2tzIjogbnVsbCwgImNoYWluIjogbnVsbCwgImNob3JkIjogbnVsbH1d",
-                    "content-encoding":"utf-8",
-                    "content-type":"application/json",
-                    "headers":{
-                        "lang":"py",
-                        "task":"tasks.example_task",
-                        "id":"7c66557d-e4bc-437f-b021-b66dcc39dfdf",
-                        "shadow":None,
-                        "eta":"2021-10-07T02:30:23.764066+00:00",
-                        "expires":None,
-                        "group":None,
-                        "group_index":None,
-                        "retries":1,
-                        "timelimit":[
-                            None,
-                            None
-                        ],
-                        "root_id":"7c66557d-e4bc-437f-b021-b66dcc39dfdf",
-                        "parent_id":"7c66557d-e4bc-437f-b021-b66dcc39dfdf",
-                        "argsrepr":"()",
-                        "kwargsrepr":"{'input_id': 4}",
-                        "origin":"gen36@94713e01a9c0",
-                        "ignore_result":1,
-                        "x_correlator":"44a1978d-c869-4173-afe4-da741f0edfb9"
-                    },
-                    "properties":{
-                        "correlation_id":"7c66557d-e4bc-437f-b021-b66dcc39dfdf",
-                        "reply_to":"7b9a3672-2fed-3e9b-8bfd-23ae2397d9ad",
-                        "origin":"gen68@c33d4eef123a",
-                        "delivery_mode":2,
-                        "delivery_info":{
-                            "exchange":"",
-                            "routing_key":"celery_task_queue"
-                        },
-                        "priority":0,
-                        "body_encoding":"base64",
-                        "delivery_tag":"dc83ddb6-8cdc-4413-b88a-06c56cbde90d"
-                    }
-                }
-                await sender.send_messages(ServiceBusMessage(json.dumps(msg)))
-                messages = await receiver.receive_messages(max_wait_time=10, max_message_count=1)
-                if not uamqp_transport:
-                    pickled = pickle.loads(pickle.dumps(messages[0]))
-                    assert json.loads(str(pickled)) == json.loads(str(messages[0]))
-                    await receiver.complete_message(pickled)
-                else:
-                    with pytest.raises(TypeError):
-                        pickled = pickle.loads(pickle.dumps(messages[0]))
-                    await receiver.complete_message(messages[0])
-    
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer()
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_github_issue_7079_async(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        async with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-    
-            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                for i in range(5):
-                    await sender.send_messages(ServiceBusMessage("ServiceBusMessage {}".format(i)))
-            async with sb_client.get_queue_receiver(servicebus_queue.name, receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE, max_wait_time=5) as messages:
-                batch = await messages.receive_messages()
-                count = len(batch)
-                async for message in messages:
-                   _logger.debug(message)
-                   count += 1
-                assert count == 5
+#                     # case: iterator + receive batch
+#                     async for msg in receiver:
+#                         assert msg.delivery_count == 0  # release would not increase delivery count
+#                         await receiver.complete_message(msg)
+#                         iterator_recv_cnt += 1
+#                         if first_time:  # for the first time, we call nested receive message call
+#                             received_msgs = []
 
-    
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer()
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @CachedServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_github_issue_6178_async(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        async with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#                             while len(received_msgs) < 4:  # there supposed to be 5 msgs in the queue
+#                                 # we issue 10 link credits, leaving more credits on the wire
+#                                 for sub_msg in (await receiver.receive_messages(max_message_count=10, max_wait_time=10)):
+#                                     assert sub_msg.delivery_count == 0
+#                                     await receiver.complete_message(sub_msg)
+#                                     received_msgs.append(sub_msg)
+#                             assert len(received_msgs) == 4
+#                             await sender.send_messages([ServiceBusMessage('test') for _ in range(10)])
+#                             await asyncio.sleep(15)  # sleep > message expiration time
 
-            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                for i in range(3):
-                    await sender.send_messages(ServiceBusMessage("Message {}".format(i)))
-            async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=60) as receiver:
-                async for message in receiver:
-                    _logger.debug(message)
-                    _logger.debug(message.sequence_number)
-                    _logger.debug(message.enqueued_time_utc)
-                    _logger.debug(message._lock_expired)
-                    await receiver.complete_message(message)
-                    await asyncio.sleep(40)
+#                             received_msgs = []
+#                             target_msgs_count = 5  # we want to receive 5 with the receive message call
+#                             while len(received_msgs) < target_msgs_count:
+#                                 for sub_msg in (await receiver.receive_messages(
+#                                         max_message_count=target_msgs_count - len(received_msgs), max_wait_time=5)):
+#                                     assert sub_msg.delivery_count == 0  # release would not increase delivery count
+#                                     await receiver.complete_message(sub_msg)
+#                                     received_msgs.append(sub_msg)
+#                             assert len(received_msgs) == target_msgs_count
+#                             first_time = False
+#                     assert iterator_recv_cnt == 6  # 1 before nested receive message call + 5 after nested receive message call
 
-    
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True, lock_duration='PT10S')
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_async_queue_by_queue_client_conn_str_receive_handler_receiveanddelete(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        async with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#                     # case: iterator + iterator case
+#                     await sender.send_messages([ServiceBusMessage('test') for _ in range(10)])
+#                     outter_recv_cnt = 0
+#                     inner_recv_cnt = 0
+#                     async for msg in receiver:
+#                         assert msg.delivery_count == 0
+#                         outter_recv_cnt += 1
+#                         await receiver.complete_message(msg)
+#                         async for sub_msg in receiver:
+#                             assert sub_msg.delivery_count == 0
+#                             inner_recv_cnt += 1
+#                             await receiver.complete_message(sub_msg)
+#                             if inner_recv_cnt == 5:
+#                                 await asyncio.sleep(15)  # innner finish receiving first 5 messages then sleep until lock expiration
+#                                 break
+#                     assert outter_recv_cnt == 1
+#                     outter_recv_cnt = 0
+#                     async for msg in receiver:
+#                         assert msg.delivery_count == 0
+#                         outter_recv_cnt += 1
+#                         await receiver.complete_message(msg)
+#                     assert outter_recv_cnt == 4
 
-            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                for i in range(10):
-                    message = ServiceBusMessage("Handler message no. {}".format(i))
-                    await sender.send_messages(message)
+#             async def sub_test_non_releasing_messages():
+#                 # test not releasing messages when prefetch is not 1
+#                 receiver = sb_client.get_queue_receiver(servicebus_queue.name)
+#                 sender = sb_client.get_queue_sender(servicebus_queue.name)
 
-            messages = []
-            async with sb_client.get_queue_receiver(servicebus_queue.name, receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE, max_wait_time=8) as receiver:
-                async for message in receiver:
-                    messages.append(message)
-                    with pytest.raises(ValueError):
-                        await receiver.complete_message(message)
-                    with pytest.raises(ValueError): # RECEIVE_AND_DELETE messages cannot be lock renewed.
-                        renewer = AutoLockRenewer()
-                        renewer.register(receiver, message)
+#                 if uamqp_transport:
+#                     def _hack_disable_receive_context_message_received(self, message):
+#                         # pylint: disable=protected-access
+#                         self._handler._was_message_received = True
+#                         self._handler._received_messages.put(message)
+#                 else:
+#                     def _hack_disable_receive_context_message_received(self, frame, message):
+#                         # pylint: disable=protected-access
+#                         self._handler._last_activity_timestamp = time.time()
+#                         self._handler._received_messages.put((frame, message))
 
-            assert not receiver._running
-            assert len(messages) == 10
-            time.sleep(10)
+#                 async with sender, receiver:
+#                     # send 5 msgs to queue first
+#                     await sender.send_messages([ServiceBusMessage('test') for _ in range(5)])
+#                     if uamqp_transport:
+#                         receiver._handler.message_handler.on_message_received = types.MethodType(
+#                             _hack_disable_receive_context_message_received, receiver)
+#                     else:
+#                         receiver._handler._link._on_transfer = types.MethodType(
+#                             _hack_disable_receive_context_message_received, receiver)
+#                     received_msgs = []
+#                     while len(received_msgs) < 5:
+#                         # issue 10 link credits, client should consume 5 msgs from the service
+#                         # leaving 5 credits on the wire
+#                         for msg in (await receiver.receive_messages(max_message_count=10, max_wait_time=10)):
+#                             await receiver.complete_message(msg)
+#                             received_msgs.append(msg)
+#                     assert len(received_msgs) == 5
 
-            messages = []
-            async with sb_client.get_queue_receiver(servicebus_queue.name, receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE, max_wait_time=5) as receiver:
-                async for message in receiver:
-                    messages.append(message)
-                assert len(messages) == 0
+#                     # send 5 more messages, those messages would arrive at the client while the program is sleeping
+#                     await sender.send_messages([ServiceBusMessage('test') for _ in range(5)])
+#                     await asyncio.sleep(15)  # sleep > message expiration time
 
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True, lock_duration='PT10S')
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_async_queue_by_queue_client_conn_str_receive_handler_receiveanddelete_prefetch(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        async with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#                     # issue 5 link credits, client should consume 5 msgs from the internal buffer which is already lock expired
+#                     target_msgs_count = 5
+#                     received_msgs = []
+#                     while len(received_msgs) < target_msgs_count:
+#                         received_msgs.extend((await receiver.receive_messages(max_message_count=5, max_wait_time=10)))
+#                     assert len(received_msgs) == 5
+#                     for msg in received_msgs:
+#                         assert msg.delivery_count == 0
+#                         with pytest.raises(ServiceBusError):
+#                             await receiver.complete_message(msg)
 
-            # send 10 messages
-            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                for i in range(10):
-                    message = ServiceBusMessage("Handler message no. {}".format(i))
-                    await sender.send_messages(message)
+#                     # re-received message with delivery count increased
+#                     target_msgs_count = 5
+#                     received_msgs = []
+#                     while len(received_msgs) < target_msgs_count:
+#                         received_msgs.extend((await receiver.receive_messages(max_message_count=5, max_wait_time=10)))
+#                     assert len(received_msgs) == 5
+#                     for msg in received_msgs:
+#                         assert msg.delivery_count > 0
+#                         await receiver.complete_message(msg)
 
-            # check peek_messages returns correctly, with default prefetch_count = 0
-            messages = []
-            async with sb_client.get_queue_receiver(servicebus_queue.name,
-                                                receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE,
-                                                max_wait_time=10) as receiver:
-                # peek messages checks current state of queue, which should return 10
-                # since none were prefetched, added to internal buffer, and deleted on receive
-                peeked_msgs = await receiver.peek_messages(max_message_count=10, timeout=10)
-                assert len(peeked_msgs) == 10
-
-                # iterator receives and deletes each message from SB queue
-                async for msg in receiver:
-                    messages.append(msg)
-                assert len(messages) == 10
-
-                # queue should be empty now
-                peeked_msgs = await receiver.peek_messages(max_message_count=10, timeout=10)
-                assert len(peeked_msgs) == 0
-
-            # send 10 messages
-            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                for i in range(10):
-                    message = ServiceBusMessage("Handler message no. {}".format(i))
-                    await sender.send_messages(message)
-
-            # check peek_messages returns correctly, with default prefetch_count > 0
-            messages = []
-            # prefetch 1 message from SB queue when receive is called and not on open
-            async with sb_client.get_queue_receiver(servicebus_queue.name,
-                                            receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE,
-                                            prefetch_count=1,
-                                            max_wait_time=30) as receiver:
-                # peek messages checks current state of SB queue, and returns 10
-                peeked_msgs = await receiver.peek_messages(max_message_count=10, timeout=10)
-                assert len(peeked_msgs) == 10
-
-                # receive 3 messages
-                recvd_msgs = await receiver.receive_messages(max_message_count=3, max_wait_time=10)
-                assert len(recvd_msgs) == 3
-
-                # receive rest of messages in queue
-                async for msg in receiver:
-                    messages.append(msg)
-                assert len(messages) == 7
-
-                # queue should be empty now
-                peeked_msgs = await receiver.peek_messages(max_message_count=10, timeout=10)
-                assert len(peeked_msgs) == 0
-
-
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_async_queue_by_queue_client_conn_str_receive_handler_with_stop(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        async with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-
-            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                for i in range(10):
-                    message = ServiceBusMessage("Stop message no. {}".format(i))
-                    await sender.send_messages(message)
-
-            messages = []
-            receiver = sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5, prefetch_count=0) 
-            async with receiver:
-                async for message in receiver:
-                    messages.append(message)
-                    await receiver.complete_message(message)
-                    if len(messages) >= 5:
-                        break
-
-                assert receiver._running
-                assert len(messages) == 5
-
-                async for message in receiver:
-                    messages.append(message)
-                    await receiver.complete_message(message)
-                    if len(messages) >= 5:
-                        break
-
-            assert not receiver._running
-            assert len(messages) == 6
+#             await sub_test_releasing_messages()
+#             await sub_test_releasing_messages_iterator()
+#             await sub_test_non_releasing_messages()
 
     
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_async_queue_by_servicebus_client_iter_messages_simple(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        async with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_async_queue_by_queue_client_send_multiple_messages(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         async with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#             sender = sb_client.get_queue_sender(servicebus_queue.name)
+#             async with sender:
+#                 messages = []
+#                 for i in range(10):
+#                     message = ServiceBusMessage("Handler message no. {}".format(i))
+#                     messages.append(message)
+#                 await sender.send_messages(messages)
 
-            async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10, receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
+#             with pytest.raises(ValueError):
+#                 async with sender:
+#                     raise AssertionError("Should raise ValueError")
+#             with pytest.raises(ValueError):
+#                 await sender.send_messages(ServiceBusMessage('msg'))
+#             with pytest.raises(ValueError):
+#                 await sender.schedule_messages(ServiceBusMessage('msg'), utc_now())
+#             with pytest.raises(ValueError):
+#                 await sender.cancel_scheduled_messages([1, 2, 3])
 
-                async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                    for i in range(10):
-                        message = ServiceBusMessage("Iter message no. {}".format(i))
-                        await sender.send_messages(message)
+#             receiver = sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5)
+#             count = 0
+#             async for message in receiver:
+#                 print_message(_logger, message)
+#                 count += 1
+#                 await receiver.complete_message(message)
 
-                count = 0
-                async for message in receiver:
-                    print_message(_logger, message)
-                    await receiver.complete_message(message)
-                    with pytest.raises(MessageAlreadySettled):
-                        await receiver.complete_message(message)
-                    with pytest.raises(MessageAlreadySettled):
-                        await receiver.renew_message_lock(message)
-                    count += 1
+#             assert count == 10
 
-                with pytest.raises(StopAsyncIteration):
-                    await receiver.__anext__()
+#             await receiver.close()
 
-            assert count == 10
+#             with pytest.raises(ValueError):
+#                 await receiver.receive_messages()
+#             with pytest.raises(ValueError):
+#                 async with receiver:
+#                     raise AssertionError("Should raise ValueError")
+#             with pytest.raises(ValueError):
+#                 await receiver.receive_deferred_messages([1, 2, 3])
+#             with pytest.raises(ValueError):
+#                 await receiver.peek_messages()
+
+#             sender = sb_client.get_queue_sender(servicebus_queue.name)
+#             receiver = sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5)
+#             async with sender, receiver:
+#                 # send previously unpicklable message
+#                 msg = {
+#                     "body":"W1tdLCB7ImlucHV0X2lkIjogNH0sIHsiY2FsbGJhY2tzIjogbnVsbCwgImVycmJhY2tzIjogbnVsbCwgImNoYWluIjogbnVsbCwgImNob3JkIjogbnVsbH1d",
+#                     "content-encoding":"utf-8",
+#                     "content-type":"application/json",
+#                     "headers":{
+#                         "lang":"py",
+#                         "task":"tasks.example_task",
+#                         "id":"7c66557d-e4bc-437f-b021-b66dcc39dfdf",
+#                         "shadow":None,
+#                         "eta":"2021-10-07T02:30:23.764066+00:00",
+#                         "expires":None,
+#                         "group":None,
+#                         "group_index":None,
+#                         "retries":1,
+#                         "timelimit":[
+#                             None,
+#                             None
+#                         ],
+#                         "root_id":"7c66557d-e4bc-437f-b021-b66dcc39dfdf",
+#                         "parent_id":"7c66557d-e4bc-437f-b021-b66dcc39dfdf",
+#                         "argsrepr":"()",
+#                         "kwargsrepr":"{'input_id': 4}",
+#                         "origin":"gen36@94713e01a9c0",
+#                         "ignore_result":1,
+#                         "x_correlator":"44a1978d-c869-4173-afe4-da741f0edfb9"
+#                     },
+#                     "properties":{
+#                         "correlation_id":"7c66557d-e4bc-437f-b021-b66dcc39dfdf",
+#                         "reply_to":"7b9a3672-2fed-3e9b-8bfd-23ae2397d9ad",
+#                         "origin":"gen68@c33d4eef123a",
+#                         "delivery_mode":2,
+#                         "delivery_info":{
+#                             "exchange":"",
+#                             "routing_key":"celery_task_queue"
+#                         },
+#                         "priority":0,
+#                         "body_encoding":"base64",
+#                         "delivery_tag":"dc83ddb6-8cdc-4413-b88a-06c56cbde90d"
+#                     }
+#                 }
+#                 await sender.send_messages(ServiceBusMessage(json.dumps(msg)))
+#                 messages = await receiver.receive_messages(max_wait_time=10, max_message_count=1)
+#                 if not uamqp_transport:
+#                     pickled = pickle.loads(pickle.dumps(messages[0]))
+#                     assert json.loads(str(pickled)) == json.loads(str(messages[0]))
+#                     await receiver.complete_message(pickled)
+#                 else:
+#                     with pytest.raises(TypeError):
+#                         pickled = pickle.loads(pickle.dumps(messages[0]))
+#                     await receiver.complete_message(messages[0])
+    
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer()
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_github_issue_7079_async(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         async with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+    
+#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 for i in range(5):
+#                     await sender.send_messages(ServiceBusMessage("ServiceBusMessage {}".format(i)))
+#             async with sb_client.get_queue_receiver(servicebus_queue.name, receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE, max_wait_time=5) as messages:
+#                 batch = await messages.receive_messages()
+#                 count = len(batch)
+#                 async for message in messages:
+#                    _logger.debug(message)
+#                    count += 1
+#                 assert count == 5
 
     
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_async_queue_by_servicebus_conn_str_client_iter_messages_with_abandon(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        async with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer()
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @CachedServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_github_issue_6178_async(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         async with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-            async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10, receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
-
-                async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                    for i in range(10):
-                        message = ServiceBusMessage("Abandoned message no. {}".format(i))
-                        await sender.send_messages(message)
-
-                count = 0
-                async for message in receiver:
-                    print_message(_logger, message)
-                    if not message.delivery_count:
-                        count += 1
-                        await receiver.abandon_message(message)
-                    else:
-                        assert message.delivery_count == 1
-                        await receiver.complete_message(message)
-
-            assert count == 10
-
-            async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10, receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
-                count = 0
-                async for message in receiver:
-                    print_message(_logger, message)
-                    await receiver.complete_message(message)
-                    count += 1
-            assert count == 0
+#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 for i in range(3):
+#                     await sender.send_messages(ServiceBusMessage("Message {}".format(i)))
+#             async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=60) as receiver:
+#                 async for message in receiver:
+#                     _logger.debug(message)
+#                     _logger.debug(message.sequence_number)
+#                     _logger.debug(message.enqueued_time_utc)
+#                     _logger.debug(message._lock_expired)
+#                     await receiver.complete_message(message)
+#                     await asyncio.sleep(40)
 
     
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_async_queue_by_servicebus_client_iter_messages_with_defer(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        async with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True, lock_duration='PT10S')
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_async_queue_by_queue_client_conn_str_receive_handler_receiveanddelete(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         async with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-            deferred_messages = []
-            async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10, receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
+#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 for i in range(10):
+#                     message = ServiceBusMessage("Handler message no. {}".format(i))
+#                     await sender.send_messages(message)
 
-                async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                    for i in range(10):
-                        message = ServiceBusMessage("Deferred message no. {}".format(i))
-                        await sender.send_messages(message)
+#             messages = []
+#             async with sb_client.get_queue_receiver(servicebus_queue.name, receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE, max_wait_time=8) as receiver:
+#                 async for message in receiver:
+#                     messages.append(message)
+#                     with pytest.raises(ValueError):
+#                         await receiver.complete_message(message)
+#                     with pytest.raises(ValueError): # RECEIVE_AND_DELETE messages cannot be lock renewed.
+#                         renewer = AutoLockRenewer()
+#                         renewer.register(receiver, message)
 
-                count = 0
-                async for message in receiver:
-                    deferred_messages.append(message.sequence_number)
-                    print_message(_logger, message)
-                    count += 1
-                    await receiver.defer_message(message)
+#             assert not receiver._running
+#             assert len(messages) == 10
+#             time.sleep(10)
 
-            assert count == 10
-            async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10, receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
-                count = 0
-                async for message in receiver:
-                    print_message(_logger, message)
-                    await receiver.complete_message(message)
-                    count += 1
-            assert count == 0
+#             messages = []
+#             async with sb_client.get_queue_receiver(servicebus_queue.name, receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE, max_wait_time=5) as receiver:
+#                 async for message in receiver:
+#                     messages.append(message)
+#                 assert len(messages) == 0
 
-    
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_async_queue_by_servicebus_client_iter_messages_with_retrieve_deferred_client(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        async with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True, lock_duration='PT10S')
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_async_queue_by_queue_client_conn_str_receive_handler_receiveanddelete_prefetch(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         async with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-            deferred_messages = []
-            async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10, receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
+#             # send 10 messages
+#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 for i in range(10):
+#                     message = ServiceBusMessage("Handler message no. {}".format(i))
+#                     await sender.send_messages(message)
 
-                async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                    for i in range(10):
-                        message = ServiceBusMessage("Deferred message no. {}".format(i))
-                        await sender.send_messages(message)
+#             # check peek_messages returns correctly, with default prefetch_count = 0
+#             messages = []
+#             async with sb_client.get_queue_receiver(servicebus_queue.name,
+#                                                 receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE,
+#                                                 max_wait_time=10) as receiver:
+#                 # peek messages checks current state of queue, which should return 10
+#                 # since none were prefetched, added to internal buffer, and deleted on receive
+#                 peeked_msgs = await receiver.peek_messages(max_message_count=10, timeout=10)
+#                 assert len(peeked_msgs) == 10
 
-                count = 0
-                async for message in receiver:
-                    deferred_messages.append(message.sequence_number)
-                    print_message(_logger, message)
-                    count += 1
-                    await receiver.defer_message(message)
+#                 # iterator receives and deletes each message from SB queue
+#                 async for msg in receiver:
+#                     messages.append(msg)
+#                 assert len(messages) == 10
 
-                assert count == 10
+#                 # queue should be empty now
+#                 peeked_msgs = await receiver.peek_messages(max_message_count=10, timeout=10)
+#                 assert len(peeked_msgs) == 0
 
-                deferred = await receiver.receive_deferred_messages(deferred_messages, timeout=10)
-                assert len(deferred) == 10
-                for message in deferred:
-                    assert isinstance(message, ServiceBusReceivedMessage)
-                    await receiver.complete_message(message)
+#             # send 10 messages
+#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 for i in range(10):
+#                     message = ServiceBusMessage("Handler message no. {}".format(i))
+#                     await sender.send_messages(message)
 
-                with pytest.raises(ServiceBusError):
-                    await receiver.receive_deferred_messages(deferred_messages)
+#             # check peek_messages returns correctly, with default prefetch_count > 0
+#             messages = []
+#             # prefetch 1 message from SB queue when receive is called and not on open
+#             async with sb_client.get_queue_receiver(servicebus_queue.name,
+#                                             receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE,
+#                                             prefetch_count=1,
+#                                             max_wait_time=30) as receiver:
+#                 # peek messages checks current state of SB queue, and returns 10
+#                 peeked_msgs = await receiver.peek_messages(max_message_count=10, timeout=10)
+#                 assert len(peeked_msgs) == 10
 
-    
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_async_queue_by_servicebus_client_iter_messages_with_retrieve_deferred_receiver_complete(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        async with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#                 # receive 3 messages
+#                 recvd_msgs = await receiver.receive_messages(max_message_count=3, max_wait_time=10)
+#                 assert len(recvd_msgs) == 3
 
-            deferred_messages = []
-            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                for message in [ServiceBusMessage("Deferred message no. {}".format(i)) for i in range(10)]:
-                    results = await sender.send_messages(message)
+#                 # receive rest of messages in queue
+#                 async for msg in receiver:
+#                     messages.append(msg)
+#                 assert len(messages) == 7
 
-            async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5, receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
-                count = 0
-                async for message in receiver:
-                    deferred_messages.append(message.sequence_number)
-                    print_message(_logger, message)
-                    count += 1
-                    await receiver.defer_message(message)
-            assert count == 10
+#                 # queue should be empty now
+#                 peeked_msgs = await receiver.peek_messages(max_message_count=10, timeout=10)
+#                 assert len(peeked_msgs) == 0
 
-            async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5) as receiver:
-                with pytest.raises(ValueError):
-                    await receiver.receive_deferred_messages(deferred_messages, timeout=0)
-                deferred = await receiver.receive_deferred_messages(deferred_messages)
-                assert len(deferred) == 10
-                for message in deferred:
-                    assert isinstance(message, ServiceBusReceivedMessage)
-                    assert message.lock_token
-                    assert message.locked_until_utc
-                    assert message._receiver
-                    await receiver.renew_message_lock(message)
-                    await receiver.complete_message(message)
 
-    
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_async_queue_by_servicebus_client_iter_messages_with_retrieve_deferred_receiver_deadletter(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        async with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_async_queue_by_queue_client_conn_str_receive_handler_with_stop(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         async with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-            deferred_messages = []
-            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                for message in [ServiceBusMessage("Deferred message no. {}".format(i)) for i in range(10)]:
-                    results = await sender.send_messages(message)
+#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 for i in range(10):
+#                     message = ServiceBusMessage("Stop message no. {}".format(i))
+#                     await sender.send_messages(message)
 
-            async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10, receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
-                count = 0
-                async for message in receiver:
-                    deferred_messages.append(message.sequence_number)
-                    print_message(_logger, message)
-                    count += 1
-                    await receiver.defer_message(message)
+#             messages = []
+#             receiver = sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5, prefetch_count=0) 
+#             async with receiver:
+#                 async for message in receiver:
+#                     messages.append(message)
+#                     await receiver.complete_message(message)
+#                     if len(messages) >= 5:
+#                         break
 
-            assert count == 10
+#                 assert receiver._running
+#                 assert len(messages) == 5
 
-            async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10) as receiver:
-                deferred = await receiver.receive_deferred_messages(deferred_messages, timeout=None)
-                assert len(deferred) == 10
-                for message in deferred:
-                    assert isinstance(message, ServiceBusReceivedMessage)
-                    await receiver.dead_letter_message(message, reason="Testing reason", error_description="Testing description")
+#                 async for message in receiver:
+#                     messages.append(message)
+#                     await receiver.complete_message(message)
+#                     if len(messages) >= 5:
+#                         break
 
-            count = 0
-            async with sb_client.get_queue_receiver(servicebus_queue.name, 
-                                                    sub_queue = ServiceBusSubQueue.DEAD_LETTER,
-                                                    max_wait_time=10) as receiver:
-                async for message in receiver:
-                    count += 1
-                    print_message(_logger, message)
-                    assert message.dead_letter_reason == 'Testing reason'
-                    assert message.dead_letter_error_description == 'Testing description'
-                    assert message.application_properties[b'DeadLetterReason'] == b'Testing reason'
-                    assert message.application_properties[b'DeadLetterErrorDescription'] == b'Testing description'
-                    await receiver.complete_message(message)
-            assert count == 10
+#             assert not receiver._running
+#             assert len(messages) == 6
 
     
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_async_queue_by_servicebus_client_iter_messages_with_retrieve_deferred_receiver_deletemode(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        async with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_async_queue_by_servicebus_client_iter_messages_simple(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         async with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-            deferred_messages = []
-            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                for message in [ServiceBusMessage("Deferred message no. {}".format(i)) for i in range(10)]:
-                    results = await sender.send_messages(message)
+#             async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10, receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
 
-            count = 0
-            async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10) as receiver:
-                async for message in receiver:
-                    deferred_messages.append(message.sequence_number)
-                    print_message(_logger, message)
-                    count += 1
-                    await receiver.defer_message(message)
+#                 async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                     for i in range(10):
+#                         message = ServiceBusMessage("Iter message no. {}".format(i))
+#                         await sender.send_messages(message)
 
-            assert count == 10
-            async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10, receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE.value) as receiver:
-                deferred = await receiver.receive_deferred_messages(deferred_messages)
-                assert len(deferred) == 10
-                for message in deferred:
-                    assert isinstance(message, ServiceBusReceivedMessage)
-                    with pytest.raises(ValueError):
-                        await receiver.complete_message(message)
-                with pytest.raises(ServiceBusError):
-                    deferred = await receiver.receive_deferred_messages(deferred_messages)
+#                 count = 0
+#                 async for message in receiver:
+#                     print_message(_logger, message)
+#                     await receiver.complete_message(message)
+#                     with pytest.raises(MessageAlreadySettled):
+#                         await receiver.complete_message(message)
+#                     with pytest.raises(MessageAlreadySettled):
+#                         await receiver.renew_message_lock(message)
+#                     count += 1
+
+#                 with pytest.raises(StopAsyncIteration):
+#                     await receiver.__anext__()
+
+#             assert count == 10
 
     
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_async_queue_by_servicebus_client_iter_messages_with_retrieve_deferred_not_found(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        async with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_async_queue_by_servicebus_conn_str_client_iter_messages_with_abandon(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         async with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-            deferred_messages = []
-            async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10, receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
+#             async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10, receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
 
-                async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                    for i in range(3):
-                        message = ServiceBusMessage("Deferred message no. {}".format(i))
-                        await sender.send_messages(message)
+#                 async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                     for i in range(10):
+#                         message = ServiceBusMessage("Abandoned message no. {}".format(i))
+#                         await sender.send_messages(message)
 
-                count = 0
-                async for message in receiver:
-                    deferred_messages.append(message.sequence_number)
-                    print_message(_logger, message)
-                    count += 1
-                    await receiver.defer_message(message)
+#                 count = 0
+#                 async for message in receiver:
+#                     print_message(_logger, message)
+#                     if not message.delivery_count:
+#                         count += 1
+#                         await receiver.abandon_message(message)
+#                     else:
+#                         assert message.delivery_count == 1
+#                         await receiver.complete_message(message)
 
-            assert count == 3
+#             assert count == 10
 
-            async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10, receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
-                with pytest.raises(ServiceBusError):
-                    deferred = await receiver.receive_deferred_messages([3, 4])
-
-                with pytest.raises(ServiceBusError):
-                    deferred = await receiver.receive_deferred_messages([5, 6, 7])
-
-    
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_async_queue_by_servicebus_client_receive_batch_with_deadletter(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        async with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-
-            async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10, receive_mode=ServiceBusReceiveMode.PEEK_LOCK, prefetch_count=10) as receiver:
-
-                async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                    for i in range(10):
-                        message = ServiceBusMessage("Dead lettered message no. {}".format(i))
-                        await sender.send_messages(message)
-
-                count = 0
-                messages = await receiver.receive_messages()
-                while messages:
-                    for message in messages:
-                        print_message(_logger, message)
-                        count += 1
-                        await receiver.dead_letter_message(message, reason="Testing reason", error_description="Testing description")
-                    messages = await receiver.receive_messages()
-
-            assert count == 10
-
-            async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10, receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
-                count = 0
-                async for message in receiver:
-                    print_message(_logger, message)
-                    await receiver.complete_message(message)
-                    count += 1
-            assert count == 0
-
-            async with sb_client.get_queue_receiver(
-                    servicebus_queue.name,
-                    sub_queue = ServiceBusSubQueue.DEAD_LETTER.value,
-                    max_wait_time=10,
-                    mode=ServiceBusReceiveMode.PEEK_LOCK) as dl_receiver:
-                count = 0
-                async for message in dl_receiver:
-                    await dl_receiver.complete_message(message)
-                    count += 1
-                    assert message.dead_letter_reason == 'Testing reason'
-                    assert message.dead_letter_error_description == 'Testing description'
-                    assert message.application_properties[b'DeadLetterReason'] == b'Testing reason'
-                    assert message.application_properties[b'DeadLetterErrorDescription'] == b'Testing description'
-                assert count == 10
+#             async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10, receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
+#                 count = 0
+#                 async for message in receiver:
+#                     print_message(_logger, message)
+#                     await receiver.complete_message(message)
+#                     count += 1
+#             assert count == 0
 
     
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_async_queue_by_servicebus_client_receive_batch_with_retrieve_deadletter(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        async with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_async_queue_by_servicebus_client_iter_messages_with_defer(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         async with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-            async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5, receive_mode=ServiceBusReceiveMode.PEEK_LOCK, prefetch_count=10) as receiver:
+#             deferred_messages = []
+#             async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10, receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
 
-                async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                    for i in range(10):
-                        message = ServiceBusMessage("Dead lettered message no. {}".format(i))
-                        await sender.send_messages(message)
+#                 async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                     for i in range(10):
+#                         message = ServiceBusMessage("Deferred message no. {}".format(i))
+#                         await sender.send_messages(message)
 
-                count = 0
-                messages = await receiver.receive_messages()
-                while messages:
-                    for message in messages:
-                        print_message(_logger, message)
-                        await receiver.dead_letter_message(message, reason="Testing reason", error_description="Testing description")
-                        count += 1
-                    messages = await receiver.receive_messages()
+#                 count = 0
+#                 async for message in receiver:
+#                     deferred_messages.append(message.sequence_number)
+#                     print_message(_logger, message)
+#                     count += 1
+#                     await receiver.defer_message(message)
 
-            assert count == 10
+#             assert count == 10
+#             async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10, receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
+#                 count = 0
+#                 async for message in receiver:
+#                     print_message(_logger, message)
+#                     await receiver.complete_message(message)
+#                     count += 1
+#             assert count == 0
 
-            async with sb_client.get_queue_receiver(
-                servicebus_queue.name,
-                sub_queue = ServiceBusSubQueue.DEAD_LETTER,
-                max_wait_time=5,
-                receive_mode=ServiceBusReceiveMode.PEEK_LOCK
-            ) as receiver:
-                count = 0
-                async for message in receiver:
-                    print_message(_logger, message)
-                    assert message.dead_letter_reason == 'Testing reason'
-                    assert message.dead_letter_error_description == 'Testing description'
-                    assert message.application_properties[b'DeadLetterReason'] == b'Testing reason'
-                    assert message.application_properties[b'DeadLetterErrorDescription'] == b'Testing description'
-                    await receiver.complete_message(message)
-                    count += 1
-            assert count == 10
+    
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_async_queue_by_servicebus_client_iter_messages_with_retrieve_deferred_client(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         async with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_async_queue_by_servicebus_client_session_fail(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        async with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#             deferred_messages = []
+#             async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10, receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
 
-            with pytest.raises(ServiceBusError):
-                await sb_client.get_queue_receiver(servicebus_queue.name, session_id="test")._open_with_retry()
+#                 async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                     for i in range(10):
+#                         message = ServiceBusMessage("Deferred message no. {}".format(i))
+#                         await sender.send_messages(message)
 
-            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                await sender.send_messages(ServiceBusMessage("test session sender", session_id="test"))
+#                 count = 0
+#                 async for message in receiver:
+#                     deferred_messages.append(message.sequence_number)
+#                     print_message(_logger, message)
+#                     count += 1
+#                     await receiver.defer_message(message)
 
-            async with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
-                messages = await receiver.receive_messages()
-                for message in messages:
-                    assert str(message) == "test session sender"
-                    await receiver.complete_message(message)
+#                 assert count == 10
+
+#                 deferred = await receiver.receive_deferred_messages(deferred_messages, timeout=10)
+#                 assert len(deferred) == 10
+#                 for message in deferred:
+#                     assert isinstance(message, ServiceBusReceivedMessage)
+#                     await receiver.complete_message(message)
+
+#                 with pytest.raises(ServiceBusError):
+#                     await receiver.receive_deferred_messages(deferred_messages)
+
+    
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_async_queue_by_servicebus_client_iter_messages_with_retrieve_deferred_receiver_complete(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         async with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+
+#             deferred_messages = []
+#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 for message in [ServiceBusMessage("Deferred message no. {}".format(i)) for i in range(10)]:
+#                     results = await sender.send_messages(message)
+
+#             async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5, receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
+#                 count = 0
+#                 async for message in receiver:
+#                     deferred_messages.append(message.sequence_number)
+#                     print_message(_logger, message)
+#                     count += 1
+#                     await receiver.defer_message(message)
+#             assert count == 10
+
+#             async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5) as receiver:
+#                 with pytest.raises(ValueError):
+#                     await receiver.receive_deferred_messages(deferred_messages, timeout=0)
+#                 deferred = await receiver.receive_deferred_messages(deferred_messages)
+#                 assert len(deferred) == 10
+#                 for message in deferred:
+#                     assert isinstance(message, ServiceBusReceivedMessage)
+#                     assert message.lock_token
+#                     assert message.locked_until_utc
+#                     assert message._receiver
+#                     await receiver.renew_message_lock(message)
+#                     await receiver.complete_message(message)
+
+    
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_async_queue_by_servicebus_client_iter_messages_with_retrieve_deferred_receiver_deadletter(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         async with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+
+#             deferred_messages = []
+#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 for message in [ServiceBusMessage("Deferred message no. {}".format(i)) for i in range(10)]:
+#                     results = await sender.send_messages(message)
+
+#             async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10, receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
+#                 count = 0
+#                 async for message in receiver:
+#                     deferred_messages.append(message.sequence_number)
+#                     print_message(_logger, message)
+#                     count += 1
+#                     await receiver.defer_message(message)
+
+#             assert count == 10
+
+#             async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10) as receiver:
+#                 deferred = await receiver.receive_deferred_messages(deferred_messages, timeout=None)
+#                 assert len(deferred) == 10
+#                 for message in deferred:
+#                     assert isinstance(message, ServiceBusReceivedMessage)
+#                     await receiver.dead_letter_message(message, reason="Testing reason", error_description="Testing description")
+
+#             count = 0
+#             async with sb_client.get_queue_receiver(servicebus_queue.name, 
+#                                                     sub_queue = ServiceBusSubQueue.DEAD_LETTER,
+#                                                     max_wait_time=10) as receiver:
+#                 async for message in receiver:
+#                     count += 1
+#                     print_message(_logger, message)
+#                     assert message.dead_letter_reason == 'Testing reason'
+#                     assert message.dead_letter_error_description == 'Testing description'
+#                     assert message.application_properties[b'DeadLetterReason'] == b'Testing reason'
+#                     assert message.application_properties[b'DeadLetterErrorDescription'] == b'Testing description'
+#                     await receiver.complete_message(message)
+#             assert count == 10
+
+    
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_async_queue_by_servicebus_client_iter_messages_with_retrieve_deferred_receiver_deletemode(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         async with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+
+#             deferred_messages = []
+#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 for message in [ServiceBusMessage("Deferred message no. {}".format(i)) for i in range(10)]:
+#                     results = await sender.send_messages(message)
+
+#             count = 0
+#             async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10) as receiver:
+#                 async for message in receiver:
+#                     deferred_messages.append(message.sequence_number)
+#                     print_message(_logger, message)
+#                     count += 1
+#                     await receiver.defer_message(message)
+
+#             assert count == 10
+#             async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10, receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE.value) as receiver:
+#                 deferred = await receiver.receive_deferred_messages(deferred_messages)
+#                 assert len(deferred) == 10
+#                 for message in deferred:
+#                     assert isinstance(message, ServiceBusReceivedMessage)
+#                     with pytest.raises(ValueError):
+#                         await receiver.complete_message(message)
+#                 with pytest.raises(ServiceBusError):
+#                     deferred = await receiver.receive_deferred_messages(deferred_messages)
+
+    
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_async_queue_by_servicebus_client_iter_messages_with_retrieve_deferred_not_found(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         async with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+
+#             deferred_messages = []
+#             async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10, receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
+
+#                 async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                     for i in range(3):
+#                         message = ServiceBusMessage("Deferred message no. {}".format(i))
+#                         await sender.send_messages(message)
+
+#                 count = 0
+#                 async for message in receiver:
+#                     deferred_messages.append(message.sequence_number)
+#                     print_message(_logger, message)
+#                     count += 1
+#                     await receiver.defer_message(message)
+
+#             assert count == 3
+
+#             async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10, receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
+#                 with pytest.raises(ServiceBusError):
+#                     deferred = await receiver.receive_deferred_messages([3, 4])
+
+#                 with pytest.raises(ServiceBusError):
+#                     deferred = await receiver.receive_deferred_messages([5, 6, 7])
+
+    
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_async_queue_by_servicebus_client_receive_batch_with_deadletter(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         async with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+
+#             async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10, receive_mode=ServiceBusReceiveMode.PEEK_LOCK, prefetch_count=10) as receiver:
+
+#                 async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                     for i in range(10):
+#                         message = ServiceBusMessage("Dead lettered message no. {}".format(i))
+#                         await sender.send_messages(message)
+
+#                 count = 0
+#                 messages = await receiver.receive_messages()
+#                 while messages:
+#                     for message in messages:
+#                         print_message(_logger, message)
+#                         count += 1
+#                         await receiver.dead_letter_message(message, reason="Testing reason", error_description="Testing description")
+#                     messages = await receiver.receive_messages()
+
+#             assert count == 10
+
+#             async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10, receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
+#                 count = 0
+#                 async for message in receiver:
+#                     print_message(_logger, message)
+#                     await receiver.complete_message(message)
+#                     count += 1
+#             assert count == 0
+
+#             async with sb_client.get_queue_receiver(
+#                     servicebus_queue.name,
+#                     sub_queue = ServiceBusSubQueue.DEAD_LETTER.value,
+#                     max_wait_time=10,
+#                     mode=ServiceBusReceiveMode.PEEK_LOCK) as dl_receiver:
+#                 count = 0
+#                 async for message in dl_receiver:
+#                     await dl_receiver.complete_message(message)
+#                     count += 1
+#                     assert message.dead_letter_reason == 'Testing reason'
+#                     assert message.dead_letter_error_description == 'Testing description'
+#                     assert message.application_properties[b'DeadLetterReason'] == b'Testing reason'
+#                     assert message.application_properties[b'DeadLetterErrorDescription'] == b'Testing description'
+#                 assert count == 10
+
+    
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_async_queue_by_servicebus_client_receive_batch_with_retrieve_deadletter(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         async with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+
+#             async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5, receive_mode=ServiceBusReceiveMode.PEEK_LOCK, prefetch_count=10) as receiver:
+
+#                 async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                     for i in range(10):
+#                         message = ServiceBusMessage("Dead lettered message no. {}".format(i))
+#                         await sender.send_messages(message)
+
+#                 count = 0
+#                 messages = await receiver.receive_messages()
+#                 while messages:
+#                     for message in messages:
+#                         print_message(_logger, message)
+#                         await receiver.dead_letter_message(message, reason="Testing reason", error_description="Testing description")
+#                         count += 1
+#                     messages = await receiver.receive_messages()
+
+#             assert count == 10
+
+#             async with sb_client.get_queue_receiver(
+#                 servicebus_queue.name,
+#                 sub_queue = ServiceBusSubQueue.DEAD_LETTER,
+#                 max_wait_time=5,
+#                 receive_mode=ServiceBusReceiveMode.PEEK_LOCK
+#             ) as receiver:
+#                 count = 0
+#                 async for message in receiver:
+#                     print_message(_logger, message)
+#                     assert message.dead_letter_reason == 'Testing reason'
+#                     assert message.dead_letter_error_description == 'Testing description'
+#                     assert message.application_properties[b'DeadLetterReason'] == b'Testing reason'
+#                     assert message.application_properties[b'DeadLetterErrorDescription'] == b'Testing description'
+#                     await receiver.complete_message(message)
+#                     count += 1
+#             assert count == 10
+
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_async_queue_by_servicebus_client_session_fail(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         async with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+
+#             with pytest.raises(ServiceBusError):
+#                 await sb_client.get_queue_receiver(servicebus_queue.name, session_id="test")._open_with_retry()
+
+#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 await sender.send_messages(ServiceBusMessage("test session sender", session_id="test"))
+
+#             async with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
+#                 messages = await receiver.receive_messages()
+#                 for message in messages:
+#                     assert str(message) == "test session sender"
+#                     await receiver.complete_message(message)
  
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_async_queue_by_servicebus_client_browse_messages_client(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        async with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_async_queue_by_servicebus_client_browse_messages_client(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         async with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                for i in range(5):
-                    message = ServiceBusMessage("Test message no. {}".format(i))
-                    await sender.send_messages(message)
+#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 for i in range(5):
+#                     message = ServiceBusMessage("Test message no. {}".format(i))
+#                     await sender.send_messages(message)
 
-            async with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
-                messages = await receiver.peek_messages(5)
-                assert len(messages) == 5
-                assert all(isinstance(m, ServiceBusReceivedMessage) for m in messages)
-                for message in messages:
-                    print_message(_logger, message)
-                    with pytest.raises(ValueError):
-                        await receiver.complete_message(message)
+#             async with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
+#                 messages = await receiver.peek_messages(5)
+#                 assert len(messages) == 5
+#                 assert all(isinstance(m, ServiceBusReceivedMessage) for m in messages)
+#                 for message in messages:
+#                     print_message(_logger, message)
+#                     with pytest.raises(ValueError):
+#                         await receiver.complete_message(message)
 
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_async_queue_by_servicebus_client_browse_messages_with_receiver(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        async with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_async_queue_by_servicebus_client_browse_messages_with_receiver(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         async with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-            async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5, receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
-                async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                    for i in range(5):
-                        message = ServiceBusMessage("Test message no. {}".format(i))
-                        await sender.send_messages(message)
+#             async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5, receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
+#                 async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                     for i in range(5):
+#                         message = ServiceBusMessage("Test message no. {}".format(i))
+#                         await sender.send_messages(message)
 
-                messages = await receiver.peek_messages(5, timeout=5)
-                assert len(messages) > 0
-                assert all(isinstance(m, ServiceBusReceivedMessage) for m in messages)
-                for message in messages:
-                    print_message(_logger, message)
-                    with pytest.raises(ValueError):
-                        await receiver.complete_message(message)
+#                 messages = await receiver.peek_messages(5, timeout=5)
+#                 assert len(messages) > 0
+#                 assert all(isinstance(m, ServiceBusReceivedMessage) for m in messages)
+#                 for message in messages:
+#                     print_message(_logger, message)
+#                     with pytest.raises(ValueError):
+#                         await receiver.complete_message(message)
 
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_async_queue_by_servicebus_client_browse_empty_messages(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        async with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_async_queue_by_servicebus_client_browse_empty_messages(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         async with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-            async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5, receive_mode=ServiceBusReceiveMode.PEEK_LOCK, prefetch_count=10) as receiver:
-                messages = await receiver.peek_messages(10)
-                assert len(messages) == 0
+#             async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5, receive_mode=ServiceBusReceiveMode.PEEK_LOCK, prefetch_count=10) as receiver:
+#                 messages = await receiver.peek_messages(10)
+#                 assert len(messages) == 0
 
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_async_queue_by_servicebus_client_renew_message_locks(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        async with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_async_queue_by_servicebus_client_renew_message_locks(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         async with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-            messages = []
-            locks = 3
-            async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5, receive_mode=ServiceBusReceiveMode.PEEK_LOCK, prefetch_count=10) as receiver:
-                async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                    for i in range(locks):
-                        message = ServiceBusMessage("Test message no. {}".format(i))
-                        await sender.send_messages(message)
+#             messages = []
+#             locks = 3
+#             async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5, receive_mode=ServiceBusReceiveMode.PEEK_LOCK, prefetch_count=10) as receiver:
+#                 async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                     for i in range(locks):
+#                         message = ServiceBusMessage("Test message no. {}".format(i))
+#                         await sender.send_messages(message)
 
-                messages.extend(await receiver.receive_messages())
-                recv = True
-                while recv:
-                    recv = await receiver.receive_messages()
-                    messages.extend(recv)
+#                 messages.extend(await receiver.receive_messages())
+#                 recv = True
+#                 while recv:
+#                     recv = await receiver.receive_messages()
+#                     messages.extend(recv)
 
-                try:
-                    with pytest.raises(AttributeError):
-                        assert not message._lock_expired
-                    for message in messages:
-                        time.sleep(5)
-                        initial_expiry = message.locked_until_utc
-                        await receiver.renew_message_lock(message)
-                        assert (message.locked_until_utc - initial_expiry) >= timedelta(seconds=5)
-                finally:
-                    await receiver.complete_message(messages[0])
-                    await receiver.complete_message(messages[1])
-                    sleep_until_expired(messages[2])
-                    with pytest.raises(MessageLockLostError):
-                        await receiver.complete_message(messages[2])
-
-    
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True, lock_duration='PT5S')
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_async_queue_by_queue_client_conn_str_receive_handler_with_autolockrenew(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        async with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-
-            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                for i in range(10):
-                    message = ServiceBusMessage("{}".format(i))
-                    await sender.send_messages(message)
-
-            # issue https://github.com/Azure/azure-sdk-for-python/issues/19642
-            empty_renewer = AutoLockRenewer()
-            async with empty_renewer:
-                pass
-
-            renewer = AutoLockRenewer()
-            messages = []
-            async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5, receive_mode=ServiceBusReceiveMode.PEEK_LOCK, prefetch_count=10) as receiver:
-                async for message in receiver:
-                    if not messages:
-                        messages.append(message)
-                        assert not message._lock_expired
-                        renewer.register(receiver, message, max_lock_renewal_duration=10)
-                        print("Registered lock renew thread", message.locked_until_utc, utc_now())
-                        await asyncio.sleep(10)
-                        print("Finished first sleep", message.locked_until_utc)
-                        assert not message._lock_expired
-                        await asyncio.sleep(15) #generate autolockrenewtimeout error by going one iteration past.
-                        sleep_until_expired(message)
-                        print("Finished second sleep", message.locked_until_utc, utc_now())
-                        assert message._lock_expired
-                        try:
-                            await receiver.complete_message(message)
-                            raise AssertionError("Didn't raise MessageLockLostError")
-                        except MessageLockLostError as e:
-                            assert isinstance(e.inner_exception, AutoLockRenewTimeout)
-                    else:
-                        if message._lock_expired:
-                            print("Remaining messages", message.locked_until_utc, utc_now())
-                            assert message._lock_expired
-                            with pytest.raises(MessageLockLostError):
-                                await receiver.complete_message(message)
-                        else:
-                            assert message.delivery_count >= 1
-                            print("Remaining messages", message.locked_until_utc, utc_now())
-                            messages.append(message)
-                            await receiver.complete_message(message)
-            await renewer.close()
-            assert len(messages) == 11
+#                 try:
+#                     with pytest.raises(AttributeError):
+#                         assert not message._lock_expired
+#                     for message in messages:
+#                         time.sleep(5)
+#                         initial_expiry = message.locked_until_utc
+#                         await receiver.renew_message_lock(message)
+#                         assert (message.locked_until_utc - initial_expiry) >= timedelta(seconds=5)
+#                 finally:
+#                     await receiver.complete_message(messages[0])
+#                     await receiver.complete_message(messages[1])
+#                     sleep_until_expired(messages[2])
+#                     with pytest.raises(MessageLockLostError):
+#                         await receiver.complete_message(messages[2])
 
     
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True, lock_duration='PT5S')
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_async_queue_by_queue_client_conn_str_receive_handler_with_auto_autolockrenew(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        async with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True, lock_duration='PT5S')
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_async_queue_by_queue_client_conn_str_receive_handler_with_autolockrenew(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         async with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                # The 10 iterations is "important" because it gives time for the timed out message to be received again.
-                for i in range(10):
-                    message = ServiceBusMessage("{}".format(i))
-                    await sender.send_messages(message)
+#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 for i in range(10):
+#                     message = ServiceBusMessage("{}".format(i))
+#                     await sender.send_messages(message)
 
-            renewer = AutoLockRenewer(max_lock_renewal_duration=10)
-            messages = []
-            async with sb_client.get_queue_receiver(servicebus_queue.name,
-                                                    max_wait_time=5,
-                                                    receive_mode=ServiceBusReceiveMode.PEEK_LOCK,
-                                                    prefetch_count=10,
-                                                    auto_lock_renewer=renewer) as receiver:
-                async for message in receiver:
-                    if not messages:
-                        messages.append(message)
-                        assert not message._lock_expired
-                        print("Registered lock renew thread", message.locked_until_utc, utc_now())
-                        await asyncio.sleep(10)
-                        print("Finished first sleep", message.locked_until_utc)
-                        assert not message._lock_expired
-                        await asyncio.sleep(15) #generate autolockrenewtimeout error by going one iteration past.
-                        sleep_until_expired(message)
-                        print("Finished second sleep", message.locked_until_utc, utc_now())
-                        assert message._lock_expired
-                        try:
-                            await receiver.complete_message(message)
-                            raise AssertionError("Didn't raise MessageLockLostError")
-                        except MessageLockLostError as e:
-                            assert isinstance(e.inner_exception, AutoLockRenewTimeout)
-                    else:
-                        if message._lock_expired:
-                            print("Remaining messages", message.locked_until_utc, utc_now())
-                            assert message._lock_expired
-                            with pytest.raises(MessageLockLostError):
-                                await receiver.complete_message(message)
-                        else:
-                            assert message.delivery_count >= 1
-                            print("Remaining messages", message.locked_until_utc, utc_now())
-                            messages.append(message)
-                            await receiver.complete_message(message)
-            await renewer.close()
-            assert len(messages) == 11
+#             # issue https://github.com/Azure/azure-sdk-for-python/issues/19642
+#             empty_renewer = AutoLockRenewer()
+#             async with empty_renewer:
+#                 pass
 
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_async_queue_by_servicebus_client_fail_send_messages(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        async with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#             renewer = AutoLockRenewer()
+#             messages = []
+#             async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5, receive_mode=ServiceBusReceiveMode.PEEK_LOCK, prefetch_count=10) as receiver:
+#                 async for message in receiver:
+#                     if not messages:
+#                         messages.append(message)
+#                         assert not message._lock_expired
+#                         renewer.register(receiver, message, max_lock_renewal_duration=10)
+#                         print("Registered lock renew thread", message.locked_until_utc, utc_now())
+#                         await asyncio.sleep(10)
+#                         print("Finished first sleep", message.locked_until_utc)
+#                         assert not message._lock_expired
+#                         await asyncio.sleep(15) #generate autolockrenewtimeout error by going one iteration past.
+#                         sleep_until_expired(message)
+#                         print("Finished second sleep", message.locked_until_utc, utc_now())
+#                         assert message._lock_expired
+#                         try:
+#                             await receiver.complete_message(message)
+#                             raise AssertionError("Didn't raise MessageLockLostError")
+#                         except MessageLockLostError as e:
+#                             assert isinstance(e.inner_exception, AutoLockRenewTimeout)
+#                     else:
+#                         if message._lock_expired:
+#                             print("Remaining messages", message.locked_until_utc, utc_now())
+#                             assert message._lock_expired
+#                             with pytest.raises(MessageLockLostError):
+#                                 await receiver.complete_message(message)
+#                         else:
+#                             assert message.delivery_count >= 1
+#                             print("Remaining messages", message.locked_until_utc, utc_now())
+#                             messages.append(message)
+#                             await receiver.complete_message(message)
+#             await renewer.close()
+#             assert len(messages) == 11
 
-            too_large = "A" * 1024 * 256
+    
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True, lock_duration='PT5S')
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_async_queue_by_queue_client_conn_str_receive_handler_with_auto_autolockrenew(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         async with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+
+#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 # The 10 iterations is "important" because it gives time for the timed out message to be received again.
+#                 for i in range(10):
+#                     message = ServiceBusMessage("{}".format(i))
+#                     await sender.send_messages(message)
+
+#             renewer = AutoLockRenewer(max_lock_renewal_duration=10)
+#             messages = []
+#             async with sb_client.get_queue_receiver(servicebus_queue.name,
+#                                                     max_wait_time=5,
+#                                                     receive_mode=ServiceBusReceiveMode.PEEK_LOCK,
+#                                                     prefetch_count=10,
+#                                                     auto_lock_renewer=renewer) as receiver:
+#                 async for message in receiver:
+#                     if not messages:
+#                         messages.append(message)
+#                         assert not message._lock_expired
+#                         print("Registered lock renew thread", message.locked_until_utc, utc_now())
+#                         await asyncio.sleep(10)
+#                         print("Finished first sleep", message.locked_until_utc)
+#                         assert not message._lock_expired
+#                         await asyncio.sleep(15) #generate autolockrenewtimeout error by going one iteration past.
+#                         sleep_until_expired(message)
+#                         print("Finished second sleep", message.locked_until_utc, utc_now())
+#                         assert message._lock_expired
+#                         try:
+#                             await receiver.complete_message(message)
+#                             raise AssertionError("Didn't raise MessageLockLostError")
+#                         except MessageLockLostError as e:
+#                             assert isinstance(e.inner_exception, AutoLockRenewTimeout)
+#                     else:
+#                         if message._lock_expired:
+#                             print("Remaining messages", message.locked_until_utc, utc_now())
+#                             assert message._lock_expired
+#                             with pytest.raises(MessageLockLostError):
+#                                 await receiver.complete_message(message)
+#                         else:
+#                             assert message.delivery_count >= 1
+#                             print("Remaining messages", message.locked_until_utc, utc_now())
+#                             messages.append(message)
+#                             await receiver.complete_message(message)
+#             await renewer.close()
+#             assert len(messages) == 11
+
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_async_queue_by_servicebus_client_fail_send_messages(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         async with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+
+#             too_large = "A" * 1024 * 256
             
-            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                with pytest.raises(MessageSizeExceededError):
-                    await sender.send_messages(ServiceBusMessage(too_large))
+#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 with pytest.raises(MessageSizeExceededError):
+#                     await sender.send_messages(ServiceBusMessage(too_large))
                     
-                half_too_large = "A" * int((1024 * 256) / 2)
-                with pytest.raises(MessageSizeExceededError):
-                    await sender.send_messages([ServiceBusMessage(half_too_large), ServiceBusMessage(half_too_large)])
+#                 half_too_large = "A" * int((1024 * 256) / 2)
+#                 with pytest.raises(MessageSizeExceededError):
+#                     await sender.send_messages([ServiceBusMessage(half_too_large), ServiceBusMessage(half_too_large)])
 
     
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_async_queue_message_time_to_live(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        async with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_async_queue_message_time_to_live(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         async with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                content = str(uuid.uuid4())
-                message_id = uuid.uuid4()
-                message = ServiceBusMessage(content)
-                message.time_to_live = timedelta(seconds=15)
-                await sender.send_messages(message)
+#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 content = str(uuid.uuid4())
+#                 message_id = uuid.uuid4()
+#                 message = ServiceBusMessage(content)
+#                 message.time_to_live = timedelta(seconds=15)
+#                 await sender.send_messages(message)
 
-            time.sleep(15)
-            async with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
-                messages = await receiver.receive_messages(max_wait_time=10)
-            assert not messages
+#             time.sleep(15)
+#             async with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
+#                 messages = await receiver.receive_messages(max_wait_time=10)
+#             assert not messages
 
-            async with sb_client.get_queue_receiver(servicebus_queue.name, 
-                                                    sub_queue = ServiceBusSubQueue.DEAD_LETTER,
-                                                    max_wait_time=5, 
-                                                    receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
-                count = 0
-                async for message in receiver:
-                    print_message(_logger, message)
-                    await receiver.complete_message(message)
-                    count += 1
-                assert count == 1
-
-    
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_duplicate_detection=True, dead_lettering_on_message_expiration=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_async_queue_message_duplicate_detection(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        async with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-
-            message_id = uuid.uuid4()
-
-            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                for i in range(5):
-                    message = ServiceBusMessage(str(i))
-                    message.message_id = message_id
-                    await sender.send_messages(message)
-
-            async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5) as receiver:
-                count = 0
-                async for message in receiver:
-                    print_message(_logger, message)
-                    assert message.message_id == message_id
-                    await receiver.complete_message(message)
-                    count += 1
-                assert count == 1
-
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_async_queue_message_connection_closed(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        async with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-
-            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                content = str(uuid.uuid4())
-                message = ServiceBusMessage(content)
-                await sender.send_messages(message)
-
-            async with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
-                messages = await receiver.receive_messages(max_wait_time=10)
-                assert len(messages) == 1
-
-            with pytest.raises(ValueError):
-                await receiver.complete_message(messages[0])
-
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_async_queue_message_expiry(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        async with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-
-            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                content = str(uuid.uuid4())
-                message = ServiceBusMessage(content)
-                await sender.send_messages(message)
-
-            async with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
-                messages = await receiver.receive_messages(max_wait_time=10)
-                assert len(messages) == 1
-                time.sleep(60)
-                assert messages[0]._lock_expired
-                with pytest.raises(MessageLockLostError):
-                    await receiver.complete_message(messages[0])
-                with pytest.raises(MessageLockLostError):
-                    await receiver.renew_message_lock(messages[0])
-
-            async with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
-                messages = await receiver.receive_messages(max_wait_time=30)
-                assert len(messages) == 1
-                print_message(_logger, messages[0])
-                assert messages[0].delivery_count > 0
-                await receiver.complete_message(messages[0])
-
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_async_queue_message_lock_renew(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        async with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-            
-            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                content = str(uuid.uuid4())
-                message = ServiceBusMessage(content)
-                await sender.send_messages(message)
-            
-            async with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
-                messages = await receiver.receive_messages(max_wait_time=10)
-                assert len(messages) == 1
-                time.sleep(15)
-                await receiver.renew_message_lock(messages[0], timeout=5)
-                time.sleep(15)
-                await receiver.renew_message_lock(messages[0])
-                time.sleep(15)
-                assert not messages[0]._lock_expired
-                await receiver.complete_message(messages[0])
-            
-            async with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
-                messages = await receiver.receive_messages(max_wait_time=10)
-                assert len(messages) == 0
-
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True, lock_duration='PT10S')
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_async_queue_message_receive_and_delete(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        if uamqp:
-            transport_type = uamqp.constants.TransportType.Amqp
-        else:
-            transport_type = TransportType.Amqp
-        async with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string,
-            transport_type=transport_type,
-            logging_enable=False,
-            uamqp_transport=uamqp_transport
-        ) as sb_client:
-
-            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                message = ServiceBusMessage("Receive and delete test")
-                await sender.send_messages(message)
-
-            async with sb_client.get_queue_receiver(servicebus_queue.name, receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE) as receiver:
-                messages = await receiver.receive_messages(max_wait_time=10)
-                assert len(messages) == 1
-                message = messages[0]
-                print_message(_logger, message)
-                with pytest.raises(ValueError):
-                    await receiver.complete_message(message)
-                with pytest.raises(ValueError):
-                    await receiver.abandon_message(message)
-                with pytest.raises(ValueError):
-                    await receiver.defer_message(message)
-                with pytest.raises(ValueError):
-                    await receiver.dead_letter_message(message)
-                with pytest.raises(ValueError):
-                    await receiver.renew_message_lock(message)
-
-            time.sleep(10)
-            async with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
-                messages = await receiver.receive_messages(max_wait_time=10)
-                for m in messages:
-                    print_message(_logger, m)
-                assert len(messages) == 0
-
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_async_queue_message_batch(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        async with ServiceBusClient.from_connection_string(
-                servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-
-            def message_content():
-                for i in range(5):
-                    message = ServiceBusMessage("ServiceBusMessage no. {}".format(i))
-                    message.application_properties = {'key': 'value'}
-                    message.subject = 'label'
-                    message.content_type = 'application/text'
-                    message.correlation_id = 'cid'
-                    message.message_id = str(i)
-                    message.to = 'to'
-                    message.reply_to = 'reply_to'
-                    message.time_to_live = timedelta(seconds=60)
-                    assert message.raw_amqp_message.properties.absolute_expiry_time == message.raw_amqp_message.properties.creation_time + message.raw_amqp_message.header.time_to_live
-
-                    yield message
-
-            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                # sending manually created message batch (with default pyamqp) should work for both uamqp/pyamqp
-                message = ServiceBusMessageBatch()
-                for each in message_content():
-                    message.add_message(each)
-                await sender.send_messages(message)
-
-            async with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
-                messages = await receiver.receive_messages(max_wait_time=10)
-                recv = True
-                while recv:
-                    recv = await receiver.receive_messages(max_wait_time=10)
-                    messages.extend(recv)
-
-                assert len(messages) == 5
-                count = 0
-                for message in messages:
-                    assert message.delivery_count == 0
-                    assert message.application_properties
-                    assert message.application_properties[b'key'] == b'value'
-                    assert message.subject == 'label'
-                    assert message.content_type == 'application/text'
-                    assert message.correlation_id == 'cid'
-                    assert message.message_id == str(count)
-                    assert message.to == 'to'
-                    assert message.reply_to == 'reply_to'
-                    assert message.sequence_number
-                    assert message.enqueued_time_utc
-                    assert message.expires_at_utc == (message.enqueued_time_utc + timedelta(seconds=60))
-                    print_message(_logger, message)
-                    await receiver.complete_message(message)
-                    count += 1
-
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_async_queue_schedule_message(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        async with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-
-            scheduled_enqueue_time = (utc_now() + timedelta(minutes=2)).replace(microsecond=0)
-            async with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
-                async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                    content = str(uuid.uuid4())
-                    message_id = uuid.uuid4()
-                    message = ServiceBusMessage(content)
-                    message.message_id = message_id
-                    message.scheduled_enqueue_time_utc = scheduled_enqueue_time
-                    await sender.send_messages(message)
-
-                messages = await receiver.receive_messages(max_wait_time=120)
-                if messages:
-                    try:
-                        data = str(messages[0])
-                        assert data == content
-                        assert messages[0].message_id == message_id
-                        assert messages[0].scheduled_enqueue_time_utc == scheduled_enqueue_time
-                        assert messages[0].scheduled_enqueue_time_utc <= messages[0].enqueued_time_utc.replace(microsecond=0)
-                        assert len(messages) == 1
-                    finally:
-                        for message in messages:
-                            await receiver.complete_message(message)
-                else:
-                    raise Exception("Failed to receive scheduled message.")
+#             async with sb_client.get_queue_receiver(servicebus_queue.name, 
+#                                                     sub_queue = ServiceBusSubQueue.DEAD_LETTER,
+#                                                     max_wait_time=5, 
+#                                                     receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
+#                 count = 0
+#                 async for message in receiver:
+#                     print_message(_logger, message)
+#                     await receiver.complete_message(message)
+#                     count += 1
+#                 assert count == 1
 
     
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_async_queue_schedule_multiple_messages(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        async with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-            scheduled_enqueue_time = (utc_now() + timedelta(minutes=2)).replace(microsecond=0)
-            messages = []
-            receiver = sb_client.get_queue_receiver(servicebus_queue.name, prefetch_count=20, max_wait_time=5)
-            sender = sb_client.get_queue_sender(servicebus_queue.name)
-            async with sender, receiver:
-                content = str(uuid.uuid4())
-                message_id_a = uuid.uuid4()
-                message_a = ServiceBusMessage(content)
-                message_a.message_id = message_id_a
-                message_id_b = uuid.uuid4()
-                message_b = ServiceBusMessage(content)
-                message_b.message_id = message_id_b
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_duplicate_detection=True, dead_lettering_on_message_expiration=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_async_queue_message_duplicate_detection(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         async with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-                await sender.send_messages([message_a, message_b])
+#             message_id = uuid.uuid4()
 
-                received_messages = []
-                async for message in receiver:
-                    received_messages.append(message)
-                    await receiver.complete_message(message)
+#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 for i in range(5):
+#                     message = ServiceBusMessage(str(i))
+#                     message.message_id = message_id
+#                     await sender.send_messages(message)
 
-                tokens = await sender.schedule_messages(received_messages, scheduled_enqueue_time, timeout=5)
-                assert len(tokens) == 2
+#             async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5) as receiver:
+#                 count = 0
+#                 async for message in receiver:
+#                     print_message(_logger, message)
+#                     assert message.message_id == message_id
+#                     await receiver.complete_message(message)
+#                     count += 1
+#                 assert count == 1
 
-                messages = await receiver.receive_messages(max_wait_time=120)
-                recv = await receiver.receive_messages(max_wait_time=5)
-                messages.extend(recv)
-                if messages:
-                    try:
-                        data = str(messages[0])
-                        assert data == content
-                        assert messages[0].message_id in (message_id_a, message_id_b)
-                        assert messages[0].scheduled_enqueue_time_utc == scheduled_enqueue_time
-                        assert messages[0].scheduled_enqueue_time_utc <= messages[0].enqueued_time_utc.replace(microsecond=0)
-                        assert len(messages) == 2
-                    finally:
-                        for message in messages:
-                            await receiver.complete_message(message)
-                        if not uamqp_transport:
-                            pickled = pickle.loads(pickle.dumps(messages[0]))
-                            assert pickled.message_id == messages[0].message_id
-                            assert pickled.scheduled_enqueue_time_utc == messages[0].scheduled_enqueue_time_utc
-                            assert pickled.scheduled_enqueue_time_utc <= pickled.enqueued_time_utc.replace(microsecond=0)
-                else:
-                    raise Exception("Failed to receive scheduled message.")
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_async_queue_message_connection_closed(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         async with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_async_queue_cancel_scheduled_messages(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        async with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 content = str(uuid.uuid4())
+#                 message = ServiceBusMessage(content)
+#                 await sender.send_messages(message)
 
-            enqueue_time = (utc_now() + timedelta(minutes=2)).replace(microsecond=0)
-            async with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
-                async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                    message_a = ServiceBusMessage("Test scheduled message")
-                    message_b = ServiceBusMessage("Test scheduled message")
-                    tokens = await sender.schedule_messages([message_a, message_b], enqueue_time)
-                    assert len(tokens) == 2
+#             async with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
+#                 messages = await receiver.receive_messages(max_wait_time=10)
+#                 assert len(messages) == 1
 
-                    await sender.cancel_scheduled_messages(tokens, timeout=None)
+#             with pytest.raises(ValueError):
+#                 await receiver.complete_message(messages[0])
 
-                messages = await receiver.receive_messages(max_wait_time=120)
-                assert len(messages) == 0
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_async_queue_message_expiry(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         async with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_queue_message_amqp_over_websocket(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        async with ServiceBusClient.from_connection_string(
-                servicebus_namespace_connection_string,
-                transport_type=TransportType.AmqpOverWebsocket,
-                logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 content = str(uuid.uuid4())
+#                 message = ServiceBusMessage(content)
+#                 await sender.send_messages(message)
 
-            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                assert sender._config.transport_type == TransportType.AmqpOverWebsocket
-                message = ServiceBusMessage("Test")
-                await sender.send_messages(message)
+#             async with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
+#                 messages = await receiver.receive_messages(max_wait_time=10)
+#                 assert len(messages) == 1
+#                 time.sleep(60)
+#                 assert messages[0]._lock_expired
+#                 with pytest.raises(MessageLockLostError):
+#                     await receiver.complete_message(messages[0])
+#                 with pytest.raises(MessageLockLostError):
+#                     await receiver.renew_message_lock(messages[0])
 
-            async with sb_client.get_queue_receiver(servicebus_queue.name, receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE) as receiver:
-                assert receiver._config.transport_type == TransportType.AmqpOverWebsocket
-                messages = await receiver.receive_messages(max_wait_time=5)
-                assert len(messages) == 1
+#             async with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
+#                 messages = await receiver.receive_messages(max_wait_time=30)
+#                 assert len(messages) == 1
+#                 print_message(_logger, messages[0])
+#                 assert messages[0].delivery_count > 0
+#                 await receiver.complete_message(messages[0])
 
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    def test_queue_message_http_proxy_setting(self, uamqp_transport):
-        mock_conn_str = "Endpoint=sb://mock.servicebus.windows.net/;SharedAccessKeyName=mock;SharedAccessKey=mock"
-        http_proxy = {
-            'proxy_hostname': '127.0.0.1',
-            'proxy_port': 8899,
-            'username': 'admin',
-            'password': '123456'
-        }
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_async_queue_message_lock_renew(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         async with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+            
+#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 content = str(uuid.uuid4())
+#                 message = ServiceBusMessage(content)
+#                 await sender.send_messages(message)
+            
+#             async with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
+#                 messages = await receiver.receive_messages(max_wait_time=10)
+#                 assert len(messages) == 1
+#                 time.sleep(15)
+#                 await receiver.renew_message_lock(messages[0], timeout=5)
+#                 time.sleep(15)
+#                 await receiver.renew_message_lock(messages[0])
+#                 time.sleep(15)
+#                 assert not messages[0]._lock_expired
+#                 await receiver.complete_message(messages[0])
+            
+#             async with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
+#                 messages = await receiver.receive_messages(max_wait_time=10)
+#                 assert len(messages) == 0
 
-        sb_client = ServiceBusClient.from_connection_string(mock_conn_str, http_proxy=http_proxy, uamqp_transport=uamqp_transport)
-        assert sb_client._config.http_proxy == http_proxy
-        assert sb_client._config.transport_type == TransportType.AmqpOverWebsocket
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True, lock_duration='PT10S')
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_async_queue_message_receive_and_delete(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         if uamqp:
+#             transport_type = uamqp.constants.TransportType.Amqp
+#         else:
+#             transport_type = TransportType.Amqp
+#         async with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string,
+#             transport_type=transport_type,
+#             logging_enable=False,
+#             uamqp_transport=uamqp_transport
+#         ) as sb_client:
 
-        sender = sb_client.get_queue_sender(queue_name="mock")
-        assert sender._config.http_proxy == http_proxy
-        assert sender._config.transport_type == TransportType.AmqpOverWebsocket
+#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 message = ServiceBusMessage("Receive and delete test")
+#                 await sender.send_messages(message)
 
-        receiver = sb_client.get_queue_receiver(queue_name="mock")
-        assert receiver._config.http_proxy == http_proxy
-        assert receiver._config.transport_type == TransportType.AmqpOverWebsocket
+#             async with sb_client.get_queue_receiver(servicebus_queue.name, receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE) as receiver:
+#                 messages = await receiver.receive_messages(max_wait_time=10)
+#                 assert len(messages) == 1
+#                 message = messages[0]
+#                 print_message(_logger, message)
+#                 with pytest.raises(ValueError):
+#                     await receiver.complete_message(message)
+#                 with pytest.raises(ValueError):
+#                     await receiver.abandon_message(message)
+#                 with pytest.raises(ValueError):
+#                     await receiver.defer_message(message)
+#                 with pytest.raises(ValueError):
+#                     await receiver.dead_letter_message(message)
+#                 with pytest.raises(ValueError):
+#                     await receiver.renew_message_lock(message)
 
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_queue_message_settle_through_mgmt_link_due_to_broken_receiver_link(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        async with ServiceBusClient.from_connection_string(
-                servicebus_namespace_connection_string,
-                logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#             time.sleep(10)
+#             async with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
+#                 messages = await receiver.receive_messages(max_wait_time=10)
+#                 for m in messages:
+#                     print_message(_logger, m)
+#                 assert len(messages) == 0
 
-            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                message = ServiceBusMessage("Test")
-                await sender.send_messages(message)
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_async_queue_message_batch(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         async with ServiceBusClient.from_connection_string(
+#                 servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-            async with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
-                messages = await receiver.receive_messages(max_wait_time=5)
-                # destroy the underlying receiver link
-                if uamqp_transport:
-                    await receiver._handler.message_handler.destroy_async()
-                else:
-                    await receiver._handler._link.detach()
-                assert len(messages) == 1
-                await receiver.complete_message(messages[0])
+#             def message_content():
+#                 for i in range(5):
+#                     message = ServiceBusMessage("ServiceBusMessage no. {}".format(i))
+#                     message.application_properties = {'key': 'value'}
+#                     message.subject = 'label'
+#                     message.content_type = 'application/text'
+#                     message.correlation_id = 'cid'
+#                     message.message_id = str(i)
+#                     message.to = 'to'
+#                     message.reply_to = 'reply_to'
+#                     message.time_to_live = timedelta(seconds=60)
+#                     assert message.raw_amqp_message.properties.absolute_expiry_time == message.raw_amqp_message.properties.creation_time + message.raw_amqp_message.header.time_to_live
 
-    @pytest.mark.skip('hard to test')
-    @AzureRecordedTestCase.await_prepared_test
-    async def test_async_queue_mock_auto_lock_renew_callback(self):
-        # A warning to future devs: If the renew period override heuristic in registration
-        # ever changes, it may break this (since it adjusts renew period if it is not short enough)
+#                     yield message
 
-        results = []
-        errors = []
-        async def callback_mock(renewable, error):
-            results.append(renewable)
-            if error:
-                errors.append(error)
+#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 # sending manually created message batch (with default pyamqp) should work for both uamqp/pyamqp
+#                 message = ServiceBusMessageBatch()
+#                 for each in message_content():
+#                     message.add_message(each)
+#                 await sender.send_messages(message)
 
-        receiver = MockReceiver()
-        auto_lock_renew = AutoLockRenewer()
-        with pytest.raises(TypeError):
-            auto_lock_renew.register(receiver, renewable=Exception())  # an arbitrary invalid type.
+#             async with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
+#                 messages = await receiver.receive_messages(max_wait_time=10)
+#                 recv = True
+#                 while recv:
+#                     recv = await receiver.receive_messages(max_wait_time=10)
+#                     messages.extend(recv)
 
-        auto_lock_renew = AutoLockRenewer()
-        auto_lock_renew._renew_period = 1  # So we can run the test fast.
-        async with auto_lock_renew:  # Check that it is called when the object expires for any reason (silent renew failure)
-            message = MockReceivedMessage(prevent_renew_lock=True)
-            auto_lock_renew.register(receiver, renewable=message, on_lock_renew_failure=callback_mock)
-            await asyncio.sleep(3)
-            assert len(results) == 1 and results[-1]._lock_expired == True
-            assert not errors
+#                 assert len(messages) == 5
+#                 count = 0
+#                 for message in messages:
+#                     assert message.delivery_count == 0
+#                     assert message.application_properties
+#                     assert message.application_properties[b'key'] == b'value'
+#                     assert message.subject == 'label'
+#                     assert message.content_type == 'application/text'
+#                     assert message.correlation_id == 'cid'
+#                     assert message.message_id == str(count)
+#                     assert message.to == 'to'
+#                     assert message.reply_to == 'reply_to'
+#                     assert message.sequence_number
+#                     assert message.enqueued_time_utc
+#                     assert message.expires_at_utc == (message.enqueued_time_utc + timedelta(seconds=60))
+#                     print_message(_logger, message)
+#                     await receiver.complete_message(message)
+#                     count += 1
 
-        del results[:]
-        del errors[:]
-        auto_lock_renew = AutoLockRenewer()
-        auto_lock_renew._renew_period = 1
-        async with auto_lock_renew:  # Check that in normal operation it does not get called
-            auto_lock_renew.register(receiver, renewable=MockReceivedMessage(), on_lock_renew_failure=callback_mock)
-            await asyncio.sleep(3)
-            assert not results
-            assert not errors
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_async_queue_schedule_message(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         async with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-        del results[:]
-        del errors[:]
-        auto_lock_renew = AutoLockRenewer()
-        auto_lock_renew._renew_period = 1
-        async with auto_lock_renew:  # Check that when a message is settled, it will not get called even after expiry
-            message = MockReceivedMessage(prevent_renew_lock=True)
-            auto_lock_renew.register(receiver, renewable=message, on_lock_renew_failure=callback_mock)
-            message._settled = True
-            await asyncio.sleep(3)
-            assert not results
-            assert not errors
+#             scheduled_enqueue_time = (utc_now() + timedelta(minutes=2)).replace(microsecond=0)
+#             async with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
+#                 async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                     content = str(uuid.uuid4())
+#                     message_id = uuid.uuid4()
+#                     message = ServiceBusMessage(content)
+#                     message.message_id = message_id
+#                     message.scheduled_enqueue_time_utc = scheduled_enqueue_time
+#                     await sender.send_messages(message)
 
-        del results[:]
-        del errors[:]
-        auto_lock_renew = AutoLockRenewer()
-        auto_lock_renew._renew_period = 1
-        async with auto_lock_renew: # Check that it is called when there is an overt renew failure
-            message = MockReceivedMessage(exception_on_renew_lock=True)
-            auto_lock_renew.register(receiver, renewable=message, on_lock_renew_failure=callback_mock)
-            await asyncio.sleep(3)
-            assert len(results) == 1 and results[-1]._lock_expired == True
-            assert errors[-1]
+#                 messages = await receiver.receive_messages(max_wait_time=120)
+#                 if messages:
+#                     try:
+#                         data = str(messages[0])
+#                         assert data == content
+#                         assert messages[0].message_id == message_id
+#                         assert messages[0].scheduled_enqueue_time_utc == scheduled_enqueue_time
+#                         assert messages[0].scheduled_enqueue_time_utc <= messages[0].enqueued_time_utc.replace(microsecond=0)
+#                         assert len(messages) == 1
+#                     finally:
+#                         for message in messages:
+#                             await receiver.complete_message(message)
+#                 else:
+#                     raise Exception("Failed to receive scheduled message.")
 
-        del results[:]
-        del errors[:]
-        auto_lock_renew = AutoLockRenewer()
-        auto_lock_renew._renew_period = 1
-        async with auto_lock_renew:  # Check that it is not called when the renewer is shutdown
-            message = MockReceivedMessage(prevent_renew_lock=True)
-            auto_lock_renew.register(receiver, renewable=message, on_lock_renew_failure=callback_mock)
-            await auto_lock_renew.close()
-            await asyncio.sleep(3)
-            assert not results
-            assert not errors
+    
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_async_queue_schedule_multiple_messages(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         async with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#             scheduled_enqueue_time = (utc_now() + timedelta(minutes=2)).replace(microsecond=0)
+#             messages = []
+#             receiver = sb_client.get_queue_receiver(servicebus_queue.name, prefetch_count=20, max_wait_time=5)
+#             sender = sb_client.get_queue_sender(servicebus_queue.name)
+#             async with sender, receiver:
+#                 content = str(uuid.uuid4())
+#                 message_id_a = uuid.uuid4()
+#                 message_a = ServiceBusMessage(content)
+#                 message_a.message_id = message_id_a
+#                 message_id_b = uuid.uuid4()
+#                 message_b = ServiceBusMessage(content)
+#                 message_b.message_id = message_id_b
 
-        del results[:]
-        del errors[:]
-        auto_lock_renew = AutoLockRenewer()
-        auto_lock_renew._renew_period = 1
-        async with auto_lock_renew:  # Check that it is not called when the receiver is shutdown
-            message = MockReceivedMessage(prevent_renew_lock=True)
-            auto_lock_renew.register(receiver, renewable=message, on_lock_renew_failure=callback_mock)
-            message._receiver._running = False
-            await asyncio.sleep(3)
-            assert not results
-            assert not errors
+#                 await sender.send_messages([message_a, message_b])
 
-    @AzureRecordedTestCase.await_prepared_test
-    async def test_async_queue_mock_no_reusing_auto_lock_renew(self):
-        auto_lock_renew = AutoLockRenewer()
-        auto_lock_renew._renew_period = 1
+#                 received_messages = []
+#                 async for message in receiver:
+#                     received_messages.append(message)
+#                     await receiver.complete_message(message)
 
-        receiver = MockReceiver()
-        async with auto_lock_renew:
-            auto_lock_renew.register(receiver, renewable=MockReceivedMessage())
-            await asyncio.sleep(3)
+#                 tokens = await sender.schedule_messages(received_messages, scheduled_enqueue_time, timeout=5)
+#                 assert len(tokens) == 2
 
-        with pytest.raises(ServiceBusError):
-            async with auto_lock_renew:
-                pass
+#                 messages = await receiver.receive_messages(max_wait_time=120)
+#                 recv = await receiver.receive_messages(max_wait_time=5)
+#                 messages.extend(recv)
+#                 if messages:
+#                     try:
+#                         data = str(messages[0])
+#                         assert data == content
+#                         assert messages[0].message_id in (message_id_a, message_id_b)
+#                         assert messages[0].scheduled_enqueue_time_utc == scheduled_enqueue_time
+#                         assert messages[0].scheduled_enqueue_time_utc <= messages[0].enqueued_time_utc.replace(microsecond=0)
+#                         assert len(messages) == 2
+#                     finally:
+#                         for message in messages:
+#                             await receiver.complete_message(message)
+#                         if not uamqp_transport:
+#                             pickled = pickle.loads(pickle.dumps(messages[0]))
+#                             assert pickled.message_id == messages[0].message_id
+#                             assert pickled.scheduled_enqueue_time_utc == messages[0].scheduled_enqueue_time_utc
+#                             assert pickled.scheduled_enqueue_time_utc <= pickled.enqueued_time_utc.replace(microsecond=0)
+#                 else:
+#                     raise Exception("Failed to receive scheduled message.")
 
-        with pytest.raises(ServiceBusError):
-            auto_lock_renew.register(receiver, renewable=MockReceivedMessage())
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_async_queue_cancel_scheduled_messages(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         async with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-        auto_lock_renew = AutoLockRenewer()
-        auto_lock_renew._renew_period = 1
+#             enqueue_time = (utc_now() + timedelta(minutes=2)).replace(microsecond=0)
+#             async with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
+#                 async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                     message_a = ServiceBusMessage("Test scheduled message")
+#                     message_b = ServiceBusMessage("Test scheduled message")
+#                     tokens = await sender.schedule_messages([message_a, message_b], enqueue_time)
+#                     assert len(tokens) == 2
 
-        auto_lock_renew.register(receiver, renewable=MockReceivedMessage())
-        time.sleep(3)
+#                     await sender.cancel_scheduled_messages(tokens, timeout=None)
 
-        await auto_lock_renew.close()
+#                 messages = await receiver.receive_messages(max_wait_time=120)
+#                 assert len(messages) == 0
 
-        with pytest.raises(ServiceBusError):
-            async with auto_lock_renew:
-                pass
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_queue_message_amqp_over_websocket(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         async with ServiceBusClient.from_connection_string(
+#                 servicebus_namespace_connection_string,
+#                 transport_type=TransportType.AmqpOverWebsocket,
+#                 logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-        with pytest.raises(ServiceBusError):
-            auto_lock_renew.register(receiver, renewable=MockReceivedMessage())
+#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 assert sender._config.transport_type == TransportType.AmqpOverWebsocket
+#                 message = ServiceBusMessage("Test")
+#                 await sender.send_messages(message)
 
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @CachedServiceBusQueuePreparer(name_prefix='servicebustest')
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_queue_receiver_invalid_autolockrenew_mode(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#             async with sb_client.get_queue_receiver(servicebus_queue.name, receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE) as receiver:
+#                 assert receiver._config.transport_type == TransportType.AmqpOverWebsocket
+#                 messages = await receiver.receive_messages(max_wait_time=5)
+#                 assert len(messages) == 1
+
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     def test_queue_message_http_proxy_setting(self, uamqp_transport):
+#         mock_conn_str = "Endpoint=sb://mock.servicebus.windows.net/;SharedAccessKeyName=mock;SharedAccessKey=mock"
+#         http_proxy = {
+#             'proxy_hostname': '127.0.0.1',
+#             'proxy_port': 8899,
+#             'username': 'admin',
+#             'password': '123456'
+#         }
+
+#         sb_client = ServiceBusClient.from_connection_string(mock_conn_str, http_proxy=http_proxy, uamqp_transport=uamqp_transport)
+#         assert sb_client._config.http_proxy == http_proxy
+#         assert sb_client._config.transport_type == TransportType.AmqpOverWebsocket
+
+#         sender = sb_client.get_queue_sender(queue_name="mock")
+#         assert sender._config.http_proxy == http_proxy
+#         assert sender._config.transport_type == TransportType.AmqpOverWebsocket
+
+#         receiver = sb_client.get_queue_receiver(queue_name="mock")
+#         assert receiver._config.http_proxy == http_proxy
+#         assert receiver._config.transport_type == TransportType.AmqpOverWebsocket
+
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_queue_message_settle_through_mgmt_link_due_to_broken_receiver_link(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         async with ServiceBusClient.from_connection_string(
+#                 servicebus_namespace_connection_string,
+#                 logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+
+#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 message = ServiceBusMessage("Test")
+#                 await sender.send_messages(message)
+
+#             async with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
+#                 messages = await receiver.receive_messages(max_wait_time=5)
+#                 # destroy the underlying receiver link
+#                 if uamqp_transport:
+#                     await receiver._handler.message_handler.destroy_async()
+#                 else:
+#                     await receiver._handler._link.detach()
+#                 assert len(messages) == 1
+#                 await receiver.complete_message(messages[0])
+
+#     @pytest.mark.skip('hard to test')
+#     @AzureRecordedTestCase.await_prepared_test
+#     async def test_async_queue_mock_auto_lock_renew_callback(self):
+#         # A warning to future devs: If the renew period override heuristic in registration
+#         # ever changes, it may break this (since it adjusts renew period if it is not short enough)
+
+#         results = []
+#         errors = []
+#         async def callback_mock(renewable, error):
+#             results.append(renewable)
+#             if error:
+#                 errors.append(error)
+
+#         receiver = MockReceiver()
+#         auto_lock_renew = AutoLockRenewer()
+#         with pytest.raises(TypeError):
+#             auto_lock_renew.register(receiver, renewable=Exception())  # an arbitrary invalid type.
+
+#         auto_lock_renew = AutoLockRenewer()
+#         auto_lock_renew._renew_period = 1  # So we can run the test fast.
+#         async with auto_lock_renew:  # Check that it is called when the object expires for any reason (silent renew failure)
+#             message = MockReceivedMessage(prevent_renew_lock=True)
+#             auto_lock_renew.register(receiver, renewable=message, on_lock_renew_failure=callback_mock)
+#             await asyncio.sleep(3)
+#             assert len(results) == 1 and results[-1]._lock_expired == True
+#             assert not errors
+
+#         del results[:]
+#         del errors[:]
+#         auto_lock_renew = AutoLockRenewer()
+#         auto_lock_renew._renew_period = 1
+#         async with auto_lock_renew:  # Check that in normal operation it does not get called
+#             auto_lock_renew.register(receiver, renewable=MockReceivedMessage(), on_lock_renew_failure=callback_mock)
+#             await asyncio.sleep(3)
+#             assert not results
+#             assert not errors
+
+#         del results[:]
+#         del errors[:]
+#         auto_lock_renew = AutoLockRenewer()
+#         auto_lock_renew._renew_period = 1
+#         async with auto_lock_renew:  # Check that when a message is settled, it will not get called even after expiry
+#             message = MockReceivedMessage(prevent_renew_lock=True)
+#             auto_lock_renew.register(receiver, renewable=message, on_lock_renew_failure=callback_mock)
+#             message._settled = True
+#             await asyncio.sleep(3)
+#             assert not results
+#             assert not errors
+
+#         del results[:]
+#         del errors[:]
+#         auto_lock_renew = AutoLockRenewer()
+#         auto_lock_renew._renew_period = 1
+#         async with auto_lock_renew: # Check that it is called when there is an overt renew failure
+#             message = MockReceivedMessage(exception_on_renew_lock=True)
+#             auto_lock_renew.register(receiver, renewable=message, on_lock_renew_failure=callback_mock)
+#             await asyncio.sleep(3)
+#             assert len(results) == 1 and results[-1]._lock_expired == True
+#             assert errors[-1]
+
+#         del results[:]
+#         del errors[:]
+#         auto_lock_renew = AutoLockRenewer()
+#         auto_lock_renew._renew_period = 1
+#         async with auto_lock_renew:  # Check that it is not called when the renewer is shutdown
+#             message = MockReceivedMessage(prevent_renew_lock=True)
+#             auto_lock_renew.register(receiver, renewable=message, on_lock_renew_failure=callback_mock)
+#             await auto_lock_renew.close()
+#             await asyncio.sleep(3)
+#             assert not results
+#             assert not errors
+
+#         del results[:]
+#         del errors[:]
+#         auto_lock_renew = AutoLockRenewer()
+#         auto_lock_renew._renew_period = 1
+#         async with auto_lock_renew:  # Check that it is not called when the receiver is shutdown
+#             message = MockReceivedMessage(prevent_renew_lock=True)
+#             auto_lock_renew.register(receiver, renewable=message, on_lock_renew_failure=callback_mock)
+#             message._receiver._running = False
+#             await asyncio.sleep(3)
+#             assert not results
+#             assert not errors
+
+#     @AzureRecordedTestCase.await_prepared_test
+#     async def test_async_queue_mock_no_reusing_auto_lock_renew(self):
+#         auto_lock_renew = AutoLockRenewer()
+#         auto_lock_renew._renew_period = 1
+
+#         receiver = MockReceiver()
+#         async with auto_lock_renew:
+#             auto_lock_renew.register(receiver, renewable=MockReceivedMessage())
+#             await asyncio.sleep(3)
+
+#         with pytest.raises(ServiceBusError):
+#             async with auto_lock_renew:
+#                 pass
+
+#         with pytest.raises(ServiceBusError):
+#             auto_lock_renew.register(receiver, renewable=MockReceivedMessage())
+
+#         auto_lock_renew = AutoLockRenewer()
+#         auto_lock_renew._renew_period = 1
+
+#         auto_lock_renew.register(receiver, renewable=MockReceivedMessage())
+#         time.sleep(3)
+
+#         await auto_lock_renew.close()
+
+#         with pytest.raises(ServiceBusError):
+#             async with auto_lock_renew:
+#                 pass
+
+#         with pytest.raises(ServiceBusError):
+#             auto_lock_renew.register(receiver, renewable=MockReceivedMessage())
+
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @CachedServiceBusQueuePreparer(name_prefix='servicebustest')
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_queue_receiver_invalid_autolockrenew_mode(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
         
-        async with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-            with pytest.raises(ValueError):
-                async with sb_client.get_queue_receiver(servicebus_queue.name, 
-                                                  receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE,
-                                                  auto_lock_renewer=AutoLockRenewer()) as receiver:
+#         async with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#             with pytest.raises(ValueError):
+#                 async with sb_client.get_queue_receiver(servicebus_queue.name, 
+#                                                   receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE,
+#                                                   auto_lock_renewer=AutoLockRenewer()) as receiver:
                 
-                    raise Exception("Should not get here, should fail fast because RECEIVE_AND_DELETE messages cannot be autorenewed.")
+#                     raise Exception("Should not get here, should fail fast because RECEIVE_AND_DELETE messages cannot be autorenewed.")
 
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_async_queue_receive_batch_without_setting_prefetch(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        async with ServiceBusClient.from_connection_string(
-                servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_async_queue_receive_batch_without_setting_prefetch(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         async with ServiceBusClient.from_connection_string(
+#                 servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-            def message_content():
-                for i in range(20):
-                    yield ServiceBusMessage(
-                        body=f"ServiceBusMessage no. {i}",
-                        subject='1st'
-                    )
+#             def message_content():
+#                 for i in range(20):
+#                     yield ServiceBusMessage(
+#                         body=f"ServiceBusMessage no. {i}",
+#                         subject='1st'
+#                     )
 
-            sender = sb_client.get_queue_sender(servicebus_queue.name)
-            receiver = sb_client.get_queue_receiver(servicebus_queue.name)
+#             sender = sb_client.get_queue_sender(servicebus_queue.name)
+#             receiver = sb_client.get_queue_receiver(servicebus_queue.name)
 
-            async with sender, receiver:
-                message = ServiceBusMessageBatch()
-                for each in message_content():
-                    message.add_message(each)
-                await sender.send_messages(message)
+#             async with sender, receiver:
+#                 message = ServiceBusMessageBatch()
+#                 for each in message_content():
+#                     message.add_message(each)
+#                 await sender.send_messages(message)
 
-                receive_counter = 0
-                message_1st_received_cnt = 0
-                message_2nd_received_cnt = 0
-                while message_1st_received_cnt < 20 or message_2nd_received_cnt < 20:
-                    messages = []
-                    batch = await receiver.receive_messages(max_message_count=20, max_wait_time=5)
-                    while batch:
-                        messages += batch
-                        batch = await receiver.receive_messages(max_message_count=20, max_wait_time=5)
-                    if not messages:
-                        break
-                    receive_counter += 1
-                    for message in messages:
-                        print_message(_logger, message)
-                        if message.subject == '1st':
-                            message_1st_received_cnt += 1
-                            await receiver.complete_message(message)
-                            message.subject = '2nd'
-                            await sender.send_messages(message)  # resending received message
-                        elif message.subject == '2nd':
-                            message_2nd_received_cnt += 1
-                            await receiver.complete_message(message)
+#                 receive_counter = 0
+#                 message_1st_received_cnt = 0
+#                 message_2nd_received_cnt = 0
+#                 while message_1st_received_cnt < 20 or message_2nd_received_cnt < 20:
+#                     messages = []
+#                     batch = await receiver.receive_messages(max_message_count=20, max_wait_time=5)
+#                     while batch:
+#                         messages += batch
+#                         batch = await receiver.receive_messages(max_message_count=20, max_wait_time=5)
+#                     if not messages:
+#                         break
+#                     receive_counter += 1
+#                     for message in messages:
+#                         print_message(_logger, message)
+#                         if message.subject == '1st':
+#                             message_1st_received_cnt += 1
+#                             await receiver.complete_message(message)
+#                             message.subject = '2nd'
+#                             await sender.send_messages(message)  # resending received message
+#                         elif message.subject == '2nd':
+#                             message_2nd_received_cnt += 1
+#                             await receiver.complete_message(message)
 
-                assert message_1st_received_cnt == 20 and message_2nd_received_cnt == 20
-                # Network/server might be unstable making flow control ineffective in the leading rounds of connection iteration
-                assert receive_counter < 10  # Dynamic link credit issuing come info effect
+#                 assert message_1st_received_cnt == 20 and message_2nd_received_cnt == 20
+#                 # Network/server might be unstable making flow control ineffective in the leading rounds of connection iteration
+#                 assert receive_counter < 10  # Dynamic link credit issuing come info effect
 
     
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_async_queue_receiver_alive_after_timeout(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        async with ServiceBusClient.from_connection_string(
-                servicebus_namespace_connection_string,
-                logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_async_queue_receiver_alive_after_timeout(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         async with ServiceBusClient.from_connection_string(
+#                 servicebus_namespace_connection_string,
+#                 logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                message = ServiceBusMessage("0")
-                message_1 = ServiceBusMessage("1")
-                await sender.send_messages([message, message_1])
+#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 message = ServiceBusMessage("0")
+#                 message_1 = ServiceBusMessage("1")
+#                 await sender.send_messages([message, message_1])
 
-                messages = []
-                async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10) as receiver:
+#                 messages = []
+#                 async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10) as receiver:
                     
-                    async for message in receiver:
-                        messages.append(message)
-                        break
+#                     async for message in receiver:
+#                         messages.append(message)
+#                         break
 
-                    async for message in receiver:
-                        messages.append(message)
+#                     async for message in receiver:
+#                         messages.append(message)
 
-                    for message in messages:
-                        await receiver.complete_message(message)
+#                     for message in messages:
+#                         await receiver.complete_message(message)
 
-                    assert len(messages) == 2
-                    assert str(messages[0]) == "0"
-                    assert str(messages[1]) == "1"
+#                     assert len(messages) == 2
+#                     assert str(messages[0]) == "0"
+#                     assert str(messages[1]) == "1"
 
-                    message_2 = ServiceBusMessage("2")
-                    message_3 = ServiceBusMessage("3")
-                    await sender.send_messages([message_2, message_3])
+#                     message_2 = ServiceBusMessage("2")
+#                     message_3 = ServiceBusMessage("3")
+#                     await sender.send_messages([message_2, message_3])
 
-                    async for message in receiver:
-                        messages.append(message)
-                        async for message in receiver:
-                            messages.append(message)
+#                     async for message in receiver:
+#                         messages.append(message)
+#                         async for message in receiver:
+#                             messages.append(message)
 
-                    assert len(messages) == 4
-                    assert str(messages[2]) == "2"
-                    assert str(messages[3]) == "3"
+#                     assert len(messages) == 4
+#                     assert str(messages[2]) == "2"
+#                     assert str(messages[3]) == "3"
 
-                    for message in messages[2:]:
-                        await receiver.complete_message(message)
+#                     for message in messages[2:]:
+#                         await receiver.complete_message(message)
 
-                    messages = await receiver.receive_messages()
-                    assert not messages
-
-    
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True, lock_duration='PT5M')
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_queue_receive_keep_conn_alive_async(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        async with ServiceBusClient.from_connection_string(
-                servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-
-            sender = sb_client.get_queue_sender(servicebus_queue.name)
-            receiver = sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5)
-
-            async with sender, receiver:
-                await sender.send_messages([ServiceBusMessage("message1"), ServiceBusMessage("message2")])
-
-                messages = []
-                async for message in receiver:
-                    messages.append(message)
-
-                receiver_handler = receiver._handler
-                assert len(messages) == 2
-                await asyncio.sleep(4 * 60 + 5)  # 240s is the service defined connection idle timeout
-                await receiver.renew_message_lock(messages[0])  # check mgmt link operation
-                await receiver.complete_message(messages[0])
-                await receiver.complete_message(messages[1])  # check receiver link operation
-
-                await asyncio.sleep(60)  # sleep another one minute to ensure we pass the lock_duration time
-                messages = []
-                async for message in receiver:
-                    messages.append(message)
-
-                assert len(messages) == 0  # make sure messages are removed from the queue
-                assert receiver_handler == receiver._handler  # make sure no reconnection happened
-    
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest')
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_async_queue_send_twice(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        if uamqp:
-            transport_type = uamqp.constants.TransportType.AmqpOverWebsocket
-        else:
-            transport_type = TransportType.AmqpOverWebsocket
-        async with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False,
-            transport_type=transport_type, uamqp_transport=uamqp_transport) as sb_client:
-
-            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                message = ServiceBusMessage("ServiceBusMessage")
-                message2 = ServiceBusMessage("Message2")
-                # first test batch message resending.
-                batch_message = await sender.create_message_batch()
-                batch_message._from_list([message, message2])  # pylint: disable=protected-access
-                await sender.send_messages(batch_message)
-                await sender.send_messages(batch_message)
-                messages = []
-                async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=20) as receiver:
-                    async for message in receiver:
-                        messages.append(message)
-                        await receiver.complete_message(message)
-                    assert len(messages) == 4
-                # then normal message resending
-                await sender.send_messages(message)
-                await sender.send_messages(message)
-                expected_count = 2
-                if not uamqp_transport:
-                    # pyamqp re-send received pickled message
-                    pickled_recvd = pickle.loads(pickle.dumps(messages[0]))
-                    await sender.send_messages(pickled_recvd)
-                    expected_count = 3
-            messages = []
-            async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=20) as receiver:
-                # pyamqp receiver should be picklable
-                async for message in receiver:
-                    messages.append(message)
-                    await receiver.complete_message(message)
-                assert len(messages) == expected_count
-
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @CachedServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_async_queue_send_timeout(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        async def _hack_amqp_sender_run_async(self, **kwargs):
-            time.sleep(6)  # sleep until timeout
-            if uamqp_transport:
-                await self.message_handler.work_async()
-                self._waiting_messages = 0
-                self._pending_messages = self._filter_pending()
-                if self._backoff and not self._waiting_messages:
-                    _logger.info("Client told to backoff - sleeping for %r seconds", self._backoff)
-                    await self._connection.sleep_async(self._backoff)
-                    self._backoff = 0
-                await self._connection.work_async()
-            else:
-                try:
-                    await self._link.update_pending_deliveries()
-                    await self._connection.listen(wait=self._socket_timeout, **kwargs)
-                except ValueError:
-                    self._shutdown = True
-                    return False
-            return True
-
-        async with ServiceBusClient.from_connection_string(
-                servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                # this one doesn't need to reset the method, as it's hacking the method on the instance
-                sender._handler._client_run_async = types.MethodType(_hack_amqp_sender_run_async, sender._handler)
-                with pytest.raises(OperationTimeoutError):
-                    await sender.send_messages(ServiceBusMessage("body"), timeout=5)
-
-        if not uamqp_transport:
-            # Amqp
-            async with ServiceBusClient.from_connection_string(
-                servicebus_namespace_connection_string,
-                uamqp_transport=uamqp_transport
-            ) as sb_client:
-                async with sb_client.get_queue_sender(servicebus_queue.name, socket_timeout=1.0) as sender:
-                    payload = "A" * 250 * 1024
-                    await sender.send_messages(ServiceBusMessage(payload))
-
-            if uamqp:
-                transport_type = uamqp.constants.TransportType.AmqpOverWebsocket
-            else:
-                transport_type = TransportType.AmqpOverWebsocket
-            # AmqpOverWebsocket
-            async with ServiceBusClient.from_connection_string(
-                servicebus_namespace_connection_string,
-                transport_type=transport_type,
-                uamqp_transport=uamqp_transport
-            ) as sb_client:
-                async with sb_client.get_queue_sender(servicebus_queue.name, socket_timeout=1.2) as sender:
-                    payload = "A" * 250 * 1024
-                    await sender.send_messages(ServiceBusMessage(payload))
-
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_async_queue_send_large_message_receive(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-
-        async with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string,
-            uamqp_transport=uamqp_transport
-        ) as sb_client:
-            async with sb_client.get_queue_sender(servicebus_queue.name, socket_timeout=1.0) as sender:
-                payload = "A" * 250 * 1024
-                await sender.send_messages(ServiceBusMessage(payload))
-
-        if uamqp:
-            transport_type = uamqp.constants.TransportType.AmqpOverWebsocket
-        else:
-            transport_type = TransportType.AmqpOverWebsocket
-        # AmqpOverWebsocket
-        async with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string,
-            transport_type=transport_type,
-            uamqp_transport=uamqp_transport
-        ) as sb_client:
-            async with sb_client.get_queue_sender(servicebus_queue.name, socket_timeout=1.2) as sender:
-                payload = "A" * 250 * 1024
-                await sender.send_messages(ServiceBusMessage(payload))
-
-        # ReceiveMessages
-        async with ServiceBusClient.from_connection_string(
-                servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-            async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5) as receiver:
-                messages = await receiver.receive_messages(max_message_count=5, max_wait_time=5)
-                for message in messages:
-                    if not uamqp_transport:
-                        assert message._delivery_id is not None
-                        assert message._message.data[0].decode("utf-8")  == "A" * 250 * 1024
-                    await receiver.complete_message(message)  # complete messages 
-
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @CachedServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_async_queue_mgmt_operation_timeout(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        if uamqp_transport:
-            async def hack_mgmt_execute_async(self, operation, op_type, message, timeout=0):
-                start_time = self._counter.get_current_ms()
-                operation_id = str(uuid.uuid4())
-                self._responses[operation_id] = None
-
-                await asyncio.sleep(6)  # sleep until timeout
-                while not self._responses[operation_id] and not self.mgmt_error:
-                    if timeout > 0:
-                        now = self._counter.get_current_ms()
-                        if (now - start_time) >= timeout:
-                            raise uamqp.compat.TimeoutException("Failed to receive mgmt response in {}ms".format(timeout))
-                    await self.connection.work_async()
-                if self.mgmt_error:
-                    raise self.mgmt_error
-                response = self._responses.pop(operation_id)
-                return response
-
-            original_execute_method = uamqp.async_ops.mgmt_operation_async.MgmtOperationAsync.execute_async
-            # hack the mgmt method on the class, not on an instance, so it needs reset
-        else:
-            async def hack_mgmt_execute_async(self, message, operation=None, operation_type=None, timeout=0):
-                start_time = time.time()
-                operation_id = str(uuid.uuid4())
-                self._responses[operation_id] = None
-                self._mgmt_error = None
-
-                await asyncio.sleep(6)  # sleep until timeout
-                while not self._responses[operation_id] and not self._mgmt_error:
-                    if timeout and timeout > 0:
-                        now = time.time()
-                        if (now - start_time) >= timeout:
-                            raise TimeoutError("Failed to receive mgmt response in {}ms".format(timeout))
-                    await self.connection.listen()
-                if self._mgmt_error:
-                    self._responses.pop(operation_id)
-                    raise self._mgmt_error
-                response = self._responses.pop(operation_id)
-                return response
-
-            original_execute_method = _management_operation_async.ManagementOperation.execute
-            # hack the mgmt method on the class, not on an instance, so it needs reset
-        try:
-            if uamqp_transport:
-                uamqp.async_ops.mgmt_operation_async.MgmtOperationAsync.execute_async = hack_mgmt_execute_async
-            else:
-                _management_operation_async.ManagementOperation.execute = hack_mgmt_execute_async
-            async with ServiceBusClient.from_connection_string(
-                    servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-                async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                    with pytest.raises(OperationTimeoutError):
-                        scheduled_time_utc = utc_now() + timedelta(seconds=30)
-                        await sender.schedule_messages(ServiceBusMessage("ServiceBusMessage to be scheduled"), scheduled_time_utc, timeout=5)
-        finally:
-            # must reset the mgmt execute method, otherwise other test cases would use the hacked execute method, leading to timeout error
-            if uamqp_transport:
-                uamqp.async_ops.mgmt_operation_async.MgmtOperationAsync.execute_async = original_execute_method
-            else:
-                _management_operation_async.ManagementOperation.execute = original_execute_method
-
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @CachedServiceBusQueuePreparer(name_prefix='servicebustest', lock_duration='PT10S')
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_async_queue_operation_negative(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        if uamqp_transport:
-            def _hack_amqp_message_complete(cls):
-                raise RuntimeError()
-
-            def _hack_amqp_mgmt_request(cls, message, operation, op_type=None, node=None, callback=None, **kwargs):
-                raise uamqp.errors.AMQPConnectionError()
-
-            def _hack_sb_receiver_settle_message(self, message, settle_operation, dead_letter_reason=None, dead_letter_error_description=None):
-                raise uamqp.errors.AMQPError()
-        else:
-            async def _hack_amqp_message_complete(cls, _, settlement):
-                if settlement == 'completed':
-                    raise RuntimeError()
-
-            async def _hack_amqp_mgmt_request(cls, message, operation, op_type=None, node=None, callback=None, **kwargs):
-                raise error.AMQPConnectionError(error.ErrorCondition.ConnectionCloseForced)
-
-            async def _hack_sb_receiver_settle_message(self, message, settle_operation, dead_letter_reason=None, dead_letter_error_description=None):
-                raise error.AMQPException(error.ErrorCondition.ClientError)
-
-        async with ServiceBusClient.from_connection_string(
-                servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-            sender = sb_client.get_queue_sender(servicebus_queue.name)
-            receiver = sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10)
-            if not uamqp_transport:
-                original_settlement = ReceiveClientAsync.settle_messages_async
-            try:
-                async with sender, receiver:
-                    # negative settlement via receiver link
-                    await sender.send_messages(ServiceBusMessage("body"), timeout=5)
-                    message = (await receiver.receive_messages(max_wait_time=10))[0]
-                    if uamqp_transport:
-                        message._message.accept = types.MethodType(_hack_amqp_message_complete, message._message)
-                    else:
-                        ReceiveClientAsync.settle_messages_async = types.MethodType(_hack_amqp_message_complete, receiver._handler)
-                    await receiver.complete_message(message)  # settle via mgmt link
-
-                    if uamqp_transport:
-                        amqp_client = uamqp.AMQPClientAsync
-                    else:
-                        amqp_client = AMQPClientAsync
-
-                    origin_amqp_client_mgmt_request_method = amqp_client.mgmt_request_async
-                    try:
-                        amqp_client.mgmt_request_async = _hack_amqp_mgmt_request
-                        with pytest.raises(ServiceBusConnectionError):
-                            receiver._handler.mgmt_request_async = types.MethodType(_hack_amqp_mgmt_request, receiver._handler)
-                            await receiver.peek_messages()
-                    finally:
-                        amqp_client.mgmt_request_async = origin_amqp_client_mgmt_request_method
-
-                    await sender.send_messages(ServiceBusMessage("body"), timeout=5)
-
-                    message = (await receiver.receive_messages(max_wait_time=10))[0]
-                    origin_sb_receiver_settle_message_method = receiver._settle_message
-                    receiver._settle_message = types.MethodType(_hack_sb_receiver_settle_message, receiver)
-                    with pytest.raises(ServiceBusError):
-                        await receiver.complete_message(message)
-
-                    receiver._settle_message = origin_sb_receiver_settle_message_method
-                    message = (await receiver.receive_messages(max_wait_time=10))[0]
-                    await receiver.complete_message(message)
-            finally:
-                if not uamqp_transport:
-                    ReceiveClientAsync.settle_messages_async = original_settlement
+#                     messages = await receiver.receive_messages()
+#                     assert not messages
 
     
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_async_send_message_no_body(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        async with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string) as sb_client:
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True, lock_duration='PT5M')
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_queue_receive_keep_conn_alive_async(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         async with ServiceBusClient.from_connection_string(
+#                 servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                await sender.send_messages(ServiceBusMessage(body=None))
+#             sender = sb_client.get_queue_sender(servicebus_queue.name)
+#             receiver = sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5)
 
-            async with sb_client.get_queue_receiver(servicebus_queue.name,  
-                                            max_wait_time=10) as receiver:
-                message = await receiver.__anext__()
-                assert message.body is None
-                await receiver.complete_message(message)
+#             async with sender, receiver:
+#                 await sender.send_messages([ServiceBusMessage("message1"), ServiceBusMessage("message2")])
 
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @CachedServiceBusQueuePreparer(name_prefix='servicebustest')
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_async_queue_by_servicebus_client_enum_case_sensitivity(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        # Note: This test is currently intended to enforce case-sensitivity.  If we eventually upgrade to the Fancy Enums being used with new autorest,
-        # we may want to tweak this.
-        async with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-            async with sb_client.get_queue_receiver(servicebus_queue.name, 
-                                              receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE.value, 
-                                              max_wait_time=5) as receiver:
-                pass
-            with pytest.raises(ValueError):
-                async with sb_client.get_queue_receiver(servicebus_queue.name, 
-                                                  receive_mode=str.upper(ServiceBusReceiveMode.RECEIVE_AND_DELETE.value),
-                                                  max_wait_time=5) as receiver:
-                    raise Exception("Should not get here, should be case sensitive.")
-            async with sb_client.get_queue_receiver(servicebus_queue.name, 
-                                              sub_queue=ServiceBusSubQueue.DEAD_LETTER.value,
-                                              max_wait_time=5) as receiver:
-                pass
-            with pytest.raises(ValueError):
-                async with sb_client.get_queue_receiver(servicebus_queue.name, 
-                                                  sub_queue=str.upper(ServiceBusSubQueue.DEAD_LETTER.value),
-                                                  max_wait_time=5) as receiver:
-                    raise Exception("Should not get here, should be case sensitive.")
+#                 messages = []
+#                 async for message in receiver:
+#                     messages.append(message)
+
+#                 receiver_handler = receiver._handler
+#                 assert len(messages) == 2
+#                 await asyncio.sleep(4 * 60 + 5)  # 240s is the service defined connection idle timeout
+#                 await receiver.renew_message_lock(messages[0])  # check mgmt link operation
+#                 await receiver.complete_message(messages[0])
+#                 await receiver.complete_message(messages[1])  # check receiver link operation
+
+#                 await asyncio.sleep(60)  # sleep another one minute to ensure we pass the lock_duration time
+#                 messages = []
+#                 async for message in receiver:
+#                     messages.append(message)
+
+#                 assert len(messages) == 0  # make sure messages are removed from the queue
+#                 assert receiver_handler == receiver._handler  # make sure no reconnection happened
+    
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest')
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_async_queue_send_twice(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         if uamqp:
+#             transport_type = uamqp.constants.TransportType.AmqpOverWebsocket
+#         else:
+#             transport_type = TransportType.AmqpOverWebsocket
+#         async with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False,
+#             transport_type=transport_type, uamqp_transport=uamqp_transport) as sb_client:
+
+#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 message = ServiceBusMessage("ServiceBusMessage")
+#                 message2 = ServiceBusMessage("Message2")
+#                 # first test batch message resending.
+#                 batch_message = await sender.create_message_batch()
+#                 batch_message._from_list([message, message2])  # pylint: disable=protected-access
+#                 await sender.send_messages(batch_message)
+#                 await sender.send_messages(batch_message)
+#                 messages = []
+#                 async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=20) as receiver:
+#                     async for message in receiver:
+#                         messages.append(message)
+#                         await receiver.complete_message(message)
+#                     assert len(messages) == 4
+#                 # then normal message resending
+#                 await sender.send_messages(message)
+#                 await sender.send_messages(message)
+#                 expected_count = 2
+#                 if not uamqp_transport:
+#                     # pyamqp re-send received pickled message
+#                     pickled_recvd = pickle.loads(pickle.dumps(messages[0]))
+#                     await sender.send_messages(pickled_recvd)
+#                     expected_count = 3
+#             messages = []
+#             async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=20) as receiver:
+#                 # pyamqp receiver should be picklable
+#                 async for message in receiver:
+#                     messages.append(message)
+#                     await receiver.complete_message(message)
+#                 assert len(messages) == expected_count
+
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @CachedServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_async_queue_send_timeout(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         async def _hack_amqp_sender_run_async(self, **kwargs):
+#             time.sleep(6)  # sleep until timeout
+#             if uamqp_transport:
+#                 await self.message_handler.work_async()
+#                 self._waiting_messages = 0
+#                 self._pending_messages = self._filter_pending()
+#                 if self._backoff and not self._waiting_messages:
+#                     _logger.info("Client told to backoff - sleeping for %r seconds", self._backoff)
+#                     await self._connection.sleep_async(self._backoff)
+#                     self._backoff = 0
+#                 await self._connection.work_async()
+#             else:
+#                 try:
+#                     await self._link.update_pending_deliveries()
+#                     await self._connection.listen(wait=self._socket_timeout, **kwargs)
+#                 except ValueError:
+#                     self._shutdown = True
+#                     return False
+#             return True
+
+#         async with ServiceBusClient.from_connection_string(
+#                 servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 # this one doesn't need to reset the method, as it's hacking the method on the instance
+#                 sender._handler._client_run_async = types.MethodType(_hack_amqp_sender_run_async, sender._handler)
+#                 with pytest.raises(OperationTimeoutError):
+#                     await sender.send_messages(ServiceBusMessage("body"), timeout=5)
+
+#         if not uamqp_transport:
+#             # Amqp
+#             async with ServiceBusClient.from_connection_string(
+#                 servicebus_namespace_connection_string,
+#                 uamqp_transport=uamqp_transport
+#             ) as sb_client:
+#                 async with sb_client.get_queue_sender(servicebus_queue.name, socket_timeout=1.0) as sender:
+#                     payload = "A" * 250 * 1024
+#                     await sender.send_messages(ServiceBusMessage(payload))
+
+#             if uamqp:
+#                 transport_type = uamqp.constants.TransportType.AmqpOverWebsocket
+#             else:
+#                 transport_type = TransportType.AmqpOverWebsocket
+#             # AmqpOverWebsocket
+#             async with ServiceBusClient.from_connection_string(
+#                 servicebus_namespace_connection_string,
+#                 transport_type=transport_type,
+#                 uamqp_transport=uamqp_transport
+#             ) as sb_client:
+#                 async with sb_client.get_queue_sender(servicebus_queue.name, socket_timeout=1.2) as sender:
+#                     payload = "A" * 250 * 1024
+#                     await sender.send_messages(ServiceBusMessage(payload))
+
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_async_queue_send_large_message_receive(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+
+#         async with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string,
+#             uamqp_transport=uamqp_transport
+#         ) as sb_client:
+#             async with sb_client.get_queue_sender(servicebus_queue.name, socket_timeout=1.0) as sender:
+#                 payload = "A" * 250 * 1024
+#                 await sender.send_messages(ServiceBusMessage(payload))
+
+#         if uamqp:
+#             transport_type = uamqp.constants.TransportType.AmqpOverWebsocket
+#         else:
+#             transport_type = TransportType.AmqpOverWebsocket
+#         # AmqpOverWebsocket
+#         async with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string,
+#             transport_type=transport_type,
+#             uamqp_transport=uamqp_transport
+#         ) as sb_client:
+#             async with sb_client.get_queue_sender(servicebus_queue.name, socket_timeout=1.2) as sender:
+#                 payload = "A" * 250 * 1024
+#                 await sender.send_messages(ServiceBusMessage(payload))
+
+#         # ReceiveMessages
+#         async with ServiceBusClient.from_connection_string(
+#                 servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#             async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5) as receiver:
+#                 messages = await receiver.receive_messages(max_message_count=5, max_wait_time=5)
+#                 for message in messages:
+#                     if not uamqp_transport:
+#                         assert message._delivery_id is not None
+#                         assert message._message.data[0].decode("utf-8")  == "A" * 250 * 1024
+#                     await receiver.complete_message(message)  # complete messages 
+
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @CachedServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_async_queue_mgmt_operation_timeout(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         if uamqp_transport:
+#             async def hack_mgmt_execute_async(self, operation, op_type, message, timeout=0):
+#                 start_time = self._counter.get_current_ms()
+#                 operation_id = str(uuid.uuid4())
+#                 self._responses[operation_id] = None
+
+#                 await asyncio.sleep(6)  # sleep until timeout
+#                 while not self._responses[operation_id] and not self.mgmt_error:
+#                     if timeout > 0:
+#                         now = self._counter.get_current_ms()
+#                         if (now - start_time) >= timeout:
+#                             raise uamqp.compat.TimeoutException("Failed to receive mgmt response in {}ms".format(timeout))
+#                     await self.connection.work_async()
+#                 if self.mgmt_error:
+#                     raise self.mgmt_error
+#                 response = self._responses.pop(operation_id)
+#                 return response
+
+#             original_execute_method = uamqp.async_ops.mgmt_operation_async.MgmtOperationAsync.execute_async
+#             # hack the mgmt method on the class, not on an instance, so it needs reset
+#         else:
+#             async def hack_mgmt_execute_async(self, message, operation=None, operation_type=None, timeout=0):
+#                 start_time = time.time()
+#                 operation_id = str(uuid.uuid4())
+#                 self._responses[operation_id] = None
+#                 self._mgmt_error = None
+
+#                 await asyncio.sleep(6)  # sleep until timeout
+#                 while not self._responses[operation_id] and not self._mgmt_error:
+#                     if timeout and timeout > 0:
+#                         now = time.time()
+#                         if (now - start_time) >= timeout:
+#                             raise TimeoutError("Failed to receive mgmt response in {}ms".format(timeout))
+#                     await self.connection.listen()
+#                 if self._mgmt_error:
+#                     self._responses.pop(operation_id)
+#                     raise self._mgmt_error
+#                 response = self._responses.pop(operation_id)
+#                 return response
+
+#             original_execute_method = _management_operation_async.ManagementOperation.execute
+#             # hack the mgmt method on the class, not on an instance, so it needs reset
+#         try:
+#             if uamqp_transport:
+#                 uamqp.async_ops.mgmt_operation_async.MgmtOperationAsync.execute_async = hack_mgmt_execute_async
+#             else:
+#                 _management_operation_async.ManagementOperation.execute = hack_mgmt_execute_async
+#             async with ServiceBusClient.from_connection_string(
+#                     servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#                 async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                     with pytest.raises(OperationTimeoutError):
+#                         scheduled_time_utc = utc_now() + timedelta(seconds=30)
+#                         await sender.schedule_messages(ServiceBusMessage("ServiceBusMessage to be scheduled"), scheduled_time_utc, timeout=5)
+#         finally:
+#             # must reset the mgmt execute method, otherwise other test cases would use the hacked execute method, leading to timeout error
+#             if uamqp_transport:
+#                 uamqp.async_ops.mgmt_operation_async.MgmtOperationAsync.execute_async = original_execute_method
+#             else:
+#                 _management_operation_async.ManagementOperation.execute = original_execute_method
+
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @CachedServiceBusQueuePreparer(name_prefix='servicebustest', lock_duration='PT10S')
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_async_queue_operation_negative(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         if uamqp_transport:
+#             def _hack_amqp_message_complete(cls):
+#                 raise RuntimeError()
+
+#             def _hack_amqp_mgmt_request(cls, message, operation, op_type=None, node=None, callback=None, **kwargs):
+#                 raise uamqp.errors.AMQPConnectionError()
+
+#             def _hack_sb_receiver_settle_message(self, message, settle_operation, dead_letter_reason=None, dead_letter_error_description=None):
+#                 raise uamqp.errors.AMQPError()
+#         else:
+#             async def _hack_amqp_message_complete(cls, _, settlement):
+#                 if settlement == 'completed':
+#                     raise RuntimeError()
+
+#             async def _hack_amqp_mgmt_request(cls, message, operation, op_type=None, node=None, callback=None, **kwargs):
+#                 raise error.AMQPConnectionError(error.ErrorCondition.ConnectionCloseForced)
+
+#             async def _hack_sb_receiver_settle_message(self, message, settle_operation, dead_letter_reason=None, dead_letter_error_description=None):
+#                 raise error.AMQPException(error.ErrorCondition.ClientError)
+
+#         async with ServiceBusClient.from_connection_string(
+#                 servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#             sender = sb_client.get_queue_sender(servicebus_queue.name)
+#             receiver = sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10)
+#             if not uamqp_transport:
+#                 original_settlement = ReceiveClientAsync.settle_messages_async
+#             try:
+#                 async with sender, receiver:
+#                     # negative settlement via receiver link
+#                     await sender.send_messages(ServiceBusMessage("body"), timeout=5)
+#                     message = (await receiver.receive_messages(max_wait_time=10))[0]
+#                     if uamqp_transport:
+#                         message._message.accept = types.MethodType(_hack_amqp_message_complete, message._message)
+#                     else:
+#                         ReceiveClientAsync.settle_messages_async = types.MethodType(_hack_amqp_message_complete, receiver._handler)
+#                     await receiver.complete_message(message)  # settle via mgmt link
+
+#                     if uamqp_transport:
+#                         amqp_client = uamqp.AMQPClientAsync
+#                     else:
+#                         amqp_client = AMQPClientAsync
+
+#                     origin_amqp_client_mgmt_request_method = amqp_client.mgmt_request_async
+#                     try:
+#                         amqp_client.mgmt_request_async = _hack_amqp_mgmt_request
+#                         with pytest.raises(ServiceBusConnectionError):
+#                             receiver._handler.mgmt_request_async = types.MethodType(_hack_amqp_mgmt_request, receiver._handler)
+#                             await receiver.peek_messages()
+#                     finally:
+#                         amqp_client.mgmt_request_async = origin_amqp_client_mgmt_request_method
+
+#                     await sender.send_messages(ServiceBusMessage("body"), timeout=5)
+
+#                     message = (await receiver.receive_messages(max_wait_time=10))[0]
+#                     origin_sb_receiver_settle_message_method = receiver._settle_message
+#                     receiver._settle_message = types.MethodType(_hack_sb_receiver_settle_message, receiver)
+#                     with pytest.raises(ServiceBusError):
+#                         await receiver.complete_message(message)
+
+#                     receiver._settle_message = origin_sb_receiver_settle_message_method
+#                     message = (await receiver.receive_messages(max_wait_time=10))[0]
+#                     await receiver.complete_message(message)
+#             finally:
+#                 if not uamqp_transport:
+#                     ReceiveClientAsync.settle_messages_async = original_settlement
+
+    
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_async_send_message_no_body(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         async with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string) as sb_client:
+
+#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 await sender.send_messages(ServiceBusMessage(body=None))
+
+#             async with sb_client.get_queue_receiver(servicebus_queue.name,  
+#                                             max_wait_time=10) as receiver:
+#                 message = await receiver.__anext__()
+#                 assert message.body is None
+#                 await receiver.complete_message(message)
+
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @CachedServiceBusQueuePreparer(name_prefix='servicebustest')
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_async_queue_by_servicebus_client_enum_case_sensitivity(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         # Note: This test is currently intended to enforce case-sensitivity.  If we eventually upgrade to the Fancy Enums being used with new autorest,
+#         # we may want to tweak this.
+#         async with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#             async with sb_client.get_queue_receiver(servicebus_queue.name, 
+#                                               receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE.value, 
+#                                               max_wait_time=5) as receiver:
+#                 pass
+#             with pytest.raises(ValueError):
+#                 async with sb_client.get_queue_receiver(servicebus_queue.name, 
+#                                                   receive_mode=str.upper(ServiceBusReceiveMode.RECEIVE_AND_DELETE.value),
+#                                                   max_wait_time=5) as receiver:
+#                     raise Exception("Should not get here, should be case sensitive.")
+#             async with sb_client.get_queue_receiver(servicebus_queue.name, 
+#                                               sub_queue=ServiceBusSubQueue.DEAD_LETTER.value,
+#                                               max_wait_time=5) as receiver:
+#                 pass
+#             with pytest.raises(ValueError):
+#                 async with sb_client.get_queue_receiver(servicebus_queue.name, 
+#                                                   sub_queue=str.upper(ServiceBusSubQueue.DEAD_LETTER.value),
+#                                                   max_wait_time=5) as receiver:
+#                     raise Exception("Should not get here, should be case sensitive.")
 
       
-    @pytest.mark.asyncio          
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest')
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_queue_async_send_dict_messages(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        async with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#     @pytest.mark.asyncio          
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest')
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_queue_async_send_dict_messages(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         async with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
 
-                message_dict = {"body": "Message"}
-                message2_dict = {"body": "Message2"}
-                list_message_dicts = [message_dict, message2_dict]
+#                 message_dict = {"body": "Message"}
+#                 message2_dict = {"body": "Message2"}
+#                 list_message_dicts = [message_dict, message2_dict]
 
-                # send single dict
-                await sender.send_messages(message_dict)
+#                 # send single dict
+#                 await sender.send_messages(message_dict)
 
-                # send list of dicts
-                await sender.send_messages(list_message_dicts)
+#                 # send list of dicts
+#                 await sender.send_messages(list_message_dicts)
 
-                # create and send BatchMessage with dicts
-                batch_message = await sender.create_message_batch()
-                batch_message._from_list(list_message_dicts)  # pylint: disable=protected-access
-                batch_message.add_message(message_dict)
-                await sender.send_messages(batch_message)
+#                 # create and send BatchMessage with dicts
+#                 batch_message = await sender.create_message_batch()
+#                 batch_message._from_list(list_message_dicts)  # pylint: disable=protected-access
+#                 batch_message.add_message(message_dict)
+#                 await sender.send_messages(batch_message)
 
-                received_messages = []
-                async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5) as receiver:
-                    async for message in receiver:
-                        received_messages.append(message)
-                assert len(received_messages) == 6
+#                 received_messages = []
+#                 async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5) as receiver:
+#                     async for message in receiver:
+#                         received_messages.append(message)
+#                 assert len(received_messages) == 6
 
-                batch_message = await sender.create_message_batch(max_size_in_bytes=73)
-                for _ in range(2):
-                    try:
-                        batch_message.add_message(message_dict)
-                    except ValueError:
-                        break
-                await sender.send_messages(batch_message)
-                received_messages = []
-                async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5) as receiver:
-                    async for message in receiver:
-                        received_messages.append(message)
-                assert len(received_messages) == 1
+#                 batch_message = await sender.create_message_batch(max_size_in_bytes=73)
+#                 for _ in range(2):
+#                     try:
+#                         batch_message.add_message(message_dict)
+#                     except ValueError:
+#                         break
+#                 await sender.send_messages(batch_message)
+#                 received_messages = []
+#                 async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5) as receiver:
+#                     async for message in receiver:
+#                         received_messages.append(message)
+#                 assert len(received_messages) == 1
 
     
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest')
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_queue_async_send_mapping_messages(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        class MappingMessage(DictMixin):
-            def __init__(self, content):
-                self.body = content
-                self.message_id = 'foo'
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest')
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_queue_async_send_mapping_messages(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         class MappingMessage(DictMixin):
+#             def __init__(self, content):
+#                 self.body = content
+#                 self.message_id = 'foo'
         
-        class BadMappingMessage(DictMixin):
-            def __init__(self):
-                self.message_id = 'foo'
+#         class BadMappingMessage(DictMixin):
+#             def __init__(self):
+#                 self.message_id = 'foo'
 
-        async with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#         async with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
 
-                message_dict = MappingMessage("Message")
-                message2_dict = MappingMessage("Message2")
-                message3_dict = BadMappingMessage()
-                list_message_dicts = [message_dict, message2_dict]
+#                 message_dict = MappingMessage("Message")
+#                 message2_dict = MappingMessage("Message2")
+#                 message3_dict = BadMappingMessage()
+#                 list_message_dicts = [message_dict, message2_dict]
 
-                # send single dict
-                await sender.send_messages(message_dict)
+#                 # send single dict
+#                 await sender.send_messages(message_dict)
 
-                # send list of dicts
-                await sender.send_messages(list_message_dicts)
+#                 # send list of dicts
+#                 await sender.send_messages(list_message_dicts)
 
-                # send bad dict
-                with pytest.raises(TypeError):
-                    await sender.send_messages(message3_dict)
+#                 # send bad dict
+#                 with pytest.raises(TypeError):
+#                     await sender.send_messages(message3_dict)
 
-                # create and send BatchMessage with dicts
-                batch_message = await sender.create_message_batch()
-                batch_message._from_list(list_message_dicts)  # pylint: disable=protected-access
-                batch_message.add_message(message_dict)
-                await sender.send_messages(batch_message)
+#                 # create and send BatchMessage with dicts
+#                 batch_message = await sender.create_message_batch()
+#                 batch_message._from_list(list_message_dicts)  # pylint: disable=protected-access
+#                 batch_message.add_message(message_dict)
+#                 await sender.send_messages(batch_message)
 
-                received_messages = []
-                async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5) as receiver:
-                    async for message in receiver:
-                        received_messages.append(message)
-                assert len(received_messages) == 6
+#                 received_messages = []
+#                 async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5) as receiver:
+#                     async for message in receiver:
+#                         received_messages.append(message)
+#                 assert len(received_messages) == 6
 
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest')
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_queue_async_send_dict_messages_error_badly_formatted_dicts(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        async with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest')
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_queue_async_send_dict_messages_error_badly_formatted_dicts(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         async with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
 
-                message_dict = {"bad_key": "Message"}
-                message2_dict = {"bad_key": "Message2"}
-                list_message_dicts = [message_dict, message2_dict]
+#                 message_dict = {"bad_key": "Message"}
+#                 message2_dict = {"bad_key": "Message2"}
+#                 list_message_dicts = [message_dict, message2_dict]
 
-                # send single dict
-                with pytest.raises(TypeError):
-                    await sender.send_messages(message_dict)
+#                 # send single dict
+#                 with pytest.raises(TypeError):
+#                     await sender.send_messages(message_dict)
 
-                # send list of dicts
-                with pytest.raises(TypeError):
-                    await sender.send_messages(list_message_dicts)
+#                 # send list of dicts
+#                 with pytest.raises(TypeError):
+#                     await sender.send_messages(list_message_dicts)
 
-                # create and send BatchMessage with dicts
-                batch_message = await sender.create_message_batch()
-                with pytest.raises(TypeError):
-                    batch_message._from_list(list_message_dicts)  # pylint: disable=protected-access
+#                 # create and send BatchMessage with dicts
+#                 batch_message = await sender.create_message_batch()
+#                 with pytest.raises(TypeError):
+#                     batch_message._from_list(list_message_dicts)  # pylint: disable=protected-access
 
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_queue_async_send_dict_messages_scheduled(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_queue_async_send_dict_messages_scheduled(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
         
-        async with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-            content = "Test scheduled message"
-            message_id = uuid.uuid4()
-            message_id2 = uuid.uuid4()
-            scheduled_enqueue_time = (utc_now() + timedelta(minutes=0.05)).replace(microsecond=0)
-            message_dict = {"message_id": message_id, "body": content}
-            message2_dict = {"message_id": message_id2, "body": content}
-            list_message_dicts = [message_dict, message2_dict]
+#         async with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#             content = "Test scheduled message"
+#             message_id = uuid.uuid4()
+#             message_id2 = uuid.uuid4()
+#             scheduled_enqueue_time = (utc_now() + timedelta(minutes=0.05)).replace(microsecond=0)
+#             message_dict = {"message_id": message_id, "body": content}
+#             message2_dict = {"message_id": message_id2, "body": content}
+#             list_message_dicts = [message_dict, message2_dict]
             
-            # send single dict
-            async with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
-                async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                    tokens = await sender.schedule_messages(message_dict, scheduled_enqueue_time)
-                    assert len(tokens) == 1
+#             # send single dict
+#             async with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
+#                 async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                     tokens = await sender.schedule_messages(message_dict, scheduled_enqueue_time)
+#                     assert len(tokens) == 1
     
-                messages = await receiver.receive_messages(max_wait_time=20)
-                if messages:
-                    try:
-                        data = str(messages[0])
-                        assert data == content
-                        assert messages[0].message_id == message_id
-                        assert messages[0].scheduled_enqueue_time_utc == scheduled_enqueue_time
-                        assert messages[0].scheduled_enqueue_time_utc <= messages[0].enqueued_time_utc.replace(microsecond=0)
-                        assert len(messages) == 1
-                    finally:
-                        for m in messages:
-                            await receiver.complete_message(m)
-                else:
-                    raise Exception("Failed to receive schdeduled message.")
+#                 messages = await receiver.receive_messages(max_wait_time=20)
+#                 if messages:
+#                     try:
+#                         data = str(messages[0])
+#                         assert data == content
+#                         assert messages[0].message_id == message_id
+#                         assert messages[0].scheduled_enqueue_time_utc == scheduled_enqueue_time
+#                         assert messages[0].scheduled_enqueue_time_utc <= messages[0].enqueued_time_utc.replace(microsecond=0)
+#                         assert len(messages) == 1
+#                     finally:
+#                         for m in messages:
+#                             await receiver.complete_message(m)
+#                 else:
+#                     raise Exception("Failed to receive schdeduled message.")
 
-            # send list of dicts
-            async with sb_client.get_queue_receiver(servicebus_queue.name, prefetch_count=20) as receiver:
-                async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                    tokens = await sender.schedule_messages(list_message_dicts, scheduled_enqueue_time)
-                    assert len(tokens) == 2
+#             # send list of dicts
+#             async with sb_client.get_queue_receiver(servicebus_queue.name, prefetch_count=20) as receiver:
+#                 async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                     tokens = await sender.schedule_messages(list_message_dicts, scheduled_enqueue_time)
+#                     assert len(tokens) == 2
     
-                messages = await receiver.receive_messages(max_wait_time=20)
-                messages.extend(await receiver.receive_messages(max_wait_time=5))
-                if messages:
-                    try:
-                        data = str(messages[0])
-                        print(messages)
-                        assert data == content
-                        assert messages[0].message_id == message_id
-                        assert messages[0].scheduled_enqueue_time_utc == scheduled_enqueue_time
-                        assert messages[0].scheduled_enqueue_time_utc <= messages[0].enqueued_time_utc.replace(microsecond=0)
-                        assert len(messages) == 2
-                    finally:
-                        for m in messages:
-                            await receiver.complete_message(m)
-                else:
-                    raise Exception("Failed to receive schdeduled message.")
+#                 messages = await receiver.receive_messages(max_wait_time=20)
+#                 messages.extend(await receiver.receive_messages(max_wait_time=5))
+#                 if messages:
+#                     try:
+#                         data = str(messages[0])
+#                         print(messages)
+#                         assert data == content
+#                         assert messages[0].message_id == message_id
+#                         assert messages[0].scheduled_enqueue_time_utc == scheduled_enqueue_time
+#                         assert messages[0].scheduled_enqueue_time_utc <= messages[0].enqueued_time_utc.replace(microsecond=0)
+#                         assert len(messages) == 2
+#                     finally:
+#                         for m in messages:
+#                             await receiver.complete_message(m)
+#                 else:
+#                     raise Exception("Failed to receive schdeduled message.")
 
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_queue_async_send_dict_messages_scheduled_error_badly_formatted_dicts(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_queue_async_send_dict_messages_scheduled_error_badly_formatted_dicts(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
         
-        async with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-            content = "Test scheduled message"
-            message_id = uuid.uuid4()
-            message_id2 = uuid.uuid4()
-            scheduled_enqueue_time = (utc_now() + timedelta(minutes=0.1)).replace(microsecond=0)
-            async with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
-                async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                    message_dict = {"message_id": message_id, "bad_key": content}
-                    message2_dict = {"message_id": message_id2, "bad_key": content}
-                    list_message_dicts = [message_dict, message2_dict]
-                    with pytest.raises(TypeError):
-                        await sender.schedule_messages(message_dict, scheduled_enqueue_time)
-                    with pytest.raises(TypeError):
-                        await sender.schedule_messages(list_message_dicts, scheduled_enqueue_time)
+#         async with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#             content = "Test scheduled message"
+#             message_id = uuid.uuid4()
+#             message_id2 = uuid.uuid4()
+#             scheduled_enqueue_time = (utc_now() + timedelta(minutes=0.1)).replace(microsecond=0)
+#             async with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
+#                 async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                     message_dict = {"message_id": message_id, "bad_key": content}
+#                     message2_dict = {"message_id": message_id2, "bad_key": content}
+#                     list_message_dicts = [message_dict, message2_dict]
+#                     with pytest.raises(TypeError):
+#                         await sender.schedule_messages(message_dict, scheduled_enqueue_time)
+#                     with pytest.raises(TypeError):
+#                         await sender.schedule_messages(list_message_dicts, scheduled_enqueue_time)
 
     
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_queue_async_receive_iterator_resume_after_link_detach(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_queue_async_receive_iterator_resume_after_link_detach(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
 
-        async def hack_iter_next_mock_error(self, wait_time=None):
-            try:
-                self._receive_context.set()
-                await self._open()
-                # when trying to receive the second message (execution_times is 1), raising LinkDetach error to mock 10 mins idle timeout
-                if self.execution_times == 1:
-                    if uamqp_transport:
-                        from uamqp.errors import LinkDetach
-                        from uamqp.constants import ErrorCodes
-                        error = LinkDetach
-                        error_condition = ErrorCodes
-                    else:
-                        from azure.servicebus._pyamqp.error import ErrorCondition, AMQPLinkError
-                        error = AMQPLinkError
-                        error_condition = ErrorCondition
-                    self.execution_times += 1
-                    self.error_raised = True
-                    raise error(error_condition.LinkDetachForced)
-                else:
-                    self.execution_times += 1
-                if not self._message_iter:
-                    if uamqp_transport:
-                        self._message_iter = self._handler.receive_messages_iter_async()
-                    else:
-                        self._message_iter = await self._handler.receive_messages_iter_async(timeout=wait_time)
-                amqp_message = await self._message_iter.__anext__()
-                message = self._build_received_message(amqp_message)
-                return message
-            finally:
-                self._receive_context.clear()
+#         async def hack_iter_next_mock_error(self, wait_time=None):
+#             try:
+#                 self._receive_context.set()
+#                 await self._open()
+#                 # when trying to receive the second message (execution_times is 1), raising LinkDetach error to mock 10 mins idle timeout
+#                 if self.execution_times == 1:
+#                     if uamqp_transport:
+#                         from uamqp.errors import LinkDetach
+#                         from uamqp.constants import ErrorCodes
+#                         error = LinkDetach
+#                         error_condition = ErrorCodes
+#                     else:
+#                         from azure.servicebus._pyamqp.error import ErrorCondition, AMQPLinkError
+#                         error = AMQPLinkError
+#                         error_condition = ErrorCondition
+#                     self.execution_times += 1
+#                     self.error_raised = True
+#                     raise error(error_condition.LinkDetachForced)
+#                 else:
+#                     self.execution_times += 1
+#                 if not self._message_iter:
+#                     if uamqp_transport:
+#                         self._message_iter = self._handler.receive_messages_iter_async()
+#                     else:
+#                         self._message_iter = await self._handler.receive_messages_iter_async(timeout=wait_time)
+#                 amqp_message = await self._message_iter.__anext__()
+#                 message = self._build_received_message(amqp_message)
+#                 return message
+#             finally:
+#                 self._receive_context.clear()
 
-        async with ServiceBusClient.from_connection_string(
-                servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                await sender.send_messages(
-                    [ServiceBusMessage("test1"), ServiceBusMessage("test2"), ServiceBusMessage("test3")]
-                )
-            async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10) as receiver:
-                receiver.execution_times = 0
-                receiver.error_raised = False
-                receiver._iter_next = types.MethodType(hack_iter_next_mock_error, receiver)
-                res = []
-                async for msg in receiver:
-                    await receiver.complete_message(msg)
-                    res.append(msg)
-                assert len(res) == 3
-                assert receiver.error_raised
-                assert receiver.execution_times >= 4  # at least 1 failure and 3 successful receiving iterator
+#         async with ServiceBusClient.from_connection_string(
+#                 servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 await sender.send_messages(
+#                     [ServiceBusMessage("test1"), ServiceBusMessage("test2"), ServiceBusMessage("test3")]
+#                 )
+#             async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10) as receiver:
+#                 receiver.execution_times = 0
+#                 receiver.error_raised = False
+#                 receiver._iter_next = types.MethodType(hack_iter_next_mock_error, receiver)
+#                 res = []
+#                 async for msg in receiver:
+#                     await receiver.complete_message(msg)
+#                     res.append(msg)
+#                 assert len(res) == 3
+#                 assert receiver.error_raised
+#                 assert receiver.execution_times >= 4  # at least 1 failure and 3 successful receiving iterator
 
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_queue_async_send_amqp_annotated_message(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_queue_async_send_amqp_annotated_message(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
 
-        async with ServiceBusClient.from_connection_string(
-                servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-            sequence_body = [b'message', 123.456, True]
-            footer = {'footer_key': 'footer_value'}
-            prop = {"subject": "sequence"}
-            seq_app_prop = {"body_type": "sequence"}
+#         async with ServiceBusClient.from_connection_string(
+#                 servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#             sequence_body = [b'message', 123.456, True]
+#             footer = {'footer_key': 'footer_value'}
+#             prop = {"subject": "sequence"}
+#             seq_app_prop = {"body_type": "sequence"}
 
-            sequence_message = AmqpAnnotatedMessage(
-                sequence_body=sequence_body,
-                footer=footer,
-                properties=prop,
-                application_properties=seq_app_prop
-            )
+#             sequence_message = AmqpAnnotatedMessage(
+#                 sequence_body=sequence_body,
+#                 footer=footer,
+#                 properties=prop,
+#                 application_properties=seq_app_prop
+#             )
 
-            value_body = {b"key": [-123, b'data', False]}
-            header = {"priority": 10}
-            anno = {"ann_key": "ann_value"}
-            value_app_prop = {"body_type": "value"}
+#             value_body = {b"key": [-123, b'data', False]}
+#             header = {"priority": 10}
+#             anno = {"ann_key": "ann_value"}
+#             value_app_prop = {"body_type": "value"}
 
-            value_message = AmqpAnnotatedMessage(
-                value_body=value_body,
-                header=header,
-                annotations=anno,
-                application_properties=value_app_prop
-            )
+#             value_message = AmqpAnnotatedMessage(
+#                 value_body=value_body,
+#                 header=header,
+#                 annotations=anno,
+#                 application_properties=value_app_prop
+#             )
 
-            data_body = [b'aa', b'bb', b'cc']
-            data_app_prop = {"body_type": "data"}
-            del_anno = {"delann_key": "delann_value"}
-            data_message = AmqpAnnotatedMessage(
-                data_body=data_body,
-                delivery_annotations=del_anno,
-                application_properties=data_app_prop
-            )
+#             data_body = [b'aa', b'bb', b'cc']
+#             data_app_prop = {"body_type": "data"}
+#             del_anno = {"delann_key": "delann_value"}
+#             data_message = AmqpAnnotatedMessage(
+#                 data_body=data_body,
+#                 delivery_annotations=del_anno,
+#                 application_properties=data_app_prop
+#             )
 
-            content = "normalmessage"
-            dict_message = {"body": content}
-            sb_message = ServiceBusMessage(body=content)
-            message_with_ttl = AmqpAnnotatedMessage(data_body=data_body, header=AmqpMessageHeader(time_to_live=60000))
-            if uamqp_transport:
-                amqp_transport = UamqpTransportAsync
-            else:
-                amqp_transport = PyamqpTransportAsync
-            amqp_with_ttl = amqp_transport.to_outgoing_amqp_message(message_with_ttl)
-            assert amqp_with_ttl.properties.absolute_expiry_time == amqp_with_ttl.properties.creation_time + amqp_with_ttl.header.ttl
+#             content = "normalmessage"
+#             dict_message = {"body": content}
+#             sb_message = ServiceBusMessage(body=content)
+#             message_with_ttl = AmqpAnnotatedMessage(data_body=data_body, header=AmqpMessageHeader(time_to_live=60000))
+#             if uamqp_transport:
+#                 amqp_transport = UamqpTransportAsync
+#             else:
+#                 amqp_transport = PyamqpTransportAsync
+#             amqp_with_ttl = amqp_transport.to_outgoing_amqp_message(message_with_ttl)
+#             assert amqp_with_ttl.properties.absolute_expiry_time == amqp_with_ttl.properties.creation_time + amqp_with_ttl.header.ttl
 
-            recv_data_msg = recv_sequence_msg = recv_value_msg = normal_msg = 0
-            async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10) as receiver:
-                async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                    batch = await sender.create_message_batch()
-                    batch.add_message(data_message)
-                    batch.add_message(value_message)
-                    batch.add_message(sequence_message)
-                    batch.add_message(dict_message)
-                    batch.add_message(sb_message)
+#             recv_data_msg = recv_sequence_msg = recv_value_msg = normal_msg = 0
+#             async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10) as receiver:
+#                 async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                     batch = await sender.create_message_batch()
+#                     batch.add_message(data_message)
+#                     batch.add_message(value_message)
+#                     batch.add_message(sequence_message)
+#                     batch.add_message(dict_message)
+#                     batch.add_message(sb_message)
 
-                    await sender.send_messages(batch)
-                    await sender.send_messages([data_message, value_message, sequence_message, dict_message, sb_message])
-                    await sender.send_messages(data_message)
-                    await sender.send_messages(value_message)
-                    await sender.send_messages(sequence_message)
+#                     await sender.send_messages(batch)
+#                     await sender.send_messages([data_message, value_message, sequence_message, dict_message, sb_message])
+#                     await sender.send_messages(data_message)
+#                     await sender.send_messages(value_message)
+#                     await sender.send_messages(sequence_message)
 
-                    async for message in receiver:
-                        raw_amqp_message = message.raw_amqp_message
-                        if raw_amqp_message.body_type == AmqpMessageBodyType.DATA:
-                            if raw_amqp_message.application_properties and raw_amqp_message.application_properties.get(b'body_type') == b'data':
-                                body = [data for data in raw_amqp_message.body]
-                                assert data_body == body
-                                assert raw_amqp_message.delivery_annotations[b'delann_key'] == b'delann_value'
-                                assert raw_amqp_message.application_properties[b'body_type'] == b'data'
-                                recv_data_msg += 1
-                            else:
-                                assert str(message) == content
-                                normal_msg += 1
-                        elif raw_amqp_message.body_type == AmqpMessageBodyType.SEQUENCE:
-                            body = [sequence for sequence in raw_amqp_message.body]
-                            assert [sequence_body] == body
-                            assert raw_amqp_message.footer[b'footer_key'] == b'footer_value'
-                            assert raw_amqp_message.properties.subject == b'sequence'
-                            assert raw_amqp_message.application_properties[b'body_type'] == b'sequence'
-                            recv_sequence_msg += 1
-                        elif raw_amqp_message.body_type == AmqpMessageBodyType.VALUE:
-                            assert raw_amqp_message.body == value_body
-                            assert raw_amqp_message.header.priority == 10
-                            assert raw_amqp_message.annotations[b'ann_key'] == b'ann_value'
-                            assert raw_amqp_message.application_properties[b'body_type'] == b'value'
-                            recv_value_msg += 1
-                        await receiver.complete_message(message)
+#                     async for message in receiver:
+#                         raw_amqp_message = message.raw_amqp_message
+#                         if raw_amqp_message.body_type == AmqpMessageBodyType.DATA:
+#                             if raw_amqp_message.application_properties and raw_amqp_message.application_properties.get(b'body_type') == b'data':
+#                                 body = [data for data in raw_amqp_message.body]
+#                                 assert data_body == body
+#                                 assert raw_amqp_message.delivery_annotations[b'delann_key'] == b'delann_value'
+#                                 assert raw_amqp_message.application_properties[b'body_type'] == b'data'
+#                                 recv_data_msg += 1
+#                             else:
+#                                 assert str(message) == content
+#                                 normal_msg += 1
+#                         elif raw_amqp_message.body_type == AmqpMessageBodyType.SEQUENCE:
+#                             body = [sequence for sequence in raw_amqp_message.body]
+#                             assert [sequence_body] == body
+#                             assert raw_amqp_message.footer[b'footer_key'] == b'footer_value'
+#                             assert raw_amqp_message.properties.subject == b'sequence'
+#                             assert raw_amqp_message.application_properties[b'body_type'] == b'sequence'
+#                             recv_sequence_msg += 1
+#                         elif raw_amqp_message.body_type == AmqpMessageBodyType.VALUE:
+#                             assert raw_amqp_message.body == value_body
+#                             assert raw_amqp_message.header.priority == 10
+#                             assert raw_amqp_message.annotations[b'ann_key'] == b'ann_value'
+#                             assert raw_amqp_message.application_properties[b'body_type'] == b'value'
+#                             recv_value_msg += 1
+#                         await receiver.complete_message(message)
 
-                    assert recv_data_msg == 3
-                    assert recv_sequence_msg == 3
-                    assert recv_value_msg == 3
-                    assert normal_msg == 4
+#                     assert recv_data_msg == 3
+#                     assert recv_sequence_msg == 3
+#                     assert recv_value_msg == 3
+#                     assert normal_msg == 4
 
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_state_scheduled_async(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        async with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, uamqp_transport=uamqp_transport) as sb_client:
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_state_scheduled_async(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         async with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, uamqp_transport=uamqp_transport) as sb_client:
 
-            sender = sb_client.get_queue_sender(servicebus_queue.name)
-            async with sender:
-                for i in range(10):
-                    message = ServiceBusMessage("message no. {}".format(i))
-                    scheduled_time_utc = datetime.utcnow() + timedelta(seconds=30)
-                    sequence_number = await sender.schedule_messages(message, scheduled_time_utc)
+#             sender = sb_client.get_queue_sender(servicebus_queue.name)
+#             async with sender:
+#                 for i in range(10):
+#                     message = ServiceBusMessage("message no. {}".format(i))
+#                     scheduled_time_utc = datetime.utcnow() + timedelta(seconds=30)
+#                     sequence_number = await sender.schedule_messages(message, scheduled_time_utc)
 
-            receiver = sb_client.get_queue_receiver(servicebus_queue.name)
-            async with receiver:
-                messages = await receiver.peek_messages()
-                for msg in messages:
-                    assert msg.state == ServiceBusMessageState.SCHEDULED
+#             receiver = sb_client.get_queue_receiver(servicebus_queue.name)
+#             async with receiver:
+#                 messages = await receiver.peek_messages()
+#                 for msg in messages:
+#                     assert msg.state == ServiceBusMessageState.SCHEDULED
 
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_state_deferred_async(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        async with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, uamqp_transport=uamqp_transport) as sb_client:
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_state_deferred_async(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         async with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, uamqp_transport=uamqp_transport) as sb_client:
 
-            sender = sb_client.get_queue_sender(servicebus_queue.name)
-            async with sender:
-                for i in range(10):
-                    message = ServiceBusMessage("message no. {}".format(i))
-                    await sender.send_messages(message)
+#             sender = sb_client.get_queue_sender(servicebus_queue.name)
+#             async with sender:
+#                 for i in range(10):
+#                     message = ServiceBusMessage("message no. {}".format(i))
+#                     await sender.send_messages(message)
 
-            receiver = sb_client.get_queue_receiver(servicebus_queue.name)
-            deferred_messages = []
-            async with receiver:
-                received_msgs = await receiver.receive_messages()
-                for message in received_msgs:
-                    assert message.state == ServiceBusMessageState.ACTIVE
-                    deferred_messages.append(message.sequence_number)
-                    await receiver.defer_message(message)
-                await asyncio.sleep(5)
-                if deferred_messages:
-                    received_deferred_msg = await receiver.receive_deferred_messages(
-                        sequence_numbers=deferred_messages
-                        )                
-                for message in received_deferred_msg:
-                    assert message.state == ServiceBusMessageState.DEFERRED
+#             receiver = sb_client.get_queue_receiver(servicebus_queue.name)
+#             deferred_messages = []
+#             async with receiver:
+#                 received_msgs = await receiver.receive_messages()
+#                 for message in received_msgs:
+#                     assert message.state == ServiceBusMessageState.ACTIVE
+#                     deferred_messages.append(message.sequence_number)
+#                     await receiver.defer_message(message)
+#                 await asyncio.sleep(5)
+#                 if deferred_messages:
+#                     received_deferred_msg = await receiver.receive_deferred_messages(
+#                         sequence_numbers=deferred_messages
+#                         )                
+#                 for message in received_deferred_msg:
+#                     assert message.state == ServiceBusMessageState.DEFERRED

--- a/sdk/servicebus/azure-servicebus/tests/async_tests/test_sb_client_async.py
+++ b/sdk/servicebus/azure-servicebus/tests/async_tests/test_sb_client_async.py
@@ -503,8 +503,9 @@ class TestServiceBusClientAsync(AzureMgmtRecordedTestCase):
             async with client.get_queue_sender(servicebus_queue.name) as sender:
                 await sender.send_messages(ServiceBusMessage("foo"))
 
+    @pytest.mark.asyncio
     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    def test_backoff_fixed_retry(self, uamqp_transport):
+    async def test_backoff_fixed_retry(self, uamqp_transport):
         client = ServiceBusClient(
             'fake.host.com',
             'fake_eh',
@@ -515,7 +516,7 @@ class TestServiceBusClientAsync(AzureMgmtRecordedTestCase):
         sender = client.get_queue_sender('fake_name')
         backoff = client._config.retry_backoff_factor
         start_time = time.time()
-        sender._backoff(retried_times=1, last_exception=Exception('fake'), abs_timeout_time=None)
+        await sender._backoff(retried_times=1, last_exception=Exception('fake'), abs_timeout_time=None)
         sleep_time_fixed = time.time() - start_time
         # exp = 0.8 * (2 ** 1) = 1.6
         # time.sleep() in _backoff will take AT LEAST time 'exp' for retry_mode='exponential'
@@ -526,7 +527,7 @@ class TestServiceBusClientAsync(AzureMgmtRecordedTestCase):
         sender = client.get_topic_sender('fake_name')
         backoff = client._config.retry_backoff_factor
         start_time = time.time()
-        sender._backoff(retried_times=1, last_exception=Exception('fake'), abs_timeout_time=None)
+        await sender._backoff(retried_times=1, last_exception=Exception('fake'), abs_timeout_time=None)
         sleep_time_fixed = time.time() - start_time
         assert sleep_time_fixed < backoff * (2 ** 1)
 
@@ -534,7 +535,7 @@ class TestServiceBusClientAsync(AzureMgmtRecordedTestCase):
         receiver = client.get_queue_receiver('fake_name')
         backoff = client._config.retry_backoff_factor
         start_time = time.time()
-        receiver._backoff(retried_times=1, last_exception=Exception('fake'), abs_timeout_time=None)
+        await receiver._backoff(retried_times=1, last_exception=Exception('fake'), abs_timeout_time=None)
         sleep_time_fixed = time.time() - start_time
         assert sleep_time_fixed < backoff * (2 ** 1)
 
@@ -542,7 +543,7 @@ class TestServiceBusClientAsync(AzureMgmtRecordedTestCase):
         receiver = client.get_subscription_receiver('fake_topic', 'fake_sub')
         backoff = client._config.retry_backoff_factor
         start_time = time.time()
-        receiver._backoff(retried_times=1, last_exception=Exception('fake'), abs_timeout_time=None)
+        await receiver._backoff(retried_times=1, last_exception=Exception('fake'), abs_timeout_time=None)
         sleep_time_fixed = time.time() - start_time
         assert sleep_time_fixed < backoff * (2 ** 1)
 

--- a/sdk/servicebus/azure-servicebus/tests/async_tests/test_sb_client_async.py
+++ b/sdk/servicebus/azure-servicebus/tests/async_tests/test_sb_client_async.py
@@ -1,691 +1,691 @@
-# #--------------------------------------------------------------------------
-# # Copyright (c) Microsoft Corporation. All rights reserved.
-# # Licensed under the MIT License. See License.txt in the project root for
-# # license information.
-# #--------------------------------------------------------------------------
+#--------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+#--------------------------------------------------------------------------
 
-# import logging
-# import sys
-# import time
-# import asyncio
-# import pytest
-# import hmac
-# import hashlib
-# import base64
-# from urllib.parse import quote as url_parse_quote
+import logging
+import sys
+import time
+import asyncio
+import pytest
+import hmac
+import hashlib
+import base64
+from urllib.parse import quote as url_parse_quote
 
-# from azure.core.credentials import AzureSasCredential, AzureNamedKeyCredential, AccessToken
-# from azure.mgmt.servicebus.models import AccessRights
-# from azure.servicebus.aio import ServiceBusClient, ServiceBusSender, ServiceBusReceiver
-# from azure.servicebus import ServiceBusMessage
-# from azure.servicebus.aio._base_handler_async import ServiceBusSharedKeyCredential
-# from azure.servicebus.exceptions import (
-#     ServiceBusError,
-#     ServiceBusAuthenticationError,
-#     ServiceBusAuthorizationError,
-#     ServiceBusConnectionError
-# )
-# from devtools_testutils import AzureMgmtRecordedTestCase
-# from tests.servicebus_preparer import (
-#     CachedServiceBusNamespacePreparer, 
-#     ServiceBusTopicPreparer, 
-#     ServiceBusQueuePreparer,
-#     ServiceBusNamespaceAuthorizationRulePreparer,
-#     ServiceBusQueueAuthorizationRulePreparer,
-#     CachedServiceBusQueuePreparer,
-#     CachedServiceBusTopicPreparer,
-#     CachedServiceBusSubscriptionPreparer,
-#     CachedServiceBusResourceGroupPreparer,
-#     SERVICEBUS_ENDPOINT_SUFFIX
-# )
-# from tests.utilities import get_logger, uamqp_transport as get_uamqp_transport, ArgPasserAsync
+from azure.core.credentials import AzureSasCredential, AzureNamedKeyCredential, AccessToken
+from azure.mgmt.servicebus.models import AccessRights
+from azure.servicebus.aio import ServiceBusClient, ServiceBusSender, ServiceBusReceiver
+from azure.servicebus import ServiceBusMessage
+from azure.servicebus.aio._base_handler_async import ServiceBusSharedKeyCredential
+from azure.servicebus.exceptions import (
+    ServiceBusError,
+    ServiceBusAuthenticationError,
+    ServiceBusAuthorizationError,
+    ServiceBusConnectionError
+)
+from devtools_testutils import AzureMgmtRecordedTestCase
+from tests.servicebus_preparer import (
+    CachedServiceBusNamespacePreparer, 
+    ServiceBusTopicPreparer, 
+    ServiceBusQueuePreparer,
+    ServiceBusNamespaceAuthorizationRulePreparer,
+    ServiceBusQueueAuthorizationRulePreparer,
+    CachedServiceBusQueuePreparer,
+    CachedServiceBusTopicPreparer,
+    CachedServiceBusSubscriptionPreparer,
+    CachedServiceBusResourceGroupPreparer,
+    SERVICEBUS_ENDPOINT_SUFFIX
+)
+from tests.utilities import get_logger, uamqp_transport as get_uamqp_transport, ArgPasserAsync
 
-# uamqp_transport_params, uamqp_transport_ids = get_uamqp_transport()
+uamqp_transport_params, uamqp_transport_ids = get_uamqp_transport()
 
-# _logger = get_logger(logging.DEBUG)
+_logger = get_logger(logging.DEBUG)
 
-# class TestServiceBusClientAsync(AzureMgmtRecordedTestCase):
+class TestServiceBusClientAsync(AzureMgmtRecordedTestCase):
 
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @CachedServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_sb_client_bad_credentials_async(self, uamqp_transport, *, servicebus_namespace, servicebus_queue, **kwargs):
-#         client = ServiceBusClient(
-#             fully_qualified_namespace=f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}",
-#             credential=ServiceBusSharedKeyCredential('invalid', 'invalid'),
-#             logging_enable=False, uamqp_transport=uamqp_transport)
-#         async with client:
-#             with pytest.raises(ServiceBusAuthenticationError):
-#                 async with client.get_queue_sender(servicebus_queue.name) as sender:
-#                     await sender.send_messages(ServiceBusMessage("test"))
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @CachedServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_sb_client_bad_credentials_async(self, uamqp_transport, *, servicebus_namespace, servicebus_queue, **kwargs):
+        client = ServiceBusClient(
+            fully_qualified_namespace=f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}",
+            credential=ServiceBusSharedKeyCredential('invalid', 'invalid'),
+            logging_enable=False, uamqp_transport=uamqp_transport)
+        async with client:
+            with pytest.raises(ServiceBusAuthenticationError):
+                async with client.get_queue_sender(servicebus_queue.name) as sender:
+                    await sender.send_messages(ServiceBusMessage("test"))
 
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_sb_client_bad_namespace_async(self, uamqp_transport, **kwargs):
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_sb_client_bad_namespace_async(self, uamqp_transport, **kwargs):
 
-#         client = ServiceBusClient(
-#             fully_qualified_namespace=f'invalid{SERVICEBUS_ENDPOINT_SUFFIX}',
-#             credential=ServiceBusSharedKeyCredential('invalid', 'invalid'),
-#             logging_enable=False, uamqp_transport=uamqp_transport)
-#         async with client:
-#             with pytest.raises(ServiceBusError):
-#                 async with client.get_queue_sender('invalidqueue') as sender:
-#                     await sender.send_messages(ServiceBusMessage("test"))
+        client = ServiceBusClient(
+            fully_qualified_namespace=f'invalid{SERVICEBUS_ENDPOINT_SUFFIX}',
+            credential=ServiceBusSharedKeyCredential('invalid', 'invalid'),
+            logging_enable=False, uamqp_transport=uamqp_transport)
+        async with client:
+            with pytest.raises(ServiceBusError):
+                async with client.get_queue_sender('invalidqueue') as sender:
+                    await sender.send_messages(ServiceBusMessage("test"))
 
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_sb_client_bad_entity_async(self, uamqp_transport, *, servicebus_namespace_connection_string=None, **kwargs):
-#         client = ServiceBusClient.from_connection_string(servicebus_namespace_connection_string, uamqp_transport=uamqp_transport)
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_sb_client_bad_entity_async(self, uamqp_transport, *, servicebus_namespace_connection_string=None, **kwargs):
+        client = ServiceBusClient.from_connection_string(servicebus_namespace_connection_string, uamqp_transport=uamqp_transport)
 
-#         async with client:
-#             with pytest.raises(ServiceBusAuthenticationError):
-#                 async with client.get_queue_sender("invalid") as sender:
-#                     await sender.send_messages(ServiceBusMessage("test"))
+        async with client:
+            with pytest.raises(ServiceBusAuthenticationError):
+                async with client.get_queue_sender("invalid") as sender:
+                    await sender.send_messages(ServiceBusMessage("test"))
 
-#         fake_str = f"Endpoint=sb://mock{SERVICEBUS_ENDPOINT_SUFFIX}/;" \
-#                    f"SharedAccessKeyName=mock;SharedAccessKey=mock;EntityPath=mockentity"
-#         fake_client = ServiceBusClient.from_connection_string(fake_str, uamqp_transport=uamqp_transport)
+        fake_str = f"Endpoint=sb://mock{SERVICEBUS_ENDPOINT_SUFFIX}/;" \
+                   f"SharedAccessKeyName=mock;SharedAccessKey=mock;EntityPath=mockentity"
+        fake_client = ServiceBusClient.from_connection_string(fake_str, uamqp_transport=uamqp_transport)
 
-#         with pytest.raises(ValueError):
-#             fake_client.get_queue_sender('queue')
+        with pytest.raises(ValueError):
+            fake_client.get_queue_sender('queue')
 
-#         with pytest.raises(ValueError):
-#             fake_client.get_queue_receiver('queue')
+        with pytest.raises(ValueError):
+            fake_client.get_queue_receiver('queue')
 
-#         with pytest.raises(ValueError):
-#             fake_client.get_topic_sender('topic')
+        with pytest.raises(ValueError):
+            fake_client.get_topic_sender('topic')
 
-#         with pytest.raises(ValueError):
-#             fake_client.get_subscription_receiver('topic', 'subscription')
+        with pytest.raises(ValueError):
+            fake_client.get_subscription_receiver('topic', 'subscription')
 
-#         fake_client.get_queue_sender('mockentity')
-#         fake_client.get_queue_receiver('mockentity')
-#         fake_client.get_topic_sender('mockentity')
-#         fake_client.get_subscription_receiver('mockentity', 'subscription')
+        fake_client.get_queue_sender('mockentity')
+        fake_client.get_queue_receiver('mockentity')
+        fake_client.get_topic_sender('mockentity')
+        fake_client.get_subscription_receiver('mockentity', 'subscription')
 
-#         fake_str = f"Endpoint=sb://mock{SERVICEBUS_ENDPOINT_SUFFIX}/;" \
-#                    f"SharedAccessKeyName=mock;SharedAccessKey=mock"
-#         fake_client = ServiceBusClient.from_connection_string(fake_str)
-#         fake_client.get_queue_sender('queue')
-#         fake_client.get_queue_receiver('queue')
-#         fake_client.get_topic_sender('topic')
-#         fake_client.get_subscription_receiver('topic', 'subscription')
+        fake_str = f"Endpoint=sb://mock{SERVICEBUS_ENDPOINT_SUFFIX}/;" \
+                   f"SharedAccessKeyName=mock;SharedAccessKey=mock"
+        fake_client = ServiceBusClient.from_connection_string(fake_str)
+        fake_client.get_queue_sender('queue')
+        fake_client.get_queue_receiver('queue')
+        fake_client.get_topic_sender('topic')
+        fake_client.get_subscription_receiver('topic', 'subscription')
 
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @CachedServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-#     @ServiceBusNamespaceAuthorizationRulePreparer(name_prefix='servicebustest', access_rights=[AccessRights.listen])
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_sb_client_readonly_credentials(self, uamqp_transport, *, servicebus_authorization_rule_connection_string=None, servicebus_queue=None, **kwargs):
-#         client = ServiceBusClient.from_connection_string(servicebus_authorization_rule_connection_string, uamqp_transport=uamqp_transport)
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @CachedServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+    @ServiceBusNamespaceAuthorizationRulePreparer(name_prefix='servicebustest', access_rights=[AccessRights.listen])
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_sb_client_readonly_credentials(self, uamqp_transport, *, servicebus_authorization_rule_connection_string=None, servicebus_queue=None, **kwargs):
+        client = ServiceBusClient.from_connection_string(servicebus_authorization_rule_connection_string, uamqp_transport=uamqp_transport)
 
-#         async with client:
-#             async with client.get_queue_receiver(servicebus_queue.name) as receiver:
-#                 messages = await receiver.receive_messages(max_message_count=1, max_wait_time=1)
+        async with client:
+            async with client.get_queue_receiver(servicebus_queue.name) as receiver:
+                messages = await receiver.receive_messages(max_message_count=1, max_wait_time=1)
 
-#             with pytest.raises(ServiceBusAuthorizationError):
-#                 async with client.get_queue_sender(servicebus_queue.name) as sender:
-#                     await sender.send_messages(ServiceBusMessage("test"))
+            with pytest.raises(ServiceBusAuthorizationError):
+                async with client.get_queue_sender(servicebus_queue.name) as sender:
+                    await sender.send_messages(ServiceBusMessage("test"))
 
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @CachedServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-#     @ServiceBusNamespaceAuthorizationRulePreparer(name_prefix='servicebustest', access_rights=[AccessRights.send])
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_sb_client_writeonly_credentials_async(self, uamqp_transport, *, servicebus_authorization_rule_connection_string=None, servicebus_queue=None, **kwargs):
-#         client = ServiceBusClient.from_connection_string(servicebus_authorization_rule_connection_string, uamqp_transport=uamqp_transport)
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @CachedServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+    @ServiceBusNamespaceAuthorizationRulePreparer(name_prefix='servicebustest', access_rights=[AccessRights.send])
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_sb_client_writeonly_credentials_async(self, uamqp_transport, *, servicebus_authorization_rule_connection_string=None, servicebus_queue=None, **kwargs):
+        client = ServiceBusClient.from_connection_string(servicebus_authorization_rule_connection_string, uamqp_transport=uamqp_transport)
 
-#         async with client:
-#             with pytest.raises(ServiceBusError):
-#                 async with client.get_queue_receiver(servicebus_queue.name) as receiver:
-#                     messages = await receiver.receive_messages(max_message_count=1, max_wait_time=1)
+        async with client:
+            with pytest.raises(ServiceBusError):
+                async with client.get_queue_receiver(servicebus_queue.name) as receiver:
+                    messages = await receiver.receive_messages(max_message_count=1, max_wait_time=1)
 
-#             async with client.get_queue_sender(servicebus_queue.name) as sender:
-#                 await sender.send_messages(ServiceBusMessage("test"))
+            async with client.get_queue_sender(servicebus_queue.name) as sender:
+                await sender.send_messages(ServiceBusMessage("test"))
 
-#                 with pytest.raises(TypeError):
-#                     await sender.send_messages("cat")
+                with pytest.raises(TypeError):
+                    await sender.send_messages("cat")
 
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer()
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @CachedServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-#     @CachedServiceBusTopicPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusSubscriptionPreparer(name_prefix='servicebustest')
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_async_sb_client_close_spawned_handlers(self, uamqp_transport, *, servicebus_namespace_connection_string, servicebus_queue, servicebus_topic, servicebus_subscription, **kwargs):
-#         client = ServiceBusClient.from_connection_string(servicebus_namespace_connection_string, uamqp_transport=uamqp_transport)
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer()
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @CachedServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+    @CachedServiceBusTopicPreparer(name_prefix='servicebustest')
+    @CachedServiceBusSubscriptionPreparer(name_prefix='servicebustest')
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_async_sb_client_close_spawned_handlers(self, uamqp_transport, *, servicebus_namespace_connection_string, servicebus_queue, servicebus_topic, servicebus_subscription, **kwargs):
+        client = ServiceBusClient.from_connection_string(servicebus_namespace_connection_string, uamqp_transport=uamqp_transport)
 
-#         await client.close()
+        await client.close()
 
-#         # context manager
-#         async with client:
-#             assert len(client._handlers) == 0
-#             sender = client.get_queue_sender(servicebus_queue.name)
-#             receiver = client.get_queue_receiver(servicebus_queue.name)
-#             await sender._open()
-#             await receiver._open()
+        # context manager
+        async with client:
+            assert len(client._handlers) == 0
+            sender = client.get_queue_sender(servicebus_queue.name)
+            receiver = client.get_queue_receiver(servicebus_queue.name)
+            await sender._open()
+            await receiver._open()
 
-#             assert sender._handler and sender._running
-#             assert receiver._handler and receiver._running
-#             assert len(client._handlers) == 2
+            assert sender._handler and sender._running
+            assert receiver._handler and receiver._running
+            assert len(client._handlers) == 2
 
-#         assert not sender._handler and not sender._running
-#         assert not receiver._handler and not receiver._running
-#         assert len(client._handlers) == 0
+        assert not sender._handler and not sender._running
+        assert not receiver._handler and not receiver._running
+        assert len(client._handlers) == 0
 
-#         # close operation
-#         sender = client.get_queue_sender(servicebus_queue.name)
-#         receiver = client.get_queue_receiver(servicebus_queue.name)
-#         await sender._open()
-#         await receiver._open()
+        # close operation
+        sender = client.get_queue_sender(servicebus_queue.name)
+        receiver = client.get_queue_receiver(servicebus_queue.name)
+        await sender._open()
+        await receiver._open()
 
-#         assert sender._handler and sender._running
-#         assert receiver._handler and receiver._running
-#         assert len(client._handlers) == 2
+        assert sender._handler and sender._running
+        assert receiver._handler and receiver._running
+        assert len(client._handlers) == 2
 
-#         await client.close()
+        await client.close()
 
-#         assert not sender._handler and not sender._running
-#         assert not receiver._handler and not receiver._running
-#         assert len(client._handlers) == 0
+        assert not sender._handler and not sender._running
+        assert not receiver._handler and not receiver._running
+        assert len(client._handlers) == 0
 
-#         queue_sender = client.get_queue_sender(servicebus_queue.name)
-#         queue_receiver = client.get_queue_receiver(servicebus_queue.name)
-#         assert len(client._handlers) == 2
-#         queue_sender = client.get_queue_sender(servicebus_queue.name)
-#         queue_receiver = client.get_queue_receiver(servicebus_queue.name)
-#         # the previous sender/receiver can not longer be referenced, there might be a delay in CPython
-#         # to remove the reference, so len of handlers should be less than 4
-#         assert len(client._handlers) < 4
-#         await client.close()
+        queue_sender = client.get_queue_sender(servicebus_queue.name)
+        queue_receiver = client.get_queue_receiver(servicebus_queue.name)
+        assert len(client._handlers) == 2
+        queue_sender = client.get_queue_sender(servicebus_queue.name)
+        queue_receiver = client.get_queue_receiver(servicebus_queue.name)
+        # the previous sender/receiver can not longer be referenced, there might be a delay in CPython
+        # to remove the reference, so len of handlers should be less than 4
+        assert len(client._handlers) < 4
+        await client.close()
 
-#         queue_sender = client.get_queue_sender(servicebus_queue.name)
-#         queue_receiver = client.get_queue_receiver(servicebus_queue.name)
-#         assert len(client._handlers) == 2
-#         queue_sender = None
-#         queue_receiver = None
-#         assert len(client._handlers) < 2
+        queue_sender = client.get_queue_sender(servicebus_queue.name)
+        queue_receiver = client.get_queue_receiver(servicebus_queue.name)
+        assert len(client._handlers) == 2
+        queue_sender = None
+        queue_receiver = None
+        assert len(client._handlers) < 2
 
-#         await client.close()
-#         topic_sender = client.get_topic_sender(servicebus_topic.name)
-#         subscription_receiver = client.get_subscription_receiver(servicebus_topic.name, servicebus_subscription.name)
-#         assert len(client._handlers) == 2
-#         topic_sender = None
-#         subscription_receiver = None
-#         # the previous sender/receiver can not longer be referenced, so len of handlers should just be 2 instead of 4
-#         assert len(client._handlers) < 4
+        await client.close()
+        topic_sender = client.get_topic_sender(servicebus_topic.name)
+        subscription_receiver = client.get_subscription_receiver(servicebus_topic.name, servicebus_subscription.name)
+        assert len(client._handlers) == 2
+        topic_sender = None
+        subscription_receiver = None
+        # the previous sender/receiver can not longer be referenced, so len of handlers should just be 2 instead of 4
+        assert len(client._handlers) < 4
 
-#         await client.close()
-#         topic_sender = client.get_topic_sender(servicebus_topic.name)
-#         subscription_receiver = client.get_subscription_receiver(servicebus_topic.name, servicebus_subscription.name)
-#         assert len(client._handlers) == 2
-#         topic_sender = client.get_topic_sender(servicebus_topic.name)
-#         subscription_receiver = client.get_subscription_receiver(servicebus_topic.name, servicebus_subscription.name)
-#         # the previous sender/receiver can not longer be referenced, so len of handlers should just be 2 instead of 4
-#         assert len(client._handlers) < 4
+        await client.close()
+        topic_sender = client.get_topic_sender(servicebus_topic.name)
+        subscription_receiver = client.get_subscription_receiver(servicebus_topic.name, servicebus_subscription.name)
+        assert len(client._handlers) == 2
+        topic_sender = client.get_topic_sender(servicebus_topic.name)
+        subscription_receiver = client.get_subscription_receiver(servicebus_topic.name, servicebus_subscription.name)
+        # the previous sender/receiver can not longer be referenced, so len of handlers should just be 2 instead of 4
+        assert len(client._handlers) < 4
 
-#         await client.close()
-#         for _ in range(5):
-#             queue_sender = client.get_queue_sender(servicebus_queue.name)
-#             queue_receiver = client.get_queue_receiver(servicebus_queue.name)
-#             topic_sender = client.get_topic_sender(servicebus_topic.name)
-#             subscription_receiver = client.get_subscription_receiver(servicebus_topic.name,
-#                                                                      servicebus_subscription.name)
-#         assert len(client._handlers) < 15
-#         await client.close()
+        await client.close()
+        for _ in range(5):
+            queue_sender = client.get_queue_sender(servicebus_queue.name)
+            queue_receiver = client.get_queue_receiver(servicebus_queue.name)
+            topic_sender = client.get_topic_sender(servicebus_topic.name)
+            subscription_receiver = client.get_subscription_receiver(servicebus_topic.name,
+                                                                     servicebus_subscription.name)
+        assert len(client._handlers) < 15
+        await client.close()
 
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusNamespaceAuthorizationRulePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest_qone', parameter_name='wrong_queue', dead_lettering_on_message_expiration=True)
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest_qtwo', dead_lettering_on_message_expiration=True)
-#     @ServiceBusQueueAuthorizationRulePreparer(name_prefix='servicebustest_qtwo')
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_sb_client_incorrect_queue_conn_str_async(self, uamqp_transport, *, servicebus_queue_authorization_rule_connection_string, servicebus_queue, wrong_queue, **kwargs):
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusNamespaceAuthorizationRulePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest_qone', parameter_name='wrong_queue', dead_lettering_on_message_expiration=True)
+    @ServiceBusQueuePreparer(name_prefix='servicebustest_qtwo', dead_lettering_on_message_expiration=True)
+    @ServiceBusQueueAuthorizationRulePreparer(name_prefix='servicebustest_qtwo')
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_sb_client_incorrect_queue_conn_str_async(self, uamqp_transport, *, servicebus_queue_authorization_rule_connection_string, servicebus_queue, wrong_queue, **kwargs):
         
-#         client = ServiceBusClient.from_connection_string(servicebus_queue_authorization_rule_connection_string, uamqp_transport=uamqp_transport)
-#         async with client:
-#             # Validate that the wrong sender/receiver queues with the right credentials fail.
-#             with pytest.raises(ValueError):
-#                 async with client.get_queue_sender(wrong_queue.name) as sender:
-#                     await sender.send_messages(ServiceBusMessage("test"))
+        client = ServiceBusClient.from_connection_string(servicebus_queue_authorization_rule_connection_string, uamqp_transport=uamqp_transport)
+        async with client:
+            # Validate that the wrong sender/receiver queues with the right credentials fail.
+            with pytest.raises(ValueError):
+                async with client.get_queue_sender(wrong_queue.name) as sender:
+                    await sender.send_messages(ServiceBusMessage("test"))
 
-#             with pytest.raises(ValueError):
-#                 async with client.get_queue_receiver(wrong_queue.name) as receiver:
-#                     messages = await receiver.receive_messages(max_message_count=1, max_wait_time=1)
+            with pytest.raises(ValueError):
+                async with client.get_queue_receiver(wrong_queue.name) as receiver:
+                    messages = await receiver.receive_messages(max_message_count=1, max_wait_time=1)
 
-#             # But that the correct ones work.
-#             async with client.get_queue_sender(servicebus_queue.name) as sender:
-#                 await sender.send_messages(ServiceBusMessage("test")) 
+            # But that the correct ones work.
+            async with client.get_queue_sender(servicebus_queue.name) as sender:
+                await sender.send_messages(ServiceBusMessage("test")) 
 
-#             async with client.get_queue_receiver(servicebus_queue.name) as receiver:
-#                 messages = await receiver.receive_messages(max_message_count=1, max_wait_time=1)
+            async with client.get_queue_receiver(servicebus_queue.name) as receiver:
+                messages = await receiver.receive_messages(max_message_count=1, max_wait_time=1)
 
-#             # Now do the same but with direct connstr initialization.
-#             with pytest.raises(ValueError):
-#                 async with ServiceBusSender._from_connection_string(
-#                     servicebus_queue_authorization_rule_connection_string,
-#                     queue_name=wrong_queue.name,
-#                 ) as sender:
-#                         await sender.send_messages(ServiceBusMessage("test"))
+            # Now do the same but with direct connstr initialization.
+            with pytest.raises(ValueError):
+                async with ServiceBusSender._from_connection_string(
+                    servicebus_queue_authorization_rule_connection_string,
+                    queue_name=wrong_queue.name,
+                ) as sender:
+                        await sender.send_messages(ServiceBusMessage("test"))
 
-#             with pytest.raises(ValueError):
-#                 async with ServiceBusReceiver._from_connection_string(
-#                     servicebus_queue_authorization_rule_connection_string,
-#                     queue_name=wrong_queue.name,
-#                 ) as receiver:
-#                     messages = await receiver.receive_messages(max_message_count=1, max_wait_time=1)
+            with pytest.raises(ValueError):
+                async with ServiceBusReceiver._from_connection_string(
+                    servicebus_queue_authorization_rule_connection_string,
+                    queue_name=wrong_queue.name,
+                ) as receiver:
+                    messages = await receiver.receive_messages(max_message_count=1, max_wait_time=1)
 
-#             async with ServiceBusSender._from_connection_string(
-#                 servicebus_queue_authorization_rule_connection_string,
-#                 queue_name=servicebus_queue.name,
-#             ) as sender:
-#                 await sender.send_messages(ServiceBusMessage("test"))
+            async with ServiceBusSender._from_connection_string(
+                servicebus_queue_authorization_rule_connection_string,
+                queue_name=servicebus_queue.name,
+            ) as sender:
+                await sender.send_messages(ServiceBusMessage("test"))
 
-#             async with ServiceBusReceiver._from_connection_string(
-#                 servicebus_queue_authorization_rule_connection_string,
-#                 queue_name=servicebus_queue.name,
-#             ) as receiver:
-#                 messages = await receiver.receive_messages(max_message_count=1, max_wait_time=1)
+            async with ServiceBusReceiver._from_connection_string(
+                servicebus_queue_authorization_rule_connection_string,
+                queue_name=servicebus_queue.name,
+            ) as receiver:
+                messages = await receiver.receive_messages(max_message_count=1, max_wait_time=1)
 
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer()
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @CachedServiceBusQueuePreparer(name_prefix='servicebustest')
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_client_sas_credential_async(self,
-#                                    uamqp_transport,
-#                                    *,
-#                                    servicebus_queue=None,
-#                                    servicebus_namespace=None,
-#                                    servicebus_namespace_key_name=None,
-#                                    servicebus_namespace_primary_key=None,
-#                                    servicebus_namespace_connection_string=None,
-#                                    **kwargs):
-#         # This should "just work" to validate known-good.
-#         credential = ServiceBusSharedKeyCredential(servicebus_namespace_key_name, servicebus_namespace_primary_key)
-#         hostname = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
-#         auth_uri = "sb://{}/{}".format(hostname, servicebus_queue.name)
-#         token = (await credential.get_token(auth_uri)).token
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer()
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @CachedServiceBusQueuePreparer(name_prefix='servicebustest')
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_client_sas_credential_async(self,
+                                   uamqp_transport,
+                                   *,
+                                   servicebus_queue=None,
+                                   servicebus_namespace=None,
+                                   servicebus_namespace_key_name=None,
+                                   servicebus_namespace_primary_key=None,
+                                   servicebus_namespace_connection_string=None,
+                                   **kwargs):
+        # This should "just work" to validate known-good.
+        credential = ServiceBusSharedKeyCredential(servicebus_namespace_key_name, servicebus_namespace_primary_key)
+        hostname = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        auth_uri = "sb://{}/{}".format(hostname, servicebus_queue.name)
+        token = (await credential.get_token(auth_uri)).token
 
-#         # Finally let's do it with SAS token + conn str
-#         token_conn_str = "Endpoint=sb://{}/;SharedAccessSignature={};".format(hostname, token)
+        # Finally let's do it with SAS token + conn str
+        token_conn_str = "Endpoint=sb://{}/;SharedAccessSignature={};".format(hostname, token)
 
-#         client = ServiceBusClient.from_connection_string(token_conn_str, uamqp_transport=uamqp_transport)
-#         async with client:
-#             assert len(client._handlers) == 0
-#             async with client.get_queue_sender(servicebus_queue.name) as sender:
-#                 await sender.send_messages(ServiceBusMessage("foo"))
+        client = ServiceBusClient.from_connection_string(token_conn_str, uamqp_transport=uamqp_transport)
+        async with client:
+            assert len(client._handlers) == 0
+            async with client.get_queue_sender(servicebus_queue.name) as sender:
+                await sender.send_messages(ServiceBusMessage("foo"))
 
-#         def generate_sas_token(uri, sas_name, sas_value, token_ttl):
-#             """Performs the signing and encoding needed to generate a sas token from a sas key."""
-#             sas = sas_value.encode('utf-8')
-#             expiry = str(int(time.time() + token_ttl))
-#             string_to_sign = (uri + '\n' + expiry).encode('utf-8')
-#             signed_hmac_sha256 = hmac.HMAC(sas, string_to_sign, hashlib.sha256)
-#             signature = url_parse_quote(base64.b64encode(signed_hmac_sha256.digest()))
-#             return 'SharedAccessSignature sr={}&sig={}&se={}&skn={}'.format(uri, signature, expiry, sas_name)
+        def generate_sas_token(uri, sas_name, sas_value, token_ttl):
+            """Performs the signing and encoding needed to generate a sas token from a sas key."""
+            sas = sas_value.encode('utf-8')
+            expiry = str(int(time.time() + token_ttl))
+            string_to_sign = (uri + '\n' + expiry).encode('utf-8')
+            signed_hmac_sha256 = hmac.HMAC(sas, string_to_sign, hashlib.sha256)
+            signature = url_parse_quote(base64.b64encode(signed_hmac_sha256.digest()))
+            return 'SharedAccessSignature sr={}&sig={}&se={}&skn={}'.format(uri, signature, expiry, sas_name)
 
-#         class CustomizedSASCredential(object):
-#             def __init__(self, token, expiry):
-#                 """
-#                 :param str token: The token string
-#                 :param float expiry: The epoch timestamp
-#                 """
-#                 self.token = token
-#                 self.expiry = expiry
-#                 self.token_type = b"servicebus.windows.net:sastoken"
+        class CustomizedSASCredential(object):
+            def __init__(self, token, expiry):
+                """
+                :param str token: The token string
+                :param float expiry: The epoch timestamp
+                """
+                self.token = token
+                self.expiry = expiry
+                self.token_type = b"servicebus.windows.net:sastoken"
 
-#             async def get_token(self, *scopes, **kwargs):
-#                 """
-#                 This method is automatically called when token is about to expire.
-#                 """
-#                 return AccessToken(self.token, self.expiry)
+            async def get_token(self, *scopes, **kwargs):
+                """
+                This method is automatically called when token is about to expire.
+                """
+                return AccessToken(self.token, self.expiry)
 
-#         token_ttl = 5  # seconds
-#         sas_token = generate_sas_token(
-#             auth_uri, servicebus_namespace_key_name, servicebus_namespace_primary_key, token_ttl
-#         )
-#         credential=CustomizedSASCredential(sas_token, time.time() + token_ttl)
+        token_ttl = 5  # seconds
+        sas_token = generate_sas_token(
+            auth_uri, servicebus_namespace_key_name, servicebus_namespace_primary_key, token_ttl
+        )
+        credential=CustomizedSASCredential(sas_token, time.time() + token_ttl)
 
-#         async with ServiceBusClient(hostname, credential, uamqp_transport=uamqp_transport) as client:
-#             sender = client.get_queue_sender(queue_name=servicebus_queue.name)
-#             await asyncio.sleep(10)
-#             with pytest.raises(ServiceBusAuthenticationError):
-#                 async with sender:
-#                     message = ServiceBusMessage("Single Message")
-#                     await sender.send_messages(message)
+        async with ServiceBusClient(hostname, credential, uamqp_transport=uamqp_transport) as client:
+            sender = client.get_queue_sender(queue_name=servicebus_queue.name)
+            await asyncio.sleep(10)
+            with pytest.raises(ServiceBusAuthenticationError):
+                async with sender:
+                    message = ServiceBusMessage("Single Message")
+                    await sender.send_messages(message)
 
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer()
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @CachedServiceBusQueuePreparer(name_prefix='servicebustest')
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_client_credential_async(self,
-#                                    uamqp_transport,
-#                                    *,
-#                                    servicebus_queue=None,
-#                                    servicebus_namespace=None,
-#                                    servicebus_namespace_key_name=None,
-#                                    servicebus_namespace_primary_key=None,
-#                                    servicebus_namespace_connection_string=None,
-#                                    **kwargs):
-#         # This should "just work" to validate known-good.
-#         credential = ServiceBusSharedKeyCredential(servicebus_namespace_key_name, servicebus_namespace_primary_key)
-#         hostname = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer()
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @CachedServiceBusQueuePreparer(name_prefix='servicebustest')
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_client_credential_async(self,
+                                   uamqp_transport,
+                                   *,
+                                   servicebus_queue=None,
+                                   servicebus_namespace=None,
+                                   servicebus_namespace_key_name=None,
+                                   servicebus_namespace_primary_key=None,
+                                   servicebus_namespace_connection_string=None,
+                                   **kwargs):
+        # This should "just work" to validate known-good.
+        credential = ServiceBusSharedKeyCredential(servicebus_namespace_key_name, servicebus_namespace_primary_key)
+        hostname = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
 
-#         client = ServiceBusClient(hostname, credential, uamqp_transport=uamqp_transport)
-#         async with client:
-#             assert len(client._handlers) == 0
-#             async with client.get_queue_sender(servicebus_queue.name) as sender:
-#                 await sender.send_messages(ServiceBusMessage("foo"))
+        client = ServiceBusClient(hostname, credential, uamqp_transport=uamqp_transport)
+        async with client:
+            assert len(client._handlers) == 0
+            async with client.get_queue_sender(servicebus_queue.name) as sender:
+                await sender.send_messages(ServiceBusMessage("foo"))
 
-#         hostname = f"sb://{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        hostname = f"sb://{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
 
-#         client = ServiceBusClient(hostname, credential, uamqp_transport=uamqp_transport)
-#         async with client:
-#             assert len(client._handlers) == 0
-#             async with client.get_queue_sender(servicebus_queue.name) as sender:
-#                 await sender.send_messages(ServiceBusMessage("foo"))
+        client = ServiceBusClient(hostname, credential, uamqp_transport=uamqp_transport)
+        async with client:
+            assert len(client._handlers) == 0
+            async with client.get_queue_sender(servicebus_queue.name) as sender:
+                await sender.send_messages(ServiceBusMessage("foo"))
 
-#         hostname = f"https://{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        hostname = f"https://{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
 
-#         client = ServiceBusClient(hostname, credential, uamqp_transport=uamqp_transport)
-#         async with client:
-#             assert len(client._handlers) == 0
-#             async with client.get_queue_sender(servicebus_queue.name) as sender:
-#                 await sender.send_messages(ServiceBusMessage("foo"))
+        client = ServiceBusClient(hostname, credential, uamqp_transport=uamqp_transport)
+        async with client:
+            assert len(client._handlers) == 0
+            async with client.get_queue_sender(servicebus_queue.name) as sender:
+                await sender.send_messages(ServiceBusMessage("foo"))
 
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer()
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @CachedServiceBusQueuePreparer(name_prefix='servicebustest')
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_client_azure_sas_credential_async(self,
-#                                    uamqp_transport,
-#                                    *,
-#                                    servicebus_queue=None,
-#                                    servicebus_namespace=None,
-#                                    servicebus_namespace_key_name=None,
-#                                    servicebus_namespace_primary_key=None,
-#                                    servicebus_namespace_connection_string=None,
-#                                    **kwargs):
-#         # This should "just work" to validate known-good.
-#         credential = ServiceBusSharedKeyCredential(servicebus_namespace_key_name, servicebus_namespace_primary_key)
-#         hostname = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
-#         auth_uri = "sb://{}/{}".format(hostname, servicebus_queue.name)
-#         token = (await credential.get_token(auth_uri)).token
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer()
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @CachedServiceBusQueuePreparer(name_prefix='servicebustest')
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_client_azure_sas_credential_async(self,
+                                   uamqp_transport,
+                                   *,
+                                   servicebus_queue=None,
+                                   servicebus_namespace=None,
+                                   servicebus_namespace_key_name=None,
+                                   servicebus_namespace_primary_key=None,
+                                   servicebus_namespace_connection_string=None,
+                                   **kwargs):
+        # This should "just work" to validate known-good.
+        credential = ServiceBusSharedKeyCredential(servicebus_namespace_key_name, servicebus_namespace_primary_key)
+        hostname = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        auth_uri = "sb://{}/{}".format(hostname, servicebus_queue.name)
+        token = (await credential.get_token(auth_uri)).token
 
-#         credential = AzureSasCredential(token)
+        credential = AzureSasCredential(token)
 
-#         client = ServiceBusClient(hostname, credential, uamqp_transport=uamqp_transport)
-#         async with client:
-#             assert len(client._handlers) == 0
-#             async with client.get_queue_sender(servicebus_queue.name) as sender:
-#                 await sender.send_messages(ServiceBusMessage("foo"))
+        client = ServiceBusClient(hostname, credential, uamqp_transport=uamqp_transport)
+        async with client:
+            assert len(client._handlers) == 0
+            async with client.get_queue_sender(servicebus_queue.name) as sender:
+                await sender.send_messages(ServiceBusMessage("foo"))
 
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer()
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @CachedServiceBusQueuePreparer(name_prefix='servicebustest')
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_azure_named_key_credential_async(self,
-#                                    uamqp_transport,
-#                                    *,
-#                                    servicebus_queue=None,
-#                                    servicebus_namespace=None,
-#                                    servicebus_namespace_key_name=None,
-#                                    servicebus_namespace_primary_key=None,
-#                                    servicebus_namespace_connection_string=None,
-#                                    **kwargs):
-#         hostname = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
-#         credential = AzureNamedKeyCredential(servicebus_namespace_key_name, servicebus_namespace_primary_key)
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer()
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @CachedServiceBusQueuePreparer(name_prefix='servicebustest')
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_azure_named_key_credential_async(self,
+                                   uamqp_transport,
+                                   *,
+                                   servicebus_queue=None,
+                                   servicebus_namespace=None,
+                                   servicebus_namespace_key_name=None,
+                                   servicebus_namespace_primary_key=None,
+                                   servicebus_namespace_connection_string=None,
+                                   **kwargs):
+        hostname = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = AzureNamedKeyCredential(servicebus_namespace_key_name, servicebus_namespace_primary_key)
 
-#         client = ServiceBusClient(hostname, credential, uamqp_transport=uamqp_transport)
-#         async with client:
-#             async with client.get_queue_sender(servicebus_queue.name) as sender:
-#                 await sender.send_messages(ServiceBusMessage("foo"))
+        client = ServiceBusClient(hostname, credential, uamqp_transport=uamqp_transport)
+        async with client:
+            async with client.get_queue_sender(servicebus_queue.name) as sender:
+                await sender.send_messages(ServiceBusMessage("foo"))
         
-#         credential.update("foo", "bar")
-#         with pytest.raises(Exception):
-#             async with client:
-#                 async with client.get_queue_sender(servicebus_queue.name) as sender:
-#                     await sender.send_messages(ServiceBusMessage("foo"))
+        credential.update("foo", "bar")
+        with pytest.raises(Exception):
+            async with client:
+                async with client.get_queue_sender(servicebus_queue.name) as sender:
+                    await sender.send_messages(ServiceBusMessage("foo"))
 
-#         # update back to the right key again
-#         credential.update(servicebus_namespace_key_name, servicebus_namespace_primary_key)
-#         async with client:
-#             async with client.get_queue_sender(servicebus_queue.name) as sender:
-#                 await sender.send_messages(ServiceBusMessage("foo"))
+        # update back to the right key again
+        credential.update(servicebus_namespace_key_name, servicebus_namespace_primary_key)
+        async with client:
+            async with client.get_queue_sender(servicebus_queue.name) as sender:
+                await sender.send_messages(ServiceBusMessage("foo"))
 
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     def test_backoff_fixed_retry(self, uamqp_transport):
-#         client = ServiceBusClient(
-#             'fake.host.com',
-#             'fake_eh',
-#             retry_mode='fixed',
-#             uamqp_transport=uamqp_transport
-#         )
-#         # queue sender
-#         sender = client.get_queue_sender('fake_name')
-#         backoff = client._config.retry_backoff_factor
-#         start_time = time.time()
-#         sender._backoff(retried_times=1, last_exception=Exception('fake'), abs_timeout_time=None)
-#         sleep_time_fixed = time.time() - start_time
-#         # exp = 0.8 * (2 ** 1) = 1.6
-#         # time.sleep() in _backoff will take AT LEAST time 'exp' for retry_mode='exponential'
-#         # check that fixed is less than 'exp'
-#         assert sleep_time_fixed < backoff * (2 ** 1)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    def test_backoff_fixed_retry(self, uamqp_transport):
+        client = ServiceBusClient(
+            'fake.host.com',
+            'fake_eh',
+            retry_mode='fixed',
+            uamqp_transport=uamqp_transport
+        )
+        # queue sender
+        sender = client.get_queue_sender('fake_name')
+        backoff = client._config.retry_backoff_factor
+        start_time = time.time()
+        sender._backoff(retried_times=1, last_exception=Exception('fake'), abs_timeout_time=None)
+        sleep_time_fixed = time.time() - start_time
+        # exp = 0.8 * (2 ** 1) = 1.6
+        # time.sleep() in _backoff will take AT LEAST time 'exp' for retry_mode='exponential'
+        # check that fixed is less than 'exp'
+        assert sleep_time_fixed < backoff * (2 ** 1)
 
-#         # topic sender
-#         sender = client.get_topic_sender('fake_name')
-#         backoff = client._config.retry_backoff_factor
-#         start_time = time.time()
-#         sender._backoff(retried_times=1, last_exception=Exception('fake'), abs_timeout_time=None)
-#         sleep_time_fixed = time.time() - start_time
-#         assert sleep_time_fixed < backoff * (2 ** 1)
+        # topic sender
+        sender = client.get_topic_sender('fake_name')
+        backoff = client._config.retry_backoff_factor
+        start_time = time.time()
+        sender._backoff(retried_times=1, last_exception=Exception('fake'), abs_timeout_time=None)
+        sleep_time_fixed = time.time() - start_time
+        assert sleep_time_fixed < backoff * (2 ** 1)
 
-#         # queue receiver 
-#         receiver = client.get_queue_receiver('fake_name')
-#         backoff = client._config.retry_backoff_factor
-#         start_time = time.time()
-#         receiver._backoff(retried_times=1, last_exception=Exception('fake'), abs_timeout_time=None)
-#         sleep_time_fixed = time.time() - start_time
-#         assert sleep_time_fixed < backoff * (2 ** 1)
+        # queue receiver 
+        receiver = client.get_queue_receiver('fake_name')
+        backoff = client._config.retry_backoff_factor
+        start_time = time.time()
+        receiver._backoff(retried_times=1, last_exception=Exception('fake'), abs_timeout_time=None)
+        sleep_time_fixed = time.time() - start_time
+        assert sleep_time_fixed < backoff * (2 ** 1)
 
-#         # subscription receiver 
-#         receiver = client.get_subscription_receiver('fake_topic', 'fake_sub')
-#         backoff = client._config.retry_backoff_factor
-#         start_time = time.time()
-#         receiver._backoff(retried_times=1, last_exception=Exception('fake'), abs_timeout_time=None)
-#         sleep_time_fixed = time.time() - start_time
-#         assert sleep_time_fixed < backoff * (2 ** 1)
+        # subscription receiver 
+        receiver = client.get_subscription_receiver('fake_topic', 'fake_sub')
+        backoff = client._config.retry_backoff_factor
+        start_time = time.time()
+        receiver._backoff(retried_times=1, last_exception=Exception('fake'), abs_timeout_time=None)
+        sleep_time_fixed = time.time() - start_time
+        assert sleep_time_fixed < backoff * (2 ** 1)
 
-#     @pytest.mark.asyncio
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     async def test_custom_client_id_queue_sender_async(self, uamqp_transport, **kwargs):
-#         servicebus_connection_str = f'Endpoint=sb://resourcename{SERVICEBUS_ENDPOINT_SUFFIX}/;SharedAccessSignature=THISISATESTKEYXXXXXXXXXXXXXXXXXXXXXXXXXXXX=;'
-#         queue_name = "queue_name"
-#         custom_id = "my_custom_id"
-#         servicebus_client = ServiceBusClient.from_connection_string(conn_str=servicebus_connection_str, uamqp_transport=uamqp_transport)
-#         async with servicebus_client:
-#             queue_sender = servicebus_client.get_queue_sender(queue_name=queue_name, client_identifier=custom_id)
-#             assert queue_sender.client_identifier is not None
-#             assert queue_sender.client_identifier == custom_id
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    async def test_custom_client_id_queue_sender_async(self, uamqp_transport, **kwargs):
+        servicebus_connection_str = f'Endpoint=sb://resourcename{SERVICEBUS_ENDPOINT_SUFFIX}/;SharedAccessSignature=THISISATESTKEYXXXXXXXXXXXXXXXXXXXXXXXXXXXX=;'
+        queue_name = "queue_name"
+        custom_id = "my_custom_id"
+        servicebus_client = ServiceBusClient.from_connection_string(conn_str=servicebus_connection_str, uamqp_transport=uamqp_transport)
+        async with servicebus_client:
+            queue_sender = servicebus_client.get_queue_sender(queue_name=queue_name, client_identifier=custom_id)
+            assert queue_sender.client_identifier is not None
+            assert queue_sender.client_identifier == custom_id
 
-#     @pytest.mark.asyncio
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     async def test_default_client_id_queue_sender(self, uamqp_transport, **kwargs):
-#         servicebus_connection_str = f'Endpoint=sb://resourcename{SERVICEBUS_ENDPOINT_SUFFIX}/;SharedAccessSignature=THISISATESTKEYXXXXXXXXXXXXXXXXXXXXXXXXXXXX=;'
-#         queue_name = "queue_name"
-#         servicebus_client = ServiceBusClient.from_connection_string(conn_str=servicebus_connection_str, uamqp_transport=uamqp_transport)
-#         async with servicebus_client:
-#             queue_sender = servicebus_client.get_queue_sender(queue_name=queue_name)
-#             assert queue_sender.client_identifier is not None
-#             assert "SBSender" in queue_sender.client_identifier
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    async def test_default_client_id_queue_sender(self, uamqp_transport, **kwargs):
+        servicebus_connection_str = f'Endpoint=sb://resourcename{SERVICEBUS_ENDPOINT_SUFFIX}/;SharedAccessSignature=THISISATESTKEYXXXXXXXXXXXXXXXXXXXXXXXXXXXX=;'
+        queue_name = "queue_name"
+        servicebus_client = ServiceBusClient.from_connection_string(conn_str=servicebus_connection_str, uamqp_transport=uamqp_transport)
+        async with servicebus_client:
+            queue_sender = servicebus_client.get_queue_sender(queue_name=queue_name)
+            assert queue_sender.client_identifier is not None
+            assert "SBSender" in queue_sender.client_identifier
 
-#     @pytest.mark.asyncio
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     async def test_custom_client_id_queue_receiver(self, uamqp_transport, **kwargs):
-#         servicebus_connection_str = f'Endpoint=sb://resourcename{SERVICEBUS_ENDPOINT_SUFFIX}/;SharedAccessSignature=THISISATESTKEYXXXXXXXXXXXXXXXXXXXXXXXXXXXX=;'
-#         queue_name = "queue_name"
-#         custom_id = "my_custom_id"
-#         servicebus_client = ServiceBusClient.from_connection_string(conn_str=servicebus_connection_str, uamqp_transport=uamqp_transport)
-#         async with servicebus_client:
-#             queue_receiver = servicebus_client.get_queue_receiver(queue_name=queue_name, client_identifier=custom_id)
-#             assert queue_receiver.client_identifier is not None
-#             assert queue_receiver.client_identifier == custom_id
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    async def test_custom_client_id_queue_receiver(self, uamqp_transport, **kwargs):
+        servicebus_connection_str = f'Endpoint=sb://resourcename{SERVICEBUS_ENDPOINT_SUFFIX}/;SharedAccessSignature=THISISATESTKEYXXXXXXXXXXXXXXXXXXXXXXXXXXXX=;'
+        queue_name = "queue_name"
+        custom_id = "my_custom_id"
+        servicebus_client = ServiceBusClient.from_connection_string(conn_str=servicebus_connection_str, uamqp_transport=uamqp_transport)
+        async with servicebus_client:
+            queue_receiver = servicebus_client.get_queue_receiver(queue_name=queue_name, client_identifier=custom_id)
+            assert queue_receiver.client_identifier is not None
+            assert queue_receiver.client_identifier == custom_id
 
-#     @pytest.mark.asyncio
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     async def test_default_client_id_queue_receiver(self, uamqp_transport, **kwargs):
-#         servicebus_connection_str = f'Endpoint=sb://resourcename{SERVICEBUS_ENDPOINT_SUFFIX}/;SharedAccessSignature=THISISATESTKEYXXXXXXXXXXXXXXXXXXXXXXXXXXXX=;'
-#         queue_name = "queue_name"
-#         servicebus_client = ServiceBusClient.from_connection_string(conn_str=servicebus_connection_str, uamqp_transport=uamqp_transport)
-#         async with servicebus_client:
-#             queue_receiver = servicebus_client.get_queue_receiver(queue_name=queue_name)
-#             assert queue_receiver.client_identifier is not None
-#             assert "SBReceiver" in queue_receiver.client_identifier
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    async def test_default_client_id_queue_receiver(self, uamqp_transport, **kwargs):
+        servicebus_connection_str = f'Endpoint=sb://resourcename{SERVICEBUS_ENDPOINT_SUFFIX}/;SharedAccessSignature=THISISATESTKEYXXXXXXXXXXXXXXXXXXXXXXXXXXXX=;'
+        queue_name = "queue_name"
+        servicebus_client = ServiceBusClient.from_connection_string(conn_str=servicebus_connection_str, uamqp_transport=uamqp_transport)
+        async with servicebus_client:
+            queue_receiver = servicebus_client.get_queue_receiver(queue_name=queue_name)
+            assert queue_receiver.client_identifier is not None
+            assert "SBReceiver" in queue_receiver.client_identifier
 
-#     @pytest.mark.asyncio
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     async def test_custom_client_id_topic_sender(self, uamqp_transport, **kwargs):
-#         servicebus_connection_str = f'Endpoint=sb://resourcename{SERVICEBUS_ENDPOINT_SUFFIX}/;SharedAccessSignature=THISISATESTKEYXXXXXXXXXXXXXXXXXXXXXXXXXXXX=;'
-#         custom_id = "my_custom_id"
-#         topic_name = "topic_name"
-#         servicebus_client = ServiceBusClient.from_connection_string(conn_str=servicebus_connection_str, uamqp_transport=uamqp_transport)
-#         async with servicebus_client:
-#             topic_sender = servicebus_client.get_topic_sender(topic_name=topic_name, client_identifier=custom_id)
-#             assert topic_sender.client_identifier is not None
-#             assert topic_sender.client_identifier == custom_id
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    async def test_custom_client_id_topic_sender(self, uamqp_transport, **kwargs):
+        servicebus_connection_str = f'Endpoint=sb://resourcename{SERVICEBUS_ENDPOINT_SUFFIX}/;SharedAccessSignature=THISISATESTKEYXXXXXXXXXXXXXXXXXXXXXXXXXXXX=;'
+        custom_id = "my_custom_id"
+        topic_name = "topic_name"
+        servicebus_client = ServiceBusClient.from_connection_string(conn_str=servicebus_connection_str, uamqp_transport=uamqp_transport)
+        async with servicebus_client:
+            topic_sender = servicebus_client.get_topic_sender(topic_name=topic_name, client_identifier=custom_id)
+            assert topic_sender.client_identifier is not None
+            assert topic_sender.client_identifier == custom_id
 
-#     @pytest.mark.asyncio
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     async def test_default_client_id_topic_sender(self, uamqp_transport, **kwargs):
-#         servicebus_connection_str = f'Endpoint=sb://resourcename{SERVICEBUS_ENDPOINT_SUFFIX}/;SharedAccessSignature=THISISATESTKEYXXXXXXXXXXXXXXXXXXXXXXXXXXXX=;'
-#         topic_name = "topic_name"
-#         servicebus_client = ServiceBusClient.from_connection_string(conn_str=servicebus_connection_str, uamqp_transport=uamqp_transport)
-#         async with servicebus_client:
-#             topic_sender = servicebus_client.get_topic_sender(topic_name=topic_name)
-#             assert topic_sender.client_identifier is not None
-#             assert "SBSender" in topic_sender.client_identifier
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    async def test_default_client_id_topic_sender(self, uamqp_transport, **kwargs):
+        servicebus_connection_str = f'Endpoint=sb://resourcename{SERVICEBUS_ENDPOINT_SUFFIX}/;SharedAccessSignature=THISISATESTKEYXXXXXXXXXXXXXXXXXXXXXXXXXXXX=;'
+        topic_name = "topic_name"
+        servicebus_client = ServiceBusClient.from_connection_string(conn_str=servicebus_connection_str, uamqp_transport=uamqp_transport)
+        async with servicebus_client:
+            topic_sender = servicebus_client.get_topic_sender(topic_name=topic_name)
+            assert topic_sender.client_identifier is not None
+            assert "SBSender" in topic_sender.client_identifier
 
-#     @pytest.mark.asyncio
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     async def test_default_client_id_subscription_receiver(self, uamqp_transport, **kwargs):
-#         servicebus_connection_str = f'Endpoint=sb://resourcename{SERVICEBUS_ENDPOINT_SUFFIX}/;SharedAccessSignature=THISISATESTKEYXXXXXXXXXXXXXXXXXXXXXXXXXXXX=;'
-#         topic_name = "topic_name"
-#         sub_name = "sub_name"
-#         servicebus_client = ServiceBusClient.from_connection_string(conn_str=servicebus_connection_str, uamqp_transport=uamqp_transport)
-#         async with servicebus_client:
-#             subscription_receiver = servicebus_client.get_subscription_receiver(topic_name, sub_name)
-#             assert subscription_receiver.client_identifier is not None
-#             assert "SBReceiver" in subscription_receiver.client_identifier
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    async def test_default_client_id_subscription_receiver(self, uamqp_transport, **kwargs):
+        servicebus_connection_str = f'Endpoint=sb://resourcename{SERVICEBUS_ENDPOINT_SUFFIX}/;SharedAccessSignature=THISISATESTKEYXXXXXXXXXXXXXXXXXXXXXXXXXXXX=;'
+        topic_name = "topic_name"
+        sub_name = "sub_name"
+        servicebus_client = ServiceBusClient.from_connection_string(conn_str=servicebus_connection_str, uamqp_transport=uamqp_transport)
+        async with servicebus_client:
+            subscription_receiver = servicebus_client.get_subscription_receiver(topic_name, sub_name)
+            assert subscription_receiver.client_identifier is not None
+            assert "SBReceiver" in subscription_receiver.client_identifier
 
-#     @pytest.mark.asyncio
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     async def test_custom_client_id_subscription_receiver(self, uamqp_transport, **kwargs):
-#         servicebus_connection_str = f'Endpoint=sb://resourcename{SERVICEBUS_ENDPOINT_SUFFIX}/;SharedAccessSignature=THISISATESTKEYXXXXXXXXXXXXXXXXXXXXXXXXXXXX=;'
-#         custom_id = "my_custom_id"
-#         topic_name = "topic_name"
-#         sub_name = "sub_name"
-#         servicebus_client = ServiceBusClient.from_connection_string(conn_str=servicebus_connection_str, uamqp_transport=uamqp_transport)
-#         async with servicebus_client:
-#             subscription_receiver = servicebus_client.get_subscription_receiver(topic_name, sub_name, client_identifier=custom_id)
-#             assert subscription_receiver.client_identifier is not None
-#             assert subscription_receiver.client_identifier == custom_id
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    async def test_custom_client_id_subscription_receiver(self, uamqp_transport, **kwargs):
+        servicebus_connection_str = f'Endpoint=sb://resourcename{SERVICEBUS_ENDPOINT_SUFFIX}/;SharedAccessSignature=THISISATESTKEYXXXXXXXXXXXXXXXXXXXXXXXXXXXX=;'
+        custom_id = "my_custom_id"
+        topic_name = "topic_name"
+        sub_name = "sub_name"
+        servicebus_client = ServiceBusClient.from_connection_string(conn_str=servicebus_connection_str, uamqp_transport=uamqp_transport)
+        async with servicebus_client:
+            subscription_receiver = servicebus_client.get_subscription_receiver(topic_name, sub_name, client_identifier=custom_id)
+            assert subscription_receiver.client_identifier is not None
+            assert subscription_receiver.client_identifier == custom_id
 
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer()
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @CachedServiceBusQueuePreparer(name_prefix='servicebustest')
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_custom_endpoint_connection_verify_exception_async(self,
-#                                    uamqp_transport,
-#                                    *,
-#                                    servicebus_queue=None,
-#                                    servicebus_namespace=None,
-#                                    servicebus_namespace_key_name=None,
-#                                    servicebus_namespace_primary_key=None,
-#                                    servicebus_namespace_connection_string=None,
-#                                    **kwargs):
-#         hostname = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
-#         credential = AzureNamedKeyCredential(servicebus_namespace_key_name, servicebus_namespace_primary_key)
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer()
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @CachedServiceBusQueuePreparer(name_prefix='servicebustest')
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_custom_endpoint_connection_verify_exception_async(self,
+                                   uamqp_transport,
+                                   *,
+                                   servicebus_queue=None,
+                                   servicebus_namespace=None,
+                                   servicebus_namespace_key_name=None,
+                                   servicebus_namespace_primary_key=None,
+                                   servicebus_namespace_connection_string=None,
+                                   **kwargs):
+        hostname = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = AzureNamedKeyCredential(servicebus_namespace_key_name, servicebus_namespace_primary_key)
 
-#         client = ServiceBusClient(hostname, credential, connection_verify="cacert.pem", uamqp_transport=uamqp_transport)
-#         async with client:
-#             with pytest.raises(ServiceBusError):
-#                 async with client.get_queue_sender(servicebus_queue.name) as sender:
-#                     await sender.send_messages(ServiceBusMessage("foo"))
+        client = ServiceBusClient(hostname, credential, connection_verify="cacert.pem", uamqp_transport=uamqp_transport)
+        async with client:
+            with pytest.raises(ServiceBusError):
+                async with client.get_queue_sender(servicebus_queue.name) as sender:
+                    await sender.send_messages(ServiceBusMessage("foo"))
 
-#         # Skipping on OSX uamqp - it's raising an Authentication/TimeoutError
-#         if not uamqp_transport or not sys.platform.startswith('darwin'):
-#             fake_addr = "fakeaddress.com:1111"
-#             client = ServiceBusClient(
-#                 hostname,
-#                 credential,
-#                 custom_endpoint_address=fake_addr,
-#                 retry_total=0,
-#                 uamqp_transport=uamqp_transport
-#             )
-#             async with client:
-#                 with pytest.raises(ServiceBusConnectionError):
-#                     async with client.get_queue_sender(servicebus_queue.name) as sender:
-#                         await sender.send_messages(ServiceBusMessage("foo"))
+        # Skipping on OSX uamqp - it's raising an Authentication/TimeoutError
+        if not uamqp_transport or not sys.platform.startswith('darwin'):
+            fake_addr = "fakeaddress.com:1111"
+            client = ServiceBusClient(
+                hostname,
+                credential,
+                custom_endpoint_address=fake_addr,
+                retry_total=0,
+                uamqp_transport=uamqp_transport
+            )
+            async with client:
+                with pytest.raises(ServiceBusConnectionError):
+                    async with client.get_queue_sender(servicebus_queue.name) as sender:
+                        await sender.send_messages(ServiceBusMessage("foo"))
 
-#             client = ServiceBusClient(
-#                 hostname,
-#                 credential,
-#                 custom_endpoint_address=fake_addr,
-#                 connection_verify="cacert.pem",
-#                 retry_total=0,
-#                 uamqp_transport=uamqp_transport,
-#             )
-#             async with client:
-#                 with pytest.raises(ServiceBusError):
-#                     async with client.get_queue_sender(servicebus_queue.name) as sender:
-#                         await sender.send_messages(ServiceBusMessage("foo"))
+            client = ServiceBusClient(
+                hostname,
+                credential,
+                custom_endpoint_address=fake_addr,
+                connection_verify="cacert.pem",
+                retry_total=0,
+                uamqp_transport=uamqp_transport,
+            )
+            async with client:
+                with pytest.raises(ServiceBusError):
+                    async with client.get_queue_sender(servicebus_queue.name) as sender:
+                        await sender.send_messages(ServiceBusMessage("foo"))

--- a/sdk/servicebus/azure-servicebus/tests/async_tests/test_sb_client_async.py
+++ b/sdk/servicebus/azure-servicebus/tests/async_tests/test_sb_client_async.py
@@ -1,691 +1,691 @@
-#--------------------------------------------------------------------------
-# Copyright (c) Microsoft Corporation. All rights reserved.
-# Licensed under the MIT License. See License.txt in the project root for
-# license information.
-#--------------------------------------------------------------------------
+# #--------------------------------------------------------------------------
+# # Copyright (c) Microsoft Corporation. All rights reserved.
+# # Licensed under the MIT License. See License.txt in the project root for
+# # license information.
+# #--------------------------------------------------------------------------
 
-import logging
-import sys
-import time
-import asyncio
-import pytest
-import hmac
-import hashlib
-import base64
-from urllib.parse import quote as url_parse_quote
+# import logging
+# import sys
+# import time
+# import asyncio
+# import pytest
+# import hmac
+# import hashlib
+# import base64
+# from urllib.parse import quote as url_parse_quote
 
-from azure.core.credentials import AzureSasCredential, AzureNamedKeyCredential, AccessToken
-from azure.mgmt.servicebus.models import AccessRights
-from azure.servicebus.aio import ServiceBusClient, ServiceBusSender, ServiceBusReceiver
-from azure.servicebus import ServiceBusMessage
-from azure.servicebus.aio._base_handler_async import ServiceBusSharedKeyCredential
-from azure.servicebus.exceptions import (
-    ServiceBusError,
-    ServiceBusAuthenticationError,
-    ServiceBusAuthorizationError,
-    ServiceBusConnectionError
-)
-from devtools_testutils import AzureMgmtRecordedTestCase
-from tests.servicebus_preparer import (
-    CachedServiceBusNamespacePreparer, 
-    ServiceBusTopicPreparer, 
-    ServiceBusQueuePreparer,
-    ServiceBusNamespaceAuthorizationRulePreparer,
-    ServiceBusQueueAuthorizationRulePreparer,
-    CachedServiceBusQueuePreparer,
-    CachedServiceBusTopicPreparer,
-    CachedServiceBusSubscriptionPreparer,
-    CachedServiceBusResourceGroupPreparer,
-    SERVICEBUS_ENDPOINT_SUFFIX
-)
-from tests.utilities import get_logger, uamqp_transport as get_uamqp_transport, ArgPasserAsync
+# from azure.core.credentials import AzureSasCredential, AzureNamedKeyCredential, AccessToken
+# from azure.mgmt.servicebus.models import AccessRights
+# from azure.servicebus.aio import ServiceBusClient, ServiceBusSender, ServiceBusReceiver
+# from azure.servicebus import ServiceBusMessage
+# from azure.servicebus.aio._base_handler_async import ServiceBusSharedKeyCredential
+# from azure.servicebus.exceptions import (
+#     ServiceBusError,
+#     ServiceBusAuthenticationError,
+#     ServiceBusAuthorizationError,
+#     ServiceBusConnectionError
+# )
+# from devtools_testutils import AzureMgmtRecordedTestCase
+# from tests.servicebus_preparer import (
+#     CachedServiceBusNamespacePreparer, 
+#     ServiceBusTopicPreparer, 
+#     ServiceBusQueuePreparer,
+#     ServiceBusNamespaceAuthorizationRulePreparer,
+#     ServiceBusQueueAuthorizationRulePreparer,
+#     CachedServiceBusQueuePreparer,
+#     CachedServiceBusTopicPreparer,
+#     CachedServiceBusSubscriptionPreparer,
+#     CachedServiceBusResourceGroupPreparer,
+#     SERVICEBUS_ENDPOINT_SUFFIX
+# )
+# from tests.utilities import get_logger, uamqp_transport as get_uamqp_transport, ArgPasserAsync
 
-uamqp_transport_params, uamqp_transport_ids = get_uamqp_transport()
+# uamqp_transport_params, uamqp_transport_ids = get_uamqp_transport()
 
-_logger = get_logger(logging.DEBUG)
+# _logger = get_logger(logging.DEBUG)
 
-class TestServiceBusClientAsync(AzureMgmtRecordedTestCase):
+# class TestServiceBusClientAsync(AzureMgmtRecordedTestCase):
 
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @CachedServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_sb_client_bad_credentials_async(self, uamqp_transport, *, servicebus_namespace, servicebus_queue, **kwargs):
-        client = ServiceBusClient(
-            fully_qualified_namespace=f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}",
-            credential=ServiceBusSharedKeyCredential('invalid', 'invalid'),
-            logging_enable=False, uamqp_transport=uamqp_transport)
-        async with client:
-            with pytest.raises(ServiceBusAuthenticationError):
-                async with client.get_queue_sender(servicebus_queue.name) as sender:
-                    await sender.send_messages(ServiceBusMessage("test"))
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @CachedServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_sb_client_bad_credentials_async(self, uamqp_transport, *, servicebus_namespace, servicebus_queue, **kwargs):
+#         client = ServiceBusClient(
+#             fully_qualified_namespace=f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}",
+#             credential=ServiceBusSharedKeyCredential('invalid', 'invalid'),
+#             logging_enable=False, uamqp_transport=uamqp_transport)
+#         async with client:
+#             with pytest.raises(ServiceBusAuthenticationError):
+#                 async with client.get_queue_sender(servicebus_queue.name) as sender:
+#                     await sender.send_messages(ServiceBusMessage("test"))
 
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_sb_client_bad_namespace_async(self, uamqp_transport, **kwargs):
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_sb_client_bad_namespace_async(self, uamqp_transport, **kwargs):
 
-        client = ServiceBusClient(
-            fully_qualified_namespace=f'invalid{SERVICEBUS_ENDPOINT_SUFFIX}',
-            credential=ServiceBusSharedKeyCredential('invalid', 'invalid'),
-            logging_enable=False, uamqp_transport=uamqp_transport)
-        async with client:
-            with pytest.raises(ServiceBusError):
-                async with client.get_queue_sender('invalidqueue') as sender:
-                    await sender.send_messages(ServiceBusMessage("test"))
+#         client = ServiceBusClient(
+#             fully_qualified_namespace=f'invalid{SERVICEBUS_ENDPOINT_SUFFIX}',
+#             credential=ServiceBusSharedKeyCredential('invalid', 'invalid'),
+#             logging_enable=False, uamqp_transport=uamqp_transport)
+#         async with client:
+#             with pytest.raises(ServiceBusError):
+#                 async with client.get_queue_sender('invalidqueue') as sender:
+#                     await sender.send_messages(ServiceBusMessage("test"))
 
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_sb_client_bad_entity_async(self, uamqp_transport, *, servicebus_namespace_connection_string=None, **kwargs):
-        client = ServiceBusClient.from_connection_string(servicebus_namespace_connection_string, uamqp_transport=uamqp_transport)
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_sb_client_bad_entity_async(self, uamqp_transport, *, servicebus_namespace_connection_string=None, **kwargs):
+#         client = ServiceBusClient.from_connection_string(servicebus_namespace_connection_string, uamqp_transport=uamqp_transport)
 
-        async with client:
-            with pytest.raises(ServiceBusAuthenticationError):
-                async with client.get_queue_sender("invalid") as sender:
-                    await sender.send_messages(ServiceBusMessage("test"))
+#         async with client:
+#             with pytest.raises(ServiceBusAuthenticationError):
+#                 async with client.get_queue_sender("invalid") as sender:
+#                     await sender.send_messages(ServiceBusMessage("test"))
 
-        fake_str = f"Endpoint=sb://mock{SERVICEBUS_ENDPOINT_SUFFIX}/;" \
-                   f"SharedAccessKeyName=mock;SharedAccessKey=mock;EntityPath=mockentity"
-        fake_client = ServiceBusClient.from_connection_string(fake_str, uamqp_transport=uamqp_transport)
+#         fake_str = f"Endpoint=sb://mock{SERVICEBUS_ENDPOINT_SUFFIX}/;" \
+#                    f"SharedAccessKeyName=mock;SharedAccessKey=mock;EntityPath=mockentity"
+#         fake_client = ServiceBusClient.from_connection_string(fake_str, uamqp_transport=uamqp_transport)
 
-        with pytest.raises(ValueError):
-            fake_client.get_queue_sender('queue')
+#         with pytest.raises(ValueError):
+#             fake_client.get_queue_sender('queue')
 
-        with pytest.raises(ValueError):
-            fake_client.get_queue_receiver('queue')
+#         with pytest.raises(ValueError):
+#             fake_client.get_queue_receiver('queue')
 
-        with pytest.raises(ValueError):
-            fake_client.get_topic_sender('topic')
+#         with pytest.raises(ValueError):
+#             fake_client.get_topic_sender('topic')
 
-        with pytest.raises(ValueError):
-            fake_client.get_subscription_receiver('topic', 'subscription')
+#         with pytest.raises(ValueError):
+#             fake_client.get_subscription_receiver('topic', 'subscription')
 
-        fake_client.get_queue_sender('mockentity')
-        fake_client.get_queue_receiver('mockentity')
-        fake_client.get_topic_sender('mockentity')
-        fake_client.get_subscription_receiver('mockentity', 'subscription')
+#         fake_client.get_queue_sender('mockentity')
+#         fake_client.get_queue_receiver('mockentity')
+#         fake_client.get_topic_sender('mockentity')
+#         fake_client.get_subscription_receiver('mockentity', 'subscription')
 
-        fake_str = f"Endpoint=sb://mock{SERVICEBUS_ENDPOINT_SUFFIX}/;" \
-                   f"SharedAccessKeyName=mock;SharedAccessKey=mock"
-        fake_client = ServiceBusClient.from_connection_string(fake_str)
-        fake_client.get_queue_sender('queue')
-        fake_client.get_queue_receiver('queue')
-        fake_client.get_topic_sender('topic')
-        fake_client.get_subscription_receiver('topic', 'subscription')
+#         fake_str = f"Endpoint=sb://mock{SERVICEBUS_ENDPOINT_SUFFIX}/;" \
+#                    f"SharedAccessKeyName=mock;SharedAccessKey=mock"
+#         fake_client = ServiceBusClient.from_connection_string(fake_str)
+#         fake_client.get_queue_sender('queue')
+#         fake_client.get_queue_receiver('queue')
+#         fake_client.get_topic_sender('topic')
+#         fake_client.get_subscription_receiver('topic', 'subscription')
 
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @CachedServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-    @ServiceBusNamespaceAuthorizationRulePreparer(name_prefix='servicebustest', access_rights=[AccessRights.listen])
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_sb_client_readonly_credentials(self, uamqp_transport, *, servicebus_authorization_rule_connection_string=None, servicebus_queue=None, **kwargs):
-        client = ServiceBusClient.from_connection_string(servicebus_authorization_rule_connection_string, uamqp_transport=uamqp_transport)
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @CachedServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+#     @ServiceBusNamespaceAuthorizationRulePreparer(name_prefix='servicebustest', access_rights=[AccessRights.listen])
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_sb_client_readonly_credentials(self, uamqp_transport, *, servicebus_authorization_rule_connection_string=None, servicebus_queue=None, **kwargs):
+#         client = ServiceBusClient.from_connection_string(servicebus_authorization_rule_connection_string, uamqp_transport=uamqp_transport)
 
-        async with client:
-            async with client.get_queue_receiver(servicebus_queue.name) as receiver:
-                messages = await receiver.receive_messages(max_message_count=1, max_wait_time=1)
+#         async with client:
+#             async with client.get_queue_receiver(servicebus_queue.name) as receiver:
+#                 messages = await receiver.receive_messages(max_message_count=1, max_wait_time=1)
 
-            with pytest.raises(ServiceBusAuthorizationError):
-                async with client.get_queue_sender(servicebus_queue.name) as sender:
-                    await sender.send_messages(ServiceBusMessage("test"))
+#             with pytest.raises(ServiceBusAuthorizationError):
+#                 async with client.get_queue_sender(servicebus_queue.name) as sender:
+#                     await sender.send_messages(ServiceBusMessage("test"))
 
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @CachedServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-    @ServiceBusNamespaceAuthorizationRulePreparer(name_prefix='servicebustest', access_rights=[AccessRights.send])
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_sb_client_writeonly_credentials_async(self, uamqp_transport, *, servicebus_authorization_rule_connection_string=None, servicebus_queue=None, **kwargs):
-        client = ServiceBusClient.from_connection_string(servicebus_authorization_rule_connection_string, uamqp_transport=uamqp_transport)
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @CachedServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+#     @ServiceBusNamespaceAuthorizationRulePreparer(name_prefix='servicebustest', access_rights=[AccessRights.send])
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_sb_client_writeonly_credentials_async(self, uamqp_transport, *, servicebus_authorization_rule_connection_string=None, servicebus_queue=None, **kwargs):
+#         client = ServiceBusClient.from_connection_string(servicebus_authorization_rule_connection_string, uamqp_transport=uamqp_transport)
 
-        async with client:
-            with pytest.raises(ServiceBusError):
-                async with client.get_queue_receiver(servicebus_queue.name) as receiver:
-                    messages = await receiver.receive_messages(max_message_count=1, max_wait_time=1)
+#         async with client:
+#             with pytest.raises(ServiceBusError):
+#                 async with client.get_queue_receiver(servicebus_queue.name) as receiver:
+#                     messages = await receiver.receive_messages(max_message_count=1, max_wait_time=1)
 
-            async with client.get_queue_sender(servicebus_queue.name) as sender:
-                await sender.send_messages(ServiceBusMessage("test"))
+#             async with client.get_queue_sender(servicebus_queue.name) as sender:
+#                 await sender.send_messages(ServiceBusMessage("test"))
 
-                with pytest.raises(TypeError):
-                    await sender.send_messages("cat")
+#                 with pytest.raises(TypeError):
+#                     await sender.send_messages("cat")
 
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer()
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @CachedServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-    @CachedServiceBusTopicPreparer(name_prefix='servicebustest')
-    @CachedServiceBusSubscriptionPreparer(name_prefix='servicebustest')
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_async_sb_client_close_spawned_handlers(self, uamqp_transport, *, servicebus_namespace_connection_string, servicebus_queue, servicebus_topic, servicebus_subscription, **kwargs):
-        client = ServiceBusClient.from_connection_string(servicebus_namespace_connection_string, uamqp_transport=uamqp_transport)
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer()
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @CachedServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+#     @CachedServiceBusTopicPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusSubscriptionPreparer(name_prefix='servicebustest')
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_async_sb_client_close_spawned_handlers(self, uamqp_transport, *, servicebus_namespace_connection_string, servicebus_queue, servicebus_topic, servicebus_subscription, **kwargs):
+#         client = ServiceBusClient.from_connection_string(servicebus_namespace_connection_string, uamqp_transport=uamqp_transport)
 
-        await client.close()
+#         await client.close()
 
-        # context manager
-        async with client:
-            assert len(client._handlers) == 0
-            sender = client.get_queue_sender(servicebus_queue.name)
-            receiver = client.get_queue_receiver(servicebus_queue.name)
-            await sender._open()
-            await receiver._open()
+#         # context manager
+#         async with client:
+#             assert len(client._handlers) == 0
+#             sender = client.get_queue_sender(servicebus_queue.name)
+#             receiver = client.get_queue_receiver(servicebus_queue.name)
+#             await sender._open()
+#             await receiver._open()
 
-            assert sender._handler and sender._running
-            assert receiver._handler and receiver._running
-            assert len(client._handlers) == 2
+#             assert sender._handler and sender._running
+#             assert receiver._handler and receiver._running
+#             assert len(client._handlers) == 2
 
-        assert not sender._handler and not sender._running
-        assert not receiver._handler and not receiver._running
-        assert len(client._handlers) == 0
+#         assert not sender._handler and not sender._running
+#         assert not receiver._handler and not receiver._running
+#         assert len(client._handlers) == 0
 
-        # close operation
-        sender = client.get_queue_sender(servicebus_queue.name)
-        receiver = client.get_queue_receiver(servicebus_queue.name)
-        await sender._open()
-        await receiver._open()
+#         # close operation
+#         sender = client.get_queue_sender(servicebus_queue.name)
+#         receiver = client.get_queue_receiver(servicebus_queue.name)
+#         await sender._open()
+#         await receiver._open()
 
-        assert sender._handler and sender._running
-        assert receiver._handler and receiver._running
-        assert len(client._handlers) == 2
+#         assert sender._handler and sender._running
+#         assert receiver._handler and receiver._running
+#         assert len(client._handlers) == 2
 
-        await client.close()
+#         await client.close()
 
-        assert not sender._handler and not sender._running
-        assert not receiver._handler and not receiver._running
-        assert len(client._handlers) == 0
+#         assert not sender._handler and not sender._running
+#         assert not receiver._handler and not receiver._running
+#         assert len(client._handlers) == 0
 
-        queue_sender = client.get_queue_sender(servicebus_queue.name)
-        queue_receiver = client.get_queue_receiver(servicebus_queue.name)
-        assert len(client._handlers) == 2
-        queue_sender = client.get_queue_sender(servicebus_queue.name)
-        queue_receiver = client.get_queue_receiver(servicebus_queue.name)
-        # the previous sender/receiver can not longer be referenced, there might be a delay in CPython
-        # to remove the reference, so len of handlers should be less than 4
-        assert len(client._handlers) < 4
-        await client.close()
+#         queue_sender = client.get_queue_sender(servicebus_queue.name)
+#         queue_receiver = client.get_queue_receiver(servicebus_queue.name)
+#         assert len(client._handlers) == 2
+#         queue_sender = client.get_queue_sender(servicebus_queue.name)
+#         queue_receiver = client.get_queue_receiver(servicebus_queue.name)
+#         # the previous sender/receiver can not longer be referenced, there might be a delay in CPython
+#         # to remove the reference, so len of handlers should be less than 4
+#         assert len(client._handlers) < 4
+#         await client.close()
 
-        queue_sender = client.get_queue_sender(servicebus_queue.name)
-        queue_receiver = client.get_queue_receiver(servicebus_queue.name)
-        assert len(client._handlers) == 2
-        queue_sender = None
-        queue_receiver = None
-        assert len(client._handlers) < 2
+#         queue_sender = client.get_queue_sender(servicebus_queue.name)
+#         queue_receiver = client.get_queue_receiver(servicebus_queue.name)
+#         assert len(client._handlers) == 2
+#         queue_sender = None
+#         queue_receiver = None
+#         assert len(client._handlers) < 2
 
-        await client.close()
-        topic_sender = client.get_topic_sender(servicebus_topic.name)
-        subscription_receiver = client.get_subscription_receiver(servicebus_topic.name, servicebus_subscription.name)
-        assert len(client._handlers) == 2
-        topic_sender = None
-        subscription_receiver = None
-        # the previous sender/receiver can not longer be referenced, so len of handlers should just be 2 instead of 4
-        assert len(client._handlers) < 4
+#         await client.close()
+#         topic_sender = client.get_topic_sender(servicebus_topic.name)
+#         subscription_receiver = client.get_subscription_receiver(servicebus_topic.name, servicebus_subscription.name)
+#         assert len(client._handlers) == 2
+#         topic_sender = None
+#         subscription_receiver = None
+#         # the previous sender/receiver can not longer be referenced, so len of handlers should just be 2 instead of 4
+#         assert len(client._handlers) < 4
 
-        await client.close()
-        topic_sender = client.get_topic_sender(servicebus_topic.name)
-        subscription_receiver = client.get_subscription_receiver(servicebus_topic.name, servicebus_subscription.name)
-        assert len(client._handlers) == 2
-        topic_sender = client.get_topic_sender(servicebus_topic.name)
-        subscription_receiver = client.get_subscription_receiver(servicebus_topic.name, servicebus_subscription.name)
-        # the previous sender/receiver can not longer be referenced, so len of handlers should just be 2 instead of 4
-        assert len(client._handlers) < 4
+#         await client.close()
+#         topic_sender = client.get_topic_sender(servicebus_topic.name)
+#         subscription_receiver = client.get_subscription_receiver(servicebus_topic.name, servicebus_subscription.name)
+#         assert len(client._handlers) == 2
+#         topic_sender = client.get_topic_sender(servicebus_topic.name)
+#         subscription_receiver = client.get_subscription_receiver(servicebus_topic.name, servicebus_subscription.name)
+#         # the previous sender/receiver can not longer be referenced, so len of handlers should just be 2 instead of 4
+#         assert len(client._handlers) < 4
 
-        await client.close()
-        for _ in range(5):
-            queue_sender = client.get_queue_sender(servicebus_queue.name)
-            queue_receiver = client.get_queue_receiver(servicebus_queue.name)
-            topic_sender = client.get_topic_sender(servicebus_topic.name)
-            subscription_receiver = client.get_subscription_receiver(servicebus_topic.name,
-                                                                     servicebus_subscription.name)
-        assert len(client._handlers) < 15
-        await client.close()
+#         await client.close()
+#         for _ in range(5):
+#             queue_sender = client.get_queue_sender(servicebus_queue.name)
+#             queue_receiver = client.get_queue_receiver(servicebus_queue.name)
+#             topic_sender = client.get_topic_sender(servicebus_topic.name)
+#             subscription_receiver = client.get_subscription_receiver(servicebus_topic.name,
+#                                                                      servicebus_subscription.name)
+#         assert len(client._handlers) < 15
+#         await client.close()
 
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusNamespaceAuthorizationRulePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest_qone', parameter_name='wrong_queue', dead_lettering_on_message_expiration=True)
-    @ServiceBusQueuePreparer(name_prefix='servicebustest_qtwo', dead_lettering_on_message_expiration=True)
-    @ServiceBusQueueAuthorizationRulePreparer(name_prefix='servicebustest_qtwo')
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_sb_client_incorrect_queue_conn_str_async(self, uamqp_transport, *, servicebus_queue_authorization_rule_connection_string, servicebus_queue, wrong_queue, **kwargs):
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusNamespaceAuthorizationRulePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest_qone', parameter_name='wrong_queue', dead_lettering_on_message_expiration=True)
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest_qtwo', dead_lettering_on_message_expiration=True)
+#     @ServiceBusQueueAuthorizationRulePreparer(name_prefix='servicebustest_qtwo')
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_sb_client_incorrect_queue_conn_str_async(self, uamqp_transport, *, servicebus_queue_authorization_rule_connection_string, servicebus_queue, wrong_queue, **kwargs):
         
-        client = ServiceBusClient.from_connection_string(servicebus_queue_authorization_rule_connection_string, uamqp_transport=uamqp_transport)
-        async with client:
-            # Validate that the wrong sender/receiver queues with the right credentials fail.
-            with pytest.raises(ValueError):
-                async with client.get_queue_sender(wrong_queue.name) as sender:
-                    await sender.send_messages(ServiceBusMessage("test"))
+#         client = ServiceBusClient.from_connection_string(servicebus_queue_authorization_rule_connection_string, uamqp_transport=uamqp_transport)
+#         async with client:
+#             # Validate that the wrong sender/receiver queues with the right credentials fail.
+#             with pytest.raises(ValueError):
+#                 async with client.get_queue_sender(wrong_queue.name) as sender:
+#                     await sender.send_messages(ServiceBusMessage("test"))
 
-            with pytest.raises(ValueError):
-                async with client.get_queue_receiver(wrong_queue.name) as receiver:
-                    messages = await receiver.receive_messages(max_message_count=1, max_wait_time=1)
+#             with pytest.raises(ValueError):
+#                 async with client.get_queue_receiver(wrong_queue.name) as receiver:
+#                     messages = await receiver.receive_messages(max_message_count=1, max_wait_time=1)
 
-            # But that the correct ones work.
-            async with client.get_queue_sender(servicebus_queue.name) as sender:
-                await sender.send_messages(ServiceBusMessage("test")) 
+#             # But that the correct ones work.
+#             async with client.get_queue_sender(servicebus_queue.name) as sender:
+#                 await sender.send_messages(ServiceBusMessage("test")) 
 
-            async with client.get_queue_receiver(servicebus_queue.name) as receiver:
-                messages = await receiver.receive_messages(max_message_count=1, max_wait_time=1)
+#             async with client.get_queue_receiver(servicebus_queue.name) as receiver:
+#                 messages = await receiver.receive_messages(max_message_count=1, max_wait_time=1)
 
-            # Now do the same but with direct connstr initialization.
-            with pytest.raises(ValueError):
-                async with ServiceBusSender._from_connection_string(
-                    servicebus_queue_authorization_rule_connection_string,
-                    queue_name=wrong_queue.name,
-                ) as sender:
-                        await sender.send_messages(ServiceBusMessage("test"))
+#             # Now do the same but with direct connstr initialization.
+#             with pytest.raises(ValueError):
+#                 async with ServiceBusSender._from_connection_string(
+#                     servicebus_queue_authorization_rule_connection_string,
+#                     queue_name=wrong_queue.name,
+#                 ) as sender:
+#                         await sender.send_messages(ServiceBusMessage("test"))
 
-            with pytest.raises(ValueError):
-                async with ServiceBusReceiver._from_connection_string(
-                    servicebus_queue_authorization_rule_connection_string,
-                    queue_name=wrong_queue.name,
-                ) as receiver:
-                    messages = await receiver.receive_messages(max_message_count=1, max_wait_time=1)
+#             with pytest.raises(ValueError):
+#                 async with ServiceBusReceiver._from_connection_string(
+#                     servicebus_queue_authorization_rule_connection_string,
+#                     queue_name=wrong_queue.name,
+#                 ) as receiver:
+#                     messages = await receiver.receive_messages(max_message_count=1, max_wait_time=1)
 
-            async with ServiceBusSender._from_connection_string(
-                servicebus_queue_authorization_rule_connection_string,
-                queue_name=servicebus_queue.name,
-            ) as sender:
-                await sender.send_messages(ServiceBusMessage("test"))
+#             async with ServiceBusSender._from_connection_string(
+#                 servicebus_queue_authorization_rule_connection_string,
+#                 queue_name=servicebus_queue.name,
+#             ) as sender:
+#                 await sender.send_messages(ServiceBusMessage("test"))
 
-            async with ServiceBusReceiver._from_connection_string(
-                servicebus_queue_authorization_rule_connection_string,
-                queue_name=servicebus_queue.name,
-            ) as receiver:
-                messages = await receiver.receive_messages(max_message_count=1, max_wait_time=1)
+#             async with ServiceBusReceiver._from_connection_string(
+#                 servicebus_queue_authorization_rule_connection_string,
+#                 queue_name=servicebus_queue.name,
+#             ) as receiver:
+#                 messages = await receiver.receive_messages(max_message_count=1, max_wait_time=1)
 
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer()
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @CachedServiceBusQueuePreparer(name_prefix='servicebustest')
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_client_sas_credential_async(self,
-                                   uamqp_transport,
-                                   *,
-                                   servicebus_queue=None,
-                                   servicebus_namespace=None,
-                                   servicebus_namespace_key_name=None,
-                                   servicebus_namespace_primary_key=None,
-                                   servicebus_namespace_connection_string=None,
-                                   **kwargs):
-        # This should "just work" to validate known-good.
-        credential = ServiceBusSharedKeyCredential(servicebus_namespace_key_name, servicebus_namespace_primary_key)
-        hostname = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
-        auth_uri = "sb://{}/{}".format(hostname, servicebus_queue.name)
-        token = (await credential.get_token(auth_uri)).token
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer()
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @CachedServiceBusQueuePreparer(name_prefix='servicebustest')
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_client_sas_credential_async(self,
+#                                    uamqp_transport,
+#                                    *,
+#                                    servicebus_queue=None,
+#                                    servicebus_namespace=None,
+#                                    servicebus_namespace_key_name=None,
+#                                    servicebus_namespace_primary_key=None,
+#                                    servicebus_namespace_connection_string=None,
+#                                    **kwargs):
+#         # This should "just work" to validate known-good.
+#         credential = ServiceBusSharedKeyCredential(servicebus_namespace_key_name, servicebus_namespace_primary_key)
+#         hostname = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+#         auth_uri = "sb://{}/{}".format(hostname, servicebus_queue.name)
+#         token = (await credential.get_token(auth_uri)).token
 
-        # Finally let's do it with SAS token + conn str
-        token_conn_str = "Endpoint=sb://{}/;SharedAccessSignature={};".format(hostname, token)
+#         # Finally let's do it with SAS token + conn str
+#         token_conn_str = "Endpoint=sb://{}/;SharedAccessSignature={};".format(hostname, token)
 
-        client = ServiceBusClient.from_connection_string(token_conn_str, uamqp_transport=uamqp_transport)
-        async with client:
-            assert len(client._handlers) == 0
-            async with client.get_queue_sender(servicebus_queue.name) as sender:
-                await sender.send_messages(ServiceBusMessage("foo"))
+#         client = ServiceBusClient.from_connection_string(token_conn_str, uamqp_transport=uamqp_transport)
+#         async with client:
+#             assert len(client._handlers) == 0
+#             async with client.get_queue_sender(servicebus_queue.name) as sender:
+#                 await sender.send_messages(ServiceBusMessage("foo"))
 
-        def generate_sas_token(uri, sas_name, sas_value, token_ttl):
-            """Performs the signing and encoding needed to generate a sas token from a sas key."""
-            sas = sas_value.encode('utf-8')
-            expiry = str(int(time.time() + token_ttl))
-            string_to_sign = (uri + '\n' + expiry).encode('utf-8')
-            signed_hmac_sha256 = hmac.HMAC(sas, string_to_sign, hashlib.sha256)
-            signature = url_parse_quote(base64.b64encode(signed_hmac_sha256.digest()))
-            return 'SharedAccessSignature sr={}&sig={}&se={}&skn={}'.format(uri, signature, expiry, sas_name)
+#         def generate_sas_token(uri, sas_name, sas_value, token_ttl):
+#             """Performs the signing and encoding needed to generate a sas token from a sas key."""
+#             sas = sas_value.encode('utf-8')
+#             expiry = str(int(time.time() + token_ttl))
+#             string_to_sign = (uri + '\n' + expiry).encode('utf-8')
+#             signed_hmac_sha256 = hmac.HMAC(sas, string_to_sign, hashlib.sha256)
+#             signature = url_parse_quote(base64.b64encode(signed_hmac_sha256.digest()))
+#             return 'SharedAccessSignature sr={}&sig={}&se={}&skn={}'.format(uri, signature, expiry, sas_name)
 
-        class CustomizedSASCredential(object):
-            def __init__(self, token, expiry):
-                """
-                :param str token: The token string
-                :param float expiry: The epoch timestamp
-                """
-                self.token = token
-                self.expiry = expiry
-                self.token_type = b"servicebus.windows.net:sastoken"
+#         class CustomizedSASCredential(object):
+#             def __init__(self, token, expiry):
+#                 """
+#                 :param str token: The token string
+#                 :param float expiry: The epoch timestamp
+#                 """
+#                 self.token = token
+#                 self.expiry = expiry
+#                 self.token_type = b"servicebus.windows.net:sastoken"
 
-            async def get_token(self, *scopes, **kwargs):
-                """
-                This method is automatically called when token is about to expire.
-                """
-                return AccessToken(self.token, self.expiry)
+#             async def get_token(self, *scopes, **kwargs):
+#                 """
+#                 This method is automatically called when token is about to expire.
+#                 """
+#                 return AccessToken(self.token, self.expiry)
 
-        token_ttl = 5  # seconds
-        sas_token = generate_sas_token(
-            auth_uri, servicebus_namespace_key_name, servicebus_namespace_primary_key, token_ttl
-        )
-        credential=CustomizedSASCredential(sas_token, time.time() + token_ttl)
+#         token_ttl = 5  # seconds
+#         sas_token = generate_sas_token(
+#             auth_uri, servicebus_namespace_key_name, servicebus_namespace_primary_key, token_ttl
+#         )
+#         credential=CustomizedSASCredential(sas_token, time.time() + token_ttl)
 
-        async with ServiceBusClient(hostname, credential, uamqp_transport=uamqp_transport) as client:
-            sender = client.get_queue_sender(queue_name=servicebus_queue.name)
-            await asyncio.sleep(10)
-            with pytest.raises(ServiceBusAuthenticationError):
-                async with sender:
-                    message = ServiceBusMessage("Single Message")
-                    await sender.send_messages(message)
+#         async with ServiceBusClient(hostname, credential, uamqp_transport=uamqp_transport) as client:
+#             sender = client.get_queue_sender(queue_name=servicebus_queue.name)
+#             await asyncio.sleep(10)
+#             with pytest.raises(ServiceBusAuthenticationError):
+#                 async with sender:
+#                     message = ServiceBusMessage("Single Message")
+#                     await sender.send_messages(message)
 
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer()
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @CachedServiceBusQueuePreparer(name_prefix='servicebustest')
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_client_credential_async(self,
-                                   uamqp_transport,
-                                   *,
-                                   servicebus_queue=None,
-                                   servicebus_namespace=None,
-                                   servicebus_namespace_key_name=None,
-                                   servicebus_namespace_primary_key=None,
-                                   servicebus_namespace_connection_string=None,
-                                   **kwargs):
-        # This should "just work" to validate known-good.
-        credential = ServiceBusSharedKeyCredential(servicebus_namespace_key_name, servicebus_namespace_primary_key)
-        hostname = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer()
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @CachedServiceBusQueuePreparer(name_prefix='servicebustest')
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_client_credential_async(self,
+#                                    uamqp_transport,
+#                                    *,
+#                                    servicebus_queue=None,
+#                                    servicebus_namespace=None,
+#                                    servicebus_namespace_key_name=None,
+#                                    servicebus_namespace_primary_key=None,
+#                                    servicebus_namespace_connection_string=None,
+#                                    **kwargs):
+#         # This should "just work" to validate known-good.
+#         credential = ServiceBusSharedKeyCredential(servicebus_namespace_key_name, servicebus_namespace_primary_key)
+#         hostname = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
 
-        client = ServiceBusClient(hostname, credential, uamqp_transport=uamqp_transport)
-        async with client:
-            assert len(client._handlers) == 0
-            async with client.get_queue_sender(servicebus_queue.name) as sender:
-                await sender.send_messages(ServiceBusMessage("foo"))
+#         client = ServiceBusClient(hostname, credential, uamqp_transport=uamqp_transport)
+#         async with client:
+#             assert len(client._handlers) == 0
+#             async with client.get_queue_sender(servicebus_queue.name) as sender:
+#                 await sender.send_messages(ServiceBusMessage("foo"))
 
-        hostname = f"sb://{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+#         hostname = f"sb://{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
 
-        client = ServiceBusClient(hostname, credential, uamqp_transport=uamqp_transport)
-        async with client:
-            assert len(client._handlers) == 0
-            async with client.get_queue_sender(servicebus_queue.name) as sender:
-                await sender.send_messages(ServiceBusMessage("foo"))
+#         client = ServiceBusClient(hostname, credential, uamqp_transport=uamqp_transport)
+#         async with client:
+#             assert len(client._handlers) == 0
+#             async with client.get_queue_sender(servicebus_queue.name) as sender:
+#                 await sender.send_messages(ServiceBusMessage("foo"))
 
-        hostname = f"https://{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+#         hostname = f"https://{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
 
-        client = ServiceBusClient(hostname, credential, uamqp_transport=uamqp_transport)
-        async with client:
-            assert len(client._handlers) == 0
-            async with client.get_queue_sender(servicebus_queue.name) as sender:
-                await sender.send_messages(ServiceBusMessage("foo"))
+#         client = ServiceBusClient(hostname, credential, uamqp_transport=uamqp_transport)
+#         async with client:
+#             assert len(client._handlers) == 0
+#             async with client.get_queue_sender(servicebus_queue.name) as sender:
+#                 await sender.send_messages(ServiceBusMessage("foo"))
 
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer()
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @CachedServiceBusQueuePreparer(name_prefix='servicebustest')
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_client_azure_sas_credential_async(self,
-                                   uamqp_transport,
-                                   *,
-                                   servicebus_queue=None,
-                                   servicebus_namespace=None,
-                                   servicebus_namespace_key_name=None,
-                                   servicebus_namespace_primary_key=None,
-                                   servicebus_namespace_connection_string=None,
-                                   **kwargs):
-        # This should "just work" to validate known-good.
-        credential = ServiceBusSharedKeyCredential(servicebus_namespace_key_name, servicebus_namespace_primary_key)
-        hostname = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
-        auth_uri = "sb://{}/{}".format(hostname, servicebus_queue.name)
-        token = (await credential.get_token(auth_uri)).token
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer()
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @CachedServiceBusQueuePreparer(name_prefix='servicebustest')
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_client_azure_sas_credential_async(self,
+#                                    uamqp_transport,
+#                                    *,
+#                                    servicebus_queue=None,
+#                                    servicebus_namespace=None,
+#                                    servicebus_namespace_key_name=None,
+#                                    servicebus_namespace_primary_key=None,
+#                                    servicebus_namespace_connection_string=None,
+#                                    **kwargs):
+#         # This should "just work" to validate known-good.
+#         credential = ServiceBusSharedKeyCredential(servicebus_namespace_key_name, servicebus_namespace_primary_key)
+#         hostname = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+#         auth_uri = "sb://{}/{}".format(hostname, servicebus_queue.name)
+#         token = (await credential.get_token(auth_uri)).token
 
-        credential = AzureSasCredential(token)
+#         credential = AzureSasCredential(token)
 
-        client = ServiceBusClient(hostname, credential, uamqp_transport=uamqp_transport)
-        async with client:
-            assert len(client._handlers) == 0
-            async with client.get_queue_sender(servicebus_queue.name) as sender:
-                await sender.send_messages(ServiceBusMessage("foo"))
+#         client = ServiceBusClient(hostname, credential, uamqp_transport=uamqp_transport)
+#         async with client:
+#             assert len(client._handlers) == 0
+#             async with client.get_queue_sender(servicebus_queue.name) as sender:
+#                 await sender.send_messages(ServiceBusMessage("foo"))
 
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer()
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @CachedServiceBusQueuePreparer(name_prefix='servicebustest')
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_azure_named_key_credential_async(self,
-                                   uamqp_transport,
-                                   *,
-                                   servicebus_queue=None,
-                                   servicebus_namespace=None,
-                                   servicebus_namespace_key_name=None,
-                                   servicebus_namespace_primary_key=None,
-                                   servicebus_namespace_connection_string=None,
-                                   **kwargs):
-        hostname = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
-        credential = AzureNamedKeyCredential(servicebus_namespace_key_name, servicebus_namespace_primary_key)
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer()
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @CachedServiceBusQueuePreparer(name_prefix='servicebustest')
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_azure_named_key_credential_async(self,
+#                                    uamqp_transport,
+#                                    *,
+#                                    servicebus_queue=None,
+#                                    servicebus_namespace=None,
+#                                    servicebus_namespace_key_name=None,
+#                                    servicebus_namespace_primary_key=None,
+#                                    servicebus_namespace_connection_string=None,
+#                                    **kwargs):
+#         hostname = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+#         credential = AzureNamedKeyCredential(servicebus_namespace_key_name, servicebus_namespace_primary_key)
 
-        client = ServiceBusClient(hostname, credential, uamqp_transport=uamqp_transport)
-        async with client:
-            async with client.get_queue_sender(servicebus_queue.name) as sender:
-                await sender.send_messages(ServiceBusMessage("foo"))
+#         client = ServiceBusClient(hostname, credential, uamqp_transport=uamqp_transport)
+#         async with client:
+#             async with client.get_queue_sender(servicebus_queue.name) as sender:
+#                 await sender.send_messages(ServiceBusMessage("foo"))
         
-        credential.update("foo", "bar")
-        with pytest.raises(Exception):
-            async with client:
-                async with client.get_queue_sender(servicebus_queue.name) as sender:
-                    await sender.send_messages(ServiceBusMessage("foo"))
+#         credential.update("foo", "bar")
+#         with pytest.raises(Exception):
+#             async with client:
+#                 async with client.get_queue_sender(servicebus_queue.name) as sender:
+#                     await sender.send_messages(ServiceBusMessage("foo"))
 
-        # update back to the right key again
-        credential.update(servicebus_namespace_key_name, servicebus_namespace_primary_key)
-        async with client:
-            async with client.get_queue_sender(servicebus_queue.name) as sender:
-                await sender.send_messages(ServiceBusMessage("foo"))
+#         # update back to the right key again
+#         credential.update(servicebus_namespace_key_name, servicebus_namespace_primary_key)
+#         async with client:
+#             async with client.get_queue_sender(servicebus_queue.name) as sender:
+#                 await sender.send_messages(ServiceBusMessage("foo"))
 
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    def test_backoff_fixed_retry(self, uamqp_transport):
-        client = ServiceBusClient(
-            'fake.host.com',
-            'fake_eh',
-            retry_mode='fixed',
-            uamqp_transport=uamqp_transport
-        )
-        # queue sender
-        sender = client.get_queue_sender('fake_name')
-        backoff = client._config.retry_backoff_factor
-        start_time = time.time()
-        sender._backoff(retried_times=1, last_exception=Exception('fake'), abs_timeout_time=None)
-        sleep_time_fixed = time.time() - start_time
-        # exp = 0.8 * (2 ** 1) = 1.6
-        # time.sleep() in _backoff will take AT LEAST time 'exp' for retry_mode='exponential'
-        # check that fixed is less than 'exp'
-        assert sleep_time_fixed < backoff * (2 ** 1)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     def test_backoff_fixed_retry(self, uamqp_transport):
+#         client = ServiceBusClient(
+#             'fake.host.com',
+#             'fake_eh',
+#             retry_mode='fixed',
+#             uamqp_transport=uamqp_transport
+#         )
+#         # queue sender
+#         sender = client.get_queue_sender('fake_name')
+#         backoff = client._config.retry_backoff_factor
+#         start_time = time.time()
+#         sender._backoff(retried_times=1, last_exception=Exception('fake'), abs_timeout_time=None)
+#         sleep_time_fixed = time.time() - start_time
+#         # exp = 0.8 * (2 ** 1) = 1.6
+#         # time.sleep() in _backoff will take AT LEAST time 'exp' for retry_mode='exponential'
+#         # check that fixed is less than 'exp'
+#         assert sleep_time_fixed < backoff * (2 ** 1)
 
-        # topic sender
-        sender = client.get_topic_sender('fake_name')
-        backoff = client._config.retry_backoff_factor
-        start_time = time.time()
-        sender._backoff(retried_times=1, last_exception=Exception('fake'), abs_timeout_time=None)
-        sleep_time_fixed = time.time() - start_time
-        assert sleep_time_fixed < backoff * (2 ** 1)
+#         # topic sender
+#         sender = client.get_topic_sender('fake_name')
+#         backoff = client._config.retry_backoff_factor
+#         start_time = time.time()
+#         sender._backoff(retried_times=1, last_exception=Exception('fake'), abs_timeout_time=None)
+#         sleep_time_fixed = time.time() - start_time
+#         assert sleep_time_fixed < backoff * (2 ** 1)
 
-        # queue receiver 
-        receiver = client.get_queue_receiver('fake_name')
-        backoff = client._config.retry_backoff_factor
-        start_time = time.time()
-        receiver._backoff(retried_times=1, last_exception=Exception('fake'), abs_timeout_time=None)
-        sleep_time_fixed = time.time() - start_time
-        assert sleep_time_fixed < backoff * (2 ** 1)
+#         # queue receiver 
+#         receiver = client.get_queue_receiver('fake_name')
+#         backoff = client._config.retry_backoff_factor
+#         start_time = time.time()
+#         receiver._backoff(retried_times=1, last_exception=Exception('fake'), abs_timeout_time=None)
+#         sleep_time_fixed = time.time() - start_time
+#         assert sleep_time_fixed < backoff * (2 ** 1)
 
-        # subscription receiver 
-        receiver = client.get_subscription_receiver('fake_topic', 'fake_sub')
-        backoff = client._config.retry_backoff_factor
-        start_time = time.time()
-        receiver._backoff(retried_times=1, last_exception=Exception('fake'), abs_timeout_time=None)
-        sleep_time_fixed = time.time() - start_time
-        assert sleep_time_fixed < backoff * (2 ** 1)
+#         # subscription receiver 
+#         receiver = client.get_subscription_receiver('fake_topic', 'fake_sub')
+#         backoff = client._config.retry_backoff_factor
+#         start_time = time.time()
+#         receiver._backoff(retried_times=1, last_exception=Exception('fake'), abs_timeout_time=None)
+#         sleep_time_fixed = time.time() - start_time
+#         assert sleep_time_fixed < backoff * (2 ** 1)
 
-    @pytest.mark.asyncio
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    async def test_custom_client_id_queue_sender_async(self, uamqp_transport, **kwargs):
-        servicebus_connection_str = f'Endpoint=sb://resourcename{SERVICEBUS_ENDPOINT_SUFFIX}/;SharedAccessSignature=THISISATESTKEYXXXXXXXXXXXXXXXXXXXXXXXXXXXX=;'
-        queue_name = "queue_name"
-        custom_id = "my_custom_id"
-        servicebus_client = ServiceBusClient.from_connection_string(conn_str=servicebus_connection_str, uamqp_transport=uamqp_transport)
-        async with servicebus_client:
-            queue_sender = servicebus_client.get_queue_sender(queue_name=queue_name, client_identifier=custom_id)
-            assert queue_sender.client_identifier is not None
-            assert queue_sender.client_identifier == custom_id
+#     @pytest.mark.asyncio
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     async def test_custom_client_id_queue_sender_async(self, uamqp_transport, **kwargs):
+#         servicebus_connection_str = f'Endpoint=sb://resourcename{SERVICEBUS_ENDPOINT_SUFFIX}/;SharedAccessSignature=THISISATESTKEYXXXXXXXXXXXXXXXXXXXXXXXXXXXX=;'
+#         queue_name = "queue_name"
+#         custom_id = "my_custom_id"
+#         servicebus_client = ServiceBusClient.from_connection_string(conn_str=servicebus_connection_str, uamqp_transport=uamqp_transport)
+#         async with servicebus_client:
+#             queue_sender = servicebus_client.get_queue_sender(queue_name=queue_name, client_identifier=custom_id)
+#             assert queue_sender.client_identifier is not None
+#             assert queue_sender.client_identifier == custom_id
 
-    @pytest.mark.asyncio
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    async def test_default_client_id_queue_sender(self, uamqp_transport, **kwargs):
-        servicebus_connection_str = f'Endpoint=sb://resourcename{SERVICEBUS_ENDPOINT_SUFFIX}/;SharedAccessSignature=THISISATESTKEYXXXXXXXXXXXXXXXXXXXXXXXXXXXX=;'
-        queue_name = "queue_name"
-        servicebus_client = ServiceBusClient.from_connection_string(conn_str=servicebus_connection_str, uamqp_transport=uamqp_transport)
-        async with servicebus_client:
-            queue_sender = servicebus_client.get_queue_sender(queue_name=queue_name)
-            assert queue_sender.client_identifier is not None
-            assert "SBSender" in queue_sender.client_identifier
+#     @pytest.mark.asyncio
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     async def test_default_client_id_queue_sender(self, uamqp_transport, **kwargs):
+#         servicebus_connection_str = f'Endpoint=sb://resourcename{SERVICEBUS_ENDPOINT_SUFFIX}/;SharedAccessSignature=THISISATESTKEYXXXXXXXXXXXXXXXXXXXXXXXXXXXX=;'
+#         queue_name = "queue_name"
+#         servicebus_client = ServiceBusClient.from_connection_string(conn_str=servicebus_connection_str, uamqp_transport=uamqp_transport)
+#         async with servicebus_client:
+#             queue_sender = servicebus_client.get_queue_sender(queue_name=queue_name)
+#             assert queue_sender.client_identifier is not None
+#             assert "SBSender" in queue_sender.client_identifier
 
-    @pytest.mark.asyncio
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    async def test_custom_client_id_queue_receiver(self, uamqp_transport, **kwargs):
-        servicebus_connection_str = f'Endpoint=sb://resourcename{SERVICEBUS_ENDPOINT_SUFFIX}/;SharedAccessSignature=THISISATESTKEYXXXXXXXXXXXXXXXXXXXXXXXXXXXX=;'
-        queue_name = "queue_name"
-        custom_id = "my_custom_id"
-        servicebus_client = ServiceBusClient.from_connection_string(conn_str=servicebus_connection_str, uamqp_transport=uamqp_transport)
-        async with servicebus_client:
-            queue_receiver = servicebus_client.get_queue_receiver(queue_name=queue_name, client_identifier=custom_id)
-            assert queue_receiver.client_identifier is not None
-            assert queue_receiver.client_identifier == custom_id
+#     @pytest.mark.asyncio
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     async def test_custom_client_id_queue_receiver(self, uamqp_transport, **kwargs):
+#         servicebus_connection_str = f'Endpoint=sb://resourcename{SERVICEBUS_ENDPOINT_SUFFIX}/;SharedAccessSignature=THISISATESTKEYXXXXXXXXXXXXXXXXXXXXXXXXXXXX=;'
+#         queue_name = "queue_name"
+#         custom_id = "my_custom_id"
+#         servicebus_client = ServiceBusClient.from_connection_string(conn_str=servicebus_connection_str, uamqp_transport=uamqp_transport)
+#         async with servicebus_client:
+#             queue_receiver = servicebus_client.get_queue_receiver(queue_name=queue_name, client_identifier=custom_id)
+#             assert queue_receiver.client_identifier is not None
+#             assert queue_receiver.client_identifier == custom_id
 
-    @pytest.mark.asyncio
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    async def test_default_client_id_queue_receiver(self, uamqp_transport, **kwargs):
-        servicebus_connection_str = f'Endpoint=sb://resourcename{SERVICEBUS_ENDPOINT_SUFFIX}/;SharedAccessSignature=THISISATESTKEYXXXXXXXXXXXXXXXXXXXXXXXXXXXX=;'
-        queue_name = "queue_name"
-        servicebus_client = ServiceBusClient.from_connection_string(conn_str=servicebus_connection_str, uamqp_transport=uamqp_transport)
-        async with servicebus_client:
-            queue_receiver = servicebus_client.get_queue_receiver(queue_name=queue_name)
-            assert queue_receiver.client_identifier is not None
-            assert "SBReceiver" in queue_receiver.client_identifier
+#     @pytest.mark.asyncio
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     async def test_default_client_id_queue_receiver(self, uamqp_transport, **kwargs):
+#         servicebus_connection_str = f'Endpoint=sb://resourcename{SERVICEBUS_ENDPOINT_SUFFIX}/;SharedAccessSignature=THISISATESTKEYXXXXXXXXXXXXXXXXXXXXXXXXXXXX=;'
+#         queue_name = "queue_name"
+#         servicebus_client = ServiceBusClient.from_connection_string(conn_str=servicebus_connection_str, uamqp_transport=uamqp_transport)
+#         async with servicebus_client:
+#             queue_receiver = servicebus_client.get_queue_receiver(queue_name=queue_name)
+#             assert queue_receiver.client_identifier is not None
+#             assert "SBReceiver" in queue_receiver.client_identifier
 
-    @pytest.mark.asyncio
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    async def test_custom_client_id_topic_sender(self, uamqp_transport, **kwargs):
-        servicebus_connection_str = f'Endpoint=sb://resourcename{SERVICEBUS_ENDPOINT_SUFFIX}/;SharedAccessSignature=THISISATESTKEYXXXXXXXXXXXXXXXXXXXXXXXXXXXX=;'
-        custom_id = "my_custom_id"
-        topic_name = "topic_name"
-        servicebus_client = ServiceBusClient.from_connection_string(conn_str=servicebus_connection_str, uamqp_transport=uamqp_transport)
-        async with servicebus_client:
-            topic_sender = servicebus_client.get_topic_sender(topic_name=topic_name, client_identifier=custom_id)
-            assert topic_sender.client_identifier is not None
-            assert topic_sender.client_identifier == custom_id
+#     @pytest.mark.asyncio
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     async def test_custom_client_id_topic_sender(self, uamqp_transport, **kwargs):
+#         servicebus_connection_str = f'Endpoint=sb://resourcename{SERVICEBUS_ENDPOINT_SUFFIX}/;SharedAccessSignature=THISISATESTKEYXXXXXXXXXXXXXXXXXXXXXXXXXXXX=;'
+#         custom_id = "my_custom_id"
+#         topic_name = "topic_name"
+#         servicebus_client = ServiceBusClient.from_connection_string(conn_str=servicebus_connection_str, uamqp_transport=uamqp_transport)
+#         async with servicebus_client:
+#             topic_sender = servicebus_client.get_topic_sender(topic_name=topic_name, client_identifier=custom_id)
+#             assert topic_sender.client_identifier is not None
+#             assert topic_sender.client_identifier == custom_id
 
-    @pytest.mark.asyncio
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    async def test_default_client_id_topic_sender(self, uamqp_transport, **kwargs):
-        servicebus_connection_str = f'Endpoint=sb://resourcename{SERVICEBUS_ENDPOINT_SUFFIX}/;SharedAccessSignature=THISISATESTKEYXXXXXXXXXXXXXXXXXXXXXXXXXXXX=;'
-        topic_name = "topic_name"
-        servicebus_client = ServiceBusClient.from_connection_string(conn_str=servicebus_connection_str, uamqp_transport=uamqp_transport)
-        async with servicebus_client:
-            topic_sender = servicebus_client.get_topic_sender(topic_name=topic_name)
-            assert topic_sender.client_identifier is not None
-            assert "SBSender" in topic_sender.client_identifier
+#     @pytest.mark.asyncio
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     async def test_default_client_id_topic_sender(self, uamqp_transport, **kwargs):
+#         servicebus_connection_str = f'Endpoint=sb://resourcename{SERVICEBUS_ENDPOINT_SUFFIX}/;SharedAccessSignature=THISISATESTKEYXXXXXXXXXXXXXXXXXXXXXXXXXXXX=;'
+#         topic_name = "topic_name"
+#         servicebus_client = ServiceBusClient.from_connection_string(conn_str=servicebus_connection_str, uamqp_transport=uamqp_transport)
+#         async with servicebus_client:
+#             topic_sender = servicebus_client.get_topic_sender(topic_name=topic_name)
+#             assert topic_sender.client_identifier is not None
+#             assert "SBSender" in topic_sender.client_identifier
 
-    @pytest.mark.asyncio
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    async def test_default_client_id_subscription_receiver(self, uamqp_transport, **kwargs):
-        servicebus_connection_str = f'Endpoint=sb://resourcename{SERVICEBUS_ENDPOINT_SUFFIX}/;SharedAccessSignature=THISISATESTKEYXXXXXXXXXXXXXXXXXXXXXXXXXXXX=;'
-        topic_name = "topic_name"
-        sub_name = "sub_name"
-        servicebus_client = ServiceBusClient.from_connection_string(conn_str=servicebus_connection_str, uamqp_transport=uamqp_transport)
-        async with servicebus_client:
-            subscription_receiver = servicebus_client.get_subscription_receiver(topic_name, sub_name)
-            assert subscription_receiver.client_identifier is not None
-            assert "SBReceiver" in subscription_receiver.client_identifier
+#     @pytest.mark.asyncio
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     async def test_default_client_id_subscription_receiver(self, uamqp_transport, **kwargs):
+#         servicebus_connection_str = f'Endpoint=sb://resourcename{SERVICEBUS_ENDPOINT_SUFFIX}/;SharedAccessSignature=THISISATESTKEYXXXXXXXXXXXXXXXXXXXXXXXXXXXX=;'
+#         topic_name = "topic_name"
+#         sub_name = "sub_name"
+#         servicebus_client = ServiceBusClient.from_connection_string(conn_str=servicebus_connection_str, uamqp_transport=uamqp_transport)
+#         async with servicebus_client:
+#             subscription_receiver = servicebus_client.get_subscription_receiver(topic_name, sub_name)
+#             assert subscription_receiver.client_identifier is not None
+#             assert "SBReceiver" in subscription_receiver.client_identifier
 
-    @pytest.mark.asyncio
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    async def test_custom_client_id_subscription_receiver(self, uamqp_transport, **kwargs):
-        servicebus_connection_str = f'Endpoint=sb://resourcename{SERVICEBUS_ENDPOINT_SUFFIX}/;SharedAccessSignature=THISISATESTKEYXXXXXXXXXXXXXXXXXXXXXXXXXXXX=;'
-        custom_id = "my_custom_id"
-        topic_name = "topic_name"
-        sub_name = "sub_name"
-        servicebus_client = ServiceBusClient.from_connection_string(conn_str=servicebus_connection_str, uamqp_transport=uamqp_transport)
-        async with servicebus_client:
-            subscription_receiver = servicebus_client.get_subscription_receiver(topic_name, sub_name, client_identifier=custom_id)
-            assert subscription_receiver.client_identifier is not None
-            assert subscription_receiver.client_identifier == custom_id
+#     @pytest.mark.asyncio
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     async def test_custom_client_id_subscription_receiver(self, uamqp_transport, **kwargs):
+#         servicebus_connection_str = f'Endpoint=sb://resourcename{SERVICEBUS_ENDPOINT_SUFFIX}/;SharedAccessSignature=THISISATESTKEYXXXXXXXXXXXXXXXXXXXXXXXXXXXX=;'
+#         custom_id = "my_custom_id"
+#         topic_name = "topic_name"
+#         sub_name = "sub_name"
+#         servicebus_client = ServiceBusClient.from_connection_string(conn_str=servicebus_connection_str, uamqp_transport=uamqp_transport)
+#         async with servicebus_client:
+#             subscription_receiver = servicebus_client.get_subscription_receiver(topic_name, sub_name, client_identifier=custom_id)
+#             assert subscription_receiver.client_identifier is not None
+#             assert subscription_receiver.client_identifier == custom_id
 
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer()
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @CachedServiceBusQueuePreparer(name_prefix='servicebustest')
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_custom_endpoint_connection_verify_exception_async(self,
-                                   uamqp_transport,
-                                   *,
-                                   servicebus_queue=None,
-                                   servicebus_namespace=None,
-                                   servicebus_namespace_key_name=None,
-                                   servicebus_namespace_primary_key=None,
-                                   servicebus_namespace_connection_string=None,
-                                   **kwargs):
-        hostname = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
-        credential = AzureNamedKeyCredential(servicebus_namespace_key_name, servicebus_namespace_primary_key)
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer()
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @CachedServiceBusQueuePreparer(name_prefix='servicebustest')
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_custom_endpoint_connection_verify_exception_async(self,
+#                                    uamqp_transport,
+#                                    *,
+#                                    servicebus_queue=None,
+#                                    servicebus_namespace=None,
+#                                    servicebus_namespace_key_name=None,
+#                                    servicebus_namespace_primary_key=None,
+#                                    servicebus_namespace_connection_string=None,
+#                                    **kwargs):
+#         hostname = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+#         credential = AzureNamedKeyCredential(servicebus_namespace_key_name, servicebus_namespace_primary_key)
 
-        client = ServiceBusClient(hostname, credential, connection_verify="cacert.pem", uamqp_transport=uamqp_transport)
-        async with client:
-            with pytest.raises(ServiceBusError):
-                async with client.get_queue_sender(servicebus_queue.name) as sender:
-                    await sender.send_messages(ServiceBusMessage("foo"))
+#         client = ServiceBusClient(hostname, credential, connection_verify="cacert.pem", uamqp_transport=uamqp_transport)
+#         async with client:
+#             with pytest.raises(ServiceBusError):
+#                 async with client.get_queue_sender(servicebus_queue.name) as sender:
+#                     await sender.send_messages(ServiceBusMessage("foo"))
 
-        # Skipping on OSX uamqp - it's raising an Authentication/TimeoutError
-        if not uamqp_transport or not sys.platform.startswith('darwin'):
-            fake_addr = "fakeaddress.com:1111"
-            client = ServiceBusClient(
-                hostname,
-                credential,
-                custom_endpoint_address=fake_addr,
-                retry_total=0,
-                uamqp_transport=uamqp_transport
-            )
-            async with client:
-                with pytest.raises(ServiceBusConnectionError):
-                    async with client.get_queue_sender(servicebus_queue.name) as sender:
-                        await sender.send_messages(ServiceBusMessage("foo"))
+#         # Skipping on OSX uamqp - it's raising an Authentication/TimeoutError
+#         if not uamqp_transport or not sys.platform.startswith('darwin'):
+#             fake_addr = "fakeaddress.com:1111"
+#             client = ServiceBusClient(
+#                 hostname,
+#                 credential,
+#                 custom_endpoint_address=fake_addr,
+#                 retry_total=0,
+#                 uamqp_transport=uamqp_transport
+#             )
+#             async with client:
+#                 with pytest.raises(ServiceBusConnectionError):
+#                     async with client.get_queue_sender(servicebus_queue.name) as sender:
+#                         await sender.send_messages(ServiceBusMessage("foo"))
 
-            client = ServiceBusClient(
-                hostname,
-                credential,
-                custom_endpoint_address=fake_addr,
-                connection_verify="cacert.pem",
-                retry_total=0,
-                uamqp_transport=uamqp_transport,
-            )
-            async with client:
-                with pytest.raises(ServiceBusError):
-                    async with client.get_queue_sender(servicebus_queue.name) as sender:
-                        await sender.send_messages(ServiceBusMessage("foo"))
+#             client = ServiceBusClient(
+#                 hostname,
+#                 credential,
+#                 custom_endpoint_address=fake_addr,
+#                 connection_verify="cacert.pem",
+#                 retry_total=0,
+#                 uamqp_transport=uamqp_transport,
+#             )
+#             async with client:
+#                 with pytest.raises(ServiceBusError):
+#                     async with client.get_queue_sender(servicebus_queue.name) as sender:
+#                         await sender.send_messages(ServiceBusMessage("foo"))

--- a/sdk/servicebus/azure-servicebus/tests/async_tests/test_sb_client_async.py
+++ b/sdk/servicebus/azure-servicebus/tests/async_tests/test_sb_client_async.py
@@ -25,7 +25,7 @@ from azure.servicebus.exceptions import (
     ServiceBusAuthorizationError,
     ServiceBusConnectionError
 )
-from devtools_testutils import AzureMgmtRecordedTestCase
+from devtools_testutils import AzureMgmtRecordedTestCase, get_credential
 from tests.servicebus_preparer import (
     CachedServiceBusNamespacePreparer, 
     ServiceBusTopicPreparer, 
@@ -87,8 +87,10 @@ class TestServiceBusClientAsync(AzureMgmtRecordedTestCase):
     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
     @ArgPasserAsync()
-    async def test_sb_client_bad_entity_async(self, uamqp_transport, *, servicebus_namespace_connection_string=None, **kwargs):
-        client = ServiceBusClient.from_connection_string(servicebus_namespace_connection_string, uamqp_transport=uamqp_transport)
+    async def test_sb_client_bad_entity_async(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_namespace=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential(is_async=True)
+        client = ServiceBusClient(fully_qualified_namespace, credential, uamqp_transport=uamqp_transport)
 
         async with client:
             with pytest.raises(ServiceBusAuthenticationError):
@@ -177,8 +179,10 @@ class TestServiceBusClientAsync(AzureMgmtRecordedTestCase):
     @CachedServiceBusSubscriptionPreparer(name_prefix='servicebustest')
     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
     @ArgPasserAsync()
-    async def test_async_sb_client_close_spawned_handlers(self, uamqp_transport, *, servicebus_namespace_connection_string, servicebus_queue, servicebus_topic, servicebus_subscription, **kwargs):
-        client = ServiceBusClient.from_connection_string(servicebus_namespace_connection_string, uamqp_transport=uamqp_transport)
+    async def test_async_sb_client_close_spawned_handlers(self, uamqp_transport, *, servicebus_namespace_connection_string, servicebus_namespace, servicebus_queue, servicebus_topic, servicebus_subscription, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential(is_async=True)
+        client = ServiceBusClient(fully_qualified_namespace, credential, uamqp_transport=uamqp_transport)
 
         await client.close()
 

--- a/sdk/servicebus/azure-servicebus/tests/async_tests/test_sessions_async.py
+++ b/sdk/servicebus/azure-servicebus/tests/async_tests/test_sessions_async.py
@@ -1,1209 +1,1299 @@
-# #-------------------------------------------------------------------------
-# # Copyright (c) Microsoft Corporation. All rights reserved.
-# # Licensed under the MIT License. See License.txt in the project root for
-# # license information.
-# #--------------------------------------------------------------------------
+#-------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+#--------------------------------------------------------------------------
 
-# import asyncio
-# import logging
-# import sys
-# import os
-# import pytest
-# import time
-# import uuid
-# import pickle
-# from datetime import datetime, timedelta
+import asyncio
+import logging
+import sys
+import os
+import pytest
+import time
+import uuid
+import pickle
+from datetime import datetime, timedelta
 
-# from azure.servicebus import (
-#     ServiceBusMessage,
-#     ServiceBusReceivedMessage,
-#     ServiceBusReceiveMode,
-#     NEXT_AVAILABLE_SESSION,
-#     ServiceBusSubQueue
-# )
-# from azure.servicebus.aio import ServiceBusClient, AutoLockRenewer
-# from azure.servicebus._common.utils import utc_now
-# from azure.servicebus.exceptions import (
-#     ServiceBusConnectionError,
-#     ServiceBusAuthenticationError,
-#     ServiceBusError,
-#     OperationTimeoutError,
-#     SessionLockLostError,
-#     MessageLockLostError,
-#     MessageAlreadySettled,
-#     AutoLockRenewTimeout
-# )
-# from devtools_testutils import AzureMgmtRecordedTestCase
-# from tests.servicebus_preparer import (
-#     CachedServiceBusNamespacePreparer,
-#     CachedServiceBusQueuePreparer,
-#     ServiceBusTopicPreparer,
-#     ServiceBusQueuePreparer,
-#     ServiceBusSubscriptionPreparer,
-#     CachedServiceBusResourceGroupPreparer
-# )
-# from tests.utilities import get_logger, print_message, uamqp_transport as get_uamqp_transport, ArgPasserAsync
+from azure.servicebus import (
+    ServiceBusMessage,
+    ServiceBusReceivedMessage,
+    ServiceBusReceiveMode,
+    NEXT_AVAILABLE_SESSION,
+    ServiceBusSubQueue
+)
+from azure.servicebus.aio import ServiceBusClient, AutoLockRenewer
+from azure.servicebus._common.utils import utc_now
+from azure.servicebus.exceptions import (
+    ServiceBusConnectionError,
+    ServiceBusAuthenticationError,
+    ServiceBusError,
+    OperationTimeoutError,
+    SessionLockLostError,
+    MessageLockLostError,
+    MessageAlreadySettled,
+    AutoLockRenewTimeout
+)
+from devtools_testutils import AzureMgmtRecordedTestCase, get_credential
+from tests.servicebus_preparer import (
+    SERVICEBUS_ENDPOINT_SUFFIX,
+    CachedServiceBusNamespacePreparer,
+    CachedServiceBusQueuePreparer,
+    ServiceBusTopicPreparer,
+    ServiceBusQueuePreparer,
+    ServiceBusSubscriptionPreparer,
+    CachedServiceBusResourceGroupPreparer
+)
+from tests.utilities import get_logger, print_message, uamqp_transport as get_uamqp_transport, ArgPasserAsync
 
-# uamqp_transport_params, uamqp_transport_ids = get_uamqp_transport()
+uamqp_transport_params, uamqp_transport_ids = get_uamqp_transport()
 
-# _logger = get_logger(logging.DEBUG)
+_logger = get_logger(logging.DEBUG)
 
 
-# class TestServiceBusAsyncSession(AzureMgmtRecordedTestCase):
+class TestServiceBusAsyncSession(AzureMgmtRecordedTestCase):
 
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_async_session_by_session_client_conn_str_receive_handler_peeklock(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         async with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_async_session_by_session_client_conn_str_receive_handler_peeklock(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential(is_async=True)
+        async with ServiceBusClient(
+            fully_qualified_namespace=fully_qualified_namespace,
+            credential=credential,
+            logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-#             session_id = str(uuid.uuid4())
-#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 for i in range(3):
-#                     message = ServiceBusMessage("Handler message no. {}".format(i), session_id=session_id)
-#                     await sender.send_messages(message)
+            session_id = str(uuid.uuid4())
+            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                for i in range(3):
+                    message = ServiceBusMessage("Handler message no. {}".format(i), session_id=session_id)
+                    await sender.send_messages(message)
 
-#             with pytest.raises(ServiceBusError):
-#                 await sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10)._open_with_retry()
+            with pytest.raises(ServiceBusError):
+                await sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10)._open_with_retry()
 
-#             receiver = sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=10)
-#             count = 0
-#             async for message in receiver:
-#                 print_message(_logger, message)
-#                 assert message.session_id == session_id
-#                 count += 1
-#                 await receiver.complete_message(message)
+            receiver = sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=10)
+            count = 0
+            async for message in receiver:
+                print_message(_logger, message)
+                assert message.session_id == session_id
+                count += 1
+                await receiver.complete_message(message)
 
-#             await receiver.close()
+            await receiver.close()
 
-#             assert count == 3
+            assert count == 3
 
-#             session_id = ""
-#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 for i in range(3):
-#                     message = ServiceBusMessage("Handler message no. {}".format(i), session_id=session_id)
-#                     await sender.send_messages(message)
+            session_id = ""
+            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                for i in range(3):
+                    message = ServiceBusMessage("Handler message no. {}".format(i), session_id=session_id)
+                    await sender.send_messages(message)
 
-#             with pytest.raises(ServiceBusError):
-#                 await sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10)._open_with_retry()
+            with pytest.raises(ServiceBusError):
+                await sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10)._open_with_retry()
 
-#             receiver = sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=10)
-#             count = 0
-#             async for message in receiver:
-#                 print_message(_logger, message)
-#                 assert message.session_id == session_id
-#                 count += 1
-#                 await receiver.complete_message(message)
+            receiver = sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=10)
+            count = 0
+            async for message in receiver:
+                print_message(_logger, message)
+                assert message.session_id == session_id
+                count += 1
+                await receiver.complete_message(message)
 
-#             await receiver.close()
+            await receiver.close()
 
-#             assert count == 3
+            assert count == 3
 
-#             with pytest.raises(ServiceBusError):
-#                 receiver = sb_client.get_queue_receiver(servicebus_queue.name, session_id=1)
-#                 async with receiver:
-#                     pass
+            with pytest.raises(ServiceBusError):
+                receiver = sb_client.get_queue_receiver(servicebus_queue.name, session_id=1)
+                async with receiver:
+                    pass
     
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True, lock_duration='PT10S')
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_async_session_by_queue_client_conn_str_receive_handler_receiveanddelete(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         async with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True, lock_duration='PT10S')
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_async_session_by_queue_client_conn_str_receive_handler_receiveanddelete(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential(is_async=True)
+        async with ServiceBusClient(
+            fully_qualified_namespace=fully_qualified_namespace,
+            credential=credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-#             session_id = str(uuid.uuid4())
-#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 for i in range(10):
-#                     message = ServiceBusMessage("Handler message no. {}".format(i), session_id=session_id)
-#                     await sender.send_messages(message)
+            session_id = str(uuid.uuid4())
+            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                for i in range(10):
+                    message = ServiceBusMessage("Handler message no. {}".format(i), session_id=session_id)
+                    await sender.send_messages(message)
 
-#             messages = []
-#             receiver = sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE, max_wait_time=10)
-#             async for message in receiver:
-#                 messages.append(message)
-#                 assert session_id == receiver.session.session_id
-#                 assert session_id == message.session_id
-#                 with pytest.raises(ValueError):
-#                     await receiver.complete_message(message)
+            messages = []
+            receiver = sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE, max_wait_time=10)
+            async for message in receiver:
+                messages.append(message)
+                assert session_id == receiver.session.session_id
+                assert session_id == message.session_id
+                with pytest.raises(ValueError):
+                    await receiver.complete_message(message)
 
-#             assert receiver._running
-#             await receiver.close()
+            assert receiver._running
+            await receiver.close()
 
-#             assert not receiver._running
-#             assert len(messages) == 10
-#             time.sleep(10)
+            assert not receiver._running
+            assert len(messages) == 10
+            time.sleep(10)
 
-#             messages = []
-#             async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE, max_wait_time=10) as receiver:
-#                 async for message in receiver:
-#                     messages.append(message)
-#             assert len(messages) == 0
-
-    
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_async_session_by_session_client_conn_str_receive_handler_with_stop(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         async with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-
-#             session_id = str(uuid.uuid4())
-#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 for i in range(10):
-#                     message = ServiceBusMessage("Stop message no. {}".format(i), session_id=session_id)
-#                     await sender.send_messages(message)
-
-#             messages = []
-#             receiver = sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=5)
-#             async with receiver:
-#                 async for message in receiver:
-#                     assert session_id == receiver.session.session_id
-#                     assert session_id == message.session_id
-#                     messages.append(message)
-#                     await receiver.complete_message(message)
-#                     if len(messages) >= 5:
-#                         break
-
-#                 assert receiver._running
-#                 assert len(messages) == 5
-
-#                 async for message in receiver:
-#                     assert session_id == receiver.session.session_id
-#                     assert session_id == message.session_id
-#                     messages.append(message)
-#                     await receiver.complete_message(message)
-#                     if len(messages) >= 5:
-#                         break
-
-#             assert not receiver._running
-#             assert len(messages) == 6
-
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @pytest.mark.xfail(reason="'Cannot open log' error, potential service bug", raises=ServiceBusError)
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_async_session_by_session_client_conn_str_receive_handler_with_no_session(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         async with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-
-#             receiver = sb_client.get_queue_receiver(servicebus_queue.name, session_id=NEXT_AVAILABLE_SESSION, max_wait_time=10)
-#             with pytest.raises(OperationTimeoutError):
-#                 await receiver._open_with_retry()
+            messages = []
+            async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE, max_wait_time=10) as receiver:
+                async for message in receiver:
+                    messages.append(message)
+            assert len(messages) == 0
 
     
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_async_session_by_session_client_conn_str_receive_handler_with_inactive_session(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         async with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_async_session_by_session_client_conn_str_receive_handler_with_stop(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential(is_async=True)
+        async with ServiceBusClient(
+            fully_qualified_namespace=fully_qualified_namespace,
+            credential=credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-#             session_id = str(uuid.uuid4())
-#             messages = []
-#             receiver = sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE, max_wait_time=5)
-#             async with receiver:
-#                 async for message in receiver:
-#                     messages.append(message)
+            session_id = str(uuid.uuid4())
+            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                for i in range(10):
+                    message = ServiceBusMessage("Stop message no. {}".format(i), session_id=session_id)
+                    await sender.send_messages(message)
 
-#             assert not receiver._running
-#             assert len(messages) == 0
+            messages = []
+            receiver = sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=5)
+            async with receiver:
+                async for message in receiver:
+                    assert session_id == receiver.session.session_id
+                    assert session_id == message.session_id
+                    messages.append(message)
+                    await receiver.complete_message(message)
+                    if len(messages) >= 5:
+                        break
 
-    
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_async_session_by_servicebus_client_iter_messages_with_retrieve_deferred_receiver_complete(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         async with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+                assert receiver._running
+                assert len(messages) == 5
 
-#             deferred_messages = []
-#             session_id = str(uuid.uuid4())
-#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 for message in [ServiceBusMessage("Deferred message no. {}".format(i), session_id=session_id) for i in range(10)]:
-#                     await sender.send_messages(message)
+                async for message in receiver:
+                    assert session_id == receiver.session.session_id
+                    assert session_id == message.session_id
+                    messages.append(message)
+                    await receiver.complete_message(message)
+                    if len(messages) >= 5:
+                        break
 
-#             count = 0
-#             async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=5) as receiver:
-#                 async for message in receiver:
-#                     deferred_messages.append(message.sequence_number)
-#                     print_message(_logger, message)
-#                     count += 1
-#                     await receiver.defer_message(message)
+            assert not receiver._running
+            assert len(messages) == 6
 
-#             assert count == 10
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @pytest.mark.xfail(reason="'Cannot open log' error, potential service bug", raises=ServiceBusError)
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_async_session_by_session_client_conn_str_receive_handler_with_no_session(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential(is_async=True)
+        async with ServiceBusClient(
+            fully_qualified_namespace=fully_qualified_namespace,
+            credential=credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-#             async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=5) as receiver:
-#                 deferred = await receiver.receive_deferred_messages(deferred_messages)
-#                 assert len(deferred) == 10
-#                 for message in deferred:
-#                     assert isinstance(message, ServiceBusReceivedMessage)
-#                     assert message.lock_token
-#                     assert not message.locked_until_utc
-#                     assert message._receiver
-#                     with pytest.raises(TypeError):
-#                         await receiver.renew_message_lock(message)
-#                     await receiver.complete_message(message)
-
-    
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_async_session_by_servicebus_client_iter_messages_with_retrieve_deferred_receiver_deadletter(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         async with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-
-#             deferred_messages = []
-#             session_id = str(uuid.uuid4())
-#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 for message in [ServiceBusMessage("Deferred message no. {}".format(i), session_id=session_id) for i in range(10)]:
-#                     await sender.send_messages(message)
-
-#             count = 0
-#             async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=5) as receiver:
-#                 async for message in receiver:
-#                     deferred_messages.append(message.sequence_number)
-#                     print_message(_logger, message)
-#                     count += 1
-#                     await receiver.defer_message(message)
-
-#             assert count == 10
-
-#             async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=5) as receiver:
-#                 deferred = await receiver.receive_deferred_messages(deferred_messages)
-#                 assert len(deferred) == 10
-#                 for message in deferred:
-#                     assert isinstance(message, ServiceBusReceivedMessage)
-#                     await receiver.dead_letter_message(message, reason="Testing reason", error_description="Testing description")
-
-#             count = 0
-#             async with sb_client.get_queue_receiver(servicebus_queue.name, 
-#                                                     sub_queue = ServiceBusSubQueue.DEAD_LETTER,
-#                                                     max_wait_time=5) as receiver:
-#                 async for message in receiver:
-#                     count += 1
-#                     print_message(_logger, message)
-#                     assert message.dead_letter_reason == 'Testing reason'
-#                     assert message.dead_letter_error_description == 'Testing description'
-#                     assert message.application_properties[b'DeadLetterReason'] == b'Testing reason'
-#                     assert message.application_properties[b'DeadLetterErrorDescription'] == b'Testing description'
-#                     await receiver.complete_message(message)
-#             assert count == 10
+            receiver = sb_client.get_queue_receiver(servicebus_queue.name, session_id=NEXT_AVAILABLE_SESSION, max_wait_time=10)
+            with pytest.raises(OperationTimeoutError):
+                await receiver._open_with_retry()
 
     
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_async_session_by_servicebus_client_iter_messages_with_retrieve_deferred_receiver_deletemode(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         async with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_async_session_by_session_client_conn_str_receive_handler_with_inactive_session(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential(is_async=True)
+        async with ServiceBusClient(
+            fully_qualified_namespace=fully_qualified_namespace,
+            credential=credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-#             deferred_messages = []
-#             session_id = str(uuid.uuid4())
-#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 for message in [ServiceBusMessage("Deferred message no. {}".format(i), session_id=session_id) for i in range(10)]:
-#                     await sender.send_messages(message)
+            session_id = str(uuid.uuid4())
+            messages = []
+            receiver = sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE, max_wait_time=5)
+            async with receiver:
+                async for message in receiver:
+                    messages.append(message)
 
-#             count = 0
-#             async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=5) as receiver:
-#                 async for message in receiver:
-#                     deferred_messages.append(message.sequence_number)
-#                     print_message(_logger, message)
-#                     count += 1
-#                     await receiver.defer_message(message)
-
-#             assert count == 10
-#             async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=5, receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE) as receiver:
-#                 deferred = await receiver.receive_deferred_messages(deferred_messages)
-#                 assert len(deferred) == 10
-#                 for message in deferred:
-#                     assert isinstance(message, ServiceBusReceivedMessage)
-#                     with pytest.raises(ValueError):
-#                         await receiver.complete_message(message)
-#                 with pytest.raises(ServiceBusError):
-#                     deferred = await receiver.receive_deferred_messages(deferred_messages)
+            assert not receiver._running
+            assert len(messages) == 0
 
     
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_async_session_by_servicebus_client_iter_messages_with_retrieve_deferred_client(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         async with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_async_session_by_servicebus_client_iter_messages_with_retrieve_deferred_receiver_complete(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential(is_async=True)
+        async with ServiceBusClient(
+            fully_qualified_namespace=fully_qualified_namespace,
+            credential=credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-#             deferred_messages = []
-#             session_id = str(uuid.uuid4())
-#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 for i in range(10):
-#                     message = ServiceBusMessage("Deferred message no. {}".format(i), session_id=session_id)
-#                     await sender.send_messages(message)
+            deferred_messages = []
+            session_id = str(uuid.uuid4())
+            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                for message in [ServiceBusMessage("Deferred message no. {}".format(i), session_id=session_id) for i in range(10)]:
+                    await sender.send_messages(message)
 
-#             receiver = sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=5)
-#             count = 0
-#             async for message in receiver:
-#                 deferred_messages.append(message.sequence_number)
-#                 print_message(_logger, message)
-#                 count += 1
-#                 await receiver.defer_message(message)
-#             await receiver.close()
+            count = 0
+            async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=5) as receiver:
+                async for message in receiver:
+                    deferred_messages.append(message.sequence_number)
+                    print_message(_logger, message)
+                    count += 1
+                    await receiver.defer_message(message)
 
-#             assert count == 10
+            assert count == 10
 
-#             with pytest.raises(ValueError):
-#                 await receiver.complete_message(message)
-
-    
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_async_session_by_servicebus_client_fetch_next_with_retrieve_deadletter(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         async with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-
-#             session_id = str(uuid.uuid4())
-#             async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=5, prefetch_count=10) as receiver:
-
-#                 async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                     for i in range(10):
-#                         message = ServiceBusMessage("Dead lettered message no. {}".format(i), session_id=session_id)
-#                         await sender.send_messages(message)
-
-#                 count = 0
-#                 messages = await receiver.receive_messages()
-#                 while messages:
-#                     for message in messages:
-#                         print_message(_logger, message)
-#                         await receiver.dead_letter_message(message, reason="Testing reason",
-#                                                            error_description="Testing description")
-#                         count += 1
-#                     messages = await receiver.receive_messages()
-#             assert count == 10
-
-#             async with sb_client.get_queue_receiver(servicebus_queue.name, 
-#                                                     sub_queue = ServiceBusSubQueue.DEAD_LETTER,
-#                                                     max_wait_time=5) as receiver:
-#                 count = 0
-#                 async for message in receiver:
-#                     print_message(_logger, message)
-#                     assert message.dead_letter_reason == 'Testing reason'
-#                     assert message.dead_letter_error_description == 'Testing description'
-#                     assert message.application_properties[b'DeadLetterReason'] == b'Testing reason'
-#                     assert message.application_properties[b'DeadLetterErrorDescription'] == b'Testing description'
-#                     await receiver.complete_message(message)
-#                     count += 1
-#             assert count == 10
-
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_async_session_by_servicebus_client_browse_messages_client(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         async with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-
-#             session_id = str(uuid.uuid4())
-#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 for i in range(5):
-#                     message = ServiceBusMessage("Test message no. {}".format(i), session_id=session_id)
-#                     await sender.send_messages(message)
-#             session_id_2 = str(uuid.uuid4())
-#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 for i in range(3):
-#                     message = ServiceBusMessage("Test message no. {}".format(i), session_id=session_id_2)
-#                     await sender.send_messages(message)
-
-#             async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id) as receiver:
-#                 messages = await receiver.peek_messages(5)
-#                 assert len(messages) == 5
-#                 assert all(isinstance(m, ServiceBusReceivedMessage) for m in messages)
-#                 for message in messages:
-#                     print_message(_logger, message)
-#                     with pytest.raises(ValueError):
-#                         await receiver.complete_message(message)
-
-#             async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id_2) as receiver:
-#                 messages = await receiver.peek_messages(5)
-#                 assert len(messages) == 3
-
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_async_session_by_servicebus_client_browse_messages_with_receiver(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         async with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-
-#             session_id = str(uuid.uuid4())
-#             async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5, session_id=session_id) as receiver:
-#                 async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                     for i in range(5):
-#                         message = ServiceBusMessage("Test message no. {}".format(i), session_id=session_id)
-#                         await sender.send_messages(message)
-
-#                 messages = await receiver.peek_messages(5)
-#                 assert len(messages) > 0
-#                 assert all(isinstance(m, ServiceBusReceivedMessage) for m in messages)
-#                 for message in messages:
-#                     print_message(_logger, message)
-#                     with pytest.raises(ValueError):
-#                         await receiver.complete_message(message)
-
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_async_session_by_servicebus_client_renew_client_locks(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         async with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-
-#             session_id = str(uuid.uuid4())
-#             messages = []
-#             locks = 3
-#             async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, prefetch_count=10) as receiver:
-#                 async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                     for i in range(locks):
-#                         message = ServiceBusMessage("Test message no. {}".format(i), session_id=session_id)
-#                         await sender.send_messages(message)
-
-#                 messages.extend(await receiver.receive_messages())
-#                 recv = True
-#                 while recv:
-#                     recv = await receiver.receive_messages(max_wait_time=10)
-#                     messages.extend(recv)
-
-#                 try:
-#                     for m in messages:
-#                         with pytest.raises(TypeError):
-#                             expired = m._lock_expired
-#                         assert m.locked_until_utc is None
-#                         assert m.lock_token is not None
-#                     time.sleep(5)
-#                     initial_expiry = receiver.session.locked_until_utc
-#                     await receiver.session.renew_lock(timeout=5)
-#                     assert (receiver.session.locked_until_utc - initial_expiry) >= timedelta(seconds=5)
-#                 finally:
-#                     await receiver.complete_message(messages[0])
-#                     await receiver.complete_message(messages[1])
-#                     time.sleep(40)
-#                     with pytest.raises(SessionLockLostError):
-#                         await receiver.complete_message(messages[2])
+            async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=5) as receiver:
+                deferred = await receiver.receive_deferred_messages(deferred_messages)
+                assert len(deferred) == 10
+                for message in deferred:
+                    assert isinstance(message, ServiceBusReceivedMessage)
+                    assert message.lock_token
+                    assert not message.locked_until_utc
+                    assert message._receiver
+                    with pytest.raises(TypeError):
+                        await receiver.renew_message_lock(message)
+                    await receiver.complete_message(message)
 
     
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True, lock_duration='PT5S')
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_async_session_by_conn_str_receive_handler_with_autolockrenew(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         async with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-#             session_id = str(uuid.uuid4())
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_async_session_by_servicebus_client_iter_messages_with_retrieve_deferred_receiver_deadletter(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential(is_async=True)
+        async with ServiceBusClient(
+            fully_qualified_namespace=fully_qualified_namespace,
+            credential=credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 for i in range(10):
-#                     message = ServiceBusMessage("{}".format(i), session_id=session_id)
-#                     await sender.send_messages(message)
+            deferred_messages = []
+            session_id = str(uuid.uuid4())
+            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                for message in [ServiceBusMessage("Deferred message no. {}".format(i), session_id=session_id) for i in range(10)]:
+                    await sender.send_messages(message)
 
-#             results = []
-#             async def lock_lost_callback(renewable, error):
-#                 results.append(renewable)
+            count = 0
+            async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=5) as receiver:
+                async for message in receiver:
+                    deferred_messages.append(message.sequence_number)
+                    print_message(_logger, message)
+                    count += 1
+                    await receiver.defer_message(message)
 
-#             renewer = AutoLockRenewer()
-#             messages = []
-#             async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=5, receive_mode=ServiceBusReceiveMode.PEEK_LOCK, prefetch_count=20) as receiver:
-#                 renewer.register(receiver, receiver.session, max_lock_renewal_duration=10)
-#                 print("Registered lock renew thread", receiver.session.locked_until_utc, utc_now())
-#                 with pytest.raises(SessionLockLostError):
-#                     async for message in receiver:
-#                         if not messages:
-#                             await asyncio.sleep(10)
-#                             print("First sleep {}".format(receiver.session.locked_until_utc - utc_now()))
-#                             assert not receiver.session._lock_expired
-#                             with pytest.raises(TypeError):
-#                                 message._lock_expired
-#                             assert message.locked_until_utc is None
-#                             with pytest.raises(TypeError):
-#                                 await receiver.renew_message_lock(message)
-#                             assert message.lock_token is not None
-#                             await receiver.complete_message(message)
-#                             messages.append(message)
+            assert count == 10
 
-#                         elif len(messages) == 1:
-#                             assert not results
-#                             await asyncio.sleep(10)
-#                             print("Second sleep {}".format(receiver.session.locked_until_utc - utc_now()))
-#                             assert receiver.session._lock_expired
-#                             assert isinstance(receiver.session.auto_renew_error, AutoLockRenewTimeout)
-#                             try:
-#                                 await receiver.complete_message(message)
-#                                 raise AssertionError("Didn't raise SessionLockExpired")
-#                             except SessionLockLostError as e:
-#                                 assert isinstance(e.inner_exception, AutoLockRenewTimeout)
-#                             messages.append(message)
+            async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=5) as receiver:
+                deferred = await receiver.receive_deferred_messages(deferred_messages)
+                assert len(deferred) == 10
+                for message in deferred:
+                    assert isinstance(message, ServiceBusReceivedMessage)
+                    await receiver.dead_letter_message(message, reason="Testing reason", error_description="Testing description")
 
-#             # While we're testing autolockrenew and sessions, let's make sure we don't call the lock-lost callback when a session exits.
-#             renewer._renew_period = 1
-#             session = None
-
-#             async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=5, receive_mode=ServiceBusReceiveMode.PEEK_LOCK, prefetch_count=10) as receiver:
-#                 session = receiver.session
-#                 renewer.register(receiver, session, max_lock_renewal_duration=5, on_lock_renew_failure=lock_lost_callback)
-#             await asyncio.sleep(max(0,(session.locked_until_utc - utc_now()).total_seconds()+1)) # If this pattern repeats make sleep_until_expired_async
-#             assert not results
-
-#             await renewer.close()
-#             assert len(messages) == 2
+            count = 0
+            async with sb_client.get_queue_receiver(servicebus_queue.name, 
+                                                    sub_queue = ServiceBusSubQueue.DEAD_LETTER,
+                                                    max_wait_time=5) as receiver:
+                async for message in receiver:
+                    count += 1
+                    print_message(_logger, message)
+                    assert message.dead_letter_reason == 'Testing reason'
+                    assert message.dead_letter_error_description == 'Testing description'
+                    assert message.application_properties[b'DeadLetterReason'] == b'Testing reason'
+                    assert message.application_properties[b'DeadLetterErrorDescription'] == b'Testing description'
+                    await receiver.complete_message(message)
+            assert count == 10
 
     
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True, lock_duration='PT10S')
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_async_session_by_conn_str_receive_handler_with_auto_autolockrenew(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         if sys.platform.startswith('darwin'):
-#             pytest.skip("Skipping for flakiness on OSX. Need to fix and unskip during MQ. Issue created: #32067.")
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_async_session_by_servicebus_client_iter_messages_with_retrieve_deferred_receiver_deletemode(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential(is_async=True)
+        async with ServiceBusClient(
+            fully_qualified_namespace=fully_qualified_namespace,
+            credential=credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-#         async with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-#             session_id = str(uuid.uuid4())
+            deferred_messages = []
+            session_id = str(uuid.uuid4())
+            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                for message in [ServiceBusMessage("Deferred message no. {}".format(i), session_id=session_id) for i in range(10)]:
+                    await sender.send_messages(message)
 
-#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 for i in range(10):
-#                     message = ServiceBusMessage("{}".format(i), session_id=session_id)
-#                     await sender.send_messages(message)
+            count = 0
+            async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=5) as receiver:
+                async for message in receiver:
+                    deferred_messages.append(message.sequence_number)
+                    print_message(_logger, message)
+                    count += 1
+                    await receiver.defer_message(message)
 
-#             results = []
-#             async def lock_lost_callback(renewable, error):
-#                 results.append(renewable)
+            assert count == 10
+            async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=5, receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE) as receiver:
+                deferred = await receiver.receive_deferred_messages(deferred_messages)
+                assert len(deferred) == 10
+                for message in deferred:
+                    assert isinstance(message, ServiceBusReceivedMessage)
+                    with pytest.raises(ValueError):
+                        await receiver.complete_message(message)
+                with pytest.raises(ServiceBusError):
+                    deferred = await receiver.receive_deferred_messages(deferred_messages)
 
-#             renewer = AutoLockRenewer(max_lock_renewal_duration=10)
-#             messages = []
-#             async with sb_client.get_queue_receiver(servicebus_queue.name,
-#                                                     session_id=session_id,
-#                                                     max_wait_time=10,
-#                                                     receive_mode=ServiceBusReceiveMode.PEEK_LOCK,
-#                                                     prefetch_count=20,
-#                                                     auto_lock_renewer=renewer) as session:
-#                 print("Registered lock renew thread", session.session.locked_until_utc, utc_now())
-#                 with pytest.raises(SessionLockLostError):
-#                     async for message in session:
-#                         if not messages:
-#                             await asyncio.sleep(10)
-#                             print("First sleep {}".format(session.session.locked_until_utc - utc_now()))
-#                             assert not session.session._lock_expired
-#                             with pytest.raises(TypeError):
-#                                 message._lock_expired
-#                             assert message.locked_until_utc is None
-#                             with pytest.raises(TypeError):
-#                                 await session.renew_message_lock(message)
-#                             assert message.lock_token is not None
-#                             await session.complete_message(message)
-#                             messages.append(message)
+    
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_async_session_by_servicebus_client_iter_messages_with_retrieve_deferred_client(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential(is_async=True)
+        async with ServiceBusClient(
+            fully_qualified_namespace=fully_qualified_namespace,
+            credential=credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-#                         elif len(messages) == 1:
-#                             assert not results
-#                             await asyncio.sleep(10)
-#                             print("Second sleep {}".format(session.session.locked_until_utc - utc_now()))
-#                             assert session.session._lock_expired
-#                             assert isinstance(session.session.auto_renew_error, AutoLockRenewTimeout)
-#                             try:
-#                                 await session.complete_message(message)
-#                                 raise AssertionError("Didn't raise SessionLockExpired")
-#                             except SessionLockLostError as e:
-#                                 assert isinstance(e.inner_exception, AutoLockRenewTimeout)
-#                             messages.append(message)
+            deferred_messages = []
+            session_id = str(uuid.uuid4())
+            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                for i in range(10):
+                    message = ServiceBusMessage("Deferred message no. {}".format(i), session_id=session_id)
+                    await sender.send_messages(message)
 
-#             # While we're testing autolockrenew and sessions, let's make sure we don't call the lock-lost callback when a session exits.
-#             renewer._renew_period = 1
-#             session = None
+            receiver = sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=5)
+            count = 0
+            async for message in receiver:
+                deferred_messages.append(message.sequence_number)
+                print_message(_logger, message)
+                count += 1
+                await receiver.defer_message(message)
+            await receiver.close()
 
-#             async with sb_client.get_queue_receiver(servicebus_queue.name,
-#                                                     session_id=session_id,
-#                                                     max_wait_time=10,
-#                                                     receive_mode=ServiceBusReceiveMode.PEEK_LOCK,
-#                                                     prefetch_count=10,
-#                                                     auto_lock_renewer=renewer) as receiver:
-#                 session = receiver.session
-#             await asyncio.sleep(max(0,(session.locked_until_utc - utc_now()).total_seconds()+1)) # If this pattern repeats make sleep_until_expired_async
-#             assert not results
+            assert count == 10
 
-#             await renewer.close()
-#             assert len(messages) == 2
+            with pytest.raises(ValueError):
+                await receiver.complete_message(message)
 
-#         session_id = str(uuid.uuid4())
-#         async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#             messages = [ServiceBusMessage("{}".format(i), session_id=session_id) for i in range(10)]
-#             await sender.send_messages(messages)
+    
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_async_session_by_servicebus_client_fetch_next_with_retrieve_deadletter(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential(is_async=True)
+        async with ServiceBusClient(
+            fully_qualified_namespace=fully_qualified_namespace,
+            credential=credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-#         renewer = AutoLockRenewer(max_lock_renewal_duration=100)
-#         receiver = sb_client.get_queue_receiver(servicebus_queue.name,
-#                                             session_id=session_id,
-#                                             max_wait_time=10,
-#                                             prefetch_count=10,
-#                                             auto_lock_renewer=renewer)
+            session_id = str(uuid.uuid4())
+            async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=5, prefetch_count=10) as receiver:
 
-#         async with receiver:
-#             received_msgs = await receiver.receive_messages(max_wait_time=10)
-#             for msg in received_msgs:
-#                 await receiver.complete_message(msg)
+                async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                    for i in range(10):
+                        message = ServiceBusMessage("Dead lettered message no. {}".format(i), session_id=session_id)
+                        await sender.send_messages(message)
 
-#         await receiver.close()
-#         assert not renewer._renewable(receiver._session)
+                count = 0
+                messages = await receiver.receive_messages()
+                while messages:
+                    for message in messages:
+                        print_message(_logger, message)
+                        await receiver.dead_letter_message(message, reason="Testing reason",
+                                                           error_description="Testing description")
+                        count += 1
+                    messages = await receiver.receive_messages()
+            assert count == 10
 
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_async_session_message_connection_closed(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         async with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+            async with sb_client.get_queue_receiver(servicebus_queue.name, 
+                                                    sub_queue = ServiceBusSubQueue.DEAD_LETTER,
+                                                    max_wait_time=5) as receiver:
+                count = 0
+                async for message in receiver:
+                    print_message(_logger, message)
+                    assert message.dead_letter_reason == 'Testing reason'
+                    assert message.dead_letter_error_description == 'Testing description'
+                    assert message.application_properties[b'DeadLetterReason'] == b'Testing reason'
+                    assert message.application_properties[b'DeadLetterErrorDescription'] == b'Testing description'
+                    await receiver.complete_message(message)
+                    count += 1
+            assert count == 10
 
-#             session_id = str(uuid.uuid4())
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_async_session_by_servicebus_client_browse_messages_client(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential(is_async=True)
+        async with ServiceBusClient(
+            fully_qualified_namespace=fully_qualified_namespace,
+            credential=credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 message = ServiceBusMessage("test")
-#                 message.session_id = session_id
-#                 await sender.send_messages(message)
+            session_id = str(uuid.uuid4())
+            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                for i in range(5):
+                    message = ServiceBusMessage("Test message no. {}".format(i), session_id=session_id)
+                    await sender.send_messages(message)
+            session_id_2 = str(uuid.uuid4())
+            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                for i in range(3):
+                    message = ServiceBusMessage("Test message no. {}".format(i), session_id=session_id_2)
+                    await sender.send_messages(message)
 
-#             async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id) as receiver:
-#                 messages = await receiver.receive_messages(max_wait_time=10)
-#                 assert len(messages) == 1
+            async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id) as receiver:
+                messages = await receiver.peek_messages(5)
+                assert len(messages) == 5
+                assert all(isinstance(m, ServiceBusReceivedMessage) for m in messages)
+                for message in messages:
+                    print_message(_logger, message)
+                    with pytest.raises(ValueError):
+                        await receiver.complete_message(message)
 
-#             with pytest.raises(ValueError):
-#                 await receiver.complete_message(messages[0])
+            async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id_2) as receiver:
+                messages = await receiver.peek_messages(5)
+                assert len(messages) == 3
 
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_async_session_message_expiry(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         async with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_async_session_by_servicebus_client_browse_messages_with_receiver(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential(is_async=True)
+        async with ServiceBusClient(
+            fully_qualified_namespace=fully_qualified_namespace,
+            credential=credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-#             session_id = str(uuid.uuid4())
+            session_id = str(uuid.uuid4())
+            async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5, session_id=session_id) as receiver:
+                async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                    for i in range(5):
+                        message = ServiceBusMessage("Test message no. {}".format(i), session_id=session_id)
+                        await sender.send_messages(message)
 
-#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 message = ServiceBusMessage("Testing expired messages")
-#                 message.session_id = session_id
-#                 await sender.send_messages(message)
+                messages = await receiver.peek_messages(5)
+                assert len(messages) > 0
+                assert all(isinstance(m, ServiceBusReceivedMessage) for m in messages)
+                for message in messages:
+                    print_message(_logger, message)
+                    with pytest.raises(ValueError):
+                        await receiver.complete_message(message)
 
-#             async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id) as receiver:
-#                 messages = await receiver.receive_messages(max_wait_time=10)
-#                 assert len(messages) == 1
-#                 print_message(_logger, messages[0])
-#                 await asyncio.sleep(60) #TODO: Was 30, but then lock isn't expired.
-#                 with pytest.raises(TypeError):
-#                     messages[0]._lock_expired
-#                 with pytest.raises(TypeError):
-#                     await receiver.renew_message_lock(messages[0])
-#                 assert receiver.session._lock_expired
-#                 with pytest.raises(SessionLockLostError):
-#                     await receiver.complete_message(messages[0])
-#                 with pytest.raises(SessionLockLostError):
-#                     await receiver.session.renew_lock()
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_async_session_by_servicebus_client_renew_client_locks(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential(is_async=True)
+        async with ServiceBusClient(
+            fully_qualified_namespace=fully_qualified_namespace,
+            credential=credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-#             async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id) as receiver:
-#                 messages = await receiver.receive_messages(max_wait_time=30)
-#                 assert len(messages) == 1
-#                 print_message(_logger, messages[0])
-#                 assert messages[0].delivery_count
-#                 await receiver.complete_message(messages[0])
+            session_id = str(uuid.uuid4())
+            messages = []
+            locks = 3
+            async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, prefetch_count=10) as receiver:
+                async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                    for i in range(locks):
+                        message = ServiceBusMessage("Test message no. {}".format(i), session_id=session_id)
+                        await sender.send_messages(message)
 
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_async_session_schedule_message(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         async with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-#             import uuid
-#             session_id = str(uuid.uuid4())
-#             enqueue_time = (utc_now() + timedelta(minutes=2)).replace(microsecond=0)
-#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 content = str(uuid.uuid4())
-#                 message_id = uuid.uuid4()
-#                 message = ServiceBusMessage(content, session_id=session_id)
-#                 message.message_id = message_id
-#                 message.scheduled_enqueue_time_utc = enqueue_time
-#                 await sender.send_messages(message)
+                messages.extend(await receiver.receive_messages())
+                recv = True
+                while recv:
+                    recv = await receiver.receive_messages(max_wait_time=10)
+                    messages.extend(recv)
 
-#             messages = []
-#             renewer = AutoLockRenewer()
-#             async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id) as receiver:
-#                 renewer.register(receiver, receiver.session, max_lock_renewal_duration=140)
-#                 messages.extend(await receiver.receive_messages(max_wait_time=120))
-#                 messages.extend(await receiver.receive_messages(max_wait_time=5))
-#                 if messages:
-#                     data = str(messages[0])
-#                     assert data == content
-#                     assert messages[0].message_id == message_id
-#                     assert messages[0].scheduled_enqueue_time_utc == enqueue_time
-#                     assert messages[0].scheduled_enqueue_time_utc == messages[0].enqueued_time_utc.replace(microsecond=0)
-#                     assert len(messages) == 1
-#                 else:
-#                     raise Exception("Failed to receive schdeduled message.")
-#             await renewer.close()
+                try:
+                    for m in messages:
+                        with pytest.raises(TypeError):
+                            expired = m._lock_expired
+                        assert m.locked_until_utc is None
+                        assert m.lock_token is not None
+                    time.sleep(5)
+                    initial_expiry = receiver.session.locked_until_utc
+                    await receiver.session.renew_lock(timeout=5)
+                    assert (receiver.session.locked_until_utc - initial_expiry) >= timedelta(seconds=5)
+                finally:
+                    await receiver.complete_message(messages[0])
+                    await receiver.complete_message(messages[1])
+                    time.sleep(40)
+                    with pytest.raises(SessionLockLostError):
+                        await receiver.complete_message(messages[2])
 
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_async_session_schedule_multiple_messages(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         async with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-#             import uuid
-#             session_id = str(uuid.uuid4())
-#             enqueue_time = (utc_now() + timedelta(minutes=2)).replace(microsecond=0)
-#             messages = []
-#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 content = str(uuid.uuid4())
-#                 message_id_a = uuid.uuid4()
-#                 message_a = ServiceBusMessage(content, session_id=session_id)
-#                 message_a.message_id = message_id_a
-#                 message_id_b = uuid.uuid4()
-#                 message_b = ServiceBusMessage(content, session_id=session_id)
-#                 message_b.message_id = message_id_b
-#                 tokens = await sender.schedule_messages([message_a, message_b], enqueue_time)
-#                 assert len(tokens) == 2
+    
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True, lock_duration='PT5S')
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_async_session_by_conn_str_receive_handler_with_autolockrenew(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential(is_async=True)
+        async with ServiceBusClient(
+            fully_qualified_namespace=fully_qualified_namespace,
+            credential=credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+            session_id = str(uuid.uuid4())
 
-#             renewer = AutoLockRenewer()
-#             async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, prefetch_count=20) as receiver:
-#                 renewer.register(receiver, receiver.session, max_lock_renewal_duration=140)
-#                 messages.extend(await receiver.receive_messages(max_wait_time=120))
-#                 messages.extend(await receiver.receive_messages(max_wait_time=5))
-#                 if messages:
-#                     data = str(messages[0])
-#                     assert data == content
-#                     assert messages[0].message_id in (message_id_a, message_id_b)
-#                     assert messages[0].scheduled_enqueue_time_utc == enqueue_time
-#                     assert messages[0].scheduled_enqueue_time_utc == messages[0].enqueued_time_utc.replace(microsecond=0)
-#                     assert len(messages) == 2
-#                 else:
-#                     raise Exception("Failed to receive schdeduled message.")
-#             await renewer.close()
+            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                for i in range(10):
+                    message = ServiceBusMessage("{}".format(i), session_id=session_id)
+                    await sender.send_messages(message)
+
+            results = []
+            async def lock_lost_callback(renewable, error):
+                results.append(renewable)
+
+            renewer = AutoLockRenewer()
+            messages = []
+            async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=5, receive_mode=ServiceBusReceiveMode.PEEK_LOCK, prefetch_count=20) as receiver:
+                renewer.register(receiver, receiver.session, max_lock_renewal_duration=10)
+                print("Registered lock renew thread", receiver.session.locked_until_utc, utc_now())
+                with pytest.raises(SessionLockLostError):
+                    async for message in receiver:
+                        if not messages:
+                            await asyncio.sleep(10)
+                            print("First sleep {}".format(receiver.session.locked_until_utc - utc_now()))
+                            assert not receiver.session._lock_expired
+                            with pytest.raises(TypeError):
+                                message._lock_expired
+                            assert message.locked_until_utc is None
+                            with pytest.raises(TypeError):
+                                await receiver.renew_message_lock(message)
+                            assert message.lock_token is not None
+                            await receiver.complete_message(message)
+                            messages.append(message)
+
+                        elif len(messages) == 1:
+                            assert not results
+                            await asyncio.sleep(10)
+                            print("Second sleep {}".format(receiver.session.locked_until_utc - utc_now()))
+                            assert receiver.session._lock_expired
+                            assert isinstance(receiver.session.auto_renew_error, AutoLockRenewTimeout)
+                            try:
+                                await receiver.complete_message(message)
+                                raise AssertionError("Didn't raise SessionLockExpired")
+                            except SessionLockLostError as e:
+                                assert isinstance(e.inner_exception, AutoLockRenewTimeout)
+                            messages.append(message)
+
+            # While we're testing autolockrenew and sessions, let's make sure we don't call the lock-lost callback when a session exits.
+            renewer._renew_period = 1
+            session = None
+
+            async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=5, receive_mode=ServiceBusReceiveMode.PEEK_LOCK, prefetch_count=10) as receiver:
+                session = receiver.session
+                renewer.register(receiver, session, max_lock_renewal_duration=5, on_lock_renew_failure=lock_lost_callback)
+            await asyncio.sleep(max(0,(session.locked_until_utc - utc_now()).total_seconds()+1)) # If this pattern repeats make sleep_until_expired_async
+            assert not results
+
+            await renewer.close()
+            assert len(messages) == 2
+
+    
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True, lock_duration='PT10S')
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_async_session_by_conn_str_receive_handler_with_auto_autolockrenew(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        if sys.platform.startswith('darwin'):
+            pytest.skip("Skipping for flakiness on OSX. Need to fix and unskip during MQ. Issue created: #32067.")
+
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential(is_async=True)
+        async with ServiceBusClient(
+            fully_qualified_namespace=fully_qualified_namespace,
+            credential=credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+            session_id = str(uuid.uuid4())
+
+            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                for i in range(10):
+                    message = ServiceBusMessage("{}".format(i), session_id=session_id)
+                    await sender.send_messages(message)
+
+            results = []
+            async def lock_lost_callback(renewable, error):
+                results.append(renewable)
+
+            renewer = AutoLockRenewer(max_lock_renewal_duration=10)
+            messages = []
+            async with sb_client.get_queue_receiver(servicebus_queue.name,
+                                                    session_id=session_id,
+                                                    max_wait_time=10,
+                                                    receive_mode=ServiceBusReceiveMode.PEEK_LOCK,
+                                                    prefetch_count=20,
+                                                    auto_lock_renewer=renewer) as session:
+                print("Registered lock renew thread", session.session.locked_until_utc, utc_now())
+                with pytest.raises(SessionLockLostError):
+                    async for message in session:
+                        if not messages:
+                            await asyncio.sleep(10)
+                            print("First sleep {}".format(session.session.locked_until_utc - utc_now()))
+                            assert not session.session._lock_expired
+                            with pytest.raises(TypeError):
+                                message._lock_expired
+                            assert message.locked_until_utc is None
+                            with pytest.raises(TypeError):
+                                await session.renew_message_lock(message)
+                            assert message.lock_token is not None
+                            await session.complete_message(message)
+                            messages.append(message)
+
+                        elif len(messages) == 1:
+                            assert not results
+                            await asyncio.sleep(10)
+                            print("Second sleep {}".format(session.session.locked_until_utc - utc_now()))
+                            assert session.session._lock_expired
+                            assert isinstance(session.session.auto_renew_error, AutoLockRenewTimeout)
+                            try:
+                                await session.complete_message(message)
+                                raise AssertionError("Didn't raise SessionLockExpired")
+                            except SessionLockLostError as e:
+                                assert isinstance(e.inner_exception, AutoLockRenewTimeout)
+                            messages.append(message)
+
+            # While we're testing autolockrenew and sessions, let's make sure we don't call the lock-lost callback when a session exits.
+            renewer._renew_period = 1
+            session = None
+
+            async with sb_client.get_queue_receiver(servicebus_queue.name,
+                                                    session_id=session_id,
+                                                    max_wait_time=10,
+                                                    receive_mode=ServiceBusReceiveMode.PEEK_LOCK,
+                                                    prefetch_count=10,
+                                                    auto_lock_renewer=renewer) as receiver:
+                session = receiver.session
+            await asyncio.sleep(max(0,(session.locked_until_utc - utc_now()).total_seconds()+1)) # If this pattern repeats make sleep_until_expired_async
+            assert not results
+
+            await renewer.close()
+            assert len(messages) == 2
+
+        session_id = str(uuid.uuid4())
+        async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+            messages = [ServiceBusMessage("{}".format(i), session_id=session_id) for i in range(10)]
+            await sender.send_messages(messages)
+
+        renewer = AutoLockRenewer(max_lock_renewal_duration=100)
+        receiver = sb_client.get_queue_receiver(servicebus_queue.name,
+                                            session_id=session_id,
+                                            max_wait_time=10,
+                                            prefetch_count=10,
+                                            auto_lock_renewer=renewer)
+
+        async with receiver:
+            received_msgs = await receiver.receive_messages(max_wait_time=10)
+            for msg in received_msgs:
+                await receiver.complete_message(msg)
+
+        await receiver.close()
+        assert not renewer._renewable(receiver._session)
+
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_async_session_message_connection_closed(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential(is_async=True)
+        async with ServiceBusClient(
+            fully_qualified_namespace=fully_qualified_namespace,
+            credential=credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+
+            session_id = str(uuid.uuid4())
+
+            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                message = ServiceBusMessage("test")
+                message.session_id = session_id
+                await sender.send_messages(message)
+
+            async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id) as receiver:
+                messages = await receiver.receive_messages(max_wait_time=10)
+                assert len(messages) == 1
+
+            with pytest.raises(ValueError):
+                await receiver.complete_message(messages[0])
+
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_async_session_message_expiry(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential(is_async=True)
+        async with ServiceBusClient(
+            fully_qualified_namespace=fully_qualified_namespace,
+            credential=credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+
+            session_id = str(uuid.uuid4())
+
+            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                message = ServiceBusMessage("Testing expired messages")
+                message.session_id = session_id
+                await sender.send_messages(message)
+
+            async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id) as receiver:
+                messages = await receiver.receive_messages(max_wait_time=10)
+                assert len(messages) == 1
+                print_message(_logger, messages[0])
+                await asyncio.sleep(60) #TODO: Was 30, but then lock isn't expired.
+                with pytest.raises(TypeError):
+                    messages[0]._lock_expired
+                with pytest.raises(TypeError):
+                    await receiver.renew_message_lock(messages[0])
+                assert receiver.session._lock_expired
+                with pytest.raises(SessionLockLostError):
+                    await receiver.complete_message(messages[0])
+                with pytest.raises(SessionLockLostError):
+                    await receiver.session.renew_lock()
+
+            async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id) as receiver:
+                messages = await receiver.receive_messages(max_wait_time=30)
+                assert len(messages) == 1
+                print_message(_logger, messages[0])
+                assert messages[0].delivery_count
+                await receiver.complete_message(messages[0])
+
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_async_session_schedule_message(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential(is_async=True)
+        async with ServiceBusClient(
+            fully_qualified_namespace=fully_qualified_namespace,
+            credential=credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+            import uuid
+            session_id = str(uuid.uuid4())
+            enqueue_time = (utc_now() + timedelta(minutes=2)).replace(microsecond=0)
+            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                content = str(uuid.uuid4())
+                message_id = uuid.uuid4()
+                message = ServiceBusMessage(content, session_id=session_id)
+                message.message_id = message_id
+                message.scheduled_enqueue_time_utc = enqueue_time
+                await sender.send_messages(message)
+
+            messages = []
+            renewer = AutoLockRenewer()
+            async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id) as receiver:
+                renewer.register(receiver, receiver.session, max_lock_renewal_duration=140)
+                messages.extend(await receiver.receive_messages(max_wait_time=120))
+                messages.extend(await receiver.receive_messages(max_wait_time=5))
+                if messages:
+                    data = str(messages[0])
+                    assert data == content
+                    assert messages[0].message_id == message_id
+                    assert messages[0].scheduled_enqueue_time_utc == enqueue_time
+                    assert messages[0].scheduled_enqueue_time_utc == messages[0].enqueued_time_utc.replace(microsecond=0)
+                    assert len(messages) == 1
+                else:
+                    raise Exception("Failed to receive schdeduled message.")
+            await renewer.close()
+
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_async_session_schedule_multiple_messages(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential(is_async=True)
+        async with ServiceBusClient(
+            fully_qualified_namespace=fully_qualified_namespace,
+            credential=credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+            import uuid
+            session_id = str(uuid.uuid4())
+            enqueue_time = (utc_now() + timedelta(minutes=2)).replace(microsecond=0)
+            messages = []
+            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                content = str(uuid.uuid4())
+                message_id_a = uuid.uuid4()
+                message_a = ServiceBusMessage(content, session_id=session_id)
+                message_a.message_id = message_id_a
+                message_id_b = uuid.uuid4()
+                message_b = ServiceBusMessage(content, session_id=session_id)
+                message_b.message_id = message_id_b
+                tokens = await sender.schedule_messages([message_a, message_b], enqueue_time)
+                assert len(tokens) == 2
+
+            renewer = AutoLockRenewer()
+            async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, prefetch_count=20) as receiver:
+                renewer.register(receiver, receiver.session, max_lock_renewal_duration=140)
+                messages.extend(await receiver.receive_messages(max_wait_time=120))
+                messages.extend(await receiver.receive_messages(max_wait_time=5))
+                if messages:
+                    data = str(messages[0])
+                    assert data == content
+                    assert messages[0].message_id in (message_id_a, message_id_b)
+                    assert messages[0].scheduled_enqueue_time_utc == enqueue_time
+                    assert messages[0].scheduled_enqueue_time_utc == messages[0].enqueued_time_utc.replace(microsecond=0)
+                    assert len(messages) == 2
+                else:
+                    raise Exception("Failed to receive schdeduled message.")
+            await renewer.close()
    
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_async_session_cancel_scheduled_messages(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         async with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_async_session_cancel_scheduled_messages(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential(is_async=True)
+        async with ServiceBusClient(
+            fully_qualified_namespace=fully_qualified_namespace,
+            credential=credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-#             session_id = str(uuid.uuid4())
-#             enqueue_time = (utc_now() + timedelta(minutes=2)).replace(microsecond=0)
-#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 message_a = ServiceBusMessage("Test scheduled message", session_id=session_id)
-#                 message_b = ServiceBusMessage("Test scheduled message", session_id=session_id)
-#                 tokens = await sender.schedule_messages([message_a, message_b], enqueue_time)
-#                 assert len(tokens) == 2
-#                 await sender.cancel_scheduled_messages(tokens)
+            session_id = str(uuid.uuid4())
+            enqueue_time = (utc_now() + timedelta(minutes=2)).replace(microsecond=0)
+            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                message_a = ServiceBusMessage("Test scheduled message", session_id=session_id)
+                message_b = ServiceBusMessage("Test scheduled message", session_id=session_id)
+                tokens = await sender.schedule_messages([message_a, message_b], enqueue_time)
+                assert len(tokens) == 2
+                await sender.cancel_scheduled_messages(tokens)
 
-#             renewer = AutoLockRenewer()
-#             messages = []
-#             async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id) as receiver:
-#                 renewer.register(receiver, receiver.session, max_lock_renewal_duration=140)
-#                 messages.extend(await receiver.receive_messages(max_wait_time=115))
-#                 messages.extend(await receiver.receive_messages(max_wait_time=10))
-#                 try:
-#                     assert len(messages) == 0
-#                 except AssertionError:
-#                     for message in messages:
-#                         print(str(message))
-#                         await receiver.complete_message(message)
-#                     raise
-#             await renewer.close()
+            renewer = AutoLockRenewer()
+            messages = []
+            async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id) as receiver:
+                renewer.register(receiver, receiver.session, max_lock_renewal_duration=140)
+                messages.extend(await receiver.receive_messages(max_wait_time=115))
+                messages.extend(await receiver.receive_messages(max_wait_time=10))
+                try:
+                    assert len(messages) == 0
+                except AssertionError:
+                    for message in messages:
+                        print(str(message))
+                        await receiver.complete_message(message)
+                    raise
+            await renewer.close()
 
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @CachedServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_session_receiver_partially_invalid_autolockrenew_mode(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         session_id = str(uuid.uuid4())
-#         async with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 await sender.send_messages(ServiceBusMessage("test_message", session_id=session_id))
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @CachedServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_session_receiver_partially_invalid_autolockrenew_mode(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        session_id = str(uuid.uuid4())
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential(is_async=True)
+        async with ServiceBusClient(
+            fully_qualified_namespace=fully_qualified_namespace,
+            credential=credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                await sender.send_messages(ServiceBusMessage("test_message", session_id=session_id))
 
-#             failures = 0
-#             async def should_not_run(*args, **kwargs):
-#                 failures += 1
+            failures = 0
+            async def should_not_run(*args, **kwargs):
+                failures += 1
 
-#             async with sb_client.get_queue_receiver(servicebus_queue.name,
-#                                               session_id=session_id,
-#                                               receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE,
-#                                               auto_lock_renewer=AutoLockRenewer()) as receiver:
-#                 assert receiver.receive_messages()
-#                 assert not failures
+            async with sb_client.get_queue_receiver(servicebus_queue.name,
+                                              session_id=session_id,
+                                              receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE,
+                                              auto_lock_renewer=AutoLockRenewer()) as receiver:
+                assert receiver.receive_messages()
+                assert not failures
 
     
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_async_session_get_set_state_with_receiver(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         async with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_async_session_get_set_state_with_receiver(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential(is_async=True)
+        async with ServiceBusClient(
+            fully_qualified_namespace=fully_qualified_namespace,
+            credential=credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-#             session_id = str(uuid.uuid4())
-#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 for i in range(3):
-#                     message = ServiceBusMessage("Handler message no. {}".format(i), session_id=session_id)
-#                     await sender.send_messages(message)
+            session_id = str(uuid.uuid4())
+            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                for i in range(3):
+                    message = ServiceBusMessage("Handler message no. {}".format(i), session_id=session_id)
+                    await sender.send_messages(message)
 
-#             async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=10) as receiver:
-#                 assert await receiver.session.get_state(timeout=5) == None
-#                 await receiver.session.set_state("first_state", timeout=5)
-#                 count = 0
-#                 async for m in receiver:
-#                     assert m.session_id == session_id
-#                     count += 1
-#                 state = await receiver.session.get_state()
-#                 assert state == b'first_state'
-#             assert count == 3
+            async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=10) as receiver:
+                assert await receiver.session.get_state(timeout=5) == None
+                await receiver.session.set_state("first_state", timeout=5)
+                count = 0
+                async for m in receiver:
+                    assert m.session_id == session_id
+                    count += 1
+                state = await receiver.session.get_state()
+                assert state == b'first_state'
+            assert count == 3
 
-#             session_id = str(uuid.uuid4())
-#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 for i in range(1):
-#                     message = ServiceBusMessage("Handler message no. {}".format(i), session_id=session_id)
-#                     await sender.send_messages(message)
+            session_id = str(uuid.uuid4())
+            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                for i in range(1):
+                    message = ServiceBusMessage("Handler message no. {}".format(i), session_id=session_id)
+                    await sender.send_messages(message)
 
-#             async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=10) as receiver:
-#                 assert await receiver.session.get_state(timeout=5) == None
-#                 await receiver.session.set_state(None, timeout=5)
-#                 count = 0
-#                 async for m in receiver:
-#                     assert m.session_id == session_id
-#                     count += 1
-#                 state = await receiver.session.get_state()
-#                 assert state == None
-#             assert count == 1
+            async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=10) as receiver:
+                assert await receiver.session.get_state(timeout=5) == None
+                await receiver.session.set_state(None, timeout=5)
+                count = 0
+                async for m in receiver:
+                    assert m.session_id == session_id
+                    count += 1
+                state = await receiver.session.get_state()
+                assert state == None
+            assert count == 1
 
-#     @pytest.mark.skip(reason='Requires list sessions')
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_async_session_by_servicebus_client_list_sessions_with_receiver(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         async with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+    @pytest.mark.skip(reason='Requires list sessions')
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_async_session_by_servicebus_client_list_sessions_with_receiver(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential(is_async=True)
+        async with ServiceBusClient(
+            fully_qualified_namespace=fully_qualified_namespace,
+            credential=credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-#             sessions = []
-#             start_time = utc_now()
-#             for i in range(5):
-#                 sessions.append(str(uuid.uuid4()))
+            sessions = []
+            start_time = utc_now()
+            for i in range(5):
+                sessions.append(str(uuid.uuid4()))
 
-#             for session in sessions:
-#                 async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                     for i in range(5):
-#                         message = ServiceBusMessage("Test message no. {}".format(i), session_id=session)
-#                         await sender.send_messages(message)
-#             for session in sessions:
-#                 async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session) as receiver:
-#                     await receiver.session.set_state("SESSION {}".format(session))
+            for session in sessions:
+                async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                    for i in range(5):
+                        message = ServiceBusMessage("Test message no. {}".format(i), session_id=session)
+                        await sender.send_messages(message)
+            for session in sessions:
+                async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session) as receiver:
+                    await receiver.session.set_state("SESSION {}".format(session))
 
-#             async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=NEXT_AVAILABLE_SESSION, max_wait_time=5, receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
-#                 current_sessions = await receiver.list_sessions(updated_since=start_time)
-#                 assert len(current_sessions) == 5
-#                 assert current_sessions == sessions
+            async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=NEXT_AVAILABLE_SESSION, max_wait_time=5, receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
+                current_sessions = await receiver.list_sessions(updated_since=start_time)
+                assert len(current_sessions) == 5
+                assert current_sessions == sessions
 
-#     @pytest.mark.skip(reason="requires list_session")
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_async_session_by_servicebus_client_list_sessions_with_client(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         async with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+    @pytest.mark.skip(reason="requires list_session")
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_async_session_by_servicebus_client_list_sessions_with_client(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential(is_async=True)
+        async with ServiceBusClient(
+            fully_qualified_namespace=fully_qualified_namespace,
+            credential=credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-#             sessions = []
-#             start_time = utc_now()
-#             for i in range(5):
-#                 sessions.append(str(uuid.uuid4()))
+            sessions = []
+            start_time = utc_now()
+            for i in range(5):
+                sessions.append(str(uuid.uuid4()))
 
-#             for session in sessions:
-#                 async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                     for i in range(5):
-#                         message = ServiceBusMessage("Test message no. {}".format(i), session_id=session)
-#                         await sender.send_messages(message)
-#             for session in sessions:
-#                 async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session) as receiver:
-#                     await receiver.session.set_state("SESSION {}".format(session))
+            for session in sessions:
+                async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                    for i in range(5):
+                        message = ServiceBusMessage("Test message no. {}".format(i), session_id=session)
+                        await sender.send_messages(message)
+            for session in sessions:
+                async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session) as receiver:
+                    await receiver.session.set_state("SESSION {}".format(session))
 
-#             current_sessions = await sb_client.list_sessions(updated_since=start_time)
-#             assert len(current_sessions) == 5
-#             assert current_sessions == sessions
+            current_sessions = await sb_client.list_sessions(updated_since=start_time)
+            assert len(current_sessions) == 5
+            assert current_sessions == sessions
 
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @pytest.mark.xfail(reason="'Cannot open log' error, potential service bug")
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_async_session_by_servicebus_client_session_pool(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @pytest.mark.xfail(reason="'Cannot open log' error, potential service bug")
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_async_session_by_servicebus_client_session_pool(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
         
-#         messages = []
-#         errors = []
-#         async def message_processing(sb_client):
-#             while True:
-#                 try:
-#                     async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=NEXT_AVAILABLE_SESSION, max_wait_time=5) as receiver:
-#                         async for message in receiver:
-#                             print("ServiceBusMessage: {}".format(message))
-#                             messages.append(message)
-#                             await receiver.complete_message(message)
-#                 except OperationTimeoutError:
-#                     return
-#                 except Exception as e:
-#                     errors.append(e)
-#                     raise
+        messages = []
+        errors = []
+        async def message_processing(sb_client):
+            while True:
+                try:
+                    async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=NEXT_AVAILABLE_SESSION, max_wait_time=5) as receiver:
+                        async for message in receiver:
+                            print("ServiceBusMessage: {}".format(message))
+                            messages.append(message)
+                            await receiver.complete_message(message)
+                except OperationTimeoutError:
+                    return
+                except Exception as e:
+                    errors.append(e)
+                    raise
 
-#         concurrent_receivers = 5
-#         sessions = [str(uuid.uuid4()) for i in range(concurrent_receivers)]
-#         async with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, retry_total=1, uamqp_transport=uamqp_transport) as sb_client:
+        concurrent_receivers = 5
+        sessions = [str(uuid.uuid4()) for i in range(concurrent_receivers)]
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential(is_async=True)
+        async with ServiceBusClient(
+            fully_qualified_namespace=fully_qualified_namespace,
+            credential=credential, logging_enable=False, retry_total=1, uamqp_transport=uamqp_transport) as sb_client:
 
-#             for session_id in sessions:
-#                 async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                     await asyncio.gather(*[sender.send_messages(ServiceBusMessage("Sample message no. {}".format(i), session_id=session_id)) for i in range(20)])
+            for session_id in sessions:
+                async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                    await asyncio.gather(*[sender.send_messages(ServiceBusMessage("Sample message no. {}".format(i), session_id=session_id)) for i in range(20)])
 
-#             receive_sessions = [message_processing(sb_client) for _ in range(concurrent_receivers)]
-#             await asyncio.gather(*receive_sessions, return_exceptions=True)
+            receive_sessions = [message_processing(sb_client) for _ in range(concurrent_receivers)]
+            await asyncio.gather(*receive_sessions, return_exceptions=True)
 
-#             assert not errors
-#             assert len(messages) == 100
+            assert not errors
+            assert len(messages) == 100
 
     
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusTopicPreparer(name_prefix='servicebustest')
-#     @ServiceBusSubscriptionPreparer(name_prefix='servicebustest', requires_session=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_async_session_basic_topic_subscription_send_and_receive(self, uamqp_transport, *, servicebus_namespace_connection_string, servicebus_topic, servicebus_subscription, **kwargs):
-#         async with ServiceBusClient.from_connection_string(
-#                 servicebus_namespace_connection_string,
-#                 logging_enable=False,
-#                 uamqp_transport=uamqp_transport
-#         ) as sb_client:
-#             async with sb_client.get_topic_sender(topic_name=servicebus_topic.name) as sender:
-#                 message = ServiceBusMessage(b"Sample topic message", session_id='test_session')
-#                 await sender.send_messages(message)
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusTopicPreparer(name_prefix='servicebustest')
+    @ServiceBusSubscriptionPreparer(name_prefix='servicebustest', requires_session=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_async_session_basic_topic_subscription_send_and_receive(self, uamqp_transport, *, fully_qualified_namespace=fully_qualified_namespace,
+            credential=credential, servicebus_topic, servicebus_subscription, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential(is_async=True)
+        async with ServiceBusClient(
+                fully_qualified_namespace=fully_qualified_namespace,
+            credential=credential,
+                logging_enable=False,
+                uamqp_transport=uamqp_transport
+        ) as sb_client:
+            async with sb_client.get_topic_sender(topic_name=servicebus_topic.name) as sender:
+                message = ServiceBusMessage(b"Sample topic message", session_id='test_session')
+                await sender.send_messages(message)
 
-#             async with sb_client.get_subscription_receiver(
-#                 topic_name=servicebus_topic.name,
-#                 subscription_name=servicebus_subscription.name,
-#                 session_id='test_session',
-#                 max_wait_time=5
-#             ) as receiver:
-#                 count = 0
-#                 async for message in receiver:
-#                     count += 1
-#                     await receiver.complete_message(message)
-#             assert count == 1
+            async with sb_client.get_subscription_receiver(
+                topic_name=servicebus_topic.name,
+                subscription_name=servicebus_subscription.name,
+                session_id='test_session',
+                max_wait_time=5
+            ) as receiver:
+                count = 0
+                async for message in receiver:
+                    count += 1
+                    await receiver.complete_message(message)
+            assert count == 1
 
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @pytest.mark.xfail(reason="'Cannot open log' error, potential service bug", raises=ServiceBusError)
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_async_session_connection_failure_is_idempotent(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         #Technically this validates for all senders/receivers, not just session, but since it uses session to generate a recoverable failure, putting it in here.
-#         async with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, retry_total=1, uamqp_transport=uamqp_transport) as sb_client:
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @pytest.mark.xfail(reason="'Cannot open log' error, potential service bug", raises=ServiceBusError)
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_async_session_connection_failure_is_idempotent(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        #Technically this validates for all senders/receivers, not just session, but since it uses session to generate a recoverable failure, putting it in here.
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential(is_async=True)
+        async with ServiceBusClient(
+            fully_qualified_namespace=fully_qualified_namespace,
+            credential=credential, logging_enable=False, retry_total=1, uamqp_transport=uamqp_transport) as sb_client:
     
-#             # First let's just try the naive failure cases.
-#             receiver = sb_client.get_queue_receiver("THIS_IS_WRONG_ON_PURPOSE")
-#             with pytest.raises(ServiceBusAuthenticationError):
-#                 await receiver._open_with_retry()
-#             assert not receiver._running
-#             assert not receiver._handler
+            # First let's just try the naive failure cases.
+            receiver = sb_client.get_queue_receiver("THIS_IS_WRONG_ON_PURPOSE")
+            with pytest.raises(ServiceBusAuthenticationError):
+                await receiver._open_with_retry()
+            assert not receiver._running
+            assert not receiver._handler
     
-#             sender = sb_client.get_queue_sender("THIS_IS_WRONG_ON_PURPOSE")
-#             with pytest.raises(ServiceBusAuthenticationError):
-#                 await sender._open_with_retry()
-#             assert not receiver._running
-#             assert not receiver._handler
+            sender = sb_client.get_queue_sender("THIS_IS_WRONG_ON_PURPOSE")
+            with pytest.raises(ServiceBusAuthenticationError):
+                await sender._open_with_retry()
+            assert not receiver._running
+            assert not receiver._handler
 
-#             # Then let's try a case we can recover from to make sure everything works on reestablishment.
-#             receiver = sb_client.get_queue_receiver(servicebus_queue.name, session_id=NEXT_AVAILABLE_SESSION)
-#             with pytest.raises(OperationTimeoutError):
-#                 await receiver._open_with_retry()
+            # Then let's try a case we can recover from to make sure everything works on reestablishment.
+            receiver = sb_client.get_queue_receiver(servicebus_queue.name, session_id=NEXT_AVAILABLE_SESSION)
+            with pytest.raises(OperationTimeoutError):
+                await receiver._open_with_retry()
 
-#             session_id = str(uuid.uuid4())
-#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 await sender.send_messages(ServiceBusMessage("test session sender", session_id=session_id))
+            session_id = str(uuid.uuid4())
+            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                await sender.send_messages(ServiceBusMessage("test session sender", session_id=session_id))
 
-#             async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=NEXT_AVAILABLE_SESSION, max_wait_time=5) as receiver:
-#                 messages = []
-#                 async for message in receiver:
-#                     messages.append(message)
-#                 assert len(messages) == 1
+            async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=NEXT_AVAILABLE_SESSION, max_wait_time=5) as receiver:
+                messages = []
+                async for message in receiver:
+                    messages.append(message)
+                assert len(messages) == 1
 
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @CachedServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_async_session_non_session_send_to_session_queue_should_fail(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         async with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @CachedServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_async_session_non_session_send_to_session_queue_should_fail(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential(is_async=True)
+        async with ServiceBusClient(
+            fully_qualified_namespace=fully_qualified_namespace,
+            credential=credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 with pytest.raises(ServiceBusError):
-#                     message = ServiceBusMessage("Handler message")
-#                     await sender.send_messages(message)
+            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                with pytest.raises(ServiceBusError):
+                    message = ServiceBusMessage("Handler message")
+                    await sender.send_messages(message)
 
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_async_next_available_session_timeout_value(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         if uamqp_transport:
-#             pytest.skip("This test is for pyamqp only")
-#         async with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_async_next_available_session_timeout_value(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        if uamqp_transport:
+            pytest.skip("This test is for pyamqp only")
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential(is_async=True)
+        async with ServiceBusClient(
+            fully_qualified_namespace=fully_qualified_namespace,
+            credential=credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
             
-#             receiver = sb_client.get_queue_receiver(servicebus_queue.name, session_id=NEXT_AVAILABLE_SESSION, max_wait_time=10)
-#             start_time = time.time()
-#             with pytest.raises(OperationTimeoutError):
-#                 await receiver.receive_messages(max_wait_time=5)
-#             assert time.time() - start_time < 65 # Default service timeout value is 65 seconds
-#             start_time2 = time.time()
-#             with pytest.raises(OperationTimeoutError):
-#                 async for msg in receiver:
-#                     pass
-#             assert time.time() - start_time2 < 65 # Default service timeout value is 65 seconds
+            receiver = sb_client.get_queue_receiver(servicebus_queue.name, session_id=NEXT_AVAILABLE_SESSION, max_wait_time=10)
+            start_time = time.time()
+            with pytest.raises(OperationTimeoutError):
+                await receiver.receive_messages(max_wait_time=5)
+            assert time.time() - start_time < 65 # Default service timeout value is 65 seconds
+            start_time2 = time.time()
+            with pytest.raises(OperationTimeoutError):
+                async for msg in receiver:
+                    pass
+            assert time.time() - start_time2 < 65 # Default service timeout value is 65 seconds
 
-#             receiver = sb_client.get_queue_receiver(servicebus_queue.name, session_id=NEXT_AVAILABLE_SESSION, max_wait_time=70)
-#             start_time = time.time()
-#             with pytest.raises(OperationTimeoutError):
-#                 await receiver.receive_messages(max_wait_time=5)
-#             assert time.time() - start_time > 65 # Default service timeout value is 65 seconds
-#             start_time2 = time.time()
-#             with pytest.raises(OperationTimeoutError):
-#                 async for msg in receiver:
-#                     pass
-#             assert time.time() - start_time2 > 65 # Default service timeout value is 65 seconds
+            receiver = sb_client.get_queue_receiver(servicebus_queue.name, session_id=NEXT_AVAILABLE_SESSION, max_wait_time=70)
+            start_time = time.time()
+            with pytest.raises(OperationTimeoutError):
+                await receiver.receive_messages(max_wait_time=5)
+            assert time.time() - start_time > 65 # Default service timeout value is 65 seconds
+            start_time2 = time.time()
+            with pytest.raises(OperationTimeoutError):
+                async for msg in receiver:
+                    pass
+            assert time.time() - start_time2 > 65 # Default service timeout value is 65 seconds

--- a/sdk/servicebus/azure-servicebus/tests/async_tests/test_sessions_async.py
+++ b/sdk/servicebus/azure-servicebus/tests/async_tests/test_sessions_async.py
@@ -1168,8 +1168,7 @@ class TestServiceBusAsyncSession(AzureMgmtRecordedTestCase):
     @ServiceBusSubscriptionPreparer(name_prefix='servicebustest', requires_session=True)
     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
     @ArgPasserAsync()
-    async def test_async_session_basic_topic_subscription_send_and_receive(self, uamqp_transport, *, fully_qualified_namespace=fully_qualified_namespace,
-            credential=credential, servicebus_topic, servicebus_subscription, **kwargs):
+    async def test_async_session_basic_topic_subscription_send_and_receive(self, uamqp_transport, *, servicebus_namespace, servicebus_topic, servicebus_subscription, **kwargs):
         fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
         credential = get_credential(is_async=True)
         async with ServiceBusClient(

--- a/sdk/servicebus/azure-servicebus/tests/async_tests/test_sessions_async.py
+++ b/sdk/servicebus/azure-servicebus/tests/async_tests/test_sessions_async.py
@@ -1173,7 +1173,7 @@ class TestServiceBusAsyncSession(AzureMgmtRecordedTestCase):
         credential = get_credential(is_async=True)
         async with ServiceBusClient(
                 fully_qualified_namespace=fully_qualified_namespace,
-            credential=credential,
+                credential=credential,
                 logging_enable=False,
                 uamqp_transport=uamqp_transport
         ) as sb_client:

--- a/sdk/servicebus/azure-servicebus/tests/async_tests/test_sessions_async.py
+++ b/sdk/servicebus/azure-servicebus/tests/async_tests/test_sessions_async.py
@@ -1,1209 +1,1209 @@
-#-------------------------------------------------------------------------
-# Copyright (c) Microsoft Corporation. All rights reserved.
-# Licensed under the MIT License. See License.txt in the project root for
-# license information.
-#--------------------------------------------------------------------------
+# #-------------------------------------------------------------------------
+# # Copyright (c) Microsoft Corporation. All rights reserved.
+# # Licensed under the MIT License. See License.txt in the project root for
+# # license information.
+# #--------------------------------------------------------------------------
 
-import asyncio
-import logging
-import sys
-import os
-import pytest
-import time
-import uuid
-import pickle
-from datetime import datetime, timedelta
+# import asyncio
+# import logging
+# import sys
+# import os
+# import pytest
+# import time
+# import uuid
+# import pickle
+# from datetime import datetime, timedelta
 
-from azure.servicebus import (
-    ServiceBusMessage,
-    ServiceBusReceivedMessage,
-    ServiceBusReceiveMode,
-    NEXT_AVAILABLE_SESSION,
-    ServiceBusSubQueue
-)
-from azure.servicebus.aio import ServiceBusClient, AutoLockRenewer
-from azure.servicebus._common.utils import utc_now
-from azure.servicebus.exceptions import (
-    ServiceBusConnectionError,
-    ServiceBusAuthenticationError,
-    ServiceBusError,
-    OperationTimeoutError,
-    SessionLockLostError,
-    MessageLockLostError,
-    MessageAlreadySettled,
-    AutoLockRenewTimeout
-)
-from devtools_testutils import AzureMgmtRecordedTestCase
-from tests.servicebus_preparer import (
-    CachedServiceBusNamespacePreparer,
-    CachedServiceBusQueuePreparer,
-    ServiceBusTopicPreparer,
-    ServiceBusQueuePreparer,
-    ServiceBusSubscriptionPreparer,
-    CachedServiceBusResourceGroupPreparer
-)
-from tests.utilities import get_logger, print_message, uamqp_transport as get_uamqp_transport, ArgPasserAsync
+# from azure.servicebus import (
+#     ServiceBusMessage,
+#     ServiceBusReceivedMessage,
+#     ServiceBusReceiveMode,
+#     NEXT_AVAILABLE_SESSION,
+#     ServiceBusSubQueue
+# )
+# from azure.servicebus.aio import ServiceBusClient, AutoLockRenewer
+# from azure.servicebus._common.utils import utc_now
+# from azure.servicebus.exceptions import (
+#     ServiceBusConnectionError,
+#     ServiceBusAuthenticationError,
+#     ServiceBusError,
+#     OperationTimeoutError,
+#     SessionLockLostError,
+#     MessageLockLostError,
+#     MessageAlreadySettled,
+#     AutoLockRenewTimeout
+# )
+# from devtools_testutils import AzureMgmtRecordedTestCase
+# from tests.servicebus_preparer import (
+#     CachedServiceBusNamespacePreparer,
+#     CachedServiceBusQueuePreparer,
+#     ServiceBusTopicPreparer,
+#     ServiceBusQueuePreparer,
+#     ServiceBusSubscriptionPreparer,
+#     CachedServiceBusResourceGroupPreparer
+# )
+# from tests.utilities import get_logger, print_message, uamqp_transport as get_uamqp_transport, ArgPasserAsync
 
-uamqp_transport_params, uamqp_transport_ids = get_uamqp_transport()
+# uamqp_transport_params, uamqp_transport_ids = get_uamqp_transport()
 
-_logger = get_logger(logging.DEBUG)
+# _logger = get_logger(logging.DEBUG)
 
 
-class TestServiceBusAsyncSession(AzureMgmtRecordedTestCase):
+# class TestServiceBusAsyncSession(AzureMgmtRecordedTestCase):
 
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_async_session_by_session_client_conn_str_receive_handler_peeklock(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        async with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_async_session_by_session_client_conn_str_receive_handler_peeklock(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         async with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-            session_id = str(uuid.uuid4())
-            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                for i in range(3):
-                    message = ServiceBusMessage("Handler message no. {}".format(i), session_id=session_id)
-                    await sender.send_messages(message)
+#             session_id = str(uuid.uuid4())
+#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 for i in range(3):
+#                     message = ServiceBusMessage("Handler message no. {}".format(i), session_id=session_id)
+#                     await sender.send_messages(message)
 
-            with pytest.raises(ServiceBusError):
-                await sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10)._open_with_retry()
+#             with pytest.raises(ServiceBusError):
+#                 await sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10)._open_with_retry()
 
-            receiver = sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=10)
-            count = 0
-            async for message in receiver:
-                print_message(_logger, message)
-                assert message.session_id == session_id
-                count += 1
-                await receiver.complete_message(message)
+#             receiver = sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=10)
+#             count = 0
+#             async for message in receiver:
+#                 print_message(_logger, message)
+#                 assert message.session_id == session_id
+#                 count += 1
+#                 await receiver.complete_message(message)
 
-            await receiver.close()
+#             await receiver.close()
 
-            assert count == 3
+#             assert count == 3
 
-            session_id = ""
-            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                for i in range(3):
-                    message = ServiceBusMessage("Handler message no. {}".format(i), session_id=session_id)
-                    await sender.send_messages(message)
+#             session_id = ""
+#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 for i in range(3):
+#                     message = ServiceBusMessage("Handler message no. {}".format(i), session_id=session_id)
+#                     await sender.send_messages(message)
 
-            with pytest.raises(ServiceBusError):
-                await sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10)._open_with_retry()
+#             with pytest.raises(ServiceBusError):
+#                 await sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10)._open_with_retry()
 
-            receiver = sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=10)
-            count = 0
-            async for message in receiver:
-                print_message(_logger, message)
-                assert message.session_id == session_id
-                count += 1
-                await receiver.complete_message(message)
+#             receiver = sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=10)
+#             count = 0
+#             async for message in receiver:
+#                 print_message(_logger, message)
+#                 assert message.session_id == session_id
+#                 count += 1
+#                 await receiver.complete_message(message)
 
-            await receiver.close()
+#             await receiver.close()
 
-            assert count == 3
+#             assert count == 3
 
-            with pytest.raises(ServiceBusError):
-                receiver = sb_client.get_queue_receiver(servicebus_queue.name, session_id=1)
-                async with receiver:
-                    pass
+#             with pytest.raises(ServiceBusError):
+#                 receiver = sb_client.get_queue_receiver(servicebus_queue.name, session_id=1)
+#                 async with receiver:
+#                     pass
     
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True, lock_duration='PT10S')
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_async_session_by_queue_client_conn_str_receive_handler_receiveanddelete(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        async with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True, lock_duration='PT10S')
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_async_session_by_queue_client_conn_str_receive_handler_receiveanddelete(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         async with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-            session_id = str(uuid.uuid4())
-            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                for i in range(10):
-                    message = ServiceBusMessage("Handler message no. {}".format(i), session_id=session_id)
-                    await sender.send_messages(message)
+#             session_id = str(uuid.uuid4())
+#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 for i in range(10):
+#                     message = ServiceBusMessage("Handler message no. {}".format(i), session_id=session_id)
+#                     await sender.send_messages(message)
 
-            messages = []
-            receiver = sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE, max_wait_time=10)
-            async for message in receiver:
-                messages.append(message)
-                assert session_id == receiver.session.session_id
-                assert session_id == message.session_id
-                with pytest.raises(ValueError):
-                    await receiver.complete_message(message)
+#             messages = []
+#             receiver = sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE, max_wait_time=10)
+#             async for message in receiver:
+#                 messages.append(message)
+#                 assert session_id == receiver.session.session_id
+#                 assert session_id == message.session_id
+#                 with pytest.raises(ValueError):
+#                     await receiver.complete_message(message)
 
-            assert receiver._running
-            await receiver.close()
+#             assert receiver._running
+#             await receiver.close()
 
-            assert not receiver._running
-            assert len(messages) == 10
-            time.sleep(10)
+#             assert not receiver._running
+#             assert len(messages) == 10
+#             time.sleep(10)
 
-            messages = []
-            async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE, max_wait_time=10) as receiver:
-                async for message in receiver:
-                    messages.append(message)
-            assert len(messages) == 0
-
-    
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_async_session_by_session_client_conn_str_receive_handler_with_stop(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        async with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-
-            session_id = str(uuid.uuid4())
-            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                for i in range(10):
-                    message = ServiceBusMessage("Stop message no. {}".format(i), session_id=session_id)
-                    await sender.send_messages(message)
-
-            messages = []
-            receiver = sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=5)
-            async with receiver:
-                async for message in receiver:
-                    assert session_id == receiver.session.session_id
-                    assert session_id == message.session_id
-                    messages.append(message)
-                    await receiver.complete_message(message)
-                    if len(messages) >= 5:
-                        break
-
-                assert receiver._running
-                assert len(messages) == 5
-
-                async for message in receiver:
-                    assert session_id == receiver.session.session_id
-                    assert session_id == message.session_id
-                    messages.append(message)
-                    await receiver.complete_message(message)
-                    if len(messages) >= 5:
-                        break
-
-            assert not receiver._running
-            assert len(messages) == 6
-
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @pytest.mark.xfail(reason="'Cannot open log' error, potential service bug", raises=ServiceBusError)
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_async_session_by_session_client_conn_str_receive_handler_with_no_session(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        async with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-
-            receiver = sb_client.get_queue_receiver(servicebus_queue.name, session_id=NEXT_AVAILABLE_SESSION, max_wait_time=10)
-            with pytest.raises(OperationTimeoutError):
-                await receiver._open_with_retry()
+#             messages = []
+#             async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE, max_wait_time=10) as receiver:
+#                 async for message in receiver:
+#                     messages.append(message)
+#             assert len(messages) == 0
 
     
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_async_session_by_session_client_conn_str_receive_handler_with_inactive_session(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        async with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_async_session_by_session_client_conn_str_receive_handler_with_stop(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         async with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-            session_id = str(uuid.uuid4())
-            messages = []
-            receiver = sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE, max_wait_time=5)
-            async with receiver:
-                async for message in receiver:
-                    messages.append(message)
+#             session_id = str(uuid.uuid4())
+#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 for i in range(10):
+#                     message = ServiceBusMessage("Stop message no. {}".format(i), session_id=session_id)
+#                     await sender.send_messages(message)
 
-            assert not receiver._running
-            assert len(messages) == 0
+#             messages = []
+#             receiver = sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=5)
+#             async with receiver:
+#                 async for message in receiver:
+#                     assert session_id == receiver.session.session_id
+#                     assert session_id == message.session_id
+#                     messages.append(message)
+#                     await receiver.complete_message(message)
+#                     if len(messages) >= 5:
+#                         break
 
-    
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_async_session_by_servicebus_client_iter_messages_with_retrieve_deferred_receiver_complete(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        async with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#                 assert receiver._running
+#                 assert len(messages) == 5
 
-            deferred_messages = []
-            session_id = str(uuid.uuid4())
-            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                for message in [ServiceBusMessage("Deferred message no. {}".format(i), session_id=session_id) for i in range(10)]:
-                    await sender.send_messages(message)
+#                 async for message in receiver:
+#                     assert session_id == receiver.session.session_id
+#                     assert session_id == message.session_id
+#                     messages.append(message)
+#                     await receiver.complete_message(message)
+#                     if len(messages) >= 5:
+#                         break
 
-            count = 0
-            async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=5) as receiver:
-                async for message in receiver:
-                    deferred_messages.append(message.sequence_number)
-                    print_message(_logger, message)
-                    count += 1
-                    await receiver.defer_message(message)
+#             assert not receiver._running
+#             assert len(messages) == 6
 
-            assert count == 10
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @pytest.mark.xfail(reason="'Cannot open log' error, potential service bug", raises=ServiceBusError)
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_async_session_by_session_client_conn_str_receive_handler_with_no_session(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         async with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-            async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=5) as receiver:
-                deferred = await receiver.receive_deferred_messages(deferred_messages)
-                assert len(deferred) == 10
-                for message in deferred:
-                    assert isinstance(message, ServiceBusReceivedMessage)
-                    assert message.lock_token
-                    assert not message.locked_until_utc
-                    assert message._receiver
-                    with pytest.raises(TypeError):
-                        await receiver.renew_message_lock(message)
-                    await receiver.complete_message(message)
+#             receiver = sb_client.get_queue_receiver(servicebus_queue.name, session_id=NEXT_AVAILABLE_SESSION, max_wait_time=10)
+#             with pytest.raises(OperationTimeoutError):
+#                 await receiver._open_with_retry()
 
     
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_async_session_by_servicebus_client_iter_messages_with_retrieve_deferred_receiver_deadletter(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        async with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_async_session_by_session_client_conn_str_receive_handler_with_inactive_session(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         async with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-            deferred_messages = []
-            session_id = str(uuid.uuid4())
-            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                for message in [ServiceBusMessage("Deferred message no. {}".format(i), session_id=session_id) for i in range(10)]:
-                    await sender.send_messages(message)
+#             session_id = str(uuid.uuid4())
+#             messages = []
+#             receiver = sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE, max_wait_time=5)
+#             async with receiver:
+#                 async for message in receiver:
+#                     messages.append(message)
 
-            count = 0
-            async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=5) as receiver:
-                async for message in receiver:
-                    deferred_messages.append(message.sequence_number)
-                    print_message(_logger, message)
-                    count += 1
-                    await receiver.defer_message(message)
-
-            assert count == 10
-
-            async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=5) as receiver:
-                deferred = await receiver.receive_deferred_messages(deferred_messages)
-                assert len(deferred) == 10
-                for message in deferred:
-                    assert isinstance(message, ServiceBusReceivedMessage)
-                    await receiver.dead_letter_message(message, reason="Testing reason", error_description="Testing description")
-
-            count = 0
-            async with sb_client.get_queue_receiver(servicebus_queue.name, 
-                                                    sub_queue = ServiceBusSubQueue.DEAD_LETTER,
-                                                    max_wait_time=5) as receiver:
-                async for message in receiver:
-                    count += 1
-                    print_message(_logger, message)
-                    assert message.dead_letter_reason == 'Testing reason'
-                    assert message.dead_letter_error_description == 'Testing description'
-                    assert message.application_properties[b'DeadLetterReason'] == b'Testing reason'
-                    assert message.application_properties[b'DeadLetterErrorDescription'] == b'Testing description'
-                    await receiver.complete_message(message)
-            assert count == 10
+#             assert not receiver._running
+#             assert len(messages) == 0
 
     
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_async_session_by_servicebus_client_iter_messages_with_retrieve_deferred_receiver_deletemode(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        async with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_async_session_by_servicebus_client_iter_messages_with_retrieve_deferred_receiver_complete(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         async with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-            deferred_messages = []
-            session_id = str(uuid.uuid4())
-            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                for message in [ServiceBusMessage("Deferred message no. {}".format(i), session_id=session_id) for i in range(10)]:
-                    await sender.send_messages(message)
+#             deferred_messages = []
+#             session_id = str(uuid.uuid4())
+#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 for message in [ServiceBusMessage("Deferred message no. {}".format(i), session_id=session_id) for i in range(10)]:
+#                     await sender.send_messages(message)
 
-            count = 0
-            async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=5) as receiver:
-                async for message in receiver:
-                    deferred_messages.append(message.sequence_number)
-                    print_message(_logger, message)
-                    count += 1
-                    await receiver.defer_message(message)
+#             count = 0
+#             async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=5) as receiver:
+#                 async for message in receiver:
+#                     deferred_messages.append(message.sequence_number)
+#                     print_message(_logger, message)
+#                     count += 1
+#                     await receiver.defer_message(message)
 
-            assert count == 10
-            async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=5, receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE) as receiver:
-                deferred = await receiver.receive_deferred_messages(deferred_messages)
-                assert len(deferred) == 10
-                for message in deferred:
-                    assert isinstance(message, ServiceBusReceivedMessage)
-                    with pytest.raises(ValueError):
-                        await receiver.complete_message(message)
-                with pytest.raises(ServiceBusError):
-                    deferred = await receiver.receive_deferred_messages(deferred_messages)
+#             assert count == 10
 
-    
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_async_session_by_servicebus_client_iter_messages_with_retrieve_deferred_client(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        async with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-
-            deferred_messages = []
-            session_id = str(uuid.uuid4())
-            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                for i in range(10):
-                    message = ServiceBusMessage("Deferred message no. {}".format(i), session_id=session_id)
-                    await sender.send_messages(message)
-
-            receiver = sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=5)
-            count = 0
-            async for message in receiver:
-                deferred_messages.append(message.sequence_number)
-                print_message(_logger, message)
-                count += 1
-                await receiver.defer_message(message)
-            await receiver.close()
-
-            assert count == 10
-
-            with pytest.raises(ValueError):
-                await receiver.complete_message(message)
+#             async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=5) as receiver:
+#                 deferred = await receiver.receive_deferred_messages(deferred_messages)
+#                 assert len(deferred) == 10
+#                 for message in deferred:
+#                     assert isinstance(message, ServiceBusReceivedMessage)
+#                     assert message.lock_token
+#                     assert not message.locked_until_utc
+#                     assert message._receiver
+#                     with pytest.raises(TypeError):
+#                         await receiver.renew_message_lock(message)
+#                     await receiver.complete_message(message)
 
     
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_async_session_by_servicebus_client_fetch_next_with_retrieve_deadletter(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        async with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_async_session_by_servicebus_client_iter_messages_with_retrieve_deferred_receiver_deadletter(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         async with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-            session_id = str(uuid.uuid4())
-            async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=5, prefetch_count=10) as receiver:
+#             deferred_messages = []
+#             session_id = str(uuid.uuid4())
+#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 for message in [ServiceBusMessage("Deferred message no. {}".format(i), session_id=session_id) for i in range(10)]:
+#                     await sender.send_messages(message)
 
-                async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                    for i in range(10):
-                        message = ServiceBusMessage("Dead lettered message no. {}".format(i), session_id=session_id)
-                        await sender.send_messages(message)
+#             count = 0
+#             async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=5) as receiver:
+#                 async for message in receiver:
+#                     deferred_messages.append(message.sequence_number)
+#                     print_message(_logger, message)
+#                     count += 1
+#                     await receiver.defer_message(message)
 
-                count = 0
-                messages = await receiver.receive_messages()
-                while messages:
-                    for message in messages:
-                        print_message(_logger, message)
-                        await receiver.dead_letter_message(message, reason="Testing reason",
-                                                           error_description="Testing description")
-                        count += 1
-                    messages = await receiver.receive_messages()
-            assert count == 10
+#             assert count == 10
 
-            async with sb_client.get_queue_receiver(servicebus_queue.name, 
-                                                    sub_queue = ServiceBusSubQueue.DEAD_LETTER,
-                                                    max_wait_time=5) as receiver:
-                count = 0
-                async for message in receiver:
-                    print_message(_logger, message)
-                    assert message.dead_letter_reason == 'Testing reason'
-                    assert message.dead_letter_error_description == 'Testing description'
-                    assert message.application_properties[b'DeadLetterReason'] == b'Testing reason'
-                    assert message.application_properties[b'DeadLetterErrorDescription'] == b'Testing description'
-                    await receiver.complete_message(message)
-                    count += 1
-            assert count == 10
+#             async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=5) as receiver:
+#                 deferred = await receiver.receive_deferred_messages(deferred_messages)
+#                 assert len(deferred) == 10
+#                 for message in deferred:
+#                     assert isinstance(message, ServiceBusReceivedMessage)
+#                     await receiver.dead_letter_message(message, reason="Testing reason", error_description="Testing description")
 
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_async_session_by_servicebus_client_browse_messages_client(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        async with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-
-            session_id = str(uuid.uuid4())
-            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                for i in range(5):
-                    message = ServiceBusMessage("Test message no. {}".format(i), session_id=session_id)
-                    await sender.send_messages(message)
-            session_id_2 = str(uuid.uuid4())
-            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                for i in range(3):
-                    message = ServiceBusMessage("Test message no. {}".format(i), session_id=session_id_2)
-                    await sender.send_messages(message)
-
-            async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id) as receiver:
-                messages = await receiver.peek_messages(5)
-                assert len(messages) == 5
-                assert all(isinstance(m, ServiceBusReceivedMessage) for m in messages)
-                for message in messages:
-                    print_message(_logger, message)
-                    with pytest.raises(ValueError):
-                        await receiver.complete_message(message)
-
-            async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id_2) as receiver:
-                messages = await receiver.peek_messages(5)
-                assert len(messages) == 3
-
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_async_session_by_servicebus_client_browse_messages_with_receiver(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        async with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-
-            session_id = str(uuid.uuid4())
-            async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5, session_id=session_id) as receiver:
-                async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                    for i in range(5):
-                        message = ServiceBusMessage("Test message no. {}".format(i), session_id=session_id)
-                        await sender.send_messages(message)
-
-                messages = await receiver.peek_messages(5)
-                assert len(messages) > 0
-                assert all(isinstance(m, ServiceBusReceivedMessage) for m in messages)
-                for message in messages:
-                    print_message(_logger, message)
-                    with pytest.raises(ValueError):
-                        await receiver.complete_message(message)
-
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_async_session_by_servicebus_client_renew_client_locks(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        async with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-
-            session_id = str(uuid.uuid4())
-            messages = []
-            locks = 3
-            async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, prefetch_count=10) as receiver:
-                async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                    for i in range(locks):
-                        message = ServiceBusMessage("Test message no. {}".format(i), session_id=session_id)
-                        await sender.send_messages(message)
-
-                messages.extend(await receiver.receive_messages())
-                recv = True
-                while recv:
-                    recv = await receiver.receive_messages(max_wait_time=10)
-                    messages.extend(recv)
-
-                try:
-                    for m in messages:
-                        with pytest.raises(TypeError):
-                            expired = m._lock_expired
-                        assert m.locked_until_utc is None
-                        assert m.lock_token is not None
-                    time.sleep(5)
-                    initial_expiry = receiver.session.locked_until_utc
-                    await receiver.session.renew_lock(timeout=5)
-                    assert (receiver.session.locked_until_utc - initial_expiry) >= timedelta(seconds=5)
-                finally:
-                    await receiver.complete_message(messages[0])
-                    await receiver.complete_message(messages[1])
-                    time.sleep(40)
-                    with pytest.raises(SessionLockLostError):
-                        await receiver.complete_message(messages[2])
+#             count = 0
+#             async with sb_client.get_queue_receiver(servicebus_queue.name, 
+#                                                     sub_queue = ServiceBusSubQueue.DEAD_LETTER,
+#                                                     max_wait_time=5) as receiver:
+#                 async for message in receiver:
+#                     count += 1
+#                     print_message(_logger, message)
+#                     assert message.dead_letter_reason == 'Testing reason'
+#                     assert message.dead_letter_error_description == 'Testing description'
+#                     assert message.application_properties[b'DeadLetterReason'] == b'Testing reason'
+#                     assert message.application_properties[b'DeadLetterErrorDescription'] == b'Testing description'
+#                     await receiver.complete_message(message)
+#             assert count == 10
 
     
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True, lock_duration='PT5S')
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_async_session_by_conn_str_receive_handler_with_autolockrenew(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        async with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-            session_id = str(uuid.uuid4())
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_async_session_by_servicebus_client_iter_messages_with_retrieve_deferred_receiver_deletemode(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         async with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                for i in range(10):
-                    message = ServiceBusMessage("{}".format(i), session_id=session_id)
-                    await sender.send_messages(message)
+#             deferred_messages = []
+#             session_id = str(uuid.uuid4())
+#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 for message in [ServiceBusMessage("Deferred message no. {}".format(i), session_id=session_id) for i in range(10)]:
+#                     await sender.send_messages(message)
 
-            results = []
-            async def lock_lost_callback(renewable, error):
-                results.append(renewable)
+#             count = 0
+#             async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=5) as receiver:
+#                 async for message in receiver:
+#                     deferred_messages.append(message.sequence_number)
+#                     print_message(_logger, message)
+#                     count += 1
+#                     await receiver.defer_message(message)
 
-            renewer = AutoLockRenewer()
-            messages = []
-            async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=5, receive_mode=ServiceBusReceiveMode.PEEK_LOCK, prefetch_count=20) as receiver:
-                renewer.register(receiver, receiver.session, max_lock_renewal_duration=10)
-                print("Registered lock renew thread", receiver.session.locked_until_utc, utc_now())
-                with pytest.raises(SessionLockLostError):
-                    async for message in receiver:
-                        if not messages:
-                            await asyncio.sleep(10)
-                            print("First sleep {}".format(receiver.session.locked_until_utc - utc_now()))
-                            assert not receiver.session._lock_expired
-                            with pytest.raises(TypeError):
-                                message._lock_expired
-                            assert message.locked_until_utc is None
-                            with pytest.raises(TypeError):
-                                await receiver.renew_message_lock(message)
-                            assert message.lock_token is not None
-                            await receiver.complete_message(message)
-                            messages.append(message)
-
-                        elif len(messages) == 1:
-                            assert not results
-                            await asyncio.sleep(10)
-                            print("Second sleep {}".format(receiver.session.locked_until_utc - utc_now()))
-                            assert receiver.session._lock_expired
-                            assert isinstance(receiver.session.auto_renew_error, AutoLockRenewTimeout)
-                            try:
-                                await receiver.complete_message(message)
-                                raise AssertionError("Didn't raise SessionLockExpired")
-                            except SessionLockLostError as e:
-                                assert isinstance(e.inner_exception, AutoLockRenewTimeout)
-                            messages.append(message)
-
-            # While we're testing autolockrenew and sessions, let's make sure we don't call the lock-lost callback when a session exits.
-            renewer._renew_period = 1
-            session = None
-
-            async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=5, receive_mode=ServiceBusReceiveMode.PEEK_LOCK, prefetch_count=10) as receiver:
-                session = receiver.session
-                renewer.register(receiver, session, max_lock_renewal_duration=5, on_lock_renew_failure=lock_lost_callback)
-            await asyncio.sleep(max(0,(session.locked_until_utc - utc_now()).total_seconds()+1)) # If this pattern repeats make sleep_until_expired_async
-            assert not results
-
-            await renewer.close()
-            assert len(messages) == 2
+#             assert count == 10
+#             async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=5, receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE) as receiver:
+#                 deferred = await receiver.receive_deferred_messages(deferred_messages)
+#                 assert len(deferred) == 10
+#                 for message in deferred:
+#                     assert isinstance(message, ServiceBusReceivedMessage)
+#                     with pytest.raises(ValueError):
+#                         await receiver.complete_message(message)
+#                 with pytest.raises(ServiceBusError):
+#                     deferred = await receiver.receive_deferred_messages(deferred_messages)
 
     
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True, lock_duration='PT10S')
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_async_session_by_conn_str_receive_handler_with_auto_autolockrenew(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        if sys.platform.startswith('darwin'):
-            pytest.skip("Skipping for flakiness on OSX. Need to fix and unskip during MQ. Issue created: #32067.")
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_async_session_by_servicebus_client_iter_messages_with_retrieve_deferred_client(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         async with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-        async with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-            session_id = str(uuid.uuid4())
+#             deferred_messages = []
+#             session_id = str(uuid.uuid4())
+#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 for i in range(10):
+#                     message = ServiceBusMessage("Deferred message no. {}".format(i), session_id=session_id)
+#                     await sender.send_messages(message)
 
-            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                for i in range(10):
-                    message = ServiceBusMessage("{}".format(i), session_id=session_id)
-                    await sender.send_messages(message)
+#             receiver = sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=5)
+#             count = 0
+#             async for message in receiver:
+#                 deferred_messages.append(message.sequence_number)
+#                 print_message(_logger, message)
+#                 count += 1
+#                 await receiver.defer_message(message)
+#             await receiver.close()
 
-            results = []
-            async def lock_lost_callback(renewable, error):
-                results.append(renewable)
+#             assert count == 10
 
-            renewer = AutoLockRenewer(max_lock_renewal_duration=10)
-            messages = []
-            async with sb_client.get_queue_receiver(servicebus_queue.name,
-                                                    session_id=session_id,
-                                                    max_wait_time=10,
-                                                    receive_mode=ServiceBusReceiveMode.PEEK_LOCK,
-                                                    prefetch_count=20,
-                                                    auto_lock_renewer=renewer) as session:
-                print("Registered lock renew thread", session.session.locked_until_utc, utc_now())
-                with pytest.raises(SessionLockLostError):
-                    async for message in session:
-                        if not messages:
-                            await asyncio.sleep(10)
-                            print("First sleep {}".format(session.session.locked_until_utc - utc_now()))
-                            assert not session.session._lock_expired
-                            with pytest.raises(TypeError):
-                                message._lock_expired
-                            assert message.locked_until_utc is None
-                            with pytest.raises(TypeError):
-                                await session.renew_message_lock(message)
-                            assert message.lock_token is not None
-                            await session.complete_message(message)
-                            messages.append(message)
+#             with pytest.raises(ValueError):
+#                 await receiver.complete_message(message)
 
-                        elif len(messages) == 1:
-                            assert not results
-                            await asyncio.sleep(10)
-                            print("Second sleep {}".format(session.session.locked_until_utc - utc_now()))
-                            assert session.session._lock_expired
-                            assert isinstance(session.session.auto_renew_error, AutoLockRenewTimeout)
-                            try:
-                                await session.complete_message(message)
-                                raise AssertionError("Didn't raise SessionLockExpired")
-                            except SessionLockLostError as e:
-                                assert isinstance(e.inner_exception, AutoLockRenewTimeout)
-                            messages.append(message)
+    
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_async_session_by_servicebus_client_fetch_next_with_retrieve_deadletter(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         async with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-            # While we're testing autolockrenew and sessions, let's make sure we don't call the lock-lost callback when a session exits.
-            renewer._renew_period = 1
-            session = None
+#             session_id = str(uuid.uuid4())
+#             async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=5, prefetch_count=10) as receiver:
 
-            async with sb_client.get_queue_receiver(servicebus_queue.name,
-                                                    session_id=session_id,
-                                                    max_wait_time=10,
-                                                    receive_mode=ServiceBusReceiveMode.PEEK_LOCK,
-                                                    prefetch_count=10,
-                                                    auto_lock_renewer=renewer) as receiver:
-                session = receiver.session
-            await asyncio.sleep(max(0,(session.locked_until_utc - utc_now()).total_seconds()+1)) # If this pattern repeats make sleep_until_expired_async
-            assert not results
+#                 async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                     for i in range(10):
+#                         message = ServiceBusMessage("Dead lettered message no. {}".format(i), session_id=session_id)
+#                         await sender.send_messages(message)
 
-            await renewer.close()
-            assert len(messages) == 2
+#                 count = 0
+#                 messages = await receiver.receive_messages()
+#                 while messages:
+#                     for message in messages:
+#                         print_message(_logger, message)
+#                         await receiver.dead_letter_message(message, reason="Testing reason",
+#                                                            error_description="Testing description")
+#                         count += 1
+#                     messages = await receiver.receive_messages()
+#             assert count == 10
 
-        session_id = str(uuid.uuid4())
-        async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-            messages = [ServiceBusMessage("{}".format(i), session_id=session_id) for i in range(10)]
-            await sender.send_messages(messages)
+#             async with sb_client.get_queue_receiver(servicebus_queue.name, 
+#                                                     sub_queue = ServiceBusSubQueue.DEAD_LETTER,
+#                                                     max_wait_time=5) as receiver:
+#                 count = 0
+#                 async for message in receiver:
+#                     print_message(_logger, message)
+#                     assert message.dead_letter_reason == 'Testing reason'
+#                     assert message.dead_letter_error_description == 'Testing description'
+#                     assert message.application_properties[b'DeadLetterReason'] == b'Testing reason'
+#                     assert message.application_properties[b'DeadLetterErrorDescription'] == b'Testing description'
+#                     await receiver.complete_message(message)
+#                     count += 1
+#             assert count == 10
 
-        renewer = AutoLockRenewer(max_lock_renewal_duration=100)
-        receiver = sb_client.get_queue_receiver(servicebus_queue.name,
-                                            session_id=session_id,
-                                            max_wait_time=10,
-                                            prefetch_count=10,
-                                            auto_lock_renewer=renewer)
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_async_session_by_servicebus_client_browse_messages_client(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         async with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-        async with receiver:
-            received_msgs = await receiver.receive_messages(max_wait_time=10)
-            for msg in received_msgs:
-                await receiver.complete_message(msg)
+#             session_id = str(uuid.uuid4())
+#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 for i in range(5):
+#                     message = ServiceBusMessage("Test message no. {}".format(i), session_id=session_id)
+#                     await sender.send_messages(message)
+#             session_id_2 = str(uuid.uuid4())
+#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 for i in range(3):
+#                     message = ServiceBusMessage("Test message no. {}".format(i), session_id=session_id_2)
+#                     await sender.send_messages(message)
 
-        await receiver.close()
-        assert not renewer._renewable(receiver._session)
+#             async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id) as receiver:
+#                 messages = await receiver.peek_messages(5)
+#                 assert len(messages) == 5
+#                 assert all(isinstance(m, ServiceBusReceivedMessage) for m in messages)
+#                 for message in messages:
+#                     print_message(_logger, message)
+#                     with pytest.raises(ValueError):
+#                         await receiver.complete_message(message)
 
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_async_session_message_connection_closed(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        async with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#             async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id_2) as receiver:
+#                 messages = await receiver.peek_messages(5)
+#                 assert len(messages) == 3
 
-            session_id = str(uuid.uuid4())
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_async_session_by_servicebus_client_browse_messages_with_receiver(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         async with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                message = ServiceBusMessage("test")
-                message.session_id = session_id
-                await sender.send_messages(message)
+#             session_id = str(uuid.uuid4())
+#             async with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5, session_id=session_id) as receiver:
+#                 async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                     for i in range(5):
+#                         message = ServiceBusMessage("Test message no. {}".format(i), session_id=session_id)
+#                         await sender.send_messages(message)
 
-            async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id) as receiver:
-                messages = await receiver.receive_messages(max_wait_time=10)
-                assert len(messages) == 1
+#                 messages = await receiver.peek_messages(5)
+#                 assert len(messages) > 0
+#                 assert all(isinstance(m, ServiceBusReceivedMessage) for m in messages)
+#                 for message in messages:
+#                     print_message(_logger, message)
+#                     with pytest.raises(ValueError):
+#                         await receiver.complete_message(message)
 
-            with pytest.raises(ValueError):
-                await receiver.complete_message(messages[0])
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_async_session_by_servicebus_client_renew_client_locks(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         async with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_async_session_message_expiry(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        async with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#             session_id = str(uuid.uuid4())
+#             messages = []
+#             locks = 3
+#             async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, prefetch_count=10) as receiver:
+#                 async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                     for i in range(locks):
+#                         message = ServiceBusMessage("Test message no. {}".format(i), session_id=session_id)
+#                         await sender.send_messages(message)
 
-            session_id = str(uuid.uuid4())
+#                 messages.extend(await receiver.receive_messages())
+#                 recv = True
+#                 while recv:
+#                     recv = await receiver.receive_messages(max_wait_time=10)
+#                     messages.extend(recv)
 
-            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                message = ServiceBusMessage("Testing expired messages")
-                message.session_id = session_id
-                await sender.send_messages(message)
+#                 try:
+#                     for m in messages:
+#                         with pytest.raises(TypeError):
+#                             expired = m._lock_expired
+#                         assert m.locked_until_utc is None
+#                         assert m.lock_token is not None
+#                     time.sleep(5)
+#                     initial_expiry = receiver.session.locked_until_utc
+#                     await receiver.session.renew_lock(timeout=5)
+#                     assert (receiver.session.locked_until_utc - initial_expiry) >= timedelta(seconds=5)
+#                 finally:
+#                     await receiver.complete_message(messages[0])
+#                     await receiver.complete_message(messages[1])
+#                     time.sleep(40)
+#                     with pytest.raises(SessionLockLostError):
+#                         await receiver.complete_message(messages[2])
 
-            async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id) as receiver:
-                messages = await receiver.receive_messages(max_wait_time=10)
-                assert len(messages) == 1
-                print_message(_logger, messages[0])
-                await asyncio.sleep(60) #TODO: Was 30, but then lock isn't expired.
-                with pytest.raises(TypeError):
-                    messages[0]._lock_expired
-                with pytest.raises(TypeError):
-                    await receiver.renew_message_lock(messages[0])
-                assert receiver.session._lock_expired
-                with pytest.raises(SessionLockLostError):
-                    await receiver.complete_message(messages[0])
-                with pytest.raises(SessionLockLostError):
-                    await receiver.session.renew_lock()
+    
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True, lock_duration='PT5S')
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_async_session_by_conn_str_receive_handler_with_autolockrenew(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         async with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#             session_id = str(uuid.uuid4())
 
-            async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id) as receiver:
-                messages = await receiver.receive_messages(max_wait_time=30)
-                assert len(messages) == 1
-                print_message(_logger, messages[0])
-                assert messages[0].delivery_count
-                await receiver.complete_message(messages[0])
+#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 for i in range(10):
+#                     message = ServiceBusMessage("{}".format(i), session_id=session_id)
+#                     await sender.send_messages(message)
 
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_async_session_schedule_message(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        async with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-            import uuid
-            session_id = str(uuid.uuid4())
-            enqueue_time = (utc_now() + timedelta(minutes=2)).replace(microsecond=0)
-            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                content = str(uuid.uuid4())
-                message_id = uuid.uuid4()
-                message = ServiceBusMessage(content, session_id=session_id)
-                message.message_id = message_id
-                message.scheduled_enqueue_time_utc = enqueue_time
-                await sender.send_messages(message)
+#             results = []
+#             async def lock_lost_callback(renewable, error):
+#                 results.append(renewable)
 
-            messages = []
-            renewer = AutoLockRenewer()
-            async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id) as receiver:
-                renewer.register(receiver, receiver.session, max_lock_renewal_duration=140)
-                messages.extend(await receiver.receive_messages(max_wait_time=120))
-                messages.extend(await receiver.receive_messages(max_wait_time=5))
-                if messages:
-                    data = str(messages[0])
-                    assert data == content
-                    assert messages[0].message_id == message_id
-                    assert messages[0].scheduled_enqueue_time_utc == enqueue_time
-                    assert messages[0].scheduled_enqueue_time_utc == messages[0].enqueued_time_utc.replace(microsecond=0)
-                    assert len(messages) == 1
-                else:
-                    raise Exception("Failed to receive schdeduled message.")
-            await renewer.close()
+#             renewer = AutoLockRenewer()
+#             messages = []
+#             async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=5, receive_mode=ServiceBusReceiveMode.PEEK_LOCK, prefetch_count=20) as receiver:
+#                 renewer.register(receiver, receiver.session, max_lock_renewal_duration=10)
+#                 print("Registered lock renew thread", receiver.session.locked_until_utc, utc_now())
+#                 with pytest.raises(SessionLockLostError):
+#                     async for message in receiver:
+#                         if not messages:
+#                             await asyncio.sleep(10)
+#                             print("First sleep {}".format(receiver.session.locked_until_utc - utc_now()))
+#                             assert not receiver.session._lock_expired
+#                             with pytest.raises(TypeError):
+#                                 message._lock_expired
+#                             assert message.locked_until_utc is None
+#                             with pytest.raises(TypeError):
+#                                 await receiver.renew_message_lock(message)
+#                             assert message.lock_token is not None
+#                             await receiver.complete_message(message)
+#                             messages.append(message)
 
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_async_session_schedule_multiple_messages(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        async with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-            import uuid
-            session_id = str(uuid.uuid4())
-            enqueue_time = (utc_now() + timedelta(minutes=2)).replace(microsecond=0)
-            messages = []
-            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                content = str(uuid.uuid4())
-                message_id_a = uuid.uuid4()
-                message_a = ServiceBusMessage(content, session_id=session_id)
-                message_a.message_id = message_id_a
-                message_id_b = uuid.uuid4()
-                message_b = ServiceBusMessage(content, session_id=session_id)
-                message_b.message_id = message_id_b
-                tokens = await sender.schedule_messages([message_a, message_b], enqueue_time)
-                assert len(tokens) == 2
+#                         elif len(messages) == 1:
+#                             assert not results
+#                             await asyncio.sleep(10)
+#                             print("Second sleep {}".format(receiver.session.locked_until_utc - utc_now()))
+#                             assert receiver.session._lock_expired
+#                             assert isinstance(receiver.session.auto_renew_error, AutoLockRenewTimeout)
+#                             try:
+#                                 await receiver.complete_message(message)
+#                                 raise AssertionError("Didn't raise SessionLockExpired")
+#                             except SessionLockLostError as e:
+#                                 assert isinstance(e.inner_exception, AutoLockRenewTimeout)
+#                             messages.append(message)
 
-            renewer = AutoLockRenewer()
-            async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, prefetch_count=20) as receiver:
-                renewer.register(receiver, receiver.session, max_lock_renewal_duration=140)
-                messages.extend(await receiver.receive_messages(max_wait_time=120))
-                messages.extend(await receiver.receive_messages(max_wait_time=5))
-                if messages:
-                    data = str(messages[0])
-                    assert data == content
-                    assert messages[0].message_id in (message_id_a, message_id_b)
-                    assert messages[0].scheduled_enqueue_time_utc == enqueue_time
-                    assert messages[0].scheduled_enqueue_time_utc == messages[0].enqueued_time_utc.replace(microsecond=0)
-                    assert len(messages) == 2
-                else:
-                    raise Exception("Failed to receive schdeduled message.")
-            await renewer.close()
+#             # While we're testing autolockrenew and sessions, let's make sure we don't call the lock-lost callback when a session exits.
+#             renewer._renew_period = 1
+#             session = None
+
+#             async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=5, receive_mode=ServiceBusReceiveMode.PEEK_LOCK, prefetch_count=10) as receiver:
+#                 session = receiver.session
+#                 renewer.register(receiver, session, max_lock_renewal_duration=5, on_lock_renew_failure=lock_lost_callback)
+#             await asyncio.sleep(max(0,(session.locked_until_utc - utc_now()).total_seconds()+1)) # If this pattern repeats make sleep_until_expired_async
+#             assert not results
+
+#             await renewer.close()
+#             assert len(messages) == 2
+
+    
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True, lock_duration='PT10S')
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_async_session_by_conn_str_receive_handler_with_auto_autolockrenew(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         if sys.platform.startswith('darwin'):
+#             pytest.skip("Skipping for flakiness on OSX. Need to fix and unskip during MQ. Issue created: #32067.")
+
+#         async with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#             session_id = str(uuid.uuid4())
+
+#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 for i in range(10):
+#                     message = ServiceBusMessage("{}".format(i), session_id=session_id)
+#                     await sender.send_messages(message)
+
+#             results = []
+#             async def lock_lost_callback(renewable, error):
+#                 results.append(renewable)
+
+#             renewer = AutoLockRenewer(max_lock_renewal_duration=10)
+#             messages = []
+#             async with sb_client.get_queue_receiver(servicebus_queue.name,
+#                                                     session_id=session_id,
+#                                                     max_wait_time=10,
+#                                                     receive_mode=ServiceBusReceiveMode.PEEK_LOCK,
+#                                                     prefetch_count=20,
+#                                                     auto_lock_renewer=renewer) as session:
+#                 print("Registered lock renew thread", session.session.locked_until_utc, utc_now())
+#                 with pytest.raises(SessionLockLostError):
+#                     async for message in session:
+#                         if not messages:
+#                             await asyncio.sleep(10)
+#                             print("First sleep {}".format(session.session.locked_until_utc - utc_now()))
+#                             assert not session.session._lock_expired
+#                             with pytest.raises(TypeError):
+#                                 message._lock_expired
+#                             assert message.locked_until_utc is None
+#                             with pytest.raises(TypeError):
+#                                 await session.renew_message_lock(message)
+#                             assert message.lock_token is not None
+#                             await session.complete_message(message)
+#                             messages.append(message)
+
+#                         elif len(messages) == 1:
+#                             assert not results
+#                             await asyncio.sleep(10)
+#                             print("Second sleep {}".format(session.session.locked_until_utc - utc_now()))
+#                             assert session.session._lock_expired
+#                             assert isinstance(session.session.auto_renew_error, AutoLockRenewTimeout)
+#                             try:
+#                                 await session.complete_message(message)
+#                                 raise AssertionError("Didn't raise SessionLockExpired")
+#                             except SessionLockLostError as e:
+#                                 assert isinstance(e.inner_exception, AutoLockRenewTimeout)
+#                             messages.append(message)
+
+#             # While we're testing autolockrenew and sessions, let's make sure we don't call the lock-lost callback when a session exits.
+#             renewer._renew_period = 1
+#             session = None
+
+#             async with sb_client.get_queue_receiver(servicebus_queue.name,
+#                                                     session_id=session_id,
+#                                                     max_wait_time=10,
+#                                                     receive_mode=ServiceBusReceiveMode.PEEK_LOCK,
+#                                                     prefetch_count=10,
+#                                                     auto_lock_renewer=renewer) as receiver:
+#                 session = receiver.session
+#             await asyncio.sleep(max(0,(session.locked_until_utc - utc_now()).total_seconds()+1)) # If this pattern repeats make sleep_until_expired_async
+#             assert not results
+
+#             await renewer.close()
+#             assert len(messages) == 2
+
+#         session_id = str(uuid.uuid4())
+#         async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#             messages = [ServiceBusMessage("{}".format(i), session_id=session_id) for i in range(10)]
+#             await sender.send_messages(messages)
+
+#         renewer = AutoLockRenewer(max_lock_renewal_duration=100)
+#         receiver = sb_client.get_queue_receiver(servicebus_queue.name,
+#                                             session_id=session_id,
+#                                             max_wait_time=10,
+#                                             prefetch_count=10,
+#                                             auto_lock_renewer=renewer)
+
+#         async with receiver:
+#             received_msgs = await receiver.receive_messages(max_wait_time=10)
+#             for msg in received_msgs:
+#                 await receiver.complete_message(msg)
+
+#         await receiver.close()
+#         assert not renewer._renewable(receiver._session)
+
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_async_session_message_connection_closed(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         async with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+
+#             session_id = str(uuid.uuid4())
+
+#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 message = ServiceBusMessage("test")
+#                 message.session_id = session_id
+#                 await sender.send_messages(message)
+
+#             async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id) as receiver:
+#                 messages = await receiver.receive_messages(max_wait_time=10)
+#                 assert len(messages) == 1
+
+#             with pytest.raises(ValueError):
+#                 await receiver.complete_message(messages[0])
+
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_async_session_message_expiry(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         async with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+
+#             session_id = str(uuid.uuid4())
+
+#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 message = ServiceBusMessage("Testing expired messages")
+#                 message.session_id = session_id
+#                 await sender.send_messages(message)
+
+#             async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id) as receiver:
+#                 messages = await receiver.receive_messages(max_wait_time=10)
+#                 assert len(messages) == 1
+#                 print_message(_logger, messages[0])
+#                 await asyncio.sleep(60) #TODO: Was 30, but then lock isn't expired.
+#                 with pytest.raises(TypeError):
+#                     messages[0]._lock_expired
+#                 with pytest.raises(TypeError):
+#                     await receiver.renew_message_lock(messages[0])
+#                 assert receiver.session._lock_expired
+#                 with pytest.raises(SessionLockLostError):
+#                     await receiver.complete_message(messages[0])
+#                 with pytest.raises(SessionLockLostError):
+#                     await receiver.session.renew_lock()
+
+#             async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id) as receiver:
+#                 messages = await receiver.receive_messages(max_wait_time=30)
+#                 assert len(messages) == 1
+#                 print_message(_logger, messages[0])
+#                 assert messages[0].delivery_count
+#                 await receiver.complete_message(messages[0])
+
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_async_session_schedule_message(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         async with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#             import uuid
+#             session_id = str(uuid.uuid4())
+#             enqueue_time = (utc_now() + timedelta(minutes=2)).replace(microsecond=0)
+#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 content = str(uuid.uuid4())
+#                 message_id = uuid.uuid4()
+#                 message = ServiceBusMessage(content, session_id=session_id)
+#                 message.message_id = message_id
+#                 message.scheduled_enqueue_time_utc = enqueue_time
+#                 await sender.send_messages(message)
+
+#             messages = []
+#             renewer = AutoLockRenewer()
+#             async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id) as receiver:
+#                 renewer.register(receiver, receiver.session, max_lock_renewal_duration=140)
+#                 messages.extend(await receiver.receive_messages(max_wait_time=120))
+#                 messages.extend(await receiver.receive_messages(max_wait_time=5))
+#                 if messages:
+#                     data = str(messages[0])
+#                     assert data == content
+#                     assert messages[0].message_id == message_id
+#                     assert messages[0].scheduled_enqueue_time_utc == enqueue_time
+#                     assert messages[0].scheduled_enqueue_time_utc == messages[0].enqueued_time_utc.replace(microsecond=0)
+#                     assert len(messages) == 1
+#                 else:
+#                     raise Exception("Failed to receive schdeduled message.")
+#             await renewer.close()
+
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_async_session_schedule_multiple_messages(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         async with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#             import uuid
+#             session_id = str(uuid.uuid4())
+#             enqueue_time = (utc_now() + timedelta(minutes=2)).replace(microsecond=0)
+#             messages = []
+#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 content = str(uuid.uuid4())
+#                 message_id_a = uuid.uuid4()
+#                 message_a = ServiceBusMessage(content, session_id=session_id)
+#                 message_a.message_id = message_id_a
+#                 message_id_b = uuid.uuid4()
+#                 message_b = ServiceBusMessage(content, session_id=session_id)
+#                 message_b.message_id = message_id_b
+#                 tokens = await sender.schedule_messages([message_a, message_b], enqueue_time)
+#                 assert len(tokens) == 2
+
+#             renewer = AutoLockRenewer()
+#             async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, prefetch_count=20) as receiver:
+#                 renewer.register(receiver, receiver.session, max_lock_renewal_duration=140)
+#                 messages.extend(await receiver.receive_messages(max_wait_time=120))
+#                 messages.extend(await receiver.receive_messages(max_wait_time=5))
+#                 if messages:
+#                     data = str(messages[0])
+#                     assert data == content
+#                     assert messages[0].message_id in (message_id_a, message_id_b)
+#                     assert messages[0].scheduled_enqueue_time_utc == enqueue_time
+#                     assert messages[0].scheduled_enqueue_time_utc == messages[0].enqueued_time_utc.replace(microsecond=0)
+#                     assert len(messages) == 2
+#                 else:
+#                     raise Exception("Failed to receive schdeduled message.")
+#             await renewer.close()
    
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_async_session_cancel_scheduled_messages(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        async with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_async_session_cancel_scheduled_messages(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         async with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-            session_id = str(uuid.uuid4())
-            enqueue_time = (utc_now() + timedelta(minutes=2)).replace(microsecond=0)
-            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                message_a = ServiceBusMessage("Test scheduled message", session_id=session_id)
-                message_b = ServiceBusMessage("Test scheduled message", session_id=session_id)
-                tokens = await sender.schedule_messages([message_a, message_b], enqueue_time)
-                assert len(tokens) == 2
-                await sender.cancel_scheduled_messages(tokens)
+#             session_id = str(uuid.uuid4())
+#             enqueue_time = (utc_now() + timedelta(minutes=2)).replace(microsecond=0)
+#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 message_a = ServiceBusMessage("Test scheduled message", session_id=session_id)
+#                 message_b = ServiceBusMessage("Test scheduled message", session_id=session_id)
+#                 tokens = await sender.schedule_messages([message_a, message_b], enqueue_time)
+#                 assert len(tokens) == 2
+#                 await sender.cancel_scheduled_messages(tokens)
 
-            renewer = AutoLockRenewer()
-            messages = []
-            async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id) as receiver:
-                renewer.register(receiver, receiver.session, max_lock_renewal_duration=140)
-                messages.extend(await receiver.receive_messages(max_wait_time=115))
-                messages.extend(await receiver.receive_messages(max_wait_time=10))
-                try:
-                    assert len(messages) == 0
-                except AssertionError:
-                    for message in messages:
-                        print(str(message))
-                        await receiver.complete_message(message)
-                    raise
-            await renewer.close()
+#             renewer = AutoLockRenewer()
+#             messages = []
+#             async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id) as receiver:
+#                 renewer.register(receiver, receiver.session, max_lock_renewal_duration=140)
+#                 messages.extend(await receiver.receive_messages(max_wait_time=115))
+#                 messages.extend(await receiver.receive_messages(max_wait_time=10))
+#                 try:
+#                     assert len(messages) == 0
+#                 except AssertionError:
+#                     for message in messages:
+#                         print(str(message))
+#                         await receiver.complete_message(message)
+#                     raise
+#             await renewer.close()
 
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @CachedServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_session_receiver_partially_invalid_autolockrenew_mode(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        session_id = str(uuid.uuid4())
-        async with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                await sender.send_messages(ServiceBusMessage("test_message", session_id=session_id))
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @CachedServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_session_receiver_partially_invalid_autolockrenew_mode(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         session_id = str(uuid.uuid4())
+#         async with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 await sender.send_messages(ServiceBusMessage("test_message", session_id=session_id))
 
-            failures = 0
-            async def should_not_run(*args, **kwargs):
-                failures += 1
+#             failures = 0
+#             async def should_not_run(*args, **kwargs):
+#                 failures += 1
 
-            async with sb_client.get_queue_receiver(servicebus_queue.name,
-                                              session_id=session_id,
-                                              receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE,
-                                              auto_lock_renewer=AutoLockRenewer()) as receiver:
-                assert receiver.receive_messages()
-                assert not failures
+#             async with sb_client.get_queue_receiver(servicebus_queue.name,
+#                                               session_id=session_id,
+#                                               receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE,
+#                                               auto_lock_renewer=AutoLockRenewer()) as receiver:
+#                 assert receiver.receive_messages()
+#                 assert not failures
 
     
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_async_session_get_set_state_with_receiver(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        async with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_async_session_get_set_state_with_receiver(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         async with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-            session_id = str(uuid.uuid4())
-            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                for i in range(3):
-                    message = ServiceBusMessage("Handler message no. {}".format(i), session_id=session_id)
-                    await sender.send_messages(message)
+#             session_id = str(uuid.uuid4())
+#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 for i in range(3):
+#                     message = ServiceBusMessage("Handler message no. {}".format(i), session_id=session_id)
+#                     await sender.send_messages(message)
 
-            async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=10) as receiver:
-                assert await receiver.session.get_state(timeout=5) == None
-                await receiver.session.set_state("first_state", timeout=5)
-                count = 0
-                async for m in receiver:
-                    assert m.session_id == session_id
-                    count += 1
-                state = await receiver.session.get_state()
-                assert state == b'first_state'
-            assert count == 3
+#             async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=10) as receiver:
+#                 assert await receiver.session.get_state(timeout=5) == None
+#                 await receiver.session.set_state("first_state", timeout=5)
+#                 count = 0
+#                 async for m in receiver:
+#                     assert m.session_id == session_id
+#                     count += 1
+#                 state = await receiver.session.get_state()
+#                 assert state == b'first_state'
+#             assert count == 3
 
-            session_id = str(uuid.uuid4())
-            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                for i in range(1):
-                    message = ServiceBusMessage("Handler message no. {}".format(i), session_id=session_id)
-                    await sender.send_messages(message)
+#             session_id = str(uuid.uuid4())
+#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 for i in range(1):
+#                     message = ServiceBusMessage("Handler message no. {}".format(i), session_id=session_id)
+#                     await sender.send_messages(message)
 
-            async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=10) as receiver:
-                assert await receiver.session.get_state(timeout=5) == None
-                await receiver.session.set_state(None, timeout=5)
-                count = 0
-                async for m in receiver:
-                    assert m.session_id == session_id
-                    count += 1
-                state = await receiver.session.get_state()
-                assert state == None
-            assert count == 1
+#             async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=10) as receiver:
+#                 assert await receiver.session.get_state(timeout=5) == None
+#                 await receiver.session.set_state(None, timeout=5)
+#                 count = 0
+#                 async for m in receiver:
+#                     assert m.session_id == session_id
+#                     count += 1
+#                 state = await receiver.session.get_state()
+#                 assert state == None
+#             assert count == 1
 
-    @pytest.mark.skip(reason='Requires list sessions')
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_async_session_by_servicebus_client_list_sessions_with_receiver(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        async with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#     @pytest.mark.skip(reason='Requires list sessions')
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_async_session_by_servicebus_client_list_sessions_with_receiver(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         async with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-            sessions = []
-            start_time = utc_now()
-            for i in range(5):
-                sessions.append(str(uuid.uuid4()))
+#             sessions = []
+#             start_time = utc_now()
+#             for i in range(5):
+#                 sessions.append(str(uuid.uuid4()))
 
-            for session in sessions:
-                async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                    for i in range(5):
-                        message = ServiceBusMessage("Test message no. {}".format(i), session_id=session)
-                        await sender.send_messages(message)
-            for session in sessions:
-                async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session) as receiver:
-                    await receiver.session.set_state("SESSION {}".format(session))
+#             for session in sessions:
+#                 async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                     for i in range(5):
+#                         message = ServiceBusMessage("Test message no. {}".format(i), session_id=session)
+#                         await sender.send_messages(message)
+#             for session in sessions:
+#                 async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session) as receiver:
+#                     await receiver.session.set_state("SESSION {}".format(session))
 
-            async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=NEXT_AVAILABLE_SESSION, max_wait_time=5, receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
-                current_sessions = await receiver.list_sessions(updated_since=start_time)
-                assert len(current_sessions) == 5
-                assert current_sessions == sessions
+#             async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=NEXT_AVAILABLE_SESSION, max_wait_time=5, receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
+#                 current_sessions = await receiver.list_sessions(updated_since=start_time)
+#                 assert len(current_sessions) == 5
+#                 assert current_sessions == sessions
 
-    @pytest.mark.skip(reason="requires list_session")
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_async_session_by_servicebus_client_list_sessions_with_client(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        async with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#     @pytest.mark.skip(reason="requires list_session")
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_async_session_by_servicebus_client_list_sessions_with_client(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         async with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-            sessions = []
-            start_time = utc_now()
-            for i in range(5):
-                sessions.append(str(uuid.uuid4()))
+#             sessions = []
+#             start_time = utc_now()
+#             for i in range(5):
+#                 sessions.append(str(uuid.uuid4()))
 
-            for session in sessions:
-                async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                    for i in range(5):
-                        message = ServiceBusMessage("Test message no. {}".format(i), session_id=session)
-                        await sender.send_messages(message)
-            for session in sessions:
-                async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session) as receiver:
-                    await receiver.session.set_state("SESSION {}".format(session))
+#             for session in sessions:
+#                 async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                     for i in range(5):
+#                         message = ServiceBusMessage("Test message no. {}".format(i), session_id=session)
+#                         await sender.send_messages(message)
+#             for session in sessions:
+#                 async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session) as receiver:
+#                     await receiver.session.set_state("SESSION {}".format(session))
 
-            current_sessions = await sb_client.list_sessions(updated_since=start_time)
-            assert len(current_sessions) == 5
-            assert current_sessions == sessions
+#             current_sessions = await sb_client.list_sessions(updated_since=start_time)
+#             assert len(current_sessions) == 5
+#             assert current_sessions == sessions
 
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @pytest.mark.xfail(reason="'Cannot open log' error, potential service bug")
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_async_session_by_servicebus_client_session_pool(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @pytest.mark.xfail(reason="'Cannot open log' error, potential service bug")
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_async_session_by_servicebus_client_session_pool(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
         
-        messages = []
-        errors = []
-        async def message_processing(sb_client):
-            while True:
-                try:
-                    async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=NEXT_AVAILABLE_SESSION, max_wait_time=5) as receiver:
-                        async for message in receiver:
-                            print("ServiceBusMessage: {}".format(message))
-                            messages.append(message)
-                            await receiver.complete_message(message)
-                except OperationTimeoutError:
-                    return
-                except Exception as e:
-                    errors.append(e)
-                    raise
+#         messages = []
+#         errors = []
+#         async def message_processing(sb_client):
+#             while True:
+#                 try:
+#                     async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=NEXT_AVAILABLE_SESSION, max_wait_time=5) as receiver:
+#                         async for message in receiver:
+#                             print("ServiceBusMessage: {}".format(message))
+#                             messages.append(message)
+#                             await receiver.complete_message(message)
+#                 except OperationTimeoutError:
+#                     return
+#                 except Exception as e:
+#                     errors.append(e)
+#                     raise
 
-        concurrent_receivers = 5
-        sessions = [str(uuid.uuid4()) for i in range(concurrent_receivers)]
-        async with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, retry_total=1, uamqp_transport=uamqp_transport) as sb_client:
+#         concurrent_receivers = 5
+#         sessions = [str(uuid.uuid4()) for i in range(concurrent_receivers)]
+#         async with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, retry_total=1, uamqp_transport=uamqp_transport) as sb_client:
 
-            for session_id in sessions:
-                async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                    await asyncio.gather(*[sender.send_messages(ServiceBusMessage("Sample message no. {}".format(i), session_id=session_id)) for i in range(20)])
+#             for session_id in sessions:
+#                 async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                     await asyncio.gather(*[sender.send_messages(ServiceBusMessage("Sample message no. {}".format(i), session_id=session_id)) for i in range(20)])
 
-            receive_sessions = [message_processing(sb_client) for _ in range(concurrent_receivers)]
-            await asyncio.gather(*receive_sessions, return_exceptions=True)
+#             receive_sessions = [message_processing(sb_client) for _ in range(concurrent_receivers)]
+#             await asyncio.gather(*receive_sessions, return_exceptions=True)
 
-            assert not errors
-            assert len(messages) == 100
+#             assert not errors
+#             assert len(messages) == 100
 
     
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusTopicPreparer(name_prefix='servicebustest')
-    @ServiceBusSubscriptionPreparer(name_prefix='servicebustest', requires_session=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_async_session_basic_topic_subscription_send_and_receive(self, uamqp_transport, *, servicebus_namespace_connection_string, servicebus_topic, servicebus_subscription, **kwargs):
-        async with ServiceBusClient.from_connection_string(
-                servicebus_namespace_connection_string,
-                logging_enable=False,
-                uamqp_transport=uamqp_transport
-        ) as sb_client:
-            async with sb_client.get_topic_sender(topic_name=servicebus_topic.name) as sender:
-                message = ServiceBusMessage(b"Sample topic message", session_id='test_session')
-                await sender.send_messages(message)
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusTopicPreparer(name_prefix='servicebustest')
+#     @ServiceBusSubscriptionPreparer(name_prefix='servicebustest', requires_session=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_async_session_basic_topic_subscription_send_and_receive(self, uamqp_transport, *, servicebus_namespace_connection_string, servicebus_topic, servicebus_subscription, **kwargs):
+#         async with ServiceBusClient.from_connection_string(
+#                 servicebus_namespace_connection_string,
+#                 logging_enable=False,
+#                 uamqp_transport=uamqp_transport
+#         ) as sb_client:
+#             async with sb_client.get_topic_sender(topic_name=servicebus_topic.name) as sender:
+#                 message = ServiceBusMessage(b"Sample topic message", session_id='test_session')
+#                 await sender.send_messages(message)
 
-            async with sb_client.get_subscription_receiver(
-                topic_name=servicebus_topic.name,
-                subscription_name=servicebus_subscription.name,
-                session_id='test_session',
-                max_wait_time=5
-            ) as receiver:
-                count = 0
-                async for message in receiver:
-                    count += 1
-                    await receiver.complete_message(message)
-            assert count == 1
+#             async with sb_client.get_subscription_receiver(
+#                 topic_name=servicebus_topic.name,
+#                 subscription_name=servicebus_subscription.name,
+#                 session_id='test_session',
+#                 max_wait_time=5
+#             ) as receiver:
+#                 count = 0
+#                 async for message in receiver:
+#                     count += 1
+#                     await receiver.complete_message(message)
+#             assert count == 1
 
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @pytest.mark.xfail(reason="'Cannot open log' error, potential service bug", raises=ServiceBusError)
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_async_session_connection_failure_is_idempotent(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        #Technically this validates for all senders/receivers, not just session, but since it uses session to generate a recoverable failure, putting it in here.
-        async with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, retry_total=1, uamqp_transport=uamqp_transport) as sb_client:
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @pytest.mark.xfail(reason="'Cannot open log' error, potential service bug", raises=ServiceBusError)
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_async_session_connection_failure_is_idempotent(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         #Technically this validates for all senders/receivers, not just session, but since it uses session to generate a recoverable failure, putting it in here.
+#         async with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, retry_total=1, uamqp_transport=uamqp_transport) as sb_client:
     
-            # First let's just try the naive failure cases.
-            receiver = sb_client.get_queue_receiver("THIS_IS_WRONG_ON_PURPOSE")
-            with pytest.raises(ServiceBusAuthenticationError):
-                await receiver._open_with_retry()
-            assert not receiver._running
-            assert not receiver._handler
+#             # First let's just try the naive failure cases.
+#             receiver = sb_client.get_queue_receiver("THIS_IS_WRONG_ON_PURPOSE")
+#             with pytest.raises(ServiceBusAuthenticationError):
+#                 await receiver._open_with_retry()
+#             assert not receiver._running
+#             assert not receiver._handler
     
-            sender = sb_client.get_queue_sender("THIS_IS_WRONG_ON_PURPOSE")
-            with pytest.raises(ServiceBusAuthenticationError):
-                await sender._open_with_retry()
-            assert not receiver._running
-            assert not receiver._handler
+#             sender = sb_client.get_queue_sender("THIS_IS_WRONG_ON_PURPOSE")
+#             with pytest.raises(ServiceBusAuthenticationError):
+#                 await sender._open_with_retry()
+#             assert not receiver._running
+#             assert not receiver._handler
 
-            # Then let's try a case we can recover from to make sure everything works on reestablishment.
-            receiver = sb_client.get_queue_receiver(servicebus_queue.name, session_id=NEXT_AVAILABLE_SESSION)
-            with pytest.raises(OperationTimeoutError):
-                await receiver._open_with_retry()
+#             # Then let's try a case we can recover from to make sure everything works on reestablishment.
+#             receiver = sb_client.get_queue_receiver(servicebus_queue.name, session_id=NEXT_AVAILABLE_SESSION)
+#             with pytest.raises(OperationTimeoutError):
+#                 await receiver._open_with_retry()
 
-            session_id = str(uuid.uuid4())
-            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                await sender.send_messages(ServiceBusMessage("test session sender", session_id=session_id))
+#             session_id = str(uuid.uuid4())
+#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 await sender.send_messages(ServiceBusMessage("test session sender", session_id=session_id))
 
-            async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=NEXT_AVAILABLE_SESSION, max_wait_time=5) as receiver:
-                messages = []
-                async for message in receiver:
-                    messages.append(message)
-                assert len(messages) == 1
+#             async with sb_client.get_queue_receiver(servicebus_queue.name, session_id=NEXT_AVAILABLE_SESSION, max_wait_time=5) as receiver:
+#                 messages = []
+#                 async for message in receiver:
+#                     messages.append(message)
+#                 assert len(messages) == 1
 
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @CachedServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_async_session_non_session_send_to_session_queue_should_fail(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        async with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @CachedServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_async_session_non_session_send_to_session_queue_should_fail(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         async with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-            async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                with pytest.raises(ServiceBusError):
-                    message = ServiceBusMessage("Handler message")
-                    await sender.send_messages(message)
+#             async with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 with pytest.raises(ServiceBusError):
+#                     message = ServiceBusMessage("Handler message")
+#                     await sender.send_messages(message)
 
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_async_next_available_session_timeout_value(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        if uamqp_transport:
-            pytest.skip("This test is for pyamqp only")
-        async with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_async_next_available_session_timeout_value(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         if uamqp_transport:
+#             pytest.skip("This test is for pyamqp only")
+#         async with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
             
-            receiver = sb_client.get_queue_receiver(servicebus_queue.name, session_id=NEXT_AVAILABLE_SESSION, max_wait_time=10)
-            start_time = time.time()
-            with pytest.raises(OperationTimeoutError):
-                await receiver.receive_messages(max_wait_time=5)
-            assert time.time() - start_time < 65 # Default service timeout value is 65 seconds
-            start_time2 = time.time()
-            with pytest.raises(OperationTimeoutError):
-                async for msg in receiver:
-                    pass
-            assert time.time() - start_time2 < 65 # Default service timeout value is 65 seconds
+#             receiver = sb_client.get_queue_receiver(servicebus_queue.name, session_id=NEXT_AVAILABLE_SESSION, max_wait_time=10)
+#             start_time = time.time()
+#             with pytest.raises(OperationTimeoutError):
+#                 await receiver.receive_messages(max_wait_time=5)
+#             assert time.time() - start_time < 65 # Default service timeout value is 65 seconds
+#             start_time2 = time.time()
+#             with pytest.raises(OperationTimeoutError):
+#                 async for msg in receiver:
+#                     pass
+#             assert time.time() - start_time2 < 65 # Default service timeout value is 65 seconds
 
-            receiver = sb_client.get_queue_receiver(servicebus_queue.name, session_id=NEXT_AVAILABLE_SESSION, max_wait_time=70)
-            start_time = time.time()
-            with pytest.raises(OperationTimeoutError):
-                await receiver.receive_messages(max_wait_time=5)
-            assert time.time() - start_time > 65 # Default service timeout value is 65 seconds
-            start_time2 = time.time()
-            with pytest.raises(OperationTimeoutError):
-                async for msg in receiver:
-                    pass
-            assert time.time() - start_time2 > 65 # Default service timeout value is 65 seconds
+#             receiver = sb_client.get_queue_receiver(servicebus_queue.name, session_id=NEXT_AVAILABLE_SESSION, max_wait_time=70)
+#             start_time = time.time()
+#             with pytest.raises(OperationTimeoutError):
+#                 await receiver.receive_messages(max_wait_time=5)
+#             assert time.time() - start_time > 65 # Default service timeout value is 65 seconds
+#             start_time2 = time.time()
+#             with pytest.raises(OperationTimeoutError):
+#                 async for msg in receiver:
+#                     pass
+#             assert time.time() - start_time2 > 65 # Default service timeout value is 65 seconds

--- a/sdk/servicebus/azure-servicebus/tests/async_tests/test_subscriptions_async.py
+++ b/sdk/servicebus/azure-servicebus/tests/async_tests/test_subscriptions_async.py
@@ -1,275 +1,275 @@
-#-------------------------------------------------------------------------
-# Copyright (c) Microsoft Corporation. All rights reserved.
-# Licensed under the MIT License. See License.txt in the project root for
-# license information.
-#-------------------------------------------------------------------------
+# #-------------------------------------------------------------------------
+# # Copyright (c) Microsoft Corporation. All rights reserved.
+# # Licensed under the MIT License. See License.txt in the project root for
+# # license information.
+# #-------------------------------------------------------------------------
 
-import logging
-import sys
-import os
-import asyncio
-import pytest
-import time
-from datetime import datetime, timedelta
+# import logging
+# import sys
+# import os
+# import asyncio
+# import pytest
+# import time
+# from datetime import datetime, timedelta
 
-from azure.servicebus import ServiceBusMessage, ServiceBusReceiveMode
-from azure.servicebus.aio import ServiceBusClient
-from azure.servicebus.aio._base_handler_async import ServiceBusSharedKeyCredential
-from azure.servicebus.exceptions import ServiceBusError, MessageLockLostError
-from azure.servicebus._common.constants import ServiceBusSubQueue
+# from azure.servicebus import ServiceBusMessage, ServiceBusReceiveMode
+# from azure.servicebus.aio import ServiceBusClient
+# from azure.servicebus.aio._base_handler_async import ServiceBusSharedKeyCredential
+# from azure.servicebus.exceptions import ServiceBusError, MessageLockLostError
+# from azure.servicebus._common.constants import ServiceBusSubQueue
 
-from devtools_testutils import AzureMgmtRecordedTestCase, RandomNameResourceGroupPreparer
-from tests.servicebus_preparer import (
-    CachedServiceBusNamespacePreparer,
-    CachedServiceBusTopicPreparer,
-    CachedServiceBusSubscriptionPreparer,
-    ServiceBusTopicPreparer,
-    ServiceBusSubscriptionPreparer,
-    CachedServiceBusResourceGroupPreparer,
-    SERVICEBUS_ENDPOINT_SUFFIX
-)
-from tests.utilities import get_logger, print_message, uamqp_transport as get_uamqp_transport, ArgPasserAsync
+# from devtools_testutils import AzureMgmtRecordedTestCase, RandomNameResourceGroupPreparer
+# from tests.servicebus_preparer import (
+#     CachedServiceBusNamespacePreparer,
+#     CachedServiceBusTopicPreparer,
+#     CachedServiceBusSubscriptionPreparer,
+#     ServiceBusTopicPreparer,
+#     ServiceBusSubscriptionPreparer,
+#     CachedServiceBusResourceGroupPreparer,
+#     SERVICEBUS_ENDPOINT_SUFFIX
+# )
+# from tests.utilities import get_logger, print_message, uamqp_transport as get_uamqp_transport, ArgPasserAsync
 
-uamqp_transport_params, uamqp_transport_ids = get_uamqp_transport()
+# uamqp_transport_params, uamqp_transport_ids = get_uamqp_transport()
 
-_logger = get_logger(logging.DEBUG)
+# _logger = get_logger(logging.DEBUG)
 
 
-class TestServiceBusSubscriptionAsync(AzureMgmtRecordedTestCase):
+# class TestServiceBusSubscriptionAsync(AzureMgmtRecordedTestCase):
 
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusTopicPreparer(name_prefix='servicebustest')
-    @ServiceBusSubscriptionPreparer(name_prefix='servicebustest')
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_subscription_by_subscription_client_conn_str_receive_basic(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_topic=None, servicebus_subscription=None, **kwargs):
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusTopicPreparer(name_prefix='servicebustest')
+#     @ServiceBusSubscriptionPreparer(name_prefix='servicebustest')
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_subscription_by_subscription_client_conn_str_receive_basic(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_topic=None, servicebus_subscription=None, **kwargs):
 
-        async with ServiceBusClient.from_connection_string(
-                servicebus_namespace_connection_string,
-                logging_enable=False,
-                uamqp_transport=uamqp_transport
-        ) as sb_client:
-            async with sb_client.get_topic_sender(topic_name=servicebus_topic.name) as sender:
-                message = ServiceBusMessage(b"Sample topic message")
-                await sender.send_messages(message)
+#         async with ServiceBusClient.from_connection_string(
+#                 servicebus_namespace_connection_string,
+#                 logging_enable=False,
+#                 uamqp_transport=uamqp_transport
+#         ) as sb_client:
+#             async with sb_client.get_topic_sender(topic_name=servicebus_topic.name) as sender:
+#                 message = ServiceBusMessage(b"Sample topic message")
+#                 await sender.send_messages(message)
 
-            with pytest.raises(ValueError):
-                sb_client.get_subscription_receiver(
-                    topic_name=servicebus_topic.name,
-                    subscription_name=servicebus_subscription.name,
-                    max_wait_time=0
-                )
+#             with pytest.raises(ValueError):
+#                 sb_client.get_subscription_receiver(
+#                     topic_name=servicebus_topic.name,
+#                     subscription_name=servicebus_subscription.name,
+#                     max_wait_time=0
+#                 )
 
-            async with sb_client.get_subscription_receiver(
-                    topic_name=servicebus_topic.name,
-                    subscription_name=servicebus_subscription.name,
-                    max_wait_time=10
-            ) as receiver:
+#             async with sb_client.get_subscription_receiver(
+#                     topic_name=servicebus_topic.name,
+#                     subscription_name=servicebus_subscription.name,
+#                     max_wait_time=10
+#             ) as receiver:
 
-                with pytest.raises(ValueError):
-                    await receiver.receive_messages(max_wait_time=-1)
+#                 with pytest.raises(ValueError):
+#                     await receiver.receive_messages(max_wait_time=-1)
 
-                count = 0
-                async for message in receiver:
-                    count += 1
-                    await receiver.complete_message(message)
-            assert count == 1
-
-    
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusTopicPreparer(name_prefix='servicebustest')
-    @ServiceBusSubscriptionPreparer(name_prefix='servicebustest')
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_subscription_by_sas_token_credential_conn_str_send_basic(self, uamqp_transport, *, servicebus_namespace=None, servicebus_namespace_key_name=None, servicebus_namespace_primary_key=None, servicebus_topic=None, servicebus_subscription=None, **kwargs):
-        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
-        async with ServiceBusClient(
-            fully_qualified_namespace=fully_qualified_namespace,
-            credential=ServiceBusSharedKeyCredential(
-                policy=servicebus_namespace_key_name,
-                key=servicebus_namespace_primary_key
-            ),
-            logging_enable=False,
-            uamqp_transport=uamqp_transport
-        ) as sb_client:
-
-            async with sb_client.get_topic_sender(topic_name=servicebus_topic.name) as sender:
-                message = ServiceBusMessage(b"Sample topic message")
-                await sender.send_messages(message)
-
-            async with sb_client.get_subscription_receiver(
-                    topic_name=servicebus_topic.name,
-                    subscription_name=servicebus_subscription.name,
-                    max_wait_time=5
-            ) as receiver:
-                count = 0
-                async for message in receiver:
-                    count += 1
-                    await receiver.complete_message(message)
-            assert count == 1
+#                 count = 0
+#                 async for message in receiver:
+#                     count += 1
+#                     await receiver.complete_message(message)
+#             assert count == 1
 
     
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusTopicPreparer(name_prefix='servicebustest')
-    @ServiceBusSubscriptionPreparer(name_prefix='servicebustest')
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_topic_by_servicebus_client_receive_batch_with_deadletter(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_topic=None, servicebus_subscription=None, **kwargs):
-        async with ServiceBusClient.from_connection_string(
-                servicebus_namespace_connection_string,
-                logging_enable=False,
-                uamqp_transport=uamqp_transport
-        ) as sb_client:
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusTopicPreparer(name_prefix='servicebustest')
+#     @ServiceBusSubscriptionPreparer(name_prefix='servicebustest')
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_subscription_by_sas_token_credential_conn_str_send_basic(self, uamqp_transport, *, servicebus_namespace=None, servicebus_namespace_key_name=None, servicebus_namespace_primary_key=None, servicebus_topic=None, servicebus_subscription=None, **kwargs):
+#         fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+#         async with ServiceBusClient(
+#             fully_qualified_namespace=fully_qualified_namespace,
+#             credential=ServiceBusSharedKeyCredential(
+#                 policy=servicebus_namespace_key_name,
+#                 key=servicebus_namespace_primary_key
+#             ),
+#             logging_enable=False,
+#             uamqp_transport=uamqp_transport
+#         ) as sb_client:
 
-            async with sb_client.get_subscription_receiver(
-                topic_name=servicebus_topic.name,
-                subscription_name=servicebus_subscription.name,
-                max_wait_time=5,
-                receive_mode=ServiceBusReceiveMode.PEEK_LOCK,
-                prefetch_count=10
-            ) as receiver:
+#             async with sb_client.get_topic_sender(topic_name=servicebus_topic.name) as sender:
+#                 message = ServiceBusMessage(b"Sample topic message")
+#                 await sender.send_messages(message)
 
-                async with sb_client.get_topic_sender(servicebus_topic.name) as sender:
-                    for i in range(10):
-                        message = ServiceBusMessage("Dead lettered message no. {}".format(i))
-                        await sender.send_messages(message)
+#             async with sb_client.get_subscription_receiver(
+#                     topic_name=servicebus_topic.name,
+#                     subscription_name=servicebus_subscription.name,
+#                     max_wait_time=5
+#             ) as receiver:
+#                 count = 0
+#                 async for message in receiver:
+#                     count += 1
+#                     await receiver.complete_message(message)
+#             assert count == 1
 
-                count = 0
-                messages = await receiver.receive_messages()
-                while messages:
-                    for message in messages:
-                        print_message(_logger, message)
-                        count += 1
-                        await receiver.dead_letter_message(message, reason="Testing reason", error_description="Testing description")
-                    messages = await receiver.receive_messages()
-
-                assert count == 10
-
-            async with sb_client.get_subscription_receiver(
-                topic_name=servicebus_topic.name,
-                subscription_name=servicebus_subscription.name,
-                max_wait_time=5,
-                receive_mode=ServiceBusReceiveMode.PEEK_LOCK
-            ) as receiver:
-                count = 0
-                async for message in receiver:
-                    print_message(_logger, message)
-                    await receiver.complete_message(message)
-                    count += 1
-            assert count == 0
-
-            async with sb_client.get_subscription_receiver(
-                topic_name=servicebus_topic.name,
-                subscription_name=servicebus_subscription.name,
-                sub_queue = ServiceBusSubQueue.DEAD_LETTER,
-                max_wait_time=5,
-                receive_mode=ServiceBusReceiveMode.PEEK_LOCK
-            ) as dl_receiver:
-                count = 0
-                async for message in dl_receiver:
-                    await dl_receiver.complete_message(message)
-                    count += 1
-                    assert message.dead_letter_reason == 'Testing reason'
-                    assert message.dead_letter_error_description == 'Testing description'
-                    assert message.application_properties[b'DeadLetterReason'] == b'Testing reason'
-                    assert message.application_properties[b'DeadLetterErrorDescription'] == b'Testing description'
-                assert count == 10
-
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusTopicPreparer(name_prefix='servicebustest')
-    @ServiceBusSubscriptionPreparer(name_prefix='servicebustest', lock_duration='PT5S')
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_subscription_message_expiry(self, uamqp_transport, *, servicebus_namespace=None, servicebus_namespace_key_name=None, servicebus_namespace_primary_key=None, servicebus_topic=None, servicebus_subscription=None, **kwargs):
-        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
-        async with ServiceBusClient(
-            fully_qualified_namespace=fully_qualified_namespace,
-            credential=ServiceBusSharedKeyCredential(
-                policy=servicebus_namespace_key_name,
-                key=servicebus_namespace_primary_key
-            ),
-            logging_enable=False,
-            uamqp_transport=uamqp_transport
-        ) as sb_client:
-
-            async with sb_client.get_topic_sender(topic_name=servicebus_topic.name) as sender:
-                message = ServiceBusMessage(b"Testing topic message expiry")
-                await sender.send_messages(message)
-
-            async with sb_client.get_subscription_receiver(
-                    topic_name=servicebus_topic.name,
-                    subscription_name=servicebus_subscription.name
-            ) as receiver:
-                messages = await receiver.receive_messages(max_wait_time=10)
-                assert len(messages) == 1
-                time.sleep(10)
-                assert messages[0]._lock_expired
-                with pytest.raises(MessageLockLostError):
-                    await receiver.complete_message(messages[0])
-                with pytest.raises(MessageLockLostError):
-                    await receiver.renew_message_lock(messages[0])
-            async with sb_client.get_subscription_receiver(
-                    topic_name=servicebus_topic.name,
-                    subscription_name=servicebus_subscription.name
-            ) as receiver:
-                messages = await receiver.receive_messages(max_wait_time=10)
-                assert len(messages) == 1
-                assert messages[0].delivery_count > 0
-                await receiver.complete_message(messages[0])
     
-    @pytest.mark.asyncio
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusTopicPreparer(name_prefix='servicebustest')
-    @ServiceBusSubscriptionPreparer(name_prefix='servicebustest', lock_duration='PT5S')
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasserAsync()
-    async def test_subscription_receive_and_delete_with_send_and_wait(self, uamqp_transport, *, servicebus_namespace=None, servicebus_namespace_key_name=None, servicebus_namespace_primary_key=None, servicebus_topic=None, servicebus_subscription=None, **kwargs):
-        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
-        async with ServiceBusClient(
-            fully_qualified_namespace=fully_qualified_namespace,
-            credential=ServiceBusSharedKeyCredential(
-                policy=servicebus_namespace_key_name,
-                key=servicebus_namespace_primary_key
-            ),
-            logging_enable=False,
-            uamqp_transport=uamqp_transport
-        ) as sb_client:
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusTopicPreparer(name_prefix='servicebustest')
+#     @ServiceBusSubscriptionPreparer(name_prefix='servicebustest')
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_topic_by_servicebus_client_receive_batch_with_deadletter(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_topic=None, servicebus_subscription=None, **kwargs):
+#         async with ServiceBusClient.from_connection_string(
+#                 servicebus_namespace_connection_string,
+#                 logging_enable=False,
+#                 uamqp_transport=uamqp_transport
+#         ) as sb_client:
 
-            sender = sb_client.get_topic_sender(topic_name=servicebus_topic.name)
-            receiver = sb_client.get_subscription_receiver(
-                    topic_name=servicebus_topic.name,
-                    subscription_name=servicebus_subscription.name,
-                    receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE,
-            )
-            async with sender, receiver:
-                # queue should be empty
-                received_msgs = await receiver.receive_messages(max_message_count=10, max_wait_time=10)
-                assert len(received_msgs) == 0
+#             async with sb_client.get_subscription_receiver(
+#                 topic_name=servicebus_topic.name,
+#                 subscription_name=servicebus_subscription.name,
+#                 max_wait_time=5,
+#                 receive_mode=ServiceBusReceiveMode.PEEK_LOCK,
+#                 prefetch_count=10
+#             ) as receiver:
 
-                messages = [ServiceBusMessage("Message") for _ in range(10)]
-                await sender.send_messages(messages)
-                # wait for all messages to be sent to queue
-                await asyncio.sleep(10)
+#                 async with sb_client.get_topic_sender(servicebus_topic.name) as sender:
+#                     for i in range(10):
+#                         message = ServiceBusMessage("Dead lettered message no. {}".format(i))
+#                         await sender.send_messages(message)
 
-                # receive messages + add to internal buffer should have messages now
-                received_msgs = await receiver.receive_messages(max_message_count=10, max_wait_time=10)
-                assert len(received_msgs) == 10
+#                 count = 0
+#                 messages = await receiver.receive_messages()
+#                 while messages:
+#                     for message in messages:
+#                         print_message(_logger, message)
+#                         count += 1
+#                         await receiver.dead_letter_message(message, reason="Testing reason", error_description="Testing description")
+#                     messages = await receiver.receive_messages()
+
+#                 assert count == 10
+
+#             async with sb_client.get_subscription_receiver(
+#                 topic_name=servicebus_topic.name,
+#                 subscription_name=servicebus_subscription.name,
+#                 max_wait_time=5,
+#                 receive_mode=ServiceBusReceiveMode.PEEK_LOCK
+#             ) as receiver:
+#                 count = 0
+#                 async for message in receiver:
+#                     print_message(_logger, message)
+#                     await receiver.complete_message(message)
+#                     count += 1
+#             assert count == 0
+
+#             async with sb_client.get_subscription_receiver(
+#                 topic_name=servicebus_topic.name,
+#                 subscription_name=servicebus_subscription.name,
+#                 sub_queue = ServiceBusSubQueue.DEAD_LETTER,
+#                 max_wait_time=5,
+#                 receive_mode=ServiceBusReceiveMode.PEEK_LOCK
+#             ) as dl_receiver:
+#                 count = 0
+#                 async for message in dl_receiver:
+#                     await dl_receiver.complete_message(message)
+#                     count += 1
+#                     assert message.dead_letter_reason == 'Testing reason'
+#                     assert message.dead_letter_error_description == 'Testing description'
+#                     assert message.application_properties[b'DeadLetterReason'] == b'Testing reason'
+#                     assert message.application_properties[b'DeadLetterErrorDescription'] == b'Testing description'
+#                 assert count == 10
+
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusTopicPreparer(name_prefix='servicebustest')
+#     @ServiceBusSubscriptionPreparer(name_prefix='servicebustest', lock_duration='PT5S')
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_subscription_message_expiry(self, uamqp_transport, *, servicebus_namespace=None, servicebus_namespace_key_name=None, servicebus_namespace_primary_key=None, servicebus_topic=None, servicebus_subscription=None, **kwargs):
+#         fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+#         async with ServiceBusClient(
+#             fully_qualified_namespace=fully_qualified_namespace,
+#             credential=ServiceBusSharedKeyCredential(
+#                 policy=servicebus_namespace_key_name,
+#                 key=servicebus_namespace_primary_key
+#             ),
+#             logging_enable=False,
+#             uamqp_transport=uamqp_transport
+#         ) as sb_client:
+
+#             async with sb_client.get_topic_sender(topic_name=servicebus_topic.name) as sender:
+#                 message = ServiceBusMessage(b"Testing topic message expiry")
+#                 await sender.send_messages(message)
+
+#             async with sb_client.get_subscription_receiver(
+#                     topic_name=servicebus_topic.name,
+#                     subscription_name=servicebus_subscription.name
+#             ) as receiver:
+#                 messages = await receiver.receive_messages(max_wait_time=10)
+#                 assert len(messages) == 1
+#                 time.sleep(10)
+#                 assert messages[0]._lock_expired
+#                 with pytest.raises(MessageLockLostError):
+#                     await receiver.complete_message(messages[0])
+#                 with pytest.raises(MessageLockLostError):
+#                     await receiver.renew_message_lock(messages[0])
+#             async with sb_client.get_subscription_receiver(
+#                     topic_name=servicebus_topic.name,
+#                     subscription_name=servicebus_subscription.name
+#             ) as receiver:
+#                 messages = await receiver.receive_messages(max_wait_time=10)
+#                 assert len(messages) == 1
+#                 assert messages[0].delivery_count > 0
+#                 await receiver.complete_message(messages[0])
+    
+#     @pytest.mark.asyncio
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusTopicPreparer(name_prefix='servicebustest')
+#     @ServiceBusSubscriptionPreparer(name_prefix='servicebustest', lock_duration='PT5S')
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasserAsync()
+#     async def test_subscription_receive_and_delete_with_send_and_wait(self, uamqp_transport, *, servicebus_namespace=None, servicebus_namespace_key_name=None, servicebus_namespace_primary_key=None, servicebus_topic=None, servicebus_subscription=None, **kwargs):
+#         fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+#         async with ServiceBusClient(
+#             fully_qualified_namespace=fully_qualified_namespace,
+#             credential=ServiceBusSharedKeyCredential(
+#                 policy=servicebus_namespace_key_name,
+#                 key=servicebus_namespace_primary_key
+#             ),
+#             logging_enable=False,
+#             uamqp_transport=uamqp_transport
+#         ) as sb_client:
+
+#             sender = sb_client.get_topic_sender(topic_name=servicebus_topic.name)
+#             receiver = sb_client.get_subscription_receiver(
+#                     topic_name=servicebus_topic.name,
+#                     subscription_name=servicebus_subscription.name,
+#                     receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE,
+#             )
+#             async with sender, receiver:
+#                 # queue should be empty
+#                 received_msgs = await receiver.receive_messages(max_message_count=10, max_wait_time=10)
+#                 assert len(received_msgs) == 0
+
+#                 messages = [ServiceBusMessage("Message") for _ in range(10)]
+#                 await sender.send_messages(messages)
+#                 # wait for all messages to be sent to queue
+#                 await asyncio.sleep(10)
+
+#                 # receive messages + add to internal buffer should have messages now
+#                 received_msgs = await receiver.receive_messages(max_message_count=10, max_wait_time=10)
+#                 assert len(received_msgs) == 10

--- a/sdk/servicebus/azure-servicebus/tests/async_tests/test_subscriptions_async.py
+++ b/sdk/servicebus/azure-servicebus/tests/async_tests/test_subscriptions_async.py
@@ -1,275 +1,281 @@
-# #-------------------------------------------------------------------------
-# # Copyright (c) Microsoft Corporation. All rights reserved.
-# # Licensed under the MIT License. See License.txt in the project root for
-# # license information.
-# #-------------------------------------------------------------------------
+#-------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+#-------------------------------------------------------------------------
 
-# import logging
-# import sys
-# import os
-# import asyncio
-# import pytest
-# import time
-# from datetime import datetime, timedelta
+import logging
+import sys
+import os
+import asyncio
+import pytest
+import time
+from datetime import datetime, timedelta
 
-# from azure.servicebus import ServiceBusMessage, ServiceBusReceiveMode
-# from azure.servicebus.aio import ServiceBusClient
-# from azure.servicebus.aio._base_handler_async import ServiceBusSharedKeyCredential
-# from azure.servicebus.exceptions import ServiceBusError, MessageLockLostError
-# from azure.servicebus._common.constants import ServiceBusSubQueue
+from azure.servicebus import ServiceBusMessage, ServiceBusReceiveMode
+from azure.servicebus.aio import ServiceBusClient
+from azure.servicebus.aio._base_handler_async import ServiceBusSharedKeyCredential
+from azure.servicebus.exceptions import ServiceBusError, MessageLockLostError
+from azure.servicebus._common.constants import ServiceBusSubQueue
 
-# from devtools_testutils import AzureMgmtRecordedTestCase, RandomNameResourceGroupPreparer
-# from tests.servicebus_preparer import (
-#     CachedServiceBusNamespacePreparer,
-#     CachedServiceBusTopicPreparer,
-#     CachedServiceBusSubscriptionPreparer,
-#     ServiceBusTopicPreparer,
-#     ServiceBusSubscriptionPreparer,
-#     CachedServiceBusResourceGroupPreparer,
-#     SERVICEBUS_ENDPOINT_SUFFIX
-# )
-# from tests.utilities import get_logger, print_message, uamqp_transport as get_uamqp_transport, ArgPasserAsync
+from devtools_testutils import AzureMgmtRecordedTestCase, RandomNameResourceGroupPreparer, get_credential
+from tests.servicebus_preparer import (
+    CachedServiceBusNamespacePreparer,
+    CachedServiceBusTopicPreparer,
+    CachedServiceBusSubscriptionPreparer,
+    ServiceBusTopicPreparer,
+    ServiceBusSubscriptionPreparer,
+    CachedServiceBusResourceGroupPreparer,
+    SERVICEBUS_ENDPOINT_SUFFIX
+)
+from tests.utilities import get_logger, print_message, uamqp_transport as get_uamqp_transport, ArgPasserAsync
 
-# uamqp_transport_params, uamqp_transport_ids = get_uamqp_transport()
+uamqp_transport_params, uamqp_transport_ids = get_uamqp_transport()
 
-# _logger = get_logger(logging.DEBUG)
+_logger = get_logger(logging.DEBUG)
 
 
-# class TestServiceBusSubscriptionAsync(AzureMgmtRecordedTestCase):
+class TestServiceBusSubscriptionAsync(AzureMgmtRecordedTestCase):
 
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusTopicPreparer(name_prefix='servicebustest')
-#     @ServiceBusSubscriptionPreparer(name_prefix='servicebustest')
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_subscription_by_subscription_client_conn_str_receive_basic(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_topic=None, servicebus_subscription=None, **kwargs):
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusTopicPreparer(name_prefix='servicebustest')
+    @ServiceBusSubscriptionPreparer(name_prefix='servicebustest')
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_subscription_by_subscription_client_conn_str_receive_basic(self, uamqp_transport, *, servicebus_namespace=None, servicebus_topic=None, servicebus_subscription=None, **kwargs):
 
-#         async with ServiceBusClient.from_connection_string(
-#                 servicebus_namespace_connection_string,
-#                 logging_enable=False,
-#                 uamqp_transport=uamqp_transport
-#         ) as sb_client:
-#             async with sb_client.get_topic_sender(topic_name=servicebus_topic.name) as sender:
-#                 message = ServiceBusMessage(b"Sample topic message")
-#                 await sender.send_messages(message)
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential(is_async=True)
+        async with ServiceBusClient(
+                fully_qualified_namespace=fully_qualified_namespace,
+                credential=credential,
+                logging_enable=False,
+                uamqp_transport=uamqp_transport
+        ) as sb_client:
+            async with sb_client.get_topic_sender(topic_name=servicebus_topic.name) as sender:
+                message = ServiceBusMessage(b"Sample topic message")
+                await sender.send_messages(message)
 
-#             with pytest.raises(ValueError):
-#                 sb_client.get_subscription_receiver(
-#                     topic_name=servicebus_topic.name,
-#                     subscription_name=servicebus_subscription.name,
-#                     max_wait_time=0
-#                 )
+            with pytest.raises(ValueError):
+                sb_client.get_subscription_receiver(
+                    topic_name=servicebus_topic.name,
+                    subscription_name=servicebus_subscription.name,
+                    max_wait_time=0
+                )
 
-#             async with sb_client.get_subscription_receiver(
-#                     topic_name=servicebus_topic.name,
-#                     subscription_name=servicebus_subscription.name,
-#                     max_wait_time=10
-#             ) as receiver:
+            async with sb_client.get_subscription_receiver(
+                    topic_name=servicebus_topic.name,
+                    subscription_name=servicebus_subscription.name,
+                    max_wait_time=10
+            ) as receiver:
 
-#                 with pytest.raises(ValueError):
-#                     await receiver.receive_messages(max_wait_time=-1)
+                with pytest.raises(ValueError):
+                    await receiver.receive_messages(max_wait_time=-1)
 
-#                 count = 0
-#                 async for message in receiver:
-#                     count += 1
-#                     await receiver.complete_message(message)
-#             assert count == 1
-
-    
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusTopicPreparer(name_prefix='servicebustest')
-#     @ServiceBusSubscriptionPreparer(name_prefix='servicebustest')
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_subscription_by_sas_token_credential_conn_str_send_basic(self, uamqp_transport, *, servicebus_namespace=None, servicebus_namespace_key_name=None, servicebus_namespace_primary_key=None, servicebus_topic=None, servicebus_subscription=None, **kwargs):
-#         fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
-#         async with ServiceBusClient(
-#             fully_qualified_namespace=fully_qualified_namespace,
-#             credential=ServiceBusSharedKeyCredential(
-#                 policy=servicebus_namespace_key_name,
-#                 key=servicebus_namespace_primary_key
-#             ),
-#             logging_enable=False,
-#             uamqp_transport=uamqp_transport
-#         ) as sb_client:
-
-#             async with sb_client.get_topic_sender(topic_name=servicebus_topic.name) as sender:
-#                 message = ServiceBusMessage(b"Sample topic message")
-#                 await sender.send_messages(message)
-
-#             async with sb_client.get_subscription_receiver(
-#                     topic_name=servicebus_topic.name,
-#                     subscription_name=servicebus_subscription.name,
-#                     max_wait_time=5
-#             ) as receiver:
-#                 count = 0
-#                 async for message in receiver:
-#                     count += 1
-#                     await receiver.complete_message(message)
-#             assert count == 1
+                count = 0
+                async for message in receiver:
+                    count += 1
+                    await receiver.complete_message(message)
+            assert count == 1
 
     
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusTopicPreparer(name_prefix='servicebustest')
-#     @ServiceBusSubscriptionPreparer(name_prefix='servicebustest')
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_topic_by_servicebus_client_receive_batch_with_deadletter(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_topic=None, servicebus_subscription=None, **kwargs):
-#         async with ServiceBusClient.from_connection_string(
-#                 servicebus_namespace_connection_string,
-#                 logging_enable=False,
-#                 uamqp_transport=uamqp_transport
-#         ) as sb_client:
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusTopicPreparer(name_prefix='servicebustest')
+    @ServiceBusSubscriptionPreparer(name_prefix='servicebustest')
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_subscription_by_sas_token_credential_conn_str_send_basic(self, uamqp_transport, *, servicebus_namespace=None, servicebus_namespace_key_name=None, servicebus_namespace_primary_key=None, servicebus_topic=None, servicebus_subscription=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        async with ServiceBusClient(
+            fully_qualified_namespace=fully_qualified_namespace,
+            credential=ServiceBusSharedKeyCredential(
+                policy=servicebus_namespace_key_name,
+                key=servicebus_namespace_primary_key
+            ),
+            logging_enable=False,
+            uamqp_transport=uamqp_transport
+        ) as sb_client:
 
-#             async with sb_client.get_subscription_receiver(
-#                 topic_name=servicebus_topic.name,
-#                 subscription_name=servicebus_subscription.name,
-#                 max_wait_time=5,
-#                 receive_mode=ServiceBusReceiveMode.PEEK_LOCK,
-#                 prefetch_count=10
-#             ) as receiver:
+            async with sb_client.get_topic_sender(topic_name=servicebus_topic.name) as sender:
+                message = ServiceBusMessage(b"Sample topic message")
+                await sender.send_messages(message)
 
-#                 async with sb_client.get_topic_sender(servicebus_topic.name) as sender:
-#                     for i in range(10):
-#                         message = ServiceBusMessage("Dead lettered message no. {}".format(i))
-#                         await sender.send_messages(message)
+            async with sb_client.get_subscription_receiver(
+                    topic_name=servicebus_topic.name,
+                    subscription_name=servicebus_subscription.name,
+                    max_wait_time=5
+            ) as receiver:
+                count = 0
+                async for message in receiver:
+                    count += 1
+                    await receiver.complete_message(message)
+            assert count == 1
 
-#                 count = 0
-#                 messages = await receiver.receive_messages()
-#                 while messages:
-#                     for message in messages:
-#                         print_message(_logger, message)
-#                         count += 1
-#                         await receiver.dead_letter_message(message, reason="Testing reason", error_description="Testing description")
-#                     messages = await receiver.receive_messages()
-
-#                 assert count == 10
-
-#             async with sb_client.get_subscription_receiver(
-#                 topic_name=servicebus_topic.name,
-#                 subscription_name=servicebus_subscription.name,
-#                 max_wait_time=5,
-#                 receive_mode=ServiceBusReceiveMode.PEEK_LOCK
-#             ) as receiver:
-#                 count = 0
-#                 async for message in receiver:
-#                     print_message(_logger, message)
-#                     await receiver.complete_message(message)
-#                     count += 1
-#             assert count == 0
-
-#             async with sb_client.get_subscription_receiver(
-#                 topic_name=servicebus_topic.name,
-#                 subscription_name=servicebus_subscription.name,
-#                 sub_queue = ServiceBusSubQueue.DEAD_LETTER,
-#                 max_wait_time=5,
-#                 receive_mode=ServiceBusReceiveMode.PEEK_LOCK
-#             ) as dl_receiver:
-#                 count = 0
-#                 async for message in dl_receiver:
-#                     await dl_receiver.complete_message(message)
-#                     count += 1
-#                     assert message.dead_letter_reason == 'Testing reason'
-#                     assert message.dead_letter_error_description == 'Testing description'
-#                     assert message.application_properties[b'DeadLetterReason'] == b'Testing reason'
-#                     assert message.application_properties[b'DeadLetterErrorDescription'] == b'Testing description'
-#                 assert count == 10
-
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusTopicPreparer(name_prefix='servicebustest')
-#     @ServiceBusSubscriptionPreparer(name_prefix='servicebustest', lock_duration='PT5S')
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_subscription_message_expiry(self, uamqp_transport, *, servicebus_namespace=None, servicebus_namespace_key_name=None, servicebus_namespace_primary_key=None, servicebus_topic=None, servicebus_subscription=None, **kwargs):
-#         fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
-#         async with ServiceBusClient(
-#             fully_qualified_namespace=fully_qualified_namespace,
-#             credential=ServiceBusSharedKeyCredential(
-#                 policy=servicebus_namespace_key_name,
-#                 key=servicebus_namespace_primary_key
-#             ),
-#             logging_enable=False,
-#             uamqp_transport=uamqp_transport
-#         ) as sb_client:
-
-#             async with sb_client.get_topic_sender(topic_name=servicebus_topic.name) as sender:
-#                 message = ServiceBusMessage(b"Testing topic message expiry")
-#                 await sender.send_messages(message)
-
-#             async with sb_client.get_subscription_receiver(
-#                     topic_name=servicebus_topic.name,
-#                     subscription_name=servicebus_subscription.name
-#             ) as receiver:
-#                 messages = await receiver.receive_messages(max_wait_time=10)
-#                 assert len(messages) == 1
-#                 time.sleep(10)
-#                 assert messages[0]._lock_expired
-#                 with pytest.raises(MessageLockLostError):
-#                     await receiver.complete_message(messages[0])
-#                 with pytest.raises(MessageLockLostError):
-#                     await receiver.renew_message_lock(messages[0])
-#             async with sb_client.get_subscription_receiver(
-#                     topic_name=servicebus_topic.name,
-#                     subscription_name=servicebus_subscription.name
-#             ) as receiver:
-#                 messages = await receiver.receive_messages(max_wait_time=10)
-#                 assert len(messages) == 1
-#                 assert messages[0].delivery_count > 0
-#                 await receiver.complete_message(messages[0])
     
-#     @pytest.mark.asyncio
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusTopicPreparer(name_prefix='servicebustest')
-#     @ServiceBusSubscriptionPreparer(name_prefix='servicebustest', lock_duration='PT5S')
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasserAsync()
-#     async def test_subscription_receive_and_delete_with_send_and_wait(self, uamqp_transport, *, servicebus_namespace=None, servicebus_namespace_key_name=None, servicebus_namespace_primary_key=None, servicebus_topic=None, servicebus_subscription=None, **kwargs):
-#         fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
-#         async with ServiceBusClient(
-#             fully_qualified_namespace=fully_qualified_namespace,
-#             credential=ServiceBusSharedKeyCredential(
-#                 policy=servicebus_namespace_key_name,
-#                 key=servicebus_namespace_primary_key
-#             ),
-#             logging_enable=False,
-#             uamqp_transport=uamqp_transport
-#         ) as sb_client:
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusTopicPreparer(name_prefix='servicebustest')
+    @ServiceBusSubscriptionPreparer(name_prefix='servicebustest')
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_topic_by_servicebus_client_receive_batch_with_deadletter(self, uamqp_transport, *, servicebus_namespace=None, servicebus_topic=None, servicebus_subscription=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential(is_async=True)
+        async with ServiceBusClient(
+                fully_qualified_namespace=fully_qualified_namespace,
+                credential=credential,
+                logging_enable=False,
+                uamqp_transport=uamqp_transport
+        ) as sb_client:
 
-#             sender = sb_client.get_topic_sender(topic_name=servicebus_topic.name)
-#             receiver = sb_client.get_subscription_receiver(
-#                     topic_name=servicebus_topic.name,
-#                     subscription_name=servicebus_subscription.name,
-#                     receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE,
-#             )
-#             async with sender, receiver:
-#                 # queue should be empty
-#                 received_msgs = await receiver.receive_messages(max_message_count=10, max_wait_time=10)
-#                 assert len(received_msgs) == 0
+            async with sb_client.get_subscription_receiver(
+                topic_name=servicebus_topic.name,
+                subscription_name=servicebus_subscription.name,
+                max_wait_time=5,
+                receive_mode=ServiceBusReceiveMode.PEEK_LOCK,
+                prefetch_count=10
+            ) as receiver:
 
-#                 messages = [ServiceBusMessage("Message") for _ in range(10)]
-#                 await sender.send_messages(messages)
-#                 # wait for all messages to be sent to queue
-#                 await asyncio.sleep(10)
+                async with sb_client.get_topic_sender(servicebus_topic.name) as sender:
+                    for i in range(10):
+                        message = ServiceBusMessage("Dead lettered message no. {}".format(i))
+                        await sender.send_messages(message)
 
-#                 # receive messages + add to internal buffer should have messages now
-#                 received_msgs = await receiver.receive_messages(max_message_count=10, max_wait_time=10)
-#                 assert len(received_msgs) == 10
+                count = 0
+                messages = await receiver.receive_messages()
+                while messages:
+                    for message in messages:
+                        print_message(_logger, message)
+                        count += 1
+                        await receiver.dead_letter_message(message, reason="Testing reason", error_description="Testing description")
+                    messages = await receiver.receive_messages()
+
+                assert count == 10
+
+            async with sb_client.get_subscription_receiver(
+                topic_name=servicebus_topic.name,
+                subscription_name=servicebus_subscription.name,
+                max_wait_time=5,
+                receive_mode=ServiceBusReceiveMode.PEEK_LOCK
+            ) as receiver:
+                count = 0
+                async for message in receiver:
+                    print_message(_logger, message)
+                    await receiver.complete_message(message)
+                    count += 1
+            assert count == 0
+
+            async with sb_client.get_subscription_receiver(
+                topic_name=servicebus_topic.name,
+                subscription_name=servicebus_subscription.name,
+                sub_queue = ServiceBusSubQueue.DEAD_LETTER,
+                max_wait_time=5,
+                receive_mode=ServiceBusReceiveMode.PEEK_LOCK
+            ) as dl_receiver:
+                count = 0
+                async for message in dl_receiver:
+                    await dl_receiver.complete_message(message)
+                    count += 1
+                    assert message.dead_letter_reason == 'Testing reason'
+                    assert message.dead_letter_error_description == 'Testing description'
+                    assert message.application_properties[b'DeadLetterReason'] == b'Testing reason'
+                    assert message.application_properties[b'DeadLetterErrorDescription'] == b'Testing description'
+                assert count == 10
+
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusTopicPreparer(name_prefix='servicebustest')
+    @ServiceBusSubscriptionPreparer(name_prefix='servicebustest', lock_duration='PT5S')
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_subscription_message_expiry(self, uamqp_transport, *, servicebus_namespace=None, servicebus_namespace_key_name=None, servicebus_namespace_primary_key=None, servicebus_topic=None, servicebus_subscription=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        async with ServiceBusClient(
+            fully_qualified_namespace=fully_qualified_namespace,
+            credential=ServiceBusSharedKeyCredential(
+                policy=servicebus_namespace_key_name,
+                key=servicebus_namespace_primary_key
+            ),
+            logging_enable=False,
+            uamqp_transport=uamqp_transport
+        ) as sb_client:
+
+            async with sb_client.get_topic_sender(topic_name=servicebus_topic.name) as sender:
+                message = ServiceBusMessage(b"Testing topic message expiry")
+                await sender.send_messages(message)
+
+            async with sb_client.get_subscription_receiver(
+                    topic_name=servicebus_topic.name,
+                    subscription_name=servicebus_subscription.name
+            ) as receiver:
+                messages = await receiver.receive_messages(max_wait_time=10)
+                assert len(messages) == 1
+                time.sleep(10)
+                assert messages[0]._lock_expired
+                with pytest.raises(MessageLockLostError):
+                    await receiver.complete_message(messages[0])
+                with pytest.raises(MessageLockLostError):
+                    await receiver.renew_message_lock(messages[0])
+            async with sb_client.get_subscription_receiver(
+                    topic_name=servicebus_topic.name,
+                    subscription_name=servicebus_subscription.name
+            ) as receiver:
+                messages = await receiver.receive_messages(max_wait_time=10)
+                assert len(messages) == 1
+                assert messages[0].delivery_count > 0
+                await receiver.complete_message(messages[0])
+    
+    @pytest.mark.asyncio
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusTopicPreparer(name_prefix='servicebustest')
+    @ServiceBusSubscriptionPreparer(name_prefix='servicebustest', lock_duration='PT5S')
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasserAsync()
+    async def test_subscription_receive_and_delete_with_send_and_wait(self, uamqp_transport, *, servicebus_namespace=None, servicebus_namespace_key_name=None, servicebus_namespace_primary_key=None, servicebus_topic=None, servicebus_subscription=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        async with ServiceBusClient(
+            fully_qualified_namespace=fully_qualified_namespace,
+            credential=ServiceBusSharedKeyCredential(
+                policy=servicebus_namespace_key_name,
+                key=servicebus_namespace_primary_key
+            ),
+            logging_enable=False,
+            uamqp_transport=uamqp_transport
+        ) as sb_client:
+
+            sender = sb_client.get_topic_sender(topic_name=servicebus_topic.name)
+            receiver = sb_client.get_subscription_receiver(
+                    topic_name=servicebus_topic.name,
+                    subscription_name=servicebus_subscription.name,
+                    receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE,
+            )
+            async with sender, receiver:
+                # queue should be empty
+                received_msgs = await receiver.receive_messages(max_message_count=10, max_wait_time=10)
+                assert len(received_msgs) == 0
+
+                messages = [ServiceBusMessage("Message") for _ in range(10)]
+                await sender.send_messages(messages)
+                # wait for all messages to be sent to queue
+                await asyncio.sleep(10)
+
+                # receive messages + add to internal buffer should have messages now
+                received_msgs = await receiver.receive_messages(max_message_count=10, max_wait_time=10)
+                assert len(received_msgs) == 10

--- a/sdk/servicebus/azure-servicebus/tests/async_tests/test_topic_async.py
+++ b/sdk/servicebus/azure-servicebus/tests/async_tests/test_topic_async.py
@@ -44,7 +44,7 @@ class TestServiceBusTopicsAsync(AzureMgmtRecordedTestCase):
     async def test_topic_by_servicebus_client_conn_str_send_basic(self, uamqp_transport, *, servicebus_namespace=None, servicebus_topic=None, **kwargs):
         fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
         credential = self.get_credential(ServiceBusClient)
-        async with ServiceBusClient.from_connection_string(
+        async with ServiceBusClient(
             fully_qualified_namespace=fully_qualified_namespace,
             credential=credential,
             logging_enable=False,

--- a/sdk/servicebus/azure-servicebus/tests/async_tests/test_topic_async.py
+++ b/sdk/servicebus/azure-servicebus/tests/async_tests/test_topic_async.py
@@ -12,7 +12,7 @@ import pytest
 import time
 from datetime import datetime, timedelta
 
-from devtools_testutils import AzureMgmtRecordedTestCase, RandomNameResourceGroupPreparer
+from devtools_testutils import AzureMgmtRecordedTestCase, RandomNameResourceGroupPreparer, get_credential
 
 from azure.servicebus.aio import ServiceBusClient
 from azure.servicebus.aio._base_handler_async import ServiceBusSharedKeyCredential
@@ -43,7 +43,7 @@ class TestServiceBusTopicsAsync(AzureMgmtRecordedTestCase):
     @ArgPasserAsync()
     async def test_topic_by_servicebus_client_conn_str_send_basic(self, uamqp_transport, *, servicebus_namespace=None, servicebus_topic=None, **kwargs):
         fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
-        credential = self.get_credential(ServiceBusClient)
+        credential = get_credential(is_async=True)
         async with ServiceBusClient(
             fully_qualified_namespace=fully_qualified_namespace,
             credential=credential,

--- a/sdk/servicebus/azure-servicebus/tests/async_tests/test_topic_async.py
+++ b/sdk/servicebus/azure-servicebus/tests/async_tests/test_topic_async.py
@@ -41,10 +41,12 @@ class TestServiceBusTopicsAsync(AzureMgmtRecordedTestCase):
     @CachedServiceBusTopicPreparer(name_prefix='servicebustest')
     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
     @ArgPasserAsync()
-    async def test_topic_by_servicebus_client_conn_str_send_basic(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_topic=None, **kwargs):
-
+    async def test_topic_by_servicebus_client_conn_str_send_basic(self, uamqp_transport, *, servicebus_namespace=None, servicebus_topic=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = self.get_credential(ServiceBusClient)
         async with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string,
+            fully_qualified_namespace=fully_qualified_namespace,
+            credential=credential,
             logging_enable=False,
             uamqp_transport=uamqp_transport
         ) as sb_client:

--- a/sdk/servicebus/azure-servicebus/tests/mgmt_tests/async/test_mgmt_namespaces_async.py
+++ b/sdk/servicebus/azure-servicebus/tests/mgmt_tests/async/test_mgmt_namespaces_async.py
@@ -7,7 +7,7 @@ import pytest
 
 from azure.servicebus.aio.management import ServiceBusAdministrationClient
 
-from devtools_testutils import AzureMgmtRecordedTestCase
+from devtools_testutils import AzureMgmtRecordedTestCase, get_credential
 from devtools_testutils.aio import recorded_by_proxy_async
 from tests.sb_env_loader import ServiceBusPreparer
 
@@ -18,7 +18,11 @@ class TestServiceBusManagementClientNamespaceAsync(AzureMgmtRecordedTestCase):
     async def test_async_mgmt_namespace_get_properties(self, servicebus_connection_str,
                                            servicebus_fully_qualified_namespace, servicebus_sas_policy,
                                            servicebus_sas_key):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+        credential = get_credential(is_async=True)
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         properties = await mgmt_service.get_namespace_properties()
         assert properties
         assert properties.messaging_sku == 'Standard'

--- a/sdk/servicebus/azure-servicebus/tests/mgmt_tests/async/test_mgmt_queues_async.py
+++ b/sdk/servicebus/azure-servicebus/tests/mgmt_tests/async/test_mgmt_queues_async.py
@@ -13,7 +13,7 @@ from azure.servicebus.management import QueueProperties
 from azure.servicebus.aio._base_handler_async import ServiceBusSharedKeyCredential
 from azure.servicebus._common.utils import utc_now
 
-from devtools_testutils import AzureMgmtRecordedTestCase
+from devtools_testutils import AzureMgmtRecordedTestCase, get_credential
 from devtools_testutils.aio import recorded_by_proxy_async
 from tests.sb_env_loader import (
     ServiceBusPreparer
@@ -38,7 +38,11 @@ class TestServiceBusAdministrationClientQueueAsync(AzureMgmtRecordedTestCase):
     async def test_async_mgmt_queue_list_basic(self, servicebus_connection_str,
                                                         servicebus_fully_qualified_namespace, servicebus_sas_policy,
                                                         servicebus_sas_key):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+        credential = get_credential(is_async=True)
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         await clear_queues(mgmt_service)
         queues = await async_pageable_to_list(mgmt_service.list_queues())
         assert len(queues) == 0
@@ -65,10 +69,14 @@ class TestServiceBusAdministrationClientQueueAsync(AzureMgmtRecordedTestCase):
 
     @ServiceBusPreparer()
     @recorded_by_proxy_async
-    async def test_async_mgmt_queue_list_with_special_chars(self, servicebus_connection_str):
+    async def test_async_mgmt_queue_list_with_special_chars(self, servicebus_fully_qualified_namespace):
         # Queue names can contain letters, numbers, periods (.), hyphens (-), underscores (_), and slashes (/), up to 260 characters. Queue names are also case-insensitive.
         queue_name = 'txt/.-_123'
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+        credential = get_credential(is_async=True)
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         await clear_queues(mgmt_service)
         queues = await async_pageable_to_list(mgmt_service.list_queues())
         assert len(queues) == 0
@@ -81,9 +89,13 @@ class TestServiceBusAdministrationClientQueueAsync(AzureMgmtRecordedTestCase):
 
     @ServiceBusPreparer()
     @recorded_by_proxy_async
-    async def test_async_mgmt_queue_list_with_parameters(self, servicebus_connection_str):
+    async def test_async_mgmt_queue_list_with_parameters(self, servicebus_fully_qualified_namespace):
         pytest.skip("start_idx and max_count are currently removed, they might come back in the future.")
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+        credential = get_credential(is_async=True)
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         await run_test_async_mgmt_list_with_parameters(AsyncMgmtQueueListTestHelper(mgmt_service))
 
     @ServiceBusPreparer()
@@ -118,15 +130,23 @@ class TestServiceBusAdministrationClientQueueAsync(AzureMgmtRecordedTestCase):
 
     @ServiceBusPreparer()
     @recorded_by_proxy_async
-    async def test_async_mgmt_queue_list_with_negative_parameters(self, servicebus_connection_str):
+    async def test_async_mgmt_queue_list_with_negative_parameters(self, servicebus_fully_qualified_namespace):
         pytest.skip("start_idx and max_count are currently removed, they might come back in the future.")
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+        credential = get_credential(is_async=True)
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         await run_test_async_mgmt_list_with_negative_parameters(AsyncMgmtQueueListTestHelper(mgmt_service))
 
     @ServiceBusPreparer()
     @recorded_by_proxy_async
-    async def test_async_mgmt_queue_delete_basic(self, servicebus_connection_str):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+    async def test_async_mgmt_queue_delete_basic(self, servicebus_fully_qualified_namespace):
+        credential = get_credential(is_async=True)
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         await clear_queues(mgmt_service)
         await mgmt_service.create_queue("test_queue")
         queues = await async_pageable_to_list(mgmt_service.list_queues())
@@ -148,8 +168,12 @@ class TestServiceBusAdministrationClientQueueAsync(AzureMgmtRecordedTestCase):
 
     @ServiceBusPreparer()
     @recorded_by_proxy_async
-    async def test_async_mgmt_queue_delete_one_and_check_not_existing(self, servicebus_connection_str):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+    async def test_async_mgmt_queue_delete_one_and_check_not_existing(self, servicebus_fully_qualified_namespace):
+        credential = get_credential(is_async=True)
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         await clear_queues(mgmt_service)
         for i in range(10):
             await mgmt_service.create_queue("queue{}".format(i))
@@ -168,8 +192,12 @@ class TestServiceBusAdministrationClientQueueAsync(AzureMgmtRecordedTestCase):
 
     @ServiceBusPreparer()
     @recorded_by_proxy_async
-    async def test_async_mgmt_queue_delete_negtive(self, servicebus_connection_str):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+    async def test_async_mgmt_queue_delete_negtive(self, servicebus_fully_qualified_namespace):
+        credential = get_credential(is_async=True)
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         await clear_queues(mgmt_service)
         await mgmt_service.create_queue("test_queue")
         queues = await async_pageable_to_list(mgmt_service.list_queues())
@@ -193,8 +221,12 @@ class TestServiceBusAdministrationClientQueueAsync(AzureMgmtRecordedTestCase):
 
     @ServiceBusPreparer()
     @recorded_by_proxy_async
-    async def test_async_mgmt_queue_create_by_name(self, servicebus_connection_str, **kwargs):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+    async def test_async_mgmt_queue_create_by_name(self, servicebus_fully_qualified_namespace, **kwargs):
+        credential = get_credential(is_async=True)
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         await clear_queues(mgmt_service)
         queue_name = "eidk"
         created_at_utc = utc_now()
@@ -210,8 +242,12 @@ class TestServiceBusAdministrationClientQueueAsync(AzureMgmtRecordedTestCase):
 
     @ServiceBusPreparer()
     @recorded_by_proxy_async
-    async def test_async_mgmt_queue_create_with_invalid_name(self, servicebus_connection_str, **kwargs):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+    async def test_async_mgmt_queue_create_with_invalid_name(self, servicebus_fully_qualified_namespace, **kwargs):
+        credential = get_credential(is_async=True)
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
 
         with pytest.raises(HttpResponseError):
             await mgmt_service.create_queue(Exception())
@@ -221,8 +257,12 @@ class TestServiceBusAdministrationClientQueueAsync(AzureMgmtRecordedTestCase):
 
     @ServiceBusPreparer()
     @recorded_by_proxy_async
-    async def test_async_mgmt_queue_create_with_queue_description(self, servicebus_connection_str, **kwargs):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+    async def test_async_mgmt_queue_create_with_queue_description(self, servicebus_fully_qualified_namespace, **kwargs):
+        credential = get_credential(is_async=True)
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         await clear_queues(mgmt_service)
         queue_name = "dkldf"
         queue_name_2 = "vjiqjx"
@@ -312,9 +352,13 @@ class TestServiceBusAdministrationClientQueueAsync(AzureMgmtRecordedTestCase):
     @pytest.mark.skip("Unkip after creating premium account in arm template")
     @ServiceBusPreparer()
     @recorded_by_proxy_async
-    async def test_async_mgmt_queue_premium_create_with_queue_description(self, servicebus_connection_str,
+    async def test_async_mgmt_queue_premium_create_with_queue_description(self, servicebus_fully_qualified_namespace,
                                                                   **kwargs):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+        credential = get_credential(is_async=True)
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         await clear_queues(mgmt_service)
         queue_name = "dkldf"
         queue_name_2 = "vjiqjx"
@@ -405,8 +449,12 @@ class TestServiceBusAdministrationClientQueueAsync(AzureMgmtRecordedTestCase):
 
     @ServiceBusPreparer()
     @recorded_by_proxy_async
-    async def test_async_mgmt_queue_create_duplicate(self, servicebus_connection_str, **kwargs):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+    async def test_async_mgmt_queue_create_duplicate(self, servicebus_fully_qualified_namespace, **kwargs):
+        credential = get_credential(is_async=True)
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         await clear_queues(mgmt_service)
         queue_name = "eriodk"
         await mgmt_service.create_queue(queue_name)
@@ -420,7 +468,11 @@ class TestServiceBusAdministrationClientQueueAsync(AzureMgmtRecordedTestCase):
     @recorded_by_proxy_async
     async def test_async_mgmt_queue_update_success(self, **kwargs):
         servicebus_connection_str, servicebus_fully_qualified_namespace = kwargs.pop('servicebus_connection_str'), kwargs.pop('servicebus_fully_qualified_namespace')
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+        credential = get_credential(is_async=True)
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         await clear_queues(mgmt_service)
         queue_name = "ewuidfj"
         topic_name = "dkfjaks"
@@ -537,8 +589,12 @@ class TestServiceBusAdministrationClientQueueAsync(AzureMgmtRecordedTestCase):
 
     @ServiceBusPreparer()
     @recorded_by_proxy_async
-    async def test_async_mgmt_queue_update_invalid(self, servicebus_connection_str, **kwargs):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+    async def test_async_mgmt_queue_update_invalid(self, servicebus_fully_qualified_namespace, **kwargs):
+        credential = get_credential(is_async=True)
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         await clear_queues(mgmt_service)
         queue_name = "vbmfm"
         queue_description = await mgmt_service.create_queue(queue_name)
@@ -579,8 +635,12 @@ class TestServiceBusAdministrationClientQueueAsync(AzureMgmtRecordedTestCase):
 
     @ServiceBusPreparer()
     @recorded_by_proxy_async
-    async def test_async_mgmt_queue_list_runtime_properties_basic(self, servicebus_connection_str):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+    async def test_async_mgmt_queue_list_runtime_properties_basic(self, servicebus_fully_qualified_namespace):
+        credential = get_credential(is_async=True)
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         await clear_queues(mgmt_service)
         queues = await async_pageable_to_list(mgmt_service.list_queues())
         queues_infos = await async_pageable_to_list(mgmt_service.list_queues_runtime_properties())
@@ -615,22 +675,34 @@ class TestServiceBusAdministrationClientQueueAsync(AzureMgmtRecordedTestCase):
 
     @ServiceBusPreparer()
     @recorded_by_proxy_async
-    async def test_async_mgmt_queue_list_runtime_prop_w_neg_params(self, servicebus_connection_str):
+    async def test_async_mgmt_queue_list_runtime_prop_w_neg_params(self, servicebus_fully_qualified_namespace):
         pytest.skip("start_idx and max_count are currently removed, they might come back in the future.")
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+        credential = get_credential(is_async=True)
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         await run_test_async_mgmt_list_with_negative_parameters(AsyncMgmtQueueListRuntimeInfoTestHelper(mgmt_service))
 
     @ServiceBusPreparer()
     @recorded_by_proxy_async
-    async def test_async_mgmt_queue_list_runtime_prop_w_param(self, servicebus_connection_str):
+    async def test_async_mgmt_queue_list_runtime_prop_w_param(self, servicebus_fully_qualified_namespace):
         pytest.skip("start_idx and max_count are currently removed, they might come back in the future.")
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+        credential = get_credential(is_async=True)
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         await run_test_async_mgmt_list_with_parameters(AsyncMgmtQueueListRuntimeInfoTestHelper(mgmt_service))
 
     @ServiceBusPreparer()
     @recorded_by_proxy_async
-    async def test_async_mgmt_queue_get_runtime_properties_basic(self, servicebus_connection_str):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+    async def test_async_mgmt_queue_get_runtime_properties_basic(self, servicebus_fully_qualified_namespace):
+        credential = get_credential(is_async=True)
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         await clear_queues(mgmt_service)
         await mgmt_service.create_queue("test_queue")
         queue_runtime_properties = await mgmt_service.get_queue_runtime_properties("test_queue")
@@ -651,8 +723,12 @@ class TestServiceBusAdministrationClientQueueAsync(AzureMgmtRecordedTestCase):
 
     @ServiceBusPreparer()
     @recorded_by_proxy_async
-    async def test_async_mgmt_queue_get_runtime_properties_negative(self, servicebus_connection_str):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+    async def test_async_mgmt_queue_get_runtime_properties_negative(self, servicebus_fully_qualified_namespace):
+        credential = get_credential(is_async=True)
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         with pytest.raises(TypeError):
             await mgmt_service.get_queue_runtime_properties(None)
 
@@ -665,7 +741,11 @@ class TestServiceBusAdministrationClientQueueAsync(AzureMgmtRecordedTestCase):
     @ServiceBusPreparer()
     @recorded_by_proxy_async
     async def test_mgmt_queue_async_update_dict_success(self, servicebus_connection_str, servicebus_fully_qualified_namespace, **kwargs):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+        credential = get_credential(is_async=True)
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         await clear_queues(mgmt_service)
         queue_name = "fjruid"
         queue_description = await mgmt_service.create_queue(queue_name)
@@ -752,8 +832,12 @@ class TestServiceBusAdministrationClientQueueAsync(AzureMgmtRecordedTestCase):
     
     @ServiceBusPreparer()
     @recorded_by_proxy_async
-    async def test_mgmt_queue_async_update_dict_error(self, servicebus_connection_str, **kwargs):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+    async def test_mgmt_queue_async_update_dict_error(self, servicebus_fully_qualified_namespace, **kwargs):
+        credential = get_credential(is_async=True)
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         await clear_queues(mgmt_service)
         queue_name = "fjruid"
         queue_description = await mgmt_service.create_queue(queue_name)

--- a/sdk/servicebus/azure-servicebus/tests/mgmt_tests/async/test_mgmt_rules_async.py
+++ b/sdk/servicebus/azure-servicebus/tests/mgmt_tests/async/test_mgmt_rules_async.py
@@ -14,7 +14,7 @@ from azure.servicebus.management._constants import INT32_MAX_VALUE
 from tests.utilities import get_logger
 from azure.core.exceptions import HttpResponseError, ResourceExistsError
 
-from devtools_testutils import AzureMgmtRecordedTestCase, CachedResourceGroupPreparer, set_bodiless_matcher
+from devtools_testutils import AzureMgmtRecordedTestCase, CachedResourceGroupPreparer, set_bodiless_matcher, get_credential
 from devtools_testutils.aio import recorded_by_proxy_async
 from tests.sb_env_loader import (
     ServiceBusPreparer
@@ -27,9 +27,13 @@ _logger = get_logger(logging.DEBUG)
 class TestServiceBusAdministrationClientRuleAsync(AzureMgmtRecordedTestCase):
     @ServiceBusPreparer()
     @recorded_by_proxy_async
-    async def test_async_mgmt_rule_create(self, servicebus_connection_str, **kwargs):
+    async def test_async_mgmt_rule_create(self, servicebus_fully_qualified_namespace, **kwargs):
         set_bodiless_matcher()
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+        credential = get_credential(is_async=True)
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         await clear_topics(mgmt_service)
         topic_name = "topic_testaddf"
         subscription_name = "sub_testkkk"
@@ -100,8 +104,12 @@ class TestServiceBusAdministrationClientRuleAsync(AzureMgmtRecordedTestCase):
 
     @ServiceBusPreparer()
     @recorded_by_proxy_async
-    async def test_async_mgmt_rule_create_duplicate(self, servicebus_connection_str, **kwargs):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+    async def test_async_mgmt_rule_create_duplicate(self, servicebus_fully_qualified_namespace, **kwargs):
+        credential = get_credential(is_async=True)
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         await clear_topics(mgmt_service)
         topic_name = "dqkodq"
         subscription_name = 'kkaqo'
@@ -120,8 +128,12 @@ class TestServiceBusAdministrationClientRuleAsync(AzureMgmtRecordedTestCase):
 
     @ServiceBusPreparer()
     @recorded_by_proxy_async
-    async def test_async_mgmt_rule_update_success(self, servicebus_connection_str, **kwargs):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+    async def test_async_mgmt_rule_update_success(self, servicebus_fully_qualified_namespace, **kwargs):
+        credential = get_credential(is_async=True)
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         await clear_topics(mgmt_service)
         topic_name = "fjrui"
         subscription_name = "eqkovc"
@@ -171,8 +183,12 @@ class TestServiceBusAdministrationClientRuleAsync(AzureMgmtRecordedTestCase):
 
     @ServiceBusPreparer()
     @recorded_by_proxy_async
-    async def test_async_mgmt_rule_update_invalid(self, servicebus_connection_str, **kwargs):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+    async def test_async_mgmt_rule_update_invalid(self, servicebus_fully_qualified_namespace, **kwargs):
+        credential = get_credential(is_async=True)
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         await clear_topics(mgmt_service)
         topic_name = "fjrui"
         subscription_name = "eqkovc"
@@ -213,8 +229,12 @@ class TestServiceBusAdministrationClientRuleAsync(AzureMgmtRecordedTestCase):
 
     @ServiceBusPreparer()
     @recorded_by_proxy_async
-    async def test_async_mgmt_rule_list_and_delete(self, servicebus_connection_str):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+    async def test_async_mgmt_rule_list_and_delete(self, servicebus_fully_qualified_namespace):
+        credential = get_credential(is_async=True)
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         await clear_topics(mgmt_service)
         topic_name = "topic_testaddf"
         subscription_name = "sub_testkkk"
@@ -263,8 +283,12 @@ class TestServiceBusAdministrationClientRuleAsync(AzureMgmtRecordedTestCase):
 
     @ServiceBusPreparer()
     @recorded_by_proxy_async
-    async def test_mgmt_rule_async_update_dict_success(self, servicebus_connection_str, **kwargs):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+    async def test_mgmt_rule_async_update_dict_success(self, servicebus_fully_qualified_namespace, **kwargs):
+        credential = get_credential(is_async=True)
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         await clear_topics(mgmt_service)
         topic_name = "fjruid"
         subscription_name = "eqkovcd"
@@ -315,8 +339,12 @@ class TestServiceBusAdministrationClientRuleAsync(AzureMgmtRecordedTestCase):
 
     @ServiceBusPreparer()
     @recorded_by_proxy_async
-    async def test_mgmt_rule_async_update_dict_error(self, servicebus_connection_str, **kwargs):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+    async def test_mgmt_rule_async_update_dict_error(self, servicebus_fully_qualified_namespace, **kwargs):
+        credential = get_credential(is_async=True)
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         await clear_topics(mgmt_service)
         topic_name = "fjrui"
         subscription_name = "eqkovc"

--- a/sdk/servicebus/azure-servicebus/tests/mgmt_tests/async/test_mgmt_subscriptions_async.py
+++ b/sdk/servicebus/azure-servicebus/tests/mgmt_tests/async/test_mgmt_subscriptions_async.py
@@ -12,7 +12,7 @@ from azure.servicebus.management import SubscriptionProperties
 from tests.utilities import get_logger
 from azure.core.exceptions import HttpResponseError, ResourceExistsError
 
-from devtools_testutils import AzureMgmtRecordedTestCase, CachedResourceGroupPreparer
+from devtools_testutils import AzureMgmtRecordedTestCase, CachedResourceGroupPreparer, get_credential
 from devtools_testutils.aio import recorded_by_proxy_async
 from tests.sb_env_loader import (
     ServiceBusPreparer
@@ -29,8 +29,12 @@ _logger = get_logger(logging.DEBUG)
 class TestServiceBusAdministrationClientSubscriptionAsync(AzureMgmtRecordedTestCase):
     @ServiceBusPreparer()
     @recorded_by_proxy_async
-    async def test_async_mgmt_subscription_create_by_name(self, servicebus_connection_str, **kwargs):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+    async def test_async_mgmt_subscription_create_by_name(self, servicebus_fully_qualified_namespace, **kwargs):
+        credential = get_credential(is_async=True)
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         await clear_topics(mgmt_service)
         topic_name = "topic_testaddf"
         subscription_name = "sub_testkkk"
@@ -48,8 +52,12 @@ class TestServiceBusAdministrationClientSubscriptionAsync(AzureMgmtRecordedTestC
 
     @ServiceBusPreparer()
     @recorded_by_proxy_async
-    async def test_async_mgmt_sub_create_w_sub_desc(self, servicebus_connection_str, **kwargs):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+    async def test_async_mgmt_sub_create_w_sub_desc(self, servicebus_fully_qualified_namespace, **kwargs):
+        credential = get_credential(is_async=True)
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         await clear_topics(mgmt_service)
         topic_name = "iweidk"
         subscription_name = "kdosako"
@@ -104,8 +112,12 @@ class TestServiceBusAdministrationClientSubscriptionAsync(AzureMgmtRecordedTestC
 
     @ServiceBusPreparer()
     @recorded_by_proxy_async
-    async def test_async_mgmt_sub_create_w_fwd_to(self, servicebus_connection_str, **kwargs):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+    async def test_async_mgmt_sub_create_w_fwd_to(self, servicebus_fully_qualified_namespace, **kwargs):
+        credential = get_credential(is_async=True)
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         await clear_topics(mgmt_service)
         topic_name = "iweidkforward"
         subscription_name = "kdosakoforward"
@@ -133,8 +145,12 @@ class TestServiceBusAdministrationClientSubscriptionAsync(AzureMgmtRecordedTestC
 
     @ServiceBusPreparer()
     @recorded_by_proxy_async
-    async def test_async_mgmt_subscription_create_duplicate(self, servicebus_connection_str, **kwargs):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+    async def test_async_mgmt_subscription_create_duplicate(self, servicebus_fully_qualified_namespace, **kwargs):
+        credential = get_credential(is_async=True)
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         await clear_topics(mgmt_service)
         topic_name = "dqkodq"
         subscription_name = 'kkaqo'
@@ -150,7 +166,11 @@ class TestServiceBusAdministrationClientSubscriptionAsync(AzureMgmtRecordedTestC
     @ServiceBusPreparer()
     @recorded_by_proxy_async
     async def test_async_mgmt_subscription_update_success(self, servicebus_connection_str, servicebus_fully_qualified_namespace, **kwargs):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+        credential = get_credential(is_async=True)
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         await clear_topics(mgmt_service)
         topic_name = "fjrui"
         subscription_name = "eqkovc"
@@ -254,8 +274,12 @@ class TestServiceBusAdministrationClientSubscriptionAsync(AzureMgmtRecordedTestC
 
     @ServiceBusPreparer()
     @recorded_by_proxy_async
-    async def test_async_mgmt_subscription_update_invalid(self, servicebus_connection_str, **kwargs):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+    async def test_async_mgmt_subscription_update_invalid(self, servicebus_fully_qualified_namespace, **kwargs):
+        credential = get_credential(is_async=True)
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         await clear_topics(mgmt_service)
         topic_name = "dfjfj"
         subscription_name = "kwqxc"
@@ -294,8 +318,12 @@ class TestServiceBusAdministrationClientSubscriptionAsync(AzureMgmtRecordedTestC
 
     @ServiceBusPreparer()
     @recorded_by_proxy_async
-    async def test_async_mgmt_subscription_delete(self, servicebus_connection_str):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+    async def test_async_mgmt_subscription_delete(self, servicebus_fully_qualified_namespace):
+        credential = get_credential(is_async=True)
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         await clear_topics(mgmt_service)
         topic_name = 'test_topicgda'
         subscription_name_1 = 'test_sub1da'
@@ -324,8 +352,12 @@ class TestServiceBusAdministrationClientSubscriptionAsync(AzureMgmtRecordedTestC
 
     @ServiceBusPreparer()
     @recorded_by_proxy_async
-    async def test_async_mgmt_subscription_list(self, servicebus_connection_str, **kwargs):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+    async def test_async_mgmt_subscription_list(self, servicebus_fully_qualified_namespace, **kwargs):
+        credential = get_credential(is_async=True)
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         await clear_topics(mgmt_service)
         topic_name = 'lkoqxc'
         subscription_name_1 = 'testsub1'
@@ -348,8 +380,12 @@ class TestServiceBusAdministrationClientSubscriptionAsync(AzureMgmtRecordedTestC
 
     @ServiceBusPreparer()
     @recorded_by_proxy_async
-    async def test_async_mgmt_sub_list_runtime_props(self, servicebus_connection_str, **kwargs):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+    async def test_async_mgmt_sub_list_runtime_props(self, servicebus_fully_qualified_namespace, **kwargs):
+        credential = get_credential(is_async=True)
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         await clear_topics(mgmt_service)
         topic_name = 'dkoamv'
         subscription_name = 'cxqplc'
@@ -388,8 +424,12 @@ class TestServiceBusAdministrationClientSubscriptionAsync(AzureMgmtRecordedTestC
 
     @ServiceBusPreparer()
     @recorded_by_proxy_async
-    async def test_async_mgmt_sub_get_runtime_props_basic(self, servicebus_connection_str):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+    async def test_async_mgmt_sub_get_runtime_props_basic(self, servicebus_fully_qualified_namespace):
+        credential = get_credential(is_async=True)
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         await clear_topics(mgmt_service)
         topic_name = 'dcvxqa'
         subscription_name = 'xvazzag'
@@ -415,7 +455,11 @@ class TestServiceBusAdministrationClientSubscriptionAsync(AzureMgmtRecordedTestC
     @ServiceBusPreparer()
     @recorded_by_proxy_async
     async def test_mgmt_sub_async_update_dict_success(self, servicebus_connection_str, servicebus_fully_qualified_namespace, **kwargs):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+        credential = get_credential(is_async=True)
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         await clear_topics(mgmt_service)
         topic_name = "fjrui"
         subscription_name = "eqkovc"
@@ -492,7 +536,11 @@ class TestServiceBusAdministrationClientSubscriptionAsync(AzureMgmtRecordedTestC
     @ServiceBusPreparer()
     @recorded_by_proxy_async
     async def test_mgmt_subscription_async_update_dict_error(self, servicebus_connection_str, **kwargs):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+        credential = get_credential(is_async=True)
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         await clear_topics(mgmt_service)
         topic_name = "fjrui"
         subscription_name = "eqkovc"

--- a/sdk/servicebus/azure-servicebus/tests/mgmt_tests/async/test_mgmt_subscriptions_async.py
+++ b/sdk/servicebus/azure-servicebus/tests/mgmt_tests/async/test_mgmt_subscriptions_async.py
@@ -535,7 +535,7 @@ class TestServiceBusAdministrationClientSubscriptionAsync(AzureMgmtRecordedTestC
 
     @ServiceBusPreparer()
     @recorded_by_proxy_async
-    async def test_mgmt_subscription_async_update_dict_error(self, servicebus_connection_str, **kwargs):
+    async def test_mgmt_subscription_async_update_dict_error(self, servicebus_fully_qualified_namespace, **kwargs):
         credential = get_credential(is_async=True)
         mgmt_service = ServiceBusAdministrationClient(
             fully_qualified_namespace=servicebus_fully_qualified_namespace,

--- a/sdk/servicebus/azure-servicebus/tests/mgmt_tests/async/test_mgmt_topics_async.py
+++ b/sdk/servicebus/azure-servicebus/tests/mgmt_tests/async/test_mgmt_topics_async.py
@@ -14,7 +14,7 @@ from azure.servicebus.management import ApiVersion
 from tests.utilities import get_logger
 from azure.core.exceptions import HttpResponseError, ResourceExistsError
 
-from devtools_testutils import AzureMgmtRecordedTestCase, CachedResourceGroupPreparer
+from devtools_testutils import AzureMgmtRecordedTestCase, CachedResourceGroupPreparer, get_credential
 from devtools_testutils.aio import recorded_by_proxy_async
 from tests.sb_env_loader import (
     ServiceBusPreparer
@@ -28,8 +28,12 @@ _logger = get_logger(logging.DEBUG)
 class TestServiceBusAdministrationClientTopicAsync(AzureMgmtRecordedTestCase):
     @ServiceBusPreparer()
     @recorded_by_proxy_async
-    async def test_async_mgmt_topic_create_by_name(self, servicebus_connection_str, **kwargs):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+    async def test_async_mgmt_topic_create_by_name(self, servicebus_fully_qualified_namespace, **kwargs):
+        credential = get_credential(is_async=True)
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         await clear_topics(mgmt_service)
         topic_name = "topic_testaddf"
 
@@ -44,8 +48,12 @@ class TestServiceBusAdministrationClientTopicAsync(AzureMgmtRecordedTestCase):
 
     @ServiceBusPreparer()
     @recorded_by_proxy_async
-    async def test_async_mgmt_topic_create_with_topic_description(self, servicebus_connection_str, **kwargs):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+    async def test_async_mgmt_topic_create_with_topic_description(self, servicebus_fully_qualified_namespace, **kwargs):
+        credential = get_credential(is_async=True)
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         await clear_topics(mgmt_service)
         topic_name = "iweidk"
         topic_name_2 = "dkozq"
@@ -104,8 +112,12 @@ class TestServiceBusAdministrationClientTopicAsync(AzureMgmtRecordedTestCase):
     @pytest.mark.skip("unblock after resolving Cannot upgrade to premium namespace.")
     @ServiceBusPreparer()
     @recorded_by_proxy_async
-    async def test_async_mgmt_topic_premium_create_with_topic_description(self, servicebus_connection_str, **kwargs):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+    async def test_async_mgmt_topic_premium_create_with_topic_description(self, servicebus_fully_qualified_namespace, **kwargs):
+        credential = get_credential(is_async=True)
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         await clear_topics(mgmt_service)
         topic_name = "iweidk"
         topic_name_2 = "dkozq"
@@ -169,8 +181,12 @@ class TestServiceBusAdministrationClientTopicAsync(AzureMgmtRecordedTestCase):
 
     @ServiceBusPreparer()
     @recorded_by_proxy_async
-    async def test_async_mgmt_topic_create_duplicate(self, servicebus_connection_str, **kwargs):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+    async def test_async_mgmt_topic_create_duplicate(self, servicebus_fully_qualified_namespace, **kwargs):
+        credential = get_credential(is_async=True)
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         await clear_topics(mgmt_service)
         topic_name = "dqkodq"
         try:
@@ -182,8 +198,12 @@ class TestServiceBusAdministrationClientTopicAsync(AzureMgmtRecordedTestCase):
 
     @ServiceBusPreparer()
     @recorded_by_proxy_async
-    async def test_async_mgmt_topic_update_success(self, servicebus_connection_str, **kwargs):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+    async def test_async_mgmt_topic_update_success(self, servicebus_fully_qualified_namespace, **kwargs):
+        credential = get_credential(is_async=True)
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         await clear_topics(mgmt_service)
         topic_name = "fjrui"
         try:
@@ -261,8 +281,12 @@ class TestServiceBusAdministrationClientTopicAsync(AzureMgmtRecordedTestCase):
 
     @ServiceBusPreparer()
     @recorded_by_proxy_async
-    async def test_async_mgmt_topic_update_invalid(self, servicebus_connection_str, **kwargs):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+    async def test_async_mgmt_topic_update_invalid(self, servicebus_fully_qualified_namespace, **kwargs):
+        credential = get_credential(is_async=True)
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         await clear_topics(mgmt_service)
         topic_name = "dfjfj"
         try:
@@ -298,8 +322,12 @@ class TestServiceBusAdministrationClientTopicAsync(AzureMgmtRecordedTestCase):
 
     @ServiceBusPreparer()
     @recorded_by_proxy_async
-    async def test_async_mgmt_topic_delete(self, servicebus_connection_str):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+    async def test_async_mgmt_topic_delete(self, servicebus_fully_qualified_namespace):
+        credential = get_credential(is_async=True)
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         await clear_topics(mgmt_service)
         await mgmt_service.create_topic('test_topic')
         topics = await async_pageable_to_list(mgmt_service.list_topics())
@@ -323,8 +351,12 @@ class TestServiceBusAdministrationClientTopicAsync(AzureMgmtRecordedTestCase):
 
     @ServiceBusPreparer()
     @recorded_by_proxy_async
-    async def test_async_mgmt_topic_list(self, servicebus_connection_str, **kwargs):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+    async def test_async_mgmt_topic_list(self, servicebus_fully_qualified_namespace, **kwargs):
+        credential = get_credential(is_async=True)
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         await clear_topics(mgmt_service)
         topics = await async_pageable_to_list(mgmt_service.list_topics())
         assert len(topics) == 0
@@ -341,8 +373,12 @@ class TestServiceBusAdministrationClientTopicAsync(AzureMgmtRecordedTestCase):
 
     @ServiceBusPreparer()
     @recorded_by_proxy_async
-    async def test_async_mgmt_topic_list_runtime_properties(self, servicebus_connection_str, **kwargs):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+    async def test_async_mgmt_topic_list_runtime_properties(self, servicebus_fully_qualified_namespace, **kwargs):
+        credential = get_credential(is_async=True)
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         await clear_topics(mgmt_service)
         topics = await async_pageable_to_list(mgmt_service.list_topics())
         topics_infos = await async_pageable_to_list(mgmt_service.list_topics_runtime_properties())
@@ -372,8 +408,12 @@ class TestServiceBusAdministrationClientTopicAsync(AzureMgmtRecordedTestCase):
 
     @ServiceBusPreparer()
     @recorded_by_proxy_async
-    async def test_async_mgmt_topic_get_runtime_properties_basic(self, servicebus_connection_str):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+    async def test_async_mgmt_topic_get_runtime_properties_basic(self, servicebus_fully_qualified_namespace):
+        credential = get_credential(is_async=True)
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         await clear_topics(mgmt_service)
         await mgmt_service.create_topic("test_topic")
         try:
@@ -392,8 +432,12 @@ class TestServiceBusAdministrationClientTopicAsync(AzureMgmtRecordedTestCase):
 
     @ServiceBusPreparer()
     @recorded_by_proxy_async
-    async def test_mgmt_topic_async_update_dict_success(self, servicebus_connection_str, **kwargs):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+    async def test_mgmt_topic_async_update_dict_success(self, servicebus_fully_qualified_namespace, **kwargs):
+        credential = get_credential(is_async=True)
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         await clear_topics(mgmt_service)
         topic_name = "fjruid"
 
@@ -463,8 +507,12 @@ class TestServiceBusAdministrationClientTopicAsync(AzureMgmtRecordedTestCase):
 
     @ServiceBusPreparer()
     @recorded_by_proxy_async
-    async def test_mgmt_topic_async_update_dict_error(self, servicebus_connection_str, **kwargs):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+    async def test_mgmt_topic_async_update_dict_error(self, servicebus_fully_qualified_namespace, **kwargs):
+        credential = get_credential(is_async=True)
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         await clear_topics(mgmt_service)
         topic_name = "fjruid"
         try:
@@ -480,7 +528,7 @@ class TestServiceBusAdministrationClientTopicAsync(AzureMgmtRecordedTestCase):
     @recorded_by_proxy_async
     async def test_async_mgmt_topic_basic_v2017_04(self, servicebus_connection_str, servicebus_fully_qualified_namespace,
                                     servicebus_sas_key, servicebus_sas_policy):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str, api_version=ApiVersion.V2017_04)
+        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_fully_qualified_namespace, api_version=ApiVersion.V2017_04)
         await clear_topics(mgmt_service)
 
         await mgmt_service.create_topic("test_topic")

--- a/sdk/servicebus/azure-servicebus/tests/mgmt_tests/async/test_mgmt_topics_async.py
+++ b/sdk/servicebus/azure-servicebus/tests/mgmt_tests/async/test_mgmt_topics_async.py
@@ -528,7 +528,11 @@ class TestServiceBusAdministrationClientTopicAsync(AzureMgmtRecordedTestCase):
     @recorded_by_proxy_async
     async def test_async_mgmt_topic_basic_v2017_04(self, servicebus_connection_str, servicebus_fully_qualified_namespace,
                                     servicebus_sas_key, servicebus_sas_policy):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_fully_qualified_namespace, api_version=ApiVersion.V2017_04)
+        credential = get_credential(is_async=True)
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential = credential,
+            api_version=ApiVersion.V2017_04)
         await clear_topics(mgmt_service)
 
         await mgmt_service.create_topic("test_topic")

--- a/sdk/servicebus/azure-servicebus/tests/mgmt_tests/test_mgmt_namespaces.py
+++ b/sdk/servicebus/azure-servicebus/tests/mgmt_tests/test_mgmt_namespaces.py
@@ -7,7 +7,7 @@ import pytest
 
 from azure.servicebus.management import ServiceBusAdministrationClient
 
-from devtools_testutils import AzureMgmtRecordedTestCase, CachedResourceGroupPreparer, recorded_by_proxy
+from devtools_testutils import AzureMgmtRecordedTestCase, CachedResourceGroupPreparer, recorded_by_proxy, get_credential
 from tests.sb_env_loader import ServiceBusPreparer
 
 
@@ -17,7 +17,11 @@ class TestServiceBusManagementClientNamespace(AzureMgmtRecordedTestCase):
     def test_mgmt_namespace_get_properties(self, servicebus_connection_str,
                                            servicebus_fully_qualified_namespace, servicebus_sas_policy,
                                            servicebus_sas_key):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+        credential = get_credential()
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         properties = mgmt_service.get_namespace_properties()
         assert properties
         assert properties.messaging_sku == 'Standard'

--- a/sdk/servicebus/azure-servicebus/tests/mgmt_tests/test_mgmt_queues.py
+++ b/sdk/servicebus/azure-servicebus/tests/mgmt_tests/test_mgmt_queues.py
@@ -16,7 +16,7 @@ from tests.utilities import get_logger
 from azure.core.exceptions import HttpResponseError, ResourceNotFoundError, ResourceExistsError
 from azure.servicebus._base_handler import ServiceBusSharedKeyCredential
 
-from devtools_testutils import AzureMgmtRecordedTestCase, CachedResourceGroupPreparer, recorded_by_proxy
+from devtools_testutils import AzureMgmtRecordedTestCase, CachedResourceGroupPreparer, recorded_by_proxy, get_credential
 from tests.sb_env_loader import (
     ServiceBusPreparer,
 )
@@ -40,7 +40,11 @@ class TestServiceBusAdministrationClientQueue(AzureMgmtRecordedTestCase):
     @recorded_by_proxy
     def test_mgmt_queue_list_basic(self, servicebus_connection_str, servicebus_fully_qualified_namespace,
                                     servicebus_sas_policy, servicebus_sas_key, **kwargs):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+        credential = get_credential()
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
 
         clear_queues(mgmt_service)
 
@@ -68,10 +72,14 @@ class TestServiceBusAdministrationClientQueue(AzureMgmtRecordedTestCase):
 
     @ServiceBusPreparer()
     @recorded_by_proxy
-    def test_mgmt_queue_list_with_special_chars(self, servicebus_connection_str):
+    def test_mgmt_queue_list_with_special_chars(self, servicebus_fully_qualified_namespace):
         # Queue names can contain letters, numbers, periods (.), hyphens (-), underscores (_), and slashes (/), up to 260 characters. Queue names are also case-insensitive.
         queue_name = 'txt/.-_123'
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+        credential = get_credential()
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         clear_queues(mgmt_service)
         queues = list(mgmt_service.list_queues())
         assert len(queues) == 0
@@ -84,9 +92,14 @@ class TestServiceBusAdministrationClientQueue(AzureMgmtRecordedTestCase):
 
     @ServiceBusPreparer()
     @recorded_by_proxy
-    def test_mgmt_queue_list_with_parameters(self, servicebus_connection_str):
+    def test_mgmt_queue_list_with_parameters(self, servicebus_fully_qualified_namespace):
         pytest.skip("start_idx and max_count are currently removed, they might come back in the future.")
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+        credential = get_credential()
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
+
         run_test_mgmt_list_with_parameters(MgmtQueueListTestHelper(mgmt_service))
 
     @ServiceBusPreparer()
@@ -121,15 +134,23 @@ class TestServiceBusAdministrationClientQueue(AzureMgmtRecordedTestCase):
 
     @ServiceBusPreparer()
     @recorded_by_proxy
-    def test_mgmt_queue_list_with_negative_parameters(self, servicebus_connection_str):
+    def test_mgmt_queue_list_with_negative_parameters(self, servicebus_fully_qualified_namespace):
         pytest.skip("start_idx and max_count are currently removed, they might come back in the future.")
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+        credential = get_credential()
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         run_test_mgmt_list_with_negative_parameters(MgmtQueueListTestHelper(mgmt_service))
 
     @ServiceBusPreparer()
     @recorded_by_proxy
-    def test_mgmt_queue_delete_basic(self, servicebus_connection_str):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+    def test_mgmt_queue_delete_basic(self, servicebus_fully_qualified_namespace):
+        credential = get_credential()
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         clear_queues(mgmt_service)
         mgmt_service.create_queue("test_queue")
         queues = list(mgmt_service.list_queues())
@@ -151,8 +172,12 @@ class TestServiceBusAdministrationClientQueue(AzureMgmtRecordedTestCase):
 
     @ServiceBusPreparer()
     @recorded_by_proxy
-    def test_mgmt_queue_delete_one_and_check_not_existing(self, servicebus_connection_str):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+    def test_mgmt_queue_delete_one_and_check_not_existing(self, servicebus_fully_qualified_namespace):
+        credential = get_credential()
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         clear_queues(mgmt_service)
         for i in range(10):
             mgmt_service.create_queue("queue{}".format(i))
@@ -171,8 +196,12 @@ class TestServiceBusAdministrationClientQueue(AzureMgmtRecordedTestCase):
 
     @ServiceBusPreparer()
     @recorded_by_proxy
-    def test_mgmt_queue_delete_negtive(self, servicebus_connection_str):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+    def test_mgmt_queue_delete_negtive(self, servicebus_fully_qualified_namespace):
+        credential = get_credential()
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         clear_queues(mgmt_service)
         mgmt_service.create_queue("test_queue")
         queues = list(mgmt_service.list_queues())
@@ -196,8 +225,12 @@ class TestServiceBusAdministrationClientQueue(AzureMgmtRecordedTestCase):
 
     @ServiceBusPreparer()
     @recorded_by_proxy
-    def test_mgmt_queue_create_by_name(self, servicebus_connection_str, **kwargs):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+    def test_mgmt_queue_create_by_name(self, servicebus_fully_qualified_namespace, **kwargs):
+        credential = get_credential()
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         clear_queues(mgmt_service)
         queue_name = "queue_testaddf"
         mgmt_service.create_queue(queue_name)
@@ -213,8 +246,12 @@ class TestServiceBusAdministrationClientQueue(AzureMgmtRecordedTestCase):
 
     @ServiceBusPreparer()
     @recorded_by_proxy
-    def test_mgmt_queue_create_with_invalid_name(self, servicebus_connection_str, **kwargs):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+    def test_mgmt_queue_create_with_invalid_name(self, servicebus_fully_qualified_namespace, **kwargs):
+        credential = get_credential()
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
 
         with pytest.raises(HttpResponseError):
             mgmt_service.create_queue(Exception())
@@ -225,8 +262,12 @@ class TestServiceBusAdministrationClientQueue(AzureMgmtRecordedTestCase):
 
     @ServiceBusPreparer()
     @recorded_by_proxy
-    def test_mgmt_queue_create_with_queue_description(self, servicebus_connection_str, **kwargs):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+    def test_mgmt_queue_create_with_queue_description(self, servicebus_fully_qualified_namespace, **kwargs):
+        credential = get_credential()
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         clear_queues(mgmt_service)
         queue_name = "iweidk"
         queue_name_2 = "vladsk"
@@ -323,8 +364,12 @@ class TestServiceBusAdministrationClientQueue(AzureMgmtRecordedTestCase):
     @pytest.mark.skip("Unkip after creating premium account in arm template")
     @ServiceBusPreparer()
     @recorded_by_proxy
-    def test_mgmt_queue_premium_create_with_queue_description(self, servicebus_connection_str, **kwargs):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+    def test_mgmt_queue_premium_create_with_queue_description(self, servicebus_fully_qualified_namespace, **kwargs):
+        credential = get_credential()
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         clear_queues(mgmt_service)
         queue_name = "iweidk"
         queue_name_2 = "cpqmva"
@@ -421,8 +466,12 @@ class TestServiceBusAdministrationClientQueue(AzureMgmtRecordedTestCase):
 
     @ServiceBusPreparer()
     @recorded_by_proxy
-    def test_mgmt_queue_create_duplicate(self, servicebus_connection_str, **kwargs):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+    def test_mgmt_queue_create_duplicate(self, servicebus_fully_qualified_namespace, **kwargs):
+        credential = get_credential()
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         clear_queues(mgmt_service)
         queue_name = "rtofdk"
         mgmt_service.create_queue(queue_name)
@@ -435,7 +484,11 @@ class TestServiceBusAdministrationClientQueue(AzureMgmtRecordedTestCase):
     @ServiceBusPreparer()
     @recorded_by_proxy
     def test_mgmt_queue_update_success(self, servicebus_connection_str, servicebus_fully_qualified_namespace, **kwargs):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+        credential = get_credential()
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         clear_queues(mgmt_service)
         queue_name = "fjrui"
         topic_name = "sagho"
@@ -552,8 +605,12 @@ class TestServiceBusAdministrationClientQueue(AzureMgmtRecordedTestCase):
 
     @ServiceBusPreparer()
     @recorded_by_proxy
-    def test_mgmt_queue_update_invalid(self, servicebus_connection_str, **kwargs):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+    def test_mgmt_queue_update_invalid(self, servicebus_fully_qualified_namespace, **kwargs):
+        credential = get_credential()
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         clear_queues(mgmt_service)
         queue_name = "dfjfj"
         queue_description = mgmt_service.create_queue(queue_name)
@@ -594,8 +651,12 @@ class TestServiceBusAdministrationClientQueue(AzureMgmtRecordedTestCase):
 
     @ServiceBusPreparer()
     @recorded_by_proxy
-    def test_mgmt_queue_list_runtime_properties_basic(self, servicebus_connection_str):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+    def test_mgmt_queue_list_runtime_properties_basic(self, servicebus_fully_qualified_namespace):
+        credential = get_credential()
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         clear_queues(mgmt_service)
         queues = list(mgmt_service.list_queues())
         queues_infos = list(mgmt_service.list_queues_runtime_properties())
@@ -630,22 +691,34 @@ class TestServiceBusAdministrationClientQueue(AzureMgmtRecordedTestCase):
 
     @ServiceBusPreparer()
     @recorded_by_proxy
-    def test_mgmt_queue_list_runtime_prop_w_neg_params(self, servicebus_connection_str):
+    def test_mgmt_queue_list_runtime_prop_w_neg_params(self, servicebus_fully_qualified_namespace):
         pytest.skip("start_idx and max_count are currently removed, they might come back in the future.")
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+        credential = get_credential()
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         run_test_mgmt_list_with_negative_parameters(MgmtQueueListRuntimeInfoTestHelper(mgmt_service))
 
     @ServiceBusPreparer()
     @recorded_by_proxy
-    def test_mgmt_queue_list_runtime_prop_w_param(self, servicebus_connection_str):
+    def test_mgmt_queue_list_runtime_prop_w_param(self, servicebus_fully_qualified_namespace):
         pytest.skip("start_idx and max_count are currently removed, they might come back in the future.")
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+        credential = get_credential()
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         run_test_mgmt_list_with_parameters(MgmtQueueListRuntimeInfoTestHelper(mgmt_service))
 
     @ServiceBusPreparer()
     @recorded_by_proxy
-    def test_mgmt_queue_get_runtime_properties_basic(self, servicebus_connection_str):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+    def test_mgmt_queue_get_runtime_properties_basic(self, servicebus_fully_qualified_namespace):
+        credential = get_credential()
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         clear_queues(mgmt_service)
         mgmt_service.create_queue("test_queue")
         try:
@@ -669,8 +742,12 @@ class TestServiceBusAdministrationClientQueue(AzureMgmtRecordedTestCase):
 
     @ServiceBusPreparer()
     @recorded_by_proxy
-    def test_mgmt_queue_get_runtime_properties_negative(self, servicebus_connection_str):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+    def test_mgmt_queue_get_runtime_properties_negative(self, servicebus_fully_qualified_namespace):
+        credential = get_credential()
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         with pytest.raises(TypeError):
             mgmt_service.get_queue_runtime_properties(None)
 
@@ -687,7 +764,11 @@ class TestServiceBusAdministrationClientQueue(AzureMgmtRecordedTestCase):
     @ServiceBusPreparer()
     @recorded_by_proxy
     def test_mgmt_queue_update_dict_success(self, servicebus_connection_str, servicebus_fully_qualified_namespace, **kwargs):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+        credential = get_credential()
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         clear_queues(mgmt_service)
         queue_name = "fjruid"
         queue_description = mgmt_service.create_queue(queue_name)
@@ -774,8 +855,12 @@ class TestServiceBusAdministrationClientQueue(AzureMgmtRecordedTestCase):
 
     @ServiceBusPreparer()
     @recorded_by_proxy
-    def test_mgmt_queue_update_dict_error(self, servicebus_connection_str, **kwargs):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+    def test_mgmt_queue_update_dict_error(self, servicebus_fully_qualified_namespace, **kwargs):
+        credential = get_credential()
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         clear_queues(mgmt_service)
         queue_name = "dfjdfj"
         queue_description = mgmt_service.create_queue(queue_name)
@@ -791,7 +876,12 @@ class TestServiceBusAdministrationClientQueue(AzureMgmtRecordedTestCase):
     @recorded_by_proxy
     def test_mgmt_queue_basic_v2017_04(self, servicebus_connection_str, servicebus_fully_qualified_namespace,
                                     servicebus_sas_policy, servicebus_sas_key):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str, api_version=ApiVersion.V2017_04)
+        credential = get_credential()
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential,
+            api_version=ApiVersion.V2017_04
+        )
         clear_queues(mgmt_service)
 
         mgmt_service.create_queue("test_queue")

--- a/sdk/servicebus/azure-servicebus/tests/mgmt_tests/test_mgmt_rules.py
+++ b/sdk/servicebus/azure-servicebus/tests/mgmt_tests/test_mgmt_rules.py
@@ -12,7 +12,7 @@ from azure.servicebus.management._constants import INT32_MAX_VALUE
 from tests.utilities import get_logger
 from azure.core.exceptions import HttpResponseError, ResourceExistsError
 
-from devtools_testutils import AzureMgmtRecordedTestCase, CachedResourceGroupPreparer, recorded_by_proxy, set_bodiless_matcher
+from devtools_testutils import AzureMgmtRecordedTestCase, CachedResourceGroupPreparer, recorded_by_proxy, set_bodiless_matcher, get_credential
 from tests.sb_env_loader import (
     ServiceBusPreparer
 )
@@ -24,9 +24,13 @@ _logger = get_logger(logging.DEBUG)
 class TestServiceBusAdministrationClientRule(AzureMgmtRecordedTestCase):
     @ServiceBusPreparer()
     @recorded_by_proxy
-    def test_mgmt_rule_create(self, servicebus_connection_str, **kwargs):
+    def test_mgmt_rule_create(self, servicebus_fully_qualified_namespace, **kwargs):
         set_bodiless_matcher()
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+        credential = get_credential()
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         clear_topics(mgmt_service)
         topic_name = "topic_testaddf"
         subscription_name = "sub_testkkk"
@@ -116,8 +120,12 @@ class TestServiceBusAdministrationClientRule(AzureMgmtRecordedTestCase):
 
     @ServiceBusPreparer()
     @recorded_by_proxy
-    def test_mgmt_rule_create_duplicate(self, servicebus_connection_str, **kwargs):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+    def test_mgmt_rule_create_duplicate(self, servicebus_fully_qualified_namespace, **kwargs):
+        credential = get_credential()
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         clear_topics(mgmt_service)
         topic_name = "dqkodq"
         subscription_name = 'kkaqo'
@@ -136,8 +144,12 @@ class TestServiceBusAdministrationClientRule(AzureMgmtRecordedTestCase):
 
     @ServiceBusPreparer()
     @recorded_by_proxy
-    def test_mgmt_rule_update_success(self, servicebus_connection_str, **kwargs):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+    def test_mgmt_rule_update_success(self, servicebus_fully_qualified_namespace, **kwargs):
+        credential = get_credential()
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         clear_topics(mgmt_service)
         topic_name = "fjrui"
         subscription_name = "eqkovc"
@@ -187,8 +199,12 @@ class TestServiceBusAdministrationClientRule(AzureMgmtRecordedTestCase):
 
     @ServiceBusPreparer()
     @recorded_by_proxy
-    def test_mgmt_rule_update_invalid(self, servicebus_connection_str, **kwargs):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+    def test_mgmt_rule_update_invalid(self, servicebus_fully_qualified_namespace, **kwargs):
+        credential = get_credential()
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         clear_topics(mgmt_service)
         topic_name = "fjrui"
         subscription_name = "eqkovc"
@@ -229,8 +245,12 @@ class TestServiceBusAdministrationClientRule(AzureMgmtRecordedTestCase):
 
     @ServiceBusPreparer()
     @recorded_by_proxy
-    def test_mgmt_rule_list_and_delete(self, servicebus_connection_str):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+    def test_mgmt_rule_list_and_delete(self, servicebus_fully_qualified_namespace):
+        credential = get_credential()
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         clear_topics(mgmt_service)
         topic_name = "topic_testaddf"
         subscription_name = "sub_testkkk"
@@ -283,8 +303,12 @@ class TestServiceBusAdministrationClientRule(AzureMgmtRecordedTestCase):
 
     @ServiceBusPreparer()
     @recorded_by_proxy
-    def test_mgmt_rule_update_dict_success(self, servicebus_connection_str, **kwargs):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+    def test_mgmt_rule_update_dict_success(self, servicebus_fully_qualified_namespace, **kwargs):
+        credential = get_credential()
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         clear_topics(mgmt_service)
         topic_name = "fjruid"
         subscription_name = "eqkovcd"
@@ -335,8 +359,12 @@ class TestServiceBusAdministrationClientRule(AzureMgmtRecordedTestCase):
 
     @ServiceBusPreparer()
     @recorded_by_proxy
-    def test_mgmt_rule_update_dict_error(self, servicebus_connection_str, **kwargs):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+    def test_mgmt_rule_update_dict_error(self, servicebus_fully_qualified_namespace, **kwargs):
+        credential = get_credential()
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         clear_topics(mgmt_service)
         topic_name = "fjruid"
         subscription_name = "eqkovcd"

--- a/sdk/servicebus/azure-servicebus/tests/mgmt_tests/test_mgmt_subscriptions.py
+++ b/sdk/servicebus/azure-servicebus/tests/mgmt_tests/test_mgmt_subscriptions.py
@@ -11,7 +11,7 @@ from azure.servicebus.management import ServiceBusAdministrationClient, Subscrip
 from tests.utilities import get_logger
 from azure.core.exceptions import HttpResponseError, ResourceExistsError
 
-from devtools_testutils import AzureMgmtRecordedTestCase, CachedResourceGroupPreparer, recorded_by_proxy
+from devtools_testutils import AzureMgmtRecordedTestCase, CachedResourceGroupPreparer, recorded_by_proxy, get_credential
 from tests.sb_env_loader import (
     ServiceBusPreparer
 )
@@ -27,8 +27,12 @@ _logger = get_logger(logging.DEBUG)
 class TestServiceBusAdministrationClientSubscription(AzureMgmtRecordedTestCase):
     @ServiceBusPreparer()
     @recorded_by_proxy
-    def test_mgmt_subscription_create_by_name(self, servicebus_connection_str, **kwargs):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+    def test_mgmt_subscription_create_by_name(self, servicebus_fully_qualified_namespace, **kwargs):
+        credential = get_credential()
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         clear_topics(mgmt_service)
         topic_name = "topic_testaddf"
         subscription_name = "sub_testkkk"
@@ -46,8 +50,12 @@ class TestServiceBusAdministrationClientSubscription(AzureMgmtRecordedTestCase):
 
     @ServiceBusPreparer()
     @recorded_by_proxy
-    def test_mgmt_sub_create_w_sub_desc(self, servicebus_connection_str, **kwargs):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+    def test_mgmt_sub_create_w_sub_desc(self, servicebus_fully_qualified_namespace, **kwargs):
+        credential = get_credential()
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         clear_topics(mgmt_service)
         topic_name = "iweidk"
         subscription_name = "kdosako"
@@ -102,8 +110,12 @@ class TestServiceBusAdministrationClientSubscription(AzureMgmtRecordedTestCase):
 
     @ServiceBusPreparer()
     @recorded_by_proxy
-    def test_mgmt_sub_create_w_fwd_to(self, servicebus_connection_str, **kwargs):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+    def test_mgmt_sub_create_w_fwd_to(self, servicebus_fully_qualified_namespace, **kwargs):
+        credential = get_credential()
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         clear_topics(mgmt_service)
         topic_name = "iweidkforward"
         subscription_name = "kdosakoforward"
@@ -131,8 +143,12 @@ class TestServiceBusAdministrationClientSubscription(AzureMgmtRecordedTestCase):
 
     @ServiceBusPreparer()
     @recorded_by_proxy
-    def test_mgmt_subscription_create_duplicate(self, servicebus_connection_str, **kwargs):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+    def test_mgmt_subscription_create_duplicate(self, servicebus_fully_qualified_namespace, **kwargs):
+        credential = get_credential()
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         clear_topics(mgmt_service)
         topic_name = "dqkodq"
         subscription_name = 'kkaqo'
@@ -147,8 +163,12 @@ class TestServiceBusAdministrationClientSubscription(AzureMgmtRecordedTestCase):
 
     @ServiceBusPreparer()
     @recorded_by_proxy
-    def test_mgmt_subscription_update_success(self, servicebus_connection_str, servicebus_fully_qualified_namespace, **kwargs):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+    def test_mgmt_subscription_update_success(self, servicebus_fully_qualified_namespace, **kwargs):
+        credential = get_credential()
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         clear_topics(mgmt_service)
         topic_name = "fjrui"
         subscription_name = "eqkovc"
@@ -251,8 +271,12 @@ class TestServiceBusAdministrationClientSubscription(AzureMgmtRecordedTestCase):
 
     @ServiceBusPreparer()
     @recorded_by_proxy
-    def test_mgmt_subscription_update_invalid(self, servicebus_connection_str, **kwargs):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+    def test_mgmt_subscription_update_invalid(self, servicebus_fully_qualified_namespace, **kwargs):
+        credential = get_credential()
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         clear_topics(mgmt_service)
         topic_name = "dfjfj"
         subscription_name = "kwqxc"
@@ -291,8 +315,12 @@ class TestServiceBusAdministrationClientSubscription(AzureMgmtRecordedTestCase):
 
     @ServiceBusPreparer()
     @recorded_by_proxy
-    def test_mgmt_subscription_delete(self, servicebus_connection_str):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+    def test_mgmt_subscription_delete(self, servicebus_fully_qualified_namespace):
+        credential = get_credential()
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         clear_topics(mgmt_service)
         topic_name = 'test_topicgda'
         subscription_name_1 = 'test_sub1da'
@@ -321,8 +349,12 @@ class TestServiceBusAdministrationClientSubscription(AzureMgmtRecordedTestCase):
 
     @ServiceBusPreparer()
     @recorded_by_proxy
-    def test_mgmt_subscription_list(self, servicebus_connection_str, **kwargs):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+    def test_mgmt_subscription_list(self, servicebus_fully_qualified_namespace, **kwargs):
+        credential = get_credential()
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         clear_topics(mgmt_service)
         topic_name = 'lkoqxc'
         subscription_name_1 = 'testsub1'
@@ -345,8 +377,12 @@ class TestServiceBusAdministrationClientSubscription(AzureMgmtRecordedTestCase):
 
     @ServiceBusPreparer()
     @recorded_by_proxy
-    def test_mgmt_sub_list_runtime_props(self, servicebus_connection_str, **kwargs):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+    def test_mgmt_sub_list_runtime_props(self, servicebus_fully_qualified_namespace, **kwargs):
+        credential = get_credential()
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         clear_topics(mgmt_service)
         topic_name = 'dkoamv'
         subscription_name = 'cxqplc'
@@ -384,8 +420,12 @@ class TestServiceBusAdministrationClientSubscription(AzureMgmtRecordedTestCase):
 
     @ServiceBusPreparer()
     @recorded_by_proxy
-    def test_mgmt_sub_get_runtime_props_basic(self, servicebus_connection_str):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+    def test_mgmt_sub_get_runtime_props_basic(self, servicebus_fully_qualified_namespace):
+        credential = get_credential()
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         clear_topics(mgmt_service)
         topic_name = 'dcvxqa'
         subscription_name = 'xvazzag'
@@ -415,9 +455,12 @@ class TestServiceBusAdministrationClientSubscription(AzureMgmtRecordedTestCase):
     @ServiceBusPreparer()
     @recorded_by_proxy
     def test_mgmt_sub_update_dict_success(self, **kwargs):
-        servicebus_connection_str = kwargs.pop('servicebus_connection_str')
         servicebus_fully_qualified_namespace = kwargs.pop('servicebus_fully_qualified_namespace')
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+        credential = get_credential()
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         clear_topics(mgmt_service)
         topic_name = "fjruid"
         subscription_name = "eqkovcd"
@@ -494,8 +537,12 @@ class TestServiceBusAdministrationClientSubscription(AzureMgmtRecordedTestCase):
 
     @ServiceBusPreparer()
     @recorded_by_proxy
-    def test_mgmt_subscription_update_dict_error(self, servicebus_connection_str, **kwargs):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+    def test_mgmt_subscription_update_dict_error(self, servicebus_fully_qualified_namespace, **kwargs):
+        credential = get_credential()
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         clear_topics(mgmt_service)
         topic_name = "dfjdfj"
         subscription_name = "kwqxd"

--- a/sdk/servicebus/azure-servicebus/tests/mgmt_tests/test_mgmt_topics.py
+++ b/sdk/servicebus/azure-servicebus/tests/mgmt_tests/test_mgmt_topics.py
@@ -12,7 +12,7 @@ from azure.servicebus._base_handler import ServiceBusSharedKeyCredential
 from tests.utilities import get_logger
 from azure.core.exceptions import HttpResponseError, ResourceExistsError
 
-from devtools_testutils import AzureMgmtRecordedTestCase, CachedResourceGroupPreparer, recorded_by_proxy
+from devtools_testutils import AzureMgmtRecordedTestCase, CachedResourceGroupPreparer, recorded_by_proxy, get_credential
 from tests.sb_env_loader import (
     ServiceBusPreparer
 )
@@ -25,8 +25,12 @@ _logger = get_logger(logging.DEBUG)
 class TestServiceBusAdministrationClientTopicTests(AzureMgmtRecordedTestCase):
     @ServiceBusPreparer()
     @recorded_by_proxy
-    def test_mgmt_topic_create_by_name(self, servicebus_connection_str, **kwargs):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+    def test_mgmt_topic_create_by_name(self, servicebus_fully_qualified_namespace, **kwargs):
+        credential = get_credential()
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         clear_topics(mgmt_service)
         topic_name = "topic_testaddf"
 
@@ -41,8 +45,12 @@ class TestServiceBusAdministrationClientTopicTests(AzureMgmtRecordedTestCase):
 
     @ServiceBusPreparer()
     @recorded_by_proxy
-    def test_mgmt_topic_create_with_topic_description(self, servicebus_connection_str, **kwargs):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+    def test_mgmt_topic_create_with_topic_description(self, servicebus_fully_qualified_namespace, **kwargs):
+        credential = get_credential()
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         clear_topics(mgmt_service)
         topic_name = "iweidk"
         topic_name_2 = "djsadq"
@@ -102,8 +110,12 @@ class TestServiceBusAdministrationClientTopicTests(AzureMgmtRecordedTestCase):
     @pytest.mark.skip("unblock after resolving Cannot upgrade to premium namespace.")
     @ServiceBusPreparer()
     @recorded_by_proxy
-    def test_mgmt_topic_premium_create_with_topic_description(self, servicebus_connection_str, **kwargs):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+    def test_mgmt_topic_premium_create_with_topic_description(self, servicebus_fully_qualified_namespace, **kwargs):
+        credential = get_credential()
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         clear_topics(mgmt_service)
         topic_name = "iweidk"
         topic_name_2 = "cdasmc"
@@ -175,8 +187,12 @@ class TestServiceBusAdministrationClientTopicTests(AzureMgmtRecordedTestCase):
 
     @ServiceBusPreparer()
     @recorded_by_proxy
-    def test_mgmt_topic_create_duplicate(self, servicebus_connection_str, **kwargs):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+    def test_mgmt_topic_create_duplicate(self, servicebus_fully_qualified_namespace, **kwargs):
+        credential = get_credential()
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         clear_topics(mgmt_service)
         topic_name = "dqkodq"
         try:
@@ -188,8 +204,12 @@ class TestServiceBusAdministrationClientTopicTests(AzureMgmtRecordedTestCase):
 
     @ServiceBusPreparer()
     @recorded_by_proxy
-    def test_mgmt_topic_update_success(self, servicebus_connection_str, **kwargs):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+    def test_mgmt_topic_update_success(self, servicebus_fully_qualified_namespace, **kwargs):
+        credential = get_credential()
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         clear_topics(mgmt_service)
         topic_name = "fjrui"
 
@@ -267,8 +287,12 @@ class TestServiceBusAdministrationClientTopicTests(AzureMgmtRecordedTestCase):
 
     @ServiceBusPreparer()
     @recorded_by_proxy
-    def test_mgmt_topic_update_invalid(self, servicebus_connection_str, **kwargs):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+    def test_mgmt_topic_update_invalid(self, servicebus_fully_qualified_namespace, **kwargs):
+        credential = get_credential()
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         clear_topics(mgmt_service)
         topic_name = "dfjfj"
         try:
@@ -304,8 +328,12 @@ class TestServiceBusAdministrationClientTopicTests(AzureMgmtRecordedTestCase):
 
     @ServiceBusPreparer()
     @recorded_by_proxy
-    def test_mgmt_topic_delete(self, servicebus_connection_str):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+    def test_mgmt_topic_delete(self, servicebus_fully_qualified_namespace):
+        credential = get_credential()
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         clear_topics(mgmt_service)
         mgmt_service.create_topic('test_topic')
         topics = list(mgmt_service.list_topics())
@@ -329,8 +357,12 @@ class TestServiceBusAdministrationClientTopicTests(AzureMgmtRecordedTestCase):
 
     @ServiceBusPreparer()
     @recorded_by_proxy
-    def test_mgmt_topic_list(self, servicebus_connection_str, **kwargs):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+    def test_mgmt_topic_list(self, servicebus_fully_qualified_namespace, **kwargs):
+        credential = get_credential()
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         clear_topics(mgmt_service)
         topics = list(mgmt_service.list_topics())
         assert len(topics) == 0
@@ -347,8 +379,12 @@ class TestServiceBusAdministrationClientTopicTests(AzureMgmtRecordedTestCase):
 
     @ServiceBusPreparer()
     @recorded_by_proxy
-    def test_mgmt_topic_list_runtime_properties(self, servicebus_connection_str, **kwargs):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+    def test_mgmt_topic_list_runtime_properties(self, servicebus_fully_qualified_namespace, **kwargs):
+        credential = get_credential()
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         clear_topics(mgmt_service)
         topics = list(mgmt_service.list_topics())
         topics_infos = list(mgmt_service.list_topics_runtime_properties())
@@ -379,8 +415,12 @@ class TestServiceBusAdministrationClientTopicTests(AzureMgmtRecordedTestCase):
 
     @ServiceBusPreparer()
     @recorded_by_proxy
-    def test_mgmt_topic_get_runtime_properties_basic(self, servicebus_connection_str):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+    def test_mgmt_topic_get_runtime_properties_basic(self, servicebus_fully_qualified_namespace):
+        credential = get_credential()
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         clear_topics(mgmt_service)
         mgmt_service.create_topic("test_topic")
         topic_runtime_properties = mgmt_service.get_topic_runtime_properties("test_topic")
@@ -401,8 +441,12 @@ class TestServiceBusAdministrationClientTopicTests(AzureMgmtRecordedTestCase):
 
     @ServiceBusPreparer()
     @recorded_by_proxy
-    def test_mgmt_topic_update_dict_success(self, servicebus_connection_str, **kwargs):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+    def test_mgmt_topic_update_dict_success(self, servicebus_fully_qualified_namespace, **kwargs):
+        credential = get_credential()
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         clear_topics(mgmt_service)
         topic_name = "fjruid"
 
@@ -473,8 +517,12 @@ class TestServiceBusAdministrationClientTopicTests(AzureMgmtRecordedTestCase):
 
     @ServiceBusPreparer()
     @recorded_by_proxy
-    def test_mgmt_topic_update_dict_error(self, servicebus_connection_str, **kwargs):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str)
+    def test_mgmt_topic_update_dict_error(self, servicebus_fully_qualified_namespace, **kwargs):
+        credential = get_credential()
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential
+        )
         clear_topics(mgmt_service)
         topic_name = "dfjdfj"
         try:
@@ -490,7 +538,12 @@ class TestServiceBusAdministrationClientTopicTests(AzureMgmtRecordedTestCase):
     @recorded_by_proxy
     def test_mgmt_topic_basic_v2017_04(self, servicebus_connection_str, servicebus_fully_qualified_namespace,
                                     servicebus_sas_policy, servicebus_sas_key):
-        mgmt_service = ServiceBusAdministrationClient.from_connection_string(servicebus_connection_str, api_version=ApiVersion.V2017_04)
+        credential = get_credential()
+        mgmt_service = ServiceBusAdministrationClient(
+            fully_qualified_namespace=servicebus_fully_qualified_namespace,
+            credential=credential,
+            api_version=ApiVersion.V2017_04
+        )
         clear_topics(mgmt_service)
 
         mgmt_service.create_topic("test_topic")

--- a/sdk/servicebus/azure-servicebus/tests/servicebus_preparer.py
+++ b/sdk/servicebus/azure-servicebus/tests/servicebus_preparer.py
@@ -59,7 +59,7 @@ class ServiceBusResourceGroupPreparer(AzureMgmtPreparer):
         self.location = location
         self.parameter_name = parameter_name
         self.parameter_name_for_location = parameter_name_for_location
-        env_value = os.environ.get("AZURE_RESOURCEGROUP_NAME", None)
+        env_value = os.environ.get("SERVICEBUS_RESOURCE_GROUP", None)
         self._need_creation = True
         if env_value:
             self.resource_random_name = env_value

--- a/sdk/servicebus/azure-servicebus/tests/servicebus_preparer.py
+++ b/sdk/servicebus/azure-servicebus/tests/servicebus_preparer.py
@@ -59,7 +59,7 @@ class ServiceBusResourceGroupPreparer(AzureMgmtPreparer):
         self.location = location
         self.parameter_name = parameter_name
         self.parameter_name_for_location = parameter_name_for_location
-        env_value = os.environ.get("SERVICEBUS_RESOURCE_GROUP", None)
+        env_value = os.environ.get("AZURE_RESOURCEGROUP_NAME", None)
         self._need_creation = True
         if env_value:
             self.resource_random_name = env_value

--- a/sdk/servicebus/azure-servicebus/tests/test_queues.py
+++ b/sdk/servicebus/azure-servicebus/tests/test_queues.py
@@ -1,3261 +1,3261 @@
-#-------------------------------------------------------------------------
-# Copyright (c) Microsoft Corporation. All rights reserved.
-# Licensed under the MIT License. See License.txt in the project root for
-# license information.
-#--------------------------------------------------------------------------
+# #-------------------------------------------------------------------------
+# # Copyright (c) Microsoft Corporation. All rights reserved.
+# # Licensed under the MIT License. See License.txt in the project root for
+# # license information.
+# #--------------------------------------------------------------------------
 
-import logging
-import sys
-import os
-import json
-from concurrent.futures import ThreadPoolExecutor
-import types
-import pytest
-import time
-import uuid
-from datetime import datetime, timedelta
-import calendar
-import unittest
-import pickle
+# import logging
+# import sys
+# import os
+# import json
+# from concurrent.futures import ThreadPoolExecutor
+# import types
+# import pytest
+# import time
+# import uuid
+# from datetime import datetime, timedelta
+# import calendar
+# import unittest
+# import pickle
 
-try:
-    import uamqp
-    from azure.servicebus._transport._uamqp_transport import UamqpTransport
-except ImportError:
-    uamqp = None
+# try:
+#     import uamqp
+#     from azure.servicebus._transport._uamqp_transport import UamqpTransport
+# except ImportError:
+#     uamqp = None
 
-from azure.servicebus._transport._pyamqp_transport import PyamqpTransport
-from azure.servicebus._pyamqp.message import Message
-from azure.servicebus._pyamqp import error, client, management_operation
-from azure.servicebus import (
-    ServiceBusClient,
-    AutoLockRenewer,
-    TransportType,
-    ServiceBusMessage,
-    ServiceBusMessageBatch,
-    ServiceBusReceivedMessage,
-    ServiceBusReceiveMode,
-    ServiceBusSubQueue,
-    ServiceBusMessageState
-)
-from azure.servicebus.amqp import (
-    AmqpMessageHeader,
-    AmqpMessageBodyType,
-    AmqpAnnotatedMessage,
-    AmqpMessageProperties,
-)
-from azure.servicebus._common.constants import (
-    _X_OPT_LOCK_TOKEN,
-    _X_OPT_PARTITION_KEY,
-    _X_OPT_VIA_PARTITION_KEY,
-    _X_OPT_SCHEDULED_ENQUEUE_TIME,
-    ServiceBusMessageState
-)
-from azure.servicebus._common.utils import utc_now
-from azure.servicebus.management._models import DictMixin
-from azure.servicebus.exceptions import (
-    ServiceBusConnectionError,
-    ServiceBusError,
-    MessageLockLostError,
-    MessageAlreadySettled,
-    AutoLockRenewTimeout,
-    MessageSizeExceededError,
-    OperationTimeoutError
-)
+# from azure.servicebus._transport._pyamqp_transport import PyamqpTransport
+# from azure.servicebus._pyamqp.message import Message
+# from azure.servicebus._pyamqp import error, client, management_operation
+# from azure.servicebus import (
+#     ServiceBusClient,
+#     AutoLockRenewer,
+#     TransportType,
+#     ServiceBusMessage,
+#     ServiceBusMessageBatch,
+#     ServiceBusReceivedMessage,
+#     ServiceBusReceiveMode,
+#     ServiceBusSubQueue,
+#     ServiceBusMessageState
+# )
+# from azure.servicebus.amqp import (
+#     AmqpMessageHeader,
+#     AmqpMessageBodyType,
+#     AmqpAnnotatedMessage,
+#     AmqpMessageProperties,
+# )
+# from azure.servicebus._common.constants import (
+#     _X_OPT_LOCK_TOKEN,
+#     _X_OPT_PARTITION_KEY,
+#     _X_OPT_VIA_PARTITION_KEY,
+#     _X_OPT_SCHEDULED_ENQUEUE_TIME,
+#     ServiceBusMessageState
+# )
+# from azure.servicebus._common.utils import utc_now
+# from azure.servicebus.management._models import DictMixin
+# from azure.servicebus.exceptions import (
+#     ServiceBusConnectionError,
+#     ServiceBusError,
+#     MessageLockLostError,
+#     MessageAlreadySettled,
+#     AutoLockRenewTimeout,
+#     MessageSizeExceededError,
+#     OperationTimeoutError
+# )
 
-from devtools_testutils import AzureMgmtRecordedTestCase
-from servicebus_preparer import (
-    CachedServiceBusNamespacePreparer,
-    ServiceBusQueuePreparer,
-    CachedServiceBusQueuePreparer,
-    CachedServiceBusResourceGroupPreparer
-)
-from utilities import get_logger, print_message, sleep_until_expired
-from mocks import MockReceivedMessage, MockReceiver
-from utilities import uamqp_transport as get_uamqp_transport, ArgPasser
+# from devtools_testutils import AzureMgmtRecordedTestCase
+# from servicebus_preparer import (
+#     CachedServiceBusNamespacePreparer,
+#     ServiceBusQueuePreparer,
+#     CachedServiceBusQueuePreparer,
+#     CachedServiceBusResourceGroupPreparer
+# )
+# from utilities import get_logger, print_message, sleep_until_expired
+# from mocks import MockReceivedMessage, MockReceiver
+# from utilities import uamqp_transport as get_uamqp_transport, ArgPasser
 
-uamqp_transport_params, uamqp_transport_ids = get_uamqp_transport()
+# uamqp_transport_params, uamqp_transport_ids = get_uamqp_transport()
 
-_logger = get_logger(logging.DEBUG)
+# _logger = get_logger(logging.DEBUG)
 
 
-# A note regarding live_test_only.
-# Old servicebus tests were not written to work on both stubs and live entities.
-# This disables those tests for non-live scenarios, and should be removed as tests
-# are ported to offline-compatible code.
-class TestServiceBusQueue(AzureMgmtRecordedTestCase):
+# # A note regarding live_test_only.
+# # Old servicebus tests were not written to work on both stubs and live entities.
+# # This disables those tests for non-live scenarios, and should be removed as tests
+# # are ported to offline-compatible code.
+# class TestServiceBusQueue(AzureMgmtRecordedTestCase):
 
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_receive_and_delete_reconnect_interaction(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        # Note: This test was to guard against github issue 7079
-        sb_client = ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport)
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_receive_and_delete_reconnect_interaction(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         # Note: This test was to guard against github issue 7079
+#         sb_client = ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport)
 
-        with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-            for i in range(5):
-                sender.send_messages(ServiceBusMessage("ServiceBusMessage {}".format(i)))
+#         with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#             for i in range(5):
+#                 sender.send_messages(ServiceBusMessage("ServiceBusMessage {}".format(i)))
 
-        with sb_client.get_queue_receiver(servicebus_queue.name,
-                                          receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE,
-                                          max_wait_time=10) as receiver:
-            batch = receiver.receive_messages()
-            count = len(batch)
+#         with sb_client.get_queue_receiver(servicebus_queue.name,
+#                                           receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE,
+#                                           max_wait_time=10) as receiver:
+#             batch = receiver.receive_messages()
+#             count = len(batch)
 
-            for message in receiver:
-               _logger.debug(message)
-               count += 1
-            assert count == 5
-
-    
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer()
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @CachedServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True, lock_duration='PT5S')
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_github_issue_6178(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-
-            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                for i in range(3):
-                    sender.send_messages(ServiceBusMessage("ServiceBusMessage {}".format(i)))
-
-                    with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=60) as receiver:
-                        for message in receiver:
-                            _logger.debug(message)
-                            _logger.debug(message.sequence_number)
-                            _logger.debug(message.enqueued_time_utc)
-                            _logger.debug(message._lock_expired)
-                            receiver.complete_message(message)
-                            time.sleep(10)
+#             for message in receiver:
+#                _logger.debug(message)
+#                count += 1
+#             assert count == 5
 
     
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True, lock_duration='PT10S')
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_queue_by_queue_client_conn_str_receive_handler_peeklock(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer()
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @CachedServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True, lock_duration='PT5S')
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_github_issue_6178(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-            sender = sb_client.get_queue_sender(servicebus_queue.name)
-            for i in range(10):
-                message = ServiceBusMessage("Handler message no. {}".format(i))
-                message.application_properties = {'key': 'value'}
-                message.subject = 'label'
-                message.content_type = 'application/text'
-                message.correlation_id = 'cid'
-                message.message_id = str(i)
-                message.partition_key = 'pk'
-                message.to = 'to'
-                message.reply_to = 'reply_to'
-                sender.send_messages(message)
+#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 for i in range(3):
+#                     sender.send_messages(ServiceBusMessage("ServiceBusMessage {}".format(i)))
 
-            # Test that noop empty send works properly.
-            sender.send_messages([])
-            sender.send_messages(ServiceBusMessageBatch())
-            assert len(sender.schedule_messages([], utc_now())) == 0
-            sender.cancel_scheduled_messages([])
-            sender.close()
-
-            # Then test expected failure modes.
-            with pytest.raises(ValueError):
-                with sender:
-                    raise AssertionError("Should raise ValueError")
-            with pytest.raises(ValueError):
-                sender.send_messages(ServiceBusMessage('msg'))
-            with pytest.raises(ValueError):
-                sender.schedule_messages(ServiceBusMessage('msg'), utc_now())
-            with pytest.raises(ValueError):
-                sender.cancel_scheduled_messages([1, 2, 3])
-
-            with pytest.raises(ValueError):
-                sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=0)
-
-            receiver = sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10)
-
-            assert len(receiver.receive_deferred_messages([])) == 0
-            with pytest.raises(ValueError):
-                receiver.receive_messages(max_wait_time=0)
-
-            count = 0
-            for message in receiver:
-                print_message(_logger, message)
-                assert message.delivery_count == 0
-                assert message.application_properties
-                assert message.application_properties[b'key'] == b'value'
-                assert message.subject == 'label'
-                assert message.content_type == 'application/text'
-                assert message.correlation_id == 'cid'
-                assert message.message_id == str(count)
-                assert message.to == 'to'
-                assert message.reply_to == 'reply_to'
-                assert message.sequence_number
-                assert message.enqueued_time_utc
-                assert message.message.delivery_tag is not None
-                assert message.lock_token == message.message.delivery_annotations.get(_X_OPT_LOCK_TOKEN)
-                assert message.lock_token == uuid.UUID(bytes_le=message.message.delivery_tag)
-                assert not message.scheduled_enqueue_time_utc
-                assert not message.time_to_live
-                assert not message.session_id
-                assert not message.reply_to_session_id
-                count += 1
-                receiver.complete_message(message)
-            receiver.close()
-
-            with pytest.raises(ValueError):
-                receiver.receive_messages()
-            with pytest.raises(ValueError):
-                with receiver:
-                    raise AssertionError("Should raise ValueError")
-            with pytest.raises(ValueError):
-                receiver.receive_deferred_messages([1, 2, 3])
-            with pytest.raises(ValueError):
-                receiver.peek_messages()
-
-            assert count == 10
-
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True, lock_duration='PT10S')
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_queue_by_queue_client_conn_str_receive_handler_release_messages(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-
-            def sub_test_releasing_messages():
-                # test releasing messages when prefetch is 1 and link credits are issue dynamically
-                receiver = sb_client.get_queue_receiver(servicebus_queue.name)
-                sender = sb_client.get_queue_sender(servicebus_queue.name)
-                with sender, receiver:
-                    # send 10 msgs to queue first
-                    sender.send_messages([ServiceBusMessage('test') for _ in range(5)])
-
-                    received_msgs = []
-                    # the amount of messages returned by receive call is not stable, especially in live tests
-                    # of different os platforms, this is why a while loop is used here to receive the specific
-                    # amount of message we want to receive
-                    while len(received_msgs) < 5:
-                        # issue link credits more than 5, client should consume 5 msgs from the service in total,
-                        # leaving the extra credits on the wire
-                        for msg in receiver.receive_messages(max_message_count=10, max_wait_time=5):
-                            receiver.complete_message(msg)
-                            received_msgs.append(received_msgs)
-                    assert len(received_msgs) == 5
-
-                    # send 5 more messages, those messages would arrive at the client while the program is sleeping
-                    sender.send_messages([ServiceBusMessage('test') for _ in range(5)])
-                    time.sleep(15)  # sleep > message expiration time
-
-                    target_msgs_count = 5
-                    received_msgs = []
-                    while len(received_msgs) < target_msgs_count:
-                        # issue 10 link credits, client should consume 5 msgs from the service, leaving no link credits
-                        for msg in receiver.receive_messages(max_message_count=target_msgs_count - len(received_msgs),
-                                                             max_wait_time=5):
-                            assert msg.delivery_count == 0  # release would not increase delivery count
-                            receiver.complete_message(msg)
-                            received_msgs.append(msg)
-                    assert len(received_msgs) == 5
-
-            def sub_test_releasing_messages_iterator():
-                # test nested iterator scenario
-                receiver = sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10)
-                sender = sb_client.get_queue_sender(servicebus_queue.name)
-                with sender, receiver:
-                    # send 5 msgs to queue first
-                    sender.send_messages([ServiceBusMessage('test') for _ in range(5)])
-                    first_time = True
-                    iterator_recv_cnt = 0
-
-                    # case: iterator + receive batch
-                    for msg in receiver:
-                        assert msg.delivery_count == 0  # release would not increase delivery count
-                        receiver.complete_message(msg)
-                        iterator_recv_cnt += 1
-                        if first_time:  # for the first time, we call nested receive message call
-                            received_msgs = []
-
-                            while len(received_msgs) < 4:  # there supposed to be 5 msgs in the queue
-                                # we issue 10 link credits, leaving more credits on the wire
-                                for sub_msg in receiver.receive_messages(max_message_count=10, max_wait_time=5):
-                                    assert sub_msg.delivery_count == 0
-                                    receiver.complete_message(sub_msg)
-                                    received_msgs.append(sub_msg)
-                            assert len(received_msgs) == 4
-                            sender.send_messages([ServiceBusMessage('test') for _ in range(10)])
-                            time.sleep(15)  # sleep > message expiration time
-
-                            received_msgs = []
-                            target_msgs_count = 5  # we want to receive 5 with the receive message call
-                            while len(received_msgs) < target_msgs_count:
-                                for sub_msg in receiver.receive_messages(
-                                        max_message_count=target_msgs_count - len(received_msgs), max_wait_time=5):
-                                    assert sub_msg.delivery_count == 0  # release would not increase delivery count
-                                    receiver.complete_message(sub_msg)
-                                    received_msgs.append(sub_msg)
-                            assert len(received_msgs) == target_msgs_count
-                            first_time = False
-                    assert iterator_recv_cnt == 6  # 1 before nested receive message call + 5 after nested receive message call
-
-                    # case: iterator + iterator case
-                    sender.send_messages([ServiceBusMessage('test') for _ in range(10)])
-                    outter_recv_cnt = 0
-                    inner_recv_cnt = 0
-                    for msg in receiver:
-                        assert msg.delivery_count == 0
-                        outter_recv_cnt += 1
-                        receiver.complete_message(msg)
-                        for sub_msg in receiver:
-                            assert sub_msg.delivery_count == 0
-                            inner_recv_cnt += 1
-                            receiver.complete_message(sub_msg)
-                            if inner_recv_cnt == 5:
-                                time.sleep(15)  # innner finish receiving first 5 messages then sleep until lock expiration
-                                break
-                    assert outter_recv_cnt == 1
-                    outter_recv_cnt = 0
-                    for msg in receiver:
-                        assert msg.delivery_count == 0
-                        outter_recv_cnt += 1
-                        receiver.complete_message(msg)
-                    assert outter_recv_cnt == 4
-
-
-            def sub_test_non_releasing_messages():
-                # test not releasing messages when prefetch is not 1
-                receiver = sb_client.get_queue_receiver(servicebus_queue.name)
-                sender = sb_client.get_queue_sender(servicebus_queue.name)
-
-                if uamqp_transport:
-                    def _hack_disable_receive_context_message_received(self, message):
-                        # pylint: disable=protected-access
-                        self._handler._was_message_received = True
-                        self._handler._received_messages.put(message)
-                else:
-                    def _hack_disable_receive_context_message_received(self, frame, message):
-                        # pylint: disable=protected-access
-                        self._handler._last_activity_timestamp = time.time()
-                        self._handler._received_messages.put((frame, message))
-
-                with sender, receiver:
-                    # send 5 msgs to queue first
-                    sender.send_messages([ServiceBusMessage('test') for _ in range(5)])
-                    if uamqp_transport:
-                        receiver._handler.message_handler.on_message_received = types.MethodType(
-                            _hack_disable_receive_context_message_received, receiver)
-                    else:
-                        receiver._handler._link._on_transfer = types.MethodType(
-                            _hack_disable_receive_context_message_received, receiver)
-                    received_msgs = []
-                    while len(received_msgs) < 5:
-                        # issue 10 link credits, client should consume 5 msgs from the service
-                        # leaving 5 credits on the wire
-                        for msg in receiver.receive_messages(max_message_count=10, max_wait_time=5):
-                            receiver.complete_message(msg)
-                            received_msgs.append(msg)
-                    assert len(received_msgs) == 5
-
-                    # send 5 more messages, those messages would arrive at the client while the program is sleeping
-                    sender.send_messages([ServiceBusMessage('test') for _ in range(5)])
-                    time.sleep(15)  # sleep > message expiration time
-
-                    # issue 5 link credits, client should consume 5 msgs from the internal buffer which is already lock expired
-                    target_msgs_count = 5
-                    received_msgs = []
-                    while len(received_msgs) < target_msgs_count:
-                        received_msgs.extend(receiver.receive_messages(max_message_count=5, max_wait_time=5))
-                    assert len(received_msgs) == 5
-                    for msg in received_msgs:
-                        # queue ordering I think
-                        assert msg.delivery_count == 0
-                        with pytest.raises(ServiceBusError):
-                            receiver.complete_message(msg)
-
-                    # re-received message with delivery count increased
-                    target_msgs_count = 5
-                    received_msgs = []
-                    while len(received_msgs) < target_msgs_count:
-                        received_msgs.extend(receiver.receive_messages(max_message_count=5, max_wait_time=5))
-                    assert len(received_msgs) == 5
-                    for msg in received_msgs:
-                        assert msg.delivery_count > 0
-                        receiver.complete_message(msg)
-
-            sub_test_releasing_messages()
-            sub_test_releasing_messages_iterator()
-            sub_test_non_releasing_messages()
+#                     with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=60) as receiver:
+#                         for message in receiver:
+#                             _logger.debug(message)
+#                             _logger.debug(message.sequence_number)
+#                             _logger.debug(message.enqueued_time_utc)
+#                             _logger.debug(message._lock_expired)
+#                             receiver.complete_message(message)
+#                             time.sleep(10)
 
     
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_queue_by_queue_client_send_multiple_messages(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True, lock_duration='PT10S')
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_queue_by_queue_client_conn_str_receive_handler_peeklock(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-            sender = sb_client.get_queue_sender(servicebus_queue.name)
-            with sender:
-                messages = []
-                for i in range(10):
-                    message = ServiceBusMessage("Handler message no. {}".format(i))
-                    message.partition_key = 'pkey'
-                    message.time_to_live = timedelta(seconds=60)
-                    message.scheduled_enqueue_time_utc = utc_now() + timedelta(seconds=60)
-                    message.partition_key = None
-                    message.time_to_live = None
-                    message.scheduled_enqueue_time_utc = None
-                    message.session_id = None
-                    messages.append(message)
-                sender.send_messages(messages)
+#             sender = sb_client.get_queue_sender(servicebus_queue.name)
+#             for i in range(10):
+#                 message = ServiceBusMessage("Handler message no. {}".format(i))
+#                 message.application_properties = {'key': 'value'}
+#                 message.subject = 'label'
+#                 message.content_type = 'application/text'
+#                 message.correlation_id = 'cid'
+#                 message.message_id = str(i)
+#                 message.partition_key = 'pk'
+#                 message.to = 'to'
+#                 message.reply_to = 'reply_to'
+#                 sender.send_messages(message)
 
-            with pytest.raises(ValueError):
-                with sender:
-                    raise AssertionError("Should raise ValueError")
-            with pytest.raises(ValueError):
-                sender.send_messages(ServiceBusMessage('msg'))
-            with pytest.raises(ValueError):
-                sender.schedule_messages(ServiceBusMessage('msg'), utc_now())
-            with pytest.raises(ValueError):
-                sender.cancel_scheduled_messages([1, 2, 3])
+#             # Test that noop empty send works properly.
+#             sender.send_messages([])
+#             sender.send_messages(ServiceBusMessageBatch())
+#             assert len(sender.schedule_messages([], utc_now())) == 0
+#             sender.cancel_scheduled_messages([])
+#             sender.close()
 
-            receiver = sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5)
-            with receiver:
-                count = 0
-                for message in receiver:
-                    print_message(_logger, message)
-                    assert message.delivery_count == 0
-                    assert not message.application_properties
-                    assert not message.subject
-                    assert not message.content_type
-                    assert not message.correlation_id
-                    assert not message.to
-                    assert not message.reply_to
-                    assert not message.scheduled_enqueue_time_utc
-                    assert not message.time_to_live
-                    assert not message.session_id
-                    assert not message.reply_to_session_id
-                    count += 1
-                    receiver.complete_message(message)
-                assert count == 10
+#             # Then test expected failure modes.
+#             with pytest.raises(ValueError):
+#                 with sender:
+#                     raise AssertionError("Should raise ValueError")
+#             with pytest.raises(ValueError):
+#                 sender.send_messages(ServiceBusMessage('msg'))
+#             with pytest.raises(ValueError):
+#                 sender.schedule_messages(ServiceBusMessage('msg'), utc_now())
+#             with pytest.raises(ValueError):
+#                 sender.cancel_scheduled_messages([1, 2, 3])
 
-            with pytest.raises(ValueError):
-                receiver.receive_messages()
-            with pytest.raises(ValueError):
-                with receiver:
-                    raise AssertionError("Should raise ValueError")
-            with pytest.raises(ValueError):
-                receiver.receive_deferred_messages([1, 2, 3])
-            with pytest.raises(ValueError):
-                receiver.peek_messages()
+#             with pytest.raises(ValueError):
+#                 sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=0)
 
-            sender = sb_client.get_queue_sender(servicebus_queue.name)
-            receiver = sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5)
-            with sender, receiver:
-                # send previously unpicklable message
-                msg = {
-                    "body":"W1tdLCB7ImlucHV0X2lkIjogNH0sIHsiY2FsbGJhY2tzIjogbnVsbCwgImVycmJhY2tzIjogbnVsbCwgImNoYWluIjogbnVsbCwgImNob3JkIjogbnVsbH1d",
-                    "content-encoding":"utf-8",
-                    "content-type":"application/json",
-                    "headers":{
-                        "lang":"py",
-                        "task":"tasks.example_task",
-                        "id":"7c66557d-e4bc-437f-b021-b66dcc39dfdf",
-                        "shadow":None,
-                        "eta":"2021-10-07T02:30:23.764066+00:00",
-                        "expires":None,
-                        "group":None,
-                        "group_index":None,
-                        "retries":1,
-                        "timelimit":[
-                            None,
-                            None
-                        ],
-                        "root_id":"7c66557d-e4bc-437f-b021-b66dcc39dfdf",
-                        "parent_id":"7c66557d-e4bc-437f-b021-b66dcc39dfdf",
-                        "argsrepr":"()",
-                        "kwargsrepr":"{'input_id': 4}",
-                        "origin":"gen36@94713e01a9c0",
-                        "ignore_result":1,
-                        "x_correlator":"44a1978d-c869-4173-afe4-da741f0edfb9"
-                    },
-                    "properties":{
-                        "correlation_id":"7c66557d-e4bc-437f-b021-b66dcc39dfdf",
-                        "reply_to":"7b9a3672-2fed-3e9b-8bfd-23ae2397d9ad",
-                        "origin":"gen68@c33d4eef123a",
-                        "delivery_mode":2,
-                        "delivery_info":{
-                            "exchange":"",
-                            "routing_key":"celery_task_queue"
-                        },
-                        "priority":0,
-                        "body_encoding":"base64",
-                        "delivery_tag":"dc83ddb6-8cdc-4413-b88a-06c56cbde90d"
-                    }
-                }
-                sender.send_messages(ServiceBusMessage(json.dumps(msg)))
-                messages = receiver.receive_messages(max_wait_time=10, max_message_count=1)
-                # complete first then pickle
-                receiver.complete_message(messages[0])
-                if not uamqp_transport:
-                    pickled = pickle.loads(pickle.dumps(messages[0]))
-                    assert json.loads(str(pickled)) == json.loads(str(messages[0]))
-                else:
-                    with pytest.raises(TypeError):
-                        pickled = pickle.loads(pickle.dumps(messages[0]))
+#             receiver = sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10)
+
+#             assert len(receiver.receive_deferred_messages([])) == 0
+#             with pytest.raises(ValueError):
+#                 receiver.receive_messages(max_wait_time=0)
+
+#             count = 0
+#             for message in receiver:
+#                 print_message(_logger, message)
+#                 assert message.delivery_count == 0
+#                 assert message.application_properties
+#                 assert message.application_properties[b'key'] == b'value'
+#                 assert message.subject == 'label'
+#                 assert message.content_type == 'application/text'
+#                 assert message.correlation_id == 'cid'
+#                 assert message.message_id == str(count)
+#                 assert message.to == 'to'
+#                 assert message.reply_to == 'reply_to'
+#                 assert message.sequence_number
+#                 assert message.enqueued_time_utc
+#                 assert message.message.delivery_tag is not None
+#                 assert message.lock_token == message.message.delivery_annotations.get(_X_OPT_LOCK_TOKEN)
+#                 assert message.lock_token == uuid.UUID(bytes_le=message.message.delivery_tag)
+#                 assert not message.scheduled_enqueue_time_utc
+#                 assert not message.time_to_live
+#                 assert not message.session_id
+#                 assert not message.reply_to_session_id
+#                 count += 1
+#                 receiver.complete_message(message)
+#             receiver.close()
+
+#             with pytest.raises(ValueError):
+#                 receiver.receive_messages()
+#             with pytest.raises(ValueError):
+#                 with receiver:
+#                     raise AssertionError("Should raise ValueError")
+#             with pytest.raises(ValueError):
+#                 receiver.receive_deferred_messages([1, 2, 3])
+#             with pytest.raises(ValueError):
+#                 receiver.peek_messages()
+
+#             assert count == 10
+
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True, lock_duration='PT10S')
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_queue_by_queue_client_conn_str_receive_handler_release_messages(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+
+#             def sub_test_releasing_messages():
+#                 # test releasing messages when prefetch is 1 and link credits are issue dynamically
+#                 receiver = sb_client.get_queue_receiver(servicebus_queue.name)
+#                 sender = sb_client.get_queue_sender(servicebus_queue.name)
+#                 with sender, receiver:
+#                     # send 10 msgs to queue first
+#                     sender.send_messages([ServiceBusMessage('test') for _ in range(5)])
+
+#                     received_msgs = []
+#                     # the amount of messages returned by receive call is not stable, especially in live tests
+#                     # of different os platforms, this is why a while loop is used here to receive the specific
+#                     # amount of message we want to receive
+#                     while len(received_msgs) < 5:
+#                         # issue link credits more than 5, client should consume 5 msgs from the service in total,
+#                         # leaving the extra credits on the wire
+#                         for msg in receiver.receive_messages(max_message_count=10, max_wait_time=5):
+#                             receiver.complete_message(msg)
+#                             received_msgs.append(received_msgs)
+#                     assert len(received_msgs) == 5
+
+#                     # send 5 more messages, those messages would arrive at the client while the program is sleeping
+#                     sender.send_messages([ServiceBusMessage('test') for _ in range(5)])
+#                     time.sleep(15)  # sleep > message expiration time
+
+#                     target_msgs_count = 5
+#                     received_msgs = []
+#                     while len(received_msgs) < target_msgs_count:
+#                         # issue 10 link credits, client should consume 5 msgs from the service, leaving no link credits
+#                         for msg in receiver.receive_messages(max_message_count=target_msgs_count - len(received_msgs),
+#                                                              max_wait_time=5):
+#                             assert msg.delivery_count == 0  # release would not increase delivery count
+#                             receiver.complete_message(msg)
+#                             received_msgs.append(msg)
+#                     assert len(received_msgs) == 5
+
+#             def sub_test_releasing_messages_iterator():
+#                 # test nested iterator scenario
+#                 receiver = sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10)
+#                 sender = sb_client.get_queue_sender(servicebus_queue.name)
+#                 with sender, receiver:
+#                     # send 5 msgs to queue first
+#                     sender.send_messages([ServiceBusMessage('test') for _ in range(5)])
+#                     first_time = True
+#                     iterator_recv_cnt = 0
+
+#                     # case: iterator + receive batch
+#                     for msg in receiver:
+#                         assert msg.delivery_count == 0  # release would not increase delivery count
+#                         receiver.complete_message(msg)
+#                         iterator_recv_cnt += 1
+#                         if first_time:  # for the first time, we call nested receive message call
+#                             received_msgs = []
+
+#                             while len(received_msgs) < 4:  # there supposed to be 5 msgs in the queue
+#                                 # we issue 10 link credits, leaving more credits on the wire
+#                                 for sub_msg in receiver.receive_messages(max_message_count=10, max_wait_time=5):
+#                                     assert sub_msg.delivery_count == 0
+#                                     receiver.complete_message(sub_msg)
+#                                     received_msgs.append(sub_msg)
+#                             assert len(received_msgs) == 4
+#                             sender.send_messages([ServiceBusMessage('test') for _ in range(10)])
+#                             time.sleep(15)  # sleep > message expiration time
+
+#                             received_msgs = []
+#                             target_msgs_count = 5  # we want to receive 5 with the receive message call
+#                             while len(received_msgs) < target_msgs_count:
+#                                 for sub_msg in receiver.receive_messages(
+#                                         max_message_count=target_msgs_count - len(received_msgs), max_wait_time=5):
+#                                     assert sub_msg.delivery_count == 0  # release would not increase delivery count
+#                                     receiver.complete_message(sub_msg)
+#                                     received_msgs.append(sub_msg)
+#                             assert len(received_msgs) == target_msgs_count
+#                             first_time = False
+#                     assert iterator_recv_cnt == 6  # 1 before nested receive message call + 5 after nested receive message call
+
+#                     # case: iterator + iterator case
+#                     sender.send_messages([ServiceBusMessage('test') for _ in range(10)])
+#                     outter_recv_cnt = 0
+#                     inner_recv_cnt = 0
+#                     for msg in receiver:
+#                         assert msg.delivery_count == 0
+#                         outter_recv_cnt += 1
+#                         receiver.complete_message(msg)
+#                         for sub_msg in receiver:
+#                             assert sub_msg.delivery_count == 0
+#                             inner_recv_cnt += 1
+#                             receiver.complete_message(sub_msg)
+#                             if inner_recv_cnt == 5:
+#                                 time.sleep(15)  # innner finish receiving first 5 messages then sleep until lock expiration
+#                                 break
+#                     assert outter_recv_cnt == 1
+#                     outter_recv_cnt = 0
+#                     for msg in receiver:
+#                         assert msg.delivery_count == 0
+#                         outter_recv_cnt += 1
+#                         receiver.complete_message(msg)
+#                     assert outter_recv_cnt == 4
+
+
+#             def sub_test_non_releasing_messages():
+#                 # test not releasing messages when prefetch is not 1
+#                 receiver = sb_client.get_queue_receiver(servicebus_queue.name)
+#                 sender = sb_client.get_queue_sender(servicebus_queue.name)
+
+#                 if uamqp_transport:
+#                     def _hack_disable_receive_context_message_received(self, message):
+#                         # pylint: disable=protected-access
+#                         self._handler._was_message_received = True
+#                         self._handler._received_messages.put(message)
+#                 else:
+#                     def _hack_disable_receive_context_message_received(self, frame, message):
+#                         # pylint: disable=protected-access
+#                         self._handler._last_activity_timestamp = time.time()
+#                         self._handler._received_messages.put((frame, message))
+
+#                 with sender, receiver:
+#                     # send 5 msgs to queue first
+#                     sender.send_messages([ServiceBusMessage('test') for _ in range(5)])
+#                     if uamqp_transport:
+#                         receiver._handler.message_handler.on_message_received = types.MethodType(
+#                             _hack_disable_receive_context_message_received, receiver)
+#                     else:
+#                         receiver._handler._link._on_transfer = types.MethodType(
+#                             _hack_disable_receive_context_message_received, receiver)
+#                     received_msgs = []
+#                     while len(received_msgs) < 5:
+#                         # issue 10 link credits, client should consume 5 msgs from the service
+#                         # leaving 5 credits on the wire
+#                         for msg in receiver.receive_messages(max_message_count=10, max_wait_time=5):
+#                             receiver.complete_message(msg)
+#                             received_msgs.append(msg)
+#                     assert len(received_msgs) == 5
+
+#                     # send 5 more messages, those messages would arrive at the client while the program is sleeping
+#                     sender.send_messages([ServiceBusMessage('test') for _ in range(5)])
+#                     time.sleep(15)  # sleep > message expiration time
+
+#                     # issue 5 link credits, client should consume 5 msgs from the internal buffer which is already lock expired
+#                     target_msgs_count = 5
+#                     received_msgs = []
+#                     while len(received_msgs) < target_msgs_count:
+#                         received_msgs.extend(receiver.receive_messages(max_message_count=5, max_wait_time=5))
+#                     assert len(received_msgs) == 5
+#                     for msg in received_msgs:
+#                         # queue ordering I think
+#                         assert msg.delivery_count == 0
+#                         with pytest.raises(ServiceBusError):
+#                             receiver.complete_message(msg)
+
+#                     # re-received message with delivery count increased
+#                     target_msgs_count = 5
+#                     received_msgs = []
+#                     while len(received_msgs) < target_msgs_count:
+#                         received_msgs.extend(receiver.receive_messages(max_message_count=5, max_wait_time=5))
+#                     assert len(received_msgs) == 5
+#                     for msg in received_msgs:
+#                         assert msg.delivery_count > 0
+#                         receiver.complete_message(msg)
+
+#             sub_test_releasing_messages()
+#             sub_test_releasing_messages_iterator()
+#             sub_test_non_releasing_messages()
 
     
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True, lock_duration='PT10S')
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_queue_by_queue_client_conn_str_receive_handler_receiveanddelete(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_queue_by_queue_client_send_multiple_messages(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+
+#             sender = sb_client.get_queue_sender(servicebus_queue.name)
+#             with sender:
+#                 messages = []
+#                 for i in range(10):
+#                     message = ServiceBusMessage("Handler message no. {}".format(i))
+#                     message.partition_key = 'pkey'
+#                     message.time_to_live = timedelta(seconds=60)
+#                     message.scheduled_enqueue_time_utc = utc_now() + timedelta(seconds=60)
+#                     message.partition_key = None
+#                     message.time_to_live = None
+#                     message.scheduled_enqueue_time_utc = None
+#                     message.session_id = None
+#                     messages.append(message)
+#                 sender.send_messages(messages)
+
+#             with pytest.raises(ValueError):
+#                 with sender:
+#                     raise AssertionError("Should raise ValueError")
+#             with pytest.raises(ValueError):
+#                 sender.send_messages(ServiceBusMessage('msg'))
+#             with pytest.raises(ValueError):
+#                 sender.schedule_messages(ServiceBusMessage('msg'), utc_now())
+#             with pytest.raises(ValueError):
+#                 sender.cancel_scheduled_messages([1, 2, 3])
+
+#             receiver = sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5)
+#             with receiver:
+#                 count = 0
+#                 for message in receiver:
+#                     print_message(_logger, message)
+#                     assert message.delivery_count == 0
+#                     assert not message.application_properties
+#                     assert not message.subject
+#                     assert not message.content_type
+#                     assert not message.correlation_id
+#                     assert not message.to
+#                     assert not message.reply_to
+#                     assert not message.scheduled_enqueue_time_utc
+#                     assert not message.time_to_live
+#                     assert not message.session_id
+#                     assert not message.reply_to_session_id
+#                     count += 1
+#                     receiver.complete_message(message)
+#                 assert count == 10
+
+#             with pytest.raises(ValueError):
+#                 receiver.receive_messages()
+#             with pytest.raises(ValueError):
+#                 with receiver:
+#                     raise AssertionError("Should raise ValueError")
+#             with pytest.raises(ValueError):
+#                 receiver.receive_deferred_messages([1, 2, 3])
+#             with pytest.raises(ValueError):
+#                 receiver.peek_messages()
+
+#             sender = sb_client.get_queue_sender(servicebus_queue.name)
+#             receiver = sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5)
+#             with sender, receiver:
+#                 # send previously unpicklable message
+#                 msg = {
+#                     "body":"W1tdLCB7ImlucHV0X2lkIjogNH0sIHsiY2FsbGJhY2tzIjogbnVsbCwgImVycmJhY2tzIjogbnVsbCwgImNoYWluIjogbnVsbCwgImNob3JkIjogbnVsbH1d",
+#                     "content-encoding":"utf-8",
+#                     "content-type":"application/json",
+#                     "headers":{
+#                         "lang":"py",
+#                         "task":"tasks.example_task",
+#                         "id":"7c66557d-e4bc-437f-b021-b66dcc39dfdf",
+#                         "shadow":None,
+#                         "eta":"2021-10-07T02:30:23.764066+00:00",
+#                         "expires":None,
+#                         "group":None,
+#                         "group_index":None,
+#                         "retries":1,
+#                         "timelimit":[
+#                             None,
+#                             None
+#                         ],
+#                         "root_id":"7c66557d-e4bc-437f-b021-b66dcc39dfdf",
+#                         "parent_id":"7c66557d-e4bc-437f-b021-b66dcc39dfdf",
+#                         "argsrepr":"()",
+#                         "kwargsrepr":"{'input_id': 4}",
+#                         "origin":"gen36@94713e01a9c0",
+#                         "ignore_result":1,
+#                         "x_correlator":"44a1978d-c869-4173-afe4-da741f0edfb9"
+#                     },
+#                     "properties":{
+#                         "correlation_id":"7c66557d-e4bc-437f-b021-b66dcc39dfdf",
+#                         "reply_to":"7b9a3672-2fed-3e9b-8bfd-23ae2397d9ad",
+#                         "origin":"gen68@c33d4eef123a",
+#                         "delivery_mode":2,
+#                         "delivery_info":{
+#                             "exchange":"",
+#                             "routing_key":"celery_task_queue"
+#                         },
+#                         "priority":0,
+#                         "body_encoding":"base64",
+#                         "delivery_tag":"dc83ddb6-8cdc-4413-b88a-06c56cbde90d"
+#                     }
+#                 }
+#                 sender.send_messages(ServiceBusMessage(json.dumps(msg)))
+#                 messages = receiver.receive_messages(max_wait_time=10, max_message_count=1)
+#                 # complete first then pickle
+#                 receiver.complete_message(messages[0])
+#                 if not uamqp_transport:
+#                     pickled = pickle.loads(pickle.dumps(messages[0]))
+#                     assert json.loads(str(pickled)) == json.loads(str(messages[0]))
+#                 else:
+#                     with pytest.raises(TypeError):
+#                         pickled = pickle.loads(pickle.dumps(messages[0]))
+
+    
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True, lock_duration='PT10S')
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_queue_by_queue_client_conn_str_receive_handler_receiveanddelete(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
         
-        with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#         with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
             
-            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                for i in range(10):
-                    message = ServiceBusMessage("Handler message no. {}".format(i))
-                    sender.send_messages(message)
+#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 for i in range(10):
+#                     message = ServiceBusMessage("Handler message no. {}".format(i))
+#                     sender.send_messages(message)
     
-            messages = []
-            with sb_client.get_queue_receiver(servicebus_queue.name, 
-                                              receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE, 
-                                              max_wait_time=8) as receiver:
-                for message in receiver:
-                    assert not message.application_properties
-                    assert not message.subject
-                    assert not message.content_type
-                    assert not message.correlation_id
-                    assert not message.partition_key
-                    assert not message.to
-                    assert not message.reply_to
-                    assert not message.scheduled_enqueue_time_utc
-                    assert not message.time_to_live
-                    assert not message.session_id
-                    assert not message.reply_to_session_id
-                    messages.append(message)
-                    with pytest.raises(ValueError):
-                        receiver.complete_message(message)
-                    with pytest.raises(ValueError): # RECEIVE_AND_DELETE messages cannot be lock renewed.
-                        renewer = AutoLockRenewer()
-                        renewer.register(receiver, message)
+#             messages = []
+#             with sb_client.get_queue_receiver(servicebus_queue.name, 
+#                                               receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE, 
+#                                               max_wait_time=8) as receiver:
+#                 for message in receiver:
+#                     assert not message.application_properties
+#                     assert not message.subject
+#                     assert not message.content_type
+#                     assert not message.correlation_id
+#                     assert not message.partition_key
+#                     assert not message.to
+#                     assert not message.reply_to
+#                     assert not message.scheduled_enqueue_time_utc
+#                     assert not message.time_to_live
+#                     assert not message.session_id
+#                     assert not message.reply_to_session_id
+#                     messages.append(message)
+#                     with pytest.raises(ValueError):
+#                         receiver.complete_message(message)
+#                     with pytest.raises(ValueError): # RECEIVE_AND_DELETE messages cannot be lock renewed.
+#                         renewer = AutoLockRenewer()
+#                         renewer.register(receiver, message)
     
-            assert len(messages) == 10
-            assert not receiver._running
-            time.sleep(10)
+#             assert len(messages) == 10
+#             assert not receiver._running
+#             time.sleep(10)
     
-            messages = []
-            with sb_client.get_queue_receiver(servicebus_queue.name, 
-                                              receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE, 
-                                              max_wait_time=5) as receiver:
-                for message in receiver:
-                    messages.append(message)
-                assert len(messages) == 0
+#             messages = []
+#             with sb_client.get_queue_receiver(servicebus_queue.name, 
+#                                               receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE, 
+#                                               max_wait_time=5) as receiver:
+#                 for message in receiver:
+#                     messages.append(message)
+#                 assert len(messages) == 0
 
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True, lock_duration='PT10S')
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_queue_by_queue_client_conn_str_receive_handler_receiveanddelete_prefetch(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-            # send 10 messages
-            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                for i in range(10):
-                    message = ServiceBusMessage("Handler message no. {}".format(i))
-                    sender.send_messages(message)
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True, lock_duration='PT10S')
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_queue_by_queue_client_conn_str_receive_handler_receiveanddelete_prefetch(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#             # send 10 messages
+#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 for i in range(10):
+#                     message = ServiceBusMessage("Handler message no. {}".format(i))
+#                     sender.send_messages(message)
 
-            # check peek_messages returns correctly, with default prefetch_count = 0
-            messages = []
-            with sb_client.get_queue_receiver(servicebus_queue.name,
-                                            receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE,
-                                            max_wait_time=10) as receiver:
-                # peek messages checks current state of queue, which should return 10
-                # since none were prefetched, added to internal queue, and deleted
-                peeked_msgs = receiver.peek_messages(max_message_count=10, timeout=10)
-                assert len(peeked_msgs) == 10
+#             # check peek_messages returns correctly, with default prefetch_count = 0
+#             messages = []
+#             with sb_client.get_queue_receiver(servicebus_queue.name,
+#                                             receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE,
+#                                             max_wait_time=10) as receiver:
+#                 # peek messages checks current state of queue, which should return 10
+#                 # since none were prefetched, added to internal queue, and deleted
+#                 peeked_msgs = receiver.peek_messages(max_message_count=10, timeout=10)
+#                 assert len(peeked_msgs) == 10
 
-                # iterator receives and deletes each message from SB queue
-                for msg in receiver:
-                    messages.append(msg)
-                assert len(messages) == 10
+#                 # iterator receives and deletes each message from SB queue
+#                 for msg in receiver:
+#                     messages.append(msg)
+#                 assert len(messages) == 10
 
-                # queue should be empty now
-                peeked_msgs = receiver.peek_messages(max_message_count=10, timeout=10)
-                assert len(peeked_msgs) == 0
+#                 # queue should be empty now
+#                 peeked_msgs = receiver.peek_messages(max_message_count=10, timeout=10)
+#                 assert len(peeked_msgs) == 0
 
-            # send 10 messages
-            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                for i in range(10):
-                    message = ServiceBusMessage("Handler message no. {}".format(i))
-                    sender.send_messages(message)
+#             # send 10 messages
+#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 for i in range(10):
+#                     message = ServiceBusMessage("Handler message no. {}".format(i))
+#                     sender.send_messages(message)
 
-            # check peek_messages returns correctly, with default prefetch_count > 0
-            messages = []
-            # prefetch 2 messages from SB queue when receive is called and not on open
-            with sb_client.get_queue_receiver(
-                servicebus_queue.name,
-                receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE,
-                prefetch_count=2,
-                max_wait_time=30
-            ) as receiver:
-                # peek messages checks current state of SB queue, and returns 10
-                peeked_msgs = receiver.peek_messages(max_message_count=10, timeout=10)
-                assert len(peeked_msgs) == 10
+#             # check peek_messages returns correctly, with default prefetch_count > 0
+#             messages = []
+#             # prefetch 2 messages from SB queue when receive is called and not on open
+#             with sb_client.get_queue_receiver(
+#                 servicebus_queue.name,
+#                 receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE,
+#                 prefetch_count=2,
+#                 max_wait_time=30
+#             ) as receiver:
+#                 # peek messages checks current state of SB queue, and returns 10
+#                 peeked_msgs = receiver.peek_messages(max_message_count=10, timeout=10)
+#                 assert len(peeked_msgs) == 10
 
-                # receive 3 messages
-                recvd_msgs = receiver.receive_messages(max_message_count=3, max_wait_time=10)
-                assert len(recvd_msgs) == 3
+#                 # receive 3 messages
+#                 recvd_msgs = receiver.receive_messages(max_message_count=3, max_wait_time=10)
+#                 assert len(recvd_msgs) == 3
 
-                # receive rest of messages in queue
-                for msg in receiver:
-                    messages.append(msg)
-                assert len(messages) == 7
+#                 # receive rest of messages in queue
+#                 for msg in receiver:
+#                     messages.append(msg)
+#                 assert len(messages) == 7
 
-                # queue should be empty now
-                peeked_msgs = receiver.peek_messages(max_message_count=10, timeout=10)
-                assert len(peeked_msgs) == 0
+#                 # queue should be empty now
+#                 peeked_msgs = receiver.peek_messages(max_message_count=10, timeout=10)
+#                 assert len(peeked_msgs) == 0
 
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_queue_by_queue_client_conn_str_receive_handler_with_stop(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_queue_by_queue_client_conn_str_receive_handler_with_stop(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
         
         
-        with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#         with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
     
-            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                for i in range(10):
-                    message = ServiceBusMessage("Stop message no. {}".format(i))
-                    sender.send_messages(message)
+#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 for i in range(10):
+#                     message = ServiceBusMessage("Stop message no. {}".format(i))
+#                     sender.send_messages(message)
     
-            messages = []
-            with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10) as receiver:
-                for message in receiver:
-                    messages.append(message)
-                    receiver.complete_message(message)
-                    if len(messages) >= 5:
-                        break
+#             messages = []
+#             with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10) as receiver:
+#                 for message in receiver:
+#                     messages.append(message)
+#                     receiver.complete_message(message)
+#                     if len(messages) >= 5:
+#                         break
                     
-                assert receiver._running
-                assert len(messages) == 5
+#                 assert receiver._running
+#                 assert len(messages) == 5
 
-                for message in receiver:
-                    messages.append(message)
-                    receiver.complete_message(message)
-                    if len(messages) >= 5:
-                        break
+#                 for message in receiver:
+#                     messages.append(message)
+#                     receiver.complete_message(message)
+#                     if len(messages) >= 5:
+#                         break
 
-            assert not receiver._running
-            assert len(messages) == 6
+#             assert not receiver._running
+#             assert len(messages) == 6
 
     
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_queue_by_servicebus_client_iter_messages_simple(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_queue_by_servicebus_client_iter_messages_simple(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
         
-        with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#         with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
     
-            with sb_client.get_queue_receiver(servicebus_queue.name, 
-                                              max_wait_time=10,
-                                              receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
+#             with sb_client.get_queue_receiver(servicebus_queue.name, 
+#                                               max_wait_time=10,
+#                                               receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
             
-                with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                    for i in range(10):
-                        message = ServiceBusMessage("Iter message no. {}".format(i))
-                        sender.send_messages(message)
+#                 with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                     for i in range(10):
+#                         message = ServiceBusMessage("Iter message no. {}".format(i))
+#                         sender.send_messages(message)
     
-                count = 0
-                for message in receiver:
-                    print_message(_logger, message)
-                    receiver.complete_message(message)
-                    with pytest.raises(MessageAlreadySettled):
-                        receiver.complete_message(message)
-                    with pytest.raises(MessageAlreadySettled):
-                        receiver.renew_message_lock(message)
-                    count += 1
+#                 count = 0
+#                 for message in receiver:
+#                     print_message(_logger, message)
+#                     receiver.complete_message(message)
+#                     with pytest.raises(MessageAlreadySettled):
+#                         receiver.complete_message(message)
+#                     with pytest.raises(MessageAlreadySettled):
+#                         receiver.renew_message_lock(message)
+#                     count += 1
 
-                with pytest.raises(StopIteration):
-                    next(receiver)
-            assert count == 10
+#                 with pytest.raises(StopIteration):
+#                     next(receiver)
+#             assert count == 10
     
     
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_queue_by_servicebus_conn_str_client_iter_messages_with_abandon(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_queue_by_servicebus_conn_str_client_iter_messages_with_abandon(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
         
-        with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#         with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
     
-            with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5, receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
+#             with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5, receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
             
-                with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                    for i in range(10):
-                        message = ServiceBusMessage("Abandoned message no. {}".format(i))
-                        sender.send_messages(message)
+#                 with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                     for i in range(10):
+#                         message = ServiceBusMessage("Abandoned message no. {}".format(i))
+#                         sender.send_messages(message)
     
-                count = 0
-                for message in receiver:
-                    print_message(_logger, message)
-                    if not message.delivery_count:
-                        count += 1
-                        receiver.abandon_message(message)
-                    else:
-                        assert message.delivery_count == 1
-                        receiver.complete_message(message)
+#                 count = 0
+#                 for message in receiver:
+#                     print_message(_logger, message)
+#                     if not message.delivery_count:
+#                         count += 1
+#                         receiver.abandon_message(message)
+#                     else:
+#                         assert message.delivery_count == 1
+#                         receiver.complete_message(message)
     
-            assert count == 10
+#             assert count == 10
     
-            with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=20, receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
-                count = 0
-                for message in receiver:
-                    print_message(_logger, message)
-                    receiver.complete_message(message)
-                    count += 1
-            assert count == 0
+#             with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=20, receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
+#                 count = 0
+#                 for message in receiver:
+#                     print_message(_logger, message)
+#                     receiver.complete_message(message)
+#                     count += 1
+#             assert count == 0
 
     
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_queue_by_servicebus_client_iter_messages_with_defer(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_queue_by_servicebus_client_iter_messages_with_defer(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
         
-        with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#         with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
     
-            deferred_messages = []
-            with sb_client.get_queue_receiver(
-                servicebus_queue.name, 
-                max_wait_time=5, 
-                receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
+#             deferred_messages = []
+#             with sb_client.get_queue_receiver(
+#                 servicebus_queue.name, 
+#                 max_wait_time=5, 
+#                 receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
             
-                with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                    for i in range(10):
-                        message = ServiceBusMessage("Deferred message no. {}".format(i))
-                        sender.send_messages(message)
+#                 with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                     for i in range(10):
+#                         message = ServiceBusMessage("Deferred message no. {}".format(i))
+#                         sender.send_messages(message)
     
-                count = 0
-                for message in receiver:
-                    deferred_messages.append(message.sequence_number)
-                    print_message(_logger, message)
-                    count += 1
-                    receiver.defer_message(message)
+#                 count = 0
+#                 for message in receiver:
+#                     deferred_messages.append(message.sequence_number)
+#                     print_message(_logger, message)
+#                     count += 1
+#                     receiver.defer_message(message)
     
-            assert count == 10
-            with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5, receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
-                count = 0
-                for message in receiver:
-                    print_message(_logger, message)
-                    receiver.complete_message(message)
-                    count += 1
-            assert count == 0
+#             assert count == 10
+#             with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5, receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
+#                 count = 0
+#                 for message in receiver:
+#                     print_message(_logger, message)
+#                     receiver.complete_message(message)
+#                     count += 1
+#             assert count == 0
     
     
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_queue_by_servicebus_client_iter_messages_with_retrieve_deferred_client(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_queue_by_servicebus_client_iter_messages_with_retrieve_deferred_client(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
     
-        with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#         with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-            deferred_messages = []
-            with sb_client.get_queue_receiver(servicebus_queue.name, 
-                                                 max_wait_time=5, 
-                                                 receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
+#             deferred_messages = []
+#             with sb_client.get_queue_receiver(servicebus_queue.name, 
+#                                                  max_wait_time=5, 
+#                                                  receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
             
-                with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                    for i in range(10):
-                        message = ServiceBusMessage("Deferred message no. {}".format(i))
-                        sender.send_messages(message)
+#                 with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                     for i in range(10):
+#                         message = ServiceBusMessage("Deferred message no. {}".format(i))
+#                         sender.send_messages(message)
     
-                count = 0
-                for message in receiver:
-                    deferred_messages.append(message.sequence_number)
-                    print_message(_logger, message)
-                    count += 1
-                    receiver.defer_message(message)
+#                 count = 0
+#                 for message in receiver:
+#                     deferred_messages.append(message.sequence_number)
+#                     print_message(_logger, message)
+#                     count += 1
+#                     receiver.defer_message(message)
     
-                assert count == 10
-                deferred = receiver.receive_deferred_messages(deferred_messages)
-                assert len(deferred) == 10
-                for message in deferred:
-                    assert isinstance(message, ServiceBusReceivedMessage)
-                    receiver.complete_message(message)
+#                 assert count == 10
+#                 deferred = receiver.receive_deferred_messages(deferred_messages)
+#                 assert len(deferred) == 10
+#                 for message in deferred:
+#                     assert isinstance(message, ServiceBusReceivedMessage)
+#                     receiver.complete_message(message)
                 
-                with pytest.raises(ServiceBusError):
-                    receiver.receive_deferred_messages(deferred_messages)
+#                 with pytest.raises(ServiceBusError):
+#                     receiver.receive_deferred_messages(deferred_messages)
 
     
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_queue_by_servicebus_client_iter_messages_with_retrieve_deferred_receiver_complete(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_queue_by_servicebus_client_iter_messages_with_retrieve_deferred_receiver_complete(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
     
-        with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#         with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                deferred_messages = []
-                for i in range(10):
-                    message = ServiceBusMessage("Deferred message no. {}".format(i), session_id="test_session")
-                    sender.send_messages(message)
+#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 deferred_messages = []
+#                 for i in range(10):
+#                     message = ServiceBusMessage("Deferred message no. {}".format(i), session_id="test_session")
+#                     sender.send_messages(message)
     
-            with sb_client.get_queue_receiver(servicebus_queue.name, 
-                                        max_wait_time=5, 
-                                        receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
-                count = 0
-                for message in receiver:
-                    deferred_messages.append(message.sequence_number)
-                    print_message(_logger, message)
-                    count += 1
-                    receiver.defer_message(message)
+#             with sb_client.get_queue_receiver(servicebus_queue.name, 
+#                                         max_wait_time=5, 
+#                                         receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
+#                 count = 0
+#                 for message in receiver:
+#                     deferred_messages.append(message.sequence_number)
+#                     print_message(_logger, message)
+#                     count += 1
+#                     receiver.defer_message(message)
     
-            assert count == 10
+#             assert count == 10
     
-            with sb_client.get_queue_receiver(servicebus_queue.name, 
-                                           max_wait_time=5, 
-                                           receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
-                deferred = receiver.receive_deferred_messages(deferred_messages)
-                assert len(deferred) == 10
-                for message in deferred:
-                    assert isinstance(message, ServiceBusReceivedMessage)
-                    assert message.lock_token
-                    assert message.locked_until_utc
-                    assert message._receiver
-                    receiver.renew_message_lock(message)
-                    receiver.complete_message(message)
-
-    
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_queue_by_servicebus_client_iter_messages_with_retrieve_deferred_receiver_deadletter(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                deferred_messages = []
-                for i in range(10):
-                    message = ServiceBusMessage("Deferred message no. {}".format(i))
-                    sender.send_messages(message)
-    
-            with sb_client.get_queue_receiver(servicebus_queue.name, 
-                                              max_wait_time=10,
-                                              receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
-                count = 0
-                for message in receiver:
-                    deferred_messages.append(message.sequence_number)
-                    print_message(_logger, message)
-                    count += 1
-                    receiver.defer_message(message)
-    
-            assert count == 10
-    
-            with sb_client.get_queue_receiver(servicebus_queue.name, 
-                                        max_wait_time=10) as receiver:
-                deferred = receiver.receive_deferred_messages(deferred_messages)
-                assert len(deferred) == 10
-                for message in deferred:
-                    assert isinstance(message, ServiceBusReceivedMessage)
-                    receiver.dead_letter_message(message, reason="Testing reason", error_description="Testing description")
-    
-            count = 0
-            with sb_client.get_queue_receiver(servicebus_queue.name,
-                                              sub_queue = ServiceBusSubQueue.DEAD_LETTER,
-                                              max_wait_time=10) as receiver:
-                for message in receiver:
-                    count += 1
-                    print_message(_logger, message)
-                    assert message.dead_letter_reason == 'Testing reason'
-                    assert message.dead_letter_error_description == 'Testing description'
-                    assert message.application_properties[b'DeadLetterReason'] == b'Testing reason'
-                    assert message.application_properties[b'DeadLetterErrorDescription'] == b'Testing description'
-                    receiver.complete_message(message)
-            assert count == 10
+#             with sb_client.get_queue_receiver(servicebus_queue.name, 
+#                                            max_wait_time=5, 
+#                                            receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
+#                 deferred = receiver.receive_deferred_messages(deferred_messages)
+#                 assert len(deferred) == 10
+#                 for message in deferred:
+#                     assert isinstance(message, ServiceBusReceivedMessage)
+#                     assert message.lock_token
+#                     assert message.locked_until_utc
+#                     assert message._receiver
+#                     receiver.renew_message_lock(message)
+#                     receiver.complete_message(message)
 
     
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_queue_by_servicebus_client_iter_messages_with_retrieve_deferred_receiver_deletemode(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-
-            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                for i in range(10):
-                    sender.send_messages(ServiceBusMessage("Deferred message no. {}".format(i)))
-
-            deferred_messages = []
-            count = 0
-            with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5) as receiver:
-                for message in receiver:
-                    deferred_messages.append(message.sequence_number)
-                    print_message(_logger, message)
-                    count += 1
-                    receiver.defer_message(message)
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_queue_by_servicebus_client_iter_messages_with_retrieve_deferred_receiver_deadletter(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 deferred_messages = []
+#                 for i in range(10):
+#                     message = ServiceBusMessage("Deferred message no. {}".format(i))
+#                     sender.send_messages(message)
     
-            assert count == 10
-            with sb_client.get_queue_receiver(servicebus_queue.name, 
-                                              receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE.value, 
-                                              max_wait_time=5) as receiver:
-                deferred = receiver.receive_deferred_messages(deferred_messages)
-                assert len(deferred) == 10
-                for message in deferred:
-                    assert isinstance(message, ServiceBusReceivedMessage)
-                    with pytest.raises(ValueError):
-                        receiver.complete_message(message)
-                with pytest.raises(ServiceBusError):
-                    deferred = receiver.receive_deferred_messages(deferred_messages)
+#             with sb_client.get_queue_receiver(servicebus_queue.name, 
+#                                               max_wait_time=10,
+#                                               receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
+#                 count = 0
+#                 for message in receiver:
+#                     deferred_messages.append(message.sequence_number)
+#                     print_message(_logger, message)
+#                     count += 1
+#                     receiver.defer_message(message)
+    
+#             assert count == 10
+    
+#             with sb_client.get_queue_receiver(servicebus_queue.name, 
+#                                         max_wait_time=10) as receiver:
+#                 deferred = receiver.receive_deferred_messages(deferred_messages)
+#                 assert len(deferred) == 10
+#                 for message in deferred:
+#                     assert isinstance(message, ServiceBusReceivedMessage)
+#                     receiver.dead_letter_message(message, reason="Testing reason", error_description="Testing description")
+    
+#             count = 0
+#             with sb_client.get_queue_receiver(servicebus_queue.name,
+#                                               sub_queue = ServiceBusSubQueue.DEAD_LETTER,
+#                                               max_wait_time=10) as receiver:
+#                 for message in receiver:
+#                     count += 1
+#                     print_message(_logger, message)
+#                     assert message.dead_letter_reason == 'Testing reason'
+#                     assert message.dead_letter_error_description == 'Testing description'
+#                     assert message.application_properties[b'DeadLetterReason'] == b'Testing reason'
+#                     assert message.application_properties[b'DeadLetterErrorDescription'] == b'Testing description'
+#                     receiver.complete_message(message)
+#             assert count == 10
 
     
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_queue_by_servicebus_client_iter_messages_with_retrieve_deferred_not_found(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_queue_by_servicebus_client_iter_messages_with_retrieve_deferred_receiver_deletemode(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-            deferred_messages = []
-            with sb_client.get_queue_receiver(servicebus_queue.name, 
-                                                 max_wait_time=5, 
-                                                 receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
+#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 for i in range(10):
+#                     sender.send_messages(ServiceBusMessage("Deferred message no. {}".format(i)))
+
+#             deferred_messages = []
+#             count = 0
+#             with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5) as receiver:
+#                 for message in receiver:
+#                     deferred_messages.append(message.sequence_number)
+#                     print_message(_logger, message)
+#                     count += 1
+#                     receiver.defer_message(message)
+    
+#             assert count == 10
+#             with sb_client.get_queue_receiver(servicebus_queue.name, 
+#                                               receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE.value, 
+#                                               max_wait_time=5) as receiver:
+#                 deferred = receiver.receive_deferred_messages(deferred_messages)
+#                 assert len(deferred) == 10
+#                 for message in deferred:
+#                     assert isinstance(message, ServiceBusReceivedMessage)
+#                     with pytest.raises(ValueError):
+#                         receiver.complete_message(message)
+#                 with pytest.raises(ServiceBusError):
+#                     deferred = receiver.receive_deferred_messages(deferred_messages)
+
+    
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_queue_by_servicebus_client_iter_messages_with_retrieve_deferred_not_found(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+
+#             deferred_messages = []
+#             with sb_client.get_queue_receiver(servicebus_queue.name, 
+#                                                  max_wait_time=5, 
+#                                                  receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
             
-                with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                    for i in range(3):
-                        message = ServiceBusMessage("Deferred message no. {}".format(i))
-                        sender.send_messages(message)
+#                 with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                     for i in range(3):
+#                         message = ServiceBusMessage("Deferred message no. {}".format(i))
+#                         sender.send_messages(message)
     
-                count = 0
-                for message in receiver:
-                    deferred_messages.append(message.sequence_number)
-                    print_message(_logger, message)
-                    count += 1
-                    receiver.defer_message(message)
+#                 count = 0
+#                 for message in receiver:
+#                     deferred_messages.append(message.sequence_number)
+#                     print_message(_logger, message)
+#                     count += 1
+#                     receiver.defer_message(message)
     
-                assert count == 3
+#                 assert count == 3
     
-                with pytest.raises(ServiceBusError):
-                    deferred = receiver.receive_deferred_messages([3, 4])
+#                 with pytest.raises(ServiceBusError):
+#                     deferred = receiver.receive_deferred_messages([3, 4])
     
-                with pytest.raises(ServiceBusError):
-                    deferred = receiver.receive_deferred_messages([5, 6, 7])
+#                 with pytest.raises(ServiceBusError):
+#                     deferred = receiver.receive_deferred_messages([5, 6, 7])
 
     
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_queue_by_servicebus_client_receive_batch_with_deadletter(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_queue_by_servicebus_client_receive_batch_with_deadletter(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
 
-        with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#         with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
     
-            with sb_client.get_queue_receiver(servicebus_queue.name, 
-                                           max_wait_time=5, 
-                                           receive_mode=ServiceBusReceiveMode.PEEK_LOCK, 
-                                           prefetch_count=10) as receiver:
+#             with sb_client.get_queue_receiver(servicebus_queue.name, 
+#                                            max_wait_time=5, 
+#                                            receive_mode=ServiceBusReceiveMode.PEEK_LOCK, 
+#                                            prefetch_count=10) as receiver:
             
-                with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                    for i in range(10):
-                        message = ServiceBusMessage("Dead lettered message no. {}".format(i))
-                        sender.send_messages(message)
+#                 with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                     for i in range(10):
+#                         message = ServiceBusMessage("Dead lettered message no. {}".format(i))
+#                         sender.send_messages(message)
     
-                count = 0
-                messages = receiver.receive_messages()
-                while messages:
-                    for message in messages:
-                        print_message(_logger, message)
-                        count += 1
-                        receiver.dead_letter_message(message, reason="Testing reason",
-                                                     error_description="Testing description")
-                    messages = receiver.receive_messages()
+#                 count = 0
+#                 messages = receiver.receive_messages()
+#                 while messages:
+#                     for message in messages:
+#                         print_message(_logger, message)
+#                         count += 1
+#                         receiver.dead_letter_message(message, reason="Testing reason",
+#                                                      error_description="Testing description")
+#                     messages = receiver.receive_messages()
     
-            assert count == 10
+#             assert count == 10
     
-            with sb_client.get_queue_receiver(servicebus_queue.name,
-                                              max_wait_time=5, 
-                                              receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
-                count = 0
-                for message in receiver:
-                    print_message(_logger, message)
-                    receiver.complete_message(message)
-                    count += 1
-            assert count == 0
+#             with sb_client.get_queue_receiver(servicebus_queue.name,
+#                                               max_wait_time=5, 
+#                                               receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
+#                 count = 0
+#                 for message in receiver:
+#                     print_message(_logger, message)
+#                     receiver.complete_message(message)
+#                     count += 1
+#             assert count == 0
 
-            with sb_client.get_queue_receiver(
-                    servicebus_queue.name,
-                    sub_queue = ServiceBusSubQueue.DEAD_LETTER.value,
-                    max_wait_time=5,
-                    receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as dl_receiver:
-                count = 0
-                for message in dl_receiver:
-                    dl_receiver.complete_message(message)
-                    count += 1
-                    assert message.dead_letter_reason == 'Testing reason'
-                    assert message.dead_letter_error_description == 'Testing description'
-                    assert message.application_properties[b'DeadLetterReason'] == b'Testing reason'
-                    assert message.application_properties[b'DeadLetterErrorDescription'] == b'Testing description'
-                assert count == 10
+#             with sb_client.get_queue_receiver(
+#                     servicebus_queue.name,
+#                     sub_queue = ServiceBusSubQueue.DEAD_LETTER.value,
+#                     max_wait_time=5,
+#                     receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as dl_receiver:
+#                 count = 0
+#                 for message in dl_receiver:
+#                     dl_receiver.complete_message(message)
+#                     count += 1
+#                     assert message.dead_letter_reason == 'Testing reason'
+#                     assert message.dead_letter_error_description == 'Testing description'
+#                     assert message.application_properties[b'DeadLetterReason'] == b'Testing reason'
+#                     assert message.application_properties[b'DeadLetterErrorDescription'] == b'Testing description'
+#                 assert count == 10
 
     
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_queue_by_servicebus_client_receive_batch_with_retrieve_deadletter(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_queue_by_servicebus_client_receive_batch_with_retrieve_deadletter(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
     
-        with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#         with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
     
-            with sb_client.get_queue_receiver(servicebus_queue.name,
-                                           max_wait_time=5,
-                                           receive_mode=ServiceBusReceiveMode.PEEK_LOCK, 
-                                           prefetch_count=10) as receiver:
+#             with sb_client.get_queue_receiver(servicebus_queue.name,
+#                                            max_wait_time=5,
+#                                            receive_mode=ServiceBusReceiveMode.PEEK_LOCK, 
+#                                            prefetch_count=10) as receiver:
             
-                with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                    for i in range(10):
-                        message = ServiceBusMessage("Dead lettered message no. {}".format(i))
-                        sender.send_messages(message)
+#                 with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                     for i in range(10):
+#                         message = ServiceBusMessage("Dead lettered message no. {}".format(i))
+#                         sender.send_messages(message)
     
-                count = 0
-                messages = receiver.receive_messages()
-                while messages:
-                    for message in messages:
-                        print_message(_logger, message)
-                        receiver.dead_letter_message(message, reason="Testing reason",
-                                                     error_description="Testing description")
-                        count += 1
-                    messages = receiver.receive_messages()
+#                 count = 0
+#                 messages = receiver.receive_messages()
+#                 while messages:
+#                     for message in messages:
+#                         print_message(_logger, message)
+#                         receiver.dead_letter_message(message, reason="Testing reason",
+#                                                      error_description="Testing description")
+#                         count += 1
+#                     messages = receiver.receive_messages()
     
-                receiver.receive_messages(1,5)
+#                 receiver.receive_messages(1,5)
     
-            assert count == 10
+#             assert count == 10
 
-            with sb_client.get_queue_receiver(
-                    servicebus_queue.name,
-                    sub_queue = ServiceBusSubQueue.DEAD_LETTER,
-                    max_wait_time=5,
-                    receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as dl_receiver:
-                count = 0
-                for message in dl_receiver:
-                    print_message(_logger, message)
-                    assert message.dead_letter_reason == 'Testing reason'
-                    assert message.dead_letter_error_description == 'Testing description'
-                    assert message.application_properties[b'DeadLetterReason'] == b'Testing reason'
-                    assert message.application_properties[b'DeadLetterErrorDescription'] == b'Testing description'
-                    dl_receiver.complete_message(message)
-                    count += 1
-            assert count == 10
+#             with sb_client.get_queue_receiver(
+#                     servicebus_queue.name,
+#                     sub_queue = ServiceBusSubQueue.DEAD_LETTER,
+#                     max_wait_time=5,
+#                     receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as dl_receiver:
+#                 count = 0
+#                 for message in dl_receiver:
+#                     print_message(_logger, message)
+#                     assert message.dead_letter_reason == 'Testing reason'
+#                     assert message.dead_letter_error_description == 'Testing description'
+#                     assert message.application_properties[b'DeadLetterReason'] == b'Testing reason'
+#                     assert message.application_properties[b'DeadLetterErrorDescription'] == b'Testing description'
+#                     dl_receiver.complete_message(message)
+#                     count += 1
+#             assert count == 10
     
 
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @CachedServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_queue_by_servicebus_client_session_fail(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @CachedServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_queue_by_servicebus_client_session_fail(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
     
-        with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#         with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
     
-            with pytest.raises(ServiceBusError):
-                sb_client.get_queue_receiver(servicebus_queue.name, session_id="test")._open_with_retry()
+#             with pytest.raises(ServiceBusError):
+#                 sb_client.get_queue_receiver(servicebus_queue.name, session_id="test")._open_with_retry()
     
-            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                sender.send_messages(ServiceBusMessage("test session sender", session_id="test"))
+#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 sender.send_messages(ServiceBusMessage("test session sender", session_id="test"))
             
-            with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
-                messages = receiver.receive_messages()
-                for message in messages:
-                    assert str(message) == "test session sender"
-                    receiver.complete_message(message)
+#             with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
+#                 messages = receiver.receive_messages()
+#                 for message in messages:
+#                     assert str(message) == "test session sender"
+#                     receiver.complete_message(message)
     
 
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_queue_by_servicebus_client_browse_messages_client(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_queue_by_servicebus_client_browse_messages_client(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
     
-        with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#         with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
     
-            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                for i in range(5):
-                    message = ServiceBusMessage("Test message no. {}".format(i))
-                    sender.send_messages(message)
+#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 for i in range(5):
+#                     message = ServiceBusMessage("Test message no. {}".format(i))
+#                     sender.send_messages(message)
     
-            with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
-                messages = receiver.peek_messages(5)
-                assert len(messages) == 5
-                assert all(isinstance(m, ServiceBusReceivedMessage) for m in messages)
-                for message in messages:
-                    print_message(_logger, message)
-                    with pytest.raises(ValueError):
-                        receiver.complete_message(message)
+#             with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
+#                 messages = receiver.peek_messages(5)
+#                 assert len(messages) == 5
+#                 assert all(isinstance(m, ServiceBusReceivedMessage) for m in messages)
+#                 for message in messages:
+#                     print_message(_logger, message)
+#                     with pytest.raises(ValueError):
+#                         receiver.complete_message(message)
 
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_queue_by_servicebus_client_browse_messages_with_receiver(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_queue_by_servicebus_client_browse_messages_with_receiver(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
     
-        with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#         with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-            receiver = sb_client.get_queue_receiver(servicebus_queue.name,
-                                           max_wait_time=5,
-                                           receive_mode=ServiceBusReceiveMode.PEEK_LOCK)
-            sender = sb_client.get_queue_sender(servicebus_queue.name)
-            with receiver, sender:
-                for i in range(5):
-                    message = ServiceBusMessage(
-                        body="Test message",
-                        application_properties={'key': 'value'},
-                        subject='label',
-                        content_type='application/text',
-                        correlation_id='cid',
-                        message_id='mid',
-                        to='to',
-                        reply_to='reply_to',
-                        time_to_live=timedelta(seconds=60)
-                    )
-                    sender.send_messages(message)
+#             receiver = sb_client.get_queue_receiver(servicebus_queue.name,
+#                                            max_wait_time=5,
+#                                            receive_mode=ServiceBusReceiveMode.PEEK_LOCK)
+#             sender = sb_client.get_queue_sender(servicebus_queue.name)
+#             with receiver, sender:
+#                 for i in range(5):
+#                     message = ServiceBusMessage(
+#                         body="Test message",
+#                         application_properties={'key': 'value'},
+#                         subject='label',
+#                         content_type='application/text',
+#                         correlation_id='cid',
+#                         message_id='mid',
+#                         to='to',
+#                         reply_to='reply_to',
+#                         time_to_live=timedelta(seconds=60)
+#                     )
+#                     sender.send_messages(message)
     
-                messages = receiver.peek_messages(5)
-                assert len(messages) > 0
-                assert all(isinstance(m, ServiceBusReceivedMessage) for m in messages)
-                for message in messages:
-                    print_message(_logger, message)
-                    assert b''.join(message.body) == b'Test message'
-                    assert message.application_properties[b'key'] == b'value'
-                    assert message.subject == 'label'
-                    assert message.content_type == 'application/text'
-                    assert message.correlation_id == 'cid'
-                    assert message.message_id == 'mid'
-                    assert message.to == 'to'
-                    assert message.reply_to == 'reply_to'
-                    assert message.time_to_live == timedelta(seconds=60)
-                    with pytest.raises(ValueError):
-                        receiver.complete_message(message)
+#                 messages = receiver.peek_messages(5)
+#                 assert len(messages) > 0
+#                 assert all(isinstance(m, ServiceBusReceivedMessage) for m in messages)
+#                 for message in messages:
+#                     print_message(_logger, message)
+#                     assert b''.join(message.body) == b'Test message'
+#                     assert message.application_properties[b'key'] == b'value'
+#                     assert message.subject == 'label'
+#                     assert message.content_type == 'application/text'
+#                     assert message.correlation_id == 'cid'
+#                     assert message.message_id == 'mid'
+#                     assert message.to == 'to'
+#                     assert message.reply_to == 'reply_to'
+#                     assert message.time_to_live == timedelta(seconds=60)
+#                     with pytest.raises(ValueError):
+#                         receiver.complete_message(message)
 
-                    sender.send_messages(message)
+#                     sender.send_messages(message)
 
-                cnt = 0
-                for message in receiver:
-                    assert b''.join(message.body) == b'Test message'
-                    assert message.application_properties[b'key'] == b'value'
-                    assert message.subject == 'label'
-                    assert message.content_type == 'application/text'
-                    assert message.correlation_id == 'cid'
-                    assert message.message_id == 'mid'
-                    assert message.to == 'to'
-                    assert message.reply_to == 'reply_to'
-                    assert message.time_to_live == timedelta(seconds=60)
-                    receiver.complete_message(message)
-                    cnt += 1
-                assert cnt == 10
+#                 cnt = 0
+#                 for message in receiver:
+#                     assert b''.join(message.body) == b'Test message'
+#                     assert message.application_properties[b'key'] == b'value'
+#                     assert message.subject == 'label'
+#                     assert message.content_type == 'application/text'
+#                     assert message.correlation_id == 'cid'
+#                     assert message.message_id == 'mid'
+#                     assert message.to == 'to'
+#                     assert message.reply_to == 'reply_to'
+#                     assert message.time_to_live == timedelta(seconds=60)
+#                     receiver.complete_message(message)
+#                     cnt += 1
+#                 assert cnt == 10
     
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_queue_by_servicebus_client_browse_empty_messages(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_queue_by_servicebus_client_browse_empty_messages(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
         
-        with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#         with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
     
-            with sb_client.get_queue_receiver(servicebus_queue.name,
-                                                 max_wait_time=5, 
-                                                 receive_mode=ServiceBusReceiveMode.PEEK_LOCK, 
-                                                 prefetch_count=10) as receiver:
-                messages = receiver.peek_messages(10)
-                assert len(messages) == 0
+#             with sb_client.get_queue_receiver(servicebus_queue.name,
+#                                                  max_wait_time=5, 
+#                                                  receive_mode=ServiceBusReceiveMode.PEEK_LOCK, 
+#                                                  prefetch_count=10) as receiver:
+#                 messages = receiver.peek_messages(10)
+#                 assert len(messages) == 0
     
 
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @CachedServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_queue_by_servicebus_client_fail_send_messages(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @CachedServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_queue_by_servicebus_client_fail_send_messages(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
         
-        with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#         with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-            too_large = "A" * 256 * 1024
+#             too_large = "A" * 256 * 1024
     
-            with sb_client.get_queue_sender(servicebus_queue.name, socket_timeout=0.5) as sender:
-                with pytest.raises(MessageSizeExceededError):
-                    sender.send_messages(ServiceBusMessage(too_large))
+#             with sb_client.get_queue_sender(servicebus_queue.name, socket_timeout=0.5) as sender:
+#                 with pytest.raises(MessageSizeExceededError):
+#                     sender.send_messages(ServiceBusMessage(too_large))
 
-                half_too_large = "A" * int((1024 * 256) / 2)
-                with pytest.raises(MessageSizeExceededError):
-                    sender.send_messages([ServiceBusMessage(half_too_large), ServiceBusMessage(half_too_large)])
+#                 half_too_large = "A" * int((1024 * 256) / 2)
+#                 with pytest.raises(MessageSizeExceededError):
+#                     sender.send_messages([ServiceBusMessage(half_too_large), ServiceBusMessage(half_too_large)])
 
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_queue_by_servicebus_client_renew_message_locks(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_queue_by_servicebus_client_renew_message_locks(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
         
-        with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#         with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
     
-            messages = []
-            locks = 3
-            with sb_client.get_queue_receiver(servicebus_queue.name,
-                                              max_wait_time=5, 
-                                              receive_mode=ServiceBusReceiveMode.PEEK_LOCK, 
-                                              prefetch_count=10) as receiver:
-                with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                    for i in range(locks):
-                        message = ServiceBusMessage("Test message no. {}".format(i))
-                        sender.send_messages(message)
+#             messages = []
+#             locks = 3
+#             with sb_client.get_queue_receiver(servicebus_queue.name,
+#                                               max_wait_time=5, 
+#                                               receive_mode=ServiceBusReceiveMode.PEEK_LOCK, 
+#                                               prefetch_count=10) as receiver:
+#                 with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                     for i in range(locks):
+#                         message = ServiceBusMessage("Test message no. {}".format(i))
+#                         sender.send_messages(message)
     
-                messages.extend(receiver.receive_messages())
-                recv = True
-                while recv:
-                    recv = receiver.receive_messages()
-                    messages.extend(recv)
+#                 messages.extend(receiver.receive_messages())
+#                 recv = True
+#                 while recv:
+#                     recv = receiver.receive_messages()
+#                     messages.extend(recv)
     
-                try:
-                    for message in messages:
-                        assert not message._lock_expired
-                        time.sleep(5)
-                        initial_expiry = message.locked_until_utc
-                        receiver.renew_message_lock(message)
-                        assert (message.locked_until_utc - initial_expiry) >= timedelta(seconds=5)
-                finally:
-                    receiver.complete_message(messages[0])
-                    receiver.complete_message(messages[1])
-                    assert (messages[2].locked_until_utc - utc_now()) <= timedelta(seconds=60)
-                    sleep_until_expired(messages[2])
-                    with pytest.raises(MessageLockLostError):
-                        receiver.complete_message(messages[2])
+#                 try:
+#                     for message in messages:
+#                         assert not message._lock_expired
+#                         time.sleep(5)
+#                         initial_expiry = message.locked_until_utc
+#                         receiver.renew_message_lock(message)
+#                         assert (message.locked_until_utc - initial_expiry) >= timedelta(seconds=5)
+#                 finally:
+#                     receiver.complete_message(messages[0])
+#                     receiver.complete_message(messages[1])
+#                     assert (messages[2].locked_until_utc - utc_now()) <= timedelta(seconds=60)
+#                     sleep_until_expired(messages[2])
+#                     with pytest.raises(MessageLockLostError):
+#                         receiver.complete_message(messages[2])
 
     
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True, lock_duration='PT10S')
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_queue_by_queue_client_conn_str_receive_handler_with_autolockrenew(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True, lock_duration='PT10S')
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_queue_by_queue_client_conn_str_receive_handler_with_autolockrenew(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
         
-        with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#         with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
     
-            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                for i in range(10):
-                    message = ServiceBusMessage("{}".format(i))
-                    sender.send_messages(message)
+#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 for i in range(10):
+#                     message = ServiceBusMessage("{}".format(i))
+#                     sender.send_messages(message)
     
-            renewer = AutoLockRenewer()
-            messages = []
-            with sb_client.get_queue_receiver(servicebus_queue.name,
-                                                 max_wait_time=10,
-                                                 receive_mode=ServiceBusReceiveMode.PEEK_LOCK, 
-                                                 prefetch_count=10) as receiver:
-                for message in receiver:
-                    if not messages:
-                        messages.append(message)
-                        assert not message._lock_expired
-                        renewer.register(receiver, message, max_lock_renewal_duration=10)
-                        print("Registered lock renew thread", message.locked_until_utc, utc_now())
-                        time.sleep(10)
-                        print("Finished first sleep", message.locked_until_utc)
-                        assert not message._lock_expired
-                        time.sleep(15) #generate autolockrenewtimeout error by going one iteration past.
-                        sleep_until_expired(message)
-                        print("Finished second sleep", message.locked_until_utc, utc_now())
-                        assert message._lock_expired
-                        try:
-                            receiver.complete_message(message)
-                            raise AssertionError("Didn't raise MessageLockLostError")
-                        except MessageLockLostError as e:
-                            assert isinstance(e.inner_exception, AutoLockRenewTimeout)
-                    else:
-                        if message._lock_expired:
-                            print("Remaining messages", message.locked_until_utc, utc_now())
-                            assert message._lock_expired
-                            with pytest.raises(MessageLockLostError):
-                                receiver.complete_message(message)
-                        else:
-                            assert message.delivery_count >= 1
-                            print("Remaining messages", message.locked_until_utc, utc_now())
-                            messages.append(message)
-                            receiver.complete_message(message)
-            renewer.close()
-            assert len(messages) == 11
+#             renewer = AutoLockRenewer()
+#             messages = []
+#             with sb_client.get_queue_receiver(servicebus_queue.name,
+#                                                  max_wait_time=10,
+#                                                  receive_mode=ServiceBusReceiveMode.PEEK_LOCK, 
+#                                                  prefetch_count=10) as receiver:
+#                 for message in receiver:
+#                     if not messages:
+#                         messages.append(message)
+#                         assert not message._lock_expired
+#                         renewer.register(receiver, message, max_lock_renewal_duration=10)
+#                         print("Registered lock renew thread", message.locked_until_utc, utc_now())
+#                         time.sleep(10)
+#                         print("Finished first sleep", message.locked_until_utc)
+#                         assert not message._lock_expired
+#                         time.sleep(15) #generate autolockrenewtimeout error by going one iteration past.
+#                         sleep_until_expired(message)
+#                         print("Finished second sleep", message.locked_until_utc, utc_now())
+#                         assert message._lock_expired
+#                         try:
+#                             receiver.complete_message(message)
+#                             raise AssertionError("Didn't raise MessageLockLostError")
+#                         except MessageLockLostError as e:
+#                             assert isinstance(e.inner_exception, AutoLockRenewTimeout)
+#                     else:
+#                         if message._lock_expired:
+#                             print("Remaining messages", message.locked_until_utc, utc_now())
+#                             assert message._lock_expired
+#                             with pytest.raises(MessageLockLostError):
+#                                 receiver.complete_message(message)
+#                         else:
+#                             assert message.delivery_count >= 1
+#                             print("Remaining messages", message.locked_until_utc, utc_now())
+#                             messages.append(message)
+#                             receiver.complete_message(message)
+#             renewer.close()
+#             assert len(messages) == 11
 
-            renewer = AutoLockRenewer(max_workers=8)
-            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                for i in range(10):
-                    message = ServiceBusMessage("{}".format(i))
-                    sender.send_messages(message)
+#             renewer = AutoLockRenewer(max_workers=8)
+#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 for i in range(10):
+#                     message = ServiceBusMessage("{}".format(i))
+#                     sender.send_messages(message)
 
-            with sb_client.get_queue_receiver(servicebus_queue.name,
-                                                 max_wait_time=10,
-                                                 receive_mode=ServiceBusReceiveMode.PEEK_LOCK,
-                                                 prefetch_count=10) as receiver:
-                received_msgs = receiver.receive_messages(max_message_count=10, max_wait_time=5)
-                for msg in received_msgs:
-                    renewer.register(receiver, msg, max_lock_renewal_duration=30)
-                time.sleep(10)
+#             with sb_client.get_queue_receiver(servicebus_queue.name,
+#                                                  max_wait_time=10,
+#                                                  receive_mode=ServiceBusReceiveMode.PEEK_LOCK,
+#                                                  prefetch_count=10) as receiver:
+#                 received_msgs = receiver.receive_messages(max_message_count=10, max_wait_time=5)
+#                 for msg in received_msgs:
+#                     renewer.register(receiver, msg, max_lock_renewal_duration=30)
+#                 time.sleep(10)
 
-                for msg in received_msgs:
-                    receiver.complete_message(msg)
-            assert len(received_msgs) == 10
-            renewer.close()
+#                 for msg in received_msgs:
+#                     receiver.complete_message(msg)
+#             assert len(received_msgs) == 10
+#             renewer.close()
 
-            executor = ThreadPoolExecutor(max_workers=1)
-            renewer = AutoLockRenewer(executor=executor)
-            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                for i in range(2):
-                    message = ServiceBusMessage("{}".format(i))
-                    sender.send_messages(message)
+#             executor = ThreadPoolExecutor(max_workers=1)
+#             renewer = AutoLockRenewer(executor=executor)
+#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 for i in range(2):
+#                     message = ServiceBusMessage("{}".format(i))
+#                     sender.send_messages(message)
 
-            with sb_client.get_queue_receiver(servicebus_queue.name,
-                                                 max_wait_time=10,
-                                                 receive_mode=ServiceBusReceiveMode.PEEK_LOCK,
-                                                 prefetch_count=3) as receiver:
-                received_msgs = receiver.receive_messages(max_message_count=3, max_wait_time=10)
-                for msg in received_msgs:
-                    renewer.register(receiver, msg, max_lock_renewal_duration=30)
-                time.sleep(10)
+#             with sb_client.get_queue_receiver(servicebus_queue.name,
+#                                                  max_wait_time=10,
+#                                                  receive_mode=ServiceBusReceiveMode.PEEK_LOCK,
+#                                                  prefetch_count=3) as receiver:
+#                 received_msgs = receiver.receive_messages(max_message_count=3, max_wait_time=10)
+#                 for msg in received_msgs:
+#                     renewer.register(receiver, msg, max_lock_renewal_duration=30)
+#                 time.sleep(10)
 
-                for msg in received_msgs:
-                    receiver.complete_message(msg)
-            assert len(received_msgs) == 2
-            assert not renewer._is_max_workers_greater_than_one
-            renewer.close()
+#                 for msg in received_msgs:
+#                     receiver.complete_message(msg)
+#             assert len(received_msgs) == 2
+#             assert not renewer._is_max_workers_greater_than_one
+#             renewer.close()
 
-            executor = ThreadPoolExecutor(max_workers=2)
-            renewer = AutoLockRenewer(executor=executor)
-            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                for i in range(3):
-                    message = ServiceBusMessage("{}".format(i))
-                    sender.send_messages(message)
+#             executor = ThreadPoolExecutor(max_workers=2)
+#             renewer = AutoLockRenewer(executor=executor)
+#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 for i in range(3):
+#                     message = ServiceBusMessage("{}".format(i))
+#                     sender.send_messages(message)
 
-            with sb_client.get_queue_receiver(servicebus_queue.name,
-                                                 max_wait_time=10,
-                                                 receive_mode=ServiceBusReceiveMode.PEEK_LOCK,
-                                                 prefetch_count=3) as receiver:
-                received_msgs = receiver.receive_messages(max_message_count=3, max_wait_time=10)
-                for msg in received_msgs:
-                    renewer.register(receiver, msg, max_lock_renewal_duration=30)
-                time.sleep(10)
+#             with sb_client.get_queue_receiver(servicebus_queue.name,
+#                                                  max_wait_time=10,
+#                                                  receive_mode=ServiceBusReceiveMode.PEEK_LOCK,
+#                                                  prefetch_count=3) as receiver:
+#                 received_msgs = receiver.receive_messages(max_message_count=3, max_wait_time=10)
+#                 for msg in received_msgs:
+#                     renewer.register(receiver, msg, max_lock_renewal_duration=30)
+#                 time.sleep(10)
 
-                for msg in received_msgs:
-                    receiver.complete_message(msg)
-            assert len(received_msgs) == 3
-            assert renewer._is_max_workers_greater_than_one
-            renewer.close()
+#                 for msg in received_msgs:
+#                     receiver.complete_message(msg)
+#             assert len(received_msgs) == 3
+#             assert renewer._is_max_workers_greater_than_one
+#             renewer.close()
 
     
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True, lock_duration='PT10S')
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_queue_by_queue_client_conn_str_receive_handler_with_auto_autolockrenew(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True, lock_duration='PT10S')
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_queue_by_queue_client_conn_str_receive_handler_with_auto_autolockrenew(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
         
-        with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#         with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
     
-            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                # The 10 iterations is "important" because it gives time for the timed out message to be received again.
-                for i in range(10):
-                    message = ServiceBusMessage("{}".format(i))
-                    sender.send_messages(message)
+#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 # The 10 iterations is "important" because it gives time for the timed out message to be received again.
+#                 for i in range(10):
+#                     message = ServiceBusMessage("{}".format(i))
+#                     sender.send_messages(message)
     
-            renewer = AutoLockRenewer(max_lock_renewal_duration=10)
-            messages = []
-            with sb_client.get_queue_receiver(servicebus_queue.name,
-                                                 max_wait_time=10,
-                                                 receive_mode=ServiceBusReceiveMode.PEEK_LOCK, 
-                                                 prefetch_count=10,
-                                                 auto_lock_renewer=renewer) as receiver:
-                for message in receiver:
-                    if not messages:
-                        messages.append(message)
-                        assert not message._lock_expired
-                        print("Registered lock renew thread", message.locked_until_utc, utc_now())
-                        time.sleep(10)
-                        print("Finished first sleep", message.locked_until_utc)
-                        assert not message._lock_expired
-                        time.sleep(15) #generate autolockrenewtimeout error by going one iteration past.
-                        sleep_until_expired(message)
-                        print("Finished second sleep", message.locked_until_utc, utc_now())
-                        assert message._lock_expired
-                        try:
-                            receiver.complete_message(message)
-                            raise AssertionError("Didn't raise MessageLockLostError")
-                        except MessageLockLostError as e:
-                            assert isinstance(e.inner_exception, AutoLockRenewTimeout)
-                    else:
-                        if message._lock_expired:
-                            print("Remaining messages", message.locked_until_utc, utc_now())
-                            assert message._lock_expired
-                            with pytest.raises(MessageLockLostError):
-                                receiver.complete_message(message)
-                        else:
-                            assert message.delivery_count >= 1
-                            print("Remaining messages", message.locked_until_utc, utc_now())
-                            messages.append(message)
-                            receiver.complete_message(message)
-            renewer.close()
-            assert len(messages) == 11
+#             renewer = AutoLockRenewer(max_lock_renewal_duration=10)
+#             messages = []
+#             with sb_client.get_queue_receiver(servicebus_queue.name,
+#                                                  max_wait_time=10,
+#                                                  receive_mode=ServiceBusReceiveMode.PEEK_LOCK, 
+#                                                  prefetch_count=10,
+#                                                  auto_lock_renewer=renewer) as receiver:
+#                 for message in receiver:
+#                     if not messages:
+#                         messages.append(message)
+#                         assert not message._lock_expired
+#                         print("Registered lock renew thread", message.locked_until_utc, utc_now())
+#                         time.sleep(10)
+#                         print("Finished first sleep", message.locked_until_utc)
+#                         assert not message._lock_expired
+#                         time.sleep(15) #generate autolockrenewtimeout error by going one iteration past.
+#                         sleep_until_expired(message)
+#                         print("Finished second sleep", message.locked_until_utc, utc_now())
+#                         assert message._lock_expired
+#                         try:
+#                             receiver.complete_message(message)
+#                             raise AssertionError("Didn't raise MessageLockLostError")
+#                         except MessageLockLostError as e:
+#                             assert isinstance(e.inner_exception, AutoLockRenewTimeout)
+#                     else:
+#                         if message._lock_expired:
+#                             print("Remaining messages", message.locked_until_utc, utc_now())
+#                             assert message._lock_expired
+#                             with pytest.raises(MessageLockLostError):
+#                                 receiver.complete_message(message)
+#                         else:
+#                             assert message.delivery_count >= 1
+#                             print("Remaining messages", message.locked_until_utc, utc_now())
+#                             messages.append(message)
+#                             receiver.complete_message(message)
+#             renewer.close()
+#             assert len(messages) == 11
 
     
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_queue_message_time_to_live(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_queue_message_time_to_live(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
         
-        with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#         with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
                
-            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                content = str(uuid.uuid4())
-                message_id = uuid.uuid4()
-                message = ServiceBusMessage(content)
-                message.time_to_live = timedelta(seconds=15)
-                sender.send_messages(message)
+#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 content = str(uuid.uuid4())
+#                 message_id = uuid.uuid4()
+#                 message = ServiceBusMessage(content)
+#                 message.time_to_live = timedelta(seconds=15)
+#                 sender.send_messages(message)
     
-            time.sleep(15)
-            with sb_client.get_queue_receiver(servicebus_queue.name, prefetch_count=5) as receiver:
-                messages = receiver.receive_messages(5, max_wait_time=10)
-            assert not messages
+#             time.sleep(15)
+#             with sb_client.get_queue_receiver(servicebus_queue.name, prefetch_count=5) as receiver:
+#                 messages = receiver.receive_messages(5, max_wait_time=10)
+#             assert not messages
 
-            with sb_client.get_queue_receiver(
-                    servicebus_queue.name,
-                    sub_queue = ServiceBusSubQueue.DEAD_LETTER,
-                    max_wait_time=5,
-                    receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as dl_receiver:
-                count = 0
-                for message in dl_receiver:
-                    print_message(_logger, message)
-                    dl_receiver.complete_message(message)
-                    count += 1
-            assert count == 1
+#             with sb_client.get_queue_receiver(
+#                     servicebus_queue.name,
+#                     sub_queue = ServiceBusSubQueue.DEAD_LETTER,
+#                     max_wait_time=5,
+#                     receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as dl_receiver:
+#                 count = 0
+#                 for message in dl_receiver:
+#                     print_message(_logger, message)
+#                     dl_receiver.complete_message(message)
+#                     count += 1
+#             assert count == 1
 
     
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_duplicate_detection=True, dead_lettering_on_message_expiration=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_queue_message_duplicate_detection(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_duplicate_detection=True, dead_lettering_on_message_expiration=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_queue_message_duplicate_detection(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
         
-        with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#         with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
     
-            message_id = uuid.uuid4()
+#             message_id = uuid.uuid4()
             
-            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                for i in range(5):
-                    message = ServiceBusMessage(str(i))
-                    message.message_id = message_id
-                    sender.send_messages(message)
+#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 for i in range(5):
+#                     message = ServiceBusMessage(str(i))
+#                     message.message_id = message_id
+#                     sender.send_messages(message)
     
-            with sb_client.get_queue_receiver(servicebus_queue.name, 
-                                                 max_wait_time=5) as receiver:
-                count = 0
-                for message in receiver:
-                    print_message(_logger, message)
-                    assert message.message_id == message_id
-                    receiver.complete_message(message)
-                    count += 1
-                assert count == 1
+#             with sb_client.get_queue_receiver(servicebus_queue.name, 
+#                                                  max_wait_time=5) as receiver:
+#                 count = 0
+#                 for message in receiver:
+#                     print_message(_logger, message)
+#                     assert message.message_id == message_id
+#                     receiver.complete_message(message)
+#                     count += 1
+#                 assert count == 1
     
 
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_queue_message_connection_closed(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_queue_message_connection_closed(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
         
-        with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#         with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
                 
-            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                content = str(uuid.uuid4())
-                message = ServiceBusMessage(content)
-                sender.send_messages(message)
+#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 content = str(uuid.uuid4())
+#                 message = ServiceBusMessage(content)
+#                 sender.send_messages(message)
     
-            with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
-                messages = receiver.receive_messages(max_wait_time=10)
-                assert len(messages) == 1
+#             with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
+#                 messages = receiver.receive_messages(max_wait_time=10)
+#                 assert len(messages) == 1
     
-            with pytest.raises(ValueError):
-                receiver.complete_message(messages[0])
+#             with pytest.raises(ValueError):
+#                 receiver.complete_message(messages[0])
     
 
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_queue_message_expiry(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_queue_message_expiry(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
         
-        with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#         with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
                        
-            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                content = str(uuid.uuid4())
-                message = ServiceBusMessage(content)
-                sender.send_messages(message)
+#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 content = str(uuid.uuid4())
+#                 message = ServiceBusMessage(content)
+#                 sender.send_messages(message)
     
-            with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
-                messages = receiver.receive_messages(max_wait_time=10)
-                assert len(messages) == 1
-                time.sleep((messages[0].locked_until_utc - utc_now()).total_seconds()+1)
-                assert messages[0]._lock_expired
-                with pytest.raises(MessageLockLostError):
-                    receiver.complete_message(messages[0])
-                with pytest.raises(MessageLockLostError):
-                    receiver.renew_message_lock(messages[0])
+#             with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
+#                 messages = receiver.receive_messages(max_wait_time=10)
+#                 assert len(messages) == 1
+#                 time.sleep((messages[0].locked_until_utc - utc_now()).total_seconds()+1)
+#                 assert messages[0]._lock_expired
+#                 with pytest.raises(MessageLockLostError):
+#                     receiver.complete_message(messages[0])
+#                 with pytest.raises(MessageLockLostError):
+#                     receiver.renew_message_lock(messages[0])
     
-            with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
-                messages = receiver.receive_messages(max_wait_time=30)
-                assert len(messages) == 1
-                print_message(_logger, messages[0])
-                assert messages[0].delivery_count > 0
-                receiver.complete_message(messages[0])
+#             with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
+#                 messages = receiver.receive_messages(max_wait_time=30)
+#                 assert len(messages) == 1
+#                 print_message(_logger, messages[0])
+#                 assert messages[0].delivery_count > 0
+#                 receiver.complete_message(messages[0])
     
 
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_queue_message_lock_renew(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_queue_message_lock_renew(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
         
-        with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#         with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                content = str(uuid.uuid4())
-                message = ServiceBusMessage(content)
-                sender.send_messages(message)
+#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 content = str(uuid.uuid4())
+#                 message = ServiceBusMessage(content)
+#                 sender.send_messages(message)
 
-            with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
-                messages = receiver.receive_messages(max_wait_time=10)
-                assert len(messages) == 1
-                time.sleep(15)
-                receiver.renew_message_lock(messages[0])
-                time.sleep(15)
-                receiver.renew_message_lock(messages[0])
-                time.sleep(15)
-                assert not messages[0]._lock_expired
-                receiver.complete_message(messages[0])
+#             with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
+#                 messages = receiver.receive_messages(max_wait_time=10)
+#                 assert len(messages) == 1
+#                 time.sleep(15)
+#                 receiver.renew_message_lock(messages[0])
+#                 time.sleep(15)
+#                 receiver.renew_message_lock(messages[0])
+#                 time.sleep(15)
+#                 assert not messages[0]._lock_expired
+#                 receiver.complete_message(messages[0])
     
-            with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
-                messages = receiver.receive_messages(max_wait_time=10)
-                assert len(messages) == 0
+#             with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
+#                 messages = receiver.receive_messages(max_wait_time=10)
+#                 assert len(messages) == 0
     
 
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True, lock_duration='PT10S')
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_queue_message_receive_and_delete(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        if uamqp:
-            transport_type = uamqp.constants.TransportType.Amqp
-        else:
-            transport_type = TransportType.Amqp
-        with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string,
-            logging_enable=False,
-            transport_time=transport_type,
-            uamqp_transport=uamqp_transport
-        ) as sb_client:
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True, lock_duration='PT10S')
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_queue_message_receive_and_delete(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         if uamqp:
+#             transport_type = uamqp.constants.TransportType.Amqp
+#         else:
+#             transport_type = TransportType.Amqp
+#         with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string,
+#             logging_enable=False,
+#             transport_time=transport_type,
+#             uamqp_transport=uamqp_transport
+#         ) as sb_client:
                 
-            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                message = ServiceBusMessage("Receive and delete test")
-                sender.send_messages(message)
+#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 message = ServiceBusMessage("Receive and delete test")
+#                 sender.send_messages(message)
     
-            with sb_client.get_queue_receiver(servicebus_queue.name,
-                                                 receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE) as receiver:
-                messages = receiver.receive_messages(max_wait_time=10)
-                assert len(messages) == 1
-                message = messages[0]
-                print_message(_logger, message)
-                with pytest.raises(ValueError):
-                    receiver.complete_message(message)
-                with pytest.raises(ValueError):
-                    receiver.abandon_message(message)
-                with pytest.raises(ValueError):
-                    receiver.defer_message(message)
-                with pytest.raises(ValueError):
-                    receiver.dead_letter_message(message)
-                with pytest.raises(ValueError):
-                    receiver.renew_message_lock(message)
+#             with sb_client.get_queue_receiver(servicebus_queue.name,
+#                                                  receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE) as receiver:
+#                 messages = receiver.receive_messages(max_wait_time=10)
+#                 assert len(messages) == 1
+#                 message = messages[0]
+#                 print_message(_logger, message)
+#                 with pytest.raises(ValueError):
+#                     receiver.complete_message(message)
+#                 with pytest.raises(ValueError):
+#                     receiver.abandon_message(message)
+#                 with pytest.raises(ValueError):
+#                     receiver.defer_message(message)
+#                 with pytest.raises(ValueError):
+#                     receiver.dead_letter_message(message)
+#                 with pytest.raises(ValueError):
+#                     receiver.renew_message_lock(message)
     
-            time.sleep(10)
+#             time.sleep(10)
     
-            with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
-                messages = receiver.receive_messages(max_wait_time=10)
-                for m in messages:
-                    print_message(_logger, m)
-                assert len(messages) == 0
+#             with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
+#                 messages = receiver.receive_messages(max_wait_time=10)
+#                 for m in messages:
+#                     print_message(_logger, m)
+#                 assert len(messages) == 0
     
 
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_queue_message_batch(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_queue_message_batch(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
 
-        with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#         with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
                             
-            def message_content():
-                for i in range(5):
-                    message = ServiceBusMessage("ServiceBusMessage no. {}".format(i))
-                    message.application_properties = {'key': 'value'}
-                    message.subject = 'label'
-                    message.content_type = 'application/text'
-                    message.correlation_id = 'cid'
-                    message.message_id = str(i)
-                    message.to = 'to'
-                    message.reply_to = 'reply_to'
-                    message.time_to_live = timedelta(seconds=60)
-                    assert message.raw_amqp_message.properties.absolute_expiry_time == message.raw_amqp_message.properties.creation_time + message.raw_amqp_message.header.time_to_live
+#             def message_content():
+#                 for i in range(5):
+#                     message = ServiceBusMessage("ServiceBusMessage no. {}".format(i))
+#                     message.application_properties = {'key': 'value'}
+#                     message.subject = 'label'
+#                     message.content_type = 'application/text'
+#                     message.correlation_id = 'cid'
+#                     message.message_id = str(i)
+#                     message.to = 'to'
+#                     message.reply_to = 'reply_to'
+#                     message.time_to_live = timedelta(seconds=60)
+#                     assert message.raw_amqp_message.properties.absolute_expiry_time == message.raw_amqp_message.properties.creation_time + message.raw_amqp_message.header.time_to_live
 
-                    yield message
+#                     yield message
 
-            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                # sending manually created message batch (with default pyamqp) should work for both uamqp/pyamqp
-                message = ServiceBusMessageBatch()
-                for each in message_content():
-                    message.add_message(each)
-                sender.send_messages(message)
+#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 # sending manually created message batch (with default pyamqp) should work for both uamqp/pyamqp
+#                 message = ServiceBusMessageBatch()
+#                 for each in message_content():
+#                     message.add_message(each)
+#                 sender.send_messages(message)
     
-            with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
-                messages =receiver.receive_messages(max_wait_time=10)
-                recv = True
-                while recv:
-                    recv = receiver.receive_messages(max_wait_time=10)
-                    messages.extend(recv)
+#             with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
+#                 messages =receiver.receive_messages(max_wait_time=10)
+#                 recv = True
+#                 while recv:
+#                     recv = receiver.receive_messages(max_wait_time=10)
+#                     messages.extend(recv)
     
-                assert len(messages) == 5
-                count = 0
-                for message in messages:
-                    assert message.delivery_count == 0
-                    assert message.application_properties
-                    assert message.application_properties[b'key'] == b'value'
-                    assert message.subject == 'label'
-                    assert message.content_type == 'application/text'
-                    assert message.correlation_id == 'cid'
-                    assert message.message_id == str(count)
-                    assert message.to == 'to'
-                    assert message.reply_to == 'reply_to'
-                    assert message.sequence_number
-                    assert message.enqueued_time_utc
-                    assert message.expires_at_utc == (message.enqueued_time_utc + timedelta(seconds=60))
-                    print_message(_logger, message)
-                    receiver.complete_message(message)
-                    count += 1
+#                 assert len(messages) == 5
+#                 count = 0
+#                 for message in messages:
+#                     assert message.delivery_count == 0
+#                     assert message.application_properties
+#                     assert message.application_properties[b'key'] == b'value'
+#                     assert message.subject == 'label'
+#                     assert message.content_type == 'application/text'
+#                     assert message.correlation_id == 'cid'
+#                     assert message.message_id == str(count)
+#                     assert message.to == 'to'
+#                     assert message.reply_to == 'reply_to'
+#                     assert message.sequence_number
+#                     assert message.enqueued_time_utc
+#                     assert message.expires_at_utc == (message.enqueued_time_utc + timedelta(seconds=60))
+#                     print_message(_logger, message)
+#                     receiver.complete_message(message)
+#                     count += 1
     
 
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_queue_schedule_message(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_queue_schedule_message(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
 
-        with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#         with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-            scheduled_enqueue_time = (utc_now() + timedelta(minutes=2)).replace(microsecond=0)
-            with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
-                with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                    content = str(uuid.uuid4())
-                    message_id = uuid.uuid4()
-                    message = ServiceBusMessage(content)
-                    message.message_id = message_id
-                    message.scheduled_enqueue_time_utc = scheduled_enqueue_time
-                    sender.send_messages(message)
+#             scheduled_enqueue_time = (utc_now() + timedelta(minutes=2)).replace(microsecond=0)
+#             with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
+#                 with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                     content = str(uuid.uuid4())
+#                     message_id = uuid.uuid4()
+#                     message = ServiceBusMessage(content)
+#                     message.message_id = message_id
+#                     message.scheduled_enqueue_time_utc = scheduled_enqueue_time
+#                     sender.send_messages(message)
     
-                messages = receiver.receive_messages(max_wait_time=120)
-                if messages:
-                    try:
-                        data = str(messages[0])
-                        assert data == content
-                        assert messages[0].message_id == message_id
-                        assert messages[0].scheduled_enqueue_time_utc == scheduled_enqueue_time
-                        assert messages[0].scheduled_enqueue_time_utc <= messages[0].enqueued_time_utc.replace(microsecond=0)
-                        assert len(messages) == 1
-                    finally:
-                        for message in messages:
-                            receiver.complete_message(message)
-                else:
-                    raise Exception("Failed to receive schdeduled message.")
+#                 messages = receiver.receive_messages(max_wait_time=120)
+#                 if messages:
+#                     try:
+#                         data = str(messages[0])
+#                         assert data == content
+#                         assert messages[0].message_id == message_id
+#                         assert messages[0].scheduled_enqueue_time_utc == scheduled_enqueue_time
+#                         assert messages[0].scheduled_enqueue_time_utc <= messages[0].enqueued_time_utc.replace(microsecond=0)
+#                         assert len(messages) == 1
+#                     finally:
+#                         for message in messages:
+#                             receiver.complete_message(message)
+#                 else:
+#                     raise Exception("Failed to receive schdeduled message.")
             
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_queue_schedule_multiple_messages(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_queue_schedule_multiple_messages(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
 
-        with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#         with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-            scheduled_enqueue_time = (utc_now() + timedelta(minutes=2)).replace(microsecond=0)
-            sender = sb_client.get_queue_sender(servicebus_queue.name)
-            receiver = sb_client.get_queue_receiver(servicebus_queue.name, prefetch_count=20, max_wait_time=5)
+#             scheduled_enqueue_time = (utc_now() + timedelta(minutes=2)).replace(microsecond=0)
+#             sender = sb_client.get_queue_sender(servicebus_queue.name)
+#             receiver = sb_client.get_queue_receiver(servicebus_queue.name, prefetch_count=20, max_wait_time=5)
 
-            with sender, receiver:
-                content = str(uuid.uuid4())
-                message_id_a = uuid.uuid4()
-                message_a = ServiceBusMessage(content)
-                message_a.message_id = message_id_a
-                message_id_b = uuid.uuid4()
-                message_b = ServiceBusMessage(content)
-                message_b.message_id = message_id_b
-                message_arry = [message_a, message_b]
-                for message in message_arry:
-                    message.application_properties = {'key': 'value'}
-                    message.subject = 'label'
-                    message.content_type = 'application/text'
-                    message.correlation_id = 'cid'
-                    message.to = 'to'
-                    message.reply_to = 'reply_to'
+#             with sender, receiver:
+#                 content = str(uuid.uuid4())
+#                 message_id_a = uuid.uuid4()
+#                 message_a = ServiceBusMessage(content)
+#                 message_a.message_id = message_id_a
+#                 message_id_b = uuid.uuid4()
+#                 message_b = ServiceBusMessage(content)
+#                 message_b.message_id = message_id_b
+#                 message_arry = [message_a, message_b]
+#                 for message in message_arry:
+#                     message.application_properties = {'key': 'value'}
+#                     message.subject = 'label'
+#                     message.content_type = 'application/text'
+#                     message.correlation_id = 'cid'
+#                     message.to = 'to'
+#                     message.reply_to = 'reply_to'
 
-                sender.send_messages(message_arry)
+#                 sender.send_messages(message_arry)
 
-                received_messages = []
-                for message in receiver:
-                    received_messages.append(message)
-                    receiver.complete_message(message)
+#                 received_messages = []
+#                 for message in receiver:
+#                     received_messages.append(message)
+#                     receiver.complete_message(message)
 
-                tokens = sender.schedule_messages(received_messages, scheduled_enqueue_time)
-                assert len(tokens) == 2
+#                 tokens = sender.schedule_messages(received_messages, scheduled_enqueue_time)
+#                 assert len(tokens) == 2
     
-                messages = receiver.receive_messages(max_wait_time=120)
-                messages.extend(receiver.receive_messages(max_wait_time=5))
-                if messages:
-                    try:
-                        data = str(messages[0])
-                        assert data == content
-                        assert messages[0].message_id in (message_id_a, message_id_b)
-                        assert messages[0].scheduled_enqueue_time_utc == scheduled_enqueue_time
-                        assert messages[0].scheduled_enqueue_time_utc <= messages[0].enqueued_time_utc.replace(microsecond=0)
-                        assert messages[0].delivery_count == 0
-                        assert messages[0].application_properties
-                        assert messages[0].application_properties[b'key'] == b'value'
-                        assert messages[0].subject == 'label'
-                        assert messages[0].content_type == 'application/text'
-                        assert messages[0].correlation_id == 'cid'
-                        assert messages[0].to == 'to'
-                        assert messages[0].reply_to == 'reply_to'
-                        assert messages[0].sequence_number
-                        assert messages[0].enqueued_time_utc
-                        assert messages[0].message.delivery_tag is not None
-                        assert len(messages) == 2
+#                 messages = receiver.receive_messages(max_wait_time=120)
+#                 messages.extend(receiver.receive_messages(max_wait_time=5))
+#                 if messages:
+#                     try:
+#                         data = str(messages[0])
+#                         assert data == content
+#                         assert messages[0].message_id in (message_id_a, message_id_b)
+#                         assert messages[0].scheduled_enqueue_time_utc == scheduled_enqueue_time
+#                         assert messages[0].scheduled_enqueue_time_utc <= messages[0].enqueued_time_utc.replace(microsecond=0)
+#                         assert messages[0].delivery_count == 0
+#                         assert messages[0].application_properties
+#                         assert messages[0].application_properties[b'key'] == b'value'
+#                         assert messages[0].subject == 'label'
+#                         assert messages[0].content_type == 'application/text'
+#                         assert messages[0].correlation_id == 'cid'
+#                         assert messages[0].to == 'to'
+#                         assert messages[0].reply_to == 'reply_to'
+#                         assert messages[0].sequence_number
+#                         assert messages[0].enqueued_time_utc
+#                         assert messages[0].message.delivery_tag is not None
+#                         assert len(messages) == 2
 
-                        if not uamqp_transport:
-                            pickled = pickle.loads(pickle.dumps(messages[0]))
-                            assert pickled.message_id == messages[0].message_id
-                            assert pickled.scheduled_enqueue_time_utc == messages[0].scheduled_enqueue_time_utc
-                            assert pickled.scheduled_enqueue_time_utc <= pickled.enqueued_time_utc.replace(microsecond=0)
-                            assert pickled.delivery_count == messages[0].delivery_count
-                            assert pickled.application_properties == messages[0].application_properties
-                            assert pickled.application_properties[b'key'] == messages[0].application_properties[b'key']
-                            assert pickled.subject == messages[0].subject
-                            assert pickled.content_type == messages[0].content_type
-                            assert pickled.correlation_id == messages[0].correlation_id
-                            assert pickled.to == messages[0].to
-                            assert pickled.reply_to == messages[0].reply_to
-                            assert pickled.sequence_number
-                            assert pickled.enqueued_time_utc
-                    finally:
-                        for message in messages:
-                            receiver.complete_message(message)
-                else:
-                    raise Exception("Failed to receive schdeduled message.")
+#                         if not uamqp_transport:
+#                             pickled = pickle.loads(pickle.dumps(messages[0]))
+#                             assert pickled.message_id == messages[0].message_id
+#                             assert pickled.scheduled_enqueue_time_utc == messages[0].scheduled_enqueue_time_utc
+#                             assert pickled.scheduled_enqueue_time_utc <= pickled.enqueued_time_utc.replace(microsecond=0)
+#                             assert pickled.delivery_count == messages[0].delivery_count
+#                             assert pickled.application_properties == messages[0].application_properties
+#                             assert pickled.application_properties[b'key'] == messages[0].application_properties[b'key']
+#                             assert pickled.subject == messages[0].subject
+#                             assert pickled.content_type == messages[0].content_type
+#                             assert pickled.correlation_id == messages[0].correlation_id
+#                             assert pickled.to == messages[0].to
+#                             assert pickled.reply_to == messages[0].reply_to
+#                             assert pickled.sequence_number
+#                             assert pickled.enqueued_time_utc
+#                     finally:
+#                         for message in messages:
+#                             receiver.complete_message(message)
+#                 else:
+#                     raise Exception("Failed to receive schdeduled message.")
 
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_queue_cancel_scheduled_messages(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_queue_cancel_scheduled_messages(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
         
-        with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#         with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-            enqueue_time = (utc_now() + timedelta(minutes=2)).replace(microsecond=0)
-            with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
-                with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                    message_a = ServiceBusMessage("Test scheduled message")
-                    message_b = ServiceBusMessage("Test scheduled message")
-                    tokens = sender.schedule_messages([message_a, message_b], enqueue_time)
-                    assert len(tokens) == 2
+#             enqueue_time = (utc_now() + timedelta(minutes=2)).replace(microsecond=0)
+#             with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
+#                 with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                     message_a = ServiceBusMessage("Test scheduled message")
+#                     message_b = ServiceBusMessage("Test scheduled message")
+#                     tokens = sender.schedule_messages([message_a, message_b], enqueue_time)
+#                     assert len(tokens) == 2
     
-                    sender.cancel_scheduled_messages(tokens)
+#                     sender.cancel_scheduled_messages(tokens)
     
-                messages = receiver.receive_messages(max_wait_time=120)
-                try:
-                    assert len(messages) == 0
-                except AssertionError:
-                    for message in messages:
-                        print(str(message))
-                        receiver.complete_message(message)
-                    raise
+#                 messages = receiver.receive_messages(max_wait_time=120)
+#                 try:
+#                     assert len(messages) == 0
+#                 except AssertionError:
+#                     for message in messages:
+#                         print(str(message))
+#                         receiver.complete_message(message)
+#                     raise
 
 
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_queue_message_amqp_over_websocket(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        with ServiceBusClient.from_connection_string(
-                servicebus_namespace_connection_string,
-                transport_type=TransportType.AmqpOverWebsocket,
-                logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_queue_message_amqp_over_websocket(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         with ServiceBusClient.from_connection_string(
+#                 servicebus_namespace_connection_string,
+#                 transport_type=TransportType.AmqpOverWebsocket,
+#                 logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                assert sender._config.transport_type == TransportType.AmqpOverWebsocket
-                message = ServiceBusMessage("Test")
-                sender.send_messages(message)
+#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 assert sender._config.transport_type == TransportType.AmqpOverWebsocket
+#                 message = ServiceBusMessage("Test")
+#                 sender.send_messages(message)
 
-            with sb_client.get_queue_receiver(servicebus_queue.name, receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE) as receiver:
-                assert receiver._config.transport_type == TransportType.AmqpOverWebsocket
-                messages = receiver.receive_messages(max_wait_time=5)
-                assert len(messages) == 1
+#             with sb_client.get_queue_receiver(servicebus_queue.name, receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE) as receiver:
+#                 assert receiver._config.transport_type == TransportType.AmqpOverWebsocket
+#                 messages = receiver.receive_messages(max_wait_time=5)
+#                 assert len(messages) == 1
 
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    def test_queue_message_http_proxy_setting(self, uamqp_transport):
-        mock_conn_str = "Endpoint=sb://mock.servicebus.windows.net/;SharedAccessKeyName=mock;SharedAccessKey=mock"
-        http_proxy = {
-            'proxy_hostname': '127.0.0.1',
-            'proxy_port': 8899,
-            'username': 'admin',
-            'password': '123456'
-        }
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     def test_queue_message_http_proxy_setting(self, uamqp_transport):
+#         mock_conn_str = "Endpoint=sb://mock.servicebus.windows.net/;SharedAccessKeyName=mock;SharedAccessKey=mock"
+#         http_proxy = {
+#             'proxy_hostname': '127.0.0.1',
+#             'proxy_port': 8899,
+#             'username': 'admin',
+#             'password': '123456'
+#         }
 
-        sb_client = ServiceBusClient.from_connection_string(mock_conn_str, http_proxy=http_proxy, uamqp_transport=uamqp_transport)
-        assert sb_client._config.http_proxy == http_proxy
-        assert sb_client._config.transport_type == TransportType.AmqpOverWebsocket
+#         sb_client = ServiceBusClient.from_connection_string(mock_conn_str, http_proxy=http_proxy, uamqp_transport=uamqp_transport)
+#         assert sb_client._config.http_proxy == http_proxy
+#         assert sb_client._config.transport_type == TransportType.AmqpOverWebsocket
 
-        sender = sb_client.get_queue_sender(queue_name="mock")
-        assert sender._config.http_proxy == http_proxy
-        assert sender._config.transport_type == TransportType.AmqpOverWebsocket
+#         sender = sb_client.get_queue_sender(queue_name="mock")
+#         assert sender._config.http_proxy == http_proxy
+#         assert sender._config.transport_type == TransportType.AmqpOverWebsocket
 
-        receiver = sb_client.get_queue_receiver(queue_name="mock")
-        assert receiver._config.http_proxy == http_proxy
-        assert receiver._config.transport_type == TransportType.AmqpOverWebsocket
+#         receiver = sb_client.get_queue_receiver(queue_name="mock")
+#         assert receiver._config.http_proxy == http_proxy
+#         assert receiver._config.transport_type == TransportType.AmqpOverWebsocket
 
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_queue_message_settle_through_mgmt_link_due_to_broken_receiver_link(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        with ServiceBusClient.from_connection_string(
-                servicebus_namespace_connection_string,
-                logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_queue_message_settle_through_mgmt_link_due_to_broken_receiver_link(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         with ServiceBusClient.from_connection_string(
+#                 servicebus_namespace_connection_string,
+#                 logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                message = ServiceBusMessage("Test")
-                sender.send_messages(message)
+#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 message = ServiceBusMessage("Test")
+#                 sender.send_messages(message)
 
-            with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
-                messages = receiver.receive_messages(max_wait_time=5)
-                # destroy the underlying receiver link
-                if uamqp_transport:
-                    receiver._handler.message_handler.destroy()
-                else:
-                    receiver._handler._link.detach()
-                assert len(messages) == 1
-                receiver.complete_message(messages[0])
+#             with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
+#                 messages = receiver.receive_messages(max_wait_time=5)
+#                 # destroy the underlying receiver link
+#                 if uamqp_transport:
+#                     receiver._handler.message_handler.destroy()
+#                 else:
+#                     receiver._handler._link.detach()
+#                 assert len(messages) == 1
+#                 receiver.complete_message(messages[0])
 
-    @unittest.skip('hard to test')
-    def test_queue_mock_auto_lock_renew_callback(self):
-        # A warning to future devs: If the renew period override heuristic in registration
-        # ever changes, it may break this (since it adjusts renew period if it is not short enough)
+#     @unittest.skip('hard to test')
+#     def test_queue_mock_auto_lock_renew_callback(self):
+#         # A warning to future devs: If the renew period override heuristic in registration
+#         # ever changes, it may break this (since it adjusts renew period if it is not short enough)
 
-        results = []
-        errors = []
-        def callback_mock(renewable, error):
-            results.append(renewable)
-            if error:
-                errors.append(error)
+#         results = []
+#         errors = []
+#         def callback_mock(renewable, error):
+#             results.append(renewable)
+#             if error:
+#                 errors.append(error)
 
-        receiver = MockReceiver()
-        auto_lock_renew = AutoLockRenewer()
-        with pytest.raises(TypeError):
-            auto_lock_renew.register(Exception())  # an arbitrary invalid type.
+#         receiver = MockReceiver()
+#         auto_lock_renew = AutoLockRenewer()
+#         with pytest.raises(TypeError):
+#             auto_lock_renew.register(Exception())  # an arbitrary invalid type.
 
-        auto_lock_renew = AutoLockRenewer()
-        auto_lock_renew._renew_period = 1 # So we can run the test fast.
-        with auto_lock_renew: # Check that it is called when the object expires for any reason (silent renew failure)
-            message = MockReceivedMessage(prevent_renew_lock=True)
-            auto_lock_renew.register(receiver, renewable=message, on_lock_renew_failure=callback_mock)
-            time.sleep(3)
-            assert len(results) == 1 and results[-1]._lock_expired is True
-            assert not errors
+#         auto_lock_renew = AutoLockRenewer()
+#         auto_lock_renew._renew_period = 1 # So we can run the test fast.
+#         with auto_lock_renew: # Check that it is called when the object expires for any reason (silent renew failure)
+#             message = MockReceivedMessage(prevent_renew_lock=True)
+#             auto_lock_renew.register(receiver, renewable=message, on_lock_renew_failure=callback_mock)
+#             time.sleep(3)
+#             assert len(results) == 1 and results[-1]._lock_expired is True
+#             assert not errors
 
-        del results[:]
-        del errors[:]
-        auto_lock_renew = AutoLockRenewer()
-        auto_lock_renew._renew_period = 1
-        with auto_lock_renew: # Check that in normal operation it does not get called
-            auto_lock_renew.register(receiver, renewable=MockReceivedMessage(lock_duration=5), on_lock_renew_failure=callback_mock)
-            time.sleep(6)
-            assert not results
-            assert not errors
+#         del results[:]
+#         del errors[:]
+#         auto_lock_renew = AutoLockRenewer()
+#         auto_lock_renew._renew_period = 1
+#         with auto_lock_renew: # Check that in normal operation it does not get called
+#             auto_lock_renew.register(receiver, renewable=MockReceivedMessage(lock_duration=5), on_lock_renew_failure=callback_mock)
+#             time.sleep(6)
+#             assert not results
+#             assert not errors
 
-        del results[:]
-        del errors[:]
-        auto_lock_renew = AutoLockRenewer()
-        auto_lock_renew._renew_period = 1
-        with auto_lock_renew: # Check that when a message is settled, it will not get called even after expiry
-            message = MockReceivedMessage(prevent_renew_lock=True)
-            auto_lock_renew.register(receiver, renewable=message, on_lock_renew_failure=callback_mock)
-            message._settled = True
-            time.sleep(3)
-            assert not results
-            assert not errors
+#         del results[:]
+#         del errors[:]
+#         auto_lock_renew = AutoLockRenewer()
+#         auto_lock_renew._renew_period = 1
+#         with auto_lock_renew: # Check that when a message is settled, it will not get called even after expiry
+#             message = MockReceivedMessage(prevent_renew_lock=True)
+#             auto_lock_renew.register(receiver, renewable=message, on_lock_renew_failure=callback_mock)
+#             message._settled = True
+#             time.sleep(3)
+#             assert not results
+#             assert not errors
 
-        del results[:]
-        del errors[:]
-        auto_lock_renew = AutoLockRenewer()
-        auto_lock_renew._renew_period = 1
-        with auto_lock_renew: # Check that it is called when there is an overt renew failure
-            message = MockReceivedMessage(exception_on_renew_lock=True)
-            auto_lock_renew.register(receiver, renewable=message, on_lock_renew_failure=callback_mock)
-            time.sleep(3)
-            assert len(results) == 1 and results[-1]._lock_expired == True
-            assert errors[-1]
+#         del results[:]
+#         del errors[:]
+#         auto_lock_renew = AutoLockRenewer()
+#         auto_lock_renew._renew_period = 1
+#         with auto_lock_renew: # Check that it is called when there is an overt renew failure
+#             message = MockReceivedMessage(exception_on_renew_lock=True)
+#             auto_lock_renew.register(receiver, renewable=message, on_lock_renew_failure=callback_mock)
+#             time.sleep(3)
+#             assert len(results) == 1 and results[-1]._lock_expired == True
+#             assert errors[-1]
 
-        del results[:]
-        del errors[:]
-        auto_lock_renew = AutoLockRenewer()
-        auto_lock_renew._renew_period = 1
-        with auto_lock_renew: # Check that it is not called when the renewer is shutdown
-            message = MockReceivedMessage(prevent_renew_lock=True)
-            auto_lock_renew.register(receiver, renewable=message, on_lock_renew_failure=callback_mock)
-            auto_lock_renew.close()
-            time.sleep(3)
-            assert not results
-            assert not errors
+#         del results[:]
+#         del errors[:]
+#         auto_lock_renew = AutoLockRenewer()
+#         auto_lock_renew._renew_period = 1
+#         with auto_lock_renew: # Check that it is not called when the renewer is shutdown
+#             message = MockReceivedMessage(prevent_renew_lock=True)
+#             auto_lock_renew.register(receiver, renewable=message, on_lock_renew_failure=callback_mock)
+#             auto_lock_renew.close()
+#             time.sleep(3)
+#             assert not results
+#             assert not errors
 
-        del results[:]
-        del errors[:]
-        auto_lock_renew = AutoLockRenewer()
-        auto_lock_renew._renew_period = 1
-        with auto_lock_renew: # Check that it is not called when the receiver is shutdown
-            message = MockReceivedMessage(prevent_renew_lock=True)
-            auto_lock_renew.register(receiver, renewable=message, on_lock_renew_failure=callback_mock)
-            message._receiver._running = False
-            time.sleep(3)
-            assert not results
-            assert not errors
+#         del results[:]
+#         del errors[:]
+#         auto_lock_renew = AutoLockRenewer()
+#         auto_lock_renew._renew_period = 1
+#         with auto_lock_renew: # Check that it is not called when the receiver is shutdown
+#             message = MockReceivedMessage(prevent_renew_lock=True)
+#             auto_lock_renew.register(receiver, renewable=message, on_lock_renew_failure=callback_mock)
+#             message._receiver._running = False
+#             time.sleep(3)
+#             assert not results
+#             assert not errors
 
-    def test_queue_mock_no_reusing_auto_lock_renew(self):
+#     def test_queue_mock_no_reusing_auto_lock_renew(self):
 
-        receiver = MockReceiver()
-        auto_lock_renew = AutoLockRenewer()
-        auto_lock_renew._renew_period = 1 # So we can run the test fast.
-        with auto_lock_renew:
-            auto_lock_renew.register(receiver, renewable=MockReceivedMessage())
-            time.sleep(3)
+#         receiver = MockReceiver()
+#         auto_lock_renew = AutoLockRenewer()
+#         auto_lock_renew._renew_period = 1 # So we can run the test fast.
+#         with auto_lock_renew:
+#             auto_lock_renew.register(receiver, renewable=MockReceivedMessage())
+#             time.sleep(3)
 
-        with pytest.raises(ServiceBusError):
-            with auto_lock_renew:
-                pass
+#         with pytest.raises(ServiceBusError):
+#             with auto_lock_renew:
+#                 pass
 
-        with pytest.raises(ServiceBusError):
-            auto_lock_renew.register(receiver, renewable=MockReceivedMessage())
+#         with pytest.raises(ServiceBusError):
+#             auto_lock_renew.register(receiver, renewable=MockReceivedMessage())
 
-        auto_lock_renew = AutoLockRenewer()
-        auto_lock_renew._renew_period = 1
+#         auto_lock_renew = AutoLockRenewer()
+#         auto_lock_renew._renew_period = 1
 
-        with auto_lock_renew:
-            auto_lock_renew.register(receiver, renewable=MockReceivedMessage())
-            time.sleep(3)
+#         with auto_lock_renew:
+#             auto_lock_renew.register(receiver, renewable=MockReceivedMessage())
+#             time.sleep(3)
 
-        auto_lock_renew.close()
+#         auto_lock_renew.close()
 
-        with pytest.raises(ServiceBusError):
-            with auto_lock_renew:
-                pass
+#         with pytest.raises(ServiceBusError):
+#             with auto_lock_renew:
+#                 pass
 
-        with pytest.raises(ServiceBusError):
-            auto_lock_renew.register(receiver, renewable=MockReceivedMessage())
+#         with pytest.raises(ServiceBusError):
+#             auto_lock_renew.register(receiver, renewable=MockReceivedMessage())
 
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    def test_queue_message_properties(self, uamqp_transport):
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     def test_queue_message_properties(self, uamqp_transport):
 
-        scheduled_enqueue_time = (utc_now() + timedelta(seconds=20)).replace(microsecond=0)
-        message = ServiceBusMessage(
-            body='data',
-            application_properties={'key': 'value'},
-            session_id='sid',
-            subject='label',
-            content_type='application/text',
-            correlation_id='cid',
-            message_id='mid',
-            to='to',
-            reply_to='reply_to',
-            reply_to_session_id='reply_to_sid',
-            scheduled_enqueue_time_utc=scheduled_enqueue_time
-        )
+#         scheduled_enqueue_time = (utc_now() + timedelta(seconds=20)).replace(microsecond=0)
+#         message = ServiceBusMessage(
+#             body='data',
+#             application_properties={'key': 'value'},
+#             session_id='sid',
+#             subject='label',
+#             content_type='application/text',
+#             correlation_id='cid',
+#             message_id='mid',
+#             to='to',
+#             reply_to='reply_to',
+#             reply_to_session_id='reply_to_sid',
+#             scheduled_enqueue_time_utc=scheduled_enqueue_time
+#         )
 
-        assert message.application_properties
-        assert message.application_properties['key'] == 'value'
-        assert message.subject == 'label'
-        assert message.content_type == 'application/text'
-        assert message.correlation_id == 'cid'
-        assert message.message_id == 'mid'
-        assert message.to == 'to'
-        assert message.reply_to == 'reply_to'
-        assert message.session_id == 'sid'
-        assert message.reply_to_session_id == 'reply_to_sid'
-        assert message.scheduled_enqueue_time_utc == scheduled_enqueue_time
+#         assert message.application_properties
+#         assert message.application_properties['key'] == 'value'
+#         assert message.subject == 'label'
+#         assert message.content_type == 'application/text'
+#         assert message.correlation_id == 'cid'
+#         assert message.message_id == 'mid'
+#         assert message.to == 'to'
+#         assert message.reply_to == 'reply_to'
+#         assert message.session_id == 'sid'
+#         assert message.reply_to_session_id == 'reply_to_sid'
+#         assert message.scheduled_enqueue_time_utc == scheduled_enqueue_time
 
-        message.partition_key = 'sid'
-        new_scheduled_time = (utc_now() + timedelta(hours=5)).replace(microsecond=0)
-        message.scheduled_enqueue_time_utc = new_scheduled_time
-        assert message.scheduled_enqueue_time_utc == new_scheduled_time
+#         message.partition_key = 'sid'
+#         new_scheduled_time = (utc_now() + timedelta(hours=5)).replace(microsecond=0)
+#         message.scheduled_enqueue_time_utc = new_scheduled_time
+#         assert message.scheduled_enqueue_time_utc == new_scheduled_time
 
-        message.via_partition_key = None
-        message.scheduled_enqueue_time_utc = None
+#         message.via_partition_key = None
+#         message.scheduled_enqueue_time_utc = None
 
-        assert message.scheduled_enqueue_time_utc is None
+#         assert message.scheduled_enqueue_time_utc is None
 
-        try:
-            timestamp = new_scheduled_time.timestamp() * 1000
-        except AttributeError:
-            timestamp = calendar.timegm(new_scheduled_time.timetuple()) * 1000
+#         try:
+#             timestamp = new_scheduled_time.timestamp() * 1000
+#         except AttributeError:
+#             timestamp = calendar.timegm(new_scheduled_time.timetuple()) * 1000
 
-        my_frame = [0,0,0]
-        if uamqp_transport:
-            amqp_transport = UamqpTransport
-            amqp_received_message = uamqp.message.Message(
-                body=[b'data'],
-                annotations={
-                    _X_OPT_PARTITION_KEY: b'r_key',
-                    _X_OPT_VIA_PARTITION_KEY: b'r_via_key',
-                    _X_OPT_SCHEDULED_ENQUEUE_TIME: timestamp,
-                },
-                properties={}
-            )
-        else:
-            amqp_transport = PyamqpTransport
-            amqp_received_message = Message(
-                data=[b'data'],
-                message_annotations={
-                    _X_OPT_PARTITION_KEY: b'r_key',
-                    _X_OPT_VIA_PARTITION_KEY: b'r_via_key',
-                    _X_OPT_SCHEDULED_ENQUEUE_TIME: timestamp,
-                },
-                properties={}
-            )
-        received_message = ServiceBusReceivedMessage(amqp_received_message, receiver=None, frame=my_frame, amqp_transport=amqp_transport)
-        assert received_message.scheduled_enqueue_time_utc == new_scheduled_time
+#         my_frame = [0,0,0]
+#         if uamqp_transport:
+#             amqp_transport = UamqpTransport
+#             amqp_received_message = uamqp.message.Message(
+#                 body=[b'data'],
+#                 annotations={
+#                     _X_OPT_PARTITION_KEY: b'r_key',
+#                     _X_OPT_VIA_PARTITION_KEY: b'r_via_key',
+#                     _X_OPT_SCHEDULED_ENQUEUE_TIME: timestamp,
+#                 },
+#                 properties={}
+#             )
+#         else:
+#             amqp_transport = PyamqpTransport
+#             amqp_received_message = Message(
+#                 data=[b'data'],
+#                 message_annotations={
+#                     _X_OPT_PARTITION_KEY: b'r_key',
+#                     _X_OPT_VIA_PARTITION_KEY: b'r_via_key',
+#                     _X_OPT_SCHEDULED_ENQUEUE_TIME: timestamp,
+#                 },
+#                 properties={}
+#             )
+#         received_message = ServiceBusReceivedMessage(amqp_received_message, receiver=None, frame=my_frame, amqp_transport=amqp_transport)
+#         assert received_message.scheduled_enqueue_time_utc == new_scheduled_time
 
-        new_scheduled_time = utc_now() + timedelta(hours=1, minutes=49, seconds=32)
+#         new_scheduled_time = utc_now() + timedelta(hours=1, minutes=49, seconds=32)
 
-        received_message.scheduled_enqueue_time_utc = new_scheduled_time
+#         received_message.scheduled_enqueue_time_utc = new_scheduled_time
 
-        assert received_message.scheduled_enqueue_time_utc == new_scheduled_time
+#         assert received_message.scheduled_enqueue_time_utc == new_scheduled_time
 
-        received_message.scheduled_enqueue_time_utc = None
+#         received_message.scheduled_enqueue_time_utc = None
 
-        assert message.scheduled_enqueue_time_utc is None
+#         assert message.scheduled_enqueue_time_utc is None
 
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_queue_receive_batch_without_setting_prefetch(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        with ServiceBusClient.from_connection_string(
-                servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_queue_receive_batch_without_setting_prefetch(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         with ServiceBusClient.from_connection_string(
+#                 servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-            def message_content():
-                for i in range(20):
-                    yield ServiceBusMessage(
-                        body="Test message",
-                        # application_properties={'key': 'value'},
-                        subject='1st',
-                        # content_type='application/text',
-                        # correlation_id='cid',
-                        # message_id='mid',
-                        # to='to',
-                        # reply_to='reply_to',
-                        # time_to_live=timedelta(seconds=60)
-                    )
+#             def message_content():
+#                 for i in range(20):
+#                     yield ServiceBusMessage(
+#                         body="Test message",
+#                         # application_properties={'key': 'value'},
+#                         subject='1st',
+#                         # content_type='application/text',
+#                         # correlation_id='cid',
+#                         # message_id='mid',
+#                         # to='to',
+#                         # reply_to='reply_to',
+#                         # time_to_live=timedelta(seconds=60)
+#                     )
 
-            sender = sb_client.get_queue_sender(servicebus_queue.name)
-            receiver = sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10)
+#             sender = sb_client.get_queue_sender(servicebus_queue.name)
+#             receiver = sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10)
 
-            with sender, receiver:
-                message = ServiceBusMessageBatch()
-                for each in message_content():
-                    message.add_message(each)
-                sender.send_messages(message)
+#             with sender, receiver:
+#                 message = ServiceBusMessageBatch()
+#                 for each in message_content():
+#                     message.add_message(each)
+#                 sender.send_messages(message)
 
-                receive_counter = 0
-                message_1st_received_cnt = 0
-                message_2nd_received_cnt = 0
-                while message_1st_received_cnt < 20 or message_2nd_received_cnt < 20:
-                    messages = []
-                    for message in receiver:
-                        messages.append(message)
-                    if not messages:
-                        break
-                    receive_counter += 1
-                    for message in messages:
-                        print_message(_logger, message)
-                        # assert b''.join(message.body) == b'Test message'
-                        # assert message.application_properties[b'key'] == b'value'
-                        # assert message.content_type == 'application/text'
-                        # assert message.correlation_id == 'cid'
-                        # assert message.message_id == 'mid'
-                        # assert message.to == 'to'
-                        # assert message.reply_to == 'reply_to'
-                        # assert message.time_to_live == timedelta(seconds=60)
+#                 receive_counter = 0
+#                 message_1st_received_cnt = 0
+#                 message_2nd_received_cnt = 0
+#                 while message_1st_received_cnt < 20 or message_2nd_received_cnt < 20:
+#                     messages = []
+#                     for message in receiver:
+#                         messages.append(message)
+#                     if not messages:
+#                         break
+#                     receive_counter += 1
+#                     for message in messages:
+#                         print_message(_logger, message)
+#                         # assert b''.join(message.body) == b'Test message'
+#                         # assert message.application_properties[b'key'] == b'value'
+#                         # assert message.content_type == 'application/text'
+#                         # assert message.correlation_id == 'cid'
+#                         # assert message.message_id == 'mid'
+#                         # assert message.to == 'to'
+#                         # assert message.reply_to == 'reply_to'
+#                         # assert message.time_to_live == timedelta(seconds=60)
 
-                        if message.subject == '1st':
-                            message_1st_received_cnt += 1
-                            receiver.complete_message(message)
-                            message.subject = '2nd'
-                            sender.send_messages(message)  # resending received message
-                        elif message.subject == '2nd':
-                            message_2nd_received_cnt += 1
-                            receiver.complete_message(message)
+#                         if message.subject == '1st':
+#                             message_1st_received_cnt += 1
+#                             receiver.complete_message(message)
+#                             message.subject = '2nd'
+#                             sender.send_messages(message)  # resending received message
+#                         elif message.subject == '2nd':
+#                             message_2nd_received_cnt += 1
+#                             receiver.complete_message(message)
 
-                assert message_1st_received_cnt == 20 and message_2nd_received_cnt == 20
-                # Network/server might be unstable making flow control ineffective in the leading rounds of connection iteration
-                assert receive_counter < 10  # Dynamic link credit issuing come info effect
+#                 assert message_1st_received_cnt == 20 and message_2nd_received_cnt == 20
+#                 # Network/server might be unstable making flow control ineffective in the leading rounds of connection iteration
+#                 assert receive_counter < 10  # Dynamic link credit issuing come info effect
 
     
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest')
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_queue_receiver_alive_after_timeout(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        with ServiceBusClient.from_connection_string(
-                servicebus_namespace_connection_string,
-                logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest')
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_queue_receiver_alive_after_timeout(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         with ServiceBusClient.from_connection_string(
+#                 servicebus_namespace_connection_string,
+#                 logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                message = ServiceBusMessage("0")
-                message_1 = ServiceBusMessage("1")
-                sender.send_messages([message, message_1])
+#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 message = ServiceBusMessage("0")
+#                 message_1 = ServiceBusMessage("1")
+#                 sender.send_messages([message, message_1])
 
-                messages = []
-                with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5) as receiver:
+#                 messages = []
+#                 with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5) as receiver:
                     
-                    for message in receiver:
-                        messages.append(message)
-                        break
+#                     for message in receiver:
+#                         messages.append(message)
+#                         break
 
-                    for message in receiver:
-                        messages.append(message)
+#                     for message in receiver:
+#                         messages.append(message)
 
-                    for message in messages:
-                        receiver.complete_message(message)
+#                     for message in messages:
+#                         receiver.complete_message(message)
 
-                    assert len(messages) == 2
-                    assert str(messages[0]) == "0"
-                    assert str(messages[1]) == "1"
+#                     assert len(messages) == 2
+#                     assert str(messages[0]) == "0"
+#                     assert str(messages[1]) == "1"
 
-                    message_2 = ServiceBusMessage("2")
-                    message_3 = ServiceBusMessage("3")
-                    sender.send_messages([message_2, message_3])
+#                     message_2 = ServiceBusMessage("2")
+#                     message_3 = ServiceBusMessage("3")
+#                     sender.send_messages([message_2, message_3])
 
-                    for message in receiver:
-                        messages.append(message)
-                        for message in receiver:
-                            messages.append(message)
+#                     for message in receiver:
+#                         messages.append(message)
+#                         for message in receiver:
+#                             messages.append(message)
 
-                    assert len(messages) == 4
-                    assert str(messages[2]) == "2"
-                    assert str(messages[3]) == "3"
+#                     assert len(messages) == 4
+#                     assert str(messages[2]) == "2"
+#                     assert str(messages[3]) == "3"
 
-                    for message in messages[2:]:
-                        receiver.complete_message(message)
+#                     for message in messages[2:]:
+#                         receiver.complete_message(message)
 
-                    messages = receiver.receive_messages()
-                    assert not messages
-
-    
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True, lock_duration='PT5M')
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_queue_receive_keep_conn_alive(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        with ServiceBusClient.from_connection_string(
-                servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-
-            sender = sb_client.get_queue_sender(servicebus_queue.name)
-            receiver = sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10)
-
-            with sender, receiver:
-                sender.send_messages([ServiceBusMessage("message1"), ServiceBusMessage("message2")])
-
-                messages = []
-                for message in receiver:
-                    messages.append(message)
-
-                receiver_handler = receiver._handler
-                assert len(messages) == 2
-                time.sleep(4 * 60 + 5)  # 240s is the service defined connection idle timeout
-                receiver.renew_message_lock(messages[0])  # check mgmt link operation
-                receiver.complete_message(messages[0])
-                receiver.complete_message(messages[1])  # check receiver link operation
-
-                time.sleep(60)  # sleep another one minute to ensure we pass the lock_duration time
-
-                messages = []
-                for message in receiver:
-                    messages.append(message)
-
-                assert len(messages) == 0  # make sure messages are removed from the queue
-                assert receiver_handler == receiver._handler  # make sure no reconnection happened
+#                     messages = receiver.receive_messages()
+#                     assert not messages
 
     
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest')
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_queue_receiver_sender_resume_after_link_timeout(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        with ServiceBusClient.from_connection_string(
-                servicebus_namespace_connection_string,
-                logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True, lock_duration='PT5M')
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_queue_receive_keep_conn_alive(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         with ServiceBusClient.from_connection_string(
+#                 servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                message = ServiceBusMessage("0")
-                sender.send_messages(message)
+#             sender = sb_client.get_queue_sender(servicebus_queue.name)
+#             receiver = sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10)
 
-                time.sleep(60 * 5)
+#             with sender, receiver:
+#                 sender.send_messages([ServiceBusMessage("message1"), ServiceBusMessage("message2")])
 
-                message_1 = ServiceBusMessage("1")
-                sender.send_messages(message_1)
+#                 messages = []
+#                 for message in receiver:
+#                     messages.append(message)
 
-                messages = []
-                with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5) as receiver:
+#                 receiver_handler = receiver._handler
+#                 assert len(messages) == 2
+#                 time.sleep(4 * 60 + 5)  # 240s is the service defined connection idle timeout
+#                 receiver.renew_message_lock(messages[0])  # check mgmt link operation
+#                 receiver.complete_message(messages[0])
+#                 receiver.complete_message(messages[1])  # check receiver link operation
+
+#                 time.sleep(60)  # sleep another one minute to ensure we pass the lock_duration time
+
+#                 messages = []
+#                 for message in receiver:
+#                     messages.append(message)
+
+#                 assert len(messages) == 0  # make sure messages are removed from the queue
+#                 assert receiver_handler == receiver._handler  # make sure no reconnection happened
+
+    
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest')
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_queue_receiver_sender_resume_after_link_timeout(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         with ServiceBusClient.from_connection_string(
+#                 servicebus_namespace_connection_string,
+#                 logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+
+#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 message = ServiceBusMessage("0")
+#                 sender.send_messages(message)
+
+#                 time.sleep(60 * 5)
+
+#                 message_1 = ServiceBusMessage("1")
+#                 sender.send_messages(message_1)
+
+#                 messages = []
+#                 with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5) as receiver:
                     
-                    for message in receiver:
-                        messages.append(message)
-                assert len(messages) == 2
+#                     for message in receiver:
+#                         messages.append(message)
+#                 assert len(messages) == 2
     
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest')
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_queue_send_twice(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        if uamqp:
-            transport_type = uamqp.constants.TransportType.AmqpOverWebsocket
-        else:
-            transport_type = TransportType.AmqpOverWebsocket
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest')
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_queue_send_twice(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         if uamqp:
+#             transport_type = uamqp.constants.TransportType.AmqpOverWebsocket
+#         else:
+#             transport_type = TransportType.AmqpOverWebsocket
 
-        with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False,
-            transport_type=transport_type, uamqp_transport=uamqp_transport) as sb_client:
+#         with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False,
+#             transport_type=transport_type, uamqp_transport=uamqp_transport) as sb_client:
 
-            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                message = ServiceBusMessage("ServiceBusMessage")
-                message2 = ServiceBusMessage("Message2")
-                # first test batch message resending.
-                batch_message = sender.create_message_batch()
-                batch_message._from_list([message, message2])  # pylint: disable=protected-access
-                sender.send_messages(batch_message)
-                sender.send_messages(batch_message)
-                messages = []
-                with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=20) as receiver:
-                    for message in receiver:
-                        messages.append(message)
-                        receiver.complete_message(message)
-                    assert len(messages) == 4
-                # then normal message resending
-                sender.send_messages(message)
-                sender.send_messages(message)
-                expected_count = 2
-                if not uamqp_transport:
-                    pickled_recvd = pickle.loads(pickle.dumps(messages[0]))
-                    sender.send_messages(pickled_recvd)
-                    expected_count = 3
-                messages = []
-                with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=20) as receiver:
-                    for message in receiver:
-                        messages.append(message)
-                        receiver.complete_message(message)
-                    assert len(messages) == expected_count
+#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 message = ServiceBusMessage("ServiceBusMessage")
+#                 message2 = ServiceBusMessage("Message2")
+#                 # first test batch message resending.
+#                 batch_message = sender.create_message_batch()
+#                 batch_message._from_list([message, message2])  # pylint: disable=protected-access
+#                 sender.send_messages(batch_message)
+#                 sender.send_messages(batch_message)
+#                 messages = []
+#                 with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=20) as receiver:
+#                     for message in receiver:
+#                         messages.append(message)
+#                         receiver.complete_message(message)
+#                     assert len(messages) == 4
+#                 # then normal message resending
+#                 sender.send_messages(message)
+#                 sender.send_messages(message)
+#                 expected_count = 2
+#                 if not uamqp_transport:
+#                     pickled_recvd = pickle.loads(pickle.dumps(messages[0]))
+#                     sender.send_messages(pickled_recvd)
+#                     expected_count = 3
+#                 messages = []
+#                 with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=20) as receiver:
+#                     for message in receiver:
+#                         messages.append(message)
+#                         receiver.complete_message(message)
+#                     assert len(messages) == expected_count
 
 
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @CachedServiceBusQueuePreparer(name_prefix='servicebustest')
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_queue_receiver_invalid_mode(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @CachedServiceBusQueuePreparer(name_prefix='servicebustest')
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_queue_receiver_invalid_mode(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
         
-        with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-            with pytest.raises(ValueError):
-                with sb_client.get_queue_receiver(servicebus_queue.name, 
-                                                  receive_mode=2) as receiver:
+#         with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#             with pytest.raises(ValueError):
+#                 with sb_client.get_queue_receiver(servicebus_queue.name, 
+#                                                   receive_mode=2) as receiver:
                 
-                    raise Exception("Should not get here, should fail fast.")
+#                     raise Exception("Should not get here, should fail fast.")
 
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @CachedServiceBusQueuePreparer(name_prefix='servicebustest')
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_queue_receiver_invalid_autolockrenew_mode(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @CachedServiceBusQueuePreparer(name_prefix='servicebustest')
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_queue_receiver_invalid_autolockrenew_mode(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
         
-        with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-            with pytest.raises(ValueError):
-                with sb_client.get_queue_receiver(servicebus_queue.name, 
-                                                  receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE,
-                                                  auto_lock_renewer=AutoLockRenewer()) as receiver:
+#         with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#             with pytest.raises(ValueError):
+#                 with sb_client.get_queue_receiver(servicebus_queue.name, 
+#                                                   receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE,
+#                                                   auto_lock_renewer=AutoLockRenewer()) as receiver:
                 
-                    raise Exception("Should not get here, should fail fast because RECEIVE_AND_DELETE messages cannot be autorenewed.")
+#                     raise Exception("Should not get here, should fail fast because RECEIVE_AND_DELETE messages cannot be autorenewed.")
 
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest')
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_message_inner_amqp_properties(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest')
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_message_inner_amqp_properties(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
         
-        message = ServiceBusMessage("body")
+#         message = ServiceBusMessage("body")
 
-        message.raw_amqp_message.properties.subject = "subject"
-        message.raw_amqp_message.application_properties = {b"application_properties":1}
-        message.raw_amqp_message.annotations = {b"annotations":2}
-        message.raw_amqp_message.delivery_annotations = {b"delivery_annotations":3}
-        message.raw_amqp_message.header.priority = 5
-        message.raw_amqp_message.footer = {b"footer":6}
+#         message.raw_amqp_message.properties.subject = "subject"
+#         message.raw_amqp_message.application_properties = {b"application_properties":1}
+#         message.raw_amqp_message.annotations = {b"annotations":2}
+#         message.raw_amqp_message.delivery_annotations = {b"delivery_annotations":3}
+#         message.raw_amqp_message.header.priority = 5
+#         message.raw_amqp_message.footer = {b"footer":6}
 
-        with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#         with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                sender.send_messages(message)
-                with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5) as receiver:
-                    message = receiver.receive_messages()[0]
-                    assert message.raw_amqp_message.application_properties != None \
-                        and message.raw_amqp_message.annotations != None \
-                        and message.raw_amqp_message.delivery_annotations != None \
-                        and message.raw_amqp_message.footer != None \
-                        and message.raw_amqp_message.properties != None \
-                        and message.raw_amqp_message.header != None
+#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 sender.send_messages(message)
+#                 with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5) as receiver:
+#                     message = receiver.receive_messages()[0]
+#                     assert message.raw_amqp_message.application_properties != None \
+#                         and message.raw_amqp_message.annotations != None \
+#                         and message.raw_amqp_message.delivery_annotations != None \
+#                         and message.raw_amqp_message.footer != None \
+#                         and message.raw_amqp_message.properties != None \
+#                         and message.raw_amqp_message.header != None
 
-                    assert message.raw_amqp_message.properties.subject == b"subject"
-                    assert message.raw_amqp_message.application_properties[b"application_properties"] == 1
-                    assert message.raw_amqp_message.annotations[b"annotations"] == 2
-                    assert message.raw_amqp_message.delivery_annotations[b"delivery_annotations"] == 3
-                    assert message.raw_amqp_message.header.priority == 5
-                    assert message.raw_amqp_message.footer[b"footer"] == 6
+#                     assert message.raw_amqp_message.properties.subject == b"subject"
+#                     assert message.raw_amqp_message.application_properties[b"application_properties"] == 1
+#                     assert message.raw_amqp_message.annotations[b"annotations"] == 2
+#                     assert message.raw_amqp_message.delivery_annotations[b"delivery_annotations"] == 3
+#                     assert message.raw_amqp_message.header.priority == 5
+#                     assert message.raw_amqp_message.footer[b"footer"] == 6
 
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @CachedServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_queue_send_timeout(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        def _hack_amqp_sender_run(self, **kwargs):
-            time.sleep(6)  # sleep until timeout
-            if uamqp_transport:
-                self.message_handler.work()
-                self._waiting_messages = 0
-                self._pending_messages = self._filter_pending()
-                if self._backoff and not self._waiting_messages:
-                    _logger.info("Client told to backoff - sleeping for %r seconds", self._backoff)
-                    self._connection.sleep(self._backoff)
-                    self._backoff = 0
-                self._connection.work()
-            else:
-                try:
-                    self._link.update_pending_deliveries()
-                    self._connection.listen(wait=self._socket_timeout, **kwargs)
-                except ValueError:
-                    self._shutdown = True
-                    return False
-            return True
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @CachedServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_queue_send_timeout(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         def _hack_amqp_sender_run(self, **kwargs):
+#             time.sleep(6)  # sleep until timeout
+#             if uamqp_transport:
+#                 self.message_handler.work()
+#                 self._waiting_messages = 0
+#                 self._pending_messages = self._filter_pending()
+#                 if self._backoff and not self._waiting_messages:
+#                     _logger.info("Client told to backoff - sleeping for %r seconds", self._backoff)
+#                     self._connection.sleep(self._backoff)
+#                     self._backoff = 0
+#                 self._connection.work()
+#             else:
+#                 try:
+#                     self._link.update_pending_deliveries()
+#                     self._connection.listen(wait=self._socket_timeout, **kwargs)
+#                 except ValueError:
+#                     self._shutdown = True
+#                     return False
+#             return True
 
-        with ServiceBusClient.from_connection_string(
-                servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                # this one doesn't need to reset the method, as it's hacking the method on the instance
-                sender._handler._client_run = types.MethodType(_hack_amqp_sender_run, sender._handler)
-                with pytest.raises(OperationTimeoutError):
-                    sender.send_messages(ServiceBusMessage("body"), timeout=5)
+#         with ServiceBusClient.from_connection_string(
+#                 servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 # this one doesn't need to reset the method, as it's hacking the method on the instance
+#                 sender._handler._client_run = types.MethodType(_hack_amqp_sender_run, sender._handler)
+#                 with pytest.raises(OperationTimeoutError):
+#                     sender.send_messages(ServiceBusMessage("body"), timeout=5)
 
-        if not uamqp_transport:
-            # Amqp
-            with ServiceBusClient.from_connection_string(
-                servicebus_namespace_connection_string,
-                uamqp_transport=uamqp_transport
-            ) as sb_client:
-                with sb_client.get_queue_sender(servicebus_queue.name, socket_timeout=0.6) as sender:
-                    payload = "A" * 250 * 1024
-                    sender.send_messages(ServiceBusMessage(payload))
+#         if not uamqp_transport:
+#             # Amqp
+#             with ServiceBusClient.from_connection_string(
+#                 servicebus_namespace_connection_string,
+#                 uamqp_transport=uamqp_transport
+#             ) as sb_client:
+#                 with sb_client.get_queue_sender(servicebus_queue.name, socket_timeout=0.6) as sender:
+#                     payload = "A" * 250 * 1024
+#                     sender.send_messages(ServiceBusMessage(payload))
 
-            if uamqp:
-                transport_type = uamqp.constants.TransportType.AmqpOverWebsocket
-            else:
-                transport_type = TransportType.AmqpOverWebsocket
-            # AmqpOverWebsocket
-            with ServiceBusClient.from_connection_string(
-                servicebus_namespace_connection_string,
-                transport_type=transport_type,
-                uamqp_transport=uamqp_transport
-            ) as sb_client:
-                with sb_client.get_queue_sender(servicebus_queue.name, socket_timeout=0.8) as sender:
-                    payload = "A" * 250 * 1024
-                    sender.send_messages(ServiceBusMessage(payload))
+#             if uamqp:
+#                 transport_type = uamqp.constants.TransportType.AmqpOverWebsocket
+#             else:
+#                 transport_type = TransportType.AmqpOverWebsocket
+#             # AmqpOverWebsocket
+#             with ServiceBusClient.from_connection_string(
+#                 servicebus_namespace_connection_string,
+#                 transport_type=transport_type,
+#                 uamqp_transport=uamqp_transport
+#             ) as sb_client:
+#                 with sb_client.get_queue_sender(servicebus_queue.name, socket_timeout=0.8) as sender:
+#                     payload = "A" * 250 * 1024
+#                     sender.send_messages(ServiceBusMessage(payload))
 
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @CachedServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_queue_send_large_message_receive(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        # Amqp
-        with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string,
-            uamqp_transport=uamqp_transport
-        ) as sb_client:
-            with sb_client.get_queue_sender(servicebus_queue.name, socket_timeout=0.6) as sender:
-                payload = "A" * 250 * 1024
-                sender.send_messages(ServiceBusMessage(payload))
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @CachedServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_queue_send_large_message_receive(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         # Amqp
+#         with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string,
+#             uamqp_transport=uamqp_transport
+#         ) as sb_client:
+#             with sb_client.get_queue_sender(servicebus_queue.name, socket_timeout=0.6) as sender:
+#                 payload = "A" * 250 * 1024
+#                 sender.send_messages(ServiceBusMessage(payload))
 
-        if uamqp:
-            transport_type = uamqp.constants.TransportType.AmqpOverWebsocket
-        else:
-            transport_type = TransportType.AmqpOverWebsocket
-        # AmqpOverWebsocket
-        with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string,
-            transport_type=transport_type,
-            uamqp_transport=uamqp_transport
-        ) as sb_client:
-            with sb_client.get_queue_sender(servicebus_queue.name, socket_timeout=0.8) as sender:
-                payload = "A" * 250 * 1024
-                sender.send_messages(ServiceBusMessage(payload))
+#         if uamqp:
+#             transport_type = uamqp.constants.TransportType.AmqpOverWebsocket
+#         else:
+#             transport_type = TransportType.AmqpOverWebsocket
+#         # AmqpOverWebsocket
+#         with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string,
+#             transport_type=transport_type,
+#             uamqp_transport=uamqp_transport
+#         ) as sb_client:
+#             with sb_client.get_queue_sender(servicebus_queue.name, socket_timeout=0.8) as sender:
+#                 payload = "A" * 250 * 1024
+#                 sender.send_messages(ServiceBusMessage(payload))
 
-        # ReceiveMessages
-        with ServiceBusClient.from_connection_string(
-                servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-            with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5) as receiver:
-                messages = receiver.receive_messages(max_message_count=5, max_wait_time=5)
-                for message in messages:
-                    if not uamqp_transport:
-                        assert message._delivery_id is not None
-                        assert message._message.data[0].decode("utf-8")  == "A" * 250 * 1024
-                    receiver.complete_message(message)  # complete messages             
+#         # ReceiveMessages
+#         with ServiceBusClient.from_connection_string(
+#                 servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#             with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5) as receiver:
+#                 messages = receiver.receive_messages(max_message_count=5, max_wait_time=5)
+#                 for message in messages:
+#                     if not uamqp_transport:
+#                         assert message._delivery_id is not None
+#                         assert message._message.data[0].decode("utf-8")  == "A" * 250 * 1024
+#                     receiver.complete_message(message)  # complete messages             
 
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @CachedServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_queue_mgmt_operation_timeout(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        if uamqp_transport:
-            def hack_mgmt_execute(self, operation, op_type, message, timeout=0):
-                start_time = self._counter.get_current_ms()
-                operation_id = str(uuid.uuid4())
-                self._responses[operation_id] = None
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @CachedServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_queue_mgmt_operation_timeout(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         if uamqp_transport:
+#             def hack_mgmt_execute(self, operation, op_type, message, timeout=0):
+#                 start_time = self._counter.get_current_ms()
+#                 operation_id = str(uuid.uuid4())
+#                 self._responses[operation_id] = None
 
-                time.sleep(6)  # sleep until timeout
-                while not self._responses[operation_id] and not self.mgmt_error:
-                    if timeout > 0:
-                        now = self._counter.get_current_ms()
-                        if (now - start_time) >= timeout:
-                            raise uamqp.compat.TimeoutException("Failed to receive mgmt response in {}ms".format(timeout))
-                    self.connection.work()
-                if self.mgmt_error:
-                    raise self.mgmt_error
-                response = self._responses.pop(operation_id)
-                return response
+#                 time.sleep(6)  # sleep until timeout
+#                 while not self._responses[operation_id] and not self.mgmt_error:
+#                     if timeout > 0:
+#                         now = self._counter.get_current_ms()
+#                         if (now - start_time) >= timeout:
+#                             raise uamqp.compat.TimeoutException("Failed to receive mgmt response in {}ms".format(timeout))
+#                     self.connection.work()
+#                 if self.mgmt_error:
+#                     raise self.mgmt_error
+#                 response = self._responses.pop(operation_id)
+#                 return response
 
-            original_execute_method = uamqp.mgmt_operation.MgmtOperation.execute
-            # hack the mgmt method on the class, not on an instance, so it needs reset
-        else:
-            def hack_mgmt_execute(self, message, operation=None, operation_type=None, timeout=0):
-                start_time = time.time()
-                operation_id = str(uuid.uuid4())
-                self._responses[operation_id] = None
+#             original_execute_method = uamqp.mgmt_operation.MgmtOperation.execute
+#             # hack the mgmt method on the class, not on an instance, so it needs reset
+#         else:
+#             def hack_mgmt_execute(self, message, operation=None, operation_type=None, timeout=0):
+#                 start_time = time.time()
+#                 operation_id = str(uuid.uuid4())
+#                 self._responses[operation_id] = None
 
-                time.sleep(6)  # sleep until timeout
-                while not self._responses[operation_id] and not self._mgmt_error:
-                    if timeout and timeout > 0:
-                        now = time.time()
-                        if (now - start_time) >= timeout:
-                            raise TimeoutError("Failed to receive mgmt response in {}ms".format(timeout))
-                    self._connection.listen()
-                if self._mgmt_error:
-                    self._responses.pop(operation_id)
-                    raise self._mgmt_error
+#                 time.sleep(6)  # sleep until timeout
+#                 while not self._responses[operation_id] and not self._mgmt_error:
+#                     if timeout and timeout > 0:
+#                         now = time.time()
+#                         if (now - start_time) >= timeout:
+#                             raise TimeoutError("Failed to receive mgmt response in {}ms".format(timeout))
+#                     self._connection.listen()
+#                 if self._mgmt_error:
+#                     self._responses.pop(operation_id)
+#                     raise self._mgmt_error
 
-                response = self._responses.pop(operation_id)
-                return response
+#                 response = self._responses.pop(operation_id)
+#                 return response
 
-            original_execute_method = management_operation.ManagementOperation.execute
-            # hack the mgmt method on the class, not on an instance, so it needs reset
+#             original_execute_method = management_operation.ManagementOperation.execute
+#             # hack the mgmt method on the class, not on an instance, so it needs reset
 
-        try:
-            if uamqp_transport:
-                uamqp.mgmt_operation.MgmtOperation.execute = hack_mgmt_execute
-            else:
-                management_operation.ManagementOperation.execute = hack_mgmt_execute
-            with ServiceBusClient.from_connection_string(
-                    servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-                with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                    with pytest.raises(OperationTimeoutError):
-                        scheduled_time_utc = utc_now() + timedelta(seconds=30)
-                        sender.schedule_messages(ServiceBusMessage("ServiceBusMessage to be scheduled"), scheduled_time_utc, timeout=5)
-        finally:
-            # must reset the mgmt execute method, otherwise other test cases would use the hacked execute method, leading to timeout error
-            if uamqp_transport:
-                uamqp.mgmt_operation.MgmtOperation.execute = original_execute_method
-            else:
-                management_operation.ManagementOperation.execute = original_execute_method
+#         try:
+#             if uamqp_transport:
+#                 uamqp.mgmt_operation.MgmtOperation.execute = hack_mgmt_execute
+#             else:
+#                 management_operation.ManagementOperation.execute = hack_mgmt_execute
+#             with ServiceBusClient.from_connection_string(
+#                     servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#                 with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                     with pytest.raises(OperationTimeoutError):
+#                         scheduled_time_utc = utc_now() + timedelta(seconds=30)
+#                         sender.schedule_messages(ServiceBusMessage("ServiceBusMessage to be scheduled"), scheduled_time_utc, timeout=5)
+#         finally:
+#             # must reset the mgmt execute method, otherwise other test cases would use the hacked execute method, leading to timeout error
+#             if uamqp_transport:
+#                 uamqp.mgmt_operation.MgmtOperation.execute = original_execute_method
+#             else:
+#                 management_operation.ManagementOperation.execute = original_execute_method
 
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @CachedServiceBusQueuePreparer(name_prefix='servicebustest', lock_duration='PT5S')
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_queue_operation_negative(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        if uamqp_transport:
-            def _hack_amqp_message_complete(cls):
-                raise RuntimeError()
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @CachedServiceBusQueuePreparer(name_prefix='servicebustest', lock_duration='PT5S')
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_queue_operation_negative(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         if uamqp_transport:
+#             def _hack_amqp_message_complete(cls):
+#                 raise RuntimeError()
 
-            def _hack_amqp_mgmt_request(cls, message, operation, op_type=None, node=None, callback=None, **kwargs):
-                raise uamqp.errors.AMQPConnectionError()
+#             def _hack_amqp_mgmt_request(cls, message, operation, op_type=None, node=None, callback=None, **kwargs):
+#                 raise uamqp.errors.AMQPConnectionError()
 
-            def _hack_sb_receiver_settle_message(self, message, settle_operation, dead_letter_reason=None, dead_letter_error_description=None):
-                raise uamqp.errors.AMQPError()
-        else:
-            def _hack_amqp_message_complete(cls, _, settlement):
-                    if settlement == 'completed':
-                        raise RuntimeError()
+#             def _hack_sb_receiver_settle_message(self, message, settle_operation, dead_letter_reason=None, dead_letter_error_description=None):
+#                 raise uamqp.errors.AMQPError()
+#         else:
+#             def _hack_amqp_message_complete(cls, _, settlement):
+#                     if settlement == 'completed':
+#                         raise RuntimeError()
 
-            def _hack_amqp_mgmt_request(cls, message, operation, op_type=None, node=None, callback=None, **kwargs):
-                raise error.AMQPConnectionError(error.ErrorCondition.ConnectionCloseForced)
+#             def _hack_amqp_mgmt_request(cls, message, operation, op_type=None, node=None, callback=None, **kwargs):
+#                 raise error.AMQPConnectionError(error.ErrorCondition.ConnectionCloseForced)
 
-            def _hack_sb_receiver_settle_message(self, message, settle_operation, dead_letter_reason=None, dead_letter_error_description=None):
-                raise error.AMQPException(error.ErrorCondition.ClientError)
+#             def _hack_sb_receiver_settle_message(self, message, settle_operation, dead_letter_reason=None, dead_letter_error_description=None):
+#                 raise error.AMQPException(error.ErrorCondition.ClientError)
 
-        with ServiceBusClient.from_connection_string(
-                servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-            sender = sb_client.get_queue_sender(servicebus_queue.name)
-            receiver = sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5)
-            if not uamqp_transport:
-                original_settlement = client.ReceiveClient.settle_messages
-            try:
-                with sender, receiver:
-                    # negative settlement via receiver link
-                    sender.send_messages(ServiceBusMessage("body"), timeout=10)
-                    message = receiver.receive_messages()[0]
-                    if uamqp_transport:
-                        message._message.accept = types.MethodType(_hack_amqp_message_complete, message._message)
-                    else:
-                        client.ReceiveClient.settle_messages = types.MethodType(_hack_amqp_message_complete, receiver._handler)
-                    receiver.complete_message(message)  # settle via mgmt link
+#         with ServiceBusClient.from_connection_string(
+#                 servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#             sender = sb_client.get_queue_sender(servicebus_queue.name)
+#             receiver = sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5)
+#             if not uamqp_transport:
+#                 original_settlement = client.ReceiveClient.settle_messages
+#             try:
+#                 with sender, receiver:
+#                     # negative settlement via receiver link
+#                     sender.send_messages(ServiceBusMessage("body"), timeout=10)
+#                     message = receiver.receive_messages()[0]
+#                     if uamqp_transport:
+#                         message._message.accept = types.MethodType(_hack_amqp_message_complete, message._message)
+#                     else:
+#                         client.ReceiveClient.settle_messages = types.MethodType(_hack_amqp_message_complete, receiver._handler)
+#                     receiver.complete_message(message)  # settle via mgmt link
 
-                    if uamqp_transport:
-                        origin_amqp_client_mgmt_request_method = uamqp.AMQPClient.mgmt_request
-                        try:
-                            uamqp.AMQPClient.mgmt_request = _hack_amqp_mgmt_request
-                            with pytest.raises(ServiceBusConnectionError):
-                                receiver.peek_messages()
-                        finally:
-                            uamqp.AMQPClient.mgmt_request = origin_amqp_client_mgmt_request_method
-                    else:
-                        origin_amqp_client_mgmt_request_method = client.AMQPClient.mgmt_request
-                        try:
-                            client.AMQPClient.mgmt_request = _hack_amqp_mgmt_request
-                            with pytest.raises(ServiceBusConnectionError):
-                                receiver.peek_messages()
-                        finally:
-                            client.AMQPClient.mgmt_request = origin_amqp_client_mgmt_request_method
+#                     if uamqp_transport:
+#                         origin_amqp_client_mgmt_request_method = uamqp.AMQPClient.mgmt_request
+#                         try:
+#                             uamqp.AMQPClient.mgmt_request = _hack_amqp_mgmt_request
+#                             with pytest.raises(ServiceBusConnectionError):
+#                                 receiver.peek_messages()
+#                         finally:
+#                             uamqp.AMQPClient.mgmt_request = origin_amqp_client_mgmt_request_method
+#                     else:
+#                         origin_amqp_client_mgmt_request_method = client.AMQPClient.mgmt_request
+#                         try:
+#                             client.AMQPClient.mgmt_request = _hack_amqp_mgmt_request
+#                             with pytest.raises(ServiceBusConnectionError):
+#                                 receiver.peek_messages()
+#                         finally:
+#                             client.AMQPClient.mgmt_request = origin_amqp_client_mgmt_request_method
 
-                    sender.send_messages(ServiceBusMessage("body"), timeout=10)
+#                     sender.send_messages(ServiceBusMessage("body"), timeout=10)
 
-                    message = receiver.receive_messages()[0]
+#                     message = receiver.receive_messages()[0]
 
-                    origin_sb_receiver_settle_message_method = receiver._settle_message
-                    receiver._settle_message = types.MethodType(_hack_sb_receiver_settle_message, receiver)
-                    with pytest.raises(ServiceBusError):
-                        receiver.complete_message(message)
+#                     origin_sb_receiver_settle_message_method = receiver._settle_message
+#                     receiver._settle_message = types.MethodType(_hack_sb_receiver_settle_message, receiver)
+#                     with pytest.raises(ServiceBusError):
+#                         receiver.complete_message(message)
 
-                    receiver._settle_message = origin_sb_receiver_settle_message_method
-                    message = receiver.receive_messages(max_wait_time=6)[0]
-                    receiver.complete_message(message)
-            finally:
-                if not uamqp_transport:
-                    client.ReceiveClient.settle_messages = original_settlement
+#                     receiver._settle_message = origin_sb_receiver_settle_message_method
+#                     message = receiver.receive_messages(max_wait_time=6)[0]
+#                     receiver.complete_message(message)
+#             finally:
+#                 if not uamqp_transport:
+#                     client.ReceiveClient.settle_messages = original_settlement
 
     
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_send_message_no_body(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        sb_client = ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, uamqp_transport=uamqp_transport)
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_send_message_no_body(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         sb_client = ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, uamqp_transport=uamqp_transport)
 
-        with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-            sender.send_messages(ServiceBusMessage(body=None))
+#         with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#             sender.send_messages(ServiceBusMessage(body=None))
 
-        with sb_client.get_queue_receiver(servicebus_queue.name,  
-                                          max_wait_time=10) as receiver:
-            message = receiver.next()
-            assert message.body is None
-            receiver.complete_message(message)
+#         with sb_client.get_queue_receiver(servicebus_queue.name,  
+#                                           max_wait_time=10) as receiver:
+#             message = receiver.next()
+#             assert message.body is None
+#             receiver.complete_message(message)
 
-    def test_send_message_alternate_body_types(self, **kwargs):
-        with pytest.raises(TypeError):
-            message = ServiceBusMessage(body=['1','2'])
-        with pytest.raises(TypeError):
-            message = ServiceBusMessage(body=[None, None])
-        with pytest.raises(TypeError):
-            message = ServiceBusMessage(body=['1', None])
-        with pytest.raises(TypeError):
-            message = ServiceBusMessage(body=[Exception()])
-        with pytest.raises(TypeError):
-            message = ServiceBusMessage(body={})
-        with pytest.raises(TypeError):
-            message = ServiceBusMessage(body=Exception())
+#     def test_send_message_alternate_body_types(self, **kwargs):
+#         with pytest.raises(TypeError):
+#             message = ServiceBusMessage(body=['1','2'])
+#         with pytest.raises(TypeError):
+#             message = ServiceBusMessage(body=[None, None])
+#         with pytest.raises(TypeError):
+#             message = ServiceBusMessage(body=['1', None])
+#         with pytest.raises(TypeError):
+#             message = ServiceBusMessage(body=[Exception()])
+#         with pytest.raises(TypeError):
+#             message = ServiceBusMessage(body={})
+#         with pytest.raises(TypeError):
+#             message = ServiceBusMessage(body=Exception())
 
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @CachedServiceBusQueuePreparer(name_prefix='servicebustest')
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_queue_by_servicebus_client_enum_case_sensitivity(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        # Note: This test is currently intended to enforce case-sensitivity.  If we eventually upgrade to the Fancy Enums being used with new autorest,
-        # we may want to tweak this.
-        with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-            with sb_client.get_queue_receiver(servicebus_queue.name, 
-                                              receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE.value, 
-                                              max_wait_time=5) as receiver:
-                pass
-            with pytest.raises(ValueError):
-                with sb_client.get_queue_receiver(servicebus_queue.name, 
-                                                  receive_mode=str.upper(ServiceBusReceiveMode.RECEIVE_AND_DELETE.value),
-                                                  max_wait_time=5) as receiver:
-                    raise Exception("Should not get here, should be case sensitive.")
-            with sb_client.get_queue_receiver(servicebus_queue.name, 
-                                              sub_queue=ServiceBusSubQueue.DEAD_LETTER.value,
-                                              max_wait_time=5) as receiver:
-                pass
-            with pytest.raises(ValueError):
-                with sb_client.get_queue_receiver(servicebus_queue.name, 
-                                                  sub_queue=str.upper(ServiceBusSubQueue.DEAD_LETTER.value),
-                                                  max_wait_time=5) as receiver:
-                    raise Exception("Should not get here, should be case sensitive.")
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @CachedServiceBusQueuePreparer(name_prefix='servicebustest')
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_queue_by_servicebus_client_enum_case_sensitivity(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         # Note: This test is currently intended to enforce case-sensitivity.  If we eventually upgrade to the Fancy Enums being used with new autorest,
+#         # we may want to tweak this.
+#         with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#             with sb_client.get_queue_receiver(servicebus_queue.name, 
+#                                               receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE.value, 
+#                                               max_wait_time=5) as receiver:
+#                 pass
+#             with pytest.raises(ValueError):
+#                 with sb_client.get_queue_receiver(servicebus_queue.name, 
+#                                                   receive_mode=str.upper(ServiceBusReceiveMode.RECEIVE_AND_DELETE.value),
+#                                                   max_wait_time=5) as receiver:
+#                     raise Exception("Should not get here, should be case sensitive.")
+#             with sb_client.get_queue_receiver(servicebus_queue.name, 
+#                                               sub_queue=ServiceBusSubQueue.DEAD_LETTER.value,
+#                                               max_wait_time=5) as receiver:
+#                 pass
+#             with pytest.raises(ValueError):
+#                 with sb_client.get_queue_receiver(servicebus_queue.name, 
+#                                                   sub_queue=str.upper(ServiceBusSubQueue.DEAD_LETTER.value),
+#                                                   max_wait_time=5) as receiver:
+#                     raise Exception("Should not get here, should be case sensitive.")
 
     
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest')
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_queue_send_dict_messages(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest')
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_queue_send_dict_messages(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
 
-                message_dict = {"body": "Message"}
-                message2_dict = {"body": "Message2"}
-                list_message_dicts = [message_dict, message2_dict]
+#                 message_dict = {"body": "Message"}
+#                 message2_dict = {"body": "Message2"}
+#                 list_message_dicts = [message_dict, message2_dict]
 
-                # send single dict
-                sender.send_messages(message_dict)
+#                 # send single dict
+#                 sender.send_messages(message_dict)
 
-                # send list of dicts
-                sender.send_messages(list_message_dicts)
+#                 # send list of dicts
+#                 sender.send_messages(list_message_dicts)
 
-                # create and send BatchMessage with dicts
-                batch_message = sender.create_message_batch()
-                batch_message._from_list(list_message_dicts)  # pylint: disable=protected-access
-                batch_message.add_message(message_dict)
-                sender.send_messages(batch_message)
+#                 # create and send BatchMessage with dicts
+#                 batch_message = sender.create_message_batch()
+#                 batch_message._from_list(list_message_dicts)  # pylint: disable=protected-access
+#                 batch_message.add_message(message_dict)
+#                 sender.send_messages(batch_message)
 
-                received_messages = []
-                with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5) as receiver:
-                    for message in receiver:
-                        received_messages.append(message)
-                assert len(received_messages) == 6
+#                 received_messages = []
+#                 with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5) as receiver:
+#                     for message in receiver:
+#                         received_messages.append(message)
+#                 assert len(received_messages) == 6
 
-                batch_message = sender.create_message_batch(max_size_in_bytes=73)
-                for _ in range(2):
-                    try:
-                        batch_message.add_message(message_dict)
-                    except ValueError:
-                        break
-                sender.send_messages(batch_message)
-                received_messages = []
-                with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5) as receiver:
-                    for message in receiver:
-                        received_messages.append(message)
-                assert len(received_messages) == 1
+#                 batch_message = sender.create_message_batch(max_size_in_bytes=73)
+#                 for _ in range(2):
+#                     try:
+#                         batch_message.add_message(message_dict)
+#                     except ValueError:
+#                         break
+#                 sender.send_messages(batch_message)
+#                 received_messages = []
+#                 with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5) as receiver:
+#                     for message in receiver:
+#                         received_messages.append(message)
+#                 assert len(received_messages) == 1
     
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest')
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_queue_send_mapping_messages(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        class MappingMessage(DictMixin):
-            def __init__(self, content):
-                self.body = content
-                self.message_id = 'foo'
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest')
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_queue_send_mapping_messages(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         class MappingMessage(DictMixin):
+#             def __init__(self, content):
+#                 self.body = content
+#                 self.message_id = 'foo'
         
-        class BadMappingMessage(DictMixin):
-            def __init__(self):
-                self.message_id = 'foo'
+#         class BadMappingMessage(DictMixin):
+#             def __init__(self):
+#                 self.message_id = 'foo'
 
-        with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#         with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
 
-                message_dict = MappingMessage("Message")
-                message2_dict = MappingMessage("Message2")
-                message3_dict = BadMappingMessage()
-                list_message_dicts = [message_dict, message2_dict]
+#                 message_dict = MappingMessage("Message")
+#                 message2_dict = MappingMessage("Message2")
+#                 message3_dict = BadMappingMessage()
+#                 list_message_dicts = [message_dict, message2_dict]
 
-                # send single dict
-                sender.send_messages(message_dict)
+#                 # send single dict
+#                 sender.send_messages(message_dict)
 
-                # send list of dicts
-                sender.send_messages(list_message_dicts)
+#                 # send list of dicts
+#                 sender.send_messages(list_message_dicts)
 
-                # send bad dict
-                with pytest.raises(TypeError):
-                    sender.send_messages(message3_dict)
+#                 # send bad dict
+#                 with pytest.raises(TypeError):
+#                     sender.send_messages(message3_dict)
 
-                # create and send BatchMessage with dicts
-                batch_message = sender.create_message_batch()
-                batch_message._from_list(list_message_dicts)  # pylint: disable=protected-access
-                batch_message.add_message(message_dict)
-                sender.send_messages(batch_message)
+#                 # create and send BatchMessage with dicts
+#                 batch_message = sender.create_message_batch()
+#                 batch_message._from_list(list_message_dicts)  # pylint: disable=protected-access
+#                 batch_message.add_message(message_dict)
+#                 sender.send_messages(batch_message)
 
-                received_messages = []
-                with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5) as receiver:
-                    for message in receiver:
-                        received_messages.append(message)
-                assert len(received_messages) == 6
+#                 received_messages = []
+#                 with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5) as receiver:
+#                     for message in receiver:
+#                         received_messages.append(message)
+#                 assert len(received_messages) == 6
 
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest')
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_queue_send_dict_messages_error_badly_formatted_dicts(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest')
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_queue_send_dict_messages_error_badly_formatted_dicts(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
 
-                message_dict = {"bad_key": "Message"}
-                message2_dict = {"bad_key": "Message2"}
-                list_message_dicts = [message_dict, message2_dict]
+#                 message_dict = {"bad_key": "Message"}
+#                 message2_dict = {"bad_key": "Message2"}
+#                 list_message_dicts = [message_dict, message2_dict]
 
-                # send single dict
-                with pytest.raises(TypeError):
-                    sender.send_messages(message_dict)
+#                 # send single dict
+#                 with pytest.raises(TypeError):
+#                     sender.send_messages(message_dict)
 
-                # send list of dicts
-                with pytest.raises(TypeError):
-                    sender.send_messages(list_message_dicts)
+#                 # send list of dicts
+#                 with pytest.raises(TypeError):
+#                     sender.send_messages(list_message_dicts)
 
-                # create and send BatchMessage with dicts
-                batch_message = sender.create_message_batch()
-                with pytest.raises(TypeError):
-                    batch_message._from_list(list_message_dicts)  # pylint: disable=protected-access
+#                 # create and send BatchMessage with dicts
+#                 batch_message = sender.create_message_batch()
+#                 with pytest.raises(TypeError):
+#                     batch_message._from_list(list_message_dicts)  # pylint: disable=protected-access
 
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_queue_send_dict_messages_scheduled(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_queue_send_dict_messages_scheduled(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
         
-        with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-            content = "Test scheduled message"
-            message_id = uuid.uuid4()
-            message_id2 = uuid.uuid4()
-            scheduled_enqueue_time = (utc_now() + timedelta(minutes=0.05)).replace(microsecond=0)
-            message_dict = {"message_id": message_id, "body": content}
-            message2_dict = {"message_id": message_id2, "body": content}
-            list_message_dicts = [message_dict, message2_dict]
+#         with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#             content = "Test scheduled message"
+#             message_id = uuid.uuid4()
+#             message_id2 = uuid.uuid4()
+#             scheduled_enqueue_time = (utc_now() + timedelta(minutes=0.05)).replace(microsecond=0)
+#             message_dict = {"message_id": message_id, "body": content}
+#             message2_dict = {"message_id": message_id2, "body": content}
+#             list_message_dicts = [message_dict, message2_dict]
             
-            # send single dict
-            with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
-                with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                    tokens = sender.schedule_messages(message_dict, scheduled_enqueue_time)
-                    assert len(tokens) == 1
+#             # send single dict
+#             with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
+#                 with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                     tokens = sender.schedule_messages(message_dict, scheduled_enqueue_time)
+#                     assert len(tokens) == 1
     
-                messages = receiver.receive_messages(max_wait_time=20)
-                if messages:
-                    try:
-                        data = str(messages[0])
-                        assert data == content
-                        assert messages[0].message_id == message_id
-                        assert messages[0].scheduled_enqueue_time_utc == scheduled_enqueue_time
-                        assert messages[0].scheduled_enqueue_time_utc <= messages[0].enqueued_time_utc.replace(microsecond=0)
-                        assert len(messages) == 1
-                    finally:
-                        for m in messages:
-                            receiver.complete_message(m)
-                else:
-                    raise Exception("Failed to receive schdeduled message.")
+#                 messages = receiver.receive_messages(max_wait_time=20)
+#                 if messages:
+#                     try:
+#                         data = str(messages[0])
+#                         assert data == content
+#                         assert messages[0].message_id == message_id
+#                         assert messages[0].scheduled_enqueue_time_utc == scheduled_enqueue_time
+#                         assert messages[0].scheduled_enqueue_time_utc <= messages[0].enqueued_time_utc.replace(microsecond=0)
+#                         assert len(messages) == 1
+#                     finally:
+#                         for m in messages:
+#                             receiver.complete_message(m)
+#                 else:
+#                     raise Exception("Failed to receive schdeduled message.")
 
-            # send list of dicts
-            with sb_client.get_queue_receiver(servicebus_queue.name, prefetch_count=20) as receiver:
-                with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                    tokens = sender.schedule_messages(list_message_dicts, scheduled_enqueue_time)
-                    assert len(tokens) == 2
+#             # send list of dicts
+#             with sb_client.get_queue_receiver(servicebus_queue.name, prefetch_count=20) as receiver:
+#                 with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                     tokens = sender.schedule_messages(list_message_dicts, scheduled_enqueue_time)
+#                     assert len(tokens) == 2
     
-                messages = receiver.receive_messages(max_wait_time=20)
-                messages.extend(receiver.receive_messages(max_wait_time=5))
-                if messages:
-                    try:
-                        data = str(messages[0])
-                        print(messages)
-                        assert data == content
-                        assert messages[0].message_id == message_id
-                        assert messages[0].scheduled_enqueue_time_utc == scheduled_enqueue_time
-                        assert messages[0].scheduled_enqueue_time_utc <= messages[0].enqueued_time_utc.replace(microsecond=0)
-                        assert len(messages) == 2
-                    finally:
-                        for m in messages:
-                            receiver.complete_message(m)
-                else:
-                    raise Exception("Failed to receive schdeduled message.")                    
+#                 messages = receiver.receive_messages(max_wait_time=20)
+#                 messages.extend(receiver.receive_messages(max_wait_time=5))
+#                 if messages:
+#                     try:
+#                         data = str(messages[0])
+#                         print(messages)
+#                         assert data == content
+#                         assert messages[0].message_id == message_id
+#                         assert messages[0].scheduled_enqueue_time_utc == scheduled_enqueue_time
+#                         assert messages[0].scheduled_enqueue_time_utc <= messages[0].enqueued_time_utc.replace(microsecond=0)
+#                         assert len(messages) == 2
+#                     finally:
+#                         for m in messages:
+#                             receiver.complete_message(m)
+#                 else:
+#                     raise Exception("Failed to receive schdeduled message.")                    
 
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_queue_send_dict_messages_scheduled_error_badly_formatted_dicts(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_queue_send_dict_messages_scheduled_error_badly_formatted_dicts(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
         
-        with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-            content = "Test scheduled message"
-            message_id = uuid.uuid4()
-            message_id2 = uuid.uuid4()
-            scheduled_enqueue_time = (utc_now() + timedelta(minutes=0.1)).replace(microsecond=0)
-            with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
-                with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                    message_dict = {"message_id": message_id, "bad_key": content}
-                    message2_dict = {"message_id": message_id2, "bad_key": content}
-                    list_message_dicts = [message_dict, message2_dict]
-                    with pytest.raises(TypeError):
-                        sender.schedule_messages(message_dict, scheduled_enqueue_time)
-                    with pytest.raises(TypeError):
-                        sender.schedule_messages(list_message_dicts, scheduled_enqueue_time)
+#         with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#             content = "Test scheduled message"
+#             message_id = uuid.uuid4()
+#             message_id2 = uuid.uuid4()
+#             scheduled_enqueue_time = (utc_now() + timedelta(minutes=0.1)).replace(microsecond=0)
+#             with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
+#                 with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                     message_dict = {"message_id": message_id, "bad_key": content}
+#                     message2_dict = {"message_id": message_id2, "bad_key": content}
+#                     list_message_dicts = [message_dict, message2_dict]
+#                     with pytest.raises(TypeError):
+#                         sender.schedule_messages(message_dict, scheduled_enqueue_time)
+#                     with pytest.raises(TypeError):
+#                         sender.schedule_messages(list_message_dicts, scheduled_enqueue_time)
 
     
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_queue_receive_iterator_resume_after_link_detach(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_queue_receive_iterator_resume_after_link_detach(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
 
-        def hack_iter_next_mock_error(self, wait_time=None):
-            try:
-                self._receive_context.set()
-                self._open()
-                # when trying to receive the second message (execution_times is 1), raising LinkDetach error to mock 10 mins idle timeout
-                if self.execution_times == 1:
-                    # TODO: update uamqp errors to pyamqp
-                    if uamqp_transport:
-                        from uamqp.errors import LinkDetach
-                        from uamqp.constants import ErrorCodes
-                        error = LinkDetach
-                        error_condition = ErrorCodes
-                    else:
-                        from azure.servicebus._pyamqp.error import ErrorCondition, AMQPLinkError
-                        error = AMQPLinkError
-                        error_condition = ErrorCondition
+#         def hack_iter_next_mock_error(self, wait_time=None):
+#             try:
+#                 self._receive_context.set()
+#                 self._open()
+#                 # when trying to receive the second message (execution_times is 1), raising LinkDetach error to mock 10 mins idle timeout
+#                 if self.execution_times == 1:
+#                     # TODO: update uamqp errors to pyamqp
+#                     if uamqp_transport:
+#                         from uamqp.errors import LinkDetach
+#                         from uamqp.constants import ErrorCodes
+#                         error = LinkDetach
+#                         error_condition = ErrorCodes
+#                     else:
+#                         from azure.servicebus._pyamqp.error import ErrorCondition, AMQPLinkError
+#                         error = AMQPLinkError
+#                         error_condition = ErrorCondition
 
-                    self.execution_times += 1
-                    self.error_raised = True
-                    raise error(error_condition.LinkDetachForced)
-                else:
-                    self.execution_times += 1
-                if not self._message_iter:
-                    if uamqp_transport:
-                        self._message_iter = self._handler.receive_messages_iter()
-                    else:
-                        self._message_iter = self._handler.receive_messages_iter(timeout=wait_time)
-                amqp_message = next(self._message_iter)
-                message = self._build_received_message(amqp_message)
-                return message
-            finally:
-                self._receive_context.clear()
+#                     self.execution_times += 1
+#                     self.error_raised = True
+#                     raise error(error_condition.LinkDetachForced)
+#                 else:
+#                     self.execution_times += 1
+#                 if not self._message_iter:
+#                     if uamqp_transport:
+#                         self._message_iter = self._handler.receive_messages_iter()
+#                     else:
+#                         self._message_iter = self._handler.receive_messages_iter(timeout=wait_time)
+#                 amqp_message = next(self._message_iter)
+#                 message = self._build_received_message(amqp_message)
+#                 return message
+#             finally:
+#                 self._receive_context.clear()
 
-        with ServiceBusClient.from_connection_string(
-                servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                sender.send_messages(
-                    [ServiceBusMessage("test1"), ServiceBusMessage("test2"), ServiceBusMessage("test3")]
-                )
-            with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10) as receiver:
-                receiver.execution_times = 0
-                receiver.error_raised = False
-                receiver._iter_next = types.MethodType(hack_iter_next_mock_error, receiver)
-                res = []
-                for msg in receiver:
-                    receiver.complete_message(msg)
-                    res.append(msg)
-                assert len(res) == 3
-                assert receiver.error_raised
-                assert receiver.execution_times >= 4  # at least 1 failure and 3 successful receiving iterator
+#         with ServiceBusClient.from_connection_string(
+#                 servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 sender.send_messages(
+#                     [ServiceBusMessage("test1"), ServiceBusMessage("test2"), ServiceBusMessage("test3")]
+#                 )
+#             with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10) as receiver:
+#                 receiver.execution_times = 0
+#                 receiver.error_raised = False
+#                 receiver._iter_next = types.MethodType(hack_iter_next_mock_error, receiver)
+#                 res = []
+#                 for msg in receiver:
+#                     receiver.complete_message(msg)
+#                     res.append(msg)
+#                 assert len(res) == 3
+#                 assert receiver.error_raised
+#                 assert receiver.execution_times >= 4  # at least 1 failure and 3 successful receiving iterator
 
     
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_queue_send_amqp_annotated_message(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_queue_send_amqp_annotated_message(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
 
-        with ServiceBusClient.from_connection_string(
-                servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-            sequence_body = [b'message', 123.456, True]
-            footer = {'footer_key': 'footer_value'}
-            prop = {"subject": "sequence"}
-            seq_app_prop = {"body_type": "sequence"}
+#         with ServiceBusClient.from_connection_string(
+#                 servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#             sequence_body = [b'message', 123.456, True]
+#             footer = {'footer_key': 'footer_value'}
+#             prop = {"subject": "sequence"}
+#             seq_app_prop = {"body_type": "sequence"}
 
-            sequence_message = AmqpAnnotatedMessage(
-                sequence_body=sequence_body,
-                footer=footer,
-                properties=prop,
-                application_properties=seq_app_prop
-            )
+#             sequence_message = AmqpAnnotatedMessage(
+#                 sequence_body=sequence_body,
+#                 footer=footer,
+#                 properties=prop,
+#                 application_properties=seq_app_prop
+#             )
 
-            value_body = {b"key": [-123, b'data', False]}
-            header = {"priority": 10}
-            anno = {"ann_key": "ann_value"}
-            value_app_prop = {"body_type": "value"}
+#             value_body = {b"key": [-123, b'data', False]}
+#             header = {"priority": 10}
+#             anno = {"ann_key": "ann_value"}
+#             value_app_prop = {"body_type": "value"}
 
-            value_message = AmqpAnnotatedMessage(
-                value_body=value_body,
-                header=header,
-                annotations=anno,
-                application_properties=value_app_prop
-            )
+#             value_message = AmqpAnnotatedMessage(
+#                 value_body=value_body,
+#                 header=header,
+#                 annotations=anno,
+#                 application_properties=value_app_prop
+#             )
 
-            data_body = [b'aa', b'bb', b'cc']
-            data_app_prop = {"body_type": "data"}
-            del_anno = {"delann_key": "delann_value"}
-            data_message = AmqpAnnotatedMessage(
-                data_body=data_body,
-                delivery_annotations=del_anno,
-                application_properties=data_app_prop
-            )
+#             data_body = [b'aa', b'bb', b'cc']
+#             data_app_prop = {"body_type": "data"}
+#             del_anno = {"delann_key": "delann_value"}
+#             data_message = AmqpAnnotatedMessage(
+#                 data_body=data_body,
+#                 delivery_annotations=del_anno,
+#                 application_properties=data_app_prop
+#             )
 
-            with pytest.raises(ValueError):
-                AmqpAnnotatedMessage(data_body=data_body, value_body=value_body)
-            with pytest.raises(ValueError):
-                AmqpAnnotatedMessage()
+#             with pytest.raises(ValueError):
+#                 AmqpAnnotatedMessage(data_body=data_body, value_body=value_body)
+#             with pytest.raises(ValueError):
+#                 AmqpAnnotatedMessage()
 
-            content = "normalmessage"
-            dict_message = {"body": content}
-            sb_message = ServiceBusMessage(body=content)
-            message_with_ttl = AmqpAnnotatedMessage(data_body=data_body, header=AmqpMessageHeader(time_to_live=60000))
-            if uamqp_transport:
-                amqp_transport = UamqpTransport
-            else:
-                amqp_transport = PyamqpTransport
-            amqp_with_ttl = amqp_transport.to_outgoing_amqp_message(message_with_ttl)
-            assert amqp_with_ttl.properties.absolute_expiry_time == amqp_with_ttl.properties.creation_time + amqp_with_ttl.header.ttl
+#             content = "normalmessage"
+#             dict_message = {"body": content}
+#             sb_message = ServiceBusMessage(body=content)
+#             message_with_ttl = AmqpAnnotatedMessage(data_body=data_body, header=AmqpMessageHeader(time_to_live=60000))
+#             if uamqp_transport:
+#                 amqp_transport = UamqpTransport
+#             else:
+#                 amqp_transport = PyamqpTransport
+#             amqp_with_ttl = amqp_transport.to_outgoing_amqp_message(message_with_ttl)
+#             assert amqp_with_ttl.properties.absolute_expiry_time == amqp_with_ttl.properties.creation_time + amqp_with_ttl.header.ttl
 
-            recv_data_msg = recv_sequence_msg = recv_value_msg = normal_msg = 0
-            with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10) as receiver:
-                with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                    batch = sender.create_message_batch()
-                    batch.add_message(data_message)
-                    batch.add_message(value_message)
-                    batch.add_message(sequence_message)
-                    batch.add_message(dict_message)
-                    batch.add_message(sb_message)
+#             recv_data_msg = recv_sequence_msg = recv_value_msg = normal_msg = 0
+#             with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10) as receiver:
+#                 with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                     batch = sender.create_message_batch()
+#                     batch.add_message(data_message)
+#                     batch.add_message(value_message)
+#                     batch.add_message(sequence_message)
+#                     batch.add_message(dict_message)
+#                     batch.add_message(sb_message)
 
-                    sender.send_messages(batch)
-                    sender.send_messages([data_message, value_message, sequence_message, dict_message, sb_message])
-                    sender.send_messages(data_message)
-                    sender.send_messages(value_message)
-                    sender.send_messages(sequence_message)
+#                     sender.send_messages(batch)
+#                     sender.send_messages([data_message, value_message, sequence_message, dict_message, sb_message])
+#                     sender.send_messages(data_message)
+#                     sender.send_messages(value_message)
+#                     sender.send_messages(sequence_message)
 
-                    for message in receiver:
-                        raw_amqp_message = message.raw_amqp_message
-                        if raw_amqp_message.body_type == AmqpMessageBodyType.DATA:
-                            if raw_amqp_message.application_properties and raw_amqp_message.application_properties.get(b'body_type') == b'data':
-                                body = [data for data in raw_amqp_message.body]
-                                assert data_body == body
-                                assert raw_amqp_message.delivery_annotations[b'delann_key'] == b'delann_value'
-                                assert raw_amqp_message.application_properties[b'body_type'] == b'data'
-                                recv_data_msg += 1
-                            else:
-                                assert str(message) == content
-                                normal_msg += 1
-                        elif raw_amqp_message.body_type == AmqpMessageBodyType.SEQUENCE:
-                            body = [sequence for sequence in raw_amqp_message.body]
-                            assert [sequence_body] == body
-                            assert raw_amqp_message.footer[b'footer_key'] == b'footer_value'
-                            assert raw_amqp_message.properties.subject == b'sequence'
-                            assert raw_amqp_message.application_properties[b'body_type'] == b'sequence'
-                            recv_sequence_msg += 1
-                        elif raw_amqp_message.body_type == AmqpMessageBodyType.VALUE:
-                            assert raw_amqp_message.body == value_body
-                            assert raw_amqp_message.header.priority == 10
-                            assert raw_amqp_message.annotations[b'ann_key'] == b'ann_value'
-                            assert raw_amqp_message.application_properties[b'body_type'] == b'value'
-                            recv_value_msg += 1
+#                     for message in receiver:
+#                         raw_amqp_message = message.raw_amqp_message
+#                         if raw_amqp_message.body_type == AmqpMessageBodyType.DATA:
+#                             if raw_amqp_message.application_properties and raw_amqp_message.application_properties.get(b'body_type') == b'data':
+#                                 body = [data for data in raw_amqp_message.body]
+#                                 assert data_body == body
+#                                 assert raw_amqp_message.delivery_annotations[b'delann_key'] == b'delann_value'
+#                                 assert raw_amqp_message.application_properties[b'body_type'] == b'data'
+#                                 recv_data_msg += 1
+#                             else:
+#                                 assert str(message) == content
+#                                 normal_msg += 1
+#                         elif raw_amqp_message.body_type == AmqpMessageBodyType.SEQUENCE:
+#                             body = [sequence for sequence in raw_amqp_message.body]
+#                             assert [sequence_body] == body
+#                             assert raw_amqp_message.footer[b'footer_key'] == b'footer_value'
+#                             assert raw_amqp_message.properties.subject == b'sequence'
+#                             assert raw_amqp_message.application_properties[b'body_type'] == b'sequence'
+#                             recv_sequence_msg += 1
+#                         elif raw_amqp_message.body_type == AmqpMessageBodyType.VALUE:
+#                             assert raw_amqp_message.body == value_body
+#                             assert raw_amqp_message.header.priority == 10
+#                             assert raw_amqp_message.annotations[b'ann_key'] == b'ann_value'
+#                             assert raw_amqp_message.application_properties[b'body_type'] == b'value'
+#                             recv_value_msg += 1
                         
-                        receiver.complete_message(message)
+#                         receiver.complete_message(message)
 
-                    assert recv_sequence_msg == 3
-                    assert recv_data_msg == 3
-                    assert recv_value_msg == 3
-                    assert normal_msg == 4
-
-
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_state_scheduled(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, uamqp_transport=uamqp_transport) as sb_client:
-
-            sender = sb_client.get_queue_sender(servicebus_queue.name)
-            for i in range(10):
-                message = ServiceBusMessage("message no. {}".format(i))
-                scheduled_time_utc = datetime.utcnow() + timedelta(seconds=30)
-                sequence_number = sender.schedule_messages(message, scheduled_time_utc)
-
-            receiver = sb_client.get_queue_receiver(servicebus_queue.name)
-            with receiver:
-                for msg in receiver.peek_messages():
-                    assert msg.state == ServiceBusMessageState.SCHEDULED
+#                     assert recv_sequence_msg == 3
+#                     assert recv_data_msg == 3
+#                     assert recv_value_msg == 3
+#                     assert normal_msg == 4
 
 
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_state_deferred(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, uamqp_transport=uamqp_transport) as sb_client:
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_state_scheduled(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, uamqp_transport=uamqp_transport) as sb_client:
 
-            sender = sb_client.get_queue_sender(servicebus_queue.name)
-            for i in range(10):
-                message = ServiceBusMessage("message no. {}".format(i))
-                sender.send_messages(message)
+#             sender = sb_client.get_queue_sender(servicebus_queue.name)
+#             for i in range(10):
+#                 message = ServiceBusMessage("message no. {}".format(i))
+#                 scheduled_time_utc = datetime.utcnow() + timedelta(seconds=30)
+#                 sequence_number = sender.schedule_messages(message, scheduled_time_utc)
 
-            receiver = sb_client.get_queue_receiver(servicebus_queue.name)
-            deferred_messages = []
-            with receiver:
-                received_msgs = receiver.receive_messages()
-                for message in received_msgs:
-                    assert message.state == ServiceBusMessageState.ACTIVE
-                    deferred_messages.append(message.sequence_number)
-                    receiver.defer_message(message)
-                if deferred_messages:
-                    received_deferred_msg = receiver.receive_deferred_messages(
-                        sequence_numbers=deferred_messages
-                        )
-                for message in received_deferred_msg:
-                    assert message.state == ServiceBusMessageState.DEFERRED
+#             receiver = sb_client.get_queue_receiver(servicebus_queue.name)
+#             with receiver:
+#                 for msg in receiver.peek_messages():
+#                     assert msg.state == ServiceBusMessageState.SCHEDULED
+
+
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_state_deferred(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, uamqp_transport=uamqp_transport) as sb_client:
+
+#             sender = sb_client.get_queue_sender(servicebus_queue.name)
+#             for i in range(10):
+#                 message = ServiceBusMessage("message no. {}".format(i))
+#                 sender.send_messages(message)
+
+#             receiver = sb_client.get_queue_receiver(servicebus_queue.name)
+#             deferred_messages = []
+#             with receiver:
+#                 received_msgs = receiver.receive_messages()
+#                 for message in received_msgs:
+#                     assert message.state == ServiceBusMessageState.ACTIVE
+#                     deferred_messages.append(message.sequence_number)
+#                     receiver.defer_message(message)
+#                 if deferred_messages:
+#                     received_deferred_msg = receiver.receive_deferred_messages(
+#                         sequence_numbers=deferred_messages
+#                         )
+#                 for message in received_deferred_msg:
+#                     assert message.state == ServiceBusMessageState.DEFERRED

--- a/sdk/servicebus/azure-servicebus/tests/test_queues.py
+++ b/sdk/servicebus/azure-servicebus/tests/test_queues.py
@@ -1,3261 +1,3413 @@
-# #-------------------------------------------------------------------------
-# # Copyright (c) Microsoft Corporation. All rights reserved.
-# # Licensed under the MIT License. See License.txt in the project root for
-# # license information.
-# #--------------------------------------------------------------------------
+#-------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+#--------------------------------------------------------------------------
 
-# import logging
-# import sys
-# import os
-# import json
-# from concurrent.futures import ThreadPoolExecutor
-# import types
-# import pytest
-# import time
-# import uuid
-# from datetime import datetime, timedelta
-# import calendar
-# import unittest
-# import pickle
+import logging
+import sys
+import os
+import json
+from concurrent.futures import ThreadPoolExecutor
+import types
+import pytest
+import time
+import uuid
+from datetime import datetime, timedelta
+import calendar
+import unittest
+import pickle
 
-# try:
-#     import uamqp
-#     from azure.servicebus._transport._uamqp_transport import UamqpTransport
-# except ImportError:
-#     uamqp = None
+try:
+    import uamqp
+    from azure.servicebus._transport._uamqp_transport import UamqpTransport
+except ImportError:
+    uamqp = None
 
-# from azure.servicebus._transport._pyamqp_transport import PyamqpTransport
-# from azure.servicebus._pyamqp.message import Message
-# from azure.servicebus._pyamqp import error, client, management_operation
-# from azure.servicebus import (
-#     ServiceBusClient,
-#     AutoLockRenewer,
-#     TransportType,
-#     ServiceBusMessage,
-#     ServiceBusMessageBatch,
-#     ServiceBusReceivedMessage,
-#     ServiceBusReceiveMode,
-#     ServiceBusSubQueue,
-#     ServiceBusMessageState
-# )
-# from azure.servicebus.amqp import (
-#     AmqpMessageHeader,
-#     AmqpMessageBodyType,
-#     AmqpAnnotatedMessage,
-#     AmqpMessageProperties,
-# )
-# from azure.servicebus._common.constants import (
-#     _X_OPT_LOCK_TOKEN,
-#     _X_OPT_PARTITION_KEY,
-#     _X_OPT_VIA_PARTITION_KEY,
-#     _X_OPT_SCHEDULED_ENQUEUE_TIME,
-#     ServiceBusMessageState
-# )
-# from azure.servicebus._common.utils import utc_now
-# from azure.servicebus.management._models import DictMixin
-# from azure.servicebus.exceptions import (
-#     ServiceBusConnectionError,
-#     ServiceBusError,
-#     MessageLockLostError,
-#     MessageAlreadySettled,
-#     AutoLockRenewTimeout,
-#     MessageSizeExceededError,
-#     OperationTimeoutError
-# )
+from azure.servicebus._transport._pyamqp_transport import PyamqpTransport
+from azure.servicebus._pyamqp.message import Message
+from azure.servicebus._pyamqp import error, client, management_operation
+from azure.servicebus import (
+    ServiceBusClient,
+    AutoLockRenewer,
+    TransportType,
+    ServiceBusMessage,
+    ServiceBusMessageBatch,
+    ServiceBusReceivedMessage,
+    ServiceBusReceiveMode,
+    ServiceBusSubQueue,
+    ServiceBusMessageState
+)
+from azure.servicebus.amqp import (
+    AmqpMessageHeader,
+    AmqpMessageBodyType,
+    AmqpAnnotatedMessage,
+    AmqpMessageProperties,
+)
+from azure.servicebus._common.constants import (
+    _X_OPT_LOCK_TOKEN,
+    _X_OPT_PARTITION_KEY,
+    _X_OPT_VIA_PARTITION_KEY,
+    _X_OPT_SCHEDULED_ENQUEUE_TIME,
+    ServiceBusMessageState
+)
+from azure.servicebus._common.utils import utc_now
+from azure.servicebus.management._models import DictMixin
+from azure.servicebus.exceptions import (
+    ServiceBusConnectionError,
+    ServiceBusError,
+    MessageLockLostError,
+    MessageAlreadySettled,
+    AutoLockRenewTimeout,
+    MessageSizeExceededError,
+    OperationTimeoutError
+)
 
-# from devtools_testutils import AzureMgmtRecordedTestCase
-# from servicebus_preparer import (
-#     CachedServiceBusNamespacePreparer,
-#     ServiceBusQueuePreparer,
-#     CachedServiceBusQueuePreparer,
-#     CachedServiceBusResourceGroupPreparer
-# )
-# from utilities import get_logger, print_message, sleep_until_expired
-# from mocks import MockReceivedMessage, MockReceiver
-# from utilities import uamqp_transport as get_uamqp_transport, ArgPasser
+from devtools_testutils import AzureMgmtRecordedTestCase, get_credential
+from servicebus_preparer import (
+    SERVICEBUS_ENDPOINT_SUFFIX,
+    CachedServiceBusNamespacePreparer,
+    ServiceBusQueuePreparer,
+    CachedServiceBusQueuePreparer,
+    CachedServiceBusResourceGroupPreparer
+)
+from utilities import get_logger, print_message, sleep_until_expired
+from mocks import MockReceivedMessage, MockReceiver
+from utilities import uamqp_transport as get_uamqp_transport, ArgPasser
 
-# uamqp_transport_params, uamqp_transport_ids = get_uamqp_transport()
+uamqp_transport_params, uamqp_transport_ids = get_uamqp_transport()
 
-# _logger = get_logger(logging.DEBUG)
+_logger = get_logger(logging.DEBUG)
 
 
-# # A note regarding live_test_only.
-# # Old servicebus tests were not written to work on both stubs and live entities.
-# # This disables those tests for non-live scenarios, and should be removed as tests
-# # are ported to offline-compatible code.
-# class TestServiceBusQueue(AzureMgmtRecordedTestCase):
+# A note regarding live_test_only.
+# Old servicebus tests were not written to work on both stubs and live entities.
+# This disables those tests for non-live scenarios, and should be removed as tests
+# are ported to offline-compatible code.
+class TestServiceBusQueue(AzureMgmtRecordedTestCase):
 
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_receive_and_delete_reconnect_interaction(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         # Note: This test was to guard against github issue 7079
-#         sb_client = ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport)
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_receive_and_delete_reconnect_interaction(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        # Note: This test was to guard against github issue 7079
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        sb_client = ServiceBusClient(
+            fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport)
 
-#         with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#             for i in range(5):
-#                 sender.send_messages(ServiceBusMessage("ServiceBusMessage {}".format(i)))
+        with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+            for i in range(5):
+                sender.send_messages(ServiceBusMessage("ServiceBusMessage {}".format(i)))
 
-#         with sb_client.get_queue_receiver(servicebus_queue.name,
-#                                           receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE,
-#                                           max_wait_time=10) as receiver:
-#             batch = receiver.receive_messages()
-#             count = len(batch)
+        with sb_client.get_queue_receiver(servicebus_queue.name,
+                                          receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE,
+                                          max_wait_time=10) as receiver:
+            batch = receiver.receive_messages()
+            count = len(batch)
 
-#             for message in receiver:
-#                _logger.debug(message)
-#                count += 1
-#             assert count == 5
-
-    
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer()
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @CachedServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True, lock_duration='PT5S')
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_github_issue_6178(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-
-#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 for i in range(3):
-#                     sender.send_messages(ServiceBusMessage("ServiceBusMessage {}".format(i)))
-
-#                     with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=60) as receiver:
-#                         for message in receiver:
-#                             _logger.debug(message)
-#                             _logger.debug(message.sequence_number)
-#                             _logger.debug(message.enqueued_time_utc)
-#                             _logger.debug(message._lock_expired)
-#                             receiver.complete_message(message)
-#                             time.sleep(10)
+            for message in receiver:
+               _logger.debug(message)
+               count += 1
+            assert count == 5
 
     
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True, lock_duration='PT10S')
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_queue_by_queue_client_conn_str_receive_handler_peeklock(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer()
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @CachedServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True, lock_duration='PT5S')
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_github_issue_6178(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+            fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-#             sender = sb_client.get_queue_sender(servicebus_queue.name)
-#             for i in range(10):
-#                 message = ServiceBusMessage("Handler message no. {}".format(i))
-#                 message.application_properties = {'key': 'value'}
-#                 message.subject = 'label'
-#                 message.content_type = 'application/text'
-#                 message.correlation_id = 'cid'
-#                 message.message_id = str(i)
-#                 message.partition_key = 'pk'
-#                 message.to = 'to'
-#                 message.reply_to = 'reply_to'
-#                 sender.send_messages(message)
+            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                for i in range(3):
+                    sender.send_messages(ServiceBusMessage("ServiceBusMessage {}".format(i)))
 
-#             # Test that noop empty send works properly.
-#             sender.send_messages([])
-#             sender.send_messages(ServiceBusMessageBatch())
-#             assert len(sender.schedule_messages([], utc_now())) == 0
-#             sender.cancel_scheduled_messages([])
-#             sender.close()
-
-#             # Then test expected failure modes.
-#             with pytest.raises(ValueError):
-#                 with sender:
-#                     raise AssertionError("Should raise ValueError")
-#             with pytest.raises(ValueError):
-#                 sender.send_messages(ServiceBusMessage('msg'))
-#             with pytest.raises(ValueError):
-#                 sender.schedule_messages(ServiceBusMessage('msg'), utc_now())
-#             with pytest.raises(ValueError):
-#                 sender.cancel_scheduled_messages([1, 2, 3])
-
-#             with pytest.raises(ValueError):
-#                 sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=0)
-
-#             receiver = sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10)
-
-#             assert len(receiver.receive_deferred_messages([])) == 0
-#             with pytest.raises(ValueError):
-#                 receiver.receive_messages(max_wait_time=0)
-
-#             count = 0
-#             for message in receiver:
-#                 print_message(_logger, message)
-#                 assert message.delivery_count == 0
-#                 assert message.application_properties
-#                 assert message.application_properties[b'key'] == b'value'
-#                 assert message.subject == 'label'
-#                 assert message.content_type == 'application/text'
-#                 assert message.correlation_id == 'cid'
-#                 assert message.message_id == str(count)
-#                 assert message.to == 'to'
-#                 assert message.reply_to == 'reply_to'
-#                 assert message.sequence_number
-#                 assert message.enqueued_time_utc
-#                 assert message.message.delivery_tag is not None
-#                 assert message.lock_token == message.message.delivery_annotations.get(_X_OPT_LOCK_TOKEN)
-#                 assert message.lock_token == uuid.UUID(bytes_le=message.message.delivery_tag)
-#                 assert not message.scheduled_enqueue_time_utc
-#                 assert not message.time_to_live
-#                 assert not message.session_id
-#                 assert not message.reply_to_session_id
-#                 count += 1
-#                 receiver.complete_message(message)
-#             receiver.close()
-
-#             with pytest.raises(ValueError):
-#                 receiver.receive_messages()
-#             with pytest.raises(ValueError):
-#                 with receiver:
-#                     raise AssertionError("Should raise ValueError")
-#             with pytest.raises(ValueError):
-#                 receiver.receive_deferred_messages([1, 2, 3])
-#             with pytest.raises(ValueError):
-#                 receiver.peek_messages()
-
-#             assert count == 10
-
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True, lock_duration='PT10S')
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_queue_by_queue_client_conn_str_receive_handler_release_messages(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-
-#             def sub_test_releasing_messages():
-#                 # test releasing messages when prefetch is 1 and link credits are issue dynamically
-#                 receiver = sb_client.get_queue_receiver(servicebus_queue.name)
-#                 sender = sb_client.get_queue_sender(servicebus_queue.name)
-#                 with sender, receiver:
-#                     # send 10 msgs to queue first
-#                     sender.send_messages([ServiceBusMessage('test') for _ in range(5)])
-
-#                     received_msgs = []
-#                     # the amount of messages returned by receive call is not stable, especially in live tests
-#                     # of different os platforms, this is why a while loop is used here to receive the specific
-#                     # amount of message we want to receive
-#                     while len(received_msgs) < 5:
-#                         # issue link credits more than 5, client should consume 5 msgs from the service in total,
-#                         # leaving the extra credits on the wire
-#                         for msg in receiver.receive_messages(max_message_count=10, max_wait_time=5):
-#                             receiver.complete_message(msg)
-#                             received_msgs.append(received_msgs)
-#                     assert len(received_msgs) == 5
-
-#                     # send 5 more messages, those messages would arrive at the client while the program is sleeping
-#                     sender.send_messages([ServiceBusMessage('test') for _ in range(5)])
-#                     time.sleep(15)  # sleep > message expiration time
-
-#                     target_msgs_count = 5
-#                     received_msgs = []
-#                     while len(received_msgs) < target_msgs_count:
-#                         # issue 10 link credits, client should consume 5 msgs from the service, leaving no link credits
-#                         for msg in receiver.receive_messages(max_message_count=target_msgs_count - len(received_msgs),
-#                                                              max_wait_time=5):
-#                             assert msg.delivery_count == 0  # release would not increase delivery count
-#                             receiver.complete_message(msg)
-#                             received_msgs.append(msg)
-#                     assert len(received_msgs) == 5
-
-#             def sub_test_releasing_messages_iterator():
-#                 # test nested iterator scenario
-#                 receiver = sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10)
-#                 sender = sb_client.get_queue_sender(servicebus_queue.name)
-#                 with sender, receiver:
-#                     # send 5 msgs to queue first
-#                     sender.send_messages([ServiceBusMessage('test') for _ in range(5)])
-#                     first_time = True
-#                     iterator_recv_cnt = 0
-
-#                     # case: iterator + receive batch
-#                     for msg in receiver:
-#                         assert msg.delivery_count == 0  # release would not increase delivery count
-#                         receiver.complete_message(msg)
-#                         iterator_recv_cnt += 1
-#                         if first_time:  # for the first time, we call nested receive message call
-#                             received_msgs = []
-
-#                             while len(received_msgs) < 4:  # there supposed to be 5 msgs in the queue
-#                                 # we issue 10 link credits, leaving more credits on the wire
-#                                 for sub_msg in receiver.receive_messages(max_message_count=10, max_wait_time=5):
-#                                     assert sub_msg.delivery_count == 0
-#                                     receiver.complete_message(sub_msg)
-#                                     received_msgs.append(sub_msg)
-#                             assert len(received_msgs) == 4
-#                             sender.send_messages([ServiceBusMessage('test') for _ in range(10)])
-#                             time.sleep(15)  # sleep > message expiration time
-
-#                             received_msgs = []
-#                             target_msgs_count = 5  # we want to receive 5 with the receive message call
-#                             while len(received_msgs) < target_msgs_count:
-#                                 for sub_msg in receiver.receive_messages(
-#                                         max_message_count=target_msgs_count - len(received_msgs), max_wait_time=5):
-#                                     assert sub_msg.delivery_count == 0  # release would not increase delivery count
-#                                     receiver.complete_message(sub_msg)
-#                                     received_msgs.append(sub_msg)
-#                             assert len(received_msgs) == target_msgs_count
-#                             first_time = False
-#                     assert iterator_recv_cnt == 6  # 1 before nested receive message call + 5 after nested receive message call
-
-#                     # case: iterator + iterator case
-#                     sender.send_messages([ServiceBusMessage('test') for _ in range(10)])
-#                     outter_recv_cnt = 0
-#                     inner_recv_cnt = 0
-#                     for msg in receiver:
-#                         assert msg.delivery_count == 0
-#                         outter_recv_cnt += 1
-#                         receiver.complete_message(msg)
-#                         for sub_msg in receiver:
-#                             assert sub_msg.delivery_count == 0
-#                             inner_recv_cnt += 1
-#                             receiver.complete_message(sub_msg)
-#                             if inner_recv_cnt == 5:
-#                                 time.sleep(15)  # innner finish receiving first 5 messages then sleep until lock expiration
-#                                 break
-#                     assert outter_recv_cnt == 1
-#                     outter_recv_cnt = 0
-#                     for msg in receiver:
-#                         assert msg.delivery_count == 0
-#                         outter_recv_cnt += 1
-#                         receiver.complete_message(msg)
-#                     assert outter_recv_cnt == 4
-
-
-#             def sub_test_non_releasing_messages():
-#                 # test not releasing messages when prefetch is not 1
-#                 receiver = sb_client.get_queue_receiver(servicebus_queue.name)
-#                 sender = sb_client.get_queue_sender(servicebus_queue.name)
-
-#                 if uamqp_transport:
-#                     def _hack_disable_receive_context_message_received(self, message):
-#                         # pylint: disable=protected-access
-#                         self._handler._was_message_received = True
-#                         self._handler._received_messages.put(message)
-#                 else:
-#                     def _hack_disable_receive_context_message_received(self, frame, message):
-#                         # pylint: disable=protected-access
-#                         self._handler._last_activity_timestamp = time.time()
-#                         self._handler._received_messages.put((frame, message))
-
-#                 with sender, receiver:
-#                     # send 5 msgs to queue first
-#                     sender.send_messages([ServiceBusMessage('test') for _ in range(5)])
-#                     if uamqp_transport:
-#                         receiver._handler.message_handler.on_message_received = types.MethodType(
-#                             _hack_disable_receive_context_message_received, receiver)
-#                     else:
-#                         receiver._handler._link._on_transfer = types.MethodType(
-#                             _hack_disable_receive_context_message_received, receiver)
-#                     received_msgs = []
-#                     while len(received_msgs) < 5:
-#                         # issue 10 link credits, client should consume 5 msgs from the service
-#                         # leaving 5 credits on the wire
-#                         for msg in receiver.receive_messages(max_message_count=10, max_wait_time=5):
-#                             receiver.complete_message(msg)
-#                             received_msgs.append(msg)
-#                     assert len(received_msgs) == 5
-
-#                     # send 5 more messages, those messages would arrive at the client while the program is sleeping
-#                     sender.send_messages([ServiceBusMessage('test') for _ in range(5)])
-#                     time.sleep(15)  # sleep > message expiration time
-
-#                     # issue 5 link credits, client should consume 5 msgs from the internal buffer which is already lock expired
-#                     target_msgs_count = 5
-#                     received_msgs = []
-#                     while len(received_msgs) < target_msgs_count:
-#                         received_msgs.extend(receiver.receive_messages(max_message_count=5, max_wait_time=5))
-#                     assert len(received_msgs) == 5
-#                     for msg in received_msgs:
-#                         # queue ordering I think
-#                         assert msg.delivery_count == 0
-#                         with pytest.raises(ServiceBusError):
-#                             receiver.complete_message(msg)
-
-#                     # re-received message with delivery count increased
-#                     target_msgs_count = 5
-#                     received_msgs = []
-#                     while len(received_msgs) < target_msgs_count:
-#                         received_msgs.extend(receiver.receive_messages(max_message_count=5, max_wait_time=5))
-#                     assert len(received_msgs) == 5
-#                     for msg in received_msgs:
-#                         assert msg.delivery_count > 0
-#                         receiver.complete_message(msg)
-
-#             sub_test_releasing_messages()
-#             sub_test_releasing_messages_iterator()
-#             sub_test_non_releasing_messages()
+                    with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=60) as receiver:
+                        for message in receiver:
+                            _logger.debug(message)
+                            _logger.debug(message.sequence_number)
+                            _logger.debug(message.enqueued_time_utc)
+                            _logger.debug(message._lock_expired)
+                            receiver.complete_message(message)
+                            time.sleep(10)
 
     
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_queue_by_queue_client_send_multiple_messages(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True, lock_duration='PT10S')
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_queue_by_queue_client_conn_str_receive_handler_peeklock(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+            fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-#             sender = sb_client.get_queue_sender(servicebus_queue.name)
-#             with sender:
-#                 messages = []
-#                 for i in range(10):
-#                     message = ServiceBusMessage("Handler message no. {}".format(i))
-#                     message.partition_key = 'pkey'
-#                     message.time_to_live = timedelta(seconds=60)
-#                     message.scheduled_enqueue_time_utc = utc_now() + timedelta(seconds=60)
-#                     message.partition_key = None
-#                     message.time_to_live = None
-#                     message.scheduled_enqueue_time_utc = None
-#                     message.session_id = None
-#                     messages.append(message)
-#                 sender.send_messages(messages)
+            sender = sb_client.get_queue_sender(servicebus_queue.name)
+            for i in range(10):
+                message = ServiceBusMessage("Handler message no. {}".format(i))
+                message.application_properties = {'key': 'value'}
+                message.subject = 'label'
+                message.content_type = 'application/text'
+                message.correlation_id = 'cid'
+                message.message_id = str(i)
+                message.partition_key = 'pk'
+                message.to = 'to'
+                message.reply_to = 'reply_to'
+                sender.send_messages(message)
 
-#             with pytest.raises(ValueError):
-#                 with sender:
-#                     raise AssertionError("Should raise ValueError")
-#             with pytest.raises(ValueError):
-#                 sender.send_messages(ServiceBusMessage('msg'))
-#             with pytest.raises(ValueError):
-#                 sender.schedule_messages(ServiceBusMessage('msg'), utc_now())
-#             with pytest.raises(ValueError):
-#                 sender.cancel_scheduled_messages([1, 2, 3])
+            # Test that noop empty send works properly.
+            sender.send_messages([])
+            sender.send_messages(ServiceBusMessageBatch())
+            assert len(sender.schedule_messages([], utc_now())) == 0
+            sender.cancel_scheduled_messages([])
+            sender.close()
 
-#             receiver = sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5)
-#             with receiver:
-#                 count = 0
-#                 for message in receiver:
-#                     print_message(_logger, message)
-#                     assert message.delivery_count == 0
-#                     assert not message.application_properties
-#                     assert not message.subject
-#                     assert not message.content_type
-#                     assert not message.correlation_id
-#                     assert not message.to
-#                     assert not message.reply_to
-#                     assert not message.scheduled_enqueue_time_utc
-#                     assert not message.time_to_live
-#                     assert not message.session_id
-#                     assert not message.reply_to_session_id
-#                     count += 1
-#                     receiver.complete_message(message)
-#                 assert count == 10
+            # Then test expected failure modes.
+            with pytest.raises(ValueError):
+                with sender:
+                    raise AssertionError("Should raise ValueError")
+            with pytest.raises(ValueError):
+                sender.send_messages(ServiceBusMessage('msg'))
+            with pytest.raises(ValueError):
+                sender.schedule_messages(ServiceBusMessage('msg'), utc_now())
+            with pytest.raises(ValueError):
+                sender.cancel_scheduled_messages([1, 2, 3])
 
-#             with pytest.raises(ValueError):
-#                 receiver.receive_messages()
-#             with pytest.raises(ValueError):
-#                 with receiver:
-#                     raise AssertionError("Should raise ValueError")
-#             with pytest.raises(ValueError):
-#                 receiver.receive_deferred_messages([1, 2, 3])
-#             with pytest.raises(ValueError):
-#                 receiver.peek_messages()
+            with pytest.raises(ValueError):
+                sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=0)
 
-#             sender = sb_client.get_queue_sender(servicebus_queue.name)
-#             receiver = sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5)
-#             with sender, receiver:
-#                 # send previously unpicklable message
-#                 msg = {
-#                     "body":"W1tdLCB7ImlucHV0X2lkIjogNH0sIHsiY2FsbGJhY2tzIjogbnVsbCwgImVycmJhY2tzIjogbnVsbCwgImNoYWluIjogbnVsbCwgImNob3JkIjogbnVsbH1d",
-#                     "content-encoding":"utf-8",
-#                     "content-type":"application/json",
-#                     "headers":{
-#                         "lang":"py",
-#                         "task":"tasks.example_task",
-#                         "id":"7c66557d-e4bc-437f-b021-b66dcc39dfdf",
-#                         "shadow":None,
-#                         "eta":"2021-10-07T02:30:23.764066+00:00",
-#                         "expires":None,
-#                         "group":None,
-#                         "group_index":None,
-#                         "retries":1,
-#                         "timelimit":[
-#                             None,
-#                             None
-#                         ],
-#                         "root_id":"7c66557d-e4bc-437f-b021-b66dcc39dfdf",
-#                         "parent_id":"7c66557d-e4bc-437f-b021-b66dcc39dfdf",
-#                         "argsrepr":"()",
-#                         "kwargsrepr":"{'input_id': 4}",
-#                         "origin":"gen36@94713e01a9c0",
-#                         "ignore_result":1,
-#                         "x_correlator":"44a1978d-c869-4173-afe4-da741f0edfb9"
-#                     },
-#                     "properties":{
-#                         "correlation_id":"7c66557d-e4bc-437f-b021-b66dcc39dfdf",
-#                         "reply_to":"7b9a3672-2fed-3e9b-8bfd-23ae2397d9ad",
-#                         "origin":"gen68@c33d4eef123a",
-#                         "delivery_mode":2,
-#                         "delivery_info":{
-#                             "exchange":"",
-#                             "routing_key":"celery_task_queue"
-#                         },
-#                         "priority":0,
-#                         "body_encoding":"base64",
-#                         "delivery_tag":"dc83ddb6-8cdc-4413-b88a-06c56cbde90d"
-#                     }
-#                 }
-#                 sender.send_messages(ServiceBusMessage(json.dumps(msg)))
-#                 messages = receiver.receive_messages(max_wait_time=10, max_message_count=1)
-#                 # complete first then pickle
-#                 receiver.complete_message(messages[0])
-#                 if not uamqp_transport:
-#                     pickled = pickle.loads(pickle.dumps(messages[0]))
-#                     assert json.loads(str(pickled)) == json.loads(str(messages[0]))
-#                 else:
-#                     with pytest.raises(TypeError):
-#                         pickled = pickle.loads(pickle.dumps(messages[0]))
+            receiver = sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10)
+
+            assert len(receiver.receive_deferred_messages([])) == 0
+            with pytest.raises(ValueError):
+                receiver.receive_messages(max_wait_time=0)
+
+            count = 0
+            for message in receiver:
+                print_message(_logger, message)
+                assert message.delivery_count == 0
+                assert message.application_properties
+                assert message.application_properties[b'key'] == b'value'
+                assert message.subject == 'label'
+                assert message.content_type == 'application/text'
+                assert message.correlation_id == 'cid'
+                assert message.message_id == str(count)
+                assert message.to == 'to'
+                assert message.reply_to == 'reply_to'
+                assert message.sequence_number
+                assert message.enqueued_time_utc
+                assert message.message.delivery_tag is not None
+                assert message.lock_token == message.message.delivery_annotations.get(_X_OPT_LOCK_TOKEN)
+                assert message.lock_token == uuid.UUID(bytes_le=message.message.delivery_tag)
+                assert not message.scheduled_enqueue_time_utc
+                assert not message.time_to_live
+                assert not message.session_id
+                assert not message.reply_to_session_id
+                count += 1
+                receiver.complete_message(message)
+            receiver.close()
+
+            with pytest.raises(ValueError):
+                receiver.receive_messages()
+            with pytest.raises(ValueError):
+                with receiver:
+                    raise AssertionError("Should raise ValueError")
+            with pytest.raises(ValueError):
+                receiver.receive_deferred_messages([1, 2, 3])
+            with pytest.raises(ValueError):
+                receiver.peek_messages()
+
+            assert count == 10
+
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True, lock_duration='PT10S')
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_queue_by_queue_client_conn_str_receive_handler_release_messages(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+            fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+
+            def sub_test_releasing_messages():
+                # test releasing messages when prefetch is 1 and link credits are issue dynamically
+                receiver = sb_client.get_queue_receiver(servicebus_queue.name)
+                sender = sb_client.get_queue_sender(servicebus_queue.name)
+                with sender, receiver:
+                    # send 10 msgs to queue first
+                    sender.send_messages([ServiceBusMessage('test') for _ in range(5)])
+
+                    received_msgs = []
+                    # the amount of messages returned by receive call is not stable, especially in live tests
+                    # of different os platforms, this is why a while loop is used here to receive the specific
+                    # amount of message we want to receive
+                    while len(received_msgs) < 5:
+                        # issue link credits more than 5, client should consume 5 msgs from the service in total,
+                        # leaving the extra credits on the wire
+                        for msg in receiver.receive_messages(max_message_count=10, max_wait_time=5):
+                            receiver.complete_message(msg)
+                            received_msgs.append(received_msgs)
+                    assert len(received_msgs) == 5
+
+                    # send 5 more messages, those messages would arrive at the client while the program is sleeping
+                    sender.send_messages([ServiceBusMessage('test') for _ in range(5)])
+                    time.sleep(15)  # sleep > message expiration time
+
+                    target_msgs_count = 5
+                    received_msgs = []
+                    while len(received_msgs) < target_msgs_count:
+                        # issue 10 link credits, client should consume 5 msgs from the service, leaving no link credits
+                        for msg in receiver.receive_messages(max_message_count=target_msgs_count - len(received_msgs),
+                                                             max_wait_time=5):
+                            assert msg.delivery_count == 0  # release would not increase delivery count
+                            receiver.complete_message(msg)
+                            received_msgs.append(msg)
+                    assert len(received_msgs) == 5
+
+            def sub_test_releasing_messages_iterator():
+                # test nested iterator scenario
+                receiver = sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10)
+                sender = sb_client.get_queue_sender(servicebus_queue.name)
+                with sender, receiver:
+                    # send 5 msgs to queue first
+                    sender.send_messages([ServiceBusMessage('test') for _ in range(5)])
+                    first_time = True
+                    iterator_recv_cnt = 0
+
+                    # case: iterator + receive batch
+                    for msg in receiver:
+                        assert msg.delivery_count == 0  # release would not increase delivery count
+                        receiver.complete_message(msg)
+                        iterator_recv_cnt += 1
+                        if first_time:  # for the first time, we call nested receive message call
+                            received_msgs = []
+
+                            while len(received_msgs) < 4:  # there supposed to be 5 msgs in the queue
+                                # we issue 10 link credits, leaving more credits on the wire
+                                for sub_msg in receiver.receive_messages(max_message_count=10, max_wait_time=5):
+                                    assert sub_msg.delivery_count == 0
+                                    receiver.complete_message(sub_msg)
+                                    received_msgs.append(sub_msg)
+                            assert len(received_msgs) == 4
+                            sender.send_messages([ServiceBusMessage('test') for _ in range(10)])
+                            time.sleep(15)  # sleep > message expiration time
+
+                            received_msgs = []
+                            target_msgs_count = 5  # we want to receive 5 with the receive message call
+                            while len(received_msgs) < target_msgs_count:
+                                for sub_msg in receiver.receive_messages(
+                                        max_message_count=target_msgs_count - len(received_msgs), max_wait_time=5):
+                                    assert sub_msg.delivery_count == 0  # release would not increase delivery count
+                                    receiver.complete_message(sub_msg)
+                                    received_msgs.append(sub_msg)
+                            assert len(received_msgs) == target_msgs_count
+                            first_time = False
+                    assert iterator_recv_cnt == 6  # 1 before nested receive message call + 5 after nested receive message call
+
+                    # case: iterator + iterator case
+                    sender.send_messages([ServiceBusMessage('test') for _ in range(10)])
+                    outter_recv_cnt = 0
+                    inner_recv_cnt = 0
+                    for msg in receiver:
+                        assert msg.delivery_count == 0
+                        outter_recv_cnt += 1
+                        receiver.complete_message(msg)
+                        for sub_msg in receiver:
+                            assert sub_msg.delivery_count == 0
+                            inner_recv_cnt += 1
+                            receiver.complete_message(sub_msg)
+                            if inner_recv_cnt == 5:
+                                time.sleep(15)  # innner finish receiving first 5 messages then sleep until lock expiration
+                                break
+                    assert outter_recv_cnt == 1
+                    outter_recv_cnt = 0
+                    for msg in receiver:
+                        assert msg.delivery_count == 0
+                        outter_recv_cnt += 1
+                        receiver.complete_message(msg)
+                    assert outter_recv_cnt == 4
+
+
+            def sub_test_non_releasing_messages():
+                # test not releasing messages when prefetch is not 1
+                receiver = sb_client.get_queue_receiver(servicebus_queue.name)
+                sender = sb_client.get_queue_sender(servicebus_queue.name)
+
+                if uamqp_transport:
+                    def _hack_disable_receive_context_message_received(self, message):
+                        # pylint: disable=protected-access
+                        self._handler._was_message_received = True
+                        self._handler._received_messages.put(message)
+                else:
+                    def _hack_disable_receive_context_message_received(self, frame, message):
+                        # pylint: disable=protected-access
+                        self._handler._last_activity_timestamp = time.time()
+                        self._handler._received_messages.put((frame, message))
+
+                with sender, receiver:
+                    # send 5 msgs to queue first
+                    sender.send_messages([ServiceBusMessage('test') for _ in range(5)])
+                    if uamqp_transport:
+                        receiver._handler.message_handler.on_message_received = types.MethodType(
+                            _hack_disable_receive_context_message_received, receiver)
+                    else:
+                        receiver._handler._link._on_transfer = types.MethodType(
+                            _hack_disable_receive_context_message_received, receiver)
+                    received_msgs = []
+                    while len(received_msgs) < 5:
+                        # issue 10 link credits, client should consume 5 msgs from the service
+                        # leaving 5 credits on the wire
+                        for msg in receiver.receive_messages(max_message_count=10, max_wait_time=5):
+                            receiver.complete_message(msg)
+                            received_msgs.append(msg)
+                    assert len(received_msgs) == 5
+
+                    # send 5 more messages, those messages would arrive at the client while the program is sleeping
+                    sender.send_messages([ServiceBusMessage('test') for _ in range(5)])
+                    time.sleep(15)  # sleep > message expiration time
+
+                    # issue 5 link credits, client should consume 5 msgs from the internal buffer which is already lock expired
+                    target_msgs_count = 5
+                    received_msgs = []
+                    while len(received_msgs) < target_msgs_count:
+                        received_msgs.extend(receiver.receive_messages(max_message_count=5, max_wait_time=5))
+                    assert len(received_msgs) == 5
+                    for msg in received_msgs:
+                        # queue ordering I think
+                        assert msg.delivery_count == 0
+                        with pytest.raises(ServiceBusError):
+                            receiver.complete_message(msg)
+
+                    # re-received message with delivery count increased
+                    target_msgs_count = 5
+                    received_msgs = []
+                    while len(received_msgs) < target_msgs_count:
+                        received_msgs.extend(receiver.receive_messages(max_message_count=5, max_wait_time=5))
+                    assert len(received_msgs) == 5
+                    for msg in received_msgs:
+                        assert msg.delivery_count > 0
+                        receiver.complete_message(msg)
+
+            sub_test_releasing_messages()
+            sub_test_releasing_messages_iterator()
+            sub_test_non_releasing_messages()
 
     
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True, lock_duration='PT10S')
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_queue_by_queue_client_conn_str_receive_handler_receiveanddelete(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        
-#         with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_queue_by_queue_client_send_multiple_messages(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+            fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+
+            sender = sb_client.get_queue_sender(servicebus_queue.name)
+            with sender:
+                messages = []
+                for i in range(10):
+                    message = ServiceBusMessage("Handler message no. {}".format(i))
+                    message.partition_key = 'pkey'
+                    message.time_to_live = timedelta(seconds=60)
+                    message.scheduled_enqueue_time_utc = utc_now() + timedelta(seconds=60)
+                    message.partition_key = None
+                    message.time_to_live = None
+                    message.scheduled_enqueue_time_utc = None
+                    message.session_id = None
+                    messages.append(message)
+                sender.send_messages(messages)
+
+            with pytest.raises(ValueError):
+                with sender:
+                    raise AssertionError("Should raise ValueError")
+            with pytest.raises(ValueError):
+                sender.send_messages(ServiceBusMessage('msg'))
+            with pytest.raises(ValueError):
+                sender.schedule_messages(ServiceBusMessage('msg'), utc_now())
+            with pytest.raises(ValueError):
+                sender.cancel_scheduled_messages([1, 2, 3])
+
+            receiver = sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5)
+            with receiver:
+                count = 0
+                for message in receiver:
+                    print_message(_logger, message)
+                    assert message.delivery_count == 0
+                    assert not message.application_properties
+                    assert not message.subject
+                    assert not message.content_type
+                    assert not message.correlation_id
+                    assert not message.to
+                    assert not message.reply_to
+                    assert not message.scheduled_enqueue_time_utc
+                    assert not message.time_to_live
+                    assert not message.session_id
+                    assert not message.reply_to_session_id
+                    count += 1
+                    receiver.complete_message(message)
+                assert count == 10
+
+            with pytest.raises(ValueError):
+                receiver.receive_messages()
+            with pytest.raises(ValueError):
+                with receiver:
+                    raise AssertionError("Should raise ValueError")
+            with pytest.raises(ValueError):
+                receiver.receive_deferred_messages([1, 2, 3])
+            with pytest.raises(ValueError):
+                receiver.peek_messages()
+
+            sender = sb_client.get_queue_sender(servicebus_queue.name)
+            receiver = sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5)
+            with sender, receiver:
+                # send previously unpicklable message
+                msg = {
+                    "body":"W1tdLCB7ImlucHV0X2lkIjogNH0sIHsiY2FsbGJhY2tzIjogbnVsbCwgImVycmJhY2tzIjogbnVsbCwgImNoYWluIjogbnVsbCwgImNob3JkIjogbnVsbH1d",
+                    "content-encoding":"utf-8",
+                    "content-type":"application/json",
+                    "headers":{
+                        "lang":"py",
+                        "task":"tasks.example_task",
+                        "id":"7c66557d-e4bc-437f-b021-b66dcc39dfdf",
+                        "shadow":None,
+                        "eta":"2021-10-07T02:30:23.764066+00:00",
+                        "expires":None,
+                        "group":None,
+                        "group_index":None,
+                        "retries":1,
+                        "timelimit":[
+                            None,
+                            None
+                        ],
+                        "root_id":"7c66557d-e4bc-437f-b021-b66dcc39dfdf",
+                        "parent_id":"7c66557d-e4bc-437f-b021-b66dcc39dfdf",
+                        "argsrepr":"()",
+                        "kwargsrepr":"{'input_id': 4}",
+                        "origin":"gen36@94713e01a9c0",
+                        "ignore_result":1,
+                        "x_correlator":"44a1978d-c869-4173-afe4-da741f0edfb9"
+                    },
+                    "properties":{
+                        "correlation_id":"7c66557d-e4bc-437f-b021-b66dcc39dfdf",
+                        "reply_to":"7b9a3672-2fed-3e9b-8bfd-23ae2397d9ad",
+                        "origin":"gen68@c33d4eef123a",
+                        "delivery_mode":2,
+                        "delivery_info":{
+                            "exchange":"",
+                            "routing_key":"celery_task_queue"
+                        },
+                        "priority":0,
+                        "body_encoding":"base64",
+                        "delivery_tag":"dc83ddb6-8cdc-4413-b88a-06c56cbde90d"
+                    }
+                }
+                sender.send_messages(ServiceBusMessage(json.dumps(msg)))
+                messages = receiver.receive_messages(max_wait_time=10, max_message_count=1)
+                # complete first then pickle
+                receiver.complete_message(messages[0])
+                if not uamqp_transport:
+                    pickled = pickle.loads(pickle.dumps(messages[0]))
+                    assert json.loads(str(pickled)) == json.loads(str(messages[0]))
+                else:
+                    with pytest.raises(TypeError):
+                        pickled = pickle.loads(pickle.dumps(messages[0]))
+
+    
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True, lock_duration='PT10S')
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_queue_by_queue_client_conn_str_receive_handler_receiveanddelete(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+            fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
             
-#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 for i in range(10):
-#                     message = ServiceBusMessage("Handler message no. {}".format(i))
-#                     sender.send_messages(message)
+            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                for i in range(10):
+                    message = ServiceBusMessage("Handler message no. {}".format(i))
+                    sender.send_messages(message)
     
-#             messages = []
-#             with sb_client.get_queue_receiver(servicebus_queue.name, 
-#                                               receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE, 
-#                                               max_wait_time=8) as receiver:
-#                 for message in receiver:
-#                     assert not message.application_properties
-#                     assert not message.subject
-#                     assert not message.content_type
-#                     assert not message.correlation_id
-#                     assert not message.partition_key
-#                     assert not message.to
-#                     assert not message.reply_to
-#                     assert not message.scheduled_enqueue_time_utc
-#                     assert not message.time_to_live
-#                     assert not message.session_id
-#                     assert not message.reply_to_session_id
-#                     messages.append(message)
-#                     with pytest.raises(ValueError):
-#                         receiver.complete_message(message)
-#                     with pytest.raises(ValueError): # RECEIVE_AND_DELETE messages cannot be lock renewed.
-#                         renewer = AutoLockRenewer()
-#                         renewer.register(receiver, message)
+            messages = []
+            with sb_client.get_queue_receiver(servicebus_queue.name, 
+                                              receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE, 
+                                              max_wait_time=8) as receiver:
+                for message in receiver:
+                    assert not message.application_properties
+                    assert not message.subject
+                    assert not message.content_type
+                    assert not message.correlation_id
+                    assert not message.partition_key
+                    assert not message.to
+                    assert not message.reply_to
+                    assert not message.scheduled_enqueue_time_utc
+                    assert not message.time_to_live
+                    assert not message.session_id
+                    assert not message.reply_to_session_id
+                    messages.append(message)
+                    with pytest.raises(ValueError):
+                        receiver.complete_message(message)
+                    with pytest.raises(ValueError): # RECEIVE_AND_DELETE messages cannot be lock renewed.
+                        renewer = AutoLockRenewer()
+                        renewer.register(receiver, message)
     
-#             assert len(messages) == 10
-#             assert not receiver._running
-#             time.sleep(10)
+            assert len(messages) == 10
+            assert not receiver._running
+            time.sleep(10)
     
-#             messages = []
-#             with sb_client.get_queue_receiver(servicebus_queue.name, 
-#                                               receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE, 
-#                                               max_wait_time=5) as receiver:
-#                 for message in receiver:
-#                     messages.append(message)
-#                 assert len(messages) == 0
+            messages = []
+            with sb_client.get_queue_receiver(servicebus_queue.name, 
+                                              receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE, 
+                                              max_wait_time=5) as receiver:
+                for message in receiver:
+                    messages.append(message)
+                assert len(messages) == 0
 
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True, lock_duration='PT10S')
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_queue_by_queue_client_conn_str_receive_handler_receiveanddelete_prefetch(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-#             # send 10 messages
-#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 for i in range(10):
-#                     message = ServiceBusMessage("Handler message no. {}".format(i))
-#                     sender.send_messages(message)
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True, lock_duration='PT10S')
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_queue_by_queue_client_conn_str_receive_handler_receiveanddelete_prefetch(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+            fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+            # send 10 messages
+            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                for i in range(10):
+                    message = ServiceBusMessage("Handler message no. {}".format(i))
+                    sender.send_messages(message)
 
-#             # check peek_messages returns correctly, with default prefetch_count = 0
-#             messages = []
-#             with sb_client.get_queue_receiver(servicebus_queue.name,
-#                                             receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE,
-#                                             max_wait_time=10) as receiver:
-#                 # peek messages checks current state of queue, which should return 10
-#                 # since none were prefetched, added to internal queue, and deleted
-#                 peeked_msgs = receiver.peek_messages(max_message_count=10, timeout=10)
-#                 assert len(peeked_msgs) == 10
+            # check peek_messages returns correctly, with default prefetch_count = 0
+            messages = []
+            with sb_client.get_queue_receiver(servicebus_queue.name,
+                                            receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE,
+                                            max_wait_time=10) as receiver:
+                # peek messages checks current state of queue, which should return 10
+                # since none were prefetched, added to internal queue, and deleted
+                peeked_msgs = receiver.peek_messages(max_message_count=10, timeout=10)
+                assert len(peeked_msgs) == 10
 
-#                 # iterator receives and deletes each message from SB queue
-#                 for msg in receiver:
-#                     messages.append(msg)
-#                 assert len(messages) == 10
+                # iterator receives and deletes each message from SB queue
+                for msg in receiver:
+                    messages.append(msg)
+                assert len(messages) == 10
 
-#                 # queue should be empty now
-#                 peeked_msgs = receiver.peek_messages(max_message_count=10, timeout=10)
-#                 assert len(peeked_msgs) == 0
+                # queue should be empty now
+                peeked_msgs = receiver.peek_messages(max_message_count=10, timeout=10)
+                assert len(peeked_msgs) == 0
 
-#             # send 10 messages
-#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 for i in range(10):
-#                     message = ServiceBusMessage("Handler message no. {}".format(i))
-#                     sender.send_messages(message)
+            # send 10 messages
+            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                for i in range(10):
+                    message = ServiceBusMessage("Handler message no. {}".format(i))
+                    sender.send_messages(message)
 
-#             # check peek_messages returns correctly, with default prefetch_count > 0
-#             messages = []
-#             # prefetch 2 messages from SB queue when receive is called and not on open
-#             with sb_client.get_queue_receiver(
-#                 servicebus_queue.name,
-#                 receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE,
-#                 prefetch_count=2,
-#                 max_wait_time=30
-#             ) as receiver:
-#                 # peek messages checks current state of SB queue, and returns 10
-#                 peeked_msgs = receiver.peek_messages(max_message_count=10, timeout=10)
-#                 assert len(peeked_msgs) == 10
+            # check peek_messages returns correctly, with default prefetch_count > 0
+            messages = []
+            # prefetch 2 messages from SB queue when receive is called and not on open
+            with sb_client.get_queue_receiver(
+                servicebus_queue.name,
+                receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE,
+                prefetch_count=2,
+                max_wait_time=30
+            ) as receiver:
+                # peek messages checks current state of SB queue, and returns 10
+                peeked_msgs = receiver.peek_messages(max_message_count=10, timeout=10)
+                assert len(peeked_msgs) == 10
 
-#                 # receive 3 messages
-#                 recvd_msgs = receiver.receive_messages(max_message_count=3, max_wait_time=10)
-#                 assert len(recvd_msgs) == 3
+                # receive 3 messages
+                recvd_msgs = receiver.receive_messages(max_message_count=3, max_wait_time=10)
+                assert len(recvd_msgs) == 3
 
-#                 # receive rest of messages in queue
-#                 for msg in receiver:
-#                     messages.append(msg)
-#                 assert len(messages) == 7
+                # receive rest of messages in queue
+                for msg in receiver:
+                    messages.append(msg)
+                assert len(messages) == 7
 
-#                 # queue should be empty now
-#                 peeked_msgs = receiver.peek_messages(max_message_count=10, timeout=10)
-#                 assert len(peeked_msgs) == 0
+                # queue should be empty now
+                peeked_msgs = receiver.peek_messages(max_message_count=10, timeout=10)
+                assert len(peeked_msgs) == 0
 
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_queue_by_queue_client_conn_str_receive_handler_with_stop(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        
-        
-#         with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_queue_by_queue_client_conn_str_receive_handler_with_stop(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+            fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
     
-#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 for i in range(10):
-#                     message = ServiceBusMessage("Stop message no. {}".format(i))
-#                     sender.send_messages(message)
+            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                for i in range(10):
+                    message = ServiceBusMessage("Stop message no. {}".format(i))
+                    sender.send_messages(message)
     
-#             messages = []
-#             with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10) as receiver:
-#                 for message in receiver:
-#                     messages.append(message)
-#                     receiver.complete_message(message)
-#                     if len(messages) >= 5:
-#                         break
+            messages = []
+            with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10) as receiver:
+                for message in receiver:
+                    messages.append(message)
+                    receiver.complete_message(message)
+                    if len(messages) >= 5:
+                        break
                     
-#                 assert receiver._running
-#                 assert len(messages) == 5
+                assert receiver._running
+                assert len(messages) == 5
 
-#                 for message in receiver:
-#                     messages.append(message)
-#                     receiver.complete_message(message)
-#                     if len(messages) >= 5:
-#                         break
+                for message in receiver:
+                    messages.append(message)
+                    receiver.complete_message(message)
+                    if len(messages) >= 5:
+                        break
 
-#             assert not receiver._running
-#             assert len(messages) == 6
+            assert not receiver._running
+            assert len(messages) == 6
 
     
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_queue_by_servicebus_client_iter_messages_simple(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        
-#         with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_queue_by_servicebus_client_iter_messages_simple(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+            fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
     
-#             with sb_client.get_queue_receiver(servicebus_queue.name, 
-#                                               max_wait_time=10,
-#                                               receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
+            with sb_client.get_queue_receiver(servicebus_queue.name, 
+                                              max_wait_time=10,
+                                              receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
             
-#                 with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                     for i in range(10):
-#                         message = ServiceBusMessage("Iter message no. {}".format(i))
-#                         sender.send_messages(message)
+                with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                    for i in range(10):
+                        message = ServiceBusMessage("Iter message no. {}".format(i))
+                        sender.send_messages(message)
     
-#                 count = 0
-#                 for message in receiver:
-#                     print_message(_logger, message)
-#                     receiver.complete_message(message)
-#                     with pytest.raises(MessageAlreadySettled):
-#                         receiver.complete_message(message)
-#                     with pytest.raises(MessageAlreadySettled):
-#                         receiver.renew_message_lock(message)
-#                     count += 1
+                count = 0
+                for message in receiver:
+                    print_message(_logger, message)
+                    receiver.complete_message(message)
+                    with pytest.raises(MessageAlreadySettled):
+                        receiver.complete_message(message)
+                    with pytest.raises(MessageAlreadySettled):
+                        receiver.renew_message_lock(message)
+                    count += 1
 
-#                 with pytest.raises(StopIteration):
-#                     next(receiver)
-#             assert count == 10
+                with pytest.raises(StopIteration):
+                    next(receiver)
+            assert count == 10
     
     
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_queue_by_servicebus_conn_str_client_iter_messages_with_abandon(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        
-#         with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_queue_by_servicebus_conn_str_client_iter_messages_with_abandon(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+            fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
     
-#             with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5, receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
+            with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5, receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
             
-#                 with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                     for i in range(10):
-#                         message = ServiceBusMessage("Abandoned message no. {}".format(i))
-#                         sender.send_messages(message)
+                with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                    for i in range(10):
+                        message = ServiceBusMessage("Abandoned message no. {}".format(i))
+                        sender.send_messages(message)
     
-#                 count = 0
-#                 for message in receiver:
-#                     print_message(_logger, message)
-#                     if not message.delivery_count:
-#                         count += 1
-#                         receiver.abandon_message(message)
-#                     else:
-#                         assert message.delivery_count == 1
-#                         receiver.complete_message(message)
+                count = 0
+                for message in receiver:
+                    print_message(_logger, message)
+                    if not message.delivery_count:
+                        count += 1
+                        receiver.abandon_message(message)
+                    else:
+                        assert message.delivery_count == 1
+                        receiver.complete_message(message)
     
-#             assert count == 10
+            assert count == 10
     
-#             with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=20, receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
-#                 count = 0
-#                 for message in receiver:
-#                     print_message(_logger, message)
-#                     receiver.complete_message(message)
-#                     count += 1
-#             assert count == 0
+            with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=20, receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
+                count = 0
+                for message in receiver:
+                    print_message(_logger, message)
+                    receiver.complete_message(message)
+                    count += 1
+            assert count == 0
 
     
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_queue_by_servicebus_client_iter_messages_with_defer(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        
-#         with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_queue_by_servicebus_client_iter_messages_with_defer(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+            fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
     
-#             deferred_messages = []
-#             with sb_client.get_queue_receiver(
-#                 servicebus_queue.name, 
-#                 max_wait_time=5, 
-#                 receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
+            deferred_messages = []
+            with sb_client.get_queue_receiver(
+                servicebus_queue.name, 
+                max_wait_time=5, 
+                receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
             
-#                 with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                     for i in range(10):
-#                         message = ServiceBusMessage("Deferred message no. {}".format(i))
-#                         sender.send_messages(message)
+                with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                    for i in range(10):
+                        message = ServiceBusMessage("Deferred message no. {}".format(i))
+                        sender.send_messages(message)
     
-#                 count = 0
-#                 for message in receiver:
-#                     deferred_messages.append(message.sequence_number)
-#                     print_message(_logger, message)
-#                     count += 1
-#                     receiver.defer_message(message)
+                count = 0
+                for message in receiver:
+                    deferred_messages.append(message.sequence_number)
+                    print_message(_logger, message)
+                    count += 1
+                    receiver.defer_message(message)
     
-#             assert count == 10
-#             with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5, receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
-#                 count = 0
-#                 for message in receiver:
-#                     print_message(_logger, message)
-#                     receiver.complete_message(message)
-#                     count += 1
-#             assert count == 0
+            assert count == 10
+            with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5, receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
+                count = 0
+                for message in receiver:
+                    print_message(_logger, message)
+                    receiver.complete_message(message)
+                    count += 1
+            assert count == 0
     
     
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_queue_by_servicebus_client_iter_messages_with_retrieve_deferred_client(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-    
-#         with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_queue_by_servicebus_client_iter_messages_with_retrieve_deferred_client(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+            fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-#             deferred_messages = []
-#             with sb_client.get_queue_receiver(servicebus_queue.name, 
-#                                                  max_wait_time=5, 
-#                                                  receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
+            deferred_messages = []
+            with sb_client.get_queue_receiver(servicebus_queue.name, 
+                                                 max_wait_time=5, 
+                                                 receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
             
-#                 with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                     for i in range(10):
-#                         message = ServiceBusMessage("Deferred message no. {}".format(i))
-#                         sender.send_messages(message)
+                with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                    for i in range(10):
+                        message = ServiceBusMessage("Deferred message no. {}".format(i))
+                        sender.send_messages(message)
     
-#                 count = 0
-#                 for message in receiver:
-#                     deferred_messages.append(message.sequence_number)
-#                     print_message(_logger, message)
-#                     count += 1
-#                     receiver.defer_message(message)
+                count = 0
+                for message in receiver:
+                    deferred_messages.append(message.sequence_number)
+                    print_message(_logger, message)
+                    count += 1
+                    receiver.defer_message(message)
     
-#                 assert count == 10
-#                 deferred = receiver.receive_deferred_messages(deferred_messages)
-#                 assert len(deferred) == 10
-#                 for message in deferred:
-#                     assert isinstance(message, ServiceBusReceivedMessage)
-#                     receiver.complete_message(message)
+                assert count == 10
+                deferred = receiver.receive_deferred_messages(deferred_messages)
+                assert len(deferred) == 10
+                for message in deferred:
+                    assert isinstance(message, ServiceBusReceivedMessage)
+                    receiver.complete_message(message)
                 
-#                 with pytest.raises(ServiceBusError):
-#                     receiver.receive_deferred_messages(deferred_messages)
+                with pytest.raises(ServiceBusError):
+                    receiver.receive_deferred_messages(deferred_messages)
 
     
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_queue_by_servicebus_client_iter_messages_with_retrieve_deferred_receiver_complete(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-    
-#         with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_queue_by_servicebus_client_iter_messages_with_retrieve_deferred_receiver_complete(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+            fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 deferred_messages = []
-#                 for i in range(10):
-#                     message = ServiceBusMessage("Deferred message no. {}".format(i), session_id="test_session")
-#                     sender.send_messages(message)
+            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                deferred_messages = []
+                for i in range(10):
+                    message = ServiceBusMessage("Deferred message no. {}".format(i), session_id="test_session")
+                    sender.send_messages(message)
     
-#             with sb_client.get_queue_receiver(servicebus_queue.name, 
-#                                         max_wait_time=5, 
-#                                         receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
-#                 count = 0
-#                 for message in receiver:
-#                     deferred_messages.append(message.sequence_number)
-#                     print_message(_logger, message)
-#                     count += 1
-#                     receiver.defer_message(message)
+            with sb_client.get_queue_receiver(servicebus_queue.name, 
+                                        max_wait_time=5, 
+                                        receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
+                count = 0
+                for message in receiver:
+                    deferred_messages.append(message.sequence_number)
+                    print_message(_logger, message)
+                    count += 1
+                    receiver.defer_message(message)
     
-#             assert count == 10
+            assert count == 10
     
-#             with sb_client.get_queue_receiver(servicebus_queue.name, 
-#                                            max_wait_time=5, 
-#                                            receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
-#                 deferred = receiver.receive_deferred_messages(deferred_messages)
-#                 assert len(deferred) == 10
-#                 for message in deferred:
-#                     assert isinstance(message, ServiceBusReceivedMessage)
-#                     assert message.lock_token
-#                     assert message.locked_until_utc
-#                     assert message._receiver
-#                     receiver.renew_message_lock(message)
-#                     receiver.complete_message(message)
-
-    
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_queue_by_servicebus_client_iter_messages_with_retrieve_deferred_receiver_deadletter(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 deferred_messages = []
-#                 for i in range(10):
-#                     message = ServiceBusMessage("Deferred message no. {}".format(i))
-#                     sender.send_messages(message)
-    
-#             with sb_client.get_queue_receiver(servicebus_queue.name, 
-#                                               max_wait_time=10,
-#                                               receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
-#                 count = 0
-#                 for message in receiver:
-#                     deferred_messages.append(message.sequence_number)
-#                     print_message(_logger, message)
-#                     count += 1
-#                     receiver.defer_message(message)
-    
-#             assert count == 10
-    
-#             with sb_client.get_queue_receiver(servicebus_queue.name, 
-#                                         max_wait_time=10) as receiver:
-#                 deferred = receiver.receive_deferred_messages(deferred_messages)
-#                 assert len(deferred) == 10
-#                 for message in deferred:
-#                     assert isinstance(message, ServiceBusReceivedMessage)
-#                     receiver.dead_letter_message(message, reason="Testing reason", error_description="Testing description")
-    
-#             count = 0
-#             with sb_client.get_queue_receiver(servicebus_queue.name,
-#                                               sub_queue = ServiceBusSubQueue.DEAD_LETTER,
-#                                               max_wait_time=10) as receiver:
-#                 for message in receiver:
-#                     count += 1
-#                     print_message(_logger, message)
-#                     assert message.dead_letter_reason == 'Testing reason'
-#                     assert message.dead_letter_error_description == 'Testing description'
-#                     assert message.application_properties[b'DeadLetterReason'] == b'Testing reason'
-#                     assert message.application_properties[b'DeadLetterErrorDescription'] == b'Testing description'
-#                     receiver.complete_message(message)
-#             assert count == 10
+            with sb_client.get_queue_receiver(servicebus_queue.name, 
+                                           max_wait_time=5, 
+                                           receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
+                deferred = receiver.receive_deferred_messages(deferred_messages)
+                assert len(deferred) == 10
+                for message in deferred:
+                    assert isinstance(message, ServiceBusReceivedMessage)
+                    assert message.lock_token
+                    assert message.locked_until_utc
+                    assert message._receiver
+                    receiver.renew_message_lock(message)
+                    receiver.complete_message(message)
 
     
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_queue_by_servicebus_client_iter_messages_with_retrieve_deferred_receiver_deletemode(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-
-#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 for i in range(10):
-#                     sender.send_messages(ServiceBusMessage("Deferred message no. {}".format(i)))
-
-#             deferred_messages = []
-#             count = 0
-#             with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5) as receiver:
-#                 for message in receiver:
-#                     deferred_messages.append(message.sequence_number)
-#                     print_message(_logger, message)
-#                     count += 1
-#                     receiver.defer_message(message)
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_queue_by_servicebus_client_iter_messages_with_retrieve_deferred_receiver_deadletter(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+            fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                deferred_messages = []
+                for i in range(10):
+                    message = ServiceBusMessage("Deferred message no. {}".format(i))
+                    sender.send_messages(message)
     
-#             assert count == 10
-#             with sb_client.get_queue_receiver(servicebus_queue.name, 
-#                                               receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE.value, 
-#                                               max_wait_time=5) as receiver:
-#                 deferred = receiver.receive_deferred_messages(deferred_messages)
-#                 assert len(deferred) == 10
-#                 for message in deferred:
-#                     assert isinstance(message, ServiceBusReceivedMessage)
-#                     with pytest.raises(ValueError):
-#                         receiver.complete_message(message)
-#                 with pytest.raises(ServiceBusError):
-#                     deferred = receiver.receive_deferred_messages(deferred_messages)
+            with sb_client.get_queue_receiver(servicebus_queue.name, 
+                                              max_wait_time=10,
+                                              receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
+                count = 0
+                for message in receiver:
+                    deferred_messages.append(message.sequence_number)
+                    print_message(_logger, message)
+                    count += 1
+                    receiver.defer_message(message)
+    
+            assert count == 10
+    
+            with sb_client.get_queue_receiver(servicebus_queue.name, 
+                                        max_wait_time=10) as receiver:
+                deferred = receiver.receive_deferred_messages(deferred_messages)
+                assert len(deferred) == 10
+                for message in deferred:
+                    assert isinstance(message, ServiceBusReceivedMessage)
+                    receiver.dead_letter_message(message, reason="Testing reason", error_description="Testing description")
+    
+            count = 0
+            with sb_client.get_queue_receiver(servicebus_queue.name,
+                                              sub_queue = ServiceBusSubQueue.DEAD_LETTER,
+                                              max_wait_time=10) as receiver:
+                for message in receiver:
+                    count += 1
+                    print_message(_logger, message)
+                    assert message.dead_letter_reason == 'Testing reason'
+                    assert message.dead_letter_error_description == 'Testing description'
+                    assert message.application_properties[b'DeadLetterReason'] == b'Testing reason'
+                    assert message.application_properties[b'DeadLetterErrorDescription'] == b'Testing description'
+                    receiver.complete_message(message)
+            assert count == 10
 
     
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_queue_by_servicebus_client_iter_messages_with_retrieve_deferred_not_found(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_queue_by_servicebus_client_iter_messages_with_retrieve_deferred_receiver_deletemode(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+            fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-#             deferred_messages = []
-#             with sb_client.get_queue_receiver(servicebus_queue.name, 
-#                                                  max_wait_time=5, 
-#                                                  receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
+            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                for i in range(10):
+                    sender.send_messages(ServiceBusMessage("Deferred message no. {}".format(i)))
+
+            deferred_messages = []
+            count = 0
+            with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5) as receiver:
+                for message in receiver:
+                    deferred_messages.append(message.sequence_number)
+                    print_message(_logger, message)
+                    count += 1
+                    receiver.defer_message(message)
+    
+            assert count == 10
+            with sb_client.get_queue_receiver(servicebus_queue.name, 
+                                              receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE.value, 
+                                              max_wait_time=5) as receiver:
+                deferred = receiver.receive_deferred_messages(deferred_messages)
+                assert len(deferred) == 10
+                for message in deferred:
+                    assert isinstance(message, ServiceBusReceivedMessage)
+                    with pytest.raises(ValueError):
+                        receiver.complete_message(message)
+                with pytest.raises(ServiceBusError):
+                    deferred = receiver.receive_deferred_messages(deferred_messages)
+
+    
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_queue_by_servicebus_client_iter_messages_with_retrieve_deferred_not_found(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+            fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+
+            deferred_messages = []
+            with sb_client.get_queue_receiver(servicebus_queue.name, 
+                                                 max_wait_time=5, 
+                                                 receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
             
-#                 with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                     for i in range(3):
-#                         message = ServiceBusMessage("Deferred message no. {}".format(i))
-#                         sender.send_messages(message)
+                with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                    for i in range(3):
+                        message = ServiceBusMessage("Deferred message no. {}".format(i))
+                        sender.send_messages(message)
     
-#                 count = 0
-#                 for message in receiver:
-#                     deferred_messages.append(message.sequence_number)
-#                     print_message(_logger, message)
-#                     count += 1
-#                     receiver.defer_message(message)
+                count = 0
+                for message in receiver:
+                    deferred_messages.append(message.sequence_number)
+                    print_message(_logger, message)
+                    count += 1
+                    receiver.defer_message(message)
     
-#                 assert count == 3
+                assert count == 3
     
-#                 with pytest.raises(ServiceBusError):
-#                     deferred = receiver.receive_deferred_messages([3, 4])
+                with pytest.raises(ServiceBusError):
+                    deferred = receiver.receive_deferred_messages([3, 4])
     
-#                 with pytest.raises(ServiceBusError):
-#                     deferred = receiver.receive_deferred_messages([5, 6, 7])
+                with pytest.raises(ServiceBusError):
+                    deferred = receiver.receive_deferred_messages([5, 6, 7])
 
     
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_queue_by_servicebus_client_receive_batch_with_deadletter(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-
-#         with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_queue_by_servicebus_client_receive_batch_with_deadletter(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+            fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
     
-#             with sb_client.get_queue_receiver(servicebus_queue.name, 
-#                                            max_wait_time=5, 
-#                                            receive_mode=ServiceBusReceiveMode.PEEK_LOCK, 
-#                                            prefetch_count=10) as receiver:
+            with sb_client.get_queue_receiver(servicebus_queue.name, 
+                                           max_wait_time=5, 
+                                           receive_mode=ServiceBusReceiveMode.PEEK_LOCK, 
+                                           prefetch_count=10) as receiver:
             
-#                 with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                     for i in range(10):
-#                         message = ServiceBusMessage("Dead lettered message no. {}".format(i))
-#                         sender.send_messages(message)
+                with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                    for i in range(10):
+                        message = ServiceBusMessage("Dead lettered message no. {}".format(i))
+                        sender.send_messages(message)
     
-#                 count = 0
-#                 messages = receiver.receive_messages()
-#                 while messages:
-#                     for message in messages:
-#                         print_message(_logger, message)
-#                         count += 1
-#                         receiver.dead_letter_message(message, reason="Testing reason",
-#                                                      error_description="Testing description")
-#                     messages = receiver.receive_messages()
+                count = 0
+                messages = receiver.receive_messages()
+                while messages:
+                    for message in messages:
+                        print_message(_logger, message)
+                        count += 1
+                        receiver.dead_letter_message(message, reason="Testing reason",
+                                                     error_description="Testing description")
+                    messages = receiver.receive_messages()
     
-#             assert count == 10
+            assert count == 10
     
-#             with sb_client.get_queue_receiver(servicebus_queue.name,
-#                                               max_wait_time=5, 
-#                                               receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
-#                 count = 0
-#                 for message in receiver:
-#                     print_message(_logger, message)
-#                     receiver.complete_message(message)
-#                     count += 1
-#             assert count == 0
+            with sb_client.get_queue_receiver(servicebus_queue.name,
+                                              max_wait_time=5, 
+                                              receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
+                count = 0
+                for message in receiver:
+                    print_message(_logger, message)
+                    receiver.complete_message(message)
+                    count += 1
+            assert count == 0
 
-#             with sb_client.get_queue_receiver(
-#                     servicebus_queue.name,
-#                     sub_queue = ServiceBusSubQueue.DEAD_LETTER.value,
-#                     max_wait_time=5,
-#                     receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as dl_receiver:
-#                 count = 0
-#                 for message in dl_receiver:
-#                     dl_receiver.complete_message(message)
-#                     count += 1
-#                     assert message.dead_letter_reason == 'Testing reason'
-#                     assert message.dead_letter_error_description == 'Testing description'
-#                     assert message.application_properties[b'DeadLetterReason'] == b'Testing reason'
-#                     assert message.application_properties[b'DeadLetterErrorDescription'] == b'Testing description'
-#                 assert count == 10
+            with sb_client.get_queue_receiver(
+                    servicebus_queue.name,
+                    sub_queue = ServiceBusSubQueue.DEAD_LETTER.value,
+                    max_wait_time=5,
+                    receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as dl_receiver:
+                count = 0
+                for message in dl_receiver:
+                    dl_receiver.complete_message(message)
+                    count += 1
+                    assert message.dead_letter_reason == 'Testing reason'
+                    assert message.dead_letter_error_description == 'Testing description'
+                    assert message.application_properties[b'DeadLetterReason'] == b'Testing reason'
+                    assert message.application_properties[b'DeadLetterErrorDescription'] == b'Testing description'
+                assert count == 10
 
     
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_queue_by_servicebus_client_receive_batch_with_retrieve_deadletter(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_queue_by_servicebus_client_receive_batch_with_retrieve_deadletter(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+            fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
     
-#         with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-    
-#             with sb_client.get_queue_receiver(servicebus_queue.name,
-#                                            max_wait_time=5,
-#                                            receive_mode=ServiceBusReceiveMode.PEEK_LOCK, 
-#                                            prefetch_count=10) as receiver:
+            with sb_client.get_queue_receiver(servicebus_queue.name,
+                                           max_wait_time=5,
+                                           receive_mode=ServiceBusReceiveMode.PEEK_LOCK, 
+                                           prefetch_count=10) as receiver:
             
-#                 with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                     for i in range(10):
-#                         message = ServiceBusMessage("Dead lettered message no. {}".format(i))
-#                         sender.send_messages(message)
+                with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                    for i in range(10):
+                        message = ServiceBusMessage("Dead lettered message no. {}".format(i))
+                        sender.send_messages(message)
     
-#                 count = 0
-#                 messages = receiver.receive_messages()
-#                 while messages:
-#                     for message in messages:
-#                         print_message(_logger, message)
-#                         receiver.dead_letter_message(message, reason="Testing reason",
-#                                                      error_description="Testing description")
-#                         count += 1
-#                     messages = receiver.receive_messages()
+                count = 0
+                messages = receiver.receive_messages()
+                while messages:
+                    for message in messages:
+                        print_message(_logger, message)
+                        receiver.dead_letter_message(message, reason="Testing reason",
+                                                     error_description="Testing description")
+                        count += 1
+                    messages = receiver.receive_messages()
     
-#                 receiver.receive_messages(1,5)
+                receiver.receive_messages(1,5)
     
-#             assert count == 10
+            assert count == 10
 
-#             with sb_client.get_queue_receiver(
-#                     servicebus_queue.name,
-#                     sub_queue = ServiceBusSubQueue.DEAD_LETTER,
-#                     max_wait_time=5,
-#                     receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as dl_receiver:
-#                 count = 0
-#                 for message in dl_receiver:
-#                     print_message(_logger, message)
-#                     assert message.dead_letter_reason == 'Testing reason'
-#                     assert message.dead_letter_error_description == 'Testing description'
-#                     assert message.application_properties[b'DeadLetterReason'] == b'Testing reason'
-#                     assert message.application_properties[b'DeadLetterErrorDescription'] == b'Testing description'
-#                     dl_receiver.complete_message(message)
-#                     count += 1
-#             assert count == 10
+            with sb_client.get_queue_receiver(
+                    servicebus_queue.name,
+                    sub_queue = ServiceBusSubQueue.DEAD_LETTER,
+                    max_wait_time=5,
+                    receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as dl_receiver:
+                count = 0
+                for message in dl_receiver:
+                    print_message(_logger, message)
+                    assert message.dead_letter_reason == 'Testing reason'
+                    assert message.dead_letter_error_description == 'Testing description'
+                    assert message.application_properties[b'DeadLetterReason'] == b'Testing reason'
+                    assert message.application_properties[b'DeadLetterErrorDescription'] == b'Testing description'
+                    dl_receiver.complete_message(message)
+                    count += 1
+            assert count == 10
     
 
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @CachedServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_queue_by_servicebus_client_session_fail(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @CachedServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_queue_by_servicebus_client_session_fail(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+            fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
     
-#         with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+            with pytest.raises(ServiceBusError):
+                sb_client.get_queue_receiver(servicebus_queue.name, session_id="test")._open_with_retry()
     
-#             with pytest.raises(ServiceBusError):
-#                 sb_client.get_queue_receiver(servicebus_queue.name, session_id="test")._open_with_retry()
-    
-#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 sender.send_messages(ServiceBusMessage("test session sender", session_id="test"))
+            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                sender.send_messages(ServiceBusMessage("test session sender", session_id="test"))
             
-#             with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
-#                 messages = receiver.receive_messages()
-#                 for message in messages:
-#                     assert str(message) == "test session sender"
-#                     receiver.complete_message(message)
+            with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
+                messages = receiver.receive_messages()
+                for message in messages:
+                    assert str(message) == "test session sender"
+                    receiver.complete_message(message)
     
 
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_queue_by_servicebus_client_browse_messages_client(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_queue_by_servicebus_client_browse_messages_client(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+            fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
     
-#         with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                for i in range(5):
+                    message = ServiceBusMessage("Test message no. {}".format(i))
+                    sender.send_messages(message)
     
-#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 for i in range(5):
-#                     message = ServiceBusMessage("Test message no. {}".format(i))
-#                     sender.send_messages(message)
-    
-#             with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
-#                 messages = receiver.peek_messages(5)
-#                 assert len(messages) == 5
-#                 assert all(isinstance(m, ServiceBusReceivedMessage) for m in messages)
-#                 for message in messages:
-#                     print_message(_logger, message)
-#                     with pytest.raises(ValueError):
-#                         receiver.complete_message(message)
+            with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
+                messages = receiver.peek_messages(5)
+                assert len(messages) == 5
+                assert all(isinstance(m, ServiceBusReceivedMessage) for m in messages)
+                for message in messages:
+                    print_message(_logger, message)
+                    with pytest.raises(ValueError):
+                        receiver.complete_message(message)
 
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_queue_by_servicebus_client_browse_messages_with_receiver(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_queue_by_servicebus_client_browse_messages_with_receiver(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
     
-#         with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+            fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-#             receiver = sb_client.get_queue_receiver(servicebus_queue.name,
-#                                            max_wait_time=5,
-#                                            receive_mode=ServiceBusReceiveMode.PEEK_LOCK)
-#             sender = sb_client.get_queue_sender(servicebus_queue.name)
-#             with receiver, sender:
-#                 for i in range(5):
-#                     message = ServiceBusMessage(
-#                         body="Test message",
-#                         application_properties={'key': 'value'},
-#                         subject='label',
-#                         content_type='application/text',
-#                         correlation_id='cid',
-#                         message_id='mid',
-#                         to='to',
-#                         reply_to='reply_to',
-#                         time_to_live=timedelta(seconds=60)
-#                     )
-#                     sender.send_messages(message)
+            receiver = sb_client.get_queue_receiver(servicebus_queue.name,
+                                           max_wait_time=5,
+                                           receive_mode=ServiceBusReceiveMode.PEEK_LOCK)
+            sender = sb_client.get_queue_sender(servicebus_queue.name)
+            with receiver, sender:
+                for i in range(5):
+                    message = ServiceBusMessage(
+                        body="Test message",
+                        application_properties={'key': 'value'},
+                        subject='label',
+                        content_type='application/text',
+                        correlation_id='cid',
+                        message_id='mid',
+                        to='to',
+                        reply_to='reply_to',
+                        time_to_live=timedelta(seconds=60)
+                    )
+                    sender.send_messages(message)
     
-#                 messages = receiver.peek_messages(5)
-#                 assert len(messages) > 0
-#                 assert all(isinstance(m, ServiceBusReceivedMessage) for m in messages)
-#                 for message in messages:
-#                     print_message(_logger, message)
-#                     assert b''.join(message.body) == b'Test message'
-#                     assert message.application_properties[b'key'] == b'value'
-#                     assert message.subject == 'label'
-#                     assert message.content_type == 'application/text'
-#                     assert message.correlation_id == 'cid'
-#                     assert message.message_id == 'mid'
-#                     assert message.to == 'to'
-#                     assert message.reply_to == 'reply_to'
-#                     assert message.time_to_live == timedelta(seconds=60)
-#                     with pytest.raises(ValueError):
-#                         receiver.complete_message(message)
+                messages = receiver.peek_messages(5)
+                assert len(messages) > 0
+                assert all(isinstance(m, ServiceBusReceivedMessage) for m in messages)
+                for message in messages:
+                    print_message(_logger, message)
+                    assert b''.join(message.body) == b'Test message'
+                    assert message.application_properties[b'key'] == b'value'
+                    assert message.subject == 'label'
+                    assert message.content_type == 'application/text'
+                    assert message.correlation_id == 'cid'
+                    assert message.message_id == 'mid'
+                    assert message.to == 'to'
+                    assert message.reply_to == 'reply_to'
+                    assert message.time_to_live == timedelta(seconds=60)
+                    with pytest.raises(ValueError):
+                        receiver.complete_message(message)
 
-#                     sender.send_messages(message)
+                    sender.send_messages(message)
 
-#                 cnt = 0
-#                 for message in receiver:
-#                     assert b''.join(message.body) == b'Test message'
-#                     assert message.application_properties[b'key'] == b'value'
-#                     assert message.subject == 'label'
-#                     assert message.content_type == 'application/text'
-#                     assert message.correlation_id == 'cid'
-#                     assert message.message_id == 'mid'
-#                     assert message.to == 'to'
-#                     assert message.reply_to == 'reply_to'
-#                     assert message.time_to_live == timedelta(seconds=60)
-#                     receiver.complete_message(message)
-#                     cnt += 1
-#                 assert cnt == 10
+                cnt = 0
+                for message in receiver:
+                    assert b''.join(message.body) == b'Test message'
+                    assert message.application_properties[b'key'] == b'value'
+                    assert message.subject == 'label'
+                    assert message.content_type == 'application/text'
+                    assert message.correlation_id == 'cid'
+                    assert message.message_id == 'mid'
+                    assert message.to == 'to'
+                    assert message.reply_to == 'reply_to'
+                    assert message.time_to_live == timedelta(seconds=60)
+                    receiver.complete_message(message)
+                    cnt += 1
+                assert cnt == 10
     
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_queue_by_servicebus_client_browse_empty_messages(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_queue_by_servicebus_client_browse_empty_messages(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
         
-#         with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-    
-#             with sb_client.get_queue_receiver(servicebus_queue.name,
-#                                                  max_wait_time=5, 
-#                                                  receive_mode=ServiceBusReceiveMode.PEEK_LOCK, 
-#                                                  prefetch_count=10) as receiver:
-#                 messages = receiver.peek_messages(10)
-#                 assert len(messages) == 0
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+            with sb_client.get_queue_receiver(servicebus_queue.name,
+                                                 max_wait_time=5, 
+                                                 receive_mode=ServiceBusReceiveMode.PEEK_LOCK, 
+                                                 prefetch_count=10) as receiver:
+                messages = receiver.peek_messages(10)
+                assert len(messages) == 0
     
 
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @CachedServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_queue_by_servicebus_client_fail_send_messages(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @CachedServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_queue_by_servicebus_client_fail_send_messages(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
         
-#         with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+            fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-#             too_large = "A" * 256 * 1024
+            too_large = "A" * 256 * 1024
     
-#             with sb_client.get_queue_sender(servicebus_queue.name, socket_timeout=0.5) as sender:
-#                 with pytest.raises(MessageSizeExceededError):
-#                     sender.send_messages(ServiceBusMessage(too_large))
+            with sb_client.get_queue_sender(servicebus_queue.name, socket_timeout=0.5) as sender:
+                with pytest.raises(MessageSizeExceededError):
+                    sender.send_messages(ServiceBusMessage(too_large))
 
-#                 half_too_large = "A" * int((1024 * 256) / 2)
-#                 with pytest.raises(MessageSizeExceededError):
-#                     sender.send_messages([ServiceBusMessage(half_too_large), ServiceBusMessage(half_too_large)])
+                half_too_large = "A" * int((1024 * 256) / 2)
+                with pytest.raises(MessageSizeExceededError):
+                    sender.send_messages([ServiceBusMessage(half_too_large), ServiceBusMessage(half_too_large)])
 
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_queue_by_servicebus_client_renew_message_locks(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_queue_by_servicebus_client_renew_message_locks(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
         
-#         with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+            fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
     
-#             messages = []
-#             locks = 3
-#             with sb_client.get_queue_receiver(servicebus_queue.name,
-#                                               max_wait_time=5, 
-#                                               receive_mode=ServiceBusReceiveMode.PEEK_LOCK, 
-#                                               prefetch_count=10) as receiver:
-#                 with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                     for i in range(locks):
-#                         message = ServiceBusMessage("Test message no. {}".format(i))
-#                         sender.send_messages(message)
+            messages = []
+            locks = 3
+            with sb_client.get_queue_receiver(servicebus_queue.name,
+                                              max_wait_time=5, 
+                                              receive_mode=ServiceBusReceiveMode.PEEK_LOCK, 
+                                              prefetch_count=10) as receiver:
+                with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                    for i in range(locks):
+                        message = ServiceBusMessage("Test message no. {}".format(i))
+                        sender.send_messages(message)
     
-#                 messages.extend(receiver.receive_messages())
-#                 recv = True
-#                 while recv:
-#                     recv = receiver.receive_messages()
-#                     messages.extend(recv)
+                messages.extend(receiver.receive_messages())
+                recv = True
+                while recv:
+                    recv = receiver.receive_messages()
+                    messages.extend(recv)
     
-#                 try:
-#                     for message in messages:
-#                         assert not message._lock_expired
-#                         time.sleep(5)
-#                         initial_expiry = message.locked_until_utc
-#                         receiver.renew_message_lock(message)
-#                         assert (message.locked_until_utc - initial_expiry) >= timedelta(seconds=5)
-#                 finally:
-#                     receiver.complete_message(messages[0])
-#                     receiver.complete_message(messages[1])
-#                     assert (messages[2].locked_until_utc - utc_now()) <= timedelta(seconds=60)
-#                     sleep_until_expired(messages[2])
-#                     with pytest.raises(MessageLockLostError):
-#                         receiver.complete_message(messages[2])
+                try:
+                    for message in messages:
+                        assert not message._lock_expired
+                        time.sleep(5)
+                        initial_expiry = message.locked_until_utc
+                        receiver.renew_message_lock(message)
+                        assert (message.locked_until_utc - initial_expiry) >= timedelta(seconds=5)
+                finally:
+                    receiver.complete_message(messages[0])
+                    receiver.complete_message(messages[1])
+                    assert (messages[2].locked_until_utc - utc_now()) <= timedelta(seconds=60)
+                    sleep_until_expired(messages[2])
+                    with pytest.raises(MessageLockLostError):
+                        receiver.complete_message(messages[2])
 
     
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True, lock_duration='PT10S')
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_queue_by_queue_client_conn_str_receive_handler_with_autolockrenew(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True, lock_duration='PT10S')
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_queue_by_queue_client_conn_str_receive_handler_with_autolockrenew(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
         
-#         with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+            fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
     
-#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 for i in range(10):
-#                     message = ServiceBusMessage("{}".format(i))
-#                     sender.send_messages(message)
+            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                for i in range(10):
+                    message = ServiceBusMessage("{}".format(i))
+                    sender.send_messages(message)
     
-#             renewer = AutoLockRenewer()
-#             messages = []
-#             with sb_client.get_queue_receiver(servicebus_queue.name,
-#                                                  max_wait_time=10,
-#                                                  receive_mode=ServiceBusReceiveMode.PEEK_LOCK, 
-#                                                  prefetch_count=10) as receiver:
-#                 for message in receiver:
-#                     if not messages:
-#                         messages.append(message)
-#                         assert not message._lock_expired
-#                         renewer.register(receiver, message, max_lock_renewal_duration=10)
-#                         print("Registered lock renew thread", message.locked_until_utc, utc_now())
-#                         time.sleep(10)
-#                         print("Finished first sleep", message.locked_until_utc)
-#                         assert not message._lock_expired
-#                         time.sleep(15) #generate autolockrenewtimeout error by going one iteration past.
-#                         sleep_until_expired(message)
-#                         print("Finished second sleep", message.locked_until_utc, utc_now())
-#                         assert message._lock_expired
-#                         try:
-#                             receiver.complete_message(message)
-#                             raise AssertionError("Didn't raise MessageLockLostError")
-#                         except MessageLockLostError as e:
-#                             assert isinstance(e.inner_exception, AutoLockRenewTimeout)
-#                     else:
-#                         if message._lock_expired:
-#                             print("Remaining messages", message.locked_until_utc, utc_now())
-#                             assert message._lock_expired
-#                             with pytest.raises(MessageLockLostError):
-#                                 receiver.complete_message(message)
-#                         else:
-#                             assert message.delivery_count >= 1
-#                             print("Remaining messages", message.locked_until_utc, utc_now())
-#                             messages.append(message)
-#                             receiver.complete_message(message)
-#             renewer.close()
-#             assert len(messages) == 11
+            renewer = AutoLockRenewer()
+            messages = []
+            with sb_client.get_queue_receiver(servicebus_queue.name,
+                                                 max_wait_time=10,
+                                                 receive_mode=ServiceBusReceiveMode.PEEK_LOCK, 
+                                                 prefetch_count=10) as receiver:
+                for message in receiver:
+                    if not messages:
+                        messages.append(message)
+                        assert not message._lock_expired
+                        renewer.register(receiver, message, max_lock_renewal_duration=10)
+                        print("Registered lock renew thread", message.locked_until_utc, utc_now())
+                        time.sleep(10)
+                        print("Finished first sleep", message.locked_until_utc)
+                        assert not message._lock_expired
+                        time.sleep(15) #generate autolockrenewtimeout error by going one iteration past.
+                        sleep_until_expired(message)
+                        print("Finished second sleep", message.locked_until_utc, utc_now())
+                        assert message._lock_expired
+                        try:
+                            receiver.complete_message(message)
+                            raise AssertionError("Didn't raise MessageLockLostError")
+                        except MessageLockLostError as e:
+                            assert isinstance(e.inner_exception, AutoLockRenewTimeout)
+                    else:
+                        if message._lock_expired:
+                            print("Remaining messages", message.locked_until_utc, utc_now())
+                            assert message._lock_expired
+                            with pytest.raises(MessageLockLostError):
+                                receiver.complete_message(message)
+                        else:
+                            assert message.delivery_count >= 1
+                            print("Remaining messages", message.locked_until_utc, utc_now())
+                            messages.append(message)
+                            receiver.complete_message(message)
+            renewer.close()
+            assert len(messages) == 11
 
-#             renewer = AutoLockRenewer(max_workers=8)
-#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 for i in range(10):
-#                     message = ServiceBusMessage("{}".format(i))
-#                     sender.send_messages(message)
+            renewer = AutoLockRenewer(max_workers=8)
+            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                for i in range(10):
+                    message = ServiceBusMessage("{}".format(i))
+                    sender.send_messages(message)
 
-#             with sb_client.get_queue_receiver(servicebus_queue.name,
-#                                                  max_wait_time=10,
-#                                                  receive_mode=ServiceBusReceiveMode.PEEK_LOCK,
-#                                                  prefetch_count=10) as receiver:
-#                 received_msgs = receiver.receive_messages(max_message_count=10, max_wait_time=5)
-#                 for msg in received_msgs:
-#                     renewer.register(receiver, msg, max_lock_renewal_duration=30)
-#                 time.sleep(10)
+            with sb_client.get_queue_receiver(servicebus_queue.name,
+                                                 max_wait_time=10,
+                                                 receive_mode=ServiceBusReceiveMode.PEEK_LOCK,
+                                                 prefetch_count=10) as receiver:
+                received_msgs = receiver.receive_messages(max_message_count=10, max_wait_time=5)
+                for msg in received_msgs:
+                    renewer.register(receiver, msg, max_lock_renewal_duration=30)
+                time.sleep(10)
 
-#                 for msg in received_msgs:
-#                     receiver.complete_message(msg)
-#             assert len(received_msgs) == 10
-#             renewer.close()
+                for msg in received_msgs:
+                    receiver.complete_message(msg)
+            assert len(received_msgs) == 10
+            renewer.close()
 
-#             executor = ThreadPoolExecutor(max_workers=1)
-#             renewer = AutoLockRenewer(executor=executor)
-#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 for i in range(2):
-#                     message = ServiceBusMessage("{}".format(i))
-#                     sender.send_messages(message)
+            executor = ThreadPoolExecutor(max_workers=1)
+            renewer = AutoLockRenewer(executor=executor)
+            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                for i in range(2):
+                    message = ServiceBusMessage("{}".format(i))
+                    sender.send_messages(message)
 
-#             with sb_client.get_queue_receiver(servicebus_queue.name,
-#                                                  max_wait_time=10,
-#                                                  receive_mode=ServiceBusReceiveMode.PEEK_LOCK,
-#                                                  prefetch_count=3) as receiver:
-#                 received_msgs = receiver.receive_messages(max_message_count=3, max_wait_time=10)
-#                 for msg in received_msgs:
-#                     renewer.register(receiver, msg, max_lock_renewal_duration=30)
-#                 time.sleep(10)
+            with sb_client.get_queue_receiver(servicebus_queue.name,
+                                                 max_wait_time=10,
+                                                 receive_mode=ServiceBusReceiveMode.PEEK_LOCK,
+                                                 prefetch_count=3) as receiver:
+                received_msgs = receiver.receive_messages(max_message_count=3, max_wait_time=10)
+                for msg in received_msgs:
+                    renewer.register(receiver, msg, max_lock_renewal_duration=30)
+                time.sleep(10)
 
-#                 for msg in received_msgs:
-#                     receiver.complete_message(msg)
-#             assert len(received_msgs) == 2
-#             assert not renewer._is_max_workers_greater_than_one
-#             renewer.close()
+                for msg in received_msgs:
+                    receiver.complete_message(msg)
+            assert len(received_msgs) == 2
+            assert not renewer._is_max_workers_greater_than_one
+            renewer.close()
 
-#             executor = ThreadPoolExecutor(max_workers=2)
-#             renewer = AutoLockRenewer(executor=executor)
-#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 for i in range(3):
-#                     message = ServiceBusMessage("{}".format(i))
-#                     sender.send_messages(message)
+            executor = ThreadPoolExecutor(max_workers=2)
+            renewer = AutoLockRenewer(executor=executor)
+            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                for i in range(3):
+                    message = ServiceBusMessage("{}".format(i))
+                    sender.send_messages(message)
 
-#             with sb_client.get_queue_receiver(servicebus_queue.name,
-#                                                  max_wait_time=10,
-#                                                  receive_mode=ServiceBusReceiveMode.PEEK_LOCK,
-#                                                  prefetch_count=3) as receiver:
-#                 received_msgs = receiver.receive_messages(max_message_count=3, max_wait_time=10)
-#                 for msg in received_msgs:
-#                     renewer.register(receiver, msg, max_lock_renewal_duration=30)
-#                 time.sleep(10)
+            with sb_client.get_queue_receiver(servicebus_queue.name,
+                                                 max_wait_time=10,
+                                                 receive_mode=ServiceBusReceiveMode.PEEK_LOCK,
+                                                 prefetch_count=3) as receiver:
+                received_msgs = receiver.receive_messages(max_message_count=3, max_wait_time=10)
+                for msg in received_msgs:
+                    renewer.register(receiver, msg, max_lock_renewal_duration=30)
+                time.sleep(10)
 
-#                 for msg in received_msgs:
-#                     receiver.complete_message(msg)
-#             assert len(received_msgs) == 3
-#             assert renewer._is_max_workers_greater_than_one
-#             renewer.close()
+                for msg in received_msgs:
+                    receiver.complete_message(msg)
+            assert len(received_msgs) == 3
+            assert renewer._is_max_workers_greater_than_one
+            renewer.close()
 
     
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True, lock_duration='PT10S')
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_queue_by_queue_client_conn_str_receive_handler_with_auto_autolockrenew(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True, lock_duration='PT10S')
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_queue_by_queue_client_conn_str_receive_handler_with_auto_autolockrenew(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
         
-#         with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+            fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
     
-#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 # The 10 iterations is "important" because it gives time for the timed out message to be received again.
-#                 for i in range(10):
-#                     message = ServiceBusMessage("{}".format(i))
-#                     sender.send_messages(message)
+            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                # The 10 iterations is "important" because it gives time for the timed out message to be received again.
+                for i in range(10):
+                    message = ServiceBusMessage("{}".format(i))
+                    sender.send_messages(message)
     
-#             renewer = AutoLockRenewer(max_lock_renewal_duration=10)
-#             messages = []
-#             with sb_client.get_queue_receiver(servicebus_queue.name,
-#                                                  max_wait_time=10,
-#                                                  receive_mode=ServiceBusReceiveMode.PEEK_LOCK, 
-#                                                  prefetch_count=10,
-#                                                  auto_lock_renewer=renewer) as receiver:
-#                 for message in receiver:
-#                     if not messages:
-#                         messages.append(message)
-#                         assert not message._lock_expired
-#                         print("Registered lock renew thread", message.locked_until_utc, utc_now())
-#                         time.sleep(10)
-#                         print("Finished first sleep", message.locked_until_utc)
-#                         assert not message._lock_expired
-#                         time.sleep(15) #generate autolockrenewtimeout error by going one iteration past.
-#                         sleep_until_expired(message)
-#                         print("Finished second sleep", message.locked_until_utc, utc_now())
-#                         assert message._lock_expired
-#                         try:
-#                             receiver.complete_message(message)
-#                             raise AssertionError("Didn't raise MessageLockLostError")
-#                         except MessageLockLostError as e:
-#                             assert isinstance(e.inner_exception, AutoLockRenewTimeout)
-#                     else:
-#                         if message._lock_expired:
-#                             print("Remaining messages", message.locked_until_utc, utc_now())
-#                             assert message._lock_expired
-#                             with pytest.raises(MessageLockLostError):
-#                                 receiver.complete_message(message)
-#                         else:
-#                             assert message.delivery_count >= 1
-#                             print("Remaining messages", message.locked_until_utc, utc_now())
-#                             messages.append(message)
-#                             receiver.complete_message(message)
-#             renewer.close()
-#             assert len(messages) == 11
+            renewer = AutoLockRenewer(max_lock_renewal_duration=10)
+            messages = []
+            with sb_client.get_queue_receiver(servicebus_queue.name,
+                                                 max_wait_time=10,
+                                                 receive_mode=ServiceBusReceiveMode.PEEK_LOCK, 
+                                                 prefetch_count=10,
+                                                 auto_lock_renewer=renewer) as receiver:
+                for message in receiver:
+                    if not messages:
+                        messages.append(message)
+                        assert not message._lock_expired
+                        print("Registered lock renew thread", message.locked_until_utc, utc_now())
+                        time.sleep(10)
+                        print("Finished first sleep", message.locked_until_utc)
+                        assert not message._lock_expired
+                        time.sleep(15) #generate autolockrenewtimeout error by going one iteration past.
+                        sleep_until_expired(message)
+                        print("Finished second sleep", message.locked_until_utc, utc_now())
+                        assert message._lock_expired
+                        try:
+                            receiver.complete_message(message)
+                            raise AssertionError("Didn't raise MessageLockLostError")
+                        except MessageLockLostError as e:
+                            assert isinstance(e.inner_exception, AutoLockRenewTimeout)
+                    else:
+                        if message._lock_expired:
+                            print("Remaining messages", message.locked_until_utc, utc_now())
+                            assert message._lock_expired
+                            with pytest.raises(MessageLockLostError):
+                                receiver.complete_message(message)
+                        else:
+                            assert message.delivery_count >= 1
+                            print("Remaining messages", message.locked_until_utc, utc_now())
+                            messages.append(message)
+                            receiver.complete_message(message)
+            renewer.close()
+            assert len(messages) == 11
 
     
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_queue_message_time_to_live(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_queue_message_time_to_live(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
         
-#         with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+            fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
                
-#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 content = str(uuid.uuid4())
-#                 message_id = uuid.uuid4()
-#                 message = ServiceBusMessage(content)
-#                 message.time_to_live = timedelta(seconds=15)
-#                 sender.send_messages(message)
+            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                content = str(uuid.uuid4())
+                message_id = uuid.uuid4()
+                message = ServiceBusMessage(content)
+                message.time_to_live = timedelta(seconds=15)
+                sender.send_messages(message)
     
-#             time.sleep(15)
-#             with sb_client.get_queue_receiver(servicebus_queue.name, prefetch_count=5) as receiver:
-#                 messages = receiver.receive_messages(5, max_wait_time=10)
-#             assert not messages
+            time.sleep(15)
+            with sb_client.get_queue_receiver(servicebus_queue.name, prefetch_count=5) as receiver:
+                messages = receiver.receive_messages(5, max_wait_time=10)
+            assert not messages
 
-#             with sb_client.get_queue_receiver(
-#                     servicebus_queue.name,
-#                     sub_queue = ServiceBusSubQueue.DEAD_LETTER,
-#                     max_wait_time=5,
-#                     receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as dl_receiver:
-#                 count = 0
-#                 for message in dl_receiver:
-#                     print_message(_logger, message)
-#                     dl_receiver.complete_message(message)
-#                     count += 1
-#             assert count == 1
+            with sb_client.get_queue_receiver(
+                    servicebus_queue.name,
+                    sub_queue = ServiceBusSubQueue.DEAD_LETTER,
+                    max_wait_time=5,
+                    receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as dl_receiver:
+                count = 0
+                for message in dl_receiver:
+                    print_message(_logger, message)
+                    dl_receiver.complete_message(message)
+                    count += 1
+            assert count == 1
 
     
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_duplicate_detection=True, dead_lettering_on_message_expiration=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_queue_message_duplicate_detection(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_duplicate_detection=True, dead_lettering_on_message_expiration=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_queue_message_duplicate_detection(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
         
-#         with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+            fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
     
-#             message_id = uuid.uuid4()
+            message_id = uuid.uuid4()
             
-#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 for i in range(5):
-#                     message = ServiceBusMessage(str(i))
-#                     message.message_id = message_id
-#                     sender.send_messages(message)
+            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                for i in range(5):
+                    message = ServiceBusMessage(str(i))
+                    message.message_id = message_id
+                    sender.send_messages(message)
     
-#             with sb_client.get_queue_receiver(servicebus_queue.name, 
-#                                                  max_wait_time=5) as receiver:
-#                 count = 0
-#                 for message in receiver:
-#                     print_message(_logger, message)
-#                     assert message.message_id == message_id
-#                     receiver.complete_message(message)
-#                     count += 1
-#                 assert count == 1
+            with sb_client.get_queue_receiver(servicebus_queue.name, 
+                                                 max_wait_time=5) as receiver:
+                count = 0
+                for message in receiver:
+                    print_message(_logger, message)
+                    assert message.message_id == message_id
+                    receiver.complete_message(message)
+                    count += 1
+                assert count == 1
     
 
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_queue_message_connection_closed(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_queue_message_connection_closed(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
         
-#         with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+            fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
                 
-#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 content = str(uuid.uuid4())
-#                 message = ServiceBusMessage(content)
-#                 sender.send_messages(message)
+            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                content = str(uuid.uuid4())
+                message = ServiceBusMessage(content)
+                sender.send_messages(message)
     
-#             with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
-#                 messages = receiver.receive_messages(max_wait_time=10)
-#                 assert len(messages) == 1
+            with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
+                messages = receiver.receive_messages(max_wait_time=10)
+                assert len(messages) == 1
     
-#             with pytest.raises(ValueError):
-#                 receiver.complete_message(messages[0])
+            with pytest.raises(ValueError):
+                receiver.complete_message(messages[0])
     
 
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_queue_message_expiry(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_queue_message_expiry(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
         
-#         with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+            fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
                        
-#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 content = str(uuid.uuid4())
-#                 message = ServiceBusMessage(content)
-#                 sender.send_messages(message)
+            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                content = str(uuid.uuid4())
+                message = ServiceBusMessage(content)
+                sender.send_messages(message)
     
-#             with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
-#                 messages = receiver.receive_messages(max_wait_time=10)
-#                 assert len(messages) == 1
-#                 time.sleep((messages[0].locked_until_utc - utc_now()).total_seconds()+1)
-#                 assert messages[0]._lock_expired
-#                 with pytest.raises(MessageLockLostError):
-#                     receiver.complete_message(messages[0])
-#                 with pytest.raises(MessageLockLostError):
-#                     receiver.renew_message_lock(messages[0])
+            with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
+                messages = receiver.receive_messages(max_wait_time=10)
+                assert len(messages) == 1
+                time.sleep((messages[0].locked_until_utc - utc_now()).total_seconds()+1)
+                assert messages[0]._lock_expired
+                with pytest.raises(MessageLockLostError):
+                    receiver.complete_message(messages[0])
+                with pytest.raises(MessageLockLostError):
+                    receiver.renew_message_lock(messages[0])
     
-#             with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
-#                 messages = receiver.receive_messages(max_wait_time=30)
-#                 assert len(messages) == 1
-#                 print_message(_logger, messages[0])
-#                 assert messages[0].delivery_count > 0
-#                 receiver.complete_message(messages[0])
+            with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
+                messages = receiver.receive_messages(max_wait_time=30)
+                assert len(messages) == 1
+                print_message(_logger, messages[0])
+                assert messages[0].delivery_count > 0
+                receiver.complete_message(messages[0])
     
 
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_queue_message_lock_renew(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_queue_message_lock_renew(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
         
-#         with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+            fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 content = str(uuid.uuid4())
-#                 message = ServiceBusMessage(content)
-#                 sender.send_messages(message)
+            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                content = str(uuid.uuid4())
+                message = ServiceBusMessage(content)
+                sender.send_messages(message)
 
-#             with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
-#                 messages = receiver.receive_messages(max_wait_time=10)
-#                 assert len(messages) == 1
-#                 time.sleep(15)
-#                 receiver.renew_message_lock(messages[0])
-#                 time.sleep(15)
-#                 receiver.renew_message_lock(messages[0])
-#                 time.sleep(15)
-#                 assert not messages[0]._lock_expired
-#                 receiver.complete_message(messages[0])
+            with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
+                messages = receiver.receive_messages(max_wait_time=10)
+                assert len(messages) == 1
+                time.sleep(15)
+                receiver.renew_message_lock(messages[0])
+                time.sleep(15)
+                receiver.renew_message_lock(messages[0])
+                time.sleep(15)
+                assert not messages[0]._lock_expired
+                receiver.complete_message(messages[0])
     
-#             with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
-#                 messages = receiver.receive_messages(max_wait_time=10)
-#                 assert len(messages) == 0
+            with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
+                messages = receiver.receive_messages(max_wait_time=10)
+                assert len(messages) == 0
     
 
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True, lock_duration='PT10S')
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_queue_message_receive_and_delete(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         if uamqp:
-#             transport_type = uamqp.constants.TransportType.Amqp
-#         else:
-#             transport_type = TransportType.Amqp
-#         with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string,
-#             logging_enable=False,
-#             transport_time=transport_type,
-#             uamqp_transport=uamqp_transport
-#         ) as sb_client:
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True, lock_duration='PT10S')
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_queue_message_receive_and_delete(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        if uamqp:
+            transport_type = uamqp.constants.TransportType.Amqp
+        else:
+            transport_type = TransportType.Amqp
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+            fully_qualified_namespace, credential,
+            logging_enable=False,
+            transport_time=transport_type,
+            uamqp_transport=uamqp_transport
+        ) as sb_client:
                 
-#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 message = ServiceBusMessage("Receive and delete test")
-#                 sender.send_messages(message)
+            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                message = ServiceBusMessage("Receive and delete test")
+                sender.send_messages(message)
     
-#             with sb_client.get_queue_receiver(servicebus_queue.name,
-#                                                  receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE) as receiver:
-#                 messages = receiver.receive_messages(max_wait_time=10)
-#                 assert len(messages) == 1
-#                 message = messages[0]
-#                 print_message(_logger, message)
-#                 with pytest.raises(ValueError):
-#                     receiver.complete_message(message)
-#                 with pytest.raises(ValueError):
-#                     receiver.abandon_message(message)
-#                 with pytest.raises(ValueError):
-#                     receiver.defer_message(message)
-#                 with pytest.raises(ValueError):
-#                     receiver.dead_letter_message(message)
-#                 with pytest.raises(ValueError):
-#                     receiver.renew_message_lock(message)
+            with sb_client.get_queue_receiver(servicebus_queue.name,
+                                                 receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE) as receiver:
+                messages = receiver.receive_messages(max_wait_time=10)
+                assert len(messages) == 1
+                message = messages[0]
+                print_message(_logger, message)
+                with pytest.raises(ValueError):
+                    receiver.complete_message(message)
+                with pytest.raises(ValueError):
+                    receiver.abandon_message(message)
+                with pytest.raises(ValueError):
+                    receiver.defer_message(message)
+                with pytest.raises(ValueError):
+                    receiver.dead_letter_message(message)
+                with pytest.raises(ValueError):
+                    receiver.renew_message_lock(message)
     
-#             time.sleep(10)
+            time.sleep(10)
     
-#             with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
-#                 messages = receiver.receive_messages(max_wait_time=10)
-#                 for m in messages:
-#                     print_message(_logger, m)
-#                 assert len(messages) == 0
+            with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
+                messages = receiver.receive_messages(max_wait_time=10)
+                for m in messages:
+                    print_message(_logger, m)
+                assert len(messages) == 0
     
 
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_queue_message_batch(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_queue_message_batch(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
 
-#         with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+            fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
                             
-#             def message_content():
-#                 for i in range(5):
-#                     message = ServiceBusMessage("ServiceBusMessage no. {}".format(i))
-#                     message.application_properties = {'key': 'value'}
-#                     message.subject = 'label'
-#                     message.content_type = 'application/text'
-#                     message.correlation_id = 'cid'
-#                     message.message_id = str(i)
-#                     message.to = 'to'
-#                     message.reply_to = 'reply_to'
-#                     message.time_to_live = timedelta(seconds=60)
-#                     assert message.raw_amqp_message.properties.absolute_expiry_time == message.raw_amqp_message.properties.creation_time + message.raw_amqp_message.header.time_to_live
+            def message_content():
+                for i in range(5):
+                    message = ServiceBusMessage("ServiceBusMessage no. {}".format(i))
+                    message.application_properties = {'key': 'value'}
+                    message.subject = 'label'
+                    message.content_type = 'application/text'
+                    message.correlation_id = 'cid'
+                    message.message_id = str(i)
+                    message.to = 'to'
+                    message.reply_to = 'reply_to'
+                    message.time_to_live = timedelta(seconds=60)
+                    assert message.raw_amqp_message.properties.absolute_expiry_time == message.raw_amqp_message.properties.creation_time + message.raw_amqp_message.header.time_to_live
 
-#                     yield message
+                    yield message
 
-#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 # sending manually created message batch (with default pyamqp) should work for both uamqp/pyamqp
-#                 message = ServiceBusMessageBatch()
-#                 for each in message_content():
-#                     message.add_message(each)
-#                 sender.send_messages(message)
+            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                # sending manually created message batch (with default pyamqp) should work for both uamqp/pyamqp
+                message = ServiceBusMessageBatch()
+                for each in message_content():
+                    message.add_message(each)
+                sender.send_messages(message)
     
-#             with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
-#                 messages =receiver.receive_messages(max_wait_time=10)
-#                 recv = True
-#                 while recv:
-#                     recv = receiver.receive_messages(max_wait_time=10)
-#                     messages.extend(recv)
+            with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
+                messages =receiver.receive_messages(max_wait_time=10)
+                recv = True
+                while recv:
+                    recv = receiver.receive_messages(max_wait_time=10)
+                    messages.extend(recv)
     
-#                 assert len(messages) == 5
-#                 count = 0
-#                 for message in messages:
-#                     assert message.delivery_count == 0
-#                     assert message.application_properties
-#                     assert message.application_properties[b'key'] == b'value'
-#                     assert message.subject == 'label'
-#                     assert message.content_type == 'application/text'
-#                     assert message.correlation_id == 'cid'
-#                     assert message.message_id == str(count)
-#                     assert message.to == 'to'
-#                     assert message.reply_to == 'reply_to'
-#                     assert message.sequence_number
-#                     assert message.enqueued_time_utc
-#                     assert message.expires_at_utc == (message.enqueued_time_utc + timedelta(seconds=60))
-#                     print_message(_logger, message)
-#                     receiver.complete_message(message)
-#                     count += 1
+                assert len(messages) == 5
+                count = 0
+                for message in messages:
+                    assert message.delivery_count == 0
+                    assert message.application_properties
+                    assert message.application_properties[b'key'] == b'value'
+                    assert message.subject == 'label'
+                    assert message.content_type == 'application/text'
+                    assert message.correlation_id == 'cid'
+                    assert message.message_id == str(count)
+                    assert message.to == 'to'
+                    assert message.reply_to == 'reply_to'
+                    assert message.sequence_number
+                    assert message.enqueued_time_utc
+                    assert message.expires_at_utc == (message.enqueued_time_utc + timedelta(seconds=60))
+                    print_message(_logger, message)
+                    receiver.complete_message(message)
+                    count += 1
     
 
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_queue_schedule_message(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_queue_schedule_message(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
 
-#         with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+            fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-#             scheduled_enqueue_time = (utc_now() + timedelta(minutes=2)).replace(microsecond=0)
-#             with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
-#                 with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                     content = str(uuid.uuid4())
-#                     message_id = uuid.uuid4()
-#                     message = ServiceBusMessage(content)
-#                     message.message_id = message_id
-#                     message.scheduled_enqueue_time_utc = scheduled_enqueue_time
-#                     sender.send_messages(message)
+            scheduled_enqueue_time = (utc_now() + timedelta(minutes=2)).replace(microsecond=0)
+            with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
+                with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                    content = str(uuid.uuid4())
+                    message_id = uuid.uuid4()
+                    message = ServiceBusMessage(content)
+                    message.message_id = message_id
+                    message.scheduled_enqueue_time_utc = scheduled_enqueue_time
+                    sender.send_messages(message)
     
-#                 messages = receiver.receive_messages(max_wait_time=120)
-#                 if messages:
-#                     try:
-#                         data = str(messages[0])
-#                         assert data == content
-#                         assert messages[0].message_id == message_id
-#                         assert messages[0].scheduled_enqueue_time_utc == scheduled_enqueue_time
-#                         assert messages[0].scheduled_enqueue_time_utc <= messages[0].enqueued_time_utc.replace(microsecond=0)
-#                         assert len(messages) == 1
-#                     finally:
-#                         for message in messages:
-#                             receiver.complete_message(message)
-#                 else:
-#                     raise Exception("Failed to receive schdeduled message.")
+                messages = receiver.receive_messages(max_wait_time=120)
+                if messages:
+                    try:
+                        data = str(messages[0])
+                        assert data == content
+                        assert messages[0].message_id == message_id
+                        assert messages[0].scheduled_enqueue_time_utc == scheduled_enqueue_time
+                        assert messages[0].scheduled_enqueue_time_utc <= messages[0].enqueued_time_utc.replace(microsecond=0)
+                        assert len(messages) == 1
+                    finally:
+                        for message in messages:
+                            receiver.complete_message(message)
+                else:
+                    raise Exception("Failed to receive schdeduled message.")
             
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_queue_schedule_multiple_messages(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_queue_schedule_multiple_messages(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
 
-#         with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+            fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-#             scheduled_enqueue_time = (utc_now() + timedelta(minutes=2)).replace(microsecond=0)
-#             sender = sb_client.get_queue_sender(servicebus_queue.name)
-#             receiver = sb_client.get_queue_receiver(servicebus_queue.name, prefetch_count=20, max_wait_time=5)
+            scheduled_enqueue_time = (utc_now() + timedelta(minutes=2)).replace(microsecond=0)
+            sender = sb_client.get_queue_sender(servicebus_queue.name)
+            receiver = sb_client.get_queue_receiver(servicebus_queue.name, prefetch_count=20, max_wait_time=5)
 
-#             with sender, receiver:
-#                 content = str(uuid.uuid4())
-#                 message_id_a = uuid.uuid4()
-#                 message_a = ServiceBusMessage(content)
-#                 message_a.message_id = message_id_a
-#                 message_id_b = uuid.uuid4()
-#                 message_b = ServiceBusMessage(content)
-#                 message_b.message_id = message_id_b
-#                 message_arry = [message_a, message_b]
-#                 for message in message_arry:
-#                     message.application_properties = {'key': 'value'}
-#                     message.subject = 'label'
-#                     message.content_type = 'application/text'
-#                     message.correlation_id = 'cid'
-#                     message.to = 'to'
-#                     message.reply_to = 'reply_to'
+            with sender, receiver:
+                content = str(uuid.uuid4())
+                message_id_a = uuid.uuid4()
+                message_a = ServiceBusMessage(content)
+                message_a.message_id = message_id_a
+                message_id_b = uuid.uuid4()
+                message_b = ServiceBusMessage(content)
+                message_b.message_id = message_id_b
+                message_arry = [message_a, message_b]
+                for message in message_arry:
+                    message.application_properties = {'key': 'value'}
+                    message.subject = 'label'
+                    message.content_type = 'application/text'
+                    message.correlation_id = 'cid'
+                    message.to = 'to'
+                    message.reply_to = 'reply_to'
 
-#                 sender.send_messages(message_arry)
+                sender.send_messages(message_arry)
 
-#                 received_messages = []
-#                 for message in receiver:
-#                     received_messages.append(message)
-#                     receiver.complete_message(message)
+                received_messages = []
+                for message in receiver:
+                    received_messages.append(message)
+                    receiver.complete_message(message)
 
-#                 tokens = sender.schedule_messages(received_messages, scheduled_enqueue_time)
-#                 assert len(tokens) == 2
+                tokens = sender.schedule_messages(received_messages, scheduled_enqueue_time)
+                assert len(tokens) == 2
     
-#                 messages = receiver.receive_messages(max_wait_time=120)
-#                 messages.extend(receiver.receive_messages(max_wait_time=5))
-#                 if messages:
-#                     try:
-#                         data = str(messages[0])
-#                         assert data == content
-#                         assert messages[0].message_id in (message_id_a, message_id_b)
-#                         assert messages[0].scheduled_enqueue_time_utc == scheduled_enqueue_time
-#                         assert messages[0].scheduled_enqueue_time_utc <= messages[0].enqueued_time_utc.replace(microsecond=0)
-#                         assert messages[0].delivery_count == 0
-#                         assert messages[0].application_properties
-#                         assert messages[0].application_properties[b'key'] == b'value'
-#                         assert messages[0].subject == 'label'
-#                         assert messages[0].content_type == 'application/text'
-#                         assert messages[0].correlation_id == 'cid'
-#                         assert messages[0].to == 'to'
-#                         assert messages[0].reply_to == 'reply_to'
-#                         assert messages[0].sequence_number
-#                         assert messages[0].enqueued_time_utc
-#                         assert messages[0].message.delivery_tag is not None
-#                         assert len(messages) == 2
+                messages = receiver.receive_messages(max_wait_time=120)
+                messages.extend(receiver.receive_messages(max_wait_time=5))
+                if messages:
+                    try:
+                        data = str(messages[0])
+                        assert data == content
+                        assert messages[0].message_id in (message_id_a, message_id_b)
+                        assert messages[0].scheduled_enqueue_time_utc == scheduled_enqueue_time
+                        assert messages[0].scheduled_enqueue_time_utc <= messages[0].enqueued_time_utc.replace(microsecond=0)
+                        assert messages[0].delivery_count == 0
+                        assert messages[0].application_properties
+                        assert messages[0].application_properties[b'key'] == b'value'
+                        assert messages[0].subject == 'label'
+                        assert messages[0].content_type == 'application/text'
+                        assert messages[0].correlation_id == 'cid'
+                        assert messages[0].to == 'to'
+                        assert messages[0].reply_to == 'reply_to'
+                        assert messages[0].sequence_number
+                        assert messages[0].enqueued_time_utc
+                        assert messages[0].message.delivery_tag is not None
+                        assert len(messages) == 2
 
-#                         if not uamqp_transport:
-#                             pickled = pickle.loads(pickle.dumps(messages[0]))
-#                             assert pickled.message_id == messages[0].message_id
-#                             assert pickled.scheduled_enqueue_time_utc == messages[0].scheduled_enqueue_time_utc
-#                             assert pickled.scheduled_enqueue_time_utc <= pickled.enqueued_time_utc.replace(microsecond=0)
-#                             assert pickled.delivery_count == messages[0].delivery_count
-#                             assert pickled.application_properties == messages[0].application_properties
-#                             assert pickled.application_properties[b'key'] == messages[0].application_properties[b'key']
-#                             assert pickled.subject == messages[0].subject
-#                             assert pickled.content_type == messages[0].content_type
-#                             assert pickled.correlation_id == messages[0].correlation_id
-#                             assert pickled.to == messages[0].to
-#                             assert pickled.reply_to == messages[0].reply_to
-#                             assert pickled.sequence_number
-#                             assert pickled.enqueued_time_utc
-#                     finally:
-#                         for message in messages:
-#                             receiver.complete_message(message)
-#                 else:
-#                     raise Exception("Failed to receive schdeduled message.")
+                        if not uamqp_transport:
+                            pickled = pickle.loads(pickle.dumps(messages[0]))
+                            assert pickled.message_id == messages[0].message_id
+                            assert pickled.scheduled_enqueue_time_utc == messages[0].scheduled_enqueue_time_utc
+                            assert pickled.scheduled_enqueue_time_utc <= pickled.enqueued_time_utc.replace(microsecond=0)
+                            assert pickled.delivery_count == messages[0].delivery_count
+                            assert pickled.application_properties == messages[0].application_properties
+                            assert pickled.application_properties[b'key'] == messages[0].application_properties[b'key']
+                            assert pickled.subject == messages[0].subject
+                            assert pickled.content_type == messages[0].content_type
+                            assert pickled.correlation_id == messages[0].correlation_id
+                            assert pickled.to == messages[0].to
+                            assert pickled.reply_to == messages[0].reply_to
+                            assert pickled.sequence_number
+                            assert pickled.enqueued_time_utc
+                    finally:
+                        for message in messages:
+                            receiver.complete_message(message)
+                else:
+                    raise Exception("Failed to receive schdeduled message.")
 
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_queue_cancel_scheduled_messages(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_queue_cancel_scheduled_messages(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
         
-#         with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+            fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-#             enqueue_time = (utc_now() + timedelta(minutes=2)).replace(microsecond=0)
-#             with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
-#                 with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                     message_a = ServiceBusMessage("Test scheduled message")
-#                     message_b = ServiceBusMessage("Test scheduled message")
-#                     tokens = sender.schedule_messages([message_a, message_b], enqueue_time)
-#                     assert len(tokens) == 2
+            enqueue_time = (utc_now() + timedelta(minutes=2)).replace(microsecond=0)
+            with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
+                with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                    message_a = ServiceBusMessage("Test scheduled message")
+                    message_b = ServiceBusMessage("Test scheduled message")
+                    tokens = sender.schedule_messages([message_a, message_b], enqueue_time)
+                    assert len(tokens) == 2
     
-#                     sender.cancel_scheduled_messages(tokens)
+                    sender.cancel_scheduled_messages(tokens)
     
-#                 messages = receiver.receive_messages(max_wait_time=120)
-#                 try:
-#                     assert len(messages) == 0
-#                 except AssertionError:
-#                     for message in messages:
-#                         print(str(message))
-#                         receiver.complete_message(message)
-#                     raise
+                messages = receiver.receive_messages(max_wait_time=120)
+                try:
+                    assert len(messages) == 0
+                except AssertionError:
+                    for message in messages:
+                        print(str(message))
+                        receiver.complete_message(message)
+                    raise
 
 
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_queue_message_amqp_over_websocket(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         with ServiceBusClient.from_connection_string(
-#                 servicebus_namespace_connection_string,
-#                 transport_type=TransportType.AmqpOverWebsocket,
-#                 logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_queue_message_amqp_over_websocket(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+                fully_qualified_namespace, credential,
+                transport_type=TransportType.AmqpOverWebsocket,
+                logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 assert sender._config.transport_type == TransportType.AmqpOverWebsocket
-#                 message = ServiceBusMessage("Test")
-#                 sender.send_messages(message)
+            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                assert sender._config.transport_type == TransportType.AmqpOverWebsocket
+                message = ServiceBusMessage("Test")
+                sender.send_messages(message)
 
-#             with sb_client.get_queue_receiver(servicebus_queue.name, receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE) as receiver:
-#                 assert receiver._config.transport_type == TransportType.AmqpOverWebsocket
-#                 messages = receiver.receive_messages(max_wait_time=5)
-#                 assert len(messages) == 1
+            with sb_client.get_queue_receiver(servicebus_queue.name, receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE) as receiver:
+                assert receiver._config.transport_type == TransportType.AmqpOverWebsocket
+                messages = receiver.receive_messages(max_wait_time=5)
+                assert len(messages) == 1
 
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     def test_queue_message_http_proxy_setting(self, uamqp_transport):
-#         mock_conn_str = "Endpoint=sb://mock.servicebus.windows.net/;SharedAccessKeyName=mock;SharedAccessKey=mock"
-#         http_proxy = {
-#             'proxy_hostname': '127.0.0.1',
-#             'proxy_port': 8899,
-#             'username': 'admin',
-#             'password': '123456'
-#         }
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    def test_queue_message_http_proxy_setting(self, uamqp_transport):
+        mock_conn_str = "Endpoint=sb://mock.servicebus.windows.net/;SharedAccessKeyName=mock;SharedAccessKey=mock"
+        http_proxy = {
+            'proxy_hostname': '127.0.0.1',
+            'proxy_port': 8899,
+            'username': 'admin',
+            'password': '123456'
+        }
 
-#         sb_client = ServiceBusClient.from_connection_string(mock_conn_str, http_proxy=http_proxy, uamqp_transport=uamqp_transport)
-#         assert sb_client._config.http_proxy == http_proxy
-#         assert sb_client._config.transport_type == TransportType.AmqpOverWebsocket
+        mock_conn_str = "Endpoint=sb://mock.servicebus.windows.net/;SharedAccessKeyName=mock;SharedAccessKey=mock"
+        sb_client = ServiceBusClient(mock_conn_str, http_proxy=http_proxy, uamqp_transport=uamqp_transport)
+        assert sb_client._config.http_proxy == http_proxy
+        assert sb_client._config.transport_type == TransportType.AmqpOverWebsocket
 
-#         sender = sb_client.get_queue_sender(queue_name="mock")
-#         assert sender._config.http_proxy == http_proxy
-#         assert sender._config.transport_type == TransportType.AmqpOverWebsocket
+        sender = sb_client.get_queue_sender(queue_name="mock")
+        assert sender._config.http_proxy == http_proxy
+        assert sender._config.transport_type == TransportType.AmqpOverWebsocket
 
-#         receiver = sb_client.get_queue_receiver(queue_name="mock")
-#         assert receiver._config.http_proxy == http_proxy
-#         assert receiver._config.transport_type == TransportType.AmqpOverWebsocket
+        receiver = sb_client.get_queue_receiver(queue_name="mock")
+        assert receiver._config.http_proxy == http_proxy
+        assert receiver._config.transport_type == TransportType.AmqpOverWebsocket
 
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_queue_message_settle_through_mgmt_link_due_to_broken_receiver_link(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         with ServiceBusClient.from_connection_string(
-#                 servicebus_namespace_connection_string,
-#                 logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_queue_message_settle_through_mgmt_link_due_to_broken_receiver_link(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+                fully_qualified_namespace, credential,
+                logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 message = ServiceBusMessage("Test")
-#                 sender.send_messages(message)
+            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                message = ServiceBusMessage("Test")
+                sender.send_messages(message)
 
-#             with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
-#                 messages = receiver.receive_messages(max_wait_time=5)
-#                 # destroy the underlying receiver link
-#                 if uamqp_transport:
-#                     receiver._handler.message_handler.destroy()
-#                 else:
-#                     receiver._handler._link.detach()
-#                 assert len(messages) == 1
-#                 receiver.complete_message(messages[0])
+            with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
+                messages = receiver.receive_messages(max_wait_time=5)
+                # destroy the underlying receiver link
+                if uamqp_transport:
+                    receiver._handler.message_handler.destroy()
+                else:
+                    receiver._handler._link.detach()
+                assert len(messages) == 1
+                receiver.complete_message(messages[0])
 
-#     @unittest.skip('hard to test')
-#     def test_queue_mock_auto_lock_renew_callback(self):
-#         # A warning to future devs: If the renew period override heuristic in registration
-#         # ever changes, it may break this (since it adjusts renew period if it is not short enough)
+    @unittest.skip('hard to test')
+    def test_queue_mock_auto_lock_renew_callback(self):
+        # A warning to future devs: If the renew period override heuristic in registration
+        # ever changes, it may break this (since it adjusts renew period if it is not short enough)
 
-#         results = []
-#         errors = []
-#         def callback_mock(renewable, error):
-#             results.append(renewable)
-#             if error:
-#                 errors.append(error)
+        results = []
+        errors = []
+        def callback_mock(renewable, error):
+            results.append(renewable)
+            if error:
+                errors.append(error)
 
-#         receiver = MockReceiver()
-#         auto_lock_renew = AutoLockRenewer()
-#         with pytest.raises(TypeError):
-#             auto_lock_renew.register(Exception())  # an arbitrary invalid type.
+        receiver = MockReceiver()
+        auto_lock_renew = AutoLockRenewer()
+        with pytest.raises(TypeError):
+            auto_lock_renew.register(Exception())  # an arbitrary invalid type.
 
-#         auto_lock_renew = AutoLockRenewer()
-#         auto_lock_renew._renew_period = 1 # So we can run the test fast.
-#         with auto_lock_renew: # Check that it is called when the object expires for any reason (silent renew failure)
-#             message = MockReceivedMessage(prevent_renew_lock=True)
-#             auto_lock_renew.register(receiver, renewable=message, on_lock_renew_failure=callback_mock)
-#             time.sleep(3)
-#             assert len(results) == 1 and results[-1]._lock_expired is True
-#             assert not errors
+        auto_lock_renew = AutoLockRenewer()
+        auto_lock_renew._renew_period = 1 # So we can run the test fast.
+        with auto_lock_renew: # Check that it is called when the object expires for any reason (silent renew failure)
+            message = MockReceivedMessage(prevent_renew_lock=True)
+            auto_lock_renew.register(receiver, renewable=message, on_lock_renew_failure=callback_mock)
+            time.sleep(3)
+            assert len(results) == 1 and results[-1]._lock_expired is True
+            assert not errors
 
-#         del results[:]
-#         del errors[:]
-#         auto_lock_renew = AutoLockRenewer()
-#         auto_lock_renew._renew_period = 1
-#         with auto_lock_renew: # Check that in normal operation it does not get called
-#             auto_lock_renew.register(receiver, renewable=MockReceivedMessage(lock_duration=5), on_lock_renew_failure=callback_mock)
-#             time.sleep(6)
-#             assert not results
-#             assert not errors
+        del results[:]
+        del errors[:]
+        auto_lock_renew = AutoLockRenewer()
+        auto_lock_renew._renew_period = 1
+        with auto_lock_renew: # Check that in normal operation it does not get called
+            auto_lock_renew.register(receiver, renewable=MockReceivedMessage(lock_duration=5), on_lock_renew_failure=callback_mock)
+            time.sleep(6)
+            assert not results
+            assert not errors
 
-#         del results[:]
-#         del errors[:]
-#         auto_lock_renew = AutoLockRenewer()
-#         auto_lock_renew._renew_period = 1
-#         with auto_lock_renew: # Check that when a message is settled, it will not get called even after expiry
-#             message = MockReceivedMessage(prevent_renew_lock=True)
-#             auto_lock_renew.register(receiver, renewable=message, on_lock_renew_failure=callback_mock)
-#             message._settled = True
-#             time.sleep(3)
-#             assert not results
-#             assert not errors
+        del results[:]
+        del errors[:]
+        auto_lock_renew = AutoLockRenewer()
+        auto_lock_renew._renew_period = 1
+        with auto_lock_renew: # Check that when a message is settled, it will not get called even after expiry
+            message = MockReceivedMessage(prevent_renew_lock=True)
+            auto_lock_renew.register(receiver, renewable=message, on_lock_renew_failure=callback_mock)
+            message._settled = True
+            time.sleep(3)
+            assert not results
+            assert not errors
 
-#         del results[:]
-#         del errors[:]
-#         auto_lock_renew = AutoLockRenewer()
-#         auto_lock_renew._renew_period = 1
-#         with auto_lock_renew: # Check that it is called when there is an overt renew failure
-#             message = MockReceivedMessage(exception_on_renew_lock=True)
-#             auto_lock_renew.register(receiver, renewable=message, on_lock_renew_failure=callback_mock)
-#             time.sleep(3)
-#             assert len(results) == 1 and results[-1]._lock_expired == True
-#             assert errors[-1]
+        del results[:]
+        del errors[:]
+        auto_lock_renew = AutoLockRenewer()
+        auto_lock_renew._renew_period = 1
+        with auto_lock_renew: # Check that it is called when there is an overt renew failure
+            message = MockReceivedMessage(exception_on_renew_lock=True)
+            auto_lock_renew.register(receiver, renewable=message, on_lock_renew_failure=callback_mock)
+            time.sleep(3)
+            assert len(results) == 1 and results[-1]._lock_expired == True
+            assert errors[-1]
 
-#         del results[:]
-#         del errors[:]
-#         auto_lock_renew = AutoLockRenewer()
-#         auto_lock_renew._renew_period = 1
-#         with auto_lock_renew: # Check that it is not called when the renewer is shutdown
-#             message = MockReceivedMessage(prevent_renew_lock=True)
-#             auto_lock_renew.register(receiver, renewable=message, on_lock_renew_failure=callback_mock)
-#             auto_lock_renew.close()
-#             time.sleep(3)
-#             assert not results
-#             assert not errors
+        del results[:]
+        del errors[:]
+        auto_lock_renew = AutoLockRenewer()
+        auto_lock_renew._renew_period = 1
+        with auto_lock_renew: # Check that it is not called when the renewer is shutdown
+            message = MockReceivedMessage(prevent_renew_lock=True)
+            auto_lock_renew.register(receiver, renewable=message, on_lock_renew_failure=callback_mock)
+            auto_lock_renew.close()
+            time.sleep(3)
+            assert not results
+            assert not errors
 
-#         del results[:]
-#         del errors[:]
-#         auto_lock_renew = AutoLockRenewer()
-#         auto_lock_renew._renew_period = 1
-#         with auto_lock_renew: # Check that it is not called when the receiver is shutdown
-#             message = MockReceivedMessage(prevent_renew_lock=True)
-#             auto_lock_renew.register(receiver, renewable=message, on_lock_renew_failure=callback_mock)
-#             message._receiver._running = False
-#             time.sleep(3)
-#             assert not results
-#             assert not errors
+        del results[:]
+        del errors[:]
+        auto_lock_renew = AutoLockRenewer()
+        auto_lock_renew._renew_period = 1
+        with auto_lock_renew: # Check that it is not called when the receiver is shutdown
+            message = MockReceivedMessage(prevent_renew_lock=True)
+            auto_lock_renew.register(receiver, renewable=message, on_lock_renew_failure=callback_mock)
+            message._receiver._running = False
+            time.sleep(3)
+            assert not results
+            assert not errors
 
-#     def test_queue_mock_no_reusing_auto_lock_renew(self):
+    def test_queue_mock_no_reusing_auto_lock_renew(self):
 
-#         receiver = MockReceiver()
-#         auto_lock_renew = AutoLockRenewer()
-#         auto_lock_renew._renew_period = 1 # So we can run the test fast.
-#         with auto_lock_renew:
-#             auto_lock_renew.register(receiver, renewable=MockReceivedMessage())
-#             time.sleep(3)
+        receiver = MockReceiver()
+        auto_lock_renew = AutoLockRenewer()
+        auto_lock_renew._renew_period = 1 # So we can run the test fast.
+        with auto_lock_renew:
+            auto_lock_renew.register(receiver, renewable=MockReceivedMessage())
+            time.sleep(3)
 
-#         with pytest.raises(ServiceBusError):
-#             with auto_lock_renew:
-#                 pass
+        with pytest.raises(ServiceBusError):
+            with auto_lock_renew:
+                pass
 
-#         with pytest.raises(ServiceBusError):
-#             auto_lock_renew.register(receiver, renewable=MockReceivedMessage())
+        with pytest.raises(ServiceBusError):
+            auto_lock_renew.register(receiver, renewable=MockReceivedMessage())
 
-#         auto_lock_renew = AutoLockRenewer()
-#         auto_lock_renew._renew_period = 1
+        auto_lock_renew = AutoLockRenewer()
+        auto_lock_renew._renew_period = 1
 
-#         with auto_lock_renew:
-#             auto_lock_renew.register(receiver, renewable=MockReceivedMessage())
-#             time.sleep(3)
+        with auto_lock_renew:
+            auto_lock_renew.register(receiver, renewable=MockReceivedMessage())
+            time.sleep(3)
 
-#         auto_lock_renew.close()
+        auto_lock_renew.close()
 
-#         with pytest.raises(ServiceBusError):
-#             with auto_lock_renew:
-#                 pass
+        with pytest.raises(ServiceBusError):
+            with auto_lock_renew:
+                pass
 
-#         with pytest.raises(ServiceBusError):
-#             auto_lock_renew.register(receiver, renewable=MockReceivedMessage())
+        with pytest.raises(ServiceBusError):
+            auto_lock_renew.register(receiver, renewable=MockReceivedMessage())
 
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     def test_queue_message_properties(self, uamqp_transport):
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    def test_queue_message_properties(self, uamqp_transport):
 
-#         scheduled_enqueue_time = (utc_now() + timedelta(seconds=20)).replace(microsecond=0)
-#         message = ServiceBusMessage(
-#             body='data',
-#             application_properties={'key': 'value'},
-#             session_id='sid',
-#             subject='label',
-#             content_type='application/text',
-#             correlation_id='cid',
-#             message_id='mid',
-#             to='to',
-#             reply_to='reply_to',
-#             reply_to_session_id='reply_to_sid',
-#             scheduled_enqueue_time_utc=scheduled_enqueue_time
-#         )
+        scheduled_enqueue_time = (utc_now() + timedelta(seconds=20)).replace(microsecond=0)
+        message = ServiceBusMessage(
+            body='data',
+            application_properties={'key': 'value'},
+            session_id='sid',
+            subject='label',
+            content_type='application/text',
+            correlation_id='cid',
+            message_id='mid',
+            to='to',
+            reply_to='reply_to',
+            reply_to_session_id='reply_to_sid',
+            scheduled_enqueue_time_utc=scheduled_enqueue_time
+        )
 
-#         assert message.application_properties
-#         assert message.application_properties['key'] == 'value'
-#         assert message.subject == 'label'
-#         assert message.content_type == 'application/text'
-#         assert message.correlation_id == 'cid'
-#         assert message.message_id == 'mid'
-#         assert message.to == 'to'
-#         assert message.reply_to == 'reply_to'
-#         assert message.session_id == 'sid'
-#         assert message.reply_to_session_id == 'reply_to_sid'
-#         assert message.scheduled_enqueue_time_utc == scheduled_enqueue_time
+        assert message.application_properties
+        assert message.application_properties['key'] == 'value'
+        assert message.subject == 'label'
+        assert message.content_type == 'application/text'
+        assert message.correlation_id == 'cid'
+        assert message.message_id == 'mid'
+        assert message.to == 'to'
+        assert message.reply_to == 'reply_to'
+        assert message.session_id == 'sid'
+        assert message.reply_to_session_id == 'reply_to_sid'
+        assert message.scheduled_enqueue_time_utc == scheduled_enqueue_time
 
-#         message.partition_key = 'sid'
-#         new_scheduled_time = (utc_now() + timedelta(hours=5)).replace(microsecond=0)
-#         message.scheduled_enqueue_time_utc = new_scheduled_time
-#         assert message.scheduled_enqueue_time_utc == new_scheduled_time
+        message.partition_key = 'sid'
+        new_scheduled_time = (utc_now() + timedelta(hours=5)).replace(microsecond=0)
+        message.scheduled_enqueue_time_utc = new_scheduled_time
+        assert message.scheduled_enqueue_time_utc == new_scheduled_time
 
-#         message.via_partition_key = None
-#         message.scheduled_enqueue_time_utc = None
+        message.via_partition_key = None
+        message.scheduled_enqueue_time_utc = None
 
-#         assert message.scheduled_enqueue_time_utc is None
+        assert message.scheduled_enqueue_time_utc is None
 
-#         try:
-#             timestamp = new_scheduled_time.timestamp() * 1000
-#         except AttributeError:
-#             timestamp = calendar.timegm(new_scheduled_time.timetuple()) * 1000
+        try:
+            timestamp = new_scheduled_time.timestamp() * 1000
+        except AttributeError:
+            timestamp = calendar.timegm(new_scheduled_time.timetuple()) * 1000
 
-#         my_frame = [0,0,0]
-#         if uamqp_transport:
-#             amqp_transport = UamqpTransport
-#             amqp_received_message = uamqp.message.Message(
-#                 body=[b'data'],
-#                 annotations={
-#                     _X_OPT_PARTITION_KEY: b'r_key',
-#                     _X_OPT_VIA_PARTITION_KEY: b'r_via_key',
-#                     _X_OPT_SCHEDULED_ENQUEUE_TIME: timestamp,
-#                 },
-#                 properties={}
-#             )
-#         else:
-#             amqp_transport = PyamqpTransport
-#             amqp_received_message = Message(
-#                 data=[b'data'],
-#                 message_annotations={
-#                     _X_OPT_PARTITION_KEY: b'r_key',
-#                     _X_OPT_VIA_PARTITION_KEY: b'r_via_key',
-#                     _X_OPT_SCHEDULED_ENQUEUE_TIME: timestamp,
-#                 },
-#                 properties={}
-#             )
-#         received_message = ServiceBusReceivedMessage(amqp_received_message, receiver=None, frame=my_frame, amqp_transport=amqp_transport)
-#         assert received_message.scheduled_enqueue_time_utc == new_scheduled_time
+        my_frame = [0,0,0]
+        if uamqp_transport:
+            amqp_transport = UamqpTransport
+            amqp_received_message = uamqp.message.Message(
+                body=[b'data'],
+                annotations={
+                    _X_OPT_PARTITION_KEY: b'r_key',
+                    _X_OPT_VIA_PARTITION_KEY: b'r_via_key',
+                    _X_OPT_SCHEDULED_ENQUEUE_TIME: timestamp,
+                },
+                properties={}
+            )
+        else:
+            amqp_transport = PyamqpTransport
+            amqp_received_message = Message(
+                data=[b'data'],
+                message_annotations={
+                    _X_OPT_PARTITION_KEY: b'r_key',
+                    _X_OPT_VIA_PARTITION_KEY: b'r_via_key',
+                    _X_OPT_SCHEDULED_ENQUEUE_TIME: timestamp,
+                },
+                properties={}
+            )
+        received_message = ServiceBusReceivedMessage(amqp_received_message, receiver=None, frame=my_frame, amqp_transport=amqp_transport)
+        assert received_message.scheduled_enqueue_time_utc == new_scheduled_time
 
-#         new_scheduled_time = utc_now() + timedelta(hours=1, minutes=49, seconds=32)
+        new_scheduled_time = utc_now() + timedelta(hours=1, minutes=49, seconds=32)
 
-#         received_message.scheduled_enqueue_time_utc = new_scheduled_time
+        received_message.scheduled_enqueue_time_utc = new_scheduled_time
 
-#         assert received_message.scheduled_enqueue_time_utc == new_scheduled_time
+        assert received_message.scheduled_enqueue_time_utc == new_scheduled_time
 
-#         received_message.scheduled_enqueue_time_utc = None
+        received_message.scheduled_enqueue_time_utc = None
 
-#         assert message.scheduled_enqueue_time_utc is None
+        assert message.scheduled_enqueue_time_utc is None
 
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_queue_receive_batch_without_setting_prefetch(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         with ServiceBusClient.from_connection_string(
-#                 servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_queue_receive_batch_without_setting_prefetch(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+                fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-#             def message_content():
-#                 for i in range(20):
-#                     yield ServiceBusMessage(
-#                         body="Test message",
-#                         # application_properties={'key': 'value'},
-#                         subject='1st',
-#                         # content_type='application/text',
-#                         # correlation_id='cid',
-#                         # message_id='mid',
-#                         # to='to',
-#                         # reply_to='reply_to',
-#                         # time_to_live=timedelta(seconds=60)
-#                     )
+            def message_content():
+                for i in range(20):
+                    yield ServiceBusMessage(
+                        body="Test message",
+                        # application_properties={'key': 'value'},
+                        subject='1st',
+                        # content_type='application/text',
+                        # correlation_id='cid',
+                        # message_id='mid',
+                        # to='to',
+                        # reply_to='reply_to',
+                        # time_to_live=timedelta(seconds=60)
+                    )
 
-#             sender = sb_client.get_queue_sender(servicebus_queue.name)
-#             receiver = sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10)
+            sender = sb_client.get_queue_sender(servicebus_queue.name)
+            receiver = sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10)
 
-#             with sender, receiver:
-#                 message = ServiceBusMessageBatch()
-#                 for each in message_content():
-#                     message.add_message(each)
-#                 sender.send_messages(message)
+            with sender, receiver:
+                message = ServiceBusMessageBatch()
+                for each in message_content():
+                    message.add_message(each)
+                sender.send_messages(message)
 
-#                 receive_counter = 0
-#                 message_1st_received_cnt = 0
-#                 message_2nd_received_cnt = 0
-#                 while message_1st_received_cnt < 20 or message_2nd_received_cnt < 20:
-#                     messages = []
-#                     for message in receiver:
-#                         messages.append(message)
-#                     if not messages:
-#                         break
-#                     receive_counter += 1
-#                     for message in messages:
-#                         print_message(_logger, message)
-#                         # assert b''.join(message.body) == b'Test message'
-#                         # assert message.application_properties[b'key'] == b'value'
-#                         # assert message.content_type == 'application/text'
-#                         # assert message.correlation_id == 'cid'
-#                         # assert message.message_id == 'mid'
-#                         # assert message.to == 'to'
-#                         # assert message.reply_to == 'reply_to'
-#                         # assert message.time_to_live == timedelta(seconds=60)
+                receive_counter = 0
+                message_1st_received_cnt = 0
+                message_2nd_received_cnt = 0
+                while message_1st_received_cnt < 20 or message_2nd_received_cnt < 20:
+                    messages = []
+                    for message in receiver:
+                        messages.append(message)
+                    if not messages:
+                        break
+                    receive_counter += 1
+                    for message in messages:
+                        print_message(_logger, message)
+                        # assert b''.join(message.body) == b'Test message'
+                        # assert message.application_properties[b'key'] == b'value'
+                        # assert message.content_type == 'application/text'
+                        # assert message.correlation_id == 'cid'
+                        # assert message.message_id == 'mid'
+                        # assert message.to == 'to'
+                        # assert message.reply_to == 'reply_to'
+                        # assert message.time_to_live == timedelta(seconds=60)
 
-#                         if message.subject == '1st':
-#                             message_1st_received_cnt += 1
-#                             receiver.complete_message(message)
-#                             message.subject = '2nd'
-#                             sender.send_messages(message)  # resending received message
-#                         elif message.subject == '2nd':
-#                             message_2nd_received_cnt += 1
-#                             receiver.complete_message(message)
+                        if message.subject == '1st':
+                            message_1st_received_cnt += 1
+                            receiver.complete_message(message)
+                            message.subject = '2nd'
+                            sender.send_messages(message)  # resending received message
+                        elif message.subject == '2nd':
+                            message_2nd_received_cnt += 1
+                            receiver.complete_message(message)
 
-#                 assert message_1st_received_cnt == 20 and message_2nd_received_cnt == 20
-#                 # Network/server might be unstable making flow control ineffective in the leading rounds of connection iteration
-#                 assert receive_counter < 10  # Dynamic link credit issuing come info effect
+                assert message_1st_received_cnt == 20 and message_2nd_received_cnt == 20
+                # Network/server might be unstable making flow control ineffective in the leading rounds of connection iteration
+                assert receive_counter < 10  # Dynamic link credit issuing come info effect
 
     
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest')
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_queue_receiver_alive_after_timeout(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         with ServiceBusClient.from_connection_string(
-#                 servicebus_namespace_connection_string,
-#                 logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest')
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_queue_receiver_alive_after_timeout(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+                fully_qualified_namespace, credential,
+                logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 message = ServiceBusMessage("0")
-#                 message_1 = ServiceBusMessage("1")
-#                 sender.send_messages([message, message_1])
+            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                message = ServiceBusMessage("0")
+                message_1 = ServiceBusMessage("1")
+                sender.send_messages([message, message_1])
 
-#                 messages = []
-#                 with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5) as receiver:
+                messages = []
+                with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5) as receiver:
                     
-#                     for message in receiver:
-#                         messages.append(message)
-#                         break
+                    for message in receiver:
+                        messages.append(message)
+                        break
 
-#                     for message in receiver:
-#                         messages.append(message)
+                    for message in receiver:
+                        messages.append(message)
 
-#                     for message in messages:
-#                         receiver.complete_message(message)
+                    for message in messages:
+                        receiver.complete_message(message)
 
-#                     assert len(messages) == 2
-#                     assert str(messages[0]) == "0"
-#                     assert str(messages[1]) == "1"
+                    assert len(messages) == 2
+                    assert str(messages[0]) == "0"
+                    assert str(messages[1]) == "1"
 
-#                     message_2 = ServiceBusMessage("2")
-#                     message_3 = ServiceBusMessage("3")
-#                     sender.send_messages([message_2, message_3])
+                    message_2 = ServiceBusMessage("2")
+                    message_3 = ServiceBusMessage("3")
+                    sender.send_messages([message_2, message_3])
 
-#                     for message in receiver:
-#                         messages.append(message)
-#                         for message in receiver:
-#                             messages.append(message)
+                    for message in receiver:
+                        messages.append(message)
+                        for message in receiver:
+                            messages.append(message)
 
-#                     assert len(messages) == 4
-#                     assert str(messages[2]) == "2"
-#                     assert str(messages[3]) == "3"
+                    assert len(messages) == 4
+                    assert str(messages[2]) == "2"
+                    assert str(messages[3]) == "3"
 
-#                     for message in messages[2:]:
-#                         receiver.complete_message(message)
+                    for message in messages[2:]:
+                        receiver.complete_message(message)
 
-#                     messages = receiver.receive_messages()
-#                     assert not messages
-
-    
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True, lock_duration='PT5M')
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_queue_receive_keep_conn_alive(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         with ServiceBusClient.from_connection_string(
-#                 servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-
-#             sender = sb_client.get_queue_sender(servicebus_queue.name)
-#             receiver = sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10)
-
-#             with sender, receiver:
-#                 sender.send_messages([ServiceBusMessage("message1"), ServiceBusMessage("message2")])
-
-#                 messages = []
-#                 for message in receiver:
-#                     messages.append(message)
-
-#                 receiver_handler = receiver._handler
-#                 assert len(messages) == 2
-#                 time.sleep(4 * 60 + 5)  # 240s is the service defined connection idle timeout
-#                 receiver.renew_message_lock(messages[0])  # check mgmt link operation
-#                 receiver.complete_message(messages[0])
-#                 receiver.complete_message(messages[1])  # check receiver link operation
-
-#                 time.sleep(60)  # sleep another one minute to ensure we pass the lock_duration time
-
-#                 messages = []
-#                 for message in receiver:
-#                     messages.append(message)
-
-#                 assert len(messages) == 0  # make sure messages are removed from the queue
-#                 assert receiver_handler == receiver._handler  # make sure no reconnection happened
+                    messages = receiver.receive_messages()
+                    assert not messages
 
     
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest')
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_queue_receiver_sender_resume_after_link_timeout(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         with ServiceBusClient.from_connection_string(
-#                 servicebus_namespace_connection_string,
-#                 logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True, lock_duration='PT5M')
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_queue_receive_keep_conn_alive(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+                fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 message = ServiceBusMessage("0")
-#                 sender.send_messages(message)
+            sender = sb_client.get_queue_sender(servicebus_queue.name)
+            receiver = sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10)
 
-#                 time.sleep(60 * 5)
+            with sender, receiver:
+                sender.send_messages([ServiceBusMessage("message1"), ServiceBusMessage("message2")])
 
-#                 message_1 = ServiceBusMessage("1")
-#                 sender.send_messages(message_1)
+                messages = []
+                for message in receiver:
+                    messages.append(message)
 
-#                 messages = []
-#                 with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5) as receiver:
+                receiver_handler = receiver._handler
+                assert len(messages) == 2
+                time.sleep(4 * 60 + 5)  # 240s is the service defined connection idle timeout
+                receiver.renew_message_lock(messages[0])  # check mgmt link operation
+                receiver.complete_message(messages[0])
+                receiver.complete_message(messages[1])  # check receiver link operation
+
+                time.sleep(60)  # sleep another one minute to ensure we pass the lock_duration time
+
+                messages = []
+                for message in receiver:
+                    messages.append(message)
+
+                assert len(messages) == 0  # make sure messages are removed from the queue
+                assert receiver_handler == receiver._handler  # make sure no reconnection happened
+
+    
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest')
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_queue_receiver_sender_resume_after_link_timeout(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+                fully_qualified_namespace, credential,
+                logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+
+            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                message = ServiceBusMessage("0")
+                sender.send_messages(message)
+
+                time.sleep(60 * 5)
+
+                message_1 = ServiceBusMessage("1")
+                sender.send_messages(message_1)
+
+                messages = []
+                with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5) as receiver:
                     
-#                     for message in receiver:
-#                         messages.append(message)
-#                 assert len(messages) == 2
+                    for message in receiver:
+                        messages.append(message)
+                assert len(messages) == 2
     
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest')
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_queue_send_twice(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         if uamqp:
-#             transport_type = uamqp.constants.TransportType.AmqpOverWebsocket
-#         else:
-#             transport_type = TransportType.AmqpOverWebsocket
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest')
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_queue_send_twice(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        if uamqp:
+            transport_type = uamqp.constants.TransportType.AmqpOverWebsocket
+        else:
+            transport_type = TransportType.AmqpOverWebsocket
 
-#         with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False,
-#             transport_type=transport_type, uamqp_transport=uamqp_transport) as sb_client:
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+            fully_qualified_namespace, credential, logging_enable=False,
+            transport_type=transport_type, uamqp_transport=uamqp_transport) as sb_client:
 
-#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 message = ServiceBusMessage("ServiceBusMessage")
-#                 message2 = ServiceBusMessage("Message2")
-#                 # first test batch message resending.
-#                 batch_message = sender.create_message_batch()
-#                 batch_message._from_list([message, message2])  # pylint: disable=protected-access
-#                 sender.send_messages(batch_message)
-#                 sender.send_messages(batch_message)
-#                 messages = []
-#                 with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=20) as receiver:
-#                     for message in receiver:
-#                         messages.append(message)
-#                         receiver.complete_message(message)
-#                     assert len(messages) == 4
-#                 # then normal message resending
-#                 sender.send_messages(message)
-#                 sender.send_messages(message)
-#                 expected_count = 2
-#                 if not uamqp_transport:
-#                     pickled_recvd = pickle.loads(pickle.dumps(messages[0]))
-#                     sender.send_messages(pickled_recvd)
-#                     expected_count = 3
-#                 messages = []
-#                 with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=20) as receiver:
-#                     for message in receiver:
-#                         messages.append(message)
-#                         receiver.complete_message(message)
-#                     assert len(messages) == expected_count
+            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                message = ServiceBusMessage("ServiceBusMessage")
+                message2 = ServiceBusMessage("Message2")
+                # first test batch message resending.
+                batch_message = sender.create_message_batch()
+                batch_message._from_list([message, message2])  # pylint: disable=protected-access
+                sender.send_messages(batch_message)
+                sender.send_messages(batch_message)
+                messages = []
+                with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=20) as receiver:
+                    for message in receiver:
+                        messages.append(message)
+                        receiver.complete_message(message)
+                    assert len(messages) == 4
+                # then normal message resending
+                sender.send_messages(message)
+                sender.send_messages(message)
+                expected_count = 2
+                if not uamqp_transport:
+                    pickled_recvd = pickle.loads(pickle.dumps(messages[0]))
+                    sender.send_messages(pickled_recvd)
+                    expected_count = 3
+                messages = []
+                with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=20) as receiver:
+                    for message in receiver:
+                        messages.append(message)
+                        receiver.complete_message(message)
+                    assert len(messages) == expected_count
 
 
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @CachedServiceBusQueuePreparer(name_prefix='servicebustest')
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_queue_receiver_invalid_mode(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @CachedServiceBusQueuePreparer(name_prefix='servicebustest')
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_queue_receiver_invalid_mode(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
         
-#         with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-#             with pytest.raises(ValueError):
-#                 with sb_client.get_queue_receiver(servicebus_queue.name, 
-#                                                   receive_mode=2) as receiver:
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+            fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+            with pytest.raises(ValueError):
+                with sb_client.get_queue_receiver(servicebus_queue.name, 
+                                                  receive_mode=2) as receiver:
                 
-#                     raise Exception("Should not get here, should fail fast.")
+                    raise Exception("Should not get here, should fail fast.")
 
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @CachedServiceBusQueuePreparer(name_prefix='servicebustest')
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_queue_receiver_invalid_autolockrenew_mode(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @CachedServiceBusQueuePreparer(name_prefix='servicebustest')
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_queue_receiver_invalid_autolockrenew_mode(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
         
-#         with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-#             with pytest.raises(ValueError):
-#                 with sb_client.get_queue_receiver(servicebus_queue.name, 
-#                                                   receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE,
-#                                                   auto_lock_renewer=AutoLockRenewer()) as receiver:
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+            fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+            with pytest.raises(ValueError):
+                with sb_client.get_queue_receiver(servicebus_queue.name, 
+                                                  receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE,
+                                                  auto_lock_renewer=AutoLockRenewer()) as receiver:
                 
-#                     raise Exception("Should not get here, should fail fast because RECEIVE_AND_DELETE messages cannot be autorenewed.")
+                    raise Exception("Should not get here, should fail fast because RECEIVE_AND_DELETE messages cannot be autorenewed.")
 
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest')
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_message_inner_amqp_properties(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest')
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_message_inner_amqp_properties(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
         
-#         message = ServiceBusMessage("body")
+        message = ServiceBusMessage("body")
 
-#         message.raw_amqp_message.properties.subject = "subject"
-#         message.raw_amqp_message.application_properties = {b"application_properties":1}
-#         message.raw_amqp_message.annotations = {b"annotations":2}
-#         message.raw_amqp_message.delivery_annotations = {b"delivery_annotations":3}
-#         message.raw_amqp_message.header.priority = 5
-#         message.raw_amqp_message.footer = {b"footer":6}
+        message.raw_amqp_message.properties.subject = "subject"
+        message.raw_amqp_message.application_properties = {b"application_properties":1}
+        message.raw_amqp_message.annotations = {b"annotations":2}
+        message.raw_amqp_message.delivery_annotations = {b"delivery_annotations":3}
+        message.raw_amqp_message.header.priority = 5
+        message.raw_amqp_message.footer = {b"footer":6}
 
-#         with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+            fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 sender.send_messages(message)
-#                 with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5) as receiver:
-#                     message = receiver.receive_messages()[0]
-#                     assert message.raw_amqp_message.application_properties != None \
-#                         and message.raw_amqp_message.annotations != None \
-#                         and message.raw_amqp_message.delivery_annotations != None \
-#                         and message.raw_amqp_message.footer != None \
-#                         and message.raw_amqp_message.properties != None \
-#                         and message.raw_amqp_message.header != None
+            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                sender.send_messages(message)
+                with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5) as receiver:
+                    message = receiver.receive_messages()[0]
+                    assert message.raw_amqp_message.application_properties != None \
+                        and message.raw_amqp_message.annotations != None \
+                        and message.raw_amqp_message.delivery_annotations != None \
+                        and message.raw_amqp_message.footer != None \
+                        and message.raw_amqp_message.properties != None \
+                        and message.raw_amqp_message.header != None
 
-#                     assert message.raw_amqp_message.properties.subject == b"subject"
-#                     assert message.raw_amqp_message.application_properties[b"application_properties"] == 1
-#                     assert message.raw_amqp_message.annotations[b"annotations"] == 2
-#                     assert message.raw_amqp_message.delivery_annotations[b"delivery_annotations"] == 3
-#                     assert message.raw_amqp_message.header.priority == 5
-#                     assert message.raw_amqp_message.footer[b"footer"] == 6
+                    assert message.raw_amqp_message.properties.subject == b"subject"
+                    assert message.raw_amqp_message.application_properties[b"application_properties"] == 1
+                    assert message.raw_amqp_message.annotations[b"annotations"] == 2
+                    assert message.raw_amqp_message.delivery_annotations[b"delivery_annotations"] == 3
+                    assert message.raw_amqp_message.header.priority == 5
+                    assert message.raw_amqp_message.footer[b"footer"] == 6
 
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @CachedServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_queue_send_timeout(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         def _hack_amqp_sender_run(self, **kwargs):
-#             time.sleep(6)  # sleep until timeout
-#             if uamqp_transport:
-#                 self.message_handler.work()
-#                 self._waiting_messages = 0
-#                 self._pending_messages = self._filter_pending()
-#                 if self._backoff and not self._waiting_messages:
-#                     _logger.info("Client told to backoff - sleeping for %r seconds", self._backoff)
-#                     self._connection.sleep(self._backoff)
-#                     self._backoff = 0
-#                 self._connection.work()
-#             else:
-#                 try:
-#                     self._link.update_pending_deliveries()
-#                     self._connection.listen(wait=self._socket_timeout, **kwargs)
-#                 except ValueError:
-#                     self._shutdown = True
-#                     return False
-#             return True
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @CachedServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_queue_send_timeout(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        def _hack_amqp_sender_run(self, **kwargs):
+            time.sleep(6)  # sleep until timeout
+            if uamqp_transport:
+                self.message_handler.work()
+                self._waiting_messages = 0
+                self._pending_messages = self._filter_pending()
+                if self._backoff and not self._waiting_messages:
+                    _logger.info("Client told to backoff - sleeping for %r seconds", self._backoff)
+                    self._connection.sleep(self._backoff)
+                    self._backoff = 0
+                self._connection.work()
+            else:
+                try:
+                    self._link.update_pending_deliveries()
+                    self._connection.listen(wait=self._socket_timeout, **kwargs)
+                except ValueError:
+                    self._shutdown = True
+                    return False
+            return True
 
-#         with ServiceBusClient.from_connection_string(
-#                 servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 # this one doesn't need to reset the method, as it's hacking the method on the instance
-#                 sender._handler._client_run = types.MethodType(_hack_amqp_sender_run, sender._handler)
-#                 with pytest.raises(OperationTimeoutError):
-#                     sender.send_messages(ServiceBusMessage("body"), timeout=5)
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+                fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                # this one doesn't need to reset the method, as it's hacking the method on the instance
+                sender._handler._client_run = types.MethodType(_hack_amqp_sender_run, sender._handler)
+                with pytest.raises(OperationTimeoutError):
+                    sender.send_messages(ServiceBusMessage("body"), timeout=5)
 
-#         if not uamqp_transport:
-#             # Amqp
-#             with ServiceBusClient.from_connection_string(
-#                 servicebus_namespace_connection_string,
-#                 uamqp_transport=uamqp_transport
-#             ) as sb_client:
-#                 with sb_client.get_queue_sender(servicebus_queue.name, socket_timeout=0.6) as sender:
-#                     payload = "A" * 250 * 1024
-#                     sender.send_messages(ServiceBusMessage(payload))
+        if not uamqp_transport:
+            # Amqp
+            with ServiceBusClient(
+                fully_qualified_namespace,
+                credential,
+                uamqp_transport=uamqp_transport
+            ) as sb_client:
+                with sb_client.get_queue_sender(servicebus_queue.name, socket_timeout=0.6) as sender:
+                    payload = "A" * 250 * 1024
+                    sender.send_messages(ServiceBusMessage(payload))
 
-#             if uamqp:
-#                 transport_type = uamqp.constants.TransportType.AmqpOverWebsocket
-#             else:
-#                 transport_type = TransportType.AmqpOverWebsocket
-#             # AmqpOverWebsocket
-#             with ServiceBusClient.from_connection_string(
-#                 servicebus_namespace_connection_string,
-#                 transport_type=transport_type,
-#                 uamqp_transport=uamqp_transport
-#             ) as sb_client:
-#                 with sb_client.get_queue_sender(servicebus_queue.name, socket_timeout=0.8) as sender:
-#                     payload = "A" * 250 * 1024
-#                     sender.send_messages(ServiceBusMessage(payload))
+            if uamqp:
+                transport_type = uamqp.constants.TransportType.AmqpOverWebsocket
+            else:
+                transport_type = TransportType.AmqpOverWebsocket
+            # AmqpOverWebsocket
+            with ServiceBusClient(
+                fully_qualified_namespace,
+                credential,
+                transport_type=transport_type,
+                uamqp_transport=uamqp_transport
+            ) as sb_client:
+                with sb_client.get_queue_sender(servicebus_queue.name, socket_timeout=0.8) as sender:
+                    payload = "A" * 250 * 1024
+                    sender.send_messages(ServiceBusMessage(payload))
 
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @CachedServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_queue_send_large_message_receive(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         # Amqp
-#         with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string,
-#             uamqp_transport=uamqp_transport
-#         ) as sb_client:
-#             with sb_client.get_queue_sender(servicebus_queue.name, socket_timeout=0.6) as sender:
-#                 payload = "A" * 250 * 1024
-#                 sender.send_messages(ServiceBusMessage(payload))
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @CachedServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_queue_send_large_message_receive(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        # Amqp
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+            fully_qualified_namespace, credential,
+            uamqp_transport=uamqp_transport
+        ) as sb_client:
+            with sb_client.get_queue_sender(servicebus_queue.name, socket_timeout=0.6) as sender:
+                payload = "A" * 250 * 1024
+                sender.send_messages(ServiceBusMessage(payload))
 
-#         if uamqp:
-#             transport_type = uamqp.constants.TransportType.AmqpOverWebsocket
-#         else:
-#             transport_type = TransportType.AmqpOverWebsocket
-#         # AmqpOverWebsocket
-#         with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string,
-#             transport_type=transport_type,
-#             uamqp_transport=uamqp_transport
-#         ) as sb_client:
-#             with sb_client.get_queue_sender(servicebus_queue.name, socket_timeout=0.8) as sender:
-#                 payload = "A" * 250 * 1024
-#                 sender.send_messages(ServiceBusMessage(payload))
+        if uamqp:
+            transport_type = uamqp.constants.TransportType.AmqpOverWebsocket
+        else:
+            transport_type = TransportType.AmqpOverWebsocket
+        # AmqpOverWebsocket
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+            fully_qualified_namespace, credential,
+            transport_type=transport_type,
+            uamqp_transport=uamqp_transport
+        ) as sb_client:
+            with sb_client.get_queue_sender(servicebus_queue.name, socket_timeout=0.8) as sender:
+                payload = "A" * 250 * 1024
+                sender.send_messages(ServiceBusMessage(payload))
 
-#         # ReceiveMessages
-#         with ServiceBusClient.from_connection_string(
-#                 servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-#             with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5) as receiver:
-#                 messages = receiver.receive_messages(max_message_count=5, max_wait_time=5)
-#                 for message in messages:
-#                     if not uamqp_transport:
-#                         assert message._delivery_id is not None
-#                         assert message._message.data[0].decode("utf-8")  == "A" * 250 * 1024
-#                     receiver.complete_message(message)  # complete messages             
+        # ReceiveMessages
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+                fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+            with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5) as receiver:
+                messages = receiver.receive_messages(max_message_count=5, max_wait_time=5)
+                for message in messages:
+                    if not uamqp_transport:
+                        assert message._delivery_id is not None
+                        assert message._message.data[0].decode("utf-8")  == "A" * 250 * 1024
+                    receiver.complete_message(message)  # complete messages             
 
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @CachedServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_queue_mgmt_operation_timeout(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         if uamqp_transport:
-#             def hack_mgmt_execute(self, operation, op_type, message, timeout=0):
-#                 start_time = self._counter.get_current_ms()
-#                 operation_id = str(uuid.uuid4())
-#                 self._responses[operation_id] = None
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @CachedServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_queue_mgmt_operation_timeout(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        if uamqp_transport:
+            def hack_mgmt_execute(self, operation, op_type, message, timeout=0):
+                start_time = self._counter.get_current_ms()
+                operation_id = str(uuid.uuid4())
+                self._responses[operation_id] = None
 
-#                 time.sleep(6)  # sleep until timeout
-#                 while not self._responses[operation_id] and not self.mgmt_error:
-#                     if timeout > 0:
-#                         now = self._counter.get_current_ms()
-#                         if (now - start_time) >= timeout:
-#                             raise uamqp.compat.TimeoutException("Failed to receive mgmt response in {}ms".format(timeout))
-#                     self.connection.work()
-#                 if self.mgmt_error:
-#                     raise self.mgmt_error
-#                 response = self._responses.pop(operation_id)
-#                 return response
+                time.sleep(6)  # sleep until timeout
+                while not self._responses[operation_id] and not self.mgmt_error:
+                    if timeout > 0:
+                        now = self._counter.get_current_ms()
+                        if (now - start_time) >= timeout:
+                            raise uamqp.compat.TimeoutException("Failed to receive mgmt response in {}ms".format(timeout))
+                    self.connection.work()
+                if self.mgmt_error:
+                    raise self.mgmt_error
+                response = self._responses.pop(operation_id)
+                return response
 
-#             original_execute_method = uamqp.mgmt_operation.MgmtOperation.execute
-#             # hack the mgmt method on the class, not on an instance, so it needs reset
-#         else:
-#             def hack_mgmt_execute(self, message, operation=None, operation_type=None, timeout=0):
-#                 start_time = time.time()
-#                 operation_id = str(uuid.uuid4())
-#                 self._responses[operation_id] = None
+            original_execute_method = uamqp.mgmt_operation.MgmtOperation.execute
+            # hack the mgmt method on the class, not on an instance, so it needs reset
+        else:
+            def hack_mgmt_execute(self, message, operation=None, operation_type=None, timeout=0):
+                start_time = time.time()
+                operation_id = str(uuid.uuid4())
+                self._responses[operation_id] = None
 
-#                 time.sleep(6)  # sleep until timeout
-#                 while not self._responses[operation_id] and not self._mgmt_error:
-#                     if timeout and timeout > 0:
-#                         now = time.time()
-#                         if (now - start_time) >= timeout:
-#                             raise TimeoutError("Failed to receive mgmt response in {}ms".format(timeout))
-#                     self._connection.listen()
-#                 if self._mgmt_error:
-#                     self._responses.pop(operation_id)
-#                     raise self._mgmt_error
+                time.sleep(6)  # sleep until timeout
+                while not self._responses[operation_id] and not self._mgmt_error:
+                    if timeout and timeout > 0:
+                        now = time.time()
+                        if (now - start_time) >= timeout:
+                            raise TimeoutError("Failed to receive mgmt response in {}ms".format(timeout))
+                    self._connection.listen()
+                if self._mgmt_error:
+                    self._responses.pop(operation_id)
+                    raise self._mgmt_error
 
-#                 response = self._responses.pop(operation_id)
-#                 return response
+                response = self._responses.pop(operation_id)
+                return response
 
-#             original_execute_method = management_operation.ManagementOperation.execute
-#             # hack the mgmt method on the class, not on an instance, so it needs reset
+            original_execute_method = management_operation.ManagementOperation.execute
+            # hack the mgmt method on the class, not on an instance, so it needs reset
 
-#         try:
-#             if uamqp_transport:
-#                 uamqp.mgmt_operation.MgmtOperation.execute = hack_mgmt_execute
-#             else:
-#                 management_operation.ManagementOperation.execute = hack_mgmt_execute
-#             with ServiceBusClient.from_connection_string(
-#                     servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-#                 with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                     with pytest.raises(OperationTimeoutError):
-#                         scheduled_time_utc = utc_now() + timedelta(seconds=30)
-#                         sender.schedule_messages(ServiceBusMessage("ServiceBusMessage to be scheduled"), scheduled_time_utc, timeout=5)
-#         finally:
-#             # must reset the mgmt execute method, otherwise other test cases would use the hacked execute method, leading to timeout error
-#             if uamqp_transport:
-#                 uamqp.mgmt_operation.MgmtOperation.execute = original_execute_method
-#             else:
-#                 management_operation.ManagementOperation.execute = original_execute_method
+        try:
+            if uamqp_transport:
+                uamqp.mgmt_operation.MgmtOperation.execute = hack_mgmt_execute
+            else:
+                management_operation.ManagementOperation.execute = hack_mgmt_execute
+            fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+            credential = get_credential()
+            with ServiceBusClient(
+                    fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+                with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                    with pytest.raises(OperationTimeoutError):
+                        scheduled_time_utc = utc_now() + timedelta(seconds=30)
+                        sender.schedule_messages(ServiceBusMessage("ServiceBusMessage to be scheduled"), scheduled_time_utc, timeout=5)
+        finally:
+            # must reset the mgmt execute method, otherwise other test cases would use the hacked execute method, leading to timeout error
+            if uamqp_transport:
+                uamqp.mgmt_operation.MgmtOperation.execute = original_execute_method
+            else:
+                management_operation.ManagementOperation.execute = original_execute_method
 
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @CachedServiceBusQueuePreparer(name_prefix='servicebustest', lock_duration='PT5S')
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_queue_operation_negative(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         if uamqp_transport:
-#             def _hack_amqp_message_complete(cls):
-#                 raise RuntimeError()
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @CachedServiceBusQueuePreparer(name_prefix='servicebustest', lock_duration='PT5S')
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_queue_operation_negative(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        if uamqp_transport:
+            def _hack_amqp_message_complete(cls):
+                raise RuntimeError()
 
-#             def _hack_amqp_mgmt_request(cls, message, operation, op_type=None, node=None, callback=None, **kwargs):
-#                 raise uamqp.errors.AMQPConnectionError()
+            def _hack_amqp_mgmt_request(cls, message, operation, op_type=None, node=None, callback=None, **kwargs):
+                raise uamqp.errors.AMQPConnectionError()
 
-#             def _hack_sb_receiver_settle_message(self, message, settle_operation, dead_letter_reason=None, dead_letter_error_description=None):
-#                 raise uamqp.errors.AMQPError()
-#         else:
-#             def _hack_amqp_message_complete(cls, _, settlement):
-#                     if settlement == 'completed':
-#                         raise RuntimeError()
+            def _hack_sb_receiver_settle_message(self, message, settle_operation, dead_letter_reason=None, dead_letter_error_description=None):
+                raise uamqp.errors.AMQPError()
+        else:
+            def _hack_amqp_message_complete(cls, _, settlement):
+                    if settlement == 'completed':
+                        raise RuntimeError()
 
-#             def _hack_amqp_mgmt_request(cls, message, operation, op_type=None, node=None, callback=None, **kwargs):
-#                 raise error.AMQPConnectionError(error.ErrorCondition.ConnectionCloseForced)
+            def _hack_amqp_mgmt_request(cls, message, operation, op_type=None, node=None, callback=None, **kwargs):
+                raise error.AMQPConnectionError(error.ErrorCondition.ConnectionCloseForced)
 
-#             def _hack_sb_receiver_settle_message(self, message, settle_operation, dead_letter_reason=None, dead_letter_error_description=None):
-#                 raise error.AMQPException(error.ErrorCondition.ClientError)
+            def _hack_sb_receiver_settle_message(self, message, settle_operation, dead_letter_reason=None, dead_letter_error_description=None):
+                raise error.AMQPException(error.ErrorCondition.ClientError)
 
-#         with ServiceBusClient.from_connection_string(
-#                 servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-#             sender = sb_client.get_queue_sender(servicebus_queue.name)
-#             receiver = sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5)
-#             if not uamqp_transport:
-#                 original_settlement = client.ReceiveClient.settle_messages
-#             try:
-#                 with sender, receiver:
-#                     # negative settlement via receiver link
-#                     sender.send_messages(ServiceBusMessage("body"), timeout=10)
-#                     message = receiver.receive_messages()[0]
-#                     if uamqp_transport:
-#                         message._message.accept = types.MethodType(_hack_amqp_message_complete, message._message)
-#                     else:
-#                         client.ReceiveClient.settle_messages = types.MethodType(_hack_amqp_message_complete, receiver._handler)
-#                     receiver.complete_message(message)  # settle via mgmt link
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+                fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+            sender = sb_client.get_queue_sender(servicebus_queue.name)
+            receiver = sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5)
+            if not uamqp_transport:
+                original_settlement = client.ReceiveClient.settle_messages
+            try:
+                with sender, receiver:
+                    # negative settlement via receiver link
+                    sender.send_messages(ServiceBusMessage("body"), timeout=10)
+                    message = receiver.receive_messages()[0]
+                    if uamqp_transport:
+                        message._message.accept = types.MethodType(_hack_amqp_message_complete, message._message)
+                    else:
+                        client.ReceiveClient.settle_messages = types.MethodType(_hack_amqp_message_complete, receiver._handler)
+                    receiver.complete_message(message)  # settle via mgmt link
 
-#                     if uamqp_transport:
-#                         origin_amqp_client_mgmt_request_method = uamqp.AMQPClient.mgmt_request
-#                         try:
-#                             uamqp.AMQPClient.mgmt_request = _hack_amqp_mgmt_request
-#                             with pytest.raises(ServiceBusConnectionError):
-#                                 receiver.peek_messages()
-#                         finally:
-#                             uamqp.AMQPClient.mgmt_request = origin_amqp_client_mgmt_request_method
-#                     else:
-#                         origin_amqp_client_mgmt_request_method = client.AMQPClient.mgmt_request
-#                         try:
-#                             client.AMQPClient.mgmt_request = _hack_amqp_mgmt_request
-#                             with pytest.raises(ServiceBusConnectionError):
-#                                 receiver.peek_messages()
-#                         finally:
-#                             client.AMQPClient.mgmt_request = origin_amqp_client_mgmt_request_method
+                    if uamqp_transport:
+                        origin_amqp_client_mgmt_request_method = uamqp.AMQPClient.mgmt_request
+                        try:
+                            uamqp.AMQPClient.mgmt_request = _hack_amqp_mgmt_request
+                            with pytest.raises(ServiceBusConnectionError):
+                                receiver.peek_messages()
+                        finally:
+                            uamqp.AMQPClient.mgmt_request = origin_amqp_client_mgmt_request_method
+                    else:
+                        origin_amqp_client_mgmt_request_method = client.AMQPClient.mgmt_request
+                        try:
+                            client.AMQPClient.mgmt_request = _hack_amqp_mgmt_request
+                            with pytest.raises(ServiceBusConnectionError):
+                                receiver.peek_messages()
+                        finally:
+                            client.AMQPClient.mgmt_request = origin_amqp_client_mgmt_request_method
 
-#                     sender.send_messages(ServiceBusMessage("body"), timeout=10)
+                    sender.send_messages(ServiceBusMessage("body"), timeout=10)
 
-#                     message = receiver.receive_messages()[0]
+                    message = receiver.receive_messages()[0]
 
-#                     origin_sb_receiver_settle_message_method = receiver._settle_message
-#                     receiver._settle_message = types.MethodType(_hack_sb_receiver_settle_message, receiver)
-#                     with pytest.raises(ServiceBusError):
-#                         receiver.complete_message(message)
+                    origin_sb_receiver_settle_message_method = receiver._settle_message
+                    receiver._settle_message = types.MethodType(_hack_sb_receiver_settle_message, receiver)
+                    with pytest.raises(ServiceBusError):
+                        receiver.complete_message(message)
 
-#                     receiver._settle_message = origin_sb_receiver_settle_message_method
-#                     message = receiver.receive_messages(max_wait_time=6)[0]
-#                     receiver.complete_message(message)
-#             finally:
-#                 if not uamqp_transport:
-#                     client.ReceiveClient.settle_messages = original_settlement
+                    receiver._settle_message = origin_sb_receiver_settle_message_method
+                    message = receiver.receive_messages(max_wait_time=6)[0]
+                    receiver.complete_message(message)
+            finally:
+                if not uamqp_transport:
+                    client.ReceiveClient.settle_messages = original_settlement
 
     
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_send_message_no_body(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         sb_client = ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, uamqp_transport=uamqp_transport)
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_send_message_no_body(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        sb_client = ServiceBusClient(
+            fully_qualified_namespace, credential, uamqp_transport=uamqp_transport)
 
-#         with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#             sender.send_messages(ServiceBusMessage(body=None))
+        with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+            sender.send_messages(ServiceBusMessage(body=None))
 
-#         with sb_client.get_queue_receiver(servicebus_queue.name,  
-#                                           max_wait_time=10) as receiver:
-#             message = receiver.next()
-#             assert message.body is None
-#             receiver.complete_message(message)
+        with sb_client.get_queue_receiver(servicebus_queue.name,  
+                                          max_wait_time=10) as receiver:
+            message = receiver.next()
+            assert message.body is None
+            receiver.complete_message(message)
 
-#     def test_send_message_alternate_body_types(self, **kwargs):
-#         with pytest.raises(TypeError):
-#             message = ServiceBusMessage(body=['1','2'])
-#         with pytest.raises(TypeError):
-#             message = ServiceBusMessage(body=[None, None])
-#         with pytest.raises(TypeError):
-#             message = ServiceBusMessage(body=['1', None])
-#         with pytest.raises(TypeError):
-#             message = ServiceBusMessage(body=[Exception()])
-#         with pytest.raises(TypeError):
-#             message = ServiceBusMessage(body={})
-#         with pytest.raises(TypeError):
-#             message = ServiceBusMessage(body=Exception())
+    def test_send_message_alternate_body_types(self, **kwargs):
+        with pytest.raises(TypeError):
+            message = ServiceBusMessage(body=['1','2'])
+        with pytest.raises(TypeError):
+            message = ServiceBusMessage(body=[None, None])
+        with pytest.raises(TypeError):
+            message = ServiceBusMessage(body=['1', None])
+        with pytest.raises(TypeError):
+            message = ServiceBusMessage(body=[Exception()])
+        with pytest.raises(TypeError):
+            message = ServiceBusMessage(body={})
+        with pytest.raises(TypeError):
+            message = ServiceBusMessage(body=Exception())
 
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @CachedServiceBusQueuePreparer(name_prefix='servicebustest')
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_queue_by_servicebus_client_enum_case_sensitivity(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         # Note: This test is currently intended to enforce case-sensitivity.  If we eventually upgrade to the Fancy Enums being used with new autorest,
-#         # we may want to tweak this.
-#         with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-#             with sb_client.get_queue_receiver(servicebus_queue.name, 
-#                                               receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE.value, 
-#                                               max_wait_time=5) as receiver:
-#                 pass
-#             with pytest.raises(ValueError):
-#                 with sb_client.get_queue_receiver(servicebus_queue.name, 
-#                                                   receive_mode=str.upper(ServiceBusReceiveMode.RECEIVE_AND_DELETE.value),
-#                                                   max_wait_time=5) as receiver:
-#                     raise Exception("Should not get here, should be case sensitive.")
-#             with sb_client.get_queue_receiver(servicebus_queue.name, 
-#                                               sub_queue=ServiceBusSubQueue.DEAD_LETTER.value,
-#                                               max_wait_time=5) as receiver:
-#                 pass
-#             with pytest.raises(ValueError):
-#                 with sb_client.get_queue_receiver(servicebus_queue.name, 
-#                                                   sub_queue=str.upper(ServiceBusSubQueue.DEAD_LETTER.value),
-#                                                   max_wait_time=5) as receiver:
-#                     raise Exception("Should not get here, should be case sensitive.")
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @CachedServiceBusQueuePreparer(name_prefix='servicebustest')
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_queue_by_servicebus_client_enum_case_sensitivity(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        # Note: This test is currently intended to enforce case-sensitivity.  If we eventually upgrade to the Fancy Enums being used with new autorest,
+        # we may want to tweak this.
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+            fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+            with sb_client.get_queue_receiver(servicebus_queue.name, 
+                                              receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE.value, 
+                                              max_wait_time=5) as receiver:
+                pass
+            with pytest.raises(ValueError):
+                with sb_client.get_queue_receiver(servicebus_queue.name, 
+                                                  receive_mode=str.upper(ServiceBusReceiveMode.RECEIVE_AND_DELETE.value),
+                                                  max_wait_time=5) as receiver:
+                    raise Exception("Should not get here, should be case sensitive.")
+            with sb_client.get_queue_receiver(servicebus_queue.name, 
+                                              sub_queue=ServiceBusSubQueue.DEAD_LETTER.value,
+                                              max_wait_time=5) as receiver:
+                pass
+            with pytest.raises(ValueError):
+                with sb_client.get_queue_receiver(servicebus_queue.name, 
+                                                  sub_queue=str.upper(ServiceBusSubQueue.DEAD_LETTER.value),
+                                                  max_wait_time=5) as receiver:
+                    raise Exception("Should not get here, should be case sensitive.")
 
     
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest')
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_queue_send_dict_messages(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest')
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_queue_send_dict_messages(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+            fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
 
-#                 message_dict = {"body": "Message"}
-#                 message2_dict = {"body": "Message2"}
-#                 list_message_dicts = [message_dict, message2_dict]
+                message_dict = {"body": "Message"}
+                message2_dict = {"body": "Message2"}
+                list_message_dicts = [message_dict, message2_dict]
 
-#                 # send single dict
-#                 sender.send_messages(message_dict)
+                # send single dict
+                sender.send_messages(message_dict)
 
-#                 # send list of dicts
-#                 sender.send_messages(list_message_dicts)
+                # send list of dicts
+                sender.send_messages(list_message_dicts)
 
-#                 # create and send BatchMessage with dicts
-#                 batch_message = sender.create_message_batch()
-#                 batch_message._from_list(list_message_dicts)  # pylint: disable=protected-access
-#                 batch_message.add_message(message_dict)
-#                 sender.send_messages(batch_message)
+                # create and send BatchMessage with dicts
+                batch_message = sender.create_message_batch()
+                batch_message._from_list(list_message_dicts)  # pylint: disable=protected-access
+                batch_message.add_message(message_dict)
+                sender.send_messages(batch_message)
 
-#                 received_messages = []
-#                 with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5) as receiver:
-#                     for message in receiver:
-#                         received_messages.append(message)
-#                 assert len(received_messages) == 6
+                received_messages = []
+                with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5) as receiver:
+                    for message in receiver:
+                        received_messages.append(message)
+                assert len(received_messages) == 6
 
-#                 batch_message = sender.create_message_batch(max_size_in_bytes=73)
-#                 for _ in range(2):
-#                     try:
-#                         batch_message.add_message(message_dict)
-#                     except ValueError:
-#                         break
-#                 sender.send_messages(batch_message)
-#                 received_messages = []
-#                 with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5) as receiver:
-#                     for message in receiver:
-#                         received_messages.append(message)
-#                 assert len(received_messages) == 1
+                batch_message = sender.create_message_batch(max_size_in_bytes=73)
+                for _ in range(2):
+                    try:
+                        batch_message.add_message(message_dict)
+                    except ValueError:
+                        break
+                sender.send_messages(batch_message)
+                received_messages = []
+                with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5) as receiver:
+                    for message in receiver:
+                        received_messages.append(message)
+                assert len(received_messages) == 1
     
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest')
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_queue_send_mapping_messages(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         class MappingMessage(DictMixin):
-#             def __init__(self, content):
-#                 self.body = content
-#                 self.message_id = 'foo'
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest')
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_queue_send_mapping_messages(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        class MappingMessage(DictMixin):
+            def __init__(self, content):
+                self.body = content
+                self.message_id = 'foo'
         
-#         class BadMappingMessage(DictMixin):
-#             def __init__(self):
-#                 self.message_id = 'foo'
+        class BadMappingMessage(DictMixin):
+            def __init__(self):
+                self.message_id = 'foo'
 
-#         with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+            fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
 
-#                 message_dict = MappingMessage("Message")
-#                 message2_dict = MappingMessage("Message2")
-#                 message3_dict = BadMappingMessage()
-#                 list_message_dicts = [message_dict, message2_dict]
+                message_dict = MappingMessage("Message")
+                message2_dict = MappingMessage("Message2")
+                message3_dict = BadMappingMessage()
+                list_message_dicts = [message_dict, message2_dict]
 
-#                 # send single dict
-#                 sender.send_messages(message_dict)
+                # send single dict
+                sender.send_messages(message_dict)
 
-#                 # send list of dicts
-#                 sender.send_messages(list_message_dicts)
+                # send list of dicts
+                sender.send_messages(list_message_dicts)
 
-#                 # send bad dict
-#                 with pytest.raises(TypeError):
-#                     sender.send_messages(message3_dict)
+                # send bad dict
+                with pytest.raises(TypeError):
+                    sender.send_messages(message3_dict)
 
-#                 # create and send BatchMessage with dicts
-#                 batch_message = sender.create_message_batch()
-#                 batch_message._from_list(list_message_dicts)  # pylint: disable=protected-access
-#                 batch_message.add_message(message_dict)
-#                 sender.send_messages(batch_message)
+                # create and send BatchMessage with dicts
+                batch_message = sender.create_message_batch()
+                batch_message._from_list(list_message_dicts)  # pylint: disable=protected-access
+                batch_message.add_message(message_dict)
+                sender.send_messages(batch_message)
 
-#                 received_messages = []
-#                 with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5) as receiver:
-#                     for message in receiver:
-#                         received_messages.append(message)
-#                 assert len(received_messages) == 6
+                received_messages = []
+                with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5) as receiver:
+                    for message in receiver:
+                        received_messages.append(message)
+                assert len(received_messages) == 6
 
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest')
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_queue_send_dict_messages_error_badly_formatted_dicts(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest')
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_queue_send_dict_messages_error_badly_formatted_dicts(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+            fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
 
-#                 message_dict = {"bad_key": "Message"}
-#                 message2_dict = {"bad_key": "Message2"}
-#                 list_message_dicts = [message_dict, message2_dict]
+                message_dict = {"bad_key": "Message"}
+                message2_dict = {"bad_key": "Message2"}
+                list_message_dicts = [message_dict, message2_dict]
 
-#                 # send single dict
-#                 with pytest.raises(TypeError):
-#                     sender.send_messages(message_dict)
+                # send single dict
+                with pytest.raises(TypeError):
+                    sender.send_messages(message_dict)
 
-#                 # send list of dicts
-#                 with pytest.raises(TypeError):
-#                     sender.send_messages(list_message_dicts)
+                # send list of dicts
+                with pytest.raises(TypeError):
+                    sender.send_messages(list_message_dicts)
 
-#                 # create and send BatchMessage with dicts
-#                 batch_message = sender.create_message_batch()
-#                 with pytest.raises(TypeError):
-#                     batch_message._from_list(list_message_dicts)  # pylint: disable=protected-access
+                # create and send BatchMessage with dicts
+                batch_message = sender.create_message_batch()
+                with pytest.raises(TypeError):
+                    batch_message._from_list(list_message_dicts)  # pylint: disable=protected-access
 
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_queue_send_dict_messages_scheduled(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_queue_send_dict_messages_scheduled(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
         
-#         with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-#             content = "Test scheduled message"
-#             message_id = uuid.uuid4()
-#             message_id2 = uuid.uuid4()
-#             scheduled_enqueue_time = (utc_now() + timedelta(minutes=0.05)).replace(microsecond=0)
-#             message_dict = {"message_id": message_id, "body": content}
-#             message2_dict = {"message_id": message_id2, "body": content}
-#             list_message_dicts = [message_dict, message2_dict]
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+            fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+            content = "Test scheduled message"
+            message_id = uuid.uuid4()
+            message_id2 = uuid.uuid4()
+            scheduled_enqueue_time = (utc_now() + timedelta(minutes=0.05)).replace(microsecond=0)
+            message_dict = {"message_id": message_id, "body": content}
+            message2_dict = {"message_id": message_id2, "body": content}
+            list_message_dicts = [message_dict, message2_dict]
             
-#             # send single dict
-#             with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
-#                 with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                     tokens = sender.schedule_messages(message_dict, scheduled_enqueue_time)
-#                     assert len(tokens) == 1
+            # send single dict
+            with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
+                with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                    tokens = sender.schedule_messages(message_dict, scheduled_enqueue_time)
+                    assert len(tokens) == 1
     
-#                 messages = receiver.receive_messages(max_wait_time=20)
-#                 if messages:
-#                     try:
-#                         data = str(messages[0])
-#                         assert data == content
-#                         assert messages[0].message_id == message_id
-#                         assert messages[0].scheduled_enqueue_time_utc == scheduled_enqueue_time
-#                         assert messages[0].scheduled_enqueue_time_utc <= messages[0].enqueued_time_utc.replace(microsecond=0)
-#                         assert len(messages) == 1
-#                     finally:
-#                         for m in messages:
-#                             receiver.complete_message(m)
-#                 else:
-#                     raise Exception("Failed to receive schdeduled message.")
+                messages = receiver.receive_messages(max_wait_time=20)
+                if messages:
+                    try:
+                        data = str(messages[0])
+                        assert data == content
+                        assert messages[0].message_id == message_id
+                        assert messages[0].scheduled_enqueue_time_utc == scheduled_enqueue_time
+                        assert messages[0].scheduled_enqueue_time_utc <= messages[0].enqueued_time_utc.replace(microsecond=0)
+                        assert len(messages) == 1
+                    finally:
+                        for m in messages:
+                            receiver.complete_message(m)
+                else:
+                    raise Exception("Failed to receive schdeduled message.")
 
-#             # send list of dicts
-#             with sb_client.get_queue_receiver(servicebus_queue.name, prefetch_count=20) as receiver:
-#                 with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                     tokens = sender.schedule_messages(list_message_dicts, scheduled_enqueue_time)
-#                     assert len(tokens) == 2
+            # send list of dicts
+            with sb_client.get_queue_receiver(servicebus_queue.name, prefetch_count=20) as receiver:
+                with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                    tokens = sender.schedule_messages(list_message_dicts, scheduled_enqueue_time)
+                    assert len(tokens) == 2
     
-#                 messages = receiver.receive_messages(max_wait_time=20)
-#                 messages.extend(receiver.receive_messages(max_wait_time=5))
-#                 if messages:
-#                     try:
-#                         data = str(messages[0])
-#                         print(messages)
-#                         assert data == content
-#                         assert messages[0].message_id == message_id
-#                         assert messages[0].scheduled_enqueue_time_utc == scheduled_enqueue_time
-#                         assert messages[0].scheduled_enqueue_time_utc <= messages[0].enqueued_time_utc.replace(microsecond=0)
-#                         assert len(messages) == 2
-#                     finally:
-#                         for m in messages:
-#                             receiver.complete_message(m)
-#                 else:
-#                     raise Exception("Failed to receive schdeduled message.")                    
+                messages = receiver.receive_messages(max_wait_time=20)
+                messages.extend(receiver.receive_messages(max_wait_time=5))
+                if messages:
+                    try:
+                        data = str(messages[0])
+                        print(messages)
+                        assert data == content
+                        assert messages[0].message_id == message_id
+                        assert messages[0].scheduled_enqueue_time_utc == scheduled_enqueue_time
+                        assert messages[0].scheduled_enqueue_time_utc <= messages[0].enqueued_time_utc.replace(microsecond=0)
+                        assert len(messages) == 2
+                    finally:
+                        for m in messages:
+                            receiver.complete_message(m)
+                else:
+                    raise Exception("Failed to receive schdeduled message.")                    
 
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_queue_send_dict_messages_scheduled_error_badly_formatted_dicts(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_queue_send_dict_messages_scheduled_error_badly_formatted_dicts(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
         
-#         with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-#             content = "Test scheduled message"
-#             message_id = uuid.uuid4()
-#             message_id2 = uuid.uuid4()
-#             scheduled_enqueue_time = (utc_now() + timedelta(minutes=0.1)).replace(microsecond=0)
-#             with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
-#                 with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                     message_dict = {"message_id": message_id, "bad_key": content}
-#                     message2_dict = {"message_id": message_id2, "bad_key": content}
-#                     list_message_dicts = [message_dict, message2_dict]
-#                     with pytest.raises(TypeError):
-#                         sender.schedule_messages(message_dict, scheduled_enqueue_time)
-#                     with pytest.raises(TypeError):
-#                         sender.schedule_messages(list_message_dicts, scheduled_enqueue_time)
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+            fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+            content = "Test scheduled message"
+            message_id = uuid.uuid4()
+            message_id2 = uuid.uuid4()
+            scheduled_enqueue_time = (utc_now() + timedelta(minutes=0.1)).replace(microsecond=0)
+            with sb_client.get_queue_receiver(servicebus_queue.name) as receiver:
+                with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                    message_dict = {"message_id": message_id, "bad_key": content}
+                    message2_dict = {"message_id": message_id2, "bad_key": content}
+                    list_message_dicts = [message_dict, message2_dict]
+                    with pytest.raises(TypeError):
+                        sender.schedule_messages(message_dict, scheduled_enqueue_time)
+                    with pytest.raises(TypeError):
+                        sender.schedule_messages(list_message_dicts, scheduled_enqueue_time)
 
     
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_queue_receive_iterator_resume_after_link_detach(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_queue_receive_iterator_resume_after_link_detach(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
 
-#         def hack_iter_next_mock_error(self, wait_time=None):
-#             try:
-#                 self._receive_context.set()
-#                 self._open()
-#                 # when trying to receive the second message (execution_times is 1), raising LinkDetach error to mock 10 mins idle timeout
-#                 if self.execution_times == 1:
-#                     # TODO: update uamqp errors to pyamqp
-#                     if uamqp_transport:
-#                         from uamqp.errors import LinkDetach
-#                         from uamqp.constants import ErrorCodes
-#                         error = LinkDetach
-#                         error_condition = ErrorCodes
-#                     else:
-#                         from azure.servicebus._pyamqp.error import ErrorCondition, AMQPLinkError
-#                         error = AMQPLinkError
-#                         error_condition = ErrorCondition
+        def hack_iter_next_mock_error(self, wait_time=None):
+            try:
+                self._receive_context.set()
+                self._open()
+                # when trying to receive the second message (execution_times is 1), raising LinkDetach error to mock 10 mins idle timeout
+                if self.execution_times == 1:
+                    # TODO: update uamqp errors to pyamqp
+                    if uamqp_transport:
+                        from uamqp.errors import LinkDetach
+                        from uamqp.constants import ErrorCodes
+                        error = LinkDetach
+                        error_condition = ErrorCodes
+                    else:
+                        from azure.servicebus._pyamqp.error import ErrorCondition, AMQPLinkError
+                        error = AMQPLinkError
+                        error_condition = ErrorCondition
 
-#                     self.execution_times += 1
-#                     self.error_raised = True
-#                     raise error(error_condition.LinkDetachForced)
-#                 else:
-#                     self.execution_times += 1
-#                 if not self._message_iter:
-#                     if uamqp_transport:
-#                         self._message_iter = self._handler.receive_messages_iter()
-#                     else:
-#                         self._message_iter = self._handler.receive_messages_iter(timeout=wait_time)
-#                 amqp_message = next(self._message_iter)
-#                 message = self._build_received_message(amqp_message)
-#                 return message
-#             finally:
-#                 self._receive_context.clear()
+                    self.execution_times += 1
+                    self.error_raised = True
+                    raise error(error_condition.LinkDetachForced)
+                else:
+                    self.execution_times += 1
+                if not self._message_iter:
+                    if uamqp_transport:
+                        self._message_iter = self._handler.receive_messages_iter()
+                    else:
+                        self._message_iter = self._handler.receive_messages_iter(timeout=wait_time)
+                amqp_message = next(self._message_iter)
+                message = self._build_received_message(amqp_message)
+                return message
+            finally:
+                self._receive_context.clear()
 
-#         with ServiceBusClient.from_connection_string(
-#                 servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 sender.send_messages(
-#                     [ServiceBusMessage("test1"), ServiceBusMessage("test2"), ServiceBusMessage("test3")]
-#                 )
-#             with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10) as receiver:
-#                 receiver.execution_times = 0
-#                 receiver.error_raised = False
-#                 receiver._iter_next = types.MethodType(hack_iter_next_mock_error, receiver)
-#                 res = []
-#                 for msg in receiver:
-#                     receiver.complete_message(msg)
-#                     res.append(msg)
-#                 assert len(res) == 3
-#                 assert receiver.error_raised
-#                 assert receiver.execution_times >= 4  # at least 1 failure and 3 successful receiving iterator
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+                fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                sender.send_messages(
+                    [ServiceBusMessage("test1"), ServiceBusMessage("test2"), ServiceBusMessage("test3")]
+                )
+            with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10) as receiver:
+                receiver.execution_times = 0
+                receiver.error_raised = False
+                receiver._iter_next = types.MethodType(hack_iter_next_mock_error, receiver)
+                res = []
+                for msg in receiver:
+                    receiver.complete_message(msg)
+                    res.append(msg)
+                assert len(res) == 3
+                assert receiver.error_raised
+                assert receiver.execution_times >= 4  # at least 1 failure and 3 successful receiving iterator
 
     
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_queue_send_amqp_annotated_message(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_queue_send_amqp_annotated_message(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
 
-#         with ServiceBusClient.from_connection_string(
-#                 servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-#             sequence_body = [b'message', 123.456, True]
-#             footer = {'footer_key': 'footer_value'}
-#             prop = {"subject": "sequence"}
-#             seq_app_prop = {"body_type": "sequence"}
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+                fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+            sequence_body = [b'message', 123.456, True]
+            footer = {'footer_key': 'footer_value'}
+            prop = {"subject": "sequence"}
+            seq_app_prop = {"body_type": "sequence"}
 
-#             sequence_message = AmqpAnnotatedMessage(
-#                 sequence_body=sequence_body,
-#                 footer=footer,
-#                 properties=prop,
-#                 application_properties=seq_app_prop
-#             )
+            sequence_message = AmqpAnnotatedMessage(
+                sequence_body=sequence_body,
+                footer=footer,
+                properties=prop,
+                application_properties=seq_app_prop
+            )
 
-#             value_body = {b"key": [-123, b'data', False]}
-#             header = {"priority": 10}
-#             anno = {"ann_key": "ann_value"}
-#             value_app_prop = {"body_type": "value"}
+            value_body = {b"key": [-123, b'data', False]}
+            header = {"priority": 10}
+            anno = {"ann_key": "ann_value"}
+            value_app_prop = {"body_type": "value"}
 
-#             value_message = AmqpAnnotatedMessage(
-#                 value_body=value_body,
-#                 header=header,
-#                 annotations=anno,
-#                 application_properties=value_app_prop
-#             )
+            value_message = AmqpAnnotatedMessage(
+                value_body=value_body,
+                header=header,
+                annotations=anno,
+                application_properties=value_app_prop
+            )
 
-#             data_body = [b'aa', b'bb', b'cc']
-#             data_app_prop = {"body_type": "data"}
-#             del_anno = {"delann_key": "delann_value"}
-#             data_message = AmqpAnnotatedMessage(
-#                 data_body=data_body,
-#                 delivery_annotations=del_anno,
-#                 application_properties=data_app_prop
-#             )
+            data_body = [b'aa', b'bb', b'cc']
+            data_app_prop = {"body_type": "data"}
+            del_anno = {"delann_key": "delann_value"}
+            data_message = AmqpAnnotatedMessage(
+                data_body=data_body,
+                delivery_annotations=del_anno,
+                application_properties=data_app_prop
+            )
 
-#             with pytest.raises(ValueError):
-#                 AmqpAnnotatedMessage(data_body=data_body, value_body=value_body)
-#             with pytest.raises(ValueError):
-#                 AmqpAnnotatedMessage()
+            with pytest.raises(ValueError):
+                AmqpAnnotatedMessage(data_body=data_body, value_body=value_body)
+            with pytest.raises(ValueError):
+                AmqpAnnotatedMessage()
 
-#             content = "normalmessage"
-#             dict_message = {"body": content}
-#             sb_message = ServiceBusMessage(body=content)
-#             message_with_ttl = AmqpAnnotatedMessage(data_body=data_body, header=AmqpMessageHeader(time_to_live=60000))
-#             if uamqp_transport:
-#                 amqp_transport = UamqpTransport
-#             else:
-#                 amqp_transport = PyamqpTransport
-#             amqp_with_ttl = amqp_transport.to_outgoing_amqp_message(message_with_ttl)
-#             assert amqp_with_ttl.properties.absolute_expiry_time == amqp_with_ttl.properties.creation_time + amqp_with_ttl.header.ttl
+            content = "normalmessage"
+            dict_message = {"body": content}
+            sb_message = ServiceBusMessage(body=content)
+            message_with_ttl = AmqpAnnotatedMessage(data_body=data_body, header=AmqpMessageHeader(time_to_live=60000))
+            if uamqp_transport:
+                amqp_transport = UamqpTransport
+            else:
+                amqp_transport = PyamqpTransport
+            amqp_with_ttl = amqp_transport.to_outgoing_amqp_message(message_with_ttl)
+            assert amqp_with_ttl.properties.absolute_expiry_time == amqp_with_ttl.properties.creation_time + amqp_with_ttl.header.ttl
 
-#             recv_data_msg = recv_sequence_msg = recv_value_msg = normal_msg = 0
-#             with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10) as receiver:
-#                 with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                     batch = sender.create_message_batch()
-#                     batch.add_message(data_message)
-#                     batch.add_message(value_message)
-#                     batch.add_message(sequence_message)
-#                     batch.add_message(dict_message)
-#                     batch.add_message(sb_message)
+            recv_data_msg = recv_sequence_msg = recv_value_msg = normal_msg = 0
+            with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=10) as receiver:
+                with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                    batch = sender.create_message_batch()
+                    batch.add_message(data_message)
+                    batch.add_message(value_message)
+                    batch.add_message(sequence_message)
+                    batch.add_message(dict_message)
+                    batch.add_message(sb_message)
 
-#                     sender.send_messages(batch)
-#                     sender.send_messages([data_message, value_message, sequence_message, dict_message, sb_message])
-#                     sender.send_messages(data_message)
-#                     sender.send_messages(value_message)
-#                     sender.send_messages(sequence_message)
+                    sender.send_messages(batch)
+                    sender.send_messages([data_message, value_message, sequence_message, dict_message, sb_message])
+                    sender.send_messages(data_message)
+                    sender.send_messages(value_message)
+                    sender.send_messages(sequence_message)
 
-#                     for message in receiver:
-#                         raw_amqp_message = message.raw_amqp_message
-#                         if raw_amqp_message.body_type == AmqpMessageBodyType.DATA:
-#                             if raw_amqp_message.application_properties and raw_amqp_message.application_properties.get(b'body_type') == b'data':
-#                                 body = [data for data in raw_amqp_message.body]
-#                                 assert data_body == body
-#                                 assert raw_amqp_message.delivery_annotations[b'delann_key'] == b'delann_value'
-#                                 assert raw_amqp_message.application_properties[b'body_type'] == b'data'
-#                                 recv_data_msg += 1
-#                             else:
-#                                 assert str(message) == content
-#                                 normal_msg += 1
-#                         elif raw_amqp_message.body_type == AmqpMessageBodyType.SEQUENCE:
-#                             body = [sequence for sequence in raw_amqp_message.body]
-#                             assert [sequence_body] == body
-#                             assert raw_amqp_message.footer[b'footer_key'] == b'footer_value'
-#                             assert raw_amqp_message.properties.subject == b'sequence'
-#                             assert raw_amqp_message.application_properties[b'body_type'] == b'sequence'
-#                             recv_sequence_msg += 1
-#                         elif raw_amqp_message.body_type == AmqpMessageBodyType.VALUE:
-#                             assert raw_amqp_message.body == value_body
-#                             assert raw_amqp_message.header.priority == 10
-#                             assert raw_amqp_message.annotations[b'ann_key'] == b'ann_value'
-#                             assert raw_amqp_message.application_properties[b'body_type'] == b'value'
-#                             recv_value_msg += 1
+                    for message in receiver:
+                        raw_amqp_message = message.raw_amqp_message
+                        if raw_amqp_message.body_type == AmqpMessageBodyType.DATA:
+                            if raw_amqp_message.application_properties and raw_amqp_message.application_properties.get(b'body_type') == b'data':
+                                body = [data for data in raw_amqp_message.body]
+                                assert data_body == body
+                                assert raw_amqp_message.delivery_annotations[b'delann_key'] == b'delann_value'
+                                assert raw_amqp_message.application_properties[b'body_type'] == b'data'
+                                recv_data_msg += 1
+                            else:
+                                assert str(message) == content
+                                normal_msg += 1
+                        elif raw_amqp_message.body_type == AmqpMessageBodyType.SEQUENCE:
+                            body = [sequence for sequence in raw_amqp_message.body]
+                            assert [sequence_body] == body
+                            assert raw_amqp_message.footer[b'footer_key'] == b'footer_value'
+                            assert raw_amqp_message.properties.subject == b'sequence'
+                            assert raw_amqp_message.application_properties[b'body_type'] == b'sequence'
+                            recv_sequence_msg += 1
+                        elif raw_amqp_message.body_type == AmqpMessageBodyType.VALUE:
+                            assert raw_amqp_message.body == value_body
+                            assert raw_amqp_message.header.priority == 10
+                            assert raw_amqp_message.annotations[b'ann_key'] == b'ann_value'
+                            assert raw_amqp_message.application_properties[b'body_type'] == b'value'
+                            recv_value_msg += 1
                         
-#                         receiver.complete_message(message)
+                        receiver.complete_message(message)
 
-#                     assert recv_sequence_msg == 3
-#                     assert recv_data_msg == 3
-#                     assert recv_value_msg == 3
-#                     assert normal_msg == 4
-
-
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_state_scheduled(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, uamqp_transport=uamqp_transport) as sb_client:
-
-#             sender = sb_client.get_queue_sender(servicebus_queue.name)
-#             for i in range(10):
-#                 message = ServiceBusMessage("message no. {}".format(i))
-#                 scheduled_time_utc = datetime.utcnow() + timedelta(seconds=30)
-#                 sequence_number = sender.schedule_messages(message, scheduled_time_utc)
-
-#             receiver = sb_client.get_queue_receiver(servicebus_queue.name)
-#             with receiver:
-#                 for msg in receiver.peek_messages():
-#                     assert msg.state == ServiceBusMessageState.SCHEDULED
+                    assert recv_sequence_msg == 3
+                    assert recv_data_msg == 3
+                    assert recv_value_msg == 3
+                    assert normal_msg == 4
 
 
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_state_deferred(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, uamqp_transport=uamqp_transport) as sb_client:
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_state_scheduled(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+            fully_qualified_namespace, credential, uamqp_transport=uamqp_transport) as sb_client:
 
-#             sender = sb_client.get_queue_sender(servicebus_queue.name)
-#             for i in range(10):
-#                 message = ServiceBusMessage("message no. {}".format(i))
-#                 sender.send_messages(message)
+            sender = sb_client.get_queue_sender(servicebus_queue.name)
+            for i in range(10):
+                message = ServiceBusMessage("message no. {}".format(i))
+                scheduled_time_utc = datetime.utcnow() + timedelta(seconds=30)
+                sequence_number = sender.schedule_messages(message, scheduled_time_utc)
 
-#             receiver = sb_client.get_queue_receiver(servicebus_queue.name)
-#             deferred_messages = []
-#             with receiver:
-#                 received_msgs = receiver.receive_messages()
-#                 for message in received_msgs:
-#                     assert message.state == ServiceBusMessageState.ACTIVE
-#                     deferred_messages.append(message.sequence_number)
-#                     receiver.defer_message(message)
-#                 if deferred_messages:
-#                     received_deferred_msg = receiver.receive_deferred_messages(
-#                         sequence_numbers=deferred_messages
-#                         )
-#                 for message in received_deferred_msg:
-#                     assert message.state == ServiceBusMessageState.DEFERRED
+            receiver = sb_client.get_queue_receiver(servicebus_queue.name)
+            with receiver:
+                for msg in receiver.peek_messages():
+                    assert msg.state == ServiceBusMessageState.SCHEDULED
+
+
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_state_deferred(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+            fully_qualified_namespace, credential, uamqp_transport=uamqp_transport) as sb_client:
+
+            sender = sb_client.get_queue_sender(servicebus_queue.name)
+            for i in range(10):
+                message = ServiceBusMessage("message no. {}".format(i))
+                sender.send_messages(message)
+
+            receiver = sb_client.get_queue_receiver(servicebus_queue.name)
+            deferred_messages = []
+            with receiver:
+                received_msgs = receiver.receive_messages()
+                for message in received_msgs:
+                    assert message.state == ServiceBusMessageState.ACTIVE
+                    deferred_messages.append(message.sequence_number)
+                    receiver.defer_message(message)
+                if deferred_messages:
+                    received_deferred_msg = receiver.receive_deferred_messages(
+                        sequence_numbers=deferred_messages
+                        )
+                for message in received_deferred_msg:
+                    assert message.state == ServiceBusMessageState.DEFERRED

--- a/sdk/servicebus/azure-servicebus/tests/test_queues.py
+++ b/sdk/servicebus/azure-servicebus/tests/test_queues.py
@@ -126,8 +126,6 @@ class TestServiceBusQueue(AzureMgmtRecordedTestCase):
     def test_github_issue_6178(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
         fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
         credential = get_credential()
-        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
-        credential = get_credential()
         with ServiceBusClient(
             fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
@@ -153,8 +151,6 @@ class TestServiceBusQueue(AzureMgmtRecordedTestCase):
     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
     @ArgPasser()
     def test_queue_by_queue_client_conn_str_receive_handler_peeklock(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
-        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
-        credential = get_credential()
         fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
         credential = get_credential()
         with ServiceBusClient(
@@ -245,8 +241,6 @@ class TestServiceBusQueue(AzureMgmtRecordedTestCase):
     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
     @ArgPasser()
     def test_queue_by_queue_client_conn_str_receive_handler_release_messages(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
-        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
-        credential = get_credential()
         fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
         credential = get_credential()
         with ServiceBusClient(
@@ -426,8 +420,6 @@ class TestServiceBusQueue(AzureMgmtRecordedTestCase):
     def test_queue_by_queue_client_send_multiple_messages(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
         fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
         credential = get_credential()
-        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
-        credential = get_credential()
         with ServiceBusClient(
             fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
@@ -552,8 +544,6 @@ class TestServiceBusQueue(AzureMgmtRecordedTestCase):
     def test_queue_by_queue_client_conn_str_receive_handler_receiveanddelete(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
         fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
         credential = get_credential()
-        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
-        credential = get_credential()
         with ServiceBusClient(
             fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
             
@@ -605,8 +595,6 @@ class TestServiceBusQueue(AzureMgmtRecordedTestCase):
     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
     @ArgPasser()
     def test_queue_by_queue_client_conn_str_receive_handler_receiveanddelete_prefetch(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
-        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
-        credential = get_credential()
         fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
         credential = get_credential()
         with ServiceBusClient(
@@ -678,8 +666,6 @@ class TestServiceBusQueue(AzureMgmtRecordedTestCase):
     def test_queue_by_queue_client_conn_str_receive_handler_with_stop(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
         fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
         credential = get_credential()
-        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
-        credential = get_credential()
         with ServiceBusClient(
             fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
     
@@ -719,8 +705,6 @@ class TestServiceBusQueue(AzureMgmtRecordedTestCase):
     def test_queue_by_servicebus_client_iter_messages_simple(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
         fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
         credential = get_credential()
-        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
-        credential = get_credential()
         with ServiceBusClient(
             fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
     
@@ -756,8 +740,6 @@ class TestServiceBusQueue(AzureMgmtRecordedTestCase):
     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
     @ArgPasser()
     def test_queue_by_servicebus_conn_str_client_iter_messages_with_abandon(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
-        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
-        credential = get_credential()
         fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
         credential = get_credential()
         with ServiceBusClient(
@@ -801,8 +783,6 @@ class TestServiceBusQueue(AzureMgmtRecordedTestCase):
     def test_queue_by_servicebus_client_iter_messages_with_defer(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
         fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
         credential = get_credential()
-        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
-        credential = get_credential()
         with ServiceBusClient(
             fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
     
@@ -844,8 +824,6 @@ class TestServiceBusQueue(AzureMgmtRecordedTestCase):
     def test_queue_by_servicebus_client_iter_messages_with_retrieve_deferred_client(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
         fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
         credential = get_credential()
-        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
-        credential = get_credential()
         with ServiceBusClient(
             fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
@@ -885,8 +863,6 @@ class TestServiceBusQueue(AzureMgmtRecordedTestCase):
     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
     @ArgPasser()
     def test_queue_by_servicebus_client_iter_messages_with_retrieve_deferred_receiver_complete(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
-        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
-        credential = get_credential()
         fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
         credential = get_credential()
         with ServiceBusClient(
@@ -987,8 +963,6 @@ class TestServiceBusQueue(AzureMgmtRecordedTestCase):
     def test_queue_by_servicebus_client_iter_messages_with_retrieve_deferred_receiver_deletemode(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
         fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
         credential = get_credential()
-        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
-        credential = get_credential()
         with ServiceBusClient(
             fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
@@ -1029,8 +1003,6 @@ class TestServiceBusQueue(AzureMgmtRecordedTestCase):
     def test_queue_by_servicebus_client_iter_messages_with_retrieve_deferred_not_found(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
         fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
         credential = get_credential()
-        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
-        credential = get_credential()
         with ServiceBusClient(
             fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
@@ -1068,8 +1040,6 @@ class TestServiceBusQueue(AzureMgmtRecordedTestCase):
     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
     @ArgPasser()
     def test_queue_by_servicebus_client_receive_batch_with_deadletter(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
-        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
-        credential = get_credential()
         fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
         credential = get_credential()
         with ServiceBusClient(
@@ -1133,8 +1103,6 @@ class TestServiceBusQueue(AzureMgmtRecordedTestCase):
     def test_queue_by_servicebus_client_receive_batch_with_retrieve_deadletter(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
         fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
         credential = get_credential()
-        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
-        credential = get_credential()
         with ServiceBusClient(
             fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
     
@@ -1189,8 +1157,6 @@ class TestServiceBusQueue(AzureMgmtRecordedTestCase):
     def test_queue_by_servicebus_client_session_fail(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
         fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
         credential = get_credential()
-        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
-        credential = get_credential()
         with ServiceBusClient(
             fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
     
@@ -1215,8 +1181,6 @@ class TestServiceBusQueue(AzureMgmtRecordedTestCase):
     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
     @ArgPasser()
     def test_queue_by_servicebus_client_browse_messages_client(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
-        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
-        credential = get_credential()
         fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
         credential = get_credential()
         with ServiceBusClient(
@@ -2048,7 +2012,8 @@ class TestServiceBusQueue(AzureMgmtRecordedTestCase):
 
     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
     def test_queue_message_http_proxy_setting(self, uamqp_transport):
-        mock_conn_str = "Endpoint=sb://mock.servicebus.windows.net/;SharedAccessKeyName=mock;SharedAccessKey=mock"
+        mock_fully_qualified_namespace = "mock_namespace"
+        credential = get_credential()
         http_proxy = {
             'proxy_hostname': '127.0.0.1',
             'proxy_port': 8899,
@@ -2056,8 +2021,7 @@ class TestServiceBusQueue(AzureMgmtRecordedTestCase):
             'password': '123456'
         }
 
-        mock_conn_str = "Endpoint=sb://mock.servicebus.windows.net/;SharedAccessKeyName=mock;SharedAccessKey=mock"
-        sb_client = ServiceBusClient(mock_conn_str, http_proxy=http_proxy, uamqp_transport=uamqp_transport)
+        sb_client = ServiceBusClient(mock_fully_qualified_namespace, credential, http_proxy=http_proxy, uamqp_transport=uamqp_transport)
         assert sb_client._config.http_proxy == http_proxy
         assert sb_client._config.transport_type == TransportType.AmqpOverWebsocket
 
@@ -2719,8 +2683,6 @@ class TestServiceBusQueue(AzureMgmtRecordedTestCase):
                 sender.send_messages(ServiceBusMessage(payload))
 
         # ReceiveMessages
-        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
-        credential = get_credential()
         with ServiceBusClient(
                 fully_qualified_namespace, credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
             with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5) as receiver:
@@ -2893,8 +2855,7 @@ class TestServiceBusQueue(AzureMgmtRecordedTestCase):
     def test_send_message_no_body(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
         fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
         credential = get_credential()
-        sb_client = ServiceBusClient(
-            fully_qualified_namespace, credential, uamqp_transport=uamqp_transport)
+        sb_client = ServiceBusClient(fully_qualified_namespace, credential, uamqp_transport=uamqp_transport)
 
         with sb_client.get_queue_sender(servicebus_queue.name) as sender:
             sender.send_messages(ServiceBusMessage(body=None))

--- a/sdk/servicebus/azure-servicebus/tests/test_sb_client.py
+++ b/sdk/servicebus/azure-servicebus/tests/test_sb_client.py
@@ -1,716 +1,716 @@
-#-------------------------------------------------------------------------
-# Copyright (c) Microsoft Corporation. All rights reserved.
-# Licensed under the MIT License. See License.txt in the project root for
-# license information.
-#--------------------------------------------------------------------------
-
-import logging
-import sys
-import os
-import pytest
-import time
-from datetime import datetime, timedelta
-import hmac
-import hashlib
-import base64
-try:
-    from urllib.parse import quote as url_parse_quote
-except ImportError:
-    from urllib import pathname2url as url_parse_quote
-
-try:
-    from azure.servicebus._transport._uamqp_transport import UamqpTransport
-except ImportError:
-    pass
-from azure.servicebus._transport._pyamqp_transport import PyamqpTransport
-
-from azure.common import AzureHttpError, AzureConflictHttpError
-from azure.core.credentials import AzureSasCredential, AzureNamedKeyCredential, AccessToken
-from azure.core.pipeline.policies import RetryMode
-from azure.mgmt.servicebus.models import AccessRights
-from azure.servicebus import ServiceBusClient, ServiceBusSender, ServiceBusReceiver
-from azure.servicebus._base_handler import ServiceBusSharedKeyCredential
-from azure.servicebus._common.message import ServiceBusMessage, ServiceBusReceivedMessage
-from azure.servicebus.exceptions import (
-    ServiceBusError,
-    ServiceBusAuthenticationError,
-    ServiceBusAuthorizationError,
-    ServiceBusConnectionError
-)
-from devtools_testutils import AzureMgmtRecordedTestCase
-from servicebus_preparer import (
-    CachedServiceBusNamespacePreparer, 
-    ServiceBusTopicPreparer, 
-    ServiceBusQueuePreparer,
-    ServiceBusNamespaceAuthorizationRulePreparer,
-    ServiceBusQueueAuthorizationRulePreparer,
-    CachedServiceBusQueuePreparer,
-    CachedServiceBusTopicPreparer,
-    CachedServiceBusSubscriptionPreparer,
-    CachedServiceBusResourceGroupPreparer,
-    SERVICEBUS_ENDPOINT_SUFFIX
-)
-from utilities import uamqp_transport as get_uamqp_transport, ArgPasser
-uamqp_transport_params, uamqp_transport_ids = get_uamqp_transport()
-
-class TestServiceBusClient(AzureMgmtRecordedTestCase):
-
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_sb_client_bad_credentials(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
-        client = ServiceBusClient(
-            fully_qualified_namespace=servicebus_namespace.name + f"{SERVICEBUS_ENDPOINT_SUFFIX}",
-            credential=ServiceBusSharedKeyCredential('invalid', 'invalid'),
-            logging_enable=False,
-            uamqp_transport=uamqp_transport
-            )
-        with client:
-            with pytest.raises(ServiceBusAuthenticationError):
-                with client.get_queue_sender(servicebus_queue.name) as sender:
-                    sender.send_messages(ServiceBusMessage("test"))
-
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    def test_sb_client_bad_namespace(self, uamqp_transport, **kwargs):
-        client = ServiceBusClient(
-            fully_qualified_namespace=f"invalid{SERVICEBUS_ENDPOINT_SUFFIX}",
-            credential=ServiceBusSharedKeyCredential('invalid', 'invalid'),
-            logging_enable=False,
-            uamqp_transport=uamqp_transport
-            )
-        with client:
-            with pytest.raises(ServiceBusError):
-                with client.get_queue_sender('invalidqueue') as sender:
-                    sender.send_messages(ServiceBusMessage("test"))
-
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_sb_client_bad_entity(self, uamqp_transport, *, servicebus_namespace_connection_string=None, **kwargs):
-        client = ServiceBusClient.from_connection_string(servicebus_namespace_connection_string, uamqp_transport=uamqp_transport)
-
-        with client:
-            with pytest.raises(ServiceBusAuthenticationError):
-                with client.get_queue_sender("invalid") as sender:
-                    sender.send_messages(ServiceBusMessage("test"))
-
-        fake_str = f"Endpoint=sb://mock{SERVICEBUS_ENDPOINT_SUFFIX}/;" \
-                   f"SharedAccessKeyName=mock;SharedAccessKey=mock;EntityPath=mockentity"
-        fake_client = ServiceBusClient.from_connection_string(fake_str, uamqp_transport=uamqp_transport)
-
-        with pytest.raises(ValueError):
-            fake_client.get_queue_sender('queue')
-
-        with pytest.raises(ValueError):
-            fake_client.get_queue_receiver('queue')
-
-        with pytest.raises(ValueError):
-            fake_client.get_topic_sender('topic')
-
-        with pytest.raises(ValueError):
-            fake_client.get_subscription_receiver('topic', 'subscription')
-
-        fake_client.get_queue_sender('mockentity')
-        fake_client.get_queue_receiver('mockentity')
-        fake_client.get_topic_sender('mockentity')
-        fake_client.get_subscription_receiver('mockentity', 'subscription')
-
-        fake_str = f"Endpoint=sb://mock{SERVICEBUS_ENDPOINT_SUFFIX}/;" \
-                   f"SharedAccessKeyName=mock;SharedAccessKey=mock"
-        fake_client = ServiceBusClient.from_connection_string(fake_str, uamqp_transport=uamqp_transport)
-        fake_client.get_queue_sender('queue')
-        fake_client.get_queue_receiver('queue')
-        fake_client.get_topic_sender('topic')
-        fake_client.get_subscription_receiver('topic', 'subscription')
-
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-    @ServiceBusNamespaceAuthorizationRulePreparer(name_prefix='servicebustest', access_rights=[AccessRights.listen])
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_sb_client_readonly_credentials(self, uamqp_transport, *, servicebus_authorization_rule_connection_string=None, servicebus_queue=None, **kwargs):
-        client = ServiceBusClient.from_connection_string(servicebus_authorization_rule_connection_string, uamqp_transport=uamqp_transport)
-
-        with client:
-            with client.get_queue_receiver(servicebus_queue.name) as receiver:
-                messages = receiver.receive_messages(max_message_count=1, max_wait_time=1)
-
-            with pytest.raises(ServiceBusAuthorizationError):
-                with client.get_queue_sender(servicebus_queue.name) as sender:
-                    sender.send_messages(ServiceBusMessage("test"))
-
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-    @ServiceBusNamespaceAuthorizationRulePreparer(name_prefix='servicebustest', access_rights=[AccessRights.send])
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_sb_client_writeonly_credentials(self, uamqp_transport, *, servicebus_authorization_rule_connection_string=None, servicebus_queue=None, **kwargs):
-        client = ServiceBusClient.from_connection_string(servicebus_authorization_rule_connection_string, uamqp_transport=uamqp_transport)
-
-        with client:
-            with pytest.raises(ServiceBusError):
-                with client.get_queue_receiver(servicebus_queue.name) as receiver:
-                    messages = receiver.receive_messages(max_message_count=1, max_wait_time=1)
-
-            with client.get_queue_sender(servicebus_queue.name) as sender:
-                sender.send_messages(ServiceBusMessage("test"))
-
-                with pytest.raises(TypeError):
-                    sender.send_messages("cat")
-
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusNamespaceAuthorizationRulePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest_qone', parameter_name='wrong_queue', dead_lettering_on_message_expiration=True)
-    @ServiceBusQueuePreparer(name_prefix='servicebustest_qtwo', dead_lettering_on_message_expiration=True)
-    @ServiceBusQueueAuthorizationRulePreparer(name_prefix='servicebustest_qtwo')
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_sb_client_incorrect_queue_conn_str(self, uamqp_transport, *, servicebus_queue_authorization_rule_connection_string=None, servicebus_queue=None, wrong_queue=None, **kwargs):
-        if uamqp_transport:
-            amqp_transport = UamqpTransport
-        else:
-            amqp_transport = PyamqpTransport
-        client = ServiceBusClient.from_connection_string(servicebus_queue_authorization_rule_connection_string, uamqp_transport=uamqp_transport)
-        with client:
-            # Validate that the wrong sender/receiver queues with the right credentials fail.
-            with pytest.raises(ValueError):
-                with client.get_queue_sender(wrong_queue.name) as sender:
-                    sender.send_messages(ServiceBusMessage("test"))
-
-            with pytest.raises(ValueError):
-                with client.get_queue_receiver(wrong_queue.name) as receiver:
-                    messages =  receiver.receive_messages(max_message_count=1, max_wait_time=1)
-
-            # But that the correct ones work.
-            with client.get_queue_sender(servicebus_queue.name) as sender:
-                sender.send_messages(ServiceBusMessage("test")) 
-
-            with client.get_queue_receiver(servicebus_queue.name) as receiver:
-               messages =  receiver.receive_messages(max_message_count=1, max_wait_time=1)
-
-            # Now do the same but with direct connstr initialization.
-            with pytest.raises(ValueError):
-                with ServiceBusSender._from_connection_string(
-                    servicebus_queue_authorization_rule_connection_string,
-                    queue_name=wrong_queue.name,
-                    amqp_transport=amqp_transport
-                ) as sender:
-                        sender.send_messages(ServiceBusMessage("test"))
-
-            with pytest.raises(ValueError):
-                with ServiceBusReceiver._from_connection_string(
-                    servicebus_queue_authorization_rule_connection_string,
-                    queue_name=wrong_queue.name,
-                    amqp_transport=amqp_transport
-                ) as receiver:
-                    messages =  receiver.receive_messages(max_message_count=1, max_wait_time=1)
-
-            with ServiceBusSender._from_connection_string(
-                servicebus_queue_authorization_rule_connection_string,
-                queue_name=servicebus_queue.name,
-                amqp_transport=amqp_transport
-            ) as sender:
-                sender.send_messages(ServiceBusMessage("test"))
-
-            with ServiceBusReceiver._from_connection_string(
-                servicebus_queue_authorization_rule_connection_string,
-                queue_name=servicebus_queue.name,
-                amqp_transport=amqp_transport
-            ) as receiver:
-                messages =  receiver.receive_messages(max_message_count=1, max_wait_time=1)
-
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer()
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @CachedServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-    @CachedServiceBusTopicPreparer(name_prefix='servicebustest')
-    @CachedServiceBusSubscriptionPreparer(name_prefix='servicebustest')
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_sb_client_close_spawned_handlers(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, servicebus_topic=None, servicebus_subscription=None, **kwargs):
-        client = ServiceBusClient.from_connection_string(servicebus_namespace_connection_string, uamqp_transport=uamqp_transport)
-
-        client.close()
-
-        # context manager
-        with client:
-            assert len(client._handlers) == 0
-            sender = client.get_queue_sender(servicebus_queue.name)
-            receiver = client.get_queue_receiver(servicebus_queue.name)
-            sender._open()
-            receiver._open()
-
-            assert sender._handler and sender._running
-            assert receiver._handler and receiver._running
-            assert len(client._handlers) == 2
-
-        assert not sender._handler and not sender._running
-        assert not receiver._handler and not receiver._running
-        assert len(client._handlers) == 0
-
-        # close operation
-        sender = client.get_queue_sender(servicebus_queue.name)
-        receiver = client.get_queue_receiver(servicebus_queue.name)
-        sender._open()
-        receiver._open()
-
-        assert sender._handler and sender._running
-        assert receiver._handler and receiver._running
-        assert len(client._handlers) == 2
-
-        client.close()
-
-        assert not sender._handler and not sender._running
-        assert not receiver._handler and not receiver._running
-        assert len(client._handlers) == 0
-
-        queue_sender = client.get_queue_sender(servicebus_queue.name)
-        queue_receiver = client.get_queue_receiver(servicebus_queue.name)
-        assert len(client._handlers) == 2
-        queue_sender = client.get_queue_sender(servicebus_queue.name)
-        queue_receiver = client.get_queue_receiver(servicebus_queue.name)
-        # the previous sender/receiver can not longer be referenced, there might be a delay in CPython
-        # to remove the reference, so len of handlers should be less than 4
-        assert len(client._handlers) < 4
-        client.close()
-
-        queue_sender = client.get_queue_sender(servicebus_queue.name)
-        queue_receiver = client.get_queue_receiver(servicebus_queue.name)
-        assert len(client._handlers) == 2
-        queue_sender = None
-        queue_receiver = None
-        assert len(client._handlers) < 2
-
-        client.close()
-        topic_sender = client.get_topic_sender(servicebus_topic.name)
-        subscription_receiver = client.get_subscription_receiver(servicebus_topic.name, servicebus_subscription.name)
-        assert len(client._handlers) == 2
-        topic_sender = None
-        subscription_receiver = None
-        # the previous sender/receiver can not longer be referenced, so len of handlers should just be 2 instead of 4
-        assert len(client._handlers) < 4
-
-        client.close()
-        topic_sender = client.get_topic_sender(servicebus_topic.name)
-        subscription_receiver = client.get_subscription_receiver(servicebus_topic.name, servicebus_subscription.name)
-        assert len(client._handlers) == 2
-        topic_sender = client.get_topic_sender(servicebus_topic.name)
-        subscription_receiver = client.get_subscription_receiver(servicebus_topic.name, servicebus_subscription.name)
-        # the previous sender/receiver can not longer be referenced, so len of handlers should just be 2 instead of 4
-        assert len(client._handlers) < 4
-
-        client.close()
-        for _ in range(5):
-            queue_sender = client.get_queue_sender(servicebus_queue.name)
-            queue_receiver = client.get_queue_receiver(servicebus_queue.name)
-            topic_sender = client.get_topic_sender(servicebus_topic.name)
-            subscription_receiver = client.get_subscription_receiver(servicebus_topic.name,
-                                                                     servicebus_subscription.name)
-        assert len(client._handlers) < 15
-        client.close()
-
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer()
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @CachedServiceBusQueuePreparer(name_prefix='servicebustest')
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_client_sas_credential(self,
-                                   uamqp_transport,
-                                   *,
-                                   servicebus_queue,
-                                   servicebus_namespace,
-                                   servicebus_namespace_key_name,
-                                   servicebus_namespace_primary_key,
-                                   servicebus_namespace_connection_string,
-                                   **kwargs):
-        # This should "just work" to validate known-good.
-        credential = ServiceBusSharedKeyCredential(servicebus_namespace_key_name, servicebus_namespace_primary_key)
-        hostname = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
-        auth_uri = "sb://{}/{}".format(hostname, servicebus_queue.name)
-        token = credential.get_token(auth_uri).token
-
-        # Finally let's do it with SAS token + conn str
-        token_conn_str = "Endpoint=sb://{}/;SharedAccessSignature={};".format(hostname, token)
-
-        client = ServiceBusClient.from_connection_string(token_conn_str, uamqp_transport=uamqp_transport)
-        with client:
-            assert len(client._handlers) == 0
-            with client.get_queue_sender(servicebus_queue.name) as sender:
-                sender.send_messages(ServiceBusMessage("foo"))
-
-        # This is disabled pending UAMQP fix https://github.com/Azure/azure-uamqp-python/issues/170
-        #
-        #token_conn_str_without_se = token_conn_str.split('se=')[0] + token_conn_str.split('se=')[1].split('&')[1]
-        #
-        #client = ServiceBusClient.from_connection_string(token_conn_str_without_se, uamqp_transport=uamqp_transport)
-        #with client:
-        #    assert len(client._handlers) == 0
-        #    with client.get_queue_sender(servicebus_queue.name) as sender:
-        #        sender.send_messages(ServiceBusMessage("foo"))
-
-        def generate_sas_token(uri, sas_name, sas_value, token_ttl):
-            """Performs the signing and encoding needed to generate a sas token from a sas key."""
-            sas = sas_value.encode('utf-8')
-            expiry = str(int(time.time() + token_ttl))
-            string_to_sign = (uri + '\n' + expiry).encode('utf-8')
-            signed_hmac_sha256 = hmac.HMAC(sas, string_to_sign, hashlib.sha256)
-            signature = url_parse_quote(base64.b64encode(signed_hmac_sha256.digest()))
-            return 'SharedAccessSignature sr={}&sig={}&se={}&skn={}'.format(uri, signature, expiry, sas_name)
-
-        class CustomizedSASCredential(object):
-            def __init__(self, token, expiry):
-                """
-                :param str token: The token string
-                :param float expiry: The epoch timestamp
-                """
-                self.token = token
-                self.expiry = expiry
-                self.token_type = b"servicebus.windows.net:sastoken"
-
-            def get_token(self, *scopes, **kwargs):
-                """
-                This method is automatically called when token is about to expire.
-                """
-                return AccessToken(self.token, self.expiry)
-
-        token_ttl = 5  # seconds
-        sas_token = generate_sas_token(
-            auth_uri, servicebus_namespace_key_name, servicebus_namespace_primary_key, token_ttl
-        )
-        credential=CustomizedSASCredential(sas_token, time.time() + token_ttl)
-
-        with ServiceBusClient(hostname, credential, uamqp_transport=uamqp_transport) as client:
-            sender = client.get_queue_sender(queue_name=servicebus_queue.name)
-            time.sleep(10)
-            with pytest.raises(ServiceBusAuthenticationError):
-                with sender:
-                    message = ServiceBusMessage("Single Message")
-                    sender.send_messages(message)
-
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer()
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @CachedServiceBusQueuePreparer(name_prefix='servicebustest')
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_client_credential(self,
-                                   uamqp_transport,
-                                   *,
-                                   servicebus_queue=None,
-                                   servicebus_namespace=None,
-                                   servicebus_namespace_key_name=None,
-                                   servicebus_namespace_primary_key=None,
-                                   servicebus_namespace_connection_string=None,
-                                   **kwargs):
-        # This should "just work" to validate known-good.
-        credential = ServiceBusSharedKeyCredential(servicebus_namespace_key_name, servicebus_namespace_primary_key)
-        hostname = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
-
-        client = ServiceBusClient(hostname, credential, uamqp_transport=uamqp_transport)
-        with client:
-            assert len(client._handlers) == 0
-            with client.get_queue_sender(servicebus_queue.name) as sender:
-                sender.send_messages(ServiceBusMessage("foo"))
-
-        hostname = f"sb://{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
-
-        client = ServiceBusClient(hostname, credential, uamqp_transport=uamqp_transport)
-        with client:
-            assert len(client._handlers) == 0
-            with client.get_queue_sender(servicebus_queue.name) as sender:
-                sender.send_messages(ServiceBusMessage("foo"))
-
-        hostname = f"https://{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
-
-        client = ServiceBusClient(hostname, credential, uamqp_transport=uamqp_transport)
-        with client:
-            assert len(client._handlers) == 0
-            with client.get_queue_sender(servicebus_queue.name) as sender:
-                sender.send_messages(ServiceBusMessage("foo"))
-
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer()
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @CachedServiceBusQueuePreparer(name_prefix='servicebustest')
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_client_azure_sas_credential(self,
-                                   uamqp_transport,
-                                   *,
-                                   servicebus_queue=None,
-                                   servicebus_namespace=None,
-                                   servicebus_namespace_key_name=None,
-                                   servicebus_namespace_primary_key=None,
-                                   servicebus_namespace_connection_string=None,
-                                   **kwargs):
-        # This should "just work" to validate known-good.
-        credential = ServiceBusSharedKeyCredential(servicebus_namespace_key_name, servicebus_namespace_primary_key)
-        hostname = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
-        auth_uri = "sb://{}/{}".format(hostname, servicebus_queue.name)
-        token = credential.get_token(auth_uri).token
-
-        # Finally let's do it with AzureSasCredential
-        credential = AzureSasCredential(token)
-
-        client = ServiceBusClient(hostname, credential, uamqp_transport=uamqp_transport)
-        with client:
-            assert len(client._handlers) == 0
-
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer()
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @CachedServiceBusQueuePreparer(name_prefix='servicebustest')
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_azure_named_key_credential(self,
-                                   uamqp_transport,
-                                   *,
-                                   servicebus_queue=None,
-                                   servicebus_namespace=None,
-                                   servicebus_namespace_key_name=None,
-                                   servicebus_namespace_primary_key=None,
-                                   servicebus_namespace_connection_string=None,
-                                   **kwargs):
-        hostname = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
-        credential = AzureNamedKeyCredential(servicebus_namespace_key_name, servicebus_namespace_primary_key)
-
-        client = ServiceBusClient(hostname, credential, uamqp_transport=uamqp_transport)
-        with client:
-            with client.get_queue_sender(servicebus_queue.name) as sender:
-                sender.send_messages(ServiceBusMessage("foo"))
+# #-------------------------------------------------------------------------
+# # Copyright (c) Microsoft Corporation. All rights reserved.
+# # Licensed under the MIT License. See License.txt in the project root for
+# # license information.
+# #--------------------------------------------------------------------------
+
+# import logging
+# import sys
+# import os
+# import pytest
+# import time
+# from datetime import datetime, timedelta
+# import hmac
+# import hashlib
+# import base64
+# try:
+#     from urllib.parse import quote as url_parse_quote
+# except ImportError:
+#     from urllib import pathname2url as url_parse_quote
+
+# try:
+#     from azure.servicebus._transport._uamqp_transport import UamqpTransport
+# except ImportError:
+#     pass
+# from azure.servicebus._transport._pyamqp_transport import PyamqpTransport
+
+# from azure.common import AzureHttpError, AzureConflictHttpError
+# from azure.core.credentials import AzureSasCredential, AzureNamedKeyCredential, AccessToken
+# from azure.core.pipeline.policies import RetryMode
+# from azure.mgmt.servicebus.models import AccessRights
+# from azure.servicebus import ServiceBusClient, ServiceBusSender, ServiceBusReceiver
+# from azure.servicebus._base_handler import ServiceBusSharedKeyCredential
+# from azure.servicebus._common.message import ServiceBusMessage, ServiceBusReceivedMessage
+# from azure.servicebus.exceptions import (
+#     ServiceBusError,
+#     ServiceBusAuthenticationError,
+#     ServiceBusAuthorizationError,
+#     ServiceBusConnectionError
+# )
+# from devtools_testutils import AzureMgmtRecordedTestCase
+# from servicebus_preparer import (
+#     CachedServiceBusNamespacePreparer, 
+#     ServiceBusTopicPreparer, 
+#     ServiceBusQueuePreparer,
+#     ServiceBusNamespaceAuthorizationRulePreparer,
+#     ServiceBusQueueAuthorizationRulePreparer,
+#     CachedServiceBusQueuePreparer,
+#     CachedServiceBusTopicPreparer,
+#     CachedServiceBusSubscriptionPreparer,
+#     CachedServiceBusResourceGroupPreparer,
+#     SERVICEBUS_ENDPOINT_SUFFIX
+# )
+# from utilities import uamqp_transport as get_uamqp_transport, ArgPasser
+# uamqp_transport_params, uamqp_transport_ids = get_uamqp_transport()
+
+# class TestServiceBusClient(AzureMgmtRecordedTestCase):
+
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_sb_client_bad_credentials(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+#         client = ServiceBusClient(
+#             fully_qualified_namespace=servicebus_namespace.name + f"{SERVICEBUS_ENDPOINT_SUFFIX}",
+#             credential=ServiceBusSharedKeyCredential('invalid', 'invalid'),
+#             logging_enable=False,
+#             uamqp_transport=uamqp_transport
+#             )
+#         with client:
+#             with pytest.raises(ServiceBusAuthenticationError):
+#                 with client.get_queue_sender(servicebus_queue.name) as sender:
+#                     sender.send_messages(ServiceBusMessage("test"))
+
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     def test_sb_client_bad_namespace(self, uamqp_transport, **kwargs):
+#         client = ServiceBusClient(
+#             fully_qualified_namespace=f"invalid{SERVICEBUS_ENDPOINT_SUFFIX}",
+#             credential=ServiceBusSharedKeyCredential('invalid', 'invalid'),
+#             logging_enable=False,
+#             uamqp_transport=uamqp_transport
+#             )
+#         with client:
+#             with pytest.raises(ServiceBusError):
+#                 with client.get_queue_sender('invalidqueue') as sender:
+#                     sender.send_messages(ServiceBusMessage("test"))
+
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_sb_client_bad_entity(self, uamqp_transport, *, servicebus_namespace_connection_string=None, **kwargs):
+#         client = ServiceBusClient.from_connection_string(servicebus_namespace_connection_string, uamqp_transport=uamqp_transport)
+
+#         with client:
+#             with pytest.raises(ServiceBusAuthenticationError):
+#                 with client.get_queue_sender("invalid") as sender:
+#                     sender.send_messages(ServiceBusMessage("test"))
+
+#         fake_str = f"Endpoint=sb://mock{SERVICEBUS_ENDPOINT_SUFFIX}/;" \
+#                    f"SharedAccessKeyName=mock;SharedAccessKey=mock;EntityPath=mockentity"
+#         fake_client = ServiceBusClient.from_connection_string(fake_str, uamqp_transport=uamqp_transport)
+
+#         with pytest.raises(ValueError):
+#             fake_client.get_queue_sender('queue')
+
+#         with pytest.raises(ValueError):
+#             fake_client.get_queue_receiver('queue')
+
+#         with pytest.raises(ValueError):
+#             fake_client.get_topic_sender('topic')
+
+#         with pytest.raises(ValueError):
+#             fake_client.get_subscription_receiver('topic', 'subscription')
+
+#         fake_client.get_queue_sender('mockentity')
+#         fake_client.get_queue_receiver('mockentity')
+#         fake_client.get_topic_sender('mockentity')
+#         fake_client.get_subscription_receiver('mockentity', 'subscription')
+
+#         fake_str = f"Endpoint=sb://mock{SERVICEBUS_ENDPOINT_SUFFIX}/;" \
+#                    f"SharedAccessKeyName=mock;SharedAccessKey=mock"
+#         fake_client = ServiceBusClient.from_connection_string(fake_str, uamqp_transport=uamqp_transport)
+#         fake_client.get_queue_sender('queue')
+#         fake_client.get_queue_receiver('queue')
+#         fake_client.get_topic_sender('topic')
+#         fake_client.get_subscription_receiver('topic', 'subscription')
+
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+#     @ServiceBusNamespaceAuthorizationRulePreparer(name_prefix='servicebustest', access_rights=[AccessRights.listen])
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_sb_client_readonly_credentials(self, uamqp_transport, *, servicebus_authorization_rule_connection_string=None, servicebus_queue=None, **kwargs):
+#         client = ServiceBusClient.from_connection_string(servicebus_authorization_rule_connection_string, uamqp_transport=uamqp_transport)
+
+#         with client:
+#             with client.get_queue_receiver(servicebus_queue.name) as receiver:
+#                 messages = receiver.receive_messages(max_message_count=1, max_wait_time=1)
+
+#             with pytest.raises(ServiceBusAuthorizationError):
+#                 with client.get_queue_sender(servicebus_queue.name) as sender:
+#                     sender.send_messages(ServiceBusMessage("test"))
+
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+#     @ServiceBusNamespaceAuthorizationRulePreparer(name_prefix='servicebustest', access_rights=[AccessRights.send])
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_sb_client_writeonly_credentials(self, uamqp_transport, *, servicebus_authorization_rule_connection_string=None, servicebus_queue=None, **kwargs):
+#         client = ServiceBusClient.from_connection_string(servicebus_authorization_rule_connection_string, uamqp_transport=uamqp_transport)
+
+#         with client:
+#             with pytest.raises(ServiceBusError):
+#                 with client.get_queue_receiver(servicebus_queue.name) as receiver:
+#                     messages = receiver.receive_messages(max_message_count=1, max_wait_time=1)
+
+#             with client.get_queue_sender(servicebus_queue.name) as sender:
+#                 sender.send_messages(ServiceBusMessage("test"))
+
+#                 with pytest.raises(TypeError):
+#                     sender.send_messages("cat")
+
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusNamespaceAuthorizationRulePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest_qone', parameter_name='wrong_queue', dead_lettering_on_message_expiration=True)
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest_qtwo', dead_lettering_on_message_expiration=True)
+#     @ServiceBusQueueAuthorizationRulePreparer(name_prefix='servicebustest_qtwo')
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_sb_client_incorrect_queue_conn_str(self, uamqp_transport, *, servicebus_queue_authorization_rule_connection_string=None, servicebus_queue=None, wrong_queue=None, **kwargs):
+#         if uamqp_transport:
+#             amqp_transport = UamqpTransport
+#         else:
+#             amqp_transport = PyamqpTransport
+#         client = ServiceBusClient.from_connection_string(servicebus_queue_authorization_rule_connection_string, uamqp_transport=uamqp_transport)
+#         with client:
+#             # Validate that the wrong sender/receiver queues with the right credentials fail.
+#             with pytest.raises(ValueError):
+#                 with client.get_queue_sender(wrong_queue.name) as sender:
+#                     sender.send_messages(ServiceBusMessage("test"))
+
+#             with pytest.raises(ValueError):
+#                 with client.get_queue_receiver(wrong_queue.name) as receiver:
+#                     messages =  receiver.receive_messages(max_message_count=1, max_wait_time=1)
+
+#             # But that the correct ones work.
+#             with client.get_queue_sender(servicebus_queue.name) as sender:
+#                 sender.send_messages(ServiceBusMessage("test")) 
+
+#             with client.get_queue_receiver(servicebus_queue.name) as receiver:
+#                messages =  receiver.receive_messages(max_message_count=1, max_wait_time=1)
+
+#             # Now do the same but with direct connstr initialization.
+#             with pytest.raises(ValueError):
+#                 with ServiceBusSender._from_connection_string(
+#                     servicebus_queue_authorization_rule_connection_string,
+#                     queue_name=wrong_queue.name,
+#                     amqp_transport=amqp_transport
+#                 ) as sender:
+#                         sender.send_messages(ServiceBusMessage("test"))
+
+#             with pytest.raises(ValueError):
+#                 with ServiceBusReceiver._from_connection_string(
+#                     servicebus_queue_authorization_rule_connection_string,
+#                     queue_name=wrong_queue.name,
+#                     amqp_transport=amqp_transport
+#                 ) as receiver:
+#                     messages =  receiver.receive_messages(max_message_count=1, max_wait_time=1)
+
+#             with ServiceBusSender._from_connection_string(
+#                 servicebus_queue_authorization_rule_connection_string,
+#                 queue_name=servicebus_queue.name,
+#                 amqp_transport=amqp_transport
+#             ) as sender:
+#                 sender.send_messages(ServiceBusMessage("test"))
+
+#             with ServiceBusReceiver._from_connection_string(
+#                 servicebus_queue_authorization_rule_connection_string,
+#                 queue_name=servicebus_queue.name,
+#                 amqp_transport=amqp_transport
+#             ) as receiver:
+#                 messages =  receiver.receive_messages(max_message_count=1, max_wait_time=1)
+
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer()
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @CachedServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+#     @CachedServiceBusTopicPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusSubscriptionPreparer(name_prefix='servicebustest')
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_sb_client_close_spawned_handlers(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, servicebus_topic=None, servicebus_subscription=None, **kwargs):
+#         client = ServiceBusClient.from_connection_string(servicebus_namespace_connection_string, uamqp_transport=uamqp_transport)
+
+#         client.close()
+
+#         # context manager
+#         with client:
+#             assert len(client._handlers) == 0
+#             sender = client.get_queue_sender(servicebus_queue.name)
+#             receiver = client.get_queue_receiver(servicebus_queue.name)
+#             sender._open()
+#             receiver._open()
+
+#             assert sender._handler and sender._running
+#             assert receiver._handler and receiver._running
+#             assert len(client._handlers) == 2
+
+#         assert not sender._handler and not sender._running
+#         assert not receiver._handler and not receiver._running
+#         assert len(client._handlers) == 0
+
+#         # close operation
+#         sender = client.get_queue_sender(servicebus_queue.name)
+#         receiver = client.get_queue_receiver(servicebus_queue.name)
+#         sender._open()
+#         receiver._open()
+
+#         assert sender._handler and sender._running
+#         assert receiver._handler and receiver._running
+#         assert len(client._handlers) == 2
+
+#         client.close()
+
+#         assert not sender._handler and not sender._running
+#         assert not receiver._handler and not receiver._running
+#         assert len(client._handlers) == 0
+
+#         queue_sender = client.get_queue_sender(servicebus_queue.name)
+#         queue_receiver = client.get_queue_receiver(servicebus_queue.name)
+#         assert len(client._handlers) == 2
+#         queue_sender = client.get_queue_sender(servicebus_queue.name)
+#         queue_receiver = client.get_queue_receiver(servicebus_queue.name)
+#         # the previous sender/receiver can not longer be referenced, there might be a delay in CPython
+#         # to remove the reference, so len of handlers should be less than 4
+#         assert len(client._handlers) < 4
+#         client.close()
+
+#         queue_sender = client.get_queue_sender(servicebus_queue.name)
+#         queue_receiver = client.get_queue_receiver(servicebus_queue.name)
+#         assert len(client._handlers) == 2
+#         queue_sender = None
+#         queue_receiver = None
+#         assert len(client._handlers) < 2
+
+#         client.close()
+#         topic_sender = client.get_topic_sender(servicebus_topic.name)
+#         subscription_receiver = client.get_subscription_receiver(servicebus_topic.name, servicebus_subscription.name)
+#         assert len(client._handlers) == 2
+#         topic_sender = None
+#         subscription_receiver = None
+#         # the previous sender/receiver can not longer be referenced, so len of handlers should just be 2 instead of 4
+#         assert len(client._handlers) < 4
+
+#         client.close()
+#         topic_sender = client.get_topic_sender(servicebus_topic.name)
+#         subscription_receiver = client.get_subscription_receiver(servicebus_topic.name, servicebus_subscription.name)
+#         assert len(client._handlers) == 2
+#         topic_sender = client.get_topic_sender(servicebus_topic.name)
+#         subscription_receiver = client.get_subscription_receiver(servicebus_topic.name, servicebus_subscription.name)
+#         # the previous sender/receiver can not longer be referenced, so len of handlers should just be 2 instead of 4
+#         assert len(client._handlers) < 4
+
+#         client.close()
+#         for _ in range(5):
+#             queue_sender = client.get_queue_sender(servicebus_queue.name)
+#             queue_receiver = client.get_queue_receiver(servicebus_queue.name)
+#             topic_sender = client.get_topic_sender(servicebus_topic.name)
+#             subscription_receiver = client.get_subscription_receiver(servicebus_topic.name,
+#                                                                      servicebus_subscription.name)
+#         assert len(client._handlers) < 15
+#         client.close()
+
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer()
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @CachedServiceBusQueuePreparer(name_prefix='servicebustest')
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_client_sas_credential(self,
+#                                    uamqp_transport,
+#                                    *,
+#                                    servicebus_queue,
+#                                    servicebus_namespace,
+#                                    servicebus_namespace_key_name,
+#                                    servicebus_namespace_primary_key,
+#                                    servicebus_namespace_connection_string,
+#                                    **kwargs):
+#         # This should "just work" to validate known-good.
+#         credential = ServiceBusSharedKeyCredential(servicebus_namespace_key_name, servicebus_namespace_primary_key)
+#         hostname = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+#         auth_uri = "sb://{}/{}".format(hostname, servicebus_queue.name)
+#         token = credential.get_token(auth_uri).token
+
+#         # Finally let's do it with SAS token + conn str
+#         token_conn_str = "Endpoint=sb://{}/;SharedAccessSignature={};".format(hostname, token)
+
+#         client = ServiceBusClient.from_connection_string(token_conn_str, uamqp_transport=uamqp_transport)
+#         with client:
+#             assert len(client._handlers) == 0
+#             with client.get_queue_sender(servicebus_queue.name) as sender:
+#                 sender.send_messages(ServiceBusMessage("foo"))
+
+#         # This is disabled pending UAMQP fix https://github.com/Azure/azure-uamqp-python/issues/170
+#         #
+#         #token_conn_str_without_se = token_conn_str.split('se=')[0] + token_conn_str.split('se=')[1].split('&')[1]
+#         #
+#         #client = ServiceBusClient.from_connection_string(token_conn_str_without_se, uamqp_transport=uamqp_transport)
+#         #with client:
+#         #    assert len(client._handlers) == 0
+#         #    with client.get_queue_sender(servicebus_queue.name) as sender:
+#         #        sender.send_messages(ServiceBusMessage("foo"))
+
+#         def generate_sas_token(uri, sas_name, sas_value, token_ttl):
+#             """Performs the signing and encoding needed to generate a sas token from a sas key."""
+#             sas = sas_value.encode('utf-8')
+#             expiry = str(int(time.time() + token_ttl))
+#             string_to_sign = (uri + '\n' + expiry).encode('utf-8')
+#             signed_hmac_sha256 = hmac.HMAC(sas, string_to_sign, hashlib.sha256)
+#             signature = url_parse_quote(base64.b64encode(signed_hmac_sha256.digest()))
+#             return 'SharedAccessSignature sr={}&sig={}&se={}&skn={}'.format(uri, signature, expiry, sas_name)
+
+#         class CustomizedSASCredential(object):
+#             def __init__(self, token, expiry):
+#                 """
+#                 :param str token: The token string
+#                 :param float expiry: The epoch timestamp
+#                 """
+#                 self.token = token
+#                 self.expiry = expiry
+#                 self.token_type = b"servicebus.windows.net:sastoken"
+
+#             def get_token(self, *scopes, **kwargs):
+#                 """
+#                 This method is automatically called when token is about to expire.
+#                 """
+#                 return AccessToken(self.token, self.expiry)
+
+#         token_ttl = 5  # seconds
+#         sas_token = generate_sas_token(
+#             auth_uri, servicebus_namespace_key_name, servicebus_namespace_primary_key, token_ttl
+#         )
+#         credential=CustomizedSASCredential(sas_token, time.time() + token_ttl)
+
+#         with ServiceBusClient(hostname, credential, uamqp_transport=uamqp_transport) as client:
+#             sender = client.get_queue_sender(queue_name=servicebus_queue.name)
+#             time.sleep(10)
+#             with pytest.raises(ServiceBusAuthenticationError):
+#                 with sender:
+#                     message = ServiceBusMessage("Single Message")
+#                     sender.send_messages(message)
+
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer()
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @CachedServiceBusQueuePreparer(name_prefix='servicebustest')
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_client_credential(self,
+#                                    uamqp_transport,
+#                                    *,
+#                                    servicebus_queue=None,
+#                                    servicebus_namespace=None,
+#                                    servicebus_namespace_key_name=None,
+#                                    servicebus_namespace_primary_key=None,
+#                                    servicebus_namespace_connection_string=None,
+#                                    **kwargs):
+#         # This should "just work" to validate known-good.
+#         credential = ServiceBusSharedKeyCredential(servicebus_namespace_key_name, servicebus_namespace_primary_key)
+#         hostname = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+
+#         client = ServiceBusClient(hostname, credential, uamqp_transport=uamqp_transport)
+#         with client:
+#             assert len(client._handlers) == 0
+#             with client.get_queue_sender(servicebus_queue.name) as sender:
+#                 sender.send_messages(ServiceBusMessage("foo"))
+
+#         hostname = f"sb://{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+
+#         client = ServiceBusClient(hostname, credential, uamqp_transport=uamqp_transport)
+#         with client:
+#             assert len(client._handlers) == 0
+#             with client.get_queue_sender(servicebus_queue.name) as sender:
+#                 sender.send_messages(ServiceBusMessage("foo"))
+
+#         hostname = f"https://{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+
+#         client = ServiceBusClient(hostname, credential, uamqp_transport=uamqp_transport)
+#         with client:
+#             assert len(client._handlers) == 0
+#             with client.get_queue_sender(servicebus_queue.name) as sender:
+#                 sender.send_messages(ServiceBusMessage("foo"))
+
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer()
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @CachedServiceBusQueuePreparer(name_prefix='servicebustest')
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_client_azure_sas_credential(self,
+#                                    uamqp_transport,
+#                                    *,
+#                                    servicebus_queue=None,
+#                                    servicebus_namespace=None,
+#                                    servicebus_namespace_key_name=None,
+#                                    servicebus_namespace_primary_key=None,
+#                                    servicebus_namespace_connection_string=None,
+#                                    **kwargs):
+#         # This should "just work" to validate known-good.
+#         credential = ServiceBusSharedKeyCredential(servicebus_namespace_key_name, servicebus_namespace_primary_key)
+#         hostname = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+#         auth_uri = "sb://{}/{}".format(hostname, servicebus_queue.name)
+#         token = credential.get_token(auth_uri).token
+
+#         # Finally let's do it with AzureSasCredential
+#         credential = AzureSasCredential(token)
+
+#         client = ServiceBusClient(hostname, credential, uamqp_transport=uamqp_transport)
+#         with client:
+#             assert len(client._handlers) == 0
+
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer()
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @CachedServiceBusQueuePreparer(name_prefix='servicebustest')
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_azure_named_key_credential(self,
+#                                    uamqp_transport,
+#                                    *,
+#                                    servicebus_queue=None,
+#                                    servicebus_namespace=None,
+#                                    servicebus_namespace_key_name=None,
+#                                    servicebus_namespace_primary_key=None,
+#                                    servicebus_namespace_connection_string=None,
+#                                    **kwargs):
+#         hostname = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+#         credential = AzureNamedKeyCredential(servicebus_namespace_key_name, servicebus_namespace_primary_key)
+
+#         client = ServiceBusClient(hostname, credential, uamqp_transport=uamqp_transport)
+#         with client:
+#             with client.get_queue_sender(servicebus_queue.name) as sender:
+#                 sender.send_messages(ServiceBusMessage("foo"))
         
-        credential.update("foo", "bar")
-        with pytest.raises(Exception):
-            with client:
-                with client.get_queue_sender(servicebus_queue.name) as sender:
-                    sender.send_messages(ServiceBusMessage("foo"))
+#         credential.update("foo", "bar")
+#         with pytest.raises(Exception):
+#             with client:
+#                 with client.get_queue_sender(servicebus_queue.name) as sender:
+#                     sender.send_messages(ServiceBusMessage("foo"))
 
-        # update back to the right key again
-        credential.update(servicebus_namespace_key_name, servicebus_namespace_primary_key)
-        with client:
-            with client.get_queue_sender(servicebus_queue.name) as sender:
-                sender.send_messages(ServiceBusMessage("foo"))
+#         # update back to the right key again
+#         credential.update(servicebus_namespace_key_name, servicebus_namespace_primary_key)
+#         with client:
+#             with client.get_queue_sender(servicebus_queue.name) as sender:
+#                 sender.send_messages(ServiceBusMessage("foo"))
 
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    def test_backoff_fixed_retry(self, uamqp_transport):
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     def test_backoff_fixed_retry(self, uamqp_transport):
 
-        client = ServiceBusClient(
-            'fake.host.com',
-            'fake_eh',
-            retry_mode='fixed',
-            uamqp_transport=uamqp_transport
-        )
-        # queue sender
-        sender = client.get_queue_sender('fake_name')
-        backoff = client._config.retry_backoff_factor
-        start_time = time.time()
-        sender._backoff(retried_times=1, last_exception=Exception('fake'), abs_timeout_time=None)
-        sleep_time_fixed = time.time() - start_time
-        # exp = 0.8 * (2 ** 1) = 1.6
-        # time.sleep() in _backoff will take AT LEAST time 'exp' for retry_mode='exponential'
-        # check that fixed is less than 'exp'
-        assert sleep_time_fixed < backoff * (2 ** 1)
+#         client = ServiceBusClient(
+#             'fake.host.com',
+#             'fake_eh',
+#             retry_mode='fixed',
+#             uamqp_transport=uamqp_transport
+#         )
+#         # queue sender
+#         sender = client.get_queue_sender('fake_name')
+#         backoff = client._config.retry_backoff_factor
+#         start_time = time.time()
+#         sender._backoff(retried_times=1, last_exception=Exception('fake'), abs_timeout_time=None)
+#         sleep_time_fixed = time.time() - start_time
+#         # exp = 0.8 * (2 ** 1) = 1.6
+#         # time.sleep() in _backoff will take AT LEAST time 'exp' for retry_mode='exponential'
+#         # check that fixed is less than 'exp'
+#         assert sleep_time_fixed < backoff * (2 ** 1)
 
-        # topic sender
-        sender = client.get_topic_sender('fake_name')
-        backoff = client._config.retry_backoff_factor
-        start_time = time.time()
-        sender._backoff(retried_times=1, last_exception=Exception('fake'), abs_timeout_time=None)
-        sleep_time_fixed = time.time() - start_time
-        assert sleep_time_fixed < backoff * (2 ** 1)
+#         # topic sender
+#         sender = client.get_topic_sender('fake_name')
+#         backoff = client._config.retry_backoff_factor
+#         start_time = time.time()
+#         sender._backoff(retried_times=1, last_exception=Exception('fake'), abs_timeout_time=None)
+#         sleep_time_fixed = time.time() - start_time
+#         assert sleep_time_fixed < backoff * (2 ** 1)
 
-        # queue receiver 
-        receiver = client.get_queue_receiver('fake_name')
-        backoff = client._config.retry_backoff_factor
-        start_time = time.time()
-        receiver._backoff(retried_times=1, last_exception=Exception('fake'), abs_timeout_time=None)
-        sleep_time_fixed = time.time() - start_time
-        assert sleep_time_fixed < backoff * (2 ** 1)
+#         # queue receiver 
+#         receiver = client.get_queue_receiver('fake_name')
+#         backoff = client._config.retry_backoff_factor
+#         start_time = time.time()
+#         receiver._backoff(retried_times=1, last_exception=Exception('fake'), abs_timeout_time=None)
+#         sleep_time_fixed = time.time() - start_time
+#         assert sleep_time_fixed < backoff * (2 ** 1)
 
-        # subscription receiver 
-        receiver = client.get_subscription_receiver('fake_topic', 'fake_sub')
-        backoff = client._config.retry_backoff_factor
-        start_time = time.time()
-        receiver._backoff(retried_times=1, last_exception=Exception('fake'), abs_timeout_time=None)
-        sleep_time_fixed = time.time() - start_time
-        assert sleep_time_fixed < backoff * (2 ** 1)
+#         # subscription receiver 
+#         receiver = client.get_subscription_receiver('fake_topic', 'fake_sub')
+#         backoff = client._config.retry_backoff_factor
+#         start_time = time.time()
+#         receiver._backoff(retried_times=1, last_exception=Exception('fake'), abs_timeout_time=None)
+#         sleep_time_fixed = time.time() - start_time
+#         assert sleep_time_fixed < backoff * (2 ** 1)
 
-        client = ServiceBusClient(
-            'fake.host.com',
-            'fake_eh',
-            retry_mode=RetryMode.Fixed,
-            uamqp_transport=uamqp_transport
-        )
-        # queue sender
-        sender = client.get_queue_sender('fake_name')
-        backoff = client._config.retry_backoff_factor
-        start_time = time.time()
-        sender._backoff(retried_times=1, last_exception=Exception('fake'), abs_timeout_time=None)
-        sleep_time_fixed = time.time() - start_time
-        # exp = 0.8 * (2 ** 1) = 1.6
-        # time.sleep() in _backoff will take AT LEAST time 'exp' for retry_mode='exponential'
-        # check that fixed is less than 'exp'
-        assert sleep_time_fixed < backoff * (2 ** 1)
+#         client = ServiceBusClient(
+#             'fake.host.com',
+#             'fake_eh',
+#             retry_mode=RetryMode.Fixed,
+#             uamqp_transport=uamqp_transport
+#         )
+#         # queue sender
+#         sender = client.get_queue_sender('fake_name')
+#         backoff = client._config.retry_backoff_factor
+#         start_time = time.time()
+#         sender._backoff(retried_times=1, last_exception=Exception('fake'), abs_timeout_time=None)
+#         sleep_time_fixed = time.time() - start_time
+#         # exp = 0.8 * (2 ** 1) = 1.6
+#         # time.sleep() in _backoff will take AT LEAST time 'exp' for retry_mode='exponential'
+#         # check that fixed is less than 'exp'
+#         assert sleep_time_fixed < backoff * (2 ** 1)
 
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    def test_custom_client_id_queue_sender(self, uamqp_transport, **kwargs):
-        servicebus_connection_str = f'Endpoint=sb://resourcename{SERVICEBUS_ENDPOINT_SUFFIX}/;SharedAccessSignature=THISISATESTKEYXXXXXXXXXXXXXXXXXXXXXXXXXXXX=;'
-        queue_name = "queue_name"
-        custom_id = "my_custom_id"
-        servicebus_client = ServiceBusClient.from_connection_string(conn_str=servicebus_connection_str, uamqp_transport=uamqp_transport)
-        with servicebus_client:
-            queue_sender = servicebus_client.get_queue_sender(queue_name=queue_name, client_identifier=custom_id)
-            assert queue_sender.client_identifier is not None
-            assert queue_sender.client_identifier == custom_id
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     def test_custom_client_id_queue_sender(self, uamqp_transport, **kwargs):
+#         servicebus_connection_str = f'Endpoint=sb://resourcename{SERVICEBUS_ENDPOINT_SUFFIX}/;SharedAccessSignature=THISISATESTKEYXXXXXXXXXXXXXXXXXXXXXXXXXXXX=;'
+#         queue_name = "queue_name"
+#         custom_id = "my_custom_id"
+#         servicebus_client = ServiceBusClient.from_connection_string(conn_str=servicebus_connection_str, uamqp_transport=uamqp_transport)
+#         with servicebus_client:
+#             queue_sender = servicebus_client.get_queue_sender(queue_name=queue_name, client_identifier=custom_id)
+#             assert queue_sender.client_identifier is not None
+#             assert queue_sender.client_identifier == custom_id
 
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    def test_default_client_id_queue_sender(self, uamqp_transport, **kwargs):
-        servicebus_connection_str = f'Endpoint=sb://resourcename{SERVICEBUS_ENDPOINT_SUFFIX}/;SharedAccessSignature=THISISATESTKEYXXXXXXXXXXXXXXXXXXXXXXXXXXXX=;'
-        queue_name = "queue_name"
-        servicebus_client = ServiceBusClient.from_connection_string(conn_str=servicebus_connection_str, uamqp_transport=uamqp_transport)
-        with servicebus_client:
-            queue_sender = servicebus_client.get_queue_sender(queue_name=queue_name)
-            assert queue_sender.client_identifier is not None
-            assert "SBSender" in queue_sender.client_identifier
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     def test_default_client_id_queue_sender(self, uamqp_transport, **kwargs):
+#         servicebus_connection_str = f'Endpoint=sb://resourcename{SERVICEBUS_ENDPOINT_SUFFIX}/;SharedAccessSignature=THISISATESTKEYXXXXXXXXXXXXXXXXXXXXXXXXXXXX=;'
+#         queue_name = "queue_name"
+#         servicebus_client = ServiceBusClient.from_connection_string(conn_str=servicebus_connection_str, uamqp_transport=uamqp_transport)
+#         with servicebus_client:
+#             queue_sender = servicebus_client.get_queue_sender(queue_name=queue_name)
+#             assert queue_sender.client_identifier is not None
+#             assert "SBSender" in queue_sender.client_identifier
 
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    def test_custom_client_id_queue_receiver(self, uamqp_transport, **kwargs):
-        servicebus_connection_str = f'Endpoint=sb://resourcename{SERVICEBUS_ENDPOINT_SUFFIX}/;SharedAccessSignature=THISISATESTKEYXXXXXXXXXXXXXXXXXXXXXXXXXXXX=;'
-        queue_name = "queue_name"
-        custom_id = "my_custom_id"
-        servicebus_client = ServiceBusClient.from_connection_string(conn_str=servicebus_connection_str, uamqp_transport=uamqp_transport)
-        with servicebus_client:
-            queue_receiver = servicebus_client.get_queue_receiver(queue_name=queue_name, client_identifier=custom_id)
-            assert queue_receiver.client_identifier is not None
-            assert queue_receiver.client_identifier == custom_id
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     def test_custom_client_id_queue_receiver(self, uamqp_transport, **kwargs):
+#         servicebus_connection_str = f'Endpoint=sb://resourcename{SERVICEBUS_ENDPOINT_SUFFIX}/;SharedAccessSignature=THISISATESTKEYXXXXXXXXXXXXXXXXXXXXXXXXXXXX=;'
+#         queue_name = "queue_name"
+#         custom_id = "my_custom_id"
+#         servicebus_client = ServiceBusClient.from_connection_string(conn_str=servicebus_connection_str, uamqp_transport=uamqp_transport)
+#         with servicebus_client:
+#             queue_receiver = servicebus_client.get_queue_receiver(queue_name=queue_name, client_identifier=custom_id)
+#             assert queue_receiver.client_identifier is not None
+#             assert queue_receiver.client_identifier == custom_id
 
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    def test_default_client_id_queue_receiver(self, uamqp_transport, **kwargs):
-        servicebus_connection_str = f'Endpoint=sb://resourcename{SERVICEBUS_ENDPOINT_SUFFIX}/;SharedAccessSignature=THISISATESTKEYXXXXXXXXXXXXXXXXXXXXXXXXXXXX=;'
-        queue_name = "queue_name"
-        servicebus_client = ServiceBusClient.from_connection_string(conn_str=servicebus_connection_str, uamqp_transport=uamqp_transport)
-        with servicebus_client:
-            queue_receiver = servicebus_client.get_queue_receiver(queue_name=queue_name)
-            assert queue_receiver.client_identifier is not None
-            assert "SBReceiver" in queue_receiver.client_identifier
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     def test_default_client_id_queue_receiver(self, uamqp_transport, **kwargs):
+#         servicebus_connection_str = f'Endpoint=sb://resourcename{SERVICEBUS_ENDPOINT_SUFFIX}/;SharedAccessSignature=THISISATESTKEYXXXXXXXXXXXXXXXXXXXXXXXXXXXX=;'
+#         queue_name = "queue_name"
+#         servicebus_client = ServiceBusClient.from_connection_string(conn_str=servicebus_connection_str, uamqp_transport=uamqp_transport)
+#         with servicebus_client:
+#             queue_receiver = servicebus_client.get_queue_receiver(queue_name=queue_name)
+#             assert queue_receiver.client_identifier is not None
+#             assert "SBReceiver" in queue_receiver.client_identifier
 
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    def test_custom_client_id_topic_sender(self, uamqp_transport, **kwargs):
-        servicebus_connection_str = f'Endpoint=sb://resourcename{SERVICEBUS_ENDPOINT_SUFFIX}/;SharedAccessSignature=THISISATESTKEYXXXXXXXXXXXXXXXXXXXXXXXXXXXX=;'
-        custom_id = "my_custom_id"
-        topic_name = "topic_name"
-        servicebus_client = ServiceBusClient.from_connection_string(conn_str=servicebus_connection_str, uamqp_transport=uamqp_transport)
-        with servicebus_client:
-            topic_sender = servicebus_client.get_topic_sender(topic_name=topic_name, client_identifier=custom_id)
-            assert topic_sender.client_identifier is not None
-            assert topic_sender.client_identifier == custom_id
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     def test_custom_client_id_topic_sender(self, uamqp_transport, **kwargs):
+#         servicebus_connection_str = f'Endpoint=sb://resourcename{SERVICEBUS_ENDPOINT_SUFFIX}/;SharedAccessSignature=THISISATESTKEYXXXXXXXXXXXXXXXXXXXXXXXXXXXX=;'
+#         custom_id = "my_custom_id"
+#         topic_name = "topic_name"
+#         servicebus_client = ServiceBusClient.from_connection_string(conn_str=servicebus_connection_str, uamqp_transport=uamqp_transport)
+#         with servicebus_client:
+#             topic_sender = servicebus_client.get_topic_sender(topic_name=topic_name, client_identifier=custom_id)
+#             assert topic_sender.client_identifier is not None
+#             assert topic_sender.client_identifier == custom_id
 
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    def test_default_client_id_topic_sender(self, uamqp_transport, **kwargs):
-        servicebus_connection_str = f'Endpoint=sb://resourcename{SERVICEBUS_ENDPOINT_SUFFIX}/;SharedAccessSignature=THISISATESTKEYXXXXXXXXXXXXXXXXXXXXXXXXXXXX=;'
-        topic_name = "topic_name"
-        servicebus_client = ServiceBusClient.from_connection_string(conn_str=servicebus_connection_str, uamqp_transport=uamqp_transport)
-        with servicebus_client:
-            topic_sender = servicebus_client.get_topic_sender(topic_name=topic_name)
-            assert topic_sender.client_identifier is not None
-            assert "SBSender" in topic_sender.client_identifier
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     def test_default_client_id_topic_sender(self, uamqp_transport, **kwargs):
+#         servicebus_connection_str = f'Endpoint=sb://resourcename{SERVICEBUS_ENDPOINT_SUFFIX}/;SharedAccessSignature=THISISATESTKEYXXXXXXXXXXXXXXXXXXXXXXXXXXXX=;'
+#         topic_name = "topic_name"
+#         servicebus_client = ServiceBusClient.from_connection_string(conn_str=servicebus_connection_str, uamqp_transport=uamqp_transport)
+#         with servicebus_client:
+#             topic_sender = servicebus_client.get_topic_sender(topic_name=topic_name)
+#             assert topic_sender.client_identifier is not None
+#             assert "SBSender" in topic_sender.client_identifier
 
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    def test_default_client_id_subscription_receiver(self, uamqp_transport, **kwargs):
-        servicebus_connection_str = f'Endpoint=sb://resourcename{SERVICEBUS_ENDPOINT_SUFFIX}/;SharedAccessSignature=THISISATESTKEYXXXXXXXXXXXXXXXXXXXXXXXXXXXX=;'
-        topic_name = "topic_name"
-        sub_name = "sub_name"
-        servicebus_client = ServiceBusClient.from_connection_string(conn_str=servicebus_connection_str, uamqp_transport=uamqp_transport)
-        with servicebus_client:
-            subscription_receiver = servicebus_client.get_subscription_receiver(topic_name, sub_name)
-            assert subscription_receiver.client_identifier is not None
-            assert "SBReceiver" in subscription_receiver.client_identifier
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     def test_default_client_id_subscription_receiver(self, uamqp_transport, **kwargs):
+#         servicebus_connection_str = f'Endpoint=sb://resourcename{SERVICEBUS_ENDPOINT_SUFFIX}/;SharedAccessSignature=THISISATESTKEYXXXXXXXXXXXXXXXXXXXXXXXXXXXX=;'
+#         topic_name = "topic_name"
+#         sub_name = "sub_name"
+#         servicebus_client = ServiceBusClient.from_connection_string(conn_str=servicebus_connection_str, uamqp_transport=uamqp_transport)
+#         with servicebus_client:
+#             subscription_receiver = servicebus_client.get_subscription_receiver(topic_name, sub_name)
+#             assert subscription_receiver.client_identifier is not None
+#             assert "SBReceiver" in subscription_receiver.client_identifier
 
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    def test_custom_client_id_subscription_receiver(self, uamqp_transport, **kwargs):
-        servicebus_connection_str = f'Endpoint=sb://resourcename{SERVICEBUS_ENDPOINT_SUFFIX}/;SharedAccessSignature=THISISATESTKEYXXXXXXXXXXXXXXXXXXXXXXXXXXXX=;'
-        custom_id = "my_custom_id"
-        topic_name = "topic_name"
-        sub_name = "sub_name"
-        servicebus_client = ServiceBusClient.from_connection_string(conn_str=servicebus_connection_str, uamqp_transport=uamqp_transport)
-        with servicebus_client:
-            subscription_receiver = servicebus_client.get_subscription_receiver(topic_name, sub_name, client_identifier=custom_id)
-            assert subscription_receiver.client_identifier is not None
-            assert subscription_receiver.client_identifier == custom_id
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     def test_custom_client_id_subscription_receiver(self, uamqp_transport, **kwargs):
+#         servicebus_connection_str = f'Endpoint=sb://resourcename{SERVICEBUS_ENDPOINT_SUFFIX}/;SharedAccessSignature=THISISATESTKEYXXXXXXXXXXXXXXXXXXXXXXXXXXXX=;'
+#         custom_id = "my_custom_id"
+#         topic_name = "topic_name"
+#         sub_name = "sub_name"
+#         servicebus_client = ServiceBusClient.from_connection_string(conn_str=servicebus_connection_str, uamqp_transport=uamqp_transport)
+#         with servicebus_client:
+#             subscription_receiver = servicebus_client.get_subscription_receiver(topic_name, sub_name, client_identifier=custom_id)
+#             assert subscription_receiver.client_identifier is not None
+#             assert subscription_receiver.client_identifier == custom_id
 
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer()
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @CachedServiceBusQueuePreparer(name_prefix='servicebustest')
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_custom_endpoint_connection_verify_exception(self,
-                                   uamqp_transport,
-                                   *,
-                                   servicebus_queue=None,
-                                   servicebus_namespace=None,
-                                   servicebus_namespace_key_name=None,
-                                   servicebus_namespace_primary_key=None,
-                                   servicebus_namespace_connection_string=None,
-                                   **kwargs):
-        hostname = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
-        credential = AzureNamedKeyCredential(servicebus_namespace_key_name, servicebus_namespace_primary_key)
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer()
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @CachedServiceBusQueuePreparer(name_prefix='servicebustest')
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_custom_endpoint_connection_verify_exception(self,
+#                                    uamqp_transport,
+#                                    *,
+#                                    servicebus_queue=None,
+#                                    servicebus_namespace=None,
+#                                    servicebus_namespace_key_name=None,
+#                                    servicebus_namespace_primary_key=None,
+#                                    servicebus_namespace_connection_string=None,
+#                                    **kwargs):
+#         hostname = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+#         credential = AzureNamedKeyCredential(servicebus_namespace_key_name, servicebus_namespace_primary_key)
 
-        client = ServiceBusClient(hostname, credential, connection_verify="cacert.pem", uamqp_transport=uamqp_transport)
-        with client:
-            with pytest.raises(ServiceBusError):
-                with client.get_queue_sender(servicebus_queue.name) as sender:
-                    sender.send_messages(ServiceBusMessage("foo"))
+#         client = ServiceBusClient(hostname, credential, connection_verify="cacert.pem", uamqp_transport=uamqp_transport)
+#         with client:
+#             with pytest.raises(ServiceBusError):
+#                 with client.get_queue_sender(servicebus_queue.name) as sender:
+#                     sender.send_messages(ServiceBusMessage("foo"))
 
-        # Skipping on OSX uamqp - it's raising an Authentication/TimeoutError
-        if not uamqp_transport or not sys.platform.startswith('darwin'):
-            fake_addr = "fakeaddress.com:1111"
-            client = ServiceBusClient(
-                hostname,
-                credential,
-                custom_endpoint_address=fake_addr,
-                retry_total=0,
-                uamqp_transport=uamqp_transport
-            )
-            with client:
-                with pytest.raises(ServiceBusConnectionError):
-                    with client.get_queue_sender(servicebus_queue.name) as sender:
-                        sender.send_messages(ServiceBusMessage("foo"))
+#         # Skipping on OSX uamqp - it's raising an Authentication/TimeoutError
+#         if not uamqp_transport or not sys.platform.startswith('darwin'):
+#             fake_addr = "fakeaddress.com:1111"
+#             client = ServiceBusClient(
+#                 hostname,
+#                 credential,
+#                 custom_endpoint_address=fake_addr,
+#                 retry_total=0,
+#                 uamqp_transport=uamqp_transport
+#             )
+#             with client:
+#                 with pytest.raises(ServiceBusConnectionError):
+#                     with client.get_queue_sender(servicebus_queue.name) as sender:
+#                         sender.send_messages(ServiceBusMessage("foo"))
 
-            client = ServiceBusClient(
-                hostname,
-                credential,
-                custom_endpoint_address=fake_addr,
-                connection_verify="cacert.pem",
-                retry_total=0,
-                uamqp_transport=uamqp_transport,
-            )
-            with client:
-                with pytest.raises(ServiceBusError):
-                    with client.get_queue_sender(servicebus_queue.name) as sender:
-                        sender.send_messages(ServiceBusMessage("foo"))
+#             client = ServiceBusClient(
+#                 hostname,
+#                 credential,
+#                 custom_endpoint_address=fake_addr,
+#                 connection_verify="cacert.pem",
+#                 retry_total=0,
+#                 uamqp_transport=uamqp_transport,
+#             )
+#             with client:
+#                 with pytest.raises(ServiceBusError):
+#                     with client.get_queue_sender(servicebus_queue.name) as sender:
+#                         sender.send_messages(ServiceBusMessage("foo"))

--- a/sdk/servicebus/azure-servicebus/tests/test_sb_client.py
+++ b/sdk/servicebus/azure-servicebus/tests/test_sb_client.py
@@ -1,716 +1,722 @@
-# #-------------------------------------------------------------------------
-# # Copyright (c) Microsoft Corporation. All rights reserved.
-# # Licensed under the MIT License. See License.txt in the project root for
-# # license information.
-# #--------------------------------------------------------------------------
-
-# import logging
-# import sys
-# import os
-# import pytest
-# import time
-# from datetime import datetime, timedelta
-# import hmac
-# import hashlib
-# import base64
-# try:
-#     from urllib.parse import quote as url_parse_quote
-# except ImportError:
-#     from urllib import pathname2url as url_parse_quote
-
-# try:
-#     from azure.servicebus._transport._uamqp_transport import UamqpTransport
-# except ImportError:
-#     pass
-# from azure.servicebus._transport._pyamqp_transport import PyamqpTransport
-
-# from azure.common import AzureHttpError, AzureConflictHttpError
-# from azure.core.credentials import AzureSasCredential, AzureNamedKeyCredential, AccessToken
-# from azure.core.pipeline.policies import RetryMode
-# from azure.mgmt.servicebus.models import AccessRights
-# from azure.servicebus import ServiceBusClient, ServiceBusSender, ServiceBusReceiver
-# from azure.servicebus._base_handler import ServiceBusSharedKeyCredential
-# from azure.servicebus._common.message import ServiceBusMessage, ServiceBusReceivedMessage
-# from azure.servicebus.exceptions import (
-#     ServiceBusError,
-#     ServiceBusAuthenticationError,
-#     ServiceBusAuthorizationError,
-#     ServiceBusConnectionError
-# )
-# from devtools_testutils import AzureMgmtRecordedTestCase
-# from servicebus_preparer import (
-#     CachedServiceBusNamespacePreparer, 
-#     ServiceBusTopicPreparer, 
-#     ServiceBusQueuePreparer,
-#     ServiceBusNamespaceAuthorizationRulePreparer,
-#     ServiceBusQueueAuthorizationRulePreparer,
-#     CachedServiceBusQueuePreparer,
-#     CachedServiceBusTopicPreparer,
-#     CachedServiceBusSubscriptionPreparer,
-#     CachedServiceBusResourceGroupPreparer,
-#     SERVICEBUS_ENDPOINT_SUFFIX
-# )
-# from utilities import uamqp_transport as get_uamqp_transport, ArgPasser
-# uamqp_transport_params, uamqp_transport_ids = get_uamqp_transport()
-
-# class TestServiceBusClient(AzureMgmtRecordedTestCase):
-
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_sb_client_bad_credentials(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
-#         client = ServiceBusClient(
-#             fully_qualified_namespace=servicebus_namespace.name + f"{SERVICEBUS_ENDPOINT_SUFFIX}",
-#             credential=ServiceBusSharedKeyCredential('invalid', 'invalid'),
-#             logging_enable=False,
-#             uamqp_transport=uamqp_transport
-#             )
-#         with client:
-#             with pytest.raises(ServiceBusAuthenticationError):
-#                 with client.get_queue_sender(servicebus_queue.name) as sender:
-#                     sender.send_messages(ServiceBusMessage("test"))
-
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     def test_sb_client_bad_namespace(self, uamqp_transport, **kwargs):
-#         client = ServiceBusClient(
-#             fully_qualified_namespace=f"invalid{SERVICEBUS_ENDPOINT_SUFFIX}",
-#             credential=ServiceBusSharedKeyCredential('invalid', 'invalid'),
-#             logging_enable=False,
-#             uamqp_transport=uamqp_transport
-#             )
-#         with client:
-#             with pytest.raises(ServiceBusError):
-#                 with client.get_queue_sender('invalidqueue') as sender:
-#                     sender.send_messages(ServiceBusMessage("test"))
-
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_sb_client_bad_entity(self, uamqp_transport, *, servicebus_namespace_connection_string=None, **kwargs):
-#         client = ServiceBusClient.from_connection_string(servicebus_namespace_connection_string, uamqp_transport=uamqp_transport)
-
-#         with client:
-#             with pytest.raises(ServiceBusAuthenticationError):
-#                 with client.get_queue_sender("invalid") as sender:
-#                     sender.send_messages(ServiceBusMessage("test"))
-
-#         fake_str = f"Endpoint=sb://mock{SERVICEBUS_ENDPOINT_SUFFIX}/;" \
-#                    f"SharedAccessKeyName=mock;SharedAccessKey=mock;EntityPath=mockentity"
-#         fake_client = ServiceBusClient.from_connection_string(fake_str, uamqp_transport=uamqp_transport)
-
-#         with pytest.raises(ValueError):
-#             fake_client.get_queue_sender('queue')
-
-#         with pytest.raises(ValueError):
-#             fake_client.get_queue_receiver('queue')
-
-#         with pytest.raises(ValueError):
-#             fake_client.get_topic_sender('topic')
-
-#         with pytest.raises(ValueError):
-#             fake_client.get_subscription_receiver('topic', 'subscription')
-
-#         fake_client.get_queue_sender('mockentity')
-#         fake_client.get_queue_receiver('mockentity')
-#         fake_client.get_topic_sender('mockentity')
-#         fake_client.get_subscription_receiver('mockentity', 'subscription')
-
-#         fake_str = f"Endpoint=sb://mock{SERVICEBUS_ENDPOINT_SUFFIX}/;" \
-#                    f"SharedAccessKeyName=mock;SharedAccessKey=mock"
-#         fake_client = ServiceBusClient.from_connection_string(fake_str, uamqp_transport=uamqp_transport)
-#         fake_client.get_queue_sender('queue')
-#         fake_client.get_queue_receiver('queue')
-#         fake_client.get_topic_sender('topic')
-#         fake_client.get_subscription_receiver('topic', 'subscription')
-
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-#     @ServiceBusNamespaceAuthorizationRulePreparer(name_prefix='servicebustest', access_rights=[AccessRights.listen])
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_sb_client_readonly_credentials(self, uamqp_transport, *, servicebus_authorization_rule_connection_string=None, servicebus_queue=None, **kwargs):
-#         client = ServiceBusClient.from_connection_string(servicebus_authorization_rule_connection_string, uamqp_transport=uamqp_transport)
-
-#         with client:
-#             with client.get_queue_receiver(servicebus_queue.name) as receiver:
-#                 messages = receiver.receive_messages(max_message_count=1, max_wait_time=1)
-
-#             with pytest.raises(ServiceBusAuthorizationError):
-#                 with client.get_queue_sender(servicebus_queue.name) as sender:
-#                     sender.send_messages(ServiceBusMessage("test"))
-
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-#     @ServiceBusNamespaceAuthorizationRulePreparer(name_prefix='servicebustest', access_rights=[AccessRights.send])
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_sb_client_writeonly_credentials(self, uamqp_transport, *, servicebus_authorization_rule_connection_string=None, servicebus_queue=None, **kwargs):
-#         client = ServiceBusClient.from_connection_string(servicebus_authorization_rule_connection_string, uamqp_transport=uamqp_transport)
-
-#         with client:
-#             with pytest.raises(ServiceBusError):
-#                 with client.get_queue_receiver(servicebus_queue.name) as receiver:
-#                     messages = receiver.receive_messages(max_message_count=1, max_wait_time=1)
-
-#             with client.get_queue_sender(servicebus_queue.name) as sender:
-#                 sender.send_messages(ServiceBusMessage("test"))
-
-#                 with pytest.raises(TypeError):
-#                     sender.send_messages("cat")
-
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusNamespaceAuthorizationRulePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest_qone', parameter_name='wrong_queue', dead_lettering_on_message_expiration=True)
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest_qtwo', dead_lettering_on_message_expiration=True)
-#     @ServiceBusQueueAuthorizationRulePreparer(name_prefix='servicebustest_qtwo')
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_sb_client_incorrect_queue_conn_str(self, uamqp_transport, *, servicebus_queue_authorization_rule_connection_string=None, servicebus_queue=None, wrong_queue=None, **kwargs):
-#         if uamqp_transport:
-#             amqp_transport = UamqpTransport
-#         else:
-#             amqp_transport = PyamqpTransport
-#         client = ServiceBusClient.from_connection_string(servicebus_queue_authorization_rule_connection_string, uamqp_transport=uamqp_transport)
-#         with client:
-#             # Validate that the wrong sender/receiver queues with the right credentials fail.
-#             with pytest.raises(ValueError):
-#                 with client.get_queue_sender(wrong_queue.name) as sender:
-#                     sender.send_messages(ServiceBusMessage("test"))
-
-#             with pytest.raises(ValueError):
-#                 with client.get_queue_receiver(wrong_queue.name) as receiver:
-#                     messages =  receiver.receive_messages(max_message_count=1, max_wait_time=1)
-
-#             # But that the correct ones work.
-#             with client.get_queue_sender(servicebus_queue.name) as sender:
-#                 sender.send_messages(ServiceBusMessage("test")) 
-
-#             with client.get_queue_receiver(servicebus_queue.name) as receiver:
-#                messages =  receiver.receive_messages(max_message_count=1, max_wait_time=1)
-
-#             # Now do the same but with direct connstr initialization.
-#             with pytest.raises(ValueError):
-#                 with ServiceBusSender._from_connection_string(
-#                     servicebus_queue_authorization_rule_connection_string,
-#                     queue_name=wrong_queue.name,
-#                     amqp_transport=amqp_transport
-#                 ) as sender:
-#                         sender.send_messages(ServiceBusMessage("test"))
-
-#             with pytest.raises(ValueError):
-#                 with ServiceBusReceiver._from_connection_string(
-#                     servicebus_queue_authorization_rule_connection_string,
-#                     queue_name=wrong_queue.name,
-#                     amqp_transport=amqp_transport
-#                 ) as receiver:
-#                     messages =  receiver.receive_messages(max_message_count=1, max_wait_time=1)
-
-#             with ServiceBusSender._from_connection_string(
-#                 servicebus_queue_authorization_rule_connection_string,
-#                 queue_name=servicebus_queue.name,
-#                 amqp_transport=amqp_transport
-#             ) as sender:
-#                 sender.send_messages(ServiceBusMessage("test"))
-
-#             with ServiceBusReceiver._from_connection_string(
-#                 servicebus_queue_authorization_rule_connection_string,
-#                 queue_name=servicebus_queue.name,
-#                 amqp_transport=amqp_transport
-#             ) as receiver:
-#                 messages =  receiver.receive_messages(max_message_count=1, max_wait_time=1)
-
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer()
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @CachedServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
-#     @CachedServiceBusTopicPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusSubscriptionPreparer(name_prefix='servicebustest')
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_sb_client_close_spawned_handlers(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, servicebus_topic=None, servicebus_subscription=None, **kwargs):
-#         client = ServiceBusClient.from_connection_string(servicebus_namespace_connection_string, uamqp_transport=uamqp_transport)
-
-#         client.close()
-
-#         # context manager
-#         with client:
-#             assert len(client._handlers) == 0
-#             sender = client.get_queue_sender(servicebus_queue.name)
-#             receiver = client.get_queue_receiver(servicebus_queue.name)
-#             sender._open()
-#             receiver._open()
-
-#             assert sender._handler and sender._running
-#             assert receiver._handler and receiver._running
-#             assert len(client._handlers) == 2
-
-#         assert not sender._handler and not sender._running
-#         assert not receiver._handler and not receiver._running
-#         assert len(client._handlers) == 0
-
-#         # close operation
-#         sender = client.get_queue_sender(servicebus_queue.name)
-#         receiver = client.get_queue_receiver(servicebus_queue.name)
-#         sender._open()
-#         receiver._open()
-
-#         assert sender._handler and sender._running
-#         assert receiver._handler and receiver._running
-#         assert len(client._handlers) == 2
-
-#         client.close()
-
-#         assert not sender._handler and not sender._running
-#         assert not receiver._handler and not receiver._running
-#         assert len(client._handlers) == 0
-
-#         queue_sender = client.get_queue_sender(servicebus_queue.name)
-#         queue_receiver = client.get_queue_receiver(servicebus_queue.name)
-#         assert len(client._handlers) == 2
-#         queue_sender = client.get_queue_sender(servicebus_queue.name)
-#         queue_receiver = client.get_queue_receiver(servicebus_queue.name)
-#         # the previous sender/receiver can not longer be referenced, there might be a delay in CPython
-#         # to remove the reference, so len of handlers should be less than 4
-#         assert len(client._handlers) < 4
-#         client.close()
-
-#         queue_sender = client.get_queue_sender(servicebus_queue.name)
-#         queue_receiver = client.get_queue_receiver(servicebus_queue.name)
-#         assert len(client._handlers) == 2
-#         queue_sender = None
-#         queue_receiver = None
-#         assert len(client._handlers) < 2
-
-#         client.close()
-#         topic_sender = client.get_topic_sender(servicebus_topic.name)
-#         subscription_receiver = client.get_subscription_receiver(servicebus_topic.name, servicebus_subscription.name)
-#         assert len(client._handlers) == 2
-#         topic_sender = None
-#         subscription_receiver = None
-#         # the previous sender/receiver can not longer be referenced, so len of handlers should just be 2 instead of 4
-#         assert len(client._handlers) < 4
-
-#         client.close()
-#         topic_sender = client.get_topic_sender(servicebus_topic.name)
-#         subscription_receiver = client.get_subscription_receiver(servicebus_topic.name, servicebus_subscription.name)
-#         assert len(client._handlers) == 2
-#         topic_sender = client.get_topic_sender(servicebus_topic.name)
-#         subscription_receiver = client.get_subscription_receiver(servicebus_topic.name, servicebus_subscription.name)
-#         # the previous sender/receiver can not longer be referenced, so len of handlers should just be 2 instead of 4
-#         assert len(client._handlers) < 4
-
-#         client.close()
-#         for _ in range(5):
-#             queue_sender = client.get_queue_sender(servicebus_queue.name)
-#             queue_receiver = client.get_queue_receiver(servicebus_queue.name)
-#             topic_sender = client.get_topic_sender(servicebus_topic.name)
-#             subscription_receiver = client.get_subscription_receiver(servicebus_topic.name,
-#                                                                      servicebus_subscription.name)
-#         assert len(client._handlers) < 15
-#         client.close()
-
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer()
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @CachedServiceBusQueuePreparer(name_prefix='servicebustest')
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_client_sas_credential(self,
-#                                    uamqp_transport,
-#                                    *,
-#                                    servicebus_queue,
-#                                    servicebus_namespace,
-#                                    servicebus_namespace_key_name,
-#                                    servicebus_namespace_primary_key,
-#                                    servicebus_namespace_connection_string,
-#                                    **kwargs):
-#         # This should "just work" to validate known-good.
-#         credential = ServiceBusSharedKeyCredential(servicebus_namespace_key_name, servicebus_namespace_primary_key)
-#         hostname = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
-#         auth_uri = "sb://{}/{}".format(hostname, servicebus_queue.name)
-#         token = credential.get_token(auth_uri).token
-
-#         # Finally let's do it with SAS token + conn str
-#         token_conn_str = "Endpoint=sb://{}/;SharedAccessSignature={};".format(hostname, token)
-
-#         client = ServiceBusClient.from_connection_string(token_conn_str, uamqp_transport=uamqp_transport)
-#         with client:
-#             assert len(client._handlers) == 0
-#             with client.get_queue_sender(servicebus_queue.name) as sender:
-#                 sender.send_messages(ServiceBusMessage("foo"))
-
-#         # This is disabled pending UAMQP fix https://github.com/Azure/azure-uamqp-python/issues/170
-#         #
-#         #token_conn_str_without_se = token_conn_str.split('se=')[0] + token_conn_str.split('se=')[1].split('&')[1]
-#         #
-#         #client = ServiceBusClient.from_connection_string(token_conn_str_without_se, uamqp_transport=uamqp_transport)
-#         #with client:
-#         #    assert len(client._handlers) == 0
-#         #    with client.get_queue_sender(servicebus_queue.name) as sender:
-#         #        sender.send_messages(ServiceBusMessage("foo"))
-
-#         def generate_sas_token(uri, sas_name, sas_value, token_ttl):
-#             """Performs the signing and encoding needed to generate a sas token from a sas key."""
-#             sas = sas_value.encode('utf-8')
-#             expiry = str(int(time.time() + token_ttl))
-#             string_to_sign = (uri + '\n' + expiry).encode('utf-8')
-#             signed_hmac_sha256 = hmac.HMAC(sas, string_to_sign, hashlib.sha256)
-#             signature = url_parse_quote(base64.b64encode(signed_hmac_sha256.digest()))
-#             return 'SharedAccessSignature sr={}&sig={}&se={}&skn={}'.format(uri, signature, expiry, sas_name)
-
-#         class CustomizedSASCredential(object):
-#             def __init__(self, token, expiry):
-#                 """
-#                 :param str token: The token string
-#                 :param float expiry: The epoch timestamp
-#                 """
-#                 self.token = token
-#                 self.expiry = expiry
-#                 self.token_type = b"servicebus.windows.net:sastoken"
-
-#             def get_token(self, *scopes, **kwargs):
-#                 """
-#                 This method is automatically called when token is about to expire.
-#                 """
-#                 return AccessToken(self.token, self.expiry)
-
-#         token_ttl = 5  # seconds
-#         sas_token = generate_sas_token(
-#             auth_uri, servicebus_namespace_key_name, servicebus_namespace_primary_key, token_ttl
-#         )
-#         credential=CustomizedSASCredential(sas_token, time.time() + token_ttl)
-
-#         with ServiceBusClient(hostname, credential, uamqp_transport=uamqp_transport) as client:
-#             sender = client.get_queue_sender(queue_name=servicebus_queue.name)
-#             time.sleep(10)
-#             with pytest.raises(ServiceBusAuthenticationError):
-#                 with sender:
-#                     message = ServiceBusMessage("Single Message")
-#                     sender.send_messages(message)
-
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer()
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @CachedServiceBusQueuePreparer(name_prefix='servicebustest')
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_client_credential(self,
-#                                    uamqp_transport,
-#                                    *,
-#                                    servicebus_queue=None,
-#                                    servicebus_namespace=None,
-#                                    servicebus_namespace_key_name=None,
-#                                    servicebus_namespace_primary_key=None,
-#                                    servicebus_namespace_connection_string=None,
-#                                    **kwargs):
-#         # This should "just work" to validate known-good.
-#         credential = ServiceBusSharedKeyCredential(servicebus_namespace_key_name, servicebus_namespace_primary_key)
-#         hostname = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
-
-#         client = ServiceBusClient(hostname, credential, uamqp_transport=uamqp_transport)
-#         with client:
-#             assert len(client._handlers) == 0
-#             with client.get_queue_sender(servicebus_queue.name) as sender:
-#                 sender.send_messages(ServiceBusMessage("foo"))
-
-#         hostname = f"sb://{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
-
-#         client = ServiceBusClient(hostname, credential, uamqp_transport=uamqp_transport)
-#         with client:
-#             assert len(client._handlers) == 0
-#             with client.get_queue_sender(servicebus_queue.name) as sender:
-#                 sender.send_messages(ServiceBusMessage("foo"))
-
-#         hostname = f"https://{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
-
-#         client = ServiceBusClient(hostname, credential, uamqp_transport=uamqp_transport)
-#         with client:
-#             assert len(client._handlers) == 0
-#             with client.get_queue_sender(servicebus_queue.name) as sender:
-#                 sender.send_messages(ServiceBusMessage("foo"))
-
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer()
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @CachedServiceBusQueuePreparer(name_prefix='servicebustest')
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_client_azure_sas_credential(self,
-#                                    uamqp_transport,
-#                                    *,
-#                                    servicebus_queue=None,
-#                                    servicebus_namespace=None,
-#                                    servicebus_namespace_key_name=None,
-#                                    servicebus_namespace_primary_key=None,
-#                                    servicebus_namespace_connection_string=None,
-#                                    **kwargs):
-#         # This should "just work" to validate known-good.
-#         credential = ServiceBusSharedKeyCredential(servicebus_namespace_key_name, servicebus_namespace_primary_key)
-#         hostname = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
-#         auth_uri = "sb://{}/{}".format(hostname, servicebus_queue.name)
-#         token = credential.get_token(auth_uri).token
-
-#         # Finally let's do it with AzureSasCredential
-#         credential = AzureSasCredential(token)
-
-#         client = ServiceBusClient(hostname, credential, uamqp_transport=uamqp_transport)
-#         with client:
-#             assert len(client._handlers) == 0
-
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer()
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @CachedServiceBusQueuePreparer(name_prefix='servicebustest')
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_azure_named_key_credential(self,
-#                                    uamqp_transport,
-#                                    *,
-#                                    servicebus_queue=None,
-#                                    servicebus_namespace=None,
-#                                    servicebus_namespace_key_name=None,
-#                                    servicebus_namespace_primary_key=None,
-#                                    servicebus_namespace_connection_string=None,
-#                                    **kwargs):
-#         hostname = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
-#         credential = AzureNamedKeyCredential(servicebus_namespace_key_name, servicebus_namespace_primary_key)
-
-#         client = ServiceBusClient(hostname, credential, uamqp_transport=uamqp_transport)
-#         with client:
-#             with client.get_queue_sender(servicebus_queue.name) as sender:
-#                 sender.send_messages(ServiceBusMessage("foo"))
+#-------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+#--------------------------------------------------------------------------
+
+import logging
+import sys
+import os
+import pytest
+import time
+from datetime import datetime, timedelta
+import hmac
+import hashlib
+import base64
+try:
+    from urllib.parse import quote as url_parse_quote
+except ImportError:
+    from urllib import pathname2url as url_parse_quote
+
+try:
+    from azure.servicebus._transport._uamqp_transport import UamqpTransport
+except ImportError:
+    pass
+from azure.servicebus._transport._pyamqp_transport import PyamqpTransport
+
+from azure.common import AzureHttpError, AzureConflictHttpError
+from azure.core.credentials import AzureSasCredential, AzureNamedKeyCredential, AccessToken
+from azure.core.pipeline.policies import RetryMode
+from azure.mgmt.servicebus.models import AccessRights
+from azure.servicebus import ServiceBusClient, ServiceBusSender, ServiceBusReceiver
+from azure.servicebus._base_handler import ServiceBusSharedKeyCredential
+from azure.servicebus._common.message import ServiceBusMessage, ServiceBusReceivedMessage
+from azure.servicebus.exceptions import (
+    ServiceBusError,
+    ServiceBusAuthenticationError,
+    ServiceBusAuthorizationError,
+    ServiceBusConnectionError
+)
+from devtools_testutils import AzureMgmtRecordedTestCase, get_credential
+from servicebus_preparer import (
+    CachedServiceBusNamespacePreparer, 
+    ServiceBusTopicPreparer, 
+    ServiceBusQueuePreparer,
+    ServiceBusNamespaceAuthorizationRulePreparer,
+    ServiceBusQueueAuthorizationRulePreparer,
+    CachedServiceBusQueuePreparer,
+    CachedServiceBusTopicPreparer,
+    CachedServiceBusSubscriptionPreparer,
+    CachedServiceBusResourceGroupPreparer,
+    SERVICEBUS_ENDPOINT_SUFFIX
+)
+from utilities import uamqp_transport as get_uamqp_transport, ArgPasser
+uamqp_transport_params, uamqp_transport_ids = get_uamqp_transport()
+
+class TestServiceBusClient(AzureMgmtRecordedTestCase):
+
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_sb_client_bad_credentials(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        client = ServiceBusClient(
+            fully_qualified_namespace=servicebus_namespace.name + f"{SERVICEBUS_ENDPOINT_SUFFIX}",
+            credential=ServiceBusSharedKeyCredential('invalid', 'invalid'),
+            logging_enable=False,
+            uamqp_transport=uamqp_transport
+            )
+        with client:
+            with pytest.raises(ServiceBusAuthenticationError):
+                with client.get_queue_sender(servicebus_queue.name) as sender:
+                    sender.send_messages(ServiceBusMessage("test"))
+
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    def test_sb_client_bad_namespace(self, uamqp_transport, **kwargs):
+        client = ServiceBusClient(
+            fully_qualified_namespace=f"invalid{SERVICEBUS_ENDPOINT_SUFFIX}",
+            credential=ServiceBusSharedKeyCredential('invalid', 'invalid'),
+            logging_enable=False,
+            uamqp_transport=uamqp_transport
+            )
+        with client:
+            with pytest.raises(ServiceBusError):
+                with client.get_queue_sender('invalidqueue') as sender:
+                    sender.send_messages(ServiceBusMessage("test"))
+
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_sb_client_bad_entity(self, uamqp_transport, *, servicebus_namespace_connection_string=None, **kwargs):
+        client = ServiceBusClient.from_connection_string(servicebus_namespace_connection_string, uamqp_transport=uamqp_transport)
+
+        with client:
+            with pytest.raises(ServiceBusAuthenticationError):
+                with client.get_queue_sender("invalid") as sender:
+                    sender.send_messages(ServiceBusMessage("test"))
+
+        fake_str = f"Endpoint=sb://mock{SERVICEBUS_ENDPOINT_SUFFIX}/;" \
+                   f"SharedAccessKeyName=mock;SharedAccessKey=mock;EntityPath=mockentity"
+        fake_client = ServiceBusClient.from_connection_string(fake_str, uamqp_transport=uamqp_transport)
+
+        with pytest.raises(ValueError):
+            fake_client.get_queue_sender('queue')
+
+        with pytest.raises(ValueError):
+            fake_client.get_queue_receiver('queue')
+
+        with pytest.raises(ValueError):
+            fake_client.get_topic_sender('topic')
+
+        with pytest.raises(ValueError):
+            fake_client.get_subscription_receiver('topic', 'subscription')
+
+        fake_client.get_queue_sender('mockentity')
+        fake_client.get_queue_receiver('mockentity')
+        fake_client.get_topic_sender('mockentity')
+        fake_client.get_subscription_receiver('mockentity', 'subscription')
+
+        fake_str = f"Endpoint=sb://mock{SERVICEBUS_ENDPOINT_SUFFIX}/;" \
+                   f"SharedAccessKeyName=mock;SharedAccessKey=mock"
+        fake_client = ServiceBusClient.from_connection_string(fake_str, uamqp_transport=uamqp_transport)
+        fake_client.get_queue_sender('queue')
+        fake_client.get_queue_receiver('queue')
+        fake_client.get_topic_sender('topic')
+        fake_client.get_subscription_receiver('topic', 'subscription')
+
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+    @ServiceBusNamespaceAuthorizationRulePreparer(name_prefix='servicebustest', access_rights=[AccessRights.listen])
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_sb_client_readonly_credentials(self, uamqp_transport, *, servicebus_authorization_rule_connection_string=None, servicebus_queue=None, **kwargs):
+        client = ServiceBusClient.from_connection_string(servicebus_authorization_rule_connection_string, uamqp_transport=uamqp_transport)
+
+        with client:
+            with client.get_queue_receiver(servicebus_queue.name) as receiver:
+                messages = receiver.receive_messages(max_message_count=1, max_wait_time=1)
+
+            with pytest.raises(ServiceBusAuthorizationError):
+                with client.get_queue_sender(servicebus_queue.name) as sender:
+                    sender.send_messages(ServiceBusMessage("test"))
+
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+    @ServiceBusNamespaceAuthorizationRulePreparer(name_prefix='servicebustest', access_rights=[AccessRights.send])
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_sb_client_writeonly_credentials(self, uamqp_transport, *, servicebus_authorization_rule_connection_string=None, servicebus_queue=None, **kwargs):
+        client = ServiceBusClient.from_connection_string(servicebus_authorization_rule_connection_string, uamqp_transport=uamqp_transport)
+
+        with client:
+            with pytest.raises(ServiceBusError):
+                with client.get_queue_receiver(servicebus_queue.name) as receiver:
+                    messages = receiver.receive_messages(max_message_count=1, max_wait_time=1)
+
+            with client.get_queue_sender(servicebus_queue.name) as sender:
+                sender.send_messages(ServiceBusMessage("test"))
+
+                with pytest.raises(TypeError):
+                    sender.send_messages("cat")
+
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusNamespaceAuthorizationRulePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest_qone', parameter_name='wrong_queue', dead_lettering_on_message_expiration=True)
+    @ServiceBusQueuePreparer(name_prefix='servicebustest_qtwo', dead_lettering_on_message_expiration=True)
+    @ServiceBusQueueAuthorizationRulePreparer(name_prefix='servicebustest_qtwo')
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_sb_client_incorrect_queue_conn_str(self, uamqp_transport, *, servicebus_queue_authorization_rule_connection_string=None, servicebus_queue=None, wrong_queue=None, **kwargs):
+        if uamqp_transport:
+            amqp_transport = UamqpTransport
+        else:
+            amqp_transport = PyamqpTransport
+        client = ServiceBusClient.from_connection_string(servicebus_queue_authorization_rule_connection_string, uamqp_transport=uamqp_transport)
+        with client:
+            # Validate that the wrong sender/receiver queues with the right credentials fail.
+            with pytest.raises(ValueError):
+                with client.get_queue_sender(wrong_queue.name) as sender:
+                    sender.send_messages(ServiceBusMessage("test"))
+
+            with pytest.raises(ValueError):
+                with client.get_queue_receiver(wrong_queue.name) as receiver:
+                    messages =  receiver.receive_messages(max_message_count=1, max_wait_time=1)
+
+            # But that the correct ones work.
+            with client.get_queue_sender(servicebus_queue.name) as sender:
+                sender.send_messages(ServiceBusMessage("test")) 
+
+            with client.get_queue_receiver(servicebus_queue.name) as receiver:
+               messages =  receiver.receive_messages(max_message_count=1, max_wait_time=1)
+
+            # Now do the same but with direct connstr initialization.
+            with pytest.raises(ValueError):
+                with ServiceBusSender._from_connection_string(
+                    servicebus_queue_authorization_rule_connection_string,
+                    queue_name=wrong_queue.name,
+                    amqp_transport=amqp_transport
+                ) as sender:
+                        sender.send_messages(ServiceBusMessage("test"))
+
+            with pytest.raises(ValueError):
+                with ServiceBusReceiver._from_connection_string(
+                    servicebus_queue_authorization_rule_connection_string,
+                    queue_name=wrong_queue.name,
+                    amqp_transport=amqp_transport
+                ) as receiver:
+                    messages =  receiver.receive_messages(max_message_count=1, max_wait_time=1)
+
+            with ServiceBusSender._from_connection_string(
+                servicebus_queue_authorization_rule_connection_string,
+                queue_name=servicebus_queue.name,
+                amqp_transport=amqp_transport
+            ) as sender:
+                sender.send_messages(ServiceBusMessage("test"))
+
+            with ServiceBusReceiver._from_connection_string(
+                servicebus_queue_authorization_rule_connection_string,
+                queue_name=servicebus_queue.name,
+                amqp_transport=amqp_transport
+            ) as receiver:
+                messages =  receiver.receive_messages(max_message_count=1, max_wait_time=1)
+
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer()
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @CachedServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+    @CachedServiceBusTopicPreparer(name_prefix='servicebustest')
+    @CachedServiceBusSubscriptionPreparer(name_prefix='servicebustest')
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_sb_client_close_spawned_handlers(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, servicebus_topic=None, servicebus_subscription=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        client = ServiceBusClient(
+            fully_qualified_namespace=fully_qualified_namespace,
+            credential=credential,
+            uamqp_transport=uamqp_transport
+        )
+
+        client.close()
+
+        # context manager
+        with client:
+            assert len(client._handlers) == 0
+            sender = client.get_queue_sender(servicebus_queue.name)
+            receiver = client.get_queue_receiver(servicebus_queue.name)
+            sender._open()
+            receiver._open()
+
+            assert sender._handler and sender._running
+            assert receiver._handler and receiver._running
+            assert len(client._handlers) == 2
+
+        assert not sender._handler and not sender._running
+        assert not receiver._handler and not receiver._running
+        assert len(client._handlers) == 0
+
+        # close operation
+        sender = client.get_queue_sender(servicebus_queue.name)
+        receiver = client.get_queue_receiver(servicebus_queue.name)
+        sender._open()
+        receiver._open()
+
+        assert sender._handler and sender._running
+        assert receiver._handler and receiver._running
+        assert len(client._handlers) == 2
+
+        client.close()
+
+        assert not sender._handler and not sender._running
+        assert not receiver._handler and not receiver._running
+        assert len(client._handlers) == 0
+
+        queue_sender = client.get_queue_sender(servicebus_queue.name)
+        queue_receiver = client.get_queue_receiver(servicebus_queue.name)
+        assert len(client._handlers) == 2
+        queue_sender = client.get_queue_sender(servicebus_queue.name)
+        queue_receiver = client.get_queue_receiver(servicebus_queue.name)
+        # the previous sender/receiver can not longer be referenced, there might be a delay in CPython
+        # to remove the reference, so len of handlers should be less than 4
+        assert len(client._handlers) < 4
+        client.close()
+
+        queue_sender = client.get_queue_sender(servicebus_queue.name)
+        queue_receiver = client.get_queue_receiver(servicebus_queue.name)
+        assert len(client._handlers) == 2
+        queue_sender = None
+        queue_receiver = None
+        assert len(client._handlers) < 2
+
+        client.close()
+        topic_sender = client.get_topic_sender(servicebus_topic.name)
+        subscription_receiver = client.get_subscription_receiver(servicebus_topic.name, servicebus_subscription.name)
+        assert len(client._handlers) == 2
+        topic_sender = None
+        subscription_receiver = None
+        # the previous sender/receiver can not longer be referenced, so len of handlers should just be 2 instead of 4
+        assert len(client._handlers) < 4
+
+        client.close()
+        topic_sender = client.get_topic_sender(servicebus_topic.name)
+        subscription_receiver = client.get_subscription_receiver(servicebus_topic.name, servicebus_subscription.name)
+        assert len(client._handlers) == 2
+        topic_sender = client.get_topic_sender(servicebus_topic.name)
+        subscription_receiver = client.get_subscription_receiver(servicebus_topic.name, servicebus_subscription.name)
+        # the previous sender/receiver can not longer be referenced, so len of handlers should just be 2 instead of 4
+        assert len(client._handlers) < 4
+
+        client.close()
+        for _ in range(5):
+            queue_sender = client.get_queue_sender(servicebus_queue.name)
+            queue_receiver = client.get_queue_receiver(servicebus_queue.name)
+            topic_sender = client.get_topic_sender(servicebus_topic.name)
+            subscription_receiver = client.get_subscription_receiver(servicebus_topic.name,
+                                                                     servicebus_subscription.name)
+        assert len(client._handlers) < 15
+        client.close()
+
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer()
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @CachedServiceBusQueuePreparer(name_prefix='servicebustest')
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_client_sas_credential(self,
+                                   uamqp_transport,
+                                   *,
+                                   servicebus_queue,
+                                   servicebus_namespace,
+                                   servicebus_namespace_key_name,
+                                   servicebus_namespace_primary_key,
+                                   servicebus_namespace_connection_string,
+                                   **kwargs):
+        # This should "just work" to validate known-good.
+        credential = ServiceBusSharedKeyCredential(servicebus_namespace_key_name, servicebus_namespace_primary_key)
+        hostname = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        auth_uri = "sb://{}/{}".format(hostname, servicebus_queue.name)
+        token = credential.get_token(auth_uri).token
+
+        # Finally let's do it with SAS token + conn str
+        token_conn_str = "Endpoint=sb://{}/;SharedAccessSignature={};".format(hostname, token)
+
+        client = ServiceBusClient.from_connection_string(token_conn_str, uamqp_transport=uamqp_transport)
+        with client:
+            assert len(client._handlers) == 0
+            with client.get_queue_sender(servicebus_queue.name) as sender:
+                sender.send_messages(ServiceBusMessage("foo"))
+
+        # This is disabled pending UAMQP fix https://github.com/Azure/azure-uamqp-python/issues/170
+        #
+        #token_conn_str_without_se = token_conn_str.split('se=')[0] + token_conn_str.split('se=')[1].split('&')[1]
+        #
+        #client = ServiceBusClient.from_connection_string(token_conn_str_without_se, uamqp_transport=uamqp_transport)
+        #with client:
+        #    assert len(client._handlers) == 0
+        #    with client.get_queue_sender(servicebus_queue.name) as sender:
+        #        sender.send_messages(ServiceBusMessage("foo"))
+
+        def generate_sas_token(uri, sas_name, sas_value, token_ttl):
+            """Performs the signing and encoding needed to generate a sas token from a sas key."""
+            sas = sas_value.encode('utf-8')
+            expiry = str(int(time.time() + token_ttl))
+            string_to_sign = (uri + '\n' + expiry).encode('utf-8')
+            signed_hmac_sha256 = hmac.HMAC(sas, string_to_sign, hashlib.sha256)
+            signature = url_parse_quote(base64.b64encode(signed_hmac_sha256.digest()))
+            return 'SharedAccessSignature sr={}&sig={}&se={}&skn={}'.format(uri, signature, expiry, sas_name)
+
+        class CustomizedSASCredential(object):
+            def __init__(self, token, expiry):
+                """
+                :param str token: The token string
+                :param float expiry: The epoch timestamp
+                """
+                self.token = token
+                self.expiry = expiry
+                self.token_type = b"servicebus.windows.net:sastoken"
+
+            def get_token(self, *scopes, **kwargs):
+                """
+                This method is automatically called when token is about to expire.
+                """
+                return AccessToken(self.token, self.expiry)
+
+        token_ttl = 5  # seconds
+        sas_token = generate_sas_token(
+            auth_uri, servicebus_namespace_key_name, servicebus_namespace_primary_key, token_ttl
+        )
+        credential=CustomizedSASCredential(sas_token, time.time() + token_ttl)
+
+        with ServiceBusClient(hostname, credential, uamqp_transport=uamqp_transport) as client:
+            sender = client.get_queue_sender(queue_name=servicebus_queue.name)
+            time.sleep(10)
+            with pytest.raises(ServiceBusAuthenticationError):
+                with sender:
+                    message = ServiceBusMessage("Single Message")
+                    sender.send_messages(message)
+
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer()
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @CachedServiceBusQueuePreparer(name_prefix='servicebustest')
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_client_credential(self,
+                                   uamqp_transport,
+                                   *,
+                                   servicebus_queue=None,
+                                   servicebus_namespace=None,
+                                   servicebus_namespace_key_name=None,
+                                   servicebus_namespace_primary_key=None,
+                                   servicebus_namespace_connection_string=None,
+                                   **kwargs):
+        # This should "just work" to validate known-good.
+        credential = ServiceBusSharedKeyCredential(servicebus_namespace_key_name, servicebus_namespace_primary_key)
+        hostname = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+
+        client = ServiceBusClient(hostname, credential, uamqp_transport=uamqp_transport)
+        with client:
+            assert len(client._handlers) == 0
+            with client.get_queue_sender(servicebus_queue.name) as sender:
+                sender.send_messages(ServiceBusMessage("foo"))
+
+        hostname = f"sb://{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+
+        client = ServiceBusClient(hostname, credential, uamqp_transport=uamqp_transport)
+        with client:
+            assert len(client._handlers) == 0
+            with client.get_queue_sender(servicebus_queue.name) as sender:
+                sender.send_messages(ServiceBusMessage("foo"))
+
+        hostname = f"https://{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+
+        client = ServiceBusClient(hostname, credential, uamqp_transport=uamqp_transport)
+        with client:
+            assert len(client._handlers) == 0
+            with client.get_queue_sender(servicebus_queue.name) as sender:
+                sender.send_messages(ServiceBusMessage("foo"))
+
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer()
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @CachedServiceBusQueuePreparer(name_prefix='servicebustest')
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_client_azure_sas_credential(self,
+                                   uamqp_transport,
+                                   *,
+                                   servicebus_queue=None,
+                                   servicebus_namespace=None,
+                                   servicebus_namespace_key_name=None,
+                                   servicebus_namespace_primary_key=None,
+                                   servicebus_namespace_connection_string=None,
+                                   **kwargs):
+        # This should "just work" to validate known-good.
+        credential = ServiceBusSharedKeyCredential(servicebus_namespace_key_name, servicebus_namespace_primary_key)
+        hostname = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        auth_uri = "sb://{}/{}".format(hostname, servicebus_queue.name)
+        token = credential.get_token(auth_uri).token
+
+        # Finally let's do it with AzureSasCredential
+        credential = AzureSasCredential(token)
+
+        client = ServiceBusClient(hostname, credential, uamqp_transport=uamqp_transport)
+        with client:
+            assert len(client._handlers) == 0
+
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer()
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @CachedServiceBusQueuePreparer(name_prefix='servicebustest')
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_azure_named_key_credential(self,
+                                   uamqp_transport,
+                                   *,
+                                   servicebus_queue=None,
+                                   servicebus_namespace=None,
+                                   servicebus_namespace_key_name=None,
+                                   servicebus_namespace_primary_key=None,
+                                   servicebus_namespace_connection_string=None,
+                                   **kwargs):
+        hostname = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = AzureNamedKeyCredential(servicebus_namespace_key_name, servicebus_namespace_primary_key)
+
+        client = ServiceBusClient(hostname, credential, uamqp_transport=uamqp_transport)
+        with client:
+            with client.get_queue_sender(servicebus_queue.name) as sender:
+                sender.send_messages(ServiceBusMessage("foo"))
         
-#         credential.update("foo", "bar")
-#         with pytest.raises(Exception):
-#             with client:
-#                 with client.get_queue_sender(servicebus_queue.name) as sender:
-#                     sender.send_messages(ServiceBusMessage("foo"))
+        credential.update("foo", "bar")
+        with pytest.raises(Exception):
+            with client:
+                with client.get_queue_sender(servicebus_queue.name) as sender:
+                    sender.send_messages(ServiceBusMessage("foo"))
 
-#         # update back to the right key again
-#         credential.update(servicebus_namespace_key_name, servicebus_namespace_primary_key)
-#         with client:
-#             with client.get_queue_sender(servicebus_queue.name) as sender:
-#                 sender.send_messages(ServiceBusMessage("foo"))
+        # update back to the right key again
+        credential.update(servicebus_namespace_key_name, servicebus_namespace_primary_key)
+        with client:
+            with client.get_queue_sender(servicebus_queue.name) as sender:
+                sender.send_messages(ServiceBusMessage("foo"))
 
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     def test_backoff_fixed_retry(self, uamqp_transport):
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    def test_backoff_fixed_retry(self, uamqp_transport):
 
-#         client = ServiceBusClient(
-#             'fake.host.com',
-#             'fake_eh',
-#             retry_mode='fixed',
-#             uamqp_transport=uamqp_transport
-#         )
-#         # queue sender
-#         sender = client.get_queue_sender('fake_name')
-#         backoff = client._config.retry_backoff_factor
-#         start_time = time.time()
-#         sender._backoff(retried_times=1, last_exception=Exception('fake'), abs_timeout_time=None)
-#         sleep_time_fixed = time.time() - start_time
-#         # exp = 0.8 * (2 ** 1) = 1.6
-#         # time.sleep() in _backoff will take AT LEAST time 'exp' for retry_mode='exponential'
-#         # check that fixed is less than 'exp'
-#         assert sleep_time_fixed < backoff * (2 ** 1)
+        client = ServiceBusClient(
+            'fake.host.com',
+            'fake_eh',
+            retry_mode='fixed',
+            uamqp_transport=uamqp_transport
+        )
+        # queue sender
+        sender = client.get_queue_sender('fake_name')
+        backoff = client._config.retry_backoff_factor
+        start_time = time.time()
+        sender._backoff(retried_times=1, last_exception=Exception('fake'), abs_timeout_time=None)
+        sleep_time_fixed = time.time() - start_time
+        # exp = 0.8 * (2 ** 1) = 1.6
+        # time.sleep() in _backoff will take AT LEAST time 'exp' for retry_mode='exponential'
+        # check that fixed is less than 'exp'
+        assert sleep_time_fixed < backoff * (2 ** 1)
 
-#         # topic sender
-#         sender = client.get_topic_sender('fake_name')
-#         backoff = client._config.retry_backoff_factor
-#         start_time = time.time()
-#         sender._backoff(retried_times=1, last_exception=Exception('fake'), abs_timeout_time=None)
-#         sleep_time_fixed = time.time() - start_time
-#         assert sleep_time_fixed < backoff * (2 ** 1)
+        # topic sender
+        sender = client.get_topic_sender('fake_name')
+        backoff = client._config.retry_backoff_factor
+        start_time = time.time()
+        sender._backoff(retried_times=1, last_exception=Exception('fake'), abs_timeout_time=None)
+        sleep_time_fixed = time.time() - start_time
+        assert sleep_time_fixed < backoff * (2 ** 1)
 
-#         # queue receiver 
-#         receiver = client.get_queue_receiver('fake_name')
-#         backoff = client._config.retry_backoff_factor
-#         start_time = time.time()
-#         receiver._backoff(retried_times=1, last_exception=Exception('fake'), abs_timeout_time=None)
-#         sleep_time_fixed = time.time() - start_time
-#         assert sleep_time_fixed < backoff * (2 ** 1)
+        # queue receiver 
+        receiver = client.get_queue_receiver('fake_name')
+        backoff = client._config.retry_backoff_factor
+        start_time = time.time()
+        receiver._backoff(retried_times=1, last_exception=Exception('fake'), abs_timeout_time=None)
+        sleep_time_fixed = time.time() - start_time
+        assert sleep_time_fixed < backoff * (2 ** 1)
 
-#         # subscription receiver 
-#         receiver = client.get_subscription_receiver('fake_topic', 'fake_sub')
-#         backoff = client._config.retry_backoff_factor
-#         start_time = time.time()
-#         receiver._backoff(retried_times=1, last_exception=Exception('fake'), abs_timeout_time=None)
-#         sleep_time_fixed = time.time() - start_time
-#         assert sleep_time_fixed < backoff * (2 ** 1)
+        # subscription receiver 
+        receiver = client.get_subscription_receiver('fake_topic', 'fake_sub')
+        backoff = client._config.retry_backoff_factor
+        start_time = time.time()
+        receiver._backoff(retried_times=1, last_exception=Exception('fake'), abs_timeout_time=None)
+        sleep_time_fixed = time.time() - start_time
+        assert sleep_time_fixed < backoff * (2 ** 1)
 
-#         client = ServiceBusClient(
-#             'fake.host.com',
-#             'fake_eh',
-#             retry_mode=RetryMode.Fixed,
-#             uamqp_transport=uamqp_transport
-#         )
-#         # queue sender
-#         sender = client.get_queue_sender('fake_name')
-#         backoff = client._config.retry_backoff_factor
-#         start_time = time.time()
-#         sender._backoff(retried_times=1, last_exception=Exception('fake'), abs_timeout_time=None)
-#         sleep_time_fixed = time.time() - start_time
-#         # exp = 0.8 * (2 ** 1) = 1.6
-#         # time.sleep() in _backoff will take AT LEAST time 'exp' for retry_mode='exponential'
-#         # check that fixed is less than 'exp'
-#         assert sleep_time_fixed < backoff * (2 ** 1)
+        client = ServiceBusClient(
+            'fake.host.com',
+            'fake_eh',
+            retry_mode=RetryMode.Fixed,
+            uamqp_transport=uamqp_transport
+        )
+        # queue sender
+        sender = client.get_queue_sender('fake_name')
+        backoff = client._config.retry_backoff_factor
+        start_time = time.time()
+        sender._backoff(retried_times=1, last_exception=Exception('fake'), abs_timeout_time=None)
+        sleep_time_fixed = time.time() - start_time
+        # exp = 0.8 * (2 ** 1) = 1.6
+        # time.sleep() in _backoff will take AT LEAST time 'exp' for retry_mode='exponential'
+        # check that fixed is less than 'exp'
+        assert sleep_time_fixed < backoff * (2 ** 1)
 
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     def test_custom_client_id_queue_sender(self, uamqp_transport, **kwargs):
-#         servicebus_connection_str = f'Endpoint=sb://resourcename{SERVICEBUS_ENDPOINT_SUFFIX}/;SharedAccessSignature=THISISATESTKEYXXXXXXXXXXXXXXXXXXXXXXXXXXXX=;'
-#         queue_name = "queue_name"
-#         custom_id = "my_custom_id"
-#         servicebus_client = ServiceBusClient.from_connection_string(conn_str=servicebus_connection_str, uamqp_transport=uamqp_transport)
-#         with servicebus_client:
-#             queue_sender = servicebus_client.get_queue_sender(queue_name=queue_name, client_identifier=custom_id)
-#             assert queue_sender.client_identifier is not None
-#             assert queue_sender.client_identifier == custom_id
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    def test_custom_client_id_queue_sender(self, uamqp_transport, **kwargs):
+        servicebus_connection_str = f'Endpoint=sb://resourcename{SERVICEBUS_ENDPOINT_SUFFIX}/;SharedAccessSignature=THISISATESTKEYXXXXXXXXXXXXXXXXXXXXXXXXXXXX=;'
+        queue_name = "queue_name"
+        custom_id = "my_custom_id"
+        servicebus_client = ServiceBusClient.from_connection_string(conn_str=servicebus_connection_str, uamqp_transport=uamqp_transport)
+        with servicebus_client:
+            queue_sender = servicebus_client.get_queue_sender(queue_name=queue_name, client_identifier=custom_id)
+            assert queue_sender.client_identifier is not None
+            assert queue_sender.client_identifier == custom_id
 
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     def test_default_client_id_queue_sender(self, uamqp_transport, **kwargs):
-#         servicebus_connection_str = f'Endpoint=sb://resourcename{SERVICEBUS_ENDPOINT_SUFFIX}/;SharedAccessSignature=THISISATESTKEYXXXXXXXXXXXXXXXXXXXXXXXXXXXX=;'
-#         queue_name = "queue_name"
-#         servicebus_client = ServiceBusClient.from_connection_string(conn_str=servicebus_connection_str, uamqp_transport=uamqp_transport)
-#         with servicebus_client:
-#             queue_sender = servicebus_client.get_queue_sender(queue_name=queue_name)
-#             assert queue_sender.client_identifier is not None
-#             assert "SBSender" in queue_sender.client_identifier
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    def test_default_client_id_queue_sender(self, uamqp_transport, **kwargs):
+        servicebus_connection_str = f'Endpoint=sb://resourcename{SERVICEBUS_ENDPOINT_SUFFIX}/;SharedAccessSignature=THISISATESTKEYXXXXXXXXXXXXXXXXXXXXXXXXXXXX=;'
+        queue_name = "queue_name"
+        servicebus_client = ServiceBusClient.from_connection_string(conn_str=servicebus_connection_str, uamqp_transport=uamqp_transport)
+        with servicebus_client:
+            queue_sender = servicebus_client.get_queue_sender(queue_name=queue_name)
+            assert queue_sender.client_identifier is not None
+            assert "SBSender" in queue_sender.client_identifier
 
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     def test_custom_client_id_queue_receiver(self, uamqp_transport, **kwargs):
-#         servicebus_connection_str = f'Endpoint=sb://resourcename{SERVICEBUS_ENDPOINT_SUFFIX}/;SharedAccessSignature=THISISATESTKEYXXXXXXXXXXXXXXXXXXXXXXXXXXXX=;'
-#         queue_name = "queue_name"
-#         custom_id = "my_custom_id"
-#         servicebus_client = ServiceBusClient.from_connection_string(conn_str=servicebus_connection_str, uamqp_transport=uamqp_transport)
-#         with servicebus_client:
-#             queue_receiver = servicebus_client.get_queue_receiver(queue_name=queue_name, client_identifier=custom_id)
-#             assert queue_receiver.client_identifier is not None
-#             assert queue_receiver.client_identifier == custom_id
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    def test_custom_client_id_queue_receiver(self, uamqp_transport, **kwargs):
+        servicebus_connection_str = f'Endpoint=sb://resourcename{SERVICEBUS_ENDPOINT_SUFFIX}/;SharedAccessSignature=THISISATESTKEYXXXXXXXXXXXXXXXXXXXXXXXXXXXX=;'
+        queue_name = "queue_name"
+        custom_id = "my_custom_id"
+        servicebus_client = ServiceBusClient.from_connection_string(conn_str=servicebus_connection_str, uamqp_transport=uamqp_transport)
+        with servicebus_client:
+            queue_receiver = servicebus_client.get_queue_receiver(queue_name=queue_name, client_identifier=custom_id)
+            assert queue_receiver.client_identifier is not None
+            assert queue_receiver.client_identifier == custom_id
 
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     def test_default_client_id_queue_receiver(self, uamqp_transport, **kwargs):
-#         servicebus_connection_str = f'Endpoint=sb://resourcename{SERVICEBUS_ENDPOINT_SUFFIX}/;SharedAccessSignature=THISISATESTKEYXXXXXXXXXXXXXXXXXXXXXXXXXXXX=;'
-#         queue_name = "queue_name"
-#         servicebus_client = ServiceBusClient.from_connection_string(conn_str=servicebus_connection_str, uamqp_transport=uamqp_transport)
-#         with servicebus_client:
-#             queue_receiver = servicebus_client.get_queue_receiver(queue_name=queue_name)
-#             assert queue_receiver.client_identifier is not None
-#             assert "SBReceiver" in queue_receiver.client_identifier
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    def test_default_client_id_queue_receiver(self, uamqp_transport, **kwargs):
+        servicebus_connection_str = f'Endpoint=sb://resourcename{SERVICEBUS_ENDPOINT_SUFFIX}/;SharedAccessSignature=THISISATESTKEYXXXXXXXXXXXXXXXXXXXXXXXXXXXX=;'
+        queue_name = "queue_name"
+        servicebus_client = ServiceBusClient.from_connection_string(conn_str=servicebus_connection_str, uamqp_transport=uamqp_transport)
+        with servicebus_client:
+            queue_receiver = servicebus_client.get_queue_receiver(queue_name=queue_name)
+            assert queue_receiver.client_identifier is not None
+            assert "SBReceiver" in queue_receiver.client_identifier
 
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     def test_custom_client_id_topic_sender(self, uamqp_transport, **kwargs):
-#         servicebus_connection_str = f'Endpoint=sb://resourcename{SERVICEBUS_ENDPOINT_SUFFIX}/;SharedAccessSignature=THISISATESTKEYXXXXXXXXXXXXXXXXXXXXXXXXXXXX=;'
-#         custom_id = "my_custom_id"
-#         topic_name = "topic_name"
-#         servicebus_client = ServiceBusClient.from_connection_string(conn_str=servicebus_connection_str, uamqp_transport=uamqp_transport)
-#         with servicebus_client:
-#             topic_sender = servicebus_client.get_topic_sender(topic_name=topic_name, client_identifier=custom_id)
-#             assert topic_sender.client_identifier is not None
-#             assert topic_sender.client_identifier == custom_id
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    def test_custom_client_id_topic_sender(self, uamqp_transport, **kwargs):
+        servicebus_connection_str = f'Endpoint=sb://resourcename{SERVICEBUS_ENDPOINT_SUFFIX}/;SharedAccessSignature=THISISATESTKEYXXXXXXXXXXXXXXXXXXXXXXXXXXXX=;'
+        custom_id = "my_custom_id"
+        topic_name = "topic_name"
+        servicebus_client = ServiceBusClient.from_connection_string(conn_str=servicebus_connection_str, uamqp_transport=uamqp_transport)
+        with servicebus_client:
+            topic_sender = servicebus_client.get_topic_sender(topic_name=topic_name, client_identifier=custom_id)
+            assert topic_sender.client_identifier is not None
+            assert topic_sender.client_identifier == custom_id
 
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     def test_default_client_id_topic_sender(self, uamqp_transport, **kwargs):
-#         servicebus_connection_str = f'Endpoint=sb://resourcename{SERVICEBUS_ENDPOINT_SUFFIX}/;SharedAccessSignature=THISISATESTKEYXXXXXXXXXXXXXXXXXXXXXXXXXXXX=;'
-#         topic_name = "topic_name"
-#         servicebus_client = ServiceBusClient.from_connection_string(conn_str=servicebus_connection_str, uamqp_transport=uamqp_transport)
-#         with servicebus_client:
-#             topic_sender = servicebus_client.get_topic_sender(topic_name=topic_name)
-#             assert topic_sender.client_identifier is not None
-#             assert "SBSender" in topic_sender.client_identifier
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    def test_default_client_id_topic_sender(self, uamqp_transport, **kwargs):
+        servicebus_connection_str = f'Endpoint=sb://resourcename{SERVICEBUS_ENDPOINT_SUFFIX}/;SharedAccessSignature=THISISATESTKEYXXXXXXXXXXXXXXXXXXXXXXXXXXXX=;'
+        topic_name = "topic_name"
+        servicebus_client = ServiceBusClient.from_connection_string(conn_str=servicebus_connection_str, uamqp_transport=uamqp_transport)
+        with servicebus_client:
+            topic_sender = servicebus_client.get_topic_sender(topic_name=topic_name)
+            assert topic_sender.client_identifier is not None
+            assert "SBSender" in topic_sender.client_identifier
 
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     def test_default_client_id_subscription_receiver(self, uamqp_transport, **kwargs):
-#         servicebus_connection_str = f'Endpoint=sb://resourcename{SERVICEBUS_ENDPOINT_SUFFIX}/;SharedAccessSignature=THISISATESTKEYXXXXXXXXXXXXXXXXXXXXXXXXXXXX=;'
-#         topic_name = "topic_name"
-#         sub_name = "sub_name"
-#         servicebus_client = ServiceBusClient.from_connection_string(conn_str=servicebus_connection_str, uamqp_transport=uamqp_transport)
-#         with servicebus_client:
-#             subscription_receiver = servicebus_client.get_subscription_receiver(topic_name, sub_name)
-#             assert subscription_receiver.client_identifier is not None
-#             assert "SBReceiver" in subscription_receiver.client_identifier
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    def test_default_client_id_subscription_receiver(self, uamqp_transport, **kwargs):
+        servicebus_connection_str = f'Endpoint=sb://resourcename{SERVICEBUS_ENDPOINT_SUFFIX}/;SharedAccessSignature=THISISATESTKEYXXXXXXXXXXXXXXXXXXXXXXXXXXXX=;'
+        topic_name = "topic_name"
+        sub_name = "sub_name"
+        servicebus_client = ServiceBusClient.from_connection_string(conn_str=servicebus_connection_str, uamqp_transport=uamqp_transport)
+        with servicebus_client:
+            subscription_receiver = servicebus_client.get_subscription_receiver(topic_name, sub_name)
+            assert subscription_receiver.client_identifier is not None
+            assert "SBReceiver" in subscription_receiver.client_identifier
 
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     def test_custom_client_id_subscription_receiver(self, uamqp_transport, **kwargs):
-#         servicebus_connection_str = f'Endpoint=sb://resourcename{SERVICEBUS_ENDPOINT_SUFFIX}/;SharedAccessSignature=THISISATESTKEYXXXXXXXXXXXXXXXXXXXXXXXXXXXX=;'
-#         custom_id = "my_custom_id"
-#         topic_name = "topic_name"
-#         sub_name = "sub_name"
-#         servicebus_client = ServiceBusClient.from_connection_string(conn_str=servicebus_connection_str, uamqp_transport=uamqp_transport)
-#         with servicebus_client:
-#             subscription_receiver = servicebus_client.get_subscription_receiver(topic_name, sub_name, client_identifier=custom_id)
-#             assert subscription_receiver.client_identifier is not None
-#             assert subscription_receiver.client_identifier == custom_id
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    def test_custom_client_id_subscription_receiver(self, uamqp_transport, **kwargs):
+        servicebus_connection_str = f'Endpoint=sb://resourcename{SERVICEBUS_ENDPOINT_SUFFIX}/;SharedAccessSignature=THISISATESTKEYXXXXXXXXXXXXXXXXXXXXXXXXXXXX=;'
+        custom_id = "my_custom_id"
+        topic_name = "topic_name"
+        sub_name = "sub_name"
+        servicebus_client = ServiceBusClient.from_connection_string(conn_str=servicebus_connection_str, uamqp_transport=uamqp_transport)
+        with servicebus_client:
+            subscription_receiver = servicebus_client.get_subscription_receiver(topic_name, sub_name, client_identifier=custom_id)
+            assert subscription_receiver.client_identifier is not None
+            assert subscription_receiver.client_identifier == custom_id
 
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer()
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @CachedServiceBusQueuePreparer(name_prefix='servicebustest')
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_custom_endpoint_connection_verify_exception(self,
-#                                    uamqp_transport,
-#                                    *,
-#                                    servicebus_queue=None,
-#                                    servicebus_namespace=None,
-#                                    servicebus_namespace_key_name=None,
-#                                    servicebus_namespace_primary_key=None,
-#                                    servicebus_namespace_connection_string=None,
-#                                    **kwargs):
-#         hostname = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
-#         credential = AzureNamedKeyCredential(servicebus_namespace_key_name, servicebus_namespace_primary_key)
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer()
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @CachedServiceBusQueuePreparer(name_prefix='servicebustest')
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_custom_endpoint_connection_verify_exception(self,
+                                   uamqp_transport,
+                                   *,
+                                   servicebus_queue=None,
+                                   servicebus_namespace=None,
+                                   servicebus_namespace_key_name=None,
+                                   servicebus_namespace_primary_key=None,
+                                   servicebus_namespace_connection_string=None,
+                                   **kwargs):
+        hostname = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = AzureNamedKeyCredential(servicebus_namespace_key_name, servicebus_namespace_primary_key)
 
-#         client = ServiceBusClient(hostname, credential, connection_verify="cacert.pem", uamqp_transport=uamqp_transport)
-#         with client:
-#             with pytest.raises(ServiceBusError):
-#                 with client.get_queue_sender(servicebus_queue.name) as sender:
-#                     sender.send_messages(ServiceBusMessage("foo"))
+        client = ServiceBusClient(hostname, credential, connection_verify="cacert.pem", uamqp_transport=uamqp_transport)
+        with client:
+            with pytest.raises(ServiceBusError):
+                with client.get_queue_sender(servicebus_queue.name) as sender:
+                    sender.send_messages(ServiceBusMessage("foo"))
 
-#         # Skipping on OSX uamqp - it's raising an Authentication/TimeoutError
-#         if not uamqp_transport or not sys.platform.startswith('darwin'):
-#             fake_addr = "fakeaddress.com:1111"
-#             client = ServiceBusClient(
-#                 hostname,
-#                 credential,
-#                 custom_endpoint_address=fake_addr,
-#                 retry_total=0,
-#                 uamqp_transport=uamqp_transport
-#             )
-#             with client:
-#                 with pytest.raises(ServiceBusConnectionError):
-#                     with client.get_queue_sender(servicebus_queue.name) as sender:
-#                         sender.send_messages(ServiceBusMessage("foo"))
+        # Skipping on OSX uamqp - it's raising an Authentication/TimeoutError
+        if not uamqp_transport or not sys.platform.startswith('darwin'):
+            fake_addr = "fakeaddress.com:1111"
+            client = ServiceBusClient(
+                hostname,
+                credential,
+                custom_endpoint_address=fake_addr,
+                retry_total=0,
+                uamqp_transport=uamqp_transport
+            )
+            with client:
+                with pytest.raises(ServiceBusConnectionError):
+                    with client.get_queue_sender(servicebus_queue.name) as sender:
+                        sender.send_messages(ServiceBusMessage("foo"))
 
-#             client = ServiceBusClient(
-#                 hostname,
-#                 credential,
-#                 custom_endpoint_address=fake_addr,
-#                 connection_verify="cacert.pem",
-#                 retry_total=0,
-#                 uamqp_transport=uamqp_transport,
-#             )
-#             with client:
-#                 with pytest.raises(ServiceBusError):
-#                     with client.get_queue_sender(servicebus_queue.name) as sender:
-#                         sender.send_messages(ServiceBusMessage("foo"))
+            client = ServiceBusClient(
+                hostname,
+                credential,
+                custom_endpoint_address=fake_addr,
+                connection_verify="cacert.pem",
+                retry_total=0,
+                uamqp_transport=uamqp_transport,
+            )
+            with client:
+                with pytest.raises(ServiceBusError):
+                    with client.get_queue_sender(servicebus_queue.name) as sender:
+                        sender.send_messages(ServiceBusMessage("foo"))

--- a/sdk/servicebus/azure-servicebus/tests/test_sb_client.py
+++ b/sdk/servicebus/azure-servicebus/tests/test_sb_client.py
@@ -95,8 +95,10 @@ class TestServiceBusClient(AzureMgmtRecordedTestCase):
     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
     @ArgPasser()
-    def test_sb_client_bad_entity(self, uamqp_transport, *, servicebus_namespace_connection_string=None, **kwargs):
-        client = ServiceBusClient.from_connection_string(servicebus_namespace_connection_string, uamqp_transport=uamqp_transport)
+    def test_sb_client_bad_entity(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_namespace=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        client = ServiceBusClient(fully_qualified_namespace, credential, uamqp_transport=uamqp_transport)
 
         with client:
             with pytest.raises(ServiceBusAuthenticationError):

--- a/sdk/servicebus/azure-servicebus/tests/test_sessions.py
+++ b/sdk/servicebus/azure-servicebus/tests/test_sessions.py
@@ -1,1369 +1,1465 @@
-# #-------------------------------------------------------------------------
-# # Copyright (c) Microsoft Corporation. All rights reserved.
-# # Licensed under the MIT License. See License.txt in the project root for
-# # license information.
-# #--------------------------------------------------------------------------
+#-------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+#--------------------------------------------------------------------------
 
-# import logging
-# import concurrent
-# import sys
-# import os
-# import pytest
-# import time
-# import uuid
-# import pickle
-# from datetime import timedelta
+import logging
+import concurrent
+import sys
+import os
+import pytest
+import time
+import uuid
+import pickle
+from datetime import timedelta
 
-# from azure.servicebus import (
-#     ServiceBusClient,
-#     AutoLockRenewer,
-#     ServiceBusMessage,
-#     ServiceBusReceivedMessage,
-#     ServiceBusReceiveMode,
-#     NEXT_AVAILABLE_SESSION,
-#     ServiceBusSubQueue
-# )
-# from azure.servicebus._common.utils import utc_now
-# from azure.servicebus.exceptions import (
-#     ServiceBusConnectionError,
-#     ServiceBusAuthenticationError,
-#     ServiceBusError,
-#     SessionLockLostError,
-#     MessageAlreadySettled,
-#     OperationTimeoutError,
-#     AutoLockRenewTimeout
-# )
+from azure.servicebus import (
+    ServiceBusClient,
+    AutoLockRenewer,
+    ServiceBusMessage,
+    ServiceBusReceivedMessage,
+    ServiceBusReceiveMode,
+    NEXT_AVAILABLE_SESSION,
+    ServiceBusSubQueue
+)
+from azure.servicebus._common.utils import utc_now
+from azure.servicebus.exceptions import (
+    ServiceBusConnectionError,
+    ServiceBusAuthenticationError,
+    ServiceBusError,
+    SessionLockLostError,
+    MessageAlreadySettled,
+    OperationTimeoutError,
+    AutoLockRenewTimeout
+)
 
-# from devtools_testutils import AzureMgmtRecordedTestCase
-# from servicebus_preparer import (
-#     CachedServiceBusNamespacePreparer,
-#     CachedServiceBusQueuePreparer,
-#     ServiceBusTopicPreparer,
-#     ServiceBusQueuePreparer,
-#     ServiceBusSubscriptionPreparer,
-#     CachedServiceBusResourceGroupPreparer
-# )
-# from utilities import get_logger, print_message, sleep_until_expired, uamqp_transport as get_uamqp_transport, ArgPasser
-# uamqp_transport_params, uamqp_transport_ids = get_uamqp_transport()
+from devtools_testutils import AzureMgmtRecordedTestCase, get_credential
+from servicebus_preparer import (
+    SERVICEBUS_ENDPOINT_SUFFIX,
+    CachedServiceBusNamespacePreparer,
+    CachedServiceBusQueuePreparer,
+    ServiceBusTopicPreparer,
+    ServiceBusQueuePreparer,
+    ServiceBusSubscriptionPreparer,
+    CachedServiceBusResourceGroupPreparer
+)
+from utilities import get_logger, print_message, sleep_until_expired, uamqp_transport as get_uamqp_transport, ArgPasser
+uamqp_transport_params, uamqp_transport_ids = get_uamqp_transport()
 
-# _logger = get_logger(logging.DEBUG)
+_logger = get_logger(logging.DEBUG)
 
 
-# class TestServiceBusSession(AzureMgmtRecordedTestCase):
+class TestServiceBusSession(AzureMgmtRecordedTestCase):
 
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer()
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_session_by_session_client_conn_str_receive_handler_peeklock(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer()
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_session_by_session_client_conn_str_receive_handler_peeklock(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+            fully_qualified_namespace=fully_qualified_namespace,
+            credential=credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-#             session_id = str(uuid.uuid4())
-#             sender = sb_client.get_queue_sender(servicebus_queue.name)
-#             receiver = sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=5)
+            session_id = str(uuid.uuid4())
+            sender = sb_client.get_queue_sender(servicebus_queue.name)
+            receiver = sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=5)
 
-#             with sender, receiver:
-#                 for i in range(3):
-#                     message = ServiceBusMessage("Handler message no. {}".format(i))
+            with sender, receiver:
+                for i in range(3):
+                    message = ServiceBusMessage("Handler message no. {}".format(i))
 
-#                     message.partition_key = 'pkey'
+                    message.partition_key = 'pkey'
 
-#                     message.session_id = session_id
-#                     message.partition_key = session_id
-#                     message.application_properties = {'key': 'value'}
-#                     message.subject = 'label'
-#                     message.content_type = 'application/text'
-#                     message.correlation_id = 'cid'
-#                     message.message_id = str(i)
-#                     message.to = 'to'
-#                     message.reply_to = 'reply_to'
-#                     message.reply_to_session_id = 'reply_to_session_id'
+                    message.session_id = session_id
+                    message.partition_key = session_id
+                    message.application_properties = {'key': 'value'}
+                    message.subject = 'label'
+                    message.content_type = 'application/text'
+                    message.correlation_id = 'cid'
+                    message.message_id = str(i)
+                    message.to = 'to'
+                    message.reply_to = 'reply_to'
+                    message.reply_to_session_id = 'reply_to_session_id'
 
-#                     with pytest.raises(ValueError):
-#                         message.partition_key = 'pkey'
+                    with pytest.raises(ValueError):
+                        message.partition_key = 'pkey'
 
-#                     sender.send_messages(message)
+                    sender.send_messages(message)
 
-#                 with pytest.raises(ServiceBusError):
-#                     receiver = sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5)._open_with_retry()
+                with pytest.raises(ServiceBusError):
+                    receiver = sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5)._open_with_retry()
 
-#                 count = 0
-#                 received_cnt_dic = {}
-#                 for message in receiver:
-#                     print_message(_logger, message)
-#                     assert message.delivery_count == 0
-#                     assert message.application_properties
-#                     assert message.application_properties[b'key'] == b'value'
-#                     assert message.subject == 'label'
-#                     assert message.content_type == 'application/text'
-#                     assert message.correlation_id == 'cid'
-#                     assert message.partition_key == session_id
-#                     assert message.to == 'to'
-#                     assert message.reply_to == 'reply_to'
-#                     assert message.sequence_number
-#                     assert message.enqueued_time_utc
-#                     assert message.session_id == session_id
-#                     assert message.reply_to_session_id == 'reply_to_session_id'
-#                     count += 1
-#                     receiver.complete_message(message)
-#                     if message.message_id not in received_cnt_dic:
-#                         received_cnt_dic[message.message_id] = 1
-#                         sender.send_messages(message)
-#                     else:
-#                         received_cnt_dic[message.message_id] += 1
+                count = 0
+                received_cnt_dic = {}
+                for message in receiver:
+                    print_message(_logger, message)
+                    assert message.delivery_count == 0
+                    assert message.application_properties
+                    assert message.application_properties[b'key'] == b'value'
+                    assert message.subject == 'label'
+                    assert message.content_type == 'application/text'
+                    assert message.correlation_id == 'cid'
+                    assert message.partition_key == session_id
+                    assert message.to == 'to'
+                    assert message.reply_to == 'reply_to'
+                    assert message.sequence_number
+                    assert message.enqueued_time_utc
+                    assert message.session_id == session_id
+                    assert message.reply_to_session_id == 'reply_to_session_id'
+                    count += 1
+                    receiver.complete_message(message)
+                    if message.message_id not in received_cnt_dic:
+                        received_cnt_dic[message.message_id] = 1
+                        sender.send_messages(message)
+                    else:
+                        received_cnt_dic[message.message_id] += 1
 
-#                 assert received_cnt_dic['0'] == 2 and received_cnt_dic['1'] == 2 and received_cnt_dic['2'] == 2
-#                 assert count == 6
+                assert received_cnt_dic['0'] == 2 and received_cnt_dic['1'] == 2 and received_cnt_dic['2'] == 2
+                assert count == 6
 
-#             session_id = ""
-#             sender = sb_client.get_queue_sender(servicebus_queue.name)
-#             receiver = sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=5)
+            session_id = ""
+            sender = sb_client.get_queue_sender(servicebus_queue.name)
+            receiver = sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=5)
 
-#             with sender, receiver:
-#                 for i in range(3):
-#                     message = ServiceBusMessage("Handler message no. {}".format(i))
+            with sender, receiver:
+                for i in range(3):
+                    message = ServiceBusMessage("Handler message no. {}".format(i))
 
-#                     message.partition_key = 'pkey'
+                    message.partition_key = 'pkey'
 
-#                     message.session_id = session_id
-#                     message.partition_key = session_id
-#                     message.application_properties = {'key': 'value'}
-#                     message.subject = 'label'
-#                     message.content_type = 'application/text'
-#                     message.correlation_id = 'cid'
-#                     message.message_id = str(i)
-#                     message.to = 'to'
-#                     message.reply_to = 'reply_to'
-#                     message.reply_to_session_id = 'reply_to_session_id'
+                    message.session_id = session_id
+                    message.partition_key = session_id
+                    message.application_properties = {'key': 'value'}
+                    message.subject = 'label'
+                    message.content_type = 'application/text'
+                    message.correlation_id = 'cid'
+                    message.message_id = str(i)
+                    message.to = 'to'
+                    message.reply_to = 'reply_to'
+                    message.reply_to_session_id = 'reply_to_session_id'
 
-#                     with pytest.raises(ValueError):
-#                         message.partition_key = 'pkey'
+                    with pytest.raises(ValueError):
+                        message.partition_key = 'pkey'
 
-#                     sender.send_messages(message)
+                    sender.send_messages(message)
 
-#                 with pytest.raises(ServiceBusError):
-#                     receiver = sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5)._open_with_retry()
+                with pytest.raises(ServiceBusError):
+                    receiver = sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5)._open_with_retry()
 
-#                 count = 0
-#                 received_cnt_dic = {}
-#                 for message in receiver:
-#                     print_message(_logger, message)
-#                     assert message.delivery_count == 0
-#                     assert message.application_properties
-#                     assert message.application_properties[b'key'] == b'value'
-#                     assert message.subject == 'label'
-#                     assert message.content_type == 'application/text'
-#                     assert message.correlation_id == 'cid'
-#                     assert message.partition_key == session_id
-#                     assert message.to == 'to'
-#                     assert message.reply_to == 'reply_to'
-#                     assert message.sequence_number
-#                     assert message.enqueued_time_utc
-#                     assert message.session_id == session_id
-#                     assert message.reply_to_session_id == 'reply_to_session_id'
-#                     count += 1
-#                     receiver.complete_message(message)
-#                     if message.message_id not in received_cnt_dic:
-#                         received_cnt_dic[message.message_id] = 1
-#                         sender.send_messages(message)
-#                     else:
-#                         received_cnt_dic[message.message_id] += 1
+                count = 0
+                received_cnt_dic = {}
+                for message in receiver:
+                    print_message(_logger, message)
+                    assert message.delivery_count == 0
+                    assert message.application_properties
+                    assert message.application_properties[b'key'] == b'value'
+                    assert message.subject == 'label'
+                    assert message.content_type == 'application/text'
+                    assert message.correlation_id == 'cid'
+                    assert message.partition_key == session_id
+                    assert message.to == 'to'
+                    assert message.reply_to == 'reply_to'
+                    assert message.sequence_number
+                    assert message.enqueued_time_utc
+                    assert message.session_id == session_id
+                    assert message.reply_to_session_id == 'reply_to_session_id'
+                    count += 1
+                    receiver.complete_message(message)
+                    if message.message_id not in received_cnt_dic:
+                        received_cnt_dic[message.message_id] = 1
+                        sender.send_messages(message)
+                    else:
+                        received_cnt_dic[message.message_id] += 1
 
-#                 assert received_cnt_dic['0'] == 2 and received_cnt_dic['1'] == 2 and received_cnt_dic['2'] == 2
-#                 assert count == 6
+                assert received_cnt_dic['0'] == 2 and received_cnt_dic['1'] == 2 and received_cnt_dic['2'] == 2
+                assert count == 6
 
-#             with pytest.raises(ServiceBusError):
-#                 receiver = sb_client.get_queue_receiver(servicebus_queue.name, session_id=1)
-#                 with receiver:
-#                     pass
+            with pytest.raises(ServiceBusError):
+                receiver = sb_client.get_queue_receiver(servicebus_queue.name, session_id=1)
+                with receiver:
+                    pass
     
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True, lock_duration='PT5S')
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_session_by_queue_client_conn_str_receive_handler_receiveanddelete(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True, lock_duration='PT5S')
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_session_by_queue_client_conn_str_receive_handler_receiveanddelete(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+            fully_qualified_namespace=fully_qualified_namespace,
+            credential=credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-#             session_id = str(uuid.uuid4())
-#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 for i in range(10):
-#                     message = ServiceBusMessage("Handler message no. {}".format(i), session_id=session_id)
-#                     sender.send_messages(message)
+            session_id = str(uuid.uuid4())
+            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                for i in range(10):
+                    message = ServiceBusMessage("Handler message no. {}".format(i), session_id=session_id)
+                    sender.send_messages(message)
 
-#             messages = []
-#             with sb_client.get_queue_receiver(servicebus_queue.name, 
-#                                               session_id=session_id, 
-#                                               receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE, 
-#                                               max_wait_time=5) as receiver:
-#                 for message in receiver:
-#                     messages.append(message)
-#                     assert session_id == receiver._session_id
-#                     assert session_id == message.session_id
-#                     with pytest.raises(ValueError):
-#                         receiver.complete_message(message)
+            messages = []
+            with sb_client.get_queue_receiver(servicebus_queue.name, 
+                                              session_id=session_id, 
+                                              receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE, 
+                                              max_wait_time=5) as receiver:
+                for message in receiver:
+                    messages.append(message)
+                    assert session_id == receiver._session_id
+                    assert session_id == message.session_id
+                    with pytest.raises(ValueError):
+                        receiver.complete_message(message)
 
-#             assert not receiver._running
-#             assert len(messages) == 10
-#             time.sleep(5)
+            assert not receiver._running
+            assert len(messages) == 10
+            time.sleep(5)
 
-#             messages = []
-#             with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE, max_wait_time=5) as session:
-#                 for message in session:
-#                     messages.append(message)
-#                 assert len(messages) == 0
-
-    
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer()
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_session_by_session_client_conn_str_receive_handler_with_stop(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-
-#             session_id = str(uuid.uuid4())
-#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 for i in range(10):
-#                     message = ServiceBusMessage("Stop message no. {}".format(i), session_id=session_id)
-#                     sender.send_messages(message)
-
-#             messages = []
-#             with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=5) as receiver:
-#                 for message in receiver:
-#                     assert session_id == receiver.session.session_id
-#                     assert session_id == message.session_id
-#                     messages.append(message)
-#                     receiver.complete_message(message)
-#                     if len(messages) >= 5:
-#                         break
-
-#                 assert receiver._running
-#                 assert len(messages) == 5
-
-
-#                 for message in receiver:
-#                     assert session_id == receiver.session.session_id
-#                     assert session_id == message.session_id
-#                     messages.append(message)
-#                     receiver.complete_message(message)
-#                     if len(messages) >= 5:
-#                         break
-
-#             assert not receiver._running
-#             assert len(messages) == 6
-
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @pytest.mark.xfail(reason="'Cannot open log' error, potential service bug", raises=ServiceBusError)
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_session_by_session_client_conn_str_receive_handler_with_no_session(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport, retry_total=1) as sb_client:
-#             with pytest.raises(OperationTimeoutError):
-#                 with sb_client.get_queue_receiver(servicebus_queue.name, 
-#                                                   session_id=NEXT_AVAILABLE_SESSION, 
-#                                                   max_wait_time=10,) as session:
-#                     pass
-
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @pytest.mark.xfail(reason="'Cannot open log' error, potential service bug", raises=ServiceBusError)
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_session_connection_failure_is_idempotent(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         #Technically this validates for all senders/receivers, not just session, but since it uses session to generate a recoverable failure, putting it in here.
-#         with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-    
-#             # First let's just try the naive failure cases.
-#             receiver = sb_client.get_queue_receiver("THIS_IS_WRONG_ON_PURPOSE")
-#             with pytest.raises(ServiceBusAuthenticationError):
-#                 receiver._open_with_retry()
-#             assert not receiver._running
-#             assert not receiver._handler
-    
-#             sender = sb_client.get_queue_sender("THIS_IS_WRONG_ON_PURPOSE")
-#             with pytest.raises(ServiceBusAuthenticationError):
-#                 sender._open_with_retry()
-#             assert not receiver._running
-#             assert not receiver._handler
-
-#             # Then let's try a case we can recover from to make sure everything works on reestablishment.
-#             receiver = sb_client.get_queue_receiver(servicebus_queue.name, session_id=NEXT_AVAILABLE_SESSION)
-#             with pytest.raises(OperationTimeoutError):
-#                 receiver._open_with_retry()
-
-#             session_id = str(uuid.uuid4())
-#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 sender.send_messages(ServiceBusMessage("test session sender", session_id=session_id))
-
-#             with sb_client.get_queue_receiver(servicebus_queue.name, session_id=NEXT_AVAILABLE_SESSION, max_wait_time=5) as receiver:
-#                 messages = []
-#                 for message in receiver:
-#                     messages.append(message)
-#                 assert len(messages) == 1
+            messages = []
+            with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE, max_wait_time=5) as session:
+                for message in session:
+                    messages.append(message)
+                assert len(messages) == 0
 
     
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_session_by_session_client_conn_str_receive_handler_with_inactive_session(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer()
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_session_by_session_client_conn_str_receive_handler_with_stop(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+            fully_qualified_namespace=fully_qualified_namespace,
+            credential=credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-#             session_id = str(uuid.uuid4())
-#             messages = []
-#             with sb_client.get_queue_receiver(servicebus_queue.name, 
-#                                               session_id=session_id, 
-#                                               receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE, 
-#                                               max_wait_time=5) as session:
-#                 for message in session:
-#                     messages.append(message)
+            session_id = str(uuid.uuid4())
+            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                for i in range(10):
+                    message = ServiceBusMessage("Stop message no. {}".format(i), session_id=session_id)
+                    sender.send_messages(message)
 
-#                 assert session._running
-#                 assert len(messages) == 0
+            messages = []
+            with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=5) as receiver:
+                for message in receiver:
+                    assert session_id == receiver.session.session_id
+                    assert session_id == message.session_id
+                    messages.append(message)
+                    receiver.complete_message(message)
+                    if len(messages) >= 5:
+                        break
+
+                assert receiver._running
+                assert len(messages) == 5
+
+
+                for message in receiver:
+                    assert session_id == receiver.session.session_id
+                    assert session_id == message.session_id
+                    messages.append(message)
+                    receiver.complete_message(message)
+                    if len(messages) >= 5:
+                        break
+
+            assert not receiver._running
+            assert len(messages) == 6
+
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @pytest.mark.xfail(reason="'Cannot open log' error, potential service bug", raises=ServiceBusError)
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_session_by_session_client_conn_str_receive_handler_with_no_session(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+            fully_qualified_namespace=fully_qualified_namespace,
+            credential=credential, logging_enable=False, uamqp_transport=uamqp_transport, retry_total=1) as sb_client:
+            with pytest.raises(OperationTimeoutError):
+                with sb_client.get_queue_receiver(servicebus_queue.name, 
+                                                  session_id=NEXT_AVAILABLE_SESSION, 
+                                                  max_wait_time=10,) as session:
+                    pass
+
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @pytest.mark.xfail(reason="'Cannot open log' error, potential service bug", raises=ServiceBusError)
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_session_connection_failure_is_idempotent(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        #Technically this validates for all senders/receivers, not just session, but since it uses session to generate a recoverable failure, putting it in here.
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+            fully_qualified_namespace=fully_qualified_namespace,
+            credential=credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+    
+            # First let's just try the naive failure cases.
+            receiver = sb_client.get_queue_receiver("THIS_IS_WRONG_ON_PURPOSE")
+            with pytest.raises(ServiceBusAuthenticationError):
+                receiver._open_with_retry()
+            assert not receiver._running
+            assert not receiver._handler
+    
+            sender = sb_client.get_queue_sender("THIS_IS_WRONG_ON_PURPOSE")
+            with pytest.raises(ServiceBusAuthenticationError):
+                sender._open_with_retry()
+            assert not receiver._running
+            assert not receiver._handler
+
+            # Then let's try a case we can recover from to make sure everything works on reestablishment.
+            receiver = sb_client.get_queue_receiver(servicebus_queue.name, session_id=NEXT_AVAILABLE_SESSION)
+            with pytest.raises(OperationTimeoutError):
+                receiver._open_with_retry()
+
+            session_id = str(uuid.uuid4())
+            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                sender.send_messages(ServiceBusMessage("test session sender", session_id=session_id))
+
+            with sb_client.get_queue_receiver(servicebus_queue.name, session_id=NEXT_AVAILABLE_SESSION, max_wait_time=5) as receiver:
+                messages = []
+                for message in receiver:
+                    messages.append(message)
+                assert len(messages) == 1
 
     
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_session_by_servicebus_client_iter_messages_with_retrieve_deferred_receiver_complete(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_session_by_session_client_conn_str_receive_handler_with_inactive_session(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+            fully_qualified_namespace=fully_qualified_namespace,
+            credential=credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 deferred_messages = []
-#                 session_id = str(uuid.uuid4())
-#                 for i in range(10):
-#                     message = ServiceBusMessage("Deferred message no. {}".format(i), session_id=session_id)
-#                     sender.send_messages(message)
+            session_id = str(uuid.uuid4())
+            messages = []
+            with sb_client.get_queue_receiver(servicebus_queue.name, 
+                                              session_id=session_id, 
+                                              receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE, 
+                                              max_wait_time=5) as session:
+                for message in session:
+                    messages.append(message)
 
-#             count = 0
-#             with sb_client.get_queue_receiver(servicebus_queue.name, 
-#                                               session_id=session_id, 
-#                                               max_wait_time=5) as receiver:
-#                 for message in receiver:
-#                     deferred_messages.append(message.sequence_number)
-#                     print_message(_logger, message)
-#                     count += 1
-#                     receiver.defer_message(message)
-
-#             assert count == 10
-
-#             with sb_client.get_queue_receiver(servicebus_queue.name, 
-#                                               session_id=session_id, 
-#                                               max_wait_time=5) as receiver:
-#                 deferred = receiver.receive_deferred_messages(deferred_messages)
-#                 assert len(deferred) == 10
-#                 for message in deferred:
-#                     assert isinstance(message, ServiceBusReceivedMessage)
-#                     assert message.lock_token
-#                     assert not message.locked_until_utc
-#                     assert message._receiver
-#                     with pytest.raises(TypeError):
-#                         receiver.renew_message_lock(message)
-#                     receiver.complete_message(message)
+                assert session._running
+                assert len(messages) == 0
 
     
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_session_by_servicebus_client_iter_messages_with_retrieve_deferred_receiver_deadletter(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_session_by_servicebus_client_iter_messages_with_retrieve_deferred_receiver_complete(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+            fully_qualified_namespace=fully_qualified_namespace,
+            credential=credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 deferred_messages = []
-#                 session_id = str(uuid.uuid4())
-#                 messages = [ServiceBusMessage("Deferred message no. {}".format(i), session_id=session_id) for i in range(10)]
-#                 sender.send_messages(messages)
+            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                deferred_messages = []
+                session_id = str(uuid.uuid4())
+                for i in range(10):
+                    message = ServiceBusMessage("Deferred message no. {}".format(i), session_id=session_id)
+                    sender.send_messages(message)
 
-#             count = 0
-#             with sb_client.get_queue_receiver(servicebus_queue.name, 
-#                                               session_id=session_id, 
-#                                               max_wait_time=5) as receiver:
-#                 for message in receiver:
-#                     deferred_messages.append(message.sequence_number)
-#                     print_message(_logger, message)
-#                     count += 1
-#                     receiver.defer_message(message)
+            count = 0
+            with sb_client.get_queue_receiver(servicebus_queue.name, 
+                                              session_id=session_id, 
+                                              max_wait_time=5) as receiver:
+                for message in receiver:
+                    deferred_messages.append(message.sequence_number)
+                    print_message(_logger, message)
+                    count += 1
+                    receiver.defer_message(message)
 
-#                 assert count == 10
+            assert count == 10
 
-#             with sb_client.get_queue_receiver(servicebus_queue.name, 
-#                                               session_id=session_id, 
-#                                               max_wait_time=5) as receiver:
-#                 deferred = receiver.receive_deferred_messages(deferred_messages)
-#                 assert len(deferred) == 10
-#                 for message in deferred:
-#                     assert isinstance(message, ServiceBusReceivedMessage)
-#                     receiver.dead_letter_message(message, reason="Testing reason",
-#                                                  error_description="Testing description")
-
-#             count = 0
-#             with sb_client.get_queue_receiver(servicebus_queue.name, 
-#                                               sub_queue=ServiceBusSubQueue.DEAD_LETTER,
-#                                               max_wait_time=5) as receiver:
-#                 for message in receiver:
-#                     count += 1
-#                     print_message(_logger, message)
-#                     assert message.dead_letter_reason == 'Testing reason'
-#                     assert message.dead_letter_error_description == 'Testing description'
-#                     assert message.application_properties[b'DeadLetterReason'] == b'Testing reason'
-#                     assert message.application_properties[b'DeadLetterErrorDescription'] == b'Testing description'
-#                     receiver.complete_message(message)
-#             assert count == 10
+            with sb_client.get_queue_receiver(servicebus_queue.name, 
+                                              session_id=session_id, 
+                                              max_wait_time=5) as receiver:
+                deferred = receiver.receive_deferred_messages(deferred_messages)
+                assert len(deferred) == 10
+                for message in deferred:
+                    assert isinstance(message, ServiceBusReceivedMessage)
+                    assert message.lock_token
+                    assert not message.locked_until_utc
+                    assert message._receiver
+                    with pytest.raises(TypeError):
+                        receiver.renew_message_lock(message)
+                    receiver.complete_message(message)
 
     
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_session_by_servicebus_client_iter_messages_with_retrieve_deferred_receiver_deletemode(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_session_by_servicebus_client_iter_messages_with_retrieve_deferred_receiver_deadletter(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+            fully_qualified_namespace=fully_qualified_namespace,
+            credential=credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 deferred_messages = []
-#                 session_id = str(uuid.uuid4())
-#                 messages = [ServiceBusMessage("Deferred message no. {}".format(i), session_id=session_id) for i in range(10)]
-#                 for message in messages:
-#                     sender.send_messages(message)
+            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                deferred_messages = []
+                session_id = str(uuid.uuid4())
+                messages = [ServiceBusMessage("Deferred message no. {}".format(i), session_id=session_id) for i in range(10)]
+                sender.send_messages(messages)
 
-#             count = 0
-#             with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=5) as receiver:
-#                 for message in receiver:
-#                     deferred_messages.append(message.sequence_number)
-#                     print_message(_logger, message)
-#                     count += 1
-#                     receiver.defer_message(message)
+            count = 0
+            with sb_client.get_queue_receiver(servicebus_queue.name, 
+                                              session_id=session_id, 
+                                              max_wait_time=5) as receiver:
+                for message in receiver:
+                    deferred_messages.append(message.sequence_number)
+                    print_message(_logger, message)
+                    count += 1
+                    receiver.defer_message(message)
 
-#             assert count == 10
-#             with sb_client.get_queue_receiver(servicebus_queue.name, 
-#                                               session_id=session_id, 
-#                                               max_wait_time=5,
-#                                               receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE) as receiver:
-#                 deferred = receiver.receive_deferred_messages(deferred_messages)
-#                 assert len(deferred) == 10
-#                 for message in deferred:
-#                     assert isinstance(message, ServiceBusReceivedMessage)
-#                     with pytest.raises(ValueError):
-#                         receiver.complete_message(message)
-#                 with pytest.raises(ServiceBusError):
-#                     deferred = receiver.receive_deferred_messages(deferred_messages)
+                assert count == 10
 
-    
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_session_by_servicebus_client_iter_messages_with_retrieve_deferred_client(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+            with sb_client.get_queue_receiver(servicebus_queue.name, 
+                                              session_id=session_id, 
+                                              max_wait_time=5) as receiver:
+                deferred = receiver.receive_deferred_messages(deferred_messages)
+                assert len(deferred) == 10
+                for message in deferred:
+                    assert isinstance(message, ServiceBusReceivedMessage)
+                    receiver.dead_letter_message(message, reason="Testing reason",
+                                                 error_description="Testing description")
 
-#             deferred_messages = []
-#             session_id = str(uuid.uuid4())
-#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 for i in range(10):
-#                     message = ServiceBusMessage("Deferred message no. {}".format(i), session_id=session_id)
-#                     sender.send_messages(message)
-
-#             with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=5) as receiver:
-#                 count = 0
-#                 for message in receiver:
-#                     deferred_messages.append(message.sequence_number)
-#                     print_message(_logger, message)
-#                     count += 1
-#                     receiver.defer_message(message)
-
-#                 assert count == 10
-
-#                 deferred = receiver.receive_deferred_messages(deferred_messages)
-
-#                 with pytest.raises(MessageAlreadySettled):
-#                     receiver.complete_message(message)
+            count = 0
+            with sb_client.get_queue_receiver(servicebus_queue.name, 
+                                              sub_queue=ServiceBusSubQueue.DEAD_LETTER,
+                                              max_wait_time=5) as receiver:
+                for message in receiver:
+                    count += 1
+                    print_message(_logger, message)
+                    assert message.dead_letter_reason == 'Testing reason'
+                    assert message.dead_letter_error_description == 'Testing description'
+                    assert message.application_properties[b'DeadLetterReason'] == b'Testing reason'
+                    assert message.application_properties[b'DeadLetterErrorDescription'] == b'Testing description'
+                    receiver.complete_message(message)
+            assert count == 10
 
     
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_session_by_servicebus_client_receive_with_retrieve_deadletter(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_session_by_servicebus_client_iter_messages_with_retrieve_deferred_receiver_deletemode(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+            fully_qualified_namespace=fully_qualified_namespace,
+            credential=credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-#         with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                deferred_messages = []
+                session_id = str(uuid.uuid4())
+                messages = [ServiceBusMessage("Deferred message no. {}".format(i), session_id=session_id) for i in range(10)]
+                for message in messages:
+                    sender.send_messages(message)
 
-#             session_id = str(uuid.uuid4())
-#             with sb_client.get_queue_receiver(servicebus_queue.name, 
-#                                               session_id=session_id, 
-#                                               max_wait_time=5, 
-#                                               prefetch_count=10) as receiver:
+            count = 0
+            with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=5) as receiver:
+                for message in receiver:
+                    deferred_messages.append(message.sequence_number)
+                    print_message(_logger, message)
+                    count += 1
+                    receiver.defer_message(message)
 
-#                 with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                     for i in range(10):
-#                         message = ServiceBusMessage("Dead lettered message no. {}".format(i), session_id=session_id)
-#                         sender.send_messages(message)
-
-#                 count = 0
-#                 messages = receiver.receive_messages()
-#                 while messages:
-#                     for message in messages:
-#                         print_message(_logger, message)
-#                         receiver.dead_letter_message(message, reason="Testing reason", error_description="Testing description")
-#                         count += 1
-#                     messages = receiver.receive_messages()
-#             assert count == 10
-
-#             with sb_client.get_queue_receiver(servicebus_queue.name,
-#                                               sub_queue = ServiceBusSubQueue.DEAD_LETTER,
-#                                               max_wait_time=5) as receiver:
-#                 count = 0
-#                 for message in receiver:
-#                     print_message(_logger, message)
-#                     receiver.complete_message(message)
-#                     assert message.dead_letter_reason == 'Testing reason'
-#                     assert message.dead_letter_error_description == 'Testing description'
-#                     assert message.application_properties[b'DeadLetterReason'] == b'Testing reason'
-#                     assert message.application_properties[b'DeadLetterErrorDescription'] == b'Testing description'
-#                     count += 1
-#             assert count == 10
-
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_session_by_servicebus_client_browse_messages_client(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-#             session_id = str(uuid.uuid4())
-#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 for i in range(5):
-#                     message = ServiceBusMessage("Test message no. {}".format(i), session_id=session_id)
-#                     sender.send_messages(message)
-#             session_id_2 = str(uuid.uuid4())
-#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 for i in range(3):
-#                     message = ServiceBusMessage("Test message no. {}".format(i), session_id=session_id_2)
-#                     sender.send_messages(message)
-
-#             with pytest.raises(ServiceBusError):
-#                 with sb_client.get_queue_receiver(servicebus_queue.name):
-#                     messages = sb_client.peek_messages(5)
-
-#             with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id) as receiver:
-#                 messages = receiver.peek_messages(5)
-#                 assert len(messages) == 5
-#                 assert all(isinstance(m, ServiceBusReceivedMessage) for m in messages)
-#                 for message in messages:
-#                     print_message(_logger, message)
-#                     with pytest.raises(ValueError):
-#                         receiver.complete_message(message)
-
-#             with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id_2) as receiver:
-#                 messages = receiver.peek_messages(5)
-#                 assert len(messages) == 3
-
-
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_session_by_servicebus_client_browse_messages_with_receiver(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-
-#         with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-
-#             session_id = str(uuid.uuid4())
-#             with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5, session_id=session_id) as receiver:
-#                 with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                     for i in range(5):
-#                         message = ServiceBusMessage("Test message no. {}".format(i), session_id=session_id)
-#                         sender.send_messages(message)
-
-#                 messages = receiver.peek_messages(5)
-#                 assert len(messages) > 0
-#                 assert all(isinstance(m, ServiceBusReceivedMessage) for m in messages)
-#                 for message in messages:
-#                     print_message(_logger, message)
-#                     with pytest.raises(ValueError):
-#                         receiver.complete_message(message)
-
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_session_by_servicebus_client_renew_client_locks(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-
-#             session_id = str(uuid.uuid4())
-#             messages = []
-#             locks = 3
-#             with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, prefetch_count=10) as receiver:
-#                 with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                     for i in range(locks):
-#                         message = ServiceBusMessage("Test message no. {}".format(i), session_id=session_id)
-#                         sender.send_messages(message)
-
-#                 messages.extend(receiver.receive_messages())
-#                 recv = True
-#                 while recv:
-#                     recv = receiver.receive_messages(max_wait_time=5)
-#                     messages.extend(recv)
-
-#                 try:
-#                     for m in messages:
-#                         with pytest.raises(TypeError):
-#                             expired = m._lock_expired
-#                         assert m.locked_until_utc is None
-#                         assert m.lock_token is not None
-#                     time.sleep(5)
-#                     initial_expiry = receiver.session._locked_until_utc
-#                     receiver.session.renew_lock(timeout=5)
-#                     assert (receiver.session._locked_until_utc - initial_expiry) >= timedelta(seconds=5)
-#                 finally:
-#                     receiver.complete_message(messages[0])
-#                     receiver.complete_message(messages[1])
-
-#                     # This magic number is because of a 30 second lock renewal window.  Chose 31 seconds because at 30, you'll see "off by .05 seconds" flaky failures
-#                     # potentially as a side effect of network delays/sleeps/"typical distributed systems nonsense."  In a perfect world we wouldn't have a magic number/network hop but this allows
-#                     # a slightly more robust test in absence of that.
-#                     assert (receiver.session._locked_until_utc - utc_now()) <= timedelta(seconds=60)
-#                     sleep_until_expired(receiver.session)
-#                     with pytest.raises(SessionLockLostError):
-#                         receiver.complete_message(messages[2])
+            assert count == 10
+            with sb_client.get_queue_receiver(servicebus_queue.name, 
+                                              session_id=session_id, 
+                                              max_wait_time=5,
+                                              receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE) as receiver:
+                deferred = receiver.receive_deferred_messages(deferred_messages)
+                assert len(deferred) == 10
+                for message in deferred:
+                    assert isinstance(message, ServiceBusReceivedMessage)
+                    with pytest.raises(ValueError):
+                        receiver.complete_message(message)
+                with pytest.raises(ServiceBusError):
+                    deferred = receiver.receive_deferred_messages(deferred_messages)
 
     
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True, lock_duration='PT10S')
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_session_by_conn_str_receive_handler_with_autolockrenew(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_session_by_servicebus_client_iter_messages_with_retrieve_deferred_client(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+            fully_qualified_namespace=fully_qualified_namespace,
+            credential=credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-#         session_id = str(uuid.uuid4())
-#         with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+            deferred_messages = []
+            session_id = str(uuid.uuid4())
+            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                for i in range(10):
+                    message = ServiceBusMessage("Deferred message no. {}".format(i), session_id=session_id)
+                    sender.send_messages(message)
 
-#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 for i in range(10):
-#                     message = ServiceBusMessage("{}".format(i), session_id=session_id)
-#                     sender.send_messages(message)
+            with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=5) as receiver:
+                count = 0
+                for message in receiver:
+                    deferred_messages.append(message.sequence_number)
+                    print_message(_logger, message)
+                    count += 1
+                    receiver.defer_message(message)
 
-#             results = []
-#             def lock_lost_callback(renewable, error):
-#                 results.append(renewable)
+                assert count == 10
 
-#             renewer = AutoLockRenewer()
-#             messages = []
-#             with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=10, receive_mode=ServiceBusReceiveMode.PEEK_LOCK, prefetch_count=10) as receiver:
-#                 renewer.register(receiver,
-#                                  receiver.session,
-#                                  max_lock_renewal_duration=10,
-#                                  on_lock_renew_failure=lock_lost_callback)
-#                 print("Registered lock renew thread", receiver.session._locked_until_utc, utc_now())
-#                 with pytest.raises(SessionLockLostError):
-#                     for message in receiver:
-#                         if not messages:
-#                             print("Starting first sleep")
-#                             time.sleep(10)
-#                             print("First sleep {}".format(receiver.session._locked_until_utc - utc_now()))
-#                             assert not receiver.session._lock_expired
-#                             with pytest.raises(TypeError):
-#                                 message._lock_expired
-#                             assert message.locked_until_utc is None
-#                             with pytest.raises(TypeError):
-#                                 receiver.renew_message_lock(message)
-#                             assert message.lock_token is not None
-#                             receiver.complete_message(message)
-#                             messages.append(message)
+                deferred = receiver.receive_deferred_messages(deferred_messages)
 
-#                         elif len(messages) == 1:
-#                             print("Starting second sleep")
-#                             time.sleep(10) # ensure renewer expires
-#                             print("Second sleep {}".format(receiver.session._locked_until_utc - utc_now()))
-#                             assert not results
-#                             sleep_until_expired(receiver.session) # and then ensure it didn't slip a renew under the wire.
-#                             assert receiver.session._lock_expired
-#                             assert isinstance(receiver.session.auto_renew_error, AutoLockRenewTimeout)
-#                             try:
-#                                 receiver.complete_message(message)
-#                                 raise AssertionError("Didn't raise SessionLockLostError")
-#                             except SessionLockLostError as e:
-#                                 assert isinstance(e.inner_exception, AutoLockRenewTimeout)
-#                             messages.append(message)
-
-#             # While we're testing autolockrenew and sessions, let's make sure we don't call the lock-lost callback when a session exits.
-#             renewer._renew_period = 1
-#             session = None
-
-#             with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=10, receive_mode=ServiceBusReceiveMode.PEEK_LOCK, prefetch_count=10) as receiver:
-#                 session = receiver.session
-#                 renewer.register(receiver,
-#                                  session,
-#                                  max_lock_renewal_duration=10,
-#                                  on_lock_renew_failure=lock_lost_callback)
-#             sleep_until_expired(receiver.session)
-#             assert not results
-
-#             renewer.close()
-#             assert len(messages) == 2
+                with pytest.raises(MessageAlreadySettled):
+                    receiver.complete_message(message)
 
     
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True, lock_duration='PT10S')
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_session_by_conn_str_receive_handler_with_auto_autolockrenew(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_session_by_servicebus_client_receive_with_retrieve_deadletter(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
 
-#         session_id = str(uuid.uuid4())
-#         with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=True, uamqp_transport=uamqp_transport) as sb_client:
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+            fully_qualified_namespace=fully_qualified_namespace,
+            credential=credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 for i in range(10):
-#                     message = ServiceBusMessage("{}".format(i), session_id=session_id)
-#                     sender.send_messages(message)
+            session_id = str(uuid.uuid4())
+            with sb_client.get_queue_receiver(servicebus_queue.name, 
+                                              session_id=session_id, 
+                                              max_wait_time=5, 
+                                              prefetch_count=10) as receiver:
 
-#             results = []
-#             def lock_lost_callback(renewable, error):
-#                 results.append(renewable)
+                with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                    for i in range(10):
+                        message = ServiceBusMessage("Dead lettered message no. {}".format(i), session_id=session_id)
+                        sender.send_messages(message)
 
-#             renewer = AutoLockRenewer(max_lock_renewal_duration=10, on_lock_renew_failure = lock_lost_callback)
-#             messages = []
-#             with sb_client.get_queue_receiver(servicebus_queue.name,
-#                                               session_id=session_id,
-#                                               max_wait_time=10,
-#                                               receive_mode=ServiceBusReceiveMode.PEEK_LOCK,
-#                                               prefetch_count=10,
-#                                               auto_lock_renewer=renewer) as receiver:
-#                 print("Registered lock renew thread", receiver.session._locked_until_utc, utc_now())
-#                 with pytest.raises(SessionLockLostError):
-#                     for message in receiver:
-#                         if not messages:
-#                             print("Starting first sleep")
-#                             time.sleep(10)
-#                             print("First sleep {}".format(receiver.session._locked_until_utc - utc_now()))
-#                             assert not receiver.session._lock_expired
-#                             with pytest.raises(TypeError):
-#                                 message._lock_expired
-#                             assert message.locked_until_utc is None
-#                             with pytest.raises(TypeError):
-#                                 receiver.renew_message_lock(message)
-#                             assert message.lock_token is not None
-#                             receiver.complete_message(message)
-#                             messages.append(message)
+                count = 0
+                messages = receiver.receive_messages()
+                while messages:
+                    for message in messages:
+                        print_message(_logger, message)
+                        receiver.dead_letter_message(message, reason="Testing reason", error_description="Testing description")
+                        count += 1
+                    messages = receiver.receive_messages()
+            assert count == 10
 
-#                         elif len(messages) == 1:
-#                             print("Starting second sleep")
-#                             time.sleep(10) # ensure renewer expires
-#                             print("Second sleep {}".format(receiver.session._locked_until_utc - utc_now()))
-#                             assert not results
-#                             sleep_until_expired(receiver.session) # and then ensure it didn't slip a renew under the wire.
-#                             assert receiver.session._lock_expired
-#                             assert isinstance(receiver.session.auto_renew_error, AutoLockRenewTimeout)
-#                             try:
-#                                 receiver.complete_message(message)
-#                                 raise AssertionError("Didn't raise SessionLockLostError")
-#                             except SessionLockLostError as e:
-#                                 assert isinstance(e.inner_exception, AutoLockRenewTimeout)
-#                             messages.append(message)
+            with sb_client.get_queue_receiver(servicebus_queue.name,
+                                              sub_queue = ServiceBusSubQueue.DEAD_LETTER,
+                                              max_wait_time=5) as receiver:
+                count = 0
+                for message in receiver:
+                    print_message(_logger, message)
+                    receiver.complete_message(message)
+                    assert message.dead_letter_reason == 'Testing reason'
+                    assert message.dead_letter_error_description == 'Testing description'
+                    assert message.application_properties[b'DeadLetterReason'] == b'Testing reason'
+                    assert message.application_properties[b'DeadLetterErrorDescription'] == b'Testing description'
+                    count += 1
+            assert count == 10
 
-#             # While we're testing autolockrenew and sessions, let's make sure we don't call the lock-lost callback when a session exits.
-#             renewer._renew_period = 1
-#             session = None
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_session_by_servicebus_client_browse_messages_client(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+            fully_qualified_namespace=fully_qualified_namespace,
+            credential=credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+            session_id = str(uuid.uuid4())
+            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                for i in range(5):
+                    message = ServiceBusMessage("Test message no. {}".format(i), session_id=session_id)
+                    sender.send_messages(message)
+            session_id_2 = str(uuid.uuid4())
+            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                for i in range(3):
+                    message = ServiceBusMessage("Test message no. {}".format(i), session_id=session_id_2)
+                    sender.send_messages(message)
 
-#             with sb_client.get_queue_receiver(servicebus_queue.name,
-#                                               session_id=session_id,
-#                                               max_wait_time=10,
-#                                               receive_mode=ServiceBusReceiveMode.PEEK_LOCK,
-#                                               prefetch_count=10,
-#                                               auto_lock_renewer=renewer) as receiver:
-#                 session = receiver.session
-#             sleep_until_expired(receiver.session)
-#             assert not results
+            with pytest.raises(ServiceBusError):
+                with sb_client.get_queue_receiver(servicebus_queue.name):
+                    messages = sb_client.peek_messages(5)
 
-#             renewer.close()
-#             assert len(messages) == 2
+            with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id) as receiver:
+                messages = receiver.peek_messages(5)
+                assert len(messages) == 5
+                assert all(isinstance(m, ServiceBusReceivedMessage) for m in messages)
+                for message in messages:
+                    print_message(_logger, message)
+                    with pytest.raises(ValueError):
+                        receiver.complete_message(message)
 
-#         # test voluntary halt of auto lock renewer when session is closed
-#         session_id = str(uuid.uuid4())
-#         with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#             messages = [ServiceBusMessage("{}".format(i), session_id=session_id) for i in range(10)]
-#             sender.send_messages(messages)
+            with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id_2) as receiver:
+                messages = receiver.peek_messages(5)
+                assert len(messages) == 3
 
-#         renewer = AutoLockRenewer(max_lock_renewal_duration=100)
-#         receiver = sb_client.get_queue_receiver(servicebus_queue.name,
-#                                             session_id=session_id,
-#                                             max_wait_time=10,
-#                                             prefetch_count=10,
-#                                             auto_lock_renewer=renewer)
 
-#         with receiver:
-#             received_msgs = receiver.receive_messages(max_wait_time=5)
-#             for msg in received_msgs:
-#                 receiver.complete_message(msg)
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_session_by_servicebus_client_browse_messages_with_receiver(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
 
-#         receiver.close()
-#         assert not renewer._renewable(receiver._session)
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+            fully_qualified_namespace=fully_qualified_namespace,
+            credential=credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @CachedServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_session_receiver_partially_invalid_autolockrenew_mode(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         session_id = str(uuid.uuid4())
-#         with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+            session_id = str(uuid.uuid4())
+            with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5, session_id=session_id) as receiver:
+                with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                    for i in range(5):
+                        message = ServiceBusMessage("Test message no. {}".format(i), session_id=session_id)
+                        sender.send_messages(message)
 
-#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 sender.send_messages(ServiceBusMessage("test_message", session_id=session_id))
+                messages = receiver.peek_messages(5)
+                assert len(messages) > 0
+                assert all(isinstance(m, ServiceBusReceivedMessage) for m in messages)
+                for message in messages:
+                    print_message(_logger, message)
+                    with pytest.raises(ValueError):
+                        receiver.complete_message(message)
 
-#             failures = 0
-#             def should_not_run(*args, **kwargs):
-#                 failures += 1
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_session_by_servicebus_client_renew_client_locks(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+            fully_qualified_namespace=fully_qualified_namespace,
+            credential=credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-#             auto_lock_renewer = AutoLockRenewer(on_lock_renew_failure=should_not_run)
-#             with sb_client.get_queue_receiver(servicebus_queue.name, 
-#                                               session_id=session_id,
-#                                               receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE,
-#                                               auto_lock_renewer=auto_lock_renewer) as receiver:
+            session_id = str(uuid.uuid4())
+            messages = []
+            locks = 3
+            with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, prefetch_count=10) as receiver:
+                with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                    for i in range(locks):
+                        message = ServiceBusMessage("Test message no. {}".format(i), session_id=session_id)
+                        sender.send_messages(message)
+
+                messages.extend(receiver.receive_messages())
+                recv = True
+                while recv:
+                    recv = receiver.receive_messages(max_wait_time=5)
+                    messages.extend(recv)
+
+                try:
+                    for m in messages:
+                        with pytest.raises(TypeError):
+                            expired = m._lock_expired
+                        assert m.locked_until_utc is None
+                        assert m.lock_token is not None
+                    time.sleep(5)
+                    initial_expiry = receiver.session._locked_until_utc
+                    receiver.session.renew_lock(timeout=5)
+                    assert (receiver.session._locked_until_utc - initial_expiry) >= timedelta(seconds=5)
+                finally:
+                    receiver.complete_message(messages[0])
+                    receiver.complete_message(messages[1])
+
+                    # This magic number is because of a 30 second lock renewal window.  Chose 31 seconds because at 30, you'll see "off by .05 seconds" flaky failures
+                    # potentially as a side effect of network delays/sleeps/"typical distributed systems nonsense."  In a perfect world we wouldn't have a magic number/network hop but this allows
+                    # a slightly more robust test in absence of that.
+                    assert (receiver.session._locked_until_utc - utc_now()) <= timedelta(seconds=60)
+                    sleep_until_expired(receiver.session)
+                    with pytest.raises(SessionLockLostError):
+                        receiver.complete_message(messages[2])
+
+    
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True, lock_duration='PT10S')
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_session_by_conn_str_receive_handler_with_autolockrenew(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+
+        session_id = str(uuid.uuid4())
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+            fully_qualified_namespace=fully_qualified_namespace,
+            credential=credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+
+            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                for i in range(10):
+                    message = ServiceBusMessage("{}".format(i), session_id=session_id)
+                    sender.send_messages(message)
+
+            results = []
+            def lock_lost_callback(renewable, error):
+                results.append(renewable)
+
+            renewer = AutoLockRenewer()
+            messages = []
+            with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=10, receive_mode=ServiceBusReceiveMode.PEEK_LOCK, prefetch_count=10) as receiver:
+                renewer.register(receiver,
+                                 receiver.session,
+                                 max_lock_renewal_duration=10,
+                                 on_lock_renew_failure=lock_lost_callback)
+                print("Registered lock renew thread", receiver.session._locked_until_utc, utc_now())
+                with pytest.raises(SessionLockLostError):
+                    for message in receiver:
+                        if not messages:
+                            print("Starting first sleep")
+                            time.sleep(10)
+                            print("First sleep {}".format(receiver.session._locked_until_utc - utc_now()))
+                            assert not receiver.session._lock_expired
+                            with pytest.raises(TypeError):
+                                message._lock_expired
+                            assert message.locked_until_utc is None
+                            with pytest.raises(TypeError):
+                                receiver.renew_message_lock(message)
+                            assert message.lock_token is not None
+                            receiver.complete_message(message)
+                            messages.append(message)
+
+                        elif len(messages) == 1:
+                            print("Starting second sleep")
+                            time.sleep(10) # ensure renewer expires
+                            print("Second sleep {}".format(receiver.session._locked_until_utc - utc_now()))
+                            assert not results
+                            sleep_until_expired(receiver.session) # and then ensure it didn't slip a renew under the wire.
+                            assert receiver.session._lock_expired
+                            assert isinstance(receiver.session.auto_renew_error, AutoLockRenewTimeout)
+                            try:
+                                receiver.complete_message(message)
+                                raise AssertionError("Didn't raise SessionLockLostError")
+                            except SessionLockLostError as e:
+                                assert isinstance(e.inner_exception, AutoLockRenewTimeout)
+                            messages.append(message)
+
+            # While we're testing autolockrenew and sessions, let's make sure we don't call the lock-lost callback when a session exits.
+            renewer._renew_period = 1
+            session = None
+
+            with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=10, receive_mode=ServiceBusReceiveMode.PEEK_LOCK, prefetch_count=10) as receiver:
+                session = receiver.session
+                renewer.register(receiver,
+                                 session,
+                                 max_lock_renewal_duration=10,
+                                 on_lock_renew_failure=lock_lost_callback)
+            sleep_until_expired(receiver.session)
+            assert not results
+
+            renewer.close()
+            assert len(messages) == 2
+
+    
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True, lock_duration='PT10S')
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_session_by_conn_str_receive_handler_with_auto_autolockrenew(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+
+        session_id = str(uuid.uuid4())
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+            fully_qualified_namespace=fully_qualified_namespace,
+            credential=credential, logging_enable=True, uamqp_transport=uamqp_transport) as sb_client:
+
+            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                for i in range(10):
+                    message = ServiceBusMessage("{}".format(i), session_id=session_id)
+                    sender.send_messages(message)
+
+            results = []
+            def lock_lost_callback(renewable, error):
+                results.append(renewable)
+
+            renewer = AutoLockRenewer(max_lock_renewal_duration=10, on_lock_renew_failure = lock_lost_callback)
+            messages = []
+            with sb_client.get_queue_receiver(servicebus_queue.name,
+                                              session_id=session_id,
+                                              max_wait_time=10,
+                                              receive_mode=ServiceBusReceiveMode.PEEK_LOCK,
+                                              prefetch_count=10,
+                                              auto_lock_renewer=renewer) as receiver:
+                print("Registered lock renew thread", receiver.session._locked_until_utc, utc_now())
+                with pytest.raises(SessionLockLostError):
+                    for message in receiver:
+                        if not messages:
+                            print("Starting first sleep")
+                            time.sleep(10)
+                            print("First sleep {}".format(receiver.session._locked_until_utc - utc_now()))
+                            assert not receiver.session._lock_expired
+                            with pytest.raises(TypeError):
+                                message._lock_expired
+                            assert message.locked_until_utc is None
+                            with pytest.raises(TypeError):
+                                receiver.renew_message_lock(message)
+                            assert message.lock_token is not None
+                            receiver.complete_message(message)
+                            messages.append(message)
+
+                        elif len(messages) == 1:
+                            print("Starting second sleep")
+                            time.sleep(10) # ensure renewer expires
+                            print("Second sleep {}".format(receiver.session._locked_until_utc - utc_now()))
+                            assert not results
+                            sleep_until_expired(receiver.session) # and then ensure it didn't slip a renew under the wire.
+                            assert receiver.session._lock_expired
+                            assert isinstance(receiver.session.auto_renew_error, AutoLockRenewTimeout)
+                            try:
+                                receiver.complete_message(message)
+                                raise AssertionError("Didn't raise SessionLockLostError")
+                            except SessionLockLostError as e:
+                                assert isinstance(e.inner_exception, AutoLockRenewTimeout)
+                            messages.append(message)
+
+            # While we're testing autolockrenew and sessions, let's make sure we don't call the lock-lost callback when a session exits.
+            renewer._renew_period = 1
+            session = None
+
+            with sb_client.get_queue_receiver(servicebus_queue.name,
+                                              session_id=session_id,
+                                              max_wait_time=10,
+                                              receive_mode=ServiceBusReceiveMode.PEEK_LOCK,
+                                              prefetch_count=10,
+                                              auto_lock_renewer=renewer) as receiver:
+                session = receiver.session
+            sleep_until_expired(receiver.session)
+            assert not results
+
+            renewer.close()
+            assert len(messages) == 2
+
+        # test voluntary halt of auto lock renewer when session is closed
+        session_id = str(uuid.uuid4())
+        with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+            messages = [ServiceBusMessage("{}".format(i), session_id=session_id) for i in range(10)]
+            sender.send_messages(messages)
+
+        renewer = AutoLockRenewer(max_lock_renewal_duration=100)
+        receiver = sb_client.get_queue_receiver(servicebus_queue.name,
+                                            session_id=session_id,
+                                            max_wait_time=10,
+                                            prefetch_count=10,
+                                            auto_lock_renewer=renewer)
+
+        with receiver:
+            received_msgs = receiver.receive_messages(max_wait_time=5)
+            for msg in received_msgs:
+                receiver.complete_message(msg)
+
+        receiver.close()
+        assert not renewer._renewable(receiver._session)
+
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @CachedServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_session_receiver_partially_invalid_autolockrenew_mode(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        session_id = str(uuid.uuid4())
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+            fully_qualified_namespace=fully_qualified_namespace,
+            credential=credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+
+            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                sender.send_messages(ServiceBusMessage("test_message", session_id=session_id))
+
+            failures = 0
+            def should_not_run(*args, **kwargs):
+                failures += 1
+
+            auto_lock_renewer = AutoLockRenewer(on_lock_renew_failure=should_not_run)
+            with sb_client.get_queue_receiver(servicebus_queue.name, 
+                                              session_id=session_id,
+                                              receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE,
+                                              auto_lock_renewer=auto_lock_renewer) as receiver:
             
-#                 assert receiver.receive_messages()
-#                 assert not failures
+                assert receiver.receive_messages()
+                assert not failures
 
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer()
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_session_message_connection_closed(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer()
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_session_message_connection_closed(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
         
-#         with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+            fully_qualified_namespace=fully_qualified_namespace,
+            credential=credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-#             session_id = str(uuid.uuid4())
+            session_id = str(uuid.uuid4())
 
-#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 message = ServiceBusMessage("test")
-#                 message.session_id = session_id
-#                 sender.send_messages(message)
+            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                message = ServiceBusMessage("test")
+                message.session_id = session_id
+                sender.send_messages(message)
 
-#             with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id) as receiver:
-#                 messages = receiver.receive_messages(max_wait_time=10)
-#                 assert len(messages) == 1
+            with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id) as receiver:
+                messages = receiver.receive_messages(max_wait_time=10)
+                assert len(messages) == 1
 
-#             with pytest.raises(ValueError):
-#                 receiver.complete_message(messages[0])
+            with pytest.raises(ValueError):
+                receiver.complete_message(messages[0])
 
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer()
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True, lock_duration='PT5S')
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_session_message_expiry(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer()
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True, lock_duration='PT5S')
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_session_message_expiry(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
 
-#         with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-#             session_id = str(uuid.uuid4())
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+            fully_qualified_namespace=fully_qualified_namespace,
+            credential=credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+            session_id = str(uuid.uuid4())
 
-#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 message = ServiceBusMessage("Testing expired messages")
-#                 message.session_id = session_id
-#                 sender.send_messages(message)
+            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                message = ServiceBusMessage("Testing expired messages")
+                message.session_id = session_id
+                sender.send_messages(message)
 
-#             with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id) as receiver:
-#                 messages = receiver.receive_messages(max_wait_time=10)
-#                 assert len(messages) == 1
-#                 print_message(_logger, messages[0])
-#                 time.sleep(10)
-#                 with pytest.raises(TypeError):
-#                     messages[0]._lock_expired
-#                 with pytest.raises(TypeError):
-#                     receiver.renew_message_lock(messages[0])
-#                     #TODO: Bug: Why was this 30s sleep before?  compare with T1.
-#                 assert receiver.session._lock_expired
-#                 with pytest.raises(SessionLockLostError):
-#                     receiver.complete_message(messages[0])
-#                 with pytest.raises(SessionLockLostError):
-#                     receiver.session.renew_lock()
+            with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id) as receiver:
+                messages = receiver.receive_messages(max_wait_time=10)
+                assert len(messages) == 1
+                print_message(_logger, messages[0])
+                time.sleep(10)
+                with pytest.raises(TypeError):
+                    messages[0]._lock_expired
+                with pytest.raises(TypeError):
+                    receiver.renew_message_lock(messages[0])
+                    #TODO: Bug: Why was this 30s sleep before?  compare with T1.
+                assert receiver.session._lock_expired
+                with pytest.raises(SessionLockLostError):
+                    receiver.complete_message(messages[0])
+                with pytest.raises(SessionLockLostError):
+                    receiver.session.renew_lock()
 
-#             with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id) as receiver:
-#                 messages = receiver.receive_messages(max_wait_time=30)
-#                 assert len(messages) == 1
-#                 print_message(_logger, messages[0])
-#                 assert messages[0].delivery_count
-#                 receiver.complete_message(messages[0])
+            with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id) as receiver:
+                messages = receiver.receive_messages(max_wait_time=30)
+                assert len(messages) == 1
+                print_message(_logger, messages[0])
+                assert messages[0].delivery_count
+                receiver.complete_message(messages[0])
 
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_session_schedule_message(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_session_schedule_message(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
 
-#         with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+            fully_qualified_namespace=fully_qualified_namespace,
+            credential=credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-#             session_id = str(uuid.uuid4())
-#             enqueue_time = (utc_now() + timedelta(minutes=2)).replace(microsecond=0)
-#             with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id) as receiver:
-#                 with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                     content = str(uuid.uuid4())
-#                     message_id = uuid.uuid4()
-#                     message = ServiceBusMessage(content, session_id=session_id)
-#                     message.message_id = message_id
-#                     message.scheduled_enqueue_time_utc = enqueue_time
-#                     sender.send_messages(message)
+            session_id = str(uuid.uuid4())
+            enqueue_time = (utc_now() + timedelta(minutes=2)).replace(microsecond=0)
+            with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id) as receiver:
+                with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                    content = str(uuid.uuid4())
+                    message_id = uuid.uuid4()
+                    message = ServiceBusMessage(content, session_id=session_id)
+                    message.message_id = message_id
+                    message.scheduled_enqueue_time_utc = enqueue_time
+                    sender.send_messages(message)
 
-#                 messages = []
-#                 count = 0
-#                 while not messages and count < 12:
-#                     messages = receiver.receive_messages(max_wait_time=10)
-#                     receiver.session.renew_lock(timeout=None)
-#                     count += 1
+                messages = []
+                count = 0
+                while not messages and count < 12:
+                    messages = receiver.receive_messages(max_wait_time=10)
+                    receiver.session.renew_lock(timeout=None)
+                    count += 1
 
-#                 data = str(messages[0])
-#                 assert data == content
-#                 assert messages[0].message_id == message_id
-#                 assert messages[0].scheduled_enqueue_time_utc == enqueue_time
-#                 assert messages[0].scheduled_enqueue_time_utc == messages[0].enqueued_time_utc.replace(microsecond=0)
-#                 assert len(messages) == 1
-
-
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_session_schedule_multiple_messages(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-
-#         with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-
-#             session_id = str(uuid.uuid4())
-#             enqueue_time = (utc_now() + timedelta(minutes=2)).replace(microsecond=0)
-
-#             with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, prefetch_count=20) as receiver:
-#                 with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                     content = str(uuid.uuid4())
-#                     message_id_a = uuid.uuid4()
-#                     message_a = ServiceBusMessage(content, session_id=session_id)
-#                     message_a.message_id = message_id_a
-#                     message_id_b = uuid.uuid4()
-#                     message_b = ServiceBusMessage(content, session_id=session_id)
-#                     message_b.message_id = message_id_b
-#                     tokens = sender.schedule_messages([message_a, message_b], enqueue_time)
-#                     assert len(tokens) == 2
-
-#                 messages = []
-#                 count = 0
-#                 while len(messages) < 2 and count < 12:
-#                     receiver.session.renew_lock(timeout=None)
-#                     messages.extend(receiver.receive_messages(max_wait_time=15))
-#                     time.sleep(5)
-#                     count += 1
-
-#                 data = str(messages[0])
-#                 assert data == content
-#                 assert messages[0].message_id in (message_id_a, message_id_b)
-#                 assert messages[0].scheduled_enqueue_time_utc == enqueue_time
-#                 assert messages[0].scheduled_enqueue_time_utc == messages[0].enqueued_time_utc.replace(microsecond=0)
-#                 assert len(messages) == 2
+                data = str(messages[0])
+                assert data == content
+                assert messages[0].message_id == message_id
+                assert messages[0].scheduled_enqueue_time_utc == enqueue_time
+                assert messages[0].scheduled_enqueue_time_utc == messages[0].enqueued_time_utc.replace(microsecond=0)
+                assert len(messages) == 1
 
 
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_session_cancel_scheduled_messages(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_session_schedule_multiple_messages(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+            fully_qualified_namespace=fully_qualified_namespace,
+            credential=credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+
+            session_id = str(uuid.uuid4())
+            enqueue_time = (utc_now() + timedelta(minutes=2)).replace(microsecond=0)
+
+            with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, prefetch_count=20) as receiver:
+                with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                    content = str(uuid.uuid4())
+                    message_id_a = uuid.uuid4()
+                    message_a = ServiceBusMessage(content, session_id=session_id)
+                    message_a.message_id = message_id_a
+                    message_id_b = uuid.uuid4()
+                    message_b = ServiceBusMessage(content, session_id=session_id)
+                    message_b.message_id = message_id_b
+                    tokens = sender.schedule_messages([message_a, message_b], enqueue_time)
+                    assert len(tokens) == 2
+
+                messages = []
+                count = 0
+                while len(messages) < 2 and count < 12:
+                    receiver.session.renew_lock(timeout=None)
+                    messages.extend(receiver.receive_messages(max_wait_time=15))
+                    time.sleep(5)
+                    count += 1
+
+                data = str(messages[0])
+                assert data == content
+                assert messages[0].message_id in (message_id_a, message_id_b)
+                assert messages[0].scheduled_enqueue_time_utc == enqueue_time
+                assert messages[0].scheduled_enqueue_time_utc == messages[0].enqueued_time_utc.replace(microsecond=0)
+                assert len(messages) == 2
+
+
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_session_cancel_scheduled_messages(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
         
-#         with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+            fully_qualified_namespace=fully_qualified_namespace,
+            credential=credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-#             session_id = str(uuid.uuid4())
-#             enqueue_time = (utc_now() + timedelta(minutes=2)).replace(microsecond=0)
+            session_id = str(uuid.uuid4())
+            enqueue_time = (utc_now() + timedelta(minutes=2)).replace(microsecond=0)
 
-#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 message_a = ServiceBusMessage("Test scheduled message", session_id=session_id)
-#                 message_b = ServiceBusMessage("Test scheduled message", session_id=session_id)
-#                 tokens = sender.schedule_messages([message_a, message_b], enqueue_time)
-#                 assert len(tokens) == 2
-#                 sender.cancel_scheduled_messages(tokens)
+            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                message_a = ServiceBusMessage("Test scheduled message", session_id=session_id)
+                message_b = ServiceBusMessage("Test scheduled message", session_id=session_id)
+                tokens = sender.schedule_messages([message_a, message_b], enqueue_time)
+                assert len(tokens) == 2
+                sender.cancel_scheduled_messages(tokens)
 
-#             with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id) as receiver:
-#                 messages = []
-#                 count = 0
-#                 while not messages and count < 13:
-#                     messages = receiver.receive_messages(max_wait_time=20)
-#                     receiver.session.renew_lock()
-#                     count += 1
-#                 assert len(messages) == 0
+            with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id) as receiver:
+                messages = []
+                count = 0
+                while not messages and count < 13:
+                    messages = receiver.receive_messages(max_wait_time=20)
+                    receiver.session.renew_lock()
+                    count += 1
+                assert len(messages) == 0
 
     
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_session_get_set_state_with_receiver(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_session_get_set_state_with_receiver(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
 
-#         with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+            fully_qualified_namespace=fully_qualified_namespace,
+            credential=credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-#             session_id = str(uuid.uuid4())
-#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 for i in range(3):
-#                     message = ServiceBusMessage("Handler message no. {}".format(i), session_id=session_id)
-#                     sender.send_messages(message)
+            session_id = str(uuid.uuid4())
+            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                for i in range(3):
+                    message = ServiceBusMessage("Handler message no. {}".format(i), session_id=session_id)
+                    sender.send_messages(message)
 
-#             with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=5) as session:
-#                 assert session.session.get_state(timeout=5) == None
-#                 session.session.set_state("first_state", timeout=5)
-#                 count = 0
-#                 for m in session:
-#                     assert m.session_id == session_id
-#                     count += 1
-#                 state = session.session.get_state()
-#                 assert state == b'first_state'
-#             assert count == 3
+            with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=5) as session:
+                assert session.session.get_state(timeout=5) == None
+                session.session.set_state("first_state", timeout=5)
+                count = 0
+                for m in session:
+                    assert m.session_id == session_id
+                    count += 1
+                state = session.session.get_state()
+                assert state == b'first_state'
+            assert count == 3
 
-#             session_id = str(uuid.uuid4())
-#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 for i in range(1):
-#                     message = ServiceBusMessage("Handler message no. {}".format(i), session_id=session_id)
-#                     sender.send_messages(message)
+            session_id = str(uuid.uuid4())
+            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                for i in range(1):
+                    message = ServiceBusMessage("Handler message no. {}".format(i), session_id=session_id)
+                    sender.send_messages(message)
 
-#             with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=5) as session:
-#                 assert session.session.get_state(timeout=5) == None
-#                 session.session.set_state(None, timeout=5)
-#                 count = 0
-#                 for m in session:
-#                     assert m.session_id == session_id
-#                     count += 1
-#                 state = session.session.get_state()
-#                 assert state == None
-#             assert count == 1
-
-
-#     @pytest.mark.skip(reason="Needs list sessions")
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_session_by_servicebus_client_list_sessions_with_receiver(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-
-#         with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-
-#             sessions = []
-#             start_time = utc_now()
-#             for i in range(5):
-#                 sessions.append(str(uuid.uuid4()))
-
-#             for session_id in sessions:
-#                 with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                     for i in range(5):
-#                         message = ServiceBusMessage("Test message no. {}".format(i), session_id=session_id)
-#                         sender.send_messages(message)
-#             for session_id in sessions:
-#                 with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id) as receiver:
-#                     receiver.set_state("SESSION {}".format(session_id))
-
-#             with sb_client.get_queue_receiver(servicebus_queue.name, session_id=NEXT_AVAILABLE_SESSION, max_wait_time=5, receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
-#                 current_sessions = receiver.list_sessions(updated_since=start_time)
-#                 assert len(current_sessions) == 5
-#                 assert current_sessions == sessions
+            with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=5) as session:
+                assert session.session.get_state(timeout=5) == None
+                session.session.set_state(None, timeout=5)
+                count = 0
+                for m in session:
+                    assert m.session_id == session_id
+                    count += 1
+                state = session.session.get_state()
+                assert state == None
+            assert count == 1
 
 
-#     @pytest.mark.skip("Requires list sessions")
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_session_by_servicebus_client_list_sessions_with_client(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+    @pytest.mark.skip(reason="Needs list sessions")
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_session_by_servicebus_client_list_sessions_with_receiver(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
 
-#         with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+            fully_qualified_namespace=fully_qualified_namespace,
+            credential=credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-#             sessions = []
-#             start_time = utc_now()
-#             for i in range(5):
-#                 sessions.append(str(uuid.uuid4()))
+            sessions = []
+            start_time = utc_now()
+            for i in range(5):
+                sessions.append(str(uuid.uuid4()))
 
-#             for session in sessions:
-#                 with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                     for i in range(5):
-#                         message = ServiceBusMessage("Test message no. {}".format(i), session_id=session)
-#                         sender.send_messages(message)
-#             for session in sessions:
-#                 with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session) as receiver:
-#                     receiver.set_state("SESSION {}".format(session))
+            for session_id in sessions:
+                with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                    for i in range(5):
+                        message = ServiceBusMessage("Test message no. {}".format(i), session_id=session_id)
+                        sender.send_messages(message)
+            for session_id in sessions:
+                with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id) as receiver:
+                    receiver.set_state("SESSION {}".format(session_id))
 
-#                     current_sessions = receiver.list_sessions(updated_since=start_time)
-#                     assert len(current_sessions) == 5
-#                     assert current_sessions == sessions
+            with sb_client.get_queue_receiver(servicebus_queue.name, session_id=NEXT_AVAILABLE_SESSION, max_wait_time=5, receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
+                current_sessions = receiver.list_sessions(updated_since=start_time)
+                assert len(current_sessions) == 5
+                assert current_sessions == sessions
 
 
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @pytest.mark.xfail(reason="'Cannot open log' error, potential service bug")
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_session_by_servicebus_client_session_pool(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         messages = []
-#         errors = []
-#         concurrent_receivers = 5
+    @pytest.mark.skip("Requires list sessions")
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_session_by_servicebus_client_list_sessions_with_client(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+            fully_qualified_namespace=fully_qualified_namespace,
+            credential=credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+
+            sessions = []
+            start_time = utc_now()
+            for i in range(5):
+                sessions.append(str(uuid.uuid4()))
+
+            for session in sessions:
+                with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                    for i in range(5):
+                        message = ServiceBusMessage("Test message no. {}".format(i), session_id=session)
+                        sender.send_messages(message)
+            for session in sessions:
+                with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session) as receiver:
+                    receiver.set_state("SESSION {}".format(session))
+
+                    current_sessions = receiver.list_sessions(updated_since=start_time)
+                    assert len(current_sessions) == 5
+                    assert current_sessions == sessions
+
+
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @pytest.mark.xfail(reason="'Cannot open log' error, potential service bug")
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_session_by_servicebus_client_session_pool(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        messages = []
+        errors = []
+        concurrent_receivers = 5
     
-#         def message_processing(sb_client):
-#             while True:
-#                 try:
-#                     with sb_client.get_queue_receiver(servicebus_queue.name, session_id=NEXT_AVAILABLE_SESSION, max_wait_time=10) as receiver:
-#                         for message in receiver:
-#                             print("ServiceBusReceivedMessage: {}".format(message))
-#                             messages.append(message)
-#                             receiver.complete_message(message)
-#                 except OperationTimeoutError:
-#                     return
-#                 except Exception as e:
-#                     errors.append(e)
-#                     raise
+        def message_processing(sb_client):
+            while True:
+                try:
+                    with sb_client.get_queue_receiver(servicebus_queue.name, session_id=NEXT_AVAILABLE_SESSION, max_wait_time=10) as receiver:
+                        for message in receiver:
+                            print("ServiceBusReceivedMessage: {}".format(message))
+                            messages.append(message)
+                            receiver.complete_message(message)
+                except OperationTimeoutError:
+                    return
+                except Exception as e:
+                    errors.append(e)
+                    raise
                 
-#         with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+            fully_qualified_namespace=fully_qualified_namespace,
+            credential=credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
     
-#             sessions = [str(uuid.uuid4()) for i in range(concurrent_receivers)]
+            sessions = [str(uuid.uuid4()) for i in range(concurrent_receivers)]
     
-#             for session_id in sessions:
-#                 with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                     for i in range(20):
-#                         message = ServiceBusMessage("Test message no. {}".format(i), session_id=session_id)
-#                         sender.send_messages(message)
+            for session_id in sessions:
+                with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                    for i in range(20):
+                        message = ServiceBusMessage("Test message no. {}".format(i), session_id=session_id)
+                        sender.send_messages(message)
     
-#             futures = []
-#             with concurrent.futures.ThreadPoolExecutor(max_workers=concurrent_receivers) as thread_pool:
-#                 for _ in range(concurrent_receivers):
-#                     futures.append(thread_pool.submit(message_processing, sb_client))
-#                 concurrent.futures.wait(futures)
+            futures = []
+            with concurrent.futures.ThreadPoolExecutor(max_workers=concurrent_receivers) as thread_pool:
+                for _ in range(concurrent_receivers):
+                    futures.append(thread_pool.submit(message_processing, sb_client))
+                concurrent.futures.wait(futures)
     
-#             assert not errors
-#             assert len(messages) == 100
-
-    
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_session_by_session_client_conn_str_receive_handler_peeklock_abandon(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-
-#             session_id = str(uuid.uuid4())
-#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 for i in range(3):
-#                     message = ServiceBusMessage("Handler message no. {}".format(i), session_id=session_id)
-#                     sender.send_messages(message)
-
-#             with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, prefetch_count=0, max_wait_time=5) as receiver:
-#                 message = receiver.next()
-#                 assert message.sequence_number == 1
-#                 receiver.abandon_message(message)
-#                 for next_message in receiver: # we can't be sure there won't be a service delay, so we may not get the message back _immediately_, even if in most cases it shows right back up.
-#                     if not next_message:
-#                         raise Exception("Did not successfully re-receive abandoned message, sequence_number 1 was not observed.")
-#                     if next_message.sequence_number == 1:
-#                         return
+            assert not errors
+            assert len(messages) == 100
 
     
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusTopicPreparer(name_prefix='servicebustest')
-#     @ServiceBusSubscriptionPreparer(name_prefix='servicebustest', requires_session=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_session_basic_topic_subscription_send_and_receive(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_topic=None, servicebus_subscription=None, **kwargs):
-#         with ServiceBusClient.from_connection_string(
-#                 servicebus_namespace_connection_string,
-#                 logging_enable=False, uamqp_transport=uamqp_transport
-#         ) as sb_client:
-#             with sb_client.get_topic_sender(topic_name=servicebus_topic.name) as sender:
-#                 message = ServiceBusMessage(b"Sample topic message", session_id='test_session')
-#                 sender.send_messages(message)
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_session_by_session_client_conn_str_receive_handler_peeklock_abandon(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+            fully_qualified_namespace=fully_qualified_namespace,
+            credential=credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-#             with sb_client.get_subscription_receiver(
-#                 topic_name=servicebus_topic.name,
-#                 subscription_name=servicebus_subscription.name,
-#                 session_id='test_session',
-#                 max_wait_time=5
-#             ) as receiver:
-#                 count = 0
-#                 for message in receiver:
-#                     count += 1
-#                     receiver.complete_message(message)
-#             assert count == 1
+            session_id = str(uuid.uuid4())
+            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                for i in range(3):
+                    message = ServiceBusMessage("Handler message no. {}".format(i), session_id=session_id)
+                    sender.send_messages(message)
 
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @CachedServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_session_non_session_send_to_session_queue_should_fail(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+            with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, prefetch_count=0, max_wait_time=5) as receiver:
+                message = receiver.next()
+                assert message.sequence_number == 1
+                receiver.abandon_message(message)
+                for next_message in receiver: # we can't be sure there won't be a service delay, so we may not get the message back _immediately_, even if in most cases it shows right back up.
+                    if not next_message:
+                        raise Exception("Did not successfully re-receive abandoned message, sequence_number 1 was not observed.")
+                    if next_message.sequence_number == 1:
+                        return
 
-#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                 message = ServiceBusMessage("This should be an invalid non session message")
-#                 with pytest.raises(ServiceBusError):
-#                     sender.send_messages(message)
     
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_session_id_str_bytes(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusTopicPreparer(name_prefix='servicebustest')
+    @ServiceBusSubscriptionPreparer(name_prefix='servicebustest', requires_session=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_session_basic_topic_subscription_send_and_receive(self, uamqp_transport, *, servicebus_namespace=None, servicebus_topic=None, servicebus_subscription=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+                fully_qualified_namespace=fully_qualified_namespace,
+            credential=credential,
+                logging_enable=False, uamqp_transport=uamqp_transport
+        ) as sb_client:
+            with sb_client.get_topic_sender(topic_name=servicebus_topic.name) as sender:
+                message = ServiceBusMessage(b"Sample topic message", session_id='test_session')
+                sender.send_messages(message)
 
-#         with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+            with sb_client.get_subscription_receiver(
+                topic_name=servicebus_topic.name,
+                subscription_name=servicebus_subscription.name,
+                session_id='test_session',
+                max_wait_time=5
+            ) as receiver:
+                count = 0
+                for message in receiver:
+                    count += 1
+                    receiver.complete_message(message)
+            assert count == 1
 
-#             sessions = []
-#             start_time = utc_now()
-#             for i in range(5):
-#                 sessions.append('a' * (i + 1))
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @CachedServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_session_non_session_send_to_session_queue_should_fail(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+            fully_qualified_namespace=fully_qualified_namespace,
+            credential=credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-#             for session_id in sessions:
-#                 with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-#                     message = ServiceBusMessage("Test message no. {}".format(i), session_id=session_id)
-#                     sender.send_messages(message)
-#             for session_id in sessions:
-#                 with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id) as receiver:
-#                     messages = receiver.receive_messages(max_wait_time=10)
-#                     assert len(messages) == 1
-#                     assert messages[0].session_id == session_id
+            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                message = ServiceBusMessage("This should be an invalid non session message")
+                with pytest.raises(ServiceBusError):
+                    sender.send_messages(message)
+    
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_session_id_str_bytes(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+            fully_qualified_namespace=fully_qualified_namespace,
+            credential=credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+
+            sessions = []
+            start_time = utc_now()
+            for i in range(5):
+                sessions.append('a' * (i + 1))
+
+            for session_id in sessions:
+                with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+                    message = ServiceBusMessage("Test message no. {}".format(i), session_id=session_id)
+                    sender.send_messages(message)
+            for session_id in sessions:
+                with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id) as receiver:
+                    messages = receiver.receive_messages(max_wait_time=10)
+                    assert len(messages) == 1
+                    assert messages[0].session_id == session_id
     
     
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()  
-#     def test_next_available_session_timeout_value(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-#         if uamqp_transport:
-#             pytest.skip("This test is for pyamqp only")
-#         with ServiceBusClient.from_connection_string(
-#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport, retry_total=1) as sb_client:
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()  
+    def test_next_available_session_timeout_value(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
+        if uamqp_transport:
+            pytest.skip("This test is for pyamqp only")
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+            fully_qualified_namespace=fully_qualified_namespace,
+            credential=credential, logging_enable=False, uamqp_transport=uamqp_transport, retry_total=1) as sb_client:
             
-#             receiver = sb_client.get_queue_receiver(servicebus_queue.name, session_id=NEXT_AVAILABLE_SESSION, max_wait_time=10,)
+            receiver = sb_client.get_queue_receiver(servicebus_queue.name, session_id=NEXT_AVAILABLE_SESSION, max_wait_time=10,)
             
-#             start_time = time.time()
-#             with pytest.raises(OperationTimeoutError):
-#                 receiver.receive_messages(max_wait_time=5)
-#             assert time.time() - start_time < 65  # Default service operation timeout is 65 seconds
-#             start_time2 = time.time()
-#             with pytest.raises(OperationTimeoutError):
-#                 for msg in receiver:
-#                     pass
+            start_time = time.time()
+            with pytest.raises(OperationTimeoutError):
+                receiver.receive_messages(max_wait_time=5)
+            assert time.time() - start_time < 65  # Default service operation timeout is 65 seconds
+            start_time2 = time.time()
+            with pytest.raises(OperationTimeoutError):
+                for msg in receiver:
+                    pass
 
-#             assert time.time() - start_time2 < 65  # Default service operation timeout is 65 seconds
+            assert time.time() - start_time2 < 65  # Default service operation timeout is 65 seconds
 
-#             receiver = sb_client.get_queue_receiver(servicebus_queue.name, session_id=NEXT_AVAILABLE_SESSION, max_wait_time=70)
+            receiver = sb_client.get_queue_receiver(servicebus_queue.name, session_id=NEXT_AVAILABLE_SESSION, max_wait_time=70)
             
-#             start_time = time.time()
-#             with pytest.raises(OperationTimeoutError):
-#                 receiver.receive_messages(max_wait_time=5)
-#             assert time.time() - start_time > 65  # Default service operation timeout is 65 seconds
-#             start_time2 = time.time()
-#             with pytest.raises(OperationTimeoutError):
-#                 for msg in receiver:
-#                     pass
+            start_time = time.time()
+            with pytest.raises(OperationTimeoutError):
+                receiver.receive_messages(max_wait_time=5)
+            assert time.time() - start_time > 65  # Default service operation timeout is 65 seconds
+            start_time2 = time.time()
+            with pytest.raises(OperationTimeoutError):
+                for msg in receiver:
+                    pass
 
-#             assert time.time() - start_time2 > 65  # Default service operation timeout is 65 seconds
+            assert time.time() - start_time2 > 65  # Default service operation timeout is 65 seconds

--- a/sdk/servicebus/azure-servicebus/tests/test_sessions.py
+++ b/sdk/servicebus/azure-servicebus/tests/test_sessions.py
@@ -62,8 +62,6 @@ class TestServiceBusSession(AzureMgmtRecordedTestCase):
     def test_session_by_session_client_conn_str_receive_handler_peeklock(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
         fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
         credential = get_credential()
-        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
-        credential = get_credential()
         with ServiceBusClient(
             fully_qualified_namespace=fully_qualified_namespace,
             credential=credential, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:

--- a/sdk/servicebus/azure-servicebus/tests/test_sessions.py
+++ b/sdk/servicebus/azure-servicebus/tests/test_sessions.py
@@ -1,1369 +1,1369 @@
-#-------------------------------------------------------------------------
-# Copyright (c) Microsoft Corporation. All rights reserved.
-# Licensed under the MIT License. See License.txt in the project root for
-# license information.
-#--------------------------------------------------------------------------
+# #-------------------------------------------------------------------------
+# # Copyright (c) Microsoft Corporation. All rights reserved.
+# # Licensed under the MIT License. See License.txt in the project root for
+# # license information.
+# #--------------------------------------------------------------------------
 
-import logging
-import concurrent
-import sys
-import os
-import pytest
-import time
-import uuid
-import pickle
-from datetime import timedelta
+# import logging
+# import concurrent
+# import sys
+# import os
+# import pytest
+# import time
+# import uuid
+# import pickle
+# from datetime import timedelta
 
-from azure.servicebus import (
-    ServiceBusClient,
-    AutoLockRenewer,
-    ServiceBusMessage,
-    ServiceBusReceivedMessage,
-    ServiceBusReceiveMode,
-    NEXT_AVAILABLE_SESSION,
-    ServiceBusSubQueue
-)
-from azure.servicebus._common.utils import utc_now
-from azure.servicebus.exceptions import (
-    ServiceBusConnectionError,
-    ServiceBusAuthenticationError,
-    ServiceBusError,
-    SessionLockLostError,
-    MessageAlreadySettled,
-    OperationTimeoutError,
-    AutoLockRenewTimeout
-)
+# from azure.servicebus import (
+#     ServiceBusClient,
+#     AutoLockRenewer,
+#     ServiceBusMessage,
+#     ServiceBusReceivedMessage,
+#     ServiceBusReceiveMode,
+#     NEXT_AVAILABLE_SESSION,
+#     ServiceBusSubQueue
+# )
+# from azure.servicebus._common.utils import utc_now
+# from azure.servicebus.exceptions import (
+#     ServiceBusConnectionError,
+#     ServiceBusAuthenticationError,
+#     ServiceBusError,
+#     SessionLockLostError,
+#     MessageAlreadySettled,
+#     OperationTimeoutError,
+#     AutoLockRenewTimeout
+# )
 
-from devtools_testutils import AzureMgmtRecordedTestCase
-from servicebus_preparer import (
-    CachedServiceBusNamespacePreparer,
-    CachedServiceBusQueuePreparer,
-    ServiceBusTopicPreparer,
-    ServiceBusQueuePreparer,
-    ServiceBusSubscriptionPreparer,
-    CachedServiceBusResourceGroupPreparer
-)
-from utilities import get_logger, print_message, sleep_until_expired, uamqp_transport as get_uamqp_transport, ArgPasser
-uamqp_transport_params, uamqp_transport_ids = get_uamqp_transport()
+# from devtools_testutils import AzureMgmtRecordedTestCase
+# from servicebus_preparer import (
+#     CachedServiceBusNamespacePreparer,
+#     CachedServiceBusQueuePreparer,
+#     ServiceBusTopicPreparer,
+#     ServiceBusQueuePreparer,
+#     ServiceBusSubscriptionPreparer,
+#     CachedServiceBusResourceGroupPreparer
+# )
+# from utilities import get_logger, print_message, sleep_until_expired, uamqp_transport as get_uamqp_transport, ArgPasser
+# uamqp_transport_params, uamqp_transport_ids = get_uamqp_transport()
 
-_logger = get_logger(logging.DEBUG)
+# _logger = get_logger(logging.DEBUG)
 
 
-class TestServiceBusSession(AzureMgmtRecordedTestCase):
+# class TestServiceBusSession(AzureMgmtRecordedTestCase):
 
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer()
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_session_by_session_client_conn_str_receive_handler_peeklock(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer()
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_session_by_session_client_conn_str_receive_handler_peeklock(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-            session_id = str(uuid.uuid4())
-            sender = sb_client.get_queue_sender(servicebus_queue.name)
-            receiver = sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=5)
+#             session_id = str(uuid.uuid4())
+#             sender = sb_client.get_queue_sender(servicebus_queue.name)
+#             receiver = sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=5)
 
-            with sender, receiver:
-                for i in range(3):
-                    message = ServiceBusMessage("Handler message no. {}".format(i))
+#             with sender, receiver:
+#                 for i in range(3):
+#                     message = ServiceBusMessage("Handler message no. {}".format(i))
 
-                    message.partition_key = 'pkey'
+#                     message.partition_key = 'pkey'
 
-                    message.session_id = session_id
-                    message.partition_key = session_id
-                    message.application_properties = {'key': 'value'}
-                    message.subject = 'label'
-                    message.content_type = 'application/text'
-                    message.correlation_id = 'cid'
-                    message.message_id = str(i)
-                    message.to = 'to'
-                    message.reply_to = 'reply_to'
-                    message.reply_to_session_id = 'reply_to_session_id'
+#                     message.session_id = session_id
+#                     message.partition_key = session_id
+#                     message.application_properties = {'key': 'value'}
+#                     message.subject = 'label'
+#                     message.content_type = 'application/text'
+#                     message.correlation_id = 'cid'
+#                     message.message_id = str(i)
+#                     message.to = 'to'
+#                     message.reply_to = 'reply_to'
+#                     message.reply_to_session_id = 'reply_to_session_id'
 
-                    with pytest.raises(ValueError):
-                        message.partition_key = 'pkey'
+#                     with pytest.raises(ValueError):
+#                         message.partition_key = 'pkey'
 
-                    sender.send_messages(message)
+#                     sender.send_messages(message)
 
-                with pytest.raises(ServiceBusError):
-                    receiver = sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5)._open_with_retry()
+#                 with pytest.raises(ServiceBusError):
+#                     receiver = sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5)._open_with_retry()
 
-                count = 0
-                received_cnt_dic = {}
-                for message in receiver:
-                    print_message(_logger, message)
-                    assert message.delivery_count == 0
-                    assert message.application_properties
-                    assert message.application_properties[b'key'] == b'value'
-                    assert message.subject == 'label'
-                    assert message.content_type == 'application/text'
-                    assert message.correlation_id == 'cid'
-                    assert message.partition_key == session_id
-                    assert message.to == 'to'
-                    assert message.reply_to == 'reply_to'
-                    assert message.sequence_number
-                    assert message.enqueued_time_utc
-                    assert message.session_id == session_id
-                    assert message.reply_to_session_id == 'reply_to_session_id'
-                    count += 1
-                    receiver.complete_message(message)
-                    if message.message_id not in received_cnt_dic:
-                        received_cnt_dic[message.message_id] = 1
-                        sender.send_messages(message)
-                    else:
-                        received_cnt_dic[message.message_id] += 1
+#                 count = 0
+#                 received_cnt_dic = {}
+#                 for message in receiver:
+#                     print_message(_logger, message)
+#                     assert message.delivery_count == 0
+#                     assert message.application_properties
+#                     assert message.application_properties[b'key'] == b'value'
+#                     assert message.subject == 'label'
+#                     assert message.content_type == 'application/text'
+#                     assert message.correlation_id == 'cid'
+#                     assert message.partition_key == session_id
+#                     assert message.to == 'to'
+#                     assert message.reply_to == 'reply_to'
+#                     assert message.sequence_number
+#                     assert message.enqueued_time_utc
+#                     assert message.session_id == session_id
+#                     assert message.reply_to_session_id == 'reply_to_session_id'
+#                     count += 1
+#                     receiver.complete_message(message)
+#                     if message.message_id not in received_cnt_dic:
+#                         received_cnt_dic[message.message_id] = 1
+#                         sender.send_messages(message)
+#                     else:
+#                         received_cnt_dic[message.message_id] += 1
 
-                assert received_cnt_dic['0'] == 2 and received_cnt_dic['1'] == 2 and received_cnt_dic['2'] == 2
-                assert count == 6
+#                 assert received_cnt_dic['0'] == 2 and received_cnt_dic['1'] == 2 and received_cnt_dic['2'] == 2
+#                 assert count == 6
 
-            session_id = ""
-            sender = sb_client.get_queue_sender(servicebus_queue.name)
-            receiver = sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=5)
+#             session_id = ""
+#             sender = sb_client.get_queue_sender(servicebus_queue.name)
+#             receiver = sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=5)
 
-            with sender, receiver:
-                for i in range(3):
-                    message = ServiceBusMessage("Handler message no. {}".format(i))
+#             with sender, receiver:
+#                 for i in range(3):
+#                     message = ServiceBusMessage("Handler message no. {}".format(i))
 
-                    message.partition_key = 'pkey'
+#                     message.partition_key = 'pkey'
 
-                    message.session_id = session_id
-                    message.partition_key = session_id
-                    message.application_properties = {'key': 'value'}
-                    message.subject = 'label'
-                    message.content_type = 'application/text'
-                    message.correlation_id = 'cid'
-                    message.message_id = str(i)
-                    message.to = 'to'
-                    message.reply_to = 'reply_to'
-                    message.reply_to_session_id = 'reply_to_session_id'
+#                     message.session_id = session_id
+#                     message.partition_key = session_id
+#                     message.application_properties = {'key': 'value'}
+#                     message.subject = 'label'
+#                     message.content_type = 'application/text'
+#                     message.correlation_id = 'cid'
+#                     message.message_id = str(i)
+#                     message.to = 'to'
+#                     message.reply_to = 'reply_to'
+#                     message.reply_to_session_id = 'reply_to_session_id'
 
-                    with pytest.raises(ValueError):
-                        message.partition_key = 'pkey'
+#                     with pytest.raises(ValueError):
+#                         message.partition_key = 'pkey'
 
-                    sender.send_messages(message)
+#                     sender.send_messages(message)
 
-                with pytest.raises(ServiceBusError):
-                    receiver = sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5)._open_with_retry()
+#                 with pytest.raises(ServiceBusError):
+#                     receiver = sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5)._open_with_retry()
 
-                count = 0
-                received_cnt_dic = {}
-                for message in receiver:
-                    print_message(_logger, message)
-                    assert message.delivery_count == 0
-                    assert message.application_properties
-                    assert message.application_properties[b'key'] == b'value'
-                    assert message.subject == 'label'
-                    assert message.content_type == 'application/text'
-                    assert message.correlation_id == 'cid'
-                    assert message.partition_key == session_id
-                    assert message.to == 'to'
-                    assert message.reply_to == 'reply_to'
-                    assert message.sequence_number
-                    assert message.enqueued_time_utc
-                    assert message.session_id == session_id
-                    assert message.reply_to_session_id == 'reply_to_session_id'
-                    count += 1
-                    receiver.complete_message(message)
-                    if message.message_id not in received_cnt_dic:
-                        received_cnt_dic[message.message_id] = 1
-                        sender.send_messages(message)
-                    else:
-                        received_cnt_dic[message.message_id] += 1
+#                 count = 0
+#                 received_cnt_dic = {}
+#                 for message in receiver:
+#                     print_message(_logger, message)
+#                     assert message.delivery_count == 0
+#                     assert message.application_properties
+#                     assert message.application_properties[b'key'] == b'value'
+#                     assert message.subject == 'label'
+#                     assert message.content_type == 'application/text'
+#                     assert message.correlation_id == 'cid'
+#                     assert message.partition_key == session_id
+#                     assert message.to == 'to'
+#                     assert message.reply_to == 'reply_to'
+#                     assert message.sequence_number
+#                     assert message.enqueued_time_utc
+#                     assert message.session_id == session_id
+#                     assert message.reply_to_session_id == 'reply_to_session_id'
+#                     count += 1
+#                     receiver.complete_message(message)
+#                     if message.message_id not in received_cnt_dic:
+#                         received_cnt_dic[message.message_id] = 1
+#                         sender.send_messages(message)
+#                     else:
+#                         received_cnt_dic[message.message_id] += 1
 
-                assert received_cnt_dic['0'] == 2 and received_cnt_dic['1'] == 2 and received_cnt_dic['2'] == 2
-                assert count == 6
+#                 assert received_cnt_dic['0'] == 2 and received_cnt_dic['1'] == 2 and received_cnt_dic['2'] == 2
+#                 assert count == 6
 
-            with pytest.raises(ServiceBusError):
-                receiver = sb_client.get_queue_receiver(servicebus_queue.name, session_id=1)
-                with receiver:
-                    pass
+#             with pytest.raises(ServiceBusError):
+#                 receiver = sb_client.get_queue_receiver(servicebus_queue.name, session_id=1)
+#                 with receiver:
+#                     pass
     
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True, lock_duration='PT5S')
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_session_by_queue_client_conn_str_receive_handler_receiveanddelete(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True, lock_duration='PT5S')
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_session_by_queue_client_conn_str_receive_handler_receiveanddelete(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-            session_id = str(uuid.uuid4())
-            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                for i in range(10):
-                    message = ServiceBusMessage("Handler message no. {}".format(i), session_id=session_id)
-                    sender.send_messages(message)
+#             session_id = str(uuid.uuid4())
+#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 for i in range(10):
+#                     message = ServiceBusMessage("Handler message no. {}".format(i), session_id=session_id)
+#                     sender.send_messages(message)
 
-            messages = []
-            with sb_client.get_queue_receiver(servicebus_queue.name, 
-                                              session_id=session_id, 
-                                              receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE, 
-                                              max_wait_time=5) as receiver:
-                for message in receiver:
-                    messages.append(message)
-                    assert session_id == receiver._session_id
-                    assert session_id == message.session_id
-                    with pytest.raises(ValueError):
-                        receiver.complete_message(message)
+#             messages = []
+#             with sb_client.get_queue_receiver(servicebus_queue.name, 
+#                                               session_id=session_id, 
+#                                               receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE, 
+#                                               max_wait_time=5) as receiver:
+#                 for message in receiver:
+#                     messages.append(message)
+#                     assert session_id == receiver._session_id
+#                     assert session_id == message.session_id
+#                     with pytest.raises(ValueError):
+#                         receiver.complete_message(message)
 
-            assert not receiver._running
-            assert len(messages) == 10
-            time.sleep(5)
+#             assert not receiver._running
+#             assert len(messages) == 10
+#             time.sleep(5)
 
-            messages = []
-            with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE, max_wait_time=5) as session:
-                for message in session:
-                    messages.append(message)
-                assert len(messages) == 0
-
-    
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer()
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_session_by_session_client_conn_str_receive_handler_with_stop(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-
-            session_id = str(uuid.uuid4())
-            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                for i in range(10):
-                    message = ServiceBusMessage("Stop message no. {}".format(i), session_id=session_id)
-                    sender.send_messages(message)
-
-            messages = []
-            with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=5) as receiver:
-                for message in receiver:
-                    assert session_id == receiver.session.session_id
-                    assert session_id == message.session_id
-                    messages.append(message)
-                    receiver.complete_message(message)
-                    if len(messages) >= 5:
-                        break
-
-                assert receiver._running
-                assert len(messages) == 5
-
-
-                for message in receiver:
-                    assert session_id == receiver.session.session_id
-                    assert session_id == message.session_id
-                    messages.append(message)
-                    receiver.complete_message(message)
-                    if len(messages) >= 5:
-                        break
-
-            assert not receiver._running
-            assert len(messages) == 6
-
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @pytest.mark.xfail(reason="'Cannot open log' error, potential service bug", raises=ServiceBusError)
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_session_by_session_client_conn_str_receive_handler_with_no_session(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport, retry_total=1) as sb_client:
-            with pytest.raises(OperationTimeoutError):
-                with sb_client.get_queue_receiver(servicebus_queue.name, 
-                                                  session_id=NEXT_AVAILABLE_SESSION, 
-                                                  max_wait_time=10,) as session:
-                    pass
-
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @pytest.mark.xfail(reason="'Cannot open log' error, potential service bug", raises=ServiceBusError)
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_session_connection_failure_is_idempotent(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        #Technically this validates for all senders/receivers, not just session, but since it uses session to generate a recoverable failure, putting it in here.
-        with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-    
-            # First let's just try the naive failure cases.
-            receiver = sb_client.get_queue_receiver("THIS_IS_WRONG_ON_PURPOSE")
-            with pytest.raises(ServiceBusAuthenticationError):
-                receiver._open_with_retry()
-            assert not receiver._running
-            assert not receiver._handler
-    
-            sender = sb_client.get_queue_sender("THIS_IS_WRONG_ON_PURPOSE")
-            with pytest.raises(ServiceBusAuthenticationError):
-                sender._open_with_retry()
-            assert not receiver._running
-            assert not receiver._handler
-
-            # Then let's try a case we can recover from to make sure everything works on reestablishment.
-            receiver = sb_client.get_queue_receiver(servicebus_queue.name, session_id=NEXT_AVAILABLE_SESSION)
-            with pytest.raises(OperationTimeoutError):
-                receiver._open_with_retry()
-
-            session_id = str(uuid.uuid4())
-            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                sender.send_messages(ServiceBusMessage("test session sender", session_id=session_id))
-
-            with sb_client.get_queue_receiver(servicebus_queue.name, session_id=NEXT_AVAILABLE_SESSION, max_wait_time=5) as receiver:
-                messages = []
-                for message in receiver:
-                    messages.append(message)
-                assert len(messages) == 1
+#             messages = []
+#             with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE, max_wait_time=5) as session:
+#                 for message in session:
+#                     messages.append(message)
+#                 assert len(messages) == 0
 
     
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_session_by_session_client_conn_str_receive_handler_with_inactive_session(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer()
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_session_by_session_client_conn_str_receive_handler_with_stop(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-            session_id = str(uuid.uuid4())
-            messages = []
-            with sb_client.get_queue_receiver(servicebus_queue.name, 
-                                              session_id=session_id, 
-                                              receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE, 
-                                              max_wait_time=5) as session:
-                for message in session:
-                    messages.append(message)
+#             session_id = str(uuid.uuid4())
+#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 for i in range(10):
+#                     message = ServiceBusMessage("Stop message no. {}".format(i), session_id=session_id)
+#                     sender.send_messages(message)
 
-                assert session._running
-                assert len(messages) == 0
+#             messages = []
+#             with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=5) as receiver:
+#                 for message in receiver:
+#                     assert session_id == receiver.session.session_id
+#                     assert session_id == message.session_id
+#                     messages.append(message)
+#                     receiver.complete_message(message)
+#                     if len(messages) >= 5:
+#                         break
+
+#                 assert receiver._running
+#                 assert len(messages) == 5
+
+
+#                 for message in receiver:
+#                     assert session_id == receiver.session.session_id
+#                     assert session_id == message.session_id
+#                     messages.append(message)
+#                     receiver.complete_message(message)
+#                     if len(messages) >= 5:
+#                         break
+
+#             assert not receiver._running
+#             assert len(messages) == 6
+
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @pytest.mark.xfail(reason="'Cannot open log' error, potential service bug", raises=ServiceBusError)
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_session_by_session_client_conn_str_receive_handler_with_no_session(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport, retry_total=1) as sb_client:
+#             with pytest.raises(OperationTimeoutError):
+#                 with sb_client.get_queue_receiver(servicebus_queue.name, 
+#                                                   session_id=NEXT_AVAILABLE_SESSION, 
+#                                                   max_wait_time=10,) as session:
+#                     pass
+
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @pytest.mark.xfail(reason="'Cannot open log' error, potential service bug", raises=ServiceBusError)
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_session_connection_failure_is_idempotent(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         #Technically this validates for all senders/receivers, not just session, but since it uses session to generate a recoverable failure, putting it in here.
+#         with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+    
+#             # First let's just try the naive failure cases.
+#             receiver = sb_client.get_queue_receiver("THIS_IS_WRONG_ON_PURPOSE")
+#             with pytest.raises(ServiceBusAuthenticationError):
+#                 receiver._open_with_retry()
+#             assert not receiver._running
+#             assert not receiver._handler
+    
+#             sender = sb_client.get_queue_sender("THIS_IS_WRONG_ON_PURPOSE")
+#             with pytest.raises(ServiceBusAuthenticationError):
+#                 sender._open_with_retry()
+#             assert not receiver._running
+#             assert not receiver._handler
+
+#             # Then let's try a case we can recover from to make sure everything works on reestablishment.
+#             receiver = sb_client.get_queue_receiver(servicebus_queue.name, session_id=NEXT_AVAILABLE_SESSION)
+#             with pytest.raises(OperationTimeoutError):
+#                 receiver._open_with_retry()
+
+#             session_id = str(uuid.uuid4())
+#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 sender.send_messages(ServiceBusMessage("test session sender", session_id=session_id))
+
+#             with sb_client.get_queue_receiver(servicebus_queue.name, session_id=NEXT_AVAILABLE_SESSION, max_wait_time=5) as receiver:
+#                 messages = []
+#                 for message in receiver:
+#                     messages.append(message)
+#                 assert len(messages) == 1
 
     
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_session_by_servicebus_client_iter_messages_with_retrieve_deferred_receiver_complete(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_session_by_session_client_conn_str_receive_handler_with_inactive_session(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                deferred_messages = []
-                session_id = str(uuid.uuid4())
-                for i in range(10):
-                    message = ServiceBusMessage("Deferred message no. {}".format(i), session_id=session_id)
-                    sender.send_messages(message)
+#             session_id = str(uuid.uuid4())
+#             messages = []
+#             with sb_client.get_queue_receiver(servicebus_queue.name, 
+#                                               session_id=session_id, 
+#                                               receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE, 
+#                                               max_wait_time=5) as session:
+#                 for message in session:
+#                     messages.append(message)
 
-            count = 0
-            with sb_client.get_queue_receiver(servicebus_queue.name, 
-                                              session_id=session_id, 
-                                              max_wait_time=5) as receiver:
-                for message in receiver:
-                    deferred_messages.append(message.sequence_number)
-                    print_message(_logger, message)
-                    count += 1
-                    receiver.defer_message(message)
-
-            assert count == 10
-
-            with sb_client.get_queue_receiver(servicebus_queue.name, 
-                                              session_id=session_id, 
-                                              max_wait_time=5) as receiver:
-                deferred = receiver.receive_deferred_messages(deferred_messages)
-                assert len(deferred) == 10
-                for message in deferred:
-                    assert isinstance(message, ServiceBusReceivedMessage)
-                    assert message.lock_token
-                    assert not message.locked_until_utc
-                    assert message._receiver
-                    with pytest.raises(TypeError):
-                        receiver.renew_message_lock(message)
-                    receiver.complete_message(message)
+#                 assert session._running
+#                 assert len(messages) == 0
 
     
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_session_by_servicebus_client_iter_messages_with_retrieve_deferred_receiver_deadletter(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_session_by_servicebus_client_iter_messages_with_retrieve_deferred_receiver_complete(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                deferred_messages = []
-                session_id = str(uuid.uuid4())
-                messages = [ServiceBusMessage("Deferred message no. {}".format(i), session_id=session_id) for i in range(10)]
-                sender.send_messages(messages)
+#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 deferred_messages = []
+#                 session_id = str(uuid.uuid4())
+#                 for i in range(10):
+#                     message = ServiceBusMessage("Deferred message no. {}".format(i), session_id=session_id)
+#                     sender.send_messages(message)
 
-            count = 0
-            with sb_client.get_queue_receiver(servicebus_queue.name, 
-                                              session_id=session_id, 
-                                              max_wait_time=5) as receiver:
-                for message in receiver:
-                    deferred_messages.append(message.sequence_number)
-                    print_message(_logger, message)
-                    count += 1
-                    receiver.defer_message(message)
+#             count = 0
+#             with sb_client.get_queue_receiver(servicebus_queue.name, 
+#                                               session_id=session_id, 
+#                                               max_wait_time=5) as receiver:
+#                 for message in receiver:
+#                     deferred_messages.append(message.sequence_number)
+#                     print_message(_logger, message)
+#                     count += 1
+#                     receiver.defer_message(message)
 
-                assert count == 10
+#             assert count == 10
 
-            with sb_client.get_queue_receiver(servicebus_queue.name, 
-                                              session_id=session_id, 
-                                              max_wait_time=5) as receiver:
-                deferred = receiver.receive_deferred_messages(deferred_messages)
-                assert len(deferred) == 10
-                for message in deferred:
-                    assert isinstance(message, ServiceBusReceivedMessage)
-                    receiver.dead_letter_message(message, reason="Testing reason",
-                                                 error_description="Testing description")
-
-            count = 0
-            with sb_client.get_queue_receiver(servicebus_queue.name, 
-                                              sub_queue=ServiceBusSubQueue.DEAD_LETTER,
-                                              max_wait_time=5) as receiver:
-                for message in receiver:
-                    count += 1
-                    print_message(_logger, message)
-                    assert message.dead_letter_reason == 'Testing reason'
-                    assert message.dead_letter_error_description == 'Testing description'
-                    assert message.application_properties[b'DeadLetterReason'] == b'Testing reason'
-                    assert message.application_properties[b'DeadLetterErrorDescription'] == b'Testing description'
-                    receiver.complete_message(message)
-            assert count == 10
+#             with sb_client.get_queue_receiver(servicebus_queue.name, 
+#                                               session_id=session_id, 
+#                                               max_wait_time=5) as receiver:
+#                 deferred = receiver.receive_deferred_messages(deferred_messages)
+#                 assert len(deferred) == 10
+#                 for message in deferred:
+#                     assert isinstance(message, ServiceBusReceivedMessage)
+#                     assert message.lock_token
+#                     assert not message.locked_until_utc
+#                     assert message._receiver
+#                     with pytest.raises(TypeError):
+#                         receiver.renew_message_lock(message)
+#                     receiver.complete_message(message)
 
     
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_session_by_servicebus_client_iter_messages_with_retrieve_deferred_receiver_deletemode(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_session_by_servicebus_client_iter_messages_with_retrieve_deferred_receiver_deadletter(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                deferred_messages = []
-                session_id = str(uuid.uuid4())
-                messages = [ServiceBusMessage("Deferred message no. {}".format(i), session_id=session_id) for i in range(10)]
-                for message in messages:
-                    sender.send_messages(message)
+#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 deferred_messages = []
+#                 session_id = str(uuid.uuid4())
+#                 messages = [ServiceBusMessage("Deferred message no. {}".format(i), session_id=session_id) for i in range(10)]
+#                 sender.send_messages(messages)
 
-            count = 0
-            with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=5) as receiver:
-                for message in receiver:
-                    deferred_messages.append(message.sequence_number)
-                    print_message(_logger, message)
-                    count += 1
-                    receiver.defer_message(message)
+#             count = 0
+#             with sb_client.get_queue_receiver(servicebus_queue.name, 
+#                                               session_id=session_id, 
+#                                               max_wait_time=5) as receiver:
+#                 for message in receiver:
+#                     deferred_messages.append(message.sequence_number)
+#                     print_message(_logger, message)
+#                     count += 1
+#                     receiver.defer_message(message)
 
-            assert count == 10
-            with sb_client.get_queue_receiver(servicebus_queue.name, 
-                                              session_id=session_id, 
-                                              max_wait_time=5,
-                                              receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE) as receiver:
-                deferred = receiver.receive_deferred_messages(deferred_messages)
-                assert len(deferred) == 10
-                for message in deferred:
-                    assert isinstance(message, ServiceBusReceivedMessage)
-                    with pytest.raises(ValueError):
-                        receiver.complete_message(message)
-                with pytest.raises(ServiceBusError):
-                    deferred = receiver.receive_deferred_messages(deferred_messages)
+#                 assert count == 10
 
-    
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_session_by_servicebus_client_iter_messages_with_retrieve_deferred_client(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#             with sb_client.get_queue_receiver(servicebus_queue.name, 
+#                                               session_id=session_id, 
+#                                               max_wait_time=5) as receiver:
+#                 deferred = receiver.receive_deferred_messages(deferred_messages)
+#                 assert len(deferred) == 10
+#                 for message in deferred:
+#                     assert isinstance(message, ServiceBusReceivedMessage)
+#                     receiver.dead_letter_message(message, reason="Testing reason",
+#                                                  error_description="Testing description")
 
-            deferred_messages = []
-            session_id = str(uuid.uuid4())
-            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                for i in range(10):
-                    message = ServiceBusMessage("Deferred message no. {}".format(i), session_id=session_id)
-                    sender.send_messages(message)
-
-            with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=5) as receiver:
-                count = 0
-                for message in receiver:
-                    deferred_messages.append(message.sequence_number)
-                    print_message(_logger, message)
-                    count += 1
-                    receiver.defer_message(message)
-
-                assert count == 10
-
-                deferred = receiver.receive_deferred_messages(deferred_messages)
-
-                with pytest.raises(MessageAlreadySettled):
-                    receiver.complete_message(message)
+#             count = 0
+#             with sb_client.get_queue_receiver(servicebus_queue.name, 
+#                                               sub_queue=ServiceBusSubQueue.DEAD_LETTER,
+#                                               max_wait_time=5) as receiver:
+#                 for message in receiver:
+#                     count += 1
+#                     print_message(_logger, message)
+#                     assert message.dead_letter_reason == 'Testing reason'
+#                     assert message.dead_letter_error_description == 'Testing description'
+#                     assert message.application_properties[b'DeadLetterReason'] == b'Testing reason'
+#                     assert message.application_properties[b'DeadLetterErrorDescription'] == b'Testing description'
+#                     receiver.complete_message(message)
+#             assert count == 10
 
     
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_session_by_servicebus_client_receive_with_retrieve_deadletter(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_session_by_servicebus_client_iter_messages_with_retrieve_deferred_receiver_deletemode(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-        with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 deferred_messages = []
+#                 session_id = str(uuid.uuid4())
+#                 messages = [ServiceBusMessage("Deferred message no. {}".format(i), session_id=session_id) for i in range(10)]
+#                 for message in messages:
+#                     sender.send_messages(message)
 
-            session_id = str(uuid.uuid4())
-            with sb_client.get_queue_receiver(servicebus_queue.name, 
-                                              session_id=session_id, 
-                                              max_wait_time=5, 
-                                              prefetch_count=10) as receiver:
+#             count = 0
+#             with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=5) as receiver:
+#                 for message in receiver:
+#                     deferred_messages.append(message.sequence_number)
+#                     print_message(_logger, message)
+#                     count += 1
+#                     receiver.defer_message(message)
 
-                with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                    for i in range(10):
-                        message = ServiceBusMessage("Dead lettered message no. {}".format(i), session_id=session_id)
-                        sender.send_messages(message)
-
-                count = 0
-                messages = receiver.receive_messages()
-                while messages:
-                    for message in messages:
-                        print_message(_logger, message)
-                        receiver.dead_letter_message(message, reason="Testing reason", error_description="Testing description")
-                        count += 1
-                    messages = receiver.receive_messages()
-            assert count == 10
-
-            with sb_client.get_queue_receiver(servicebus_queue.name,
-                                              sub_queue = ServiceBusSubQueue.DEAD_LETTER,
-                                              max_wait_time=5) as receiver:
-                count = 0
-                for message in receiver:
-                    print_message(_logger, message)
-                    receiver.complete_message(message)
-                    assert message.dead_letter_reason == 'Testing reason'
-                    assert message.dead_letter_error_description == 'Testing description'
-                    assert message.application_properties[b'DeadLetterReason'] == b'Testing reason'
-                    assert message.application_properties[b'DeadLetterErrorDescription'] == b'Testing description'
-                    count += 1
-            assert count == 10
-
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_session_by_servicebus_client_browse_messages_client(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-            session_id = str(uuid.uuid4())
-            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                for i in range(5):
-                    message = ServiceBusMessage("Test message no. {}".format(i), session_id=session_id)
-                    sender.send_messages(message)
-            session_id_2 = str(uuid.uuid4())
-            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                for i in range(3):
-                    message = ServiceBusMessage("Test message no. {}".format(i), session_id=session_id_2)
-                    sender.send_messages(message)
-
-            with pytest.raises(ServiceBusError):
-                with sb_client.get_queue_receiver(servicebus_queue.name):
-                    messages = sb_client.peek_messages(5)
-
-            with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id) as receiver:
-                messages = receiver.peek_messages(5)
-                assert len(messages) == 5
-                assert all(isinstance(m, ServiceBusReceivedMessage) for m in messages)
-                for message in messages:
-                    print_message(_logger, message)
-                    with pytest.raises(ValueError):
-                        receiver.complete_message(message)
-
-            with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id_2) as receiver:
-                messages = receiver.peek_messages(5)
-                assert len(messages) == 3
-
-
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_session_by_servicebus_client_browse_messages_with_receiver(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-
-        with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-
-            session_id = str(uuid.uuid4())
-            with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5, session_id=session_id) as receiver:
-                with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                    for i in range(5):
-                        message = ServiceBusMessage("Test message no. {}".format(i), session_id=session_id)
-                        sender.send_messages(message)
-
-                messages = receiver.peek_messages(5)
-                assert len(messages) > 0
-                assert all(isinstance(m, ServiceBusReceivedMessage) for m in messages)
-                for message in messages:
-                    print_message(_logger, message)
-                    with pytest.raises(ValueError):
-                        receiver.complete_message(message)
-
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_session_by_servicebus_client_renew_client_locks(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-
-            session_id = str(uuid.uuid4())
-            messages = []
-            locks = 3
-            with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, prefetch_count=10) as receiver:
-                with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                    for i in range(locks):
-                        message = ServiceBusMessage("Test message no. {}".format(i), session_id=session_id)
-                        sender.send_messages(message)
-
-                messages.extend(receiver.receive_messages())
-                recv = True
-                while recv:
-                    recv = receiver.receive_messages(max_wait_time=5)
-                    messages.extend(recv)
-
-                try:
-                    for m in messages:
-                        with pytest.raises(TypeError):
-                            expired = m._lock_expired
-                        assert m.locked_until_utc is None
-                        assert m.lock_token is not None
-                    time.sleep(5)
-                    initial_expiry = receiver.session._locked_until_utc
-                    receiver.session.renew_lock(timeout=5)
-                    assert (receiver.session._locked_until_utc - initial_expiry) >= timedelta(seconds=5)
-                finally:
-                    receiver.complete_message(messages[0])
-                    receiver.complete_message(messages[1])
-
-                    # This magic number is because of a 30 second lock renewal window.  Chose 31 seconds because at 30, you'll see "off by .05 seconds" flaky failures
-                    # potentially as a side effect of network delays/sleeps/"typical distributed systems nonsense."  In a perfect world we wouldn't have a magic number/network hop but this allows
-                    # a slightly more robust test in absence of that.
-                    assert (receiver.session._locked_until_utc - utc_now()) <= timedelta(seconds=60)
-                    sleep_until_expired(receiver.session)
-                    with pytest.raises(SessionLockLostError):
-                        receiver.complete_message(messages[2])
+#             assert count == 10
+#             with sb_client.get_queue_receiver(servicebus_queue.name, 
+#                                               session_id=session_id, 
+#                                               max_wait_time=5,
+#                                               receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE) as receiver:
+#                 deferred = receiver.receive_deferred_messages(deferred_messages)
+#                 assert len(deferred) == 10
+#                 for message in deferred:
+#                     assert isinstance(message, ServiceBusReceivedMessage)
+#                     with pytest.raises(ValueError):
+#                         receiver.complete_message(message)
+#                 with pytest.raises(ServiceBusError):
+#                     deferred = receiver.receive_deferred_messages(deferred_messages)
 
     
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True, lock_duration='PT10S')
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_session_by_conn_str_receive_handler_with_autolockrenew(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_session_by_servicebus_client_iter_messages_with_retrieve_deferred_client(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-        session_id = str(uuid.uuid4())
-        with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#             deferred_messages = []
+#             session_id = str(uuid.uuid4())
+#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 for i in range(10):
+#                     message = ServiceBusMessage("Deferred message no. {}".format(i), session_id=session_id)
+#                     sender.send_messages(message)
 
-            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                for i in range(10):
-                    message = ServiceBusMessage("{}".format(i), session_id=session_id)
-                    sender.send_messages(message)
+#             with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=5) as receiver:
+#                 count = 0
+#                 for message in receiver:
+#                     deferred_messages.append(message.sequence_number)
+#                     print_message(_logger, message)
+#                     count += 1
+#                     receiver.defer_message(message)
 
-            results = []
-            def lock_lost_callback(renewable, error):
-                results.append(renewable)
+#                 assert count == 10
 
-            renewer = AutoLockRenewer()
-            messages = []
-            with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=10, receive_mode=ServiceBusReceiveMode.PEEK_LOCK, prefetch_count=10) as receiver:
-                renewer.register(receiver,
-                                 receiver.session,
-                                 max_lock_renewal_duration=10,
-                                 on_lock_renew_failure=lock_lost_callback)
-                print("Registered lock renew thread", receiver.session._locked_until_utc, utc_now())
-                with pytest.raises(SessionLockLostError):
-                    for message in receiver:
-                        if not messages:
-                            print("Starting first sleep")
-                            time.sleep(10)
-                            print("First sleep {}".format(receiver.session._locked_until_utc - utc_now()))
-                            assert not receiver.session._lock_expired
-                            with pytest.raises(TypeError):
-                                message._lock_expired
-                            assert message.locked_until_utc is None
-                            with pytest.raises(TypeError):
-                                receiver.renew_message_lock(message)
-                            assert message.lock_token is not None
-                            receiver.complete_message(message)
-                            messages.append(message)
+#                 deferred = receiver.receive_deferred_messages(deferred_messages)
 
-                        elif len(messages) == 1:
-                            print("Starting second sleep")
-                            time.sleep(10) # ensure renewer expires
-                            print("Second sleep {}".format(receiver.session._locked_until_utc - utc_now()))
-                            assert not results
-                            sleep_until_expired(receiver.session) # and then ensure it didn't slip a renew under the wire.
-                            assert receiver.session._lock_expired
-                            assert isinstance(receiver.session.auto_renew_error, AutoLockRenewTimeout)
-                            try:
-                                receiver.complete_message(message)
-                                raise AssertionError("Didn't raise SessionLockLostError")
-                            except SessionLockLostError as e:
-                                assert isinstance(e.inner_exception, AutoLockRenewTimeout)
-                            messages.append(message)
-
-            # While we're testing autolockrenew and sessions, let's make sure we don't call the lock-lost callback when a session exits.
-            renewer._renew_period = 1
-            session = None
-
-            with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=10, receive_mode=ServiceBusReceiveMode.PEEK_LOCK, prefetch_count=10) as receiver:
-                session = receiver.session
-                renewer.register(receiver,
-                                 session,
-                                 max_lock_renewal_duration=10,
-                                 on_lock_renew_failure=lock_lost_callback)
-            sleep_until_expired(receiver.session)
-            assert not results
-
-            renewer.close()
-            assert len(messages) == 2
+#                 with pytest.raises(MessageAlreadySettled):
+#                     receiver.complete_message(message)
 
     
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True, lock_duration='PT10S')
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_session_by_conn_str_receive_handler_with_auto_autolockrenew(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_session_by_servicebus_client_receive_with_retrieve_deadletter(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
 
-        session_id = str(uuid.uuid4())
-        with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=True, uamqp_transport=uamqp_transport) as sb_client:
+#         with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                for i in range(10):
-                    message = ServiceBusMessage("{}".format(i), session_id=session_id)
-                    sender.send_messages(message)
+#             session_id = str(uuid.uuid4())
+#             with sb_client.get_queue_receiver(servicebus_queue.name, 
+#                                               session_id=session_id, 
+#                                               max_wait_time=5, 
+#                                               prefetch_count=10) as receiver:
 
-            results = []
-            def lock_lost_callback(renewable, error):
-                results.append(renewable)
+#                 with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                     for i in range(10):
+#                         message = ServiceBusMessage("Dead lettered message no. {}".format(i), session_id=session_id)
+#                         sender.send_messages(message)
 
-            renewer = AutoLockRenewer(max_lock_renewal_duration=10, on_lock_renew_failure = lock_lost_callback)
-            messages = []
-            with sb_client.get_queue_receiver(servicebus_queue.name,
-                                              session_id=session_id,
-                                              max_wait_time=10,
-                                              receive_mode=ServiceBusReceiveMode.PEEK_LOCK,
-                                              prefetch_count=10,
-                                              auto_lock_renewer=renewer) as receiver:
-                print("Registered lock renew thread", receiver.session._locked_until_utc, utc_now())
-                with pytest.raises(SessionLockLostError):
-                    for message in receiver:
-                        if not messages:
-                            print("Starting first sleep")
-                            time.sleep(10)
-                            print("First sleep {}".format(receiver.session._locked_until_utc - utc_now()))
-                            assert not receiver.session._lock_expired
-                            with pytest.raises(TypeError):
-                                message._lock_expired
-                            assert message.locked_until_utc is None
-                            with pytest.raises(TypeError):
-                                receiver.renew_message_lock(message)
-                            assert message.lock_token is not None
-                            receiver.complete_message(message)
-                            messages.append(message)
+#                 count = 0
+#                 messages = receiver.receive_messages()
+#                 while messages:
+#                     for message in messages:
+#                         print_message(_logger, message)
+#                         receiver.dead_letter_message(message, reason="Testing reason", error_description="Testing description")
+#                         count += 1
+#                     messages = receiver.receive_messages()
+#             assert count == 10
 
-                        elif len(messages) == 1:
-                            print("Starting second sleep")
-                            time.sleep(10) # ensure renewer expires
-                            print("Second sleep {}".format(receiver.session._locked_until_utc - utc_now()))
-                            assert not results
-                            sleep_until_expired(receiver.session) # and then ensure it didn't slip a renew under the wire.
-                            assert receiver.session._lock_expired
-                            assert isinstance(receiver.session.auto_renew_error, AutoLockRenewTimeout)
-                            try:
-                                receiver.complete_message(message)
-                                raise AssertionError("Didn't raise SessionLockLostError")
-                            except SessionLockLostError as e:
-                                assert isinstance(e.inner_exception, AutoLockRenewTimeout)
-                            messages.append(message)
+#             with sb_client.get_queue_receiver(servicebus_queue.name,
+#                                               sub_queue = ServiceBusSubQueue.DEAD_LETTER,
+#                                               max_wait_time=5) as receiver:
+#                 count = 0
+#                 for message in receiver:
+#                     print_message(_logger, message)
+#                     receiver.complete_message(message)
+#                     assert message.dead_letter_reason == 'Testing reason'
+#                     assert message.dead_letter_error_description == 'Testing description'
+#                     assert message.application_properties[b'DeadLetterReason'] == b'Testing reason'
+#                     assert message.application_properties[b'DeadLetterErrorDescription'] == b'Testing description'
+#                     count += 1
+#             assert count == 10
 
-            # While we're testing autolockrenew and sessions, let's make sure we don't call the lock-lost callback when a session exits.
-            renewer._renew_period = 1
-            session = None
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_session_by_servicebus_client_browse_messages_client(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#             session_id = str(uuid.uuid4())
+#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 for i in range(5):
+#                     message = ServiceBusMessage("Test message no. {}".format(i), session_id=session_id)
+#                     sender.send_messages(message)
+#             session_id_2 = str(uuid.uuid4())
+#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 for i in range(3):
+#                     message = ServiceBusMessage("Test message no. {}".format(i), session_id=session_id_2)
+#                     sender.send_messages(message)
 
-            with sb_client.get_queue_receiver(servicebus_queue.name,
-                                              session_id=session_id,
-                                              max_wait_time=10,
-                                              receive_mode=ServiceBusReceiveMode.PEEK_LOCK,
-                                              prefetch_count=10,
-                                              auto_lock_renewer=renewer) as receiver:
-                session = receiver.session
-            sleep_until_expired(receiver.session)
-            assert not results
+#             with pytest.raises(ServiceBusError):
+#                 with sb_client.get_queue_receiver(servicebus_queue.name):
+#                     messages = sb_client.peek_messages(5)
 
-            renewer.close()
-            assert len(messages) == 2
+#             with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id) as receiver:
+#                 messages = receiver.peek_messages(5)
+#                 assert len(messages) == 5
+#                 assert all(isinstance(m, ServiceBusReceivedMessage) for m in messages)
+#                 for message in messages:
+#                     print_message(_logger, message)
+#                     with pytest.raises(ValueError):
+#                         receiver.complete_message(message)
 
-        # test voluntary halt of auto lock renewer when session is closed
-        session_id = str(uuid.uuid4())
-        with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-            messages = [ServiceBusMessage("{}".format(i), session_id=session_id) for i in range(10)]
-            sender.send_messages(messages)
+#             with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id_2) as receiver:
+#                 messages = receiver.peek_messages(5)
+#                 assert len(messages) == 3
 
-        renewer = AutoLockRenewer(max_lock_renewal_duration=100)
-        receiver = sb_client.get_queue_receiver(servicebus_queue.name,
-                                            session_id=session_id,
-                                            max_wait_time=10,
-                                            prefetch_count=10,
-                                            auto_lock_renewer=renewer)
 
-        with receiver:
-            received_msgs = receiver.receive_messages(max_wait_time=5)
-            for msg in received_msgs:
-                receiver.complete_message(msg)
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_session_by_servicebus_client_browse_messages_with_receiver(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
 
-        receiver.close()
-        assert not renewer._renewable(receiver._session)
+#         with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @CachedServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_session_receiver_partially_invalid_autolockrenew_mode(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        session_id = str(uuid.uuid4())
-        with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#             session_id = str(uuid.uuid4())
+#             with sb_client.get_queue_receiver(servicebus_queue.name, max_wait_time=5, session_id=session_id) as receiver:
+#                 with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                     for i in range(5):
+#                         message = ServiceBusMessage("Test message no. {}".format(i), session_id=session_id)
+#                         sender.send_messages(message)
 
-            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                sender.send_messages(ServiceBusMessage("test_message", session_id=session_id))
+#                 messages = receiver.peek_messages(5)
+#                 assert len(messages) > 0
+#                 assert all(isinstance(m, ServiceBusReceivedMessage) for m in messages)
+#                 for message in messages:
+#                     print_message(_logger, message)
+#                     with pytest.raises(ValueError):
+#                         receiver.complete_message(message)
 
-            failures = 0
-            def should_not_run(*args, **kwargs):
-                failures += 1
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_session_by_servicebus_client_renew_client_locks(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-            auto_lock_renewer = AutoLockRenewer(on_lock_renew_failure=should_not_run)
-            with sb_client.get_queue_receiver(servicebus_queue.name, 
-                                              session_id=session_id,
-                                              receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE,
-                                              auto_lock_renewer=auto_lock_renewer) as receiver:
+#             session_id = str(uuid.uuid4())
+#             messages = []
+#             locks = 3
+#             with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, prefetch_count=10) as receiver:
+#                 with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                     for i in range(locks):
+#                         message = ServiceBusMessage("Test message no. {}".format(i), session_id=session_id)
+#                         sender.send_messages(message)
+
+#                 messages.extend(receiver.receive_messages())
+#                 recv = True
+#                 while recv:
+#                     recv = receiver.receive_messages(max_wait_time=5)
+#                     messages.extend(recv)
+
+#                 try:
+#                     for m in messages:
+#                         with pytest.raises(TypeError):
+#                             expired = m._lock_expired
+#                         assert m.locked_until_utc is None
+#                         assert m.lock_token is not None
+#                     time.sleep(5)
+#                     initial_expiry = receiver.session._locked_until_utc
+#                     receiver.session.renew_lock(timeout=5)
+#                     assert (receiver.session._locked_until_utc - initial_expiry) >= timedelta(seconds=5)
+#                 finally:
+#                     receiver.complete_message(messages[0])
+#                     receiver.complete_message(messages[1])
+
+#                     # This magic number is because of a 30 second lock renewal window.  Chose 31 seconds because at 30, you'll see "off by .05 seconds" flaky failures
+#                     # potentially as a side effect of network delays/sleeps/"typical distributed systems nonsense."  In a perfect world we wouldn't have a magic number/network hop but this allows
+#                     # a slightly more robust test in absence of that.
+#                     assert (receiver.session._locked_until_utc - utc_now()) <= timedelta(seconds=60)
+#                     sleep_until_expired(receiver.session)
+#                     with pytest.raises(SessionLockLostError):
+#                         receiver.complete_message(messages[2])
+
+    
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True, lock_duration='PT10S')
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_session_by_conn_str_receive_handler_with_autolockrenew(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+
+#         session_id = str(uuid.uuid4())
+#         with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+
+#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 for i in range(10):
+#                     message = ServiceBusMessage("{}".format(i), session_id=session_id)
+#                     sender.send_messages(message)
+
+#             results = []
+#             def lock_lost_callback(renewable, error):
+#                 results.append(renewable)
+
+#             renewer = AutoLockRenewer()
+#             messages = []
+#             with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=10, receive_mode=ServiceBusReceiveMode.PEEK_LOCK, prefetch_count=10) as receiver:
+#                 renewer.register(receiver,
+#                                  receiver.session,
+#                                  max_lock_renewal_duration=10,
+#                                  on_lock_renew_failure=lock_lost_callback)
+#                 print("Registered lock renew thread", receiver.session._locked_until_utc, utc_now())
+#                 with pytest.raises(SessionLockLostError):
+#                     for message in receiver:
+#                         if not messages:
+#                             print("Starting first sleep")
+#                             time.sleep(10)
+#                             print("First sleep {}".format(receiver.session._locked_until_utc - utc_now()))
+#                             assert not receiver.session._lock_expired
+#                             with pytest.raises(TypeError):
+#                                 message._lock_expired
+#                             assert message.locked_until_utc is None
+#                             with pytest.raises(TypeError):
+#                                 receiver.renew_message_lock(message)
+#                             assert message.lock_token is not None
+#                             receiver.complete_message(message)
+#                             messages.append(message)
+
+#                         elif len(messages) == 1:
+#                             print("Starting second sleep")
+#                             time.sleep(10) # ensure renewer expires
+#                             print("Second sleep {}".format(receiver.session._locked_until_utc - utc_now()))
+#                             assert not results
+#                             sleep_until_expired(receiver.session) # and then ensure it didn't slip a renew under the wire.
+#                             assert receiver.session._lock_expired
+#                             assert isinstance(receiver.session.auto_renew_error, AutoLockRenewTimeout)
+#                             try:
+#                                 receiver.complete_message(message)
+#                                 raise AssertionError("Didn't raise SessionLockLostError")
+#                             except SessionLockLostError as e:
+#                                 assert isinstance(e.inner_exception, AutoLockRenewTimeout)
+#                             messages.append(message)
+
+#             # While we're testing autolockrenew and sessions, let's make sure we don't call the lock-lost callback when a session exits.
+#             renewer._renew_period = 1
+#             session = None
+
+#             with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=10, receive_mode=ServiceBusReceiveMode.PEEK_LOCK, prefetch_count=10) as receiver:
+#                 session = receiver.session
+#                 renewer.register(receiver,
+#                                  session,
+#                                  max_lock_renewal_duration=10,
+#                                  on_lock_renew_failure=lock_lost_callback)
+#             sleep_until_expired(receiver.session)
+#             assert not results
+
+#             renewer.close()
+#             assert len(messages) == 2
+
+    
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True, lock_duration='PT10S')
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_session_by_conn_str_receive_handler_with_auto_autolockrenew(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+
+#         session_id = str(uuid.uuid4())
+#         with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=True, uamqp_transport=uamqp_transport) as sb_client:
+
+#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 for i in range(10):
+#                     message = ServiceBusMessage("{}".format(i), session_id=session_id)
+#                     sender.send_messages(message)
+
+#             results = []
+#             def lock_lost_callback(renewable, error):
+#                 results.append(renewable)
+
+#             renewer = AutoLockRenewer(max_lock_renewal_duration=10, on_lock_renew_failure = lock_lost_callback)
+#             messages = []
+#             with sb_client.get_queue_receiver(servicebus_queue.name,
+#                                               session_id=session_id,
+#                                               max_wait_time=10,
+#                                               receive_mode=ServiceBusReceiveMode.PEEK_LOCK,
+#                                               prefetch_count=10,
+#                                               auto_lock_renewer=renewer) as receiver:
+#                 print("Registered lock renew thread", receiver.session._locked_until_utc, utc_now())
+#                 with pytest.raises(SessionLockLostError):
+#                     for message in receiver:
+#                         if not messages:
+#                             print("Starting first sleep")
+#                             time.sleep(10)
+#                             print("First sleep {}".format(receiver.session._locked_until_utc - utc_now()))
+#                             assert not receiver.session._lock_expired
+#                             with pytest.raises(TypeError):
+#                                 message._lock_expired
+#                             assert message.locked_until_utc is None
+#                             with pytest.raises(TypeError):
+#                                 receiver.renew_message_lock(message)
+#                             assert message.lock_token is not None
+#                             receiver.complete_message(message)
+#                             messages.append(message)
+
+#                         elif len(messages) == 1:
+#                             print("Starting second sleep")
+#                             time.sleep(10) # ensure renewer expires
+#                             print("Second sleep {}".format(receiver.session._locked_until_utc - utc_now()))
+#                             assert not results
+#                             sleep_until_expired(receiver.session) # and then ensure it didn't slip a renew under the wire.
+#                             assert receiver.session._lock_expired
+#                             assert isinstance(receiver.session.auto_renew_error, AutoLockRenewTimeout)
+#                             try:
+#                                 receiver.complete_message(message)
+#                                 raise AssertionError("Didn't raise SessionLockLostError")
+#                             except SessionLockLostError as e:
+#                                 assert isinstance(e.inner_exception, AutoLockRenewTimeout)
+#                             messages.append(message)
+
+#             # While we're testing autolockrenew and sessions, let's make sure we don't call the lock-lost callback when a session exits.
+#             renewer._renew_period = 1
+#             session = None
+
+#             with sb_client.get_queue_receiver(servicebus_queue.name,
+#                                               session_id=session_id,
+#                                               max_wait_time=10,
+#                                               receive_mode=ServiceBusReceiveMode.PEEK_LOCK,
+#                                               prefetch_count=10,
+#                                               auto_lock_renewer=renewer) as receiver:
+#                 session = receiver.session
+#             sleep_until_expired(receiver.session)
+#             assert not results
+
+#             renewer.close()
+#             assert len(messages) == 2
+
+#         # test voluntary halt of auto lock renewer when session is closed
+#         session_id = str(uuid.uuid4())
+#         with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#             messages = [ServiceBusMessage("{}".format(i), session_id=session_id) for i in range(10)]
+#             sender.send_messages(messages)
+
+#         renewer = AutoLockRenewer(max_lock_renewal_duration=100)
+#         receiver = sb_client.get_queue_receiver(servicebus_queue.name,
+#                                             session_id=session_id,
+#                                             max_wait_time=10,
+#                                             prefetch_count=10,
+#                                             auto_lock_renewer=renewer)
+
+#         with receiver:
+#             received_msgs = receiver.receive_messages(max_wait_time=5)
+#             for msg in received_msgs:
+#                 receiver.complete_message(msg)
+
+#         receiver.close()
+#         assert not renewer._renewable(receiver._session)
+
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @CachedServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_session_receiver_partially_invalid_autolockrenew_mode(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         session_id = str(uuid.uuid4())
+#         with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+
+#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 sender.send_messages(ServiceBusMessage("test_message", session_id=session_id))
+
+#             failures = 0
+#             def should_not_run(*args, **kwargs):
+#                 failures += 1
+
+#             auto_lock_renewer = AutoLockRenewer(on_lock_renew_failure=should_not_run)
+#             with sb_client.get_queue_receiver(servicebus_queue.name, 
+#                                               session_id=session_id,
+#                                               receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE,
+#                                               auto_lock_renewer=auto_lock_renewer) as receiver:
             
-                assert receiver.receive_messages()
-                assert not failures
+#                 assert receiver.receive_messages()
+#                 assert not failures
 
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer()
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_session_message_connection_closed(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer()
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_session_message_connection_closed(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
         
-        with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#         with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-            session_id = str(uuid.uuid4())
+#             session_id = str(uuid.uuid4())
 
-            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                message = ServiceBusMessage("test")
-                message.session_id = session_id
-                sender.send_messages(message)
+#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 message = ServiceBusMessage("test")
+#                 message.session_id = session_id
+#                 sender.send_messages(message)
 
-            with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id) as receiver:
-                messages = receiver.receive_messages(max_wait_time=10)
-                assert len(messages) == 1
+#             with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id) as receiver:
+#                 messages = receiver.receive_messages(max_wait_time=10)
+#                 assert len(messages) == 1
 
-            with pytest.raises(ValueError):
-                receiver.complete_message(messages[0])
+#             with pytest.raises(ValueError):
+#                 receiver.complete_message(messages[0])
 
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer()
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True, lock_duration='PT5S')
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_session_message_expiry(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer()
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True, lock_duration='PT5S')
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_session_message_expiry(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
 
-        with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-            session_id = str(uuid.uuid4())
+#         with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#             session_id = str(uuid.uuid4())
 
-            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                message = ServiceBusMessage("Testing expired messages")
-                message.session_id = session_id
-                sender.send_messages(message)
+#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 message = ServiceBusMessage("Testing expired messages")
+#                 message.session_id = session_id
+#                 sender.send_messages(message)
 
-            with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id) as receiver:
-                messages = receiver.receive_messages(max_wait_time=10)
-                assert len(messages) == 1
-                print_message(_logger, messages[0])
-                time.sleep(10)
-                with pytest.raises(TypeError):
-                    messages[0]._lock_expired
-                with pytest.raises(TypeError):
-                    receiver.renew_message_lock(messages[0])
-                    #TODO: Bug: Why was this 30s sleep before?  compare with T1.
-                assert receiver.session._lock_expired
-                with pytest.raises(SessionLockLostError):
-                    receiver.complete_message(messages[0])
-                with pytest.raises(SessionLockLostError):
-                    receiver.session.renew_lock()
+#             with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id) as receiver:
+#                 messages = receiver.receive_messages(max_wait_time=10)
+#                 assert len(messages) == 1
+#                 print_message(_logger, messages[0])
+#                 time.sleep(10)
+#                 with pytest.raises(TypeError):
+#                     messages[0]._lock_expired
+#                 with pytest.raises(TypeError):
+#                     receiver.renew_message_lock(messages[0])
+#                     #TODO: Bug: Why was this 30s sleep before?  compare with T1.
+#                 assert receiver.session._lock_expired
+#                 with pytest.raises(SessionLockLostError):
+#                     receiver.complete_message(messages[0])
+#                 with pytest.raises(SessionLockLostError):
+#                     receiver.session.renew_lock()
 
-            with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id) as receiver:
-                messages = receiver.receive_messages(max_wait_time=30)
-                assert len(messages) == 1
-                print_message(_logger, messages[0])
-                assert messages[0].delivery_count
-                receiver.complete_message(messages[0])
+#             with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id) as receiver:
+#                 messages = receiver.receive_messages(max_wait_time=30)
+#                 assert len(messages) == 1
+#                 print_message(_logger, messages[0])
+#                 assert messages[0].delivery_count
+#                 receiver.complete_message(messages[0])
 
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_session_schedule_message(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_session_schedule_message(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
 
-        with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#         with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-            session_id = str(uuid.uuid4())
-            enqueue_time = (utc_now() + timedelta(minutes=2)).replace(microsecond=0)
-            with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id) as receiver:
-                with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                    content = str(uuid.uuid4())
-                    message_id = uuid.uuid4()
-                    message = ServiceBusMessage(content, session_id=session_id)
-                    message.message_id = message_id
-                    message.scheduled_enqueue_time_utc = enqueue_time
-                    sender.send_messages(message)
+#             session_id = str(uuid.uuid4())
+#             enqueue_time = (utc_now() + timedelta(minutes=2)).replace(microsecond=0)
+#             with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id) as receiver:
+#                 with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                     content = str(uuid.uuid4())
+#                     message_id = uuid.uuid4()
+#                     message = ServiceBusMessage(content, session_id=session_id)
+#                     message.message_id = message_id
+#                     message.scheduled_enqueue_time_utc = enqueue_time
+#                     sender.send_messages(message)
 
-                messages = []
-                count = 0
-                while not messages and count < 12:
-                    messages = receiver.receive_messages(max_wait_time=10)
-                    receiver.session.renew_lock(timeout=None)
-                    count += 1
+#                 messages = []
+#                 count = 0
+#                 while not messages and count < 12:
+#                     messages = receiver.receive_messages(max_wait_time=10)
+#                     receiver.session.renew_lock(timeout=None)
+#                     count += 1
 
-                data = str(messages[0])
-                assert data == content
-                assert messages[0].message_id == message_id
-                assert messages[0].scheduled_enqueue_time_utc == enqueue_time
-                assert messages[0].scheduled_enqueue_time_utc == messages[0].enqueued_time_utc.replace(microsecond=0)
-                assert len(messages) == 1
-
-
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_session_schedule_multiple_messages(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-
-        with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-
-            session_id = str(uuid.uuid4())
-            enqueue_time = (utc_now() + timedelta(minutes=2)).replace(microsecond=0)
-
-            with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, prefetch_count=20) as receiver:
-                with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                    content = str(uuid.uuid4())
-                    message_id_a = uuid.uuid4()
-                    message_a = ServiceBusMessage(content, session_id=session_id)
-                    message_a.message_id = message_id_a
-                    message_id_b = uuid.uuid4()
-                    message_b = ServiceBusMessage(content, session_id=session_id)
-                    message_b.message_id = message_id_b
-                    tokens = sender.schedule_messages([message_a, message_b], enqueue_time)
-                    assert len(tokens) == 2
-
-                messages = []
-                count = 0
-                while len(messages) < 2 and count < 12:
-                    receiver.session.renew_lock(timeout=None)
-                    messages.extend(receiver.receive_messages(max_wait_time=15))
-                    time.sleep(5)
-                    count += 1
-
-                data = str(messages[0])
-                assert data == content
-                assert messages[0].message_id in (message_id_a, message_id_b)
-                assert messages[0].scheduled_enqueue_time_utc == enqueue_time
-                assert messages[0].scheduled_enqueue_time_utc == messages[0].enqueued_time_utc.replace(microsecond=0)
-                assert len(messages) == 2
+#                 data = str(messages[0])
+#                 assert data == content
+#                 assert messages[0].message_id == message_id
+#                 assert messages[0].scheduled_enqueue_time_utc == enqueue_time
+#                 assert messages[0].scheduled_enqueue_time_utc == messages[0].enqueued_time_utc.replace(microsecond=0)
+#                 assert len(messages) == 1
 
 
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_session_cancel_scheduled_messages(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_session_schedule_multiple_messages(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+
+#         with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+
+#             session_id = str(uuid.uuid4())
+#             enqueue_time = (utc_now() + timedelta(minutes=2)).replace(microsecond=0)
+
+#             with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, prefetch_count=20) as receiver:
+#                 with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                     content = str(uuid.uuid4())
+#                     message_id_a = uuid.uuid4()
+#                     message_a = ServiceBusMessage(content, session_id=session_id)
+#                     message_a.message_id = message_id_a
+#                     message_id_b = uuid.uuid4()
+#                     message_b = ServiceBusMessage(content, session_id=session_id)
+#                     message_b.message_id = message_id_b
+#                     tokens = sender.schedule_messages([message_a, message_b], enqueue_time)
+#                     assert len(tokens) == 2
+
+#                 messages = []
+#                 count = 0
+#                 while len(messages) < 2 and count < 12:
+#                     receiver.session.renew_lock(timeout=None)
+#                     messages.extend(receiver.receive_messages(max_wait_time=15))
+#                     time.sleep(5)
+#                     count += 1
+
+#                 data = str(messages[0])
+#                 assert data == content
+#                 assert messages[0].message_id in (message_id_a, message_id_b)
+#                 assert messages[0].scheduled_enqueue_time_utc == enqueue_time
+#                 assert messages[0].scheduled_enqueue_time_utc == messages[0].enqueued_time_utc.replace(microsecond=0)
+#                 assert len(messages) == 2
+
+
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_session_cancel_scheduled_messages(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
         
-        with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#         with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-            session_id = str(uuid.uuid4())
-            enqueue_time = (utc_now() + timedelta(minutes=2)).replace(microsecond=0)
+#             session_id = str(uuid.uuid4())
+#             enqueue_time = (utc_now() + timedelta(minutes=2)).replace(microsecond=0)
 
-            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                message_a = ServiceBusMessage("Test scheduled message", session_id=session_id)
-                message_b = ServiceBusMessage("Test scheduled message", session_id=session_id)
-                tokens = sender.schedule_messages([message_a, message_b], enqueue_time)
-                assert len(tokens) == 2
-                sender.cancel_scheduled_messages(tokens)
+#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 message_a = ServiceBusMessage("Test scheduled message", session_id=session_id)
+#                 message_b = ServiceBusMessage("Test scheduled message", session_id=session_id)
+#                 tokens = sender.schedule_messages([message_a, message_b], enqueue_time)
+#                 assert len(tokens) == 2
+#                 sender.cancel_scheduled_messages(tokens)
 
-            with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id) as receiver:
-                messages = []
-                count = 0
-                while not messages and count < 13:
-                    messages = receiver.receive_messages(max_wait_time=20)
-                    receiver.session.renew_lock()
-                    count += 1
-                assert len(messages) == 0
+#             with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id) as receiver:
+#                 messages = []
+#                 count = 0
+#                 while not messages and count < 13:
+#                     messages = receiver.receive_messages(max_wait_time=20)
+#                     receiver.session.renew_lock()
+#                     count += 1
+#                 assert len(messages) == 0
 
     
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_session_get_set_state_with_receiver(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_session_get_set_state_with_receiver(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
 
-        with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#         with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-            session_id = str(uuid.uuid4())
-            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                for i in range(3):
-                    message = ServiceBusMessage("Handler message no. {}".format(i), session_id=session_id)
-                    sender.send_messages(message)
+#             session_id = str(uuid.uuid4())
+#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 for i in range(3):
+#                     message = ServiceBusMessage("Handler message no. {}".format(i), session_id=session_id)
+#                     sender.send_messages(message)
 
-            with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=5) as session:
-                assert session.session.get_state(timeout=5) == None
-                session.session.set_state("first_state", timeout=5)
-                count = 0
-                for m in session:
-                    assert m.session_id == session_id
-                    count += 1
-                state = session.session.get_state()
-                assert state == b'first_state'
-            assert count == 3
+#             with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=5) as session:
+#                 assert session.session.get_state(timeout=5) == None
+#                 session.session.set_state("first_state", timeout=5)
+#                 count = 0
+#                 for m in session:
+#                     assert m.session_id == session_id
+#                     count += 1
+#                 state = session.session.get_state()
+#                 assert state == b'first_state'
+#             assert count == 3
 
-            session_id = str(uuid.uuid4())
-            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                for i in range(1):
-                    message = ServiceBusMessage("Handler message no. {}".format(i), session_id=session_id)
-                    sender.send_messages(message)
+#             session_id = str(uuid.uuid4())
+#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 for i in range(1):
+#                     message = ServiceBusMessage("Handler message no. {}".format(i), session_id=session_id)
+#                     sender.send_messages(message)
 
-            with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=5) as session:
-                assert session.session.get_state(timeout=5) == None
-                session.session.set_state(None, timeout=5)
-                count = 0
-                for m in session:
-                    assert m.session_id == session_id
-                    count += 1
-                state = session.session.get_state()
-                assert state == None
-            assert count == 1
-
-
-    @pytest.mark.skip(reason="Needs list sessions")
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_session_by_servicebus_client_list_sessions_with_receiver(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-
-        with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-
-            sessions = []
-            start_time = utc_now()
-            for i in range(5):
-                sessions.append(str(uuid.uuid4()))
-
-            for session_id in sessions:
-                with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                    for i in range(5):
-                        message = ServiceBusMessage("Test message no. {}".format(i), session_id=session_id)
-                        sender.send_messages(message)
-            for session_id in sessions:
-                with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id) as receiver:
-                    receiver.set_state("SESSION {}".format(session_id))
-
-            with sb_client.get_queue_receiver(servicebus_queue.name, session_id=NEXT_AVAILABLE_SESSION, max_wait_time=5, receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
-                current_sessions = receiver.list_sessions(updated_since=start_time)
-                assert len(current_sessions) == 5
-                assert current_sessions == sessions
+#             with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, max_wait_time=5) as session:
+#                 assert session.session.get_state(timeout=5) == None
+#                 session.session.set_state(None, timeout=5)
+#                 count = 0
+#                 for m in session:
+#                     assert m.session_id == session_id
+#                     count += 1
+#                 state = session.session.get_state()
+#                 assert state == None
+#             assert count == 1
 
 
-    @pytest.mark.skip("Requires list sessions")
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_session_by_servicebus_client_list_sessions_with_client(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#     @pytest.mark.skip(reason="Needs list sessions")
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_session_by_servicebus_client_list_sessions_with_receiver(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
 
-        with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#         with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-            sessions = []
-            start_time = utc_now()
-            for i in range(5):
-                sessions.append(str(uuid.uuid4()))
+#             sessions = []
+#             start_time = utc_now()
+#             for i in range(5):
+#                 sessions.append(str(uuid.uuid4()))
 
-            for session in sessions:
-                with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                    for i in range(5):
-                        message = ServiceBusMessage("Test message no. {}".format(i), session_id=session)
-                        sender.send_messages(message)
-            for session in sessions:
-                with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session) as receiver:
-                    receiver.set_state("SESSION {}".format(session))
+#             for session_id in sessions:
+#                 with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                     for i in range(5):
+#                         message = ServiceBusMessage("Test message no. {}".format(i), session_id=session_id)
+#                         sender.send_messages(message)
+#             for session_id in sessions:
+#                 with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id) as receiver:
+#                     receiver.set_state("SESSION {}".format(session_id))
 
-                    current_sessions = receiver.list_sessions(updated_since=start_time)
-                    assert len(current_sessions) == 5
-                    assert current_sessions == sessions
+#             with sb_client.get_queue_receiver(servicebus_queue.name, session_id=NEXT_AVAILABLE_SESSION, max_wait_time=5, receive_mode=ServiceBusReceiveMode.PEEK_LOCK) as receiver:
+#                 current_sessions = receiver.list_sessions(updated_since=start_time)
+#                 assert len(current_sessions) == 5
+#                 assert current_sessions == sessions
 
 
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @pytest.mark.xfail(reason="'Cannot open log' error, potential service bug")
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_session_by_servicebus_client_session_pool(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        messages = []
-        errors = []
-        concurrent_receivers = 5
+#     @pytest.mark.skip("Requires list sessions")
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_session_by_servicebus_client_list_sessions_with_client(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+
+#         with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+
+#             sessions = []
+#             start_time = utc_now()
+#             for i in range(5):
+#                 sessions.append(str(uuid.uuid4()))
+
+#             for session in sessions:
+#                 with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                     for i in range(5):
+#                         message = ServiceBusMessage("Test message no. {}".format(i), session_id=session)
+#                         sender.send_messages(message)
+#             for session in sessions:
+#                 with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session) as receiver:
+#                     receiver.set_state("SESSION {}".format(session))
+
+#                     current_sessions = receiver.list_sessions(updated_since=start_time)
+#                     assert len(current_sessions) == 5
+#                     assert current_sessions == sessions
+
+
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @pytest.mark.xfail(reason="'Cannot open log' error, potential service bug")
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_session_by_servicebus_client_session_pool(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         messages = []
+#         errors = []
+#         concurrent_receivers = 5
     
-        def message_processing(sb_client):
-            while True:
-                try:
-                    with sb_client.get_queue_receiver(servicebus_queue.name, session_id=NEXT_AVAILABLE_SESSION, max_wait_time=10) as receiver:
-                        for message in receiver:
-                            print("ServiceBusReceivedMessage: {}".format(message))
-                            messages.append(message)
-                            receiver.complete_message(message)
-                except OperationTimeoutError:
-                    return
-                except Exception as e:
-                    errors.append(e)
-                    raise
+#         def message_processing(sb_client):
+#             while True:
+#                 try:
+#                     with sb_client.get_queue_receiver(servicebus_queue.name, session_id=NEXT_AVAILABLE_SESSION, max_wait_time=10) as receiver:
+#                         for message in receiver:
+#                             print("ServiceBusReceivedMessage: {}".format(message))
+#                             messages.append(message)
+#                             receiver.complete_message(message)
+#                 except OperationTimeoutError:
+#                     return
+#                 except Exception as e:
+#                     errors.append(e)
+#                     raise
                 
-        with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#         with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
     
-            sessions = [str(uuid.uuid4()) for i in range(concurrent_receivers)]
+#             sessions = [str(uuid.uuid4()) for i in range(concurrent_receivers)]
     
-            for session_id in sessions:
-                with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                    for i in range(20):
-                        message = ServiceBusMessage("Test message no. {}".format(i), session_id=session_id)
-                        sender.send_messages(message)
+#             for session_id in sessions:
+#                 with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                     for i in range(20):
+#                         message = ServiceBusMessage("Test message no. {}".format(i), session_id=session_id)
+#                         sender.send_messages(message)
     
-            futures = []
-            with concurrent.futures.ThreadPoolExecutor(max_workers=concurrent_receivers) as thread_pool:
-                for _ in range(concurrent_receivers):
-                    futures.append(thread_pool.submit(message_processing, sb_client))
-                concurrent.futures.wait(futures)
+#             futures = []
+#             with concurrent.futures.ThreadPoolExecutor(max_workers=concurrent_receivers) as thread_pool:
+#                 for _ in range(concurrent_receivers):
+#                     futures.append(thread_pool.submit(message_processing, sb_client))
+#                 concurrent.futures.wait(futures)
     
-            assert not errors
-            assert len(messages) == 100
-
-    
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_session_by_session_client_conn_str_receive_handler_peeklock_abandon(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
-
-            session_id = str(uuid.uuid4())
-            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                for i in range(3):
-                    message = ServiceBusMessage("Handler message no. {}".format(i), session_id=session_id)
-                    sender.send_messages(message)
-
-            with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, prefetch_count=0, max_wait_time=5) as receiver:
-                message = receiver.next()
-                assert message.sequence_number == 1
-                receiver.abandon_message(message)
-                for next_message in receiver: # we can't be sure there won't be a service delay, so we may not get the message back _immediately_, even if in most cases it shows right back up.
-                    if not next_message:
-                        raise Exception("Did not successfully re-receive abandoned message, sequence_number 1 was not observed.")
-                    if next_message.sequence_number == 1:
-                        return
+#             assert not errors
+#             assert len(messages) == 100
 
     
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusTopicPreparer(name_prefix='servicebustest')
-    @ServiceBusSubscriptionPreparer(name_prefix='servicebustest', requires_session=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_session_basic_topic_subscription_send_and_receive(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_topic=None, servicebus_subscription=None, **kwargs):
-        with ServiceBusClient.from_connection_string(
-                servicebus_namespace_connection_string,
-                logging_enable=False, uamqp_transport=uamqp_transport
-        ) as sb_client:
-            with sb_client.get_topic_sender(topic_name=servicebus_topic.name) as sender:
-                message = ServiceBusMessage(b"Sample topic message", session_id='test_session')
-                sender.send_messages(message)
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_session_by_session_client_conn_str_receive_handler_peeklock_abandon(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-            with sb_client.get_subscription_receiver(
-                topic_name=servicebus_topic.name,
-                subscription_name=servicebus_subscription.name,
-                session_id='test_session',
-                max_wait_time=5
-            ) as receiver:
-                count = 0
-                for message in receiver:
-                    count += 1
-                    receiver.complete_message(message)
-            assert count == 1
+#             session_id = str(uuid.uuid4())
+#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 for i in range(3):
+#                     message = ServiceBusMessage("Handler message no. {}".format(i), session_id=session_id)
+#                     sender.send_messages(message)
 
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @CachedServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_session_non_session_send_to_session_queue_should_fail(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#             with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id, prefetch_count=0, max_wait_time=5) as receiver:
+#                 message = receiver.next()
+#                 assert message.sequence_number == 1
+#                 receiver.abandon_message(message)
+#                 for next_message in receiver: # we can't be sure there won't be a service delay, so we may not get the message back _immediately_, even if in most cases it shows right back up.
+#                     if not next_message:
+#                         raise Exception("Did not successfully re-receive abandoned message, sequence_number 1 was not observed.")
+#                     if next_message.sequence_number == 1:
+#                         return
 
-            with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                message = ServiceBusMessage("This should be an invalid non session message")
-                with pytest.raises(ServiceBusError):
-                    sender.send_messages(message)
     
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_session_id_str_bytes(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusTopicPreparer(name_prefix='servicebustest')
+#     @ServiceBusSubscriptionPreparer(name_prefix='servicebustest', requires_session=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_session_basic_topic_subscription_send_and_receive(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_topic=None, servicebus_subscription=None, **kwargs):
+#         with ServiceBusClient.from_connection_string(
+#                 servicebus_namespace_connection_string,
+#                 logging_enable=False, uamqp_transport=uamqp_transport
+#         ) as sb_client:
+#             with sb_client.get_topic_sender(topic_name=servicebus_topic.name) as sender:
+#                 message = ServiceBusMessage(b"Sample topic message", session_id='test_session')
+#                 sender.send_messages(message)
 
-        with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+#             with sb_client.get_subscription_receiver(
+#                 topic_name=servicebus_topic.name,
+#                 subscription_name=servicebus_subscription.name,
+#                 session_id='test_session',
+#                 max_wait_time=5
+#             ) as receiver:
+#                 count = 0
+#                 for message in receiver:
+#                     count += 1
+#                     receiver.complete_message(message)
+#             assert count == 1
 
-            sessions = []
-            start_time = utc_now()
-            for i in range(5):
-                sessions.append('a' * (i + 1))
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @CachedServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_session_non_session_send_to_session_queue_should_fail(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
 
-            for session_id in sessions:
-                with sb_client.get_queue_sender(servicebus_queue.name) as sender:
-                    message = ServiceBusMessage("Test message no. {}".format(i), session_id=session_id)
-                    sender.send_messages(message)
-            for session_id in sessions:
-                with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id) as receiver:
-                    messages = receiver.receive_messages(max_wait_time=10)
-                    assert len(messages) == 1
-                    assert messages[0].session_id == session_id
+#             with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                 message = ServiceBusMessage("This should be an invalid non session message")
+#                 with pytest.raises(ServiceBusError):
+#                     sender.send_messages(message)
+    
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_session_id_str_bytes(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+
+#         with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport) as sb_client:
+
+#             sessions = []
+#             start_time = utc_now()
+#             for i in range(5):
+#                 sessions.append('a' * (i + 1))
+
+#             for session_id in sessions:
+#                 with sb_client.get_queue_sender(servicebus_queue.name) as sender:
+#                     message = ServiceBusMessage("Test message no. {}".format(i), session_id=session_id)
+#                     sender.send_messages(message)
+#             for session_id in sessions:
+#                 with sb_client.get_queue_receiver(servicebus_queue.name, session_id=session_id) as receiver:
+#                     messages = receiver.receive_messages(max_wait_time=10)
+#                     assert len(messages) == 1
+#                     assert messages[0].session_id == session_id
     
     
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()  
-    def test_next_available_session_timeout_value(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
-        if uamqp_transport:
-            pytest.skip("This test is for pyamqp only")
-        with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport, retry_total=1) as sb_client:
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusQueuePreparer(name_prefix='servicebustest', requires_session=True)
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()  
+#     def test_next_available_session_timeout_value(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_queue=None, **kwargs):
+#         if uamqp_transport:
+#             pytest.skip("This test is for pyamqp only")
+#         with ServiceBusClient.from_connection_string(
+#             servicebus_namespace_connection_string, logging_enable=False, uamqp_transport=uamqp_transport, retry_total=1) as sb_client:
             
-            receiver = sb_client.get_queue_receiver(servicebus_queue.name, session_id=NEXT_AVAILABLE_SESSION, max_wait_time=10,)
+#             receiver = sb_client.get_queue_receiver(servicebus_queue.name, session_id=NEXT_AVAILABLE_SESSION, max_wait_time=10,)
             
-            start_time = time.time()
-            with pytest.raises(OperationTimeoutError):
-                receiver.receive_messages(max_wait_time=5)
-            assert time.time() - start_time < 65  # Default service operation timeout is 65 seconds
-            start_time2 = time.time()
-            with pytest.raises(OperationTimeoutError):
-                for msg in receiver:
-                    pass
+#             start_time = time.time()
+#             with pytest.raises(OperationTimeoutError):
+#                 receiver.receive_messages(max_wait_time=5)
+#             assert time.time() - start_time < 65  # Default service operation timeout is 65 seconds
+#             start_time2 = time.time()
+#             with pytest.raises(OperationTimeoutError):
+#                 for msg in receiver:
+#                     pass
 
-            assert time.time() - start_time2 < 65  # Default service operation timeout is 65 seconds
+#             assert time.time() - start_time2 < 65  # Default service operation timeout is 65 seconds
 
-            receiver = sb_client.get_queue_receiver(servicebus_queue.name, session_id=NEXT_AVAILABLE_SESSION, max_wait_time=70)
+#             receiver = sb_client.get_queue_receiver(servicebus_queue.name, session_id=NEXT_AVAILABLE_SESSION, max_wait_time=70)
             
-            start_time = time.time()
-            with pytest.raises(OperationTimeoutError):
-                receiver.receive_messages(max_wait_time=5)
-            assert time.time() - start_time > 65  # Default service operation timeout is 65 seconds
-            start_time2 = time.time()
-            with pytest.raises(OperationTimeoutError):
-                for msg in receiver:
-                    pass
+#             start_time = time.time()
+#             with pytest.raises(OperationTimeoutError):
+#                 receiver.receive_messages(max_wait_time=5)
+#             assert time.time() - start_time > 65  # Default service operation timeout is 65 seconds
+#             start_time2 = time.time()
+#             with pytest.raises(OperationTimeoutError):
+#                 for msg in receiver:
+#                     pass
 
-            assert time.time() - start_time2 > 65  # Default service operation timeout is 65 seconds
+#             assert time.time() - start_time2 > 65  # Default service operation timeout is 65 seconds

--- a/sdk/servicebus/azure-servicebus/tests/test_subscriptions.py
+++ b/sdk/servicebus/azure-servicebus/tests/test_subscriptions.py
@@ -1,296 +1,296 @@
-#-------------------------------------------------------------------------
-# Copyright (c) Microsoft Corporation. All rights reserved.
-# Licensed under the MIT License. See License.txt in the project root for
-# license information.
-#-------------------------------------------------------------------------
+# #-------------------------------------------------------------------------
+# # Copyright (c) Microsoft Corporation. All rights reserved.
+# # Licensed under the MIT License. See License.txt in the project root for
+# # license information.
+# #-------------------------------------------------------------------------
 
-import logging
-import sys
-import os
-import pytest
-import time
-from datetime import datetime, timedelta
+# import logging
+# import sys
+# import os
+# import pytest
+# import time
+# from datetime import datetime, timedelta
 
-from azure.servicebus._common.utils import utc_now
-from azure.servicebus import ServiceBusClient, ServiceBusMessage, ServiceBusReceiveMode
-from azure.servicebus._base_handler import ServiceBusSharedKeyCredential
-from azure.servicebus.exceptions import ServiceBusError, MessageLockLostError
-from azure.servicebus._common.constants import ServiceBusSubQueue
+# from azure.servicebus._common.utils import utc_now
+# from azure.servicebus import ServiceBusClient, ServiceBusMessage, ServiceBusReceiveMode
+# from azure.servicebus._base_handler import ServiceBusSharedKeyCredential
+# from azure.servicebus.exceptions import ServiceBusError, MessageLockLostError
+# from azure.servicebus._common.constants import ServiceBusSubQueue
 
-from devtools_testutils import AzureMgmtRecordedTestCase, RandomNameResourceGroupPreparer
-from servicebus_preparer import (
-    CachedServiceBusNamespacePreparer,
-    CachedServiceBusTopicPreparer,
-    CachedServiceBusSubscriptionPreparer,
-    ServiceBusTopicPreparer,
-    ServiceBusSubscriptionPreparer,
-    CachedServiceBusResourceGroupPreparer,
-    SERVICEBUS_ENDPOINT_SUFFIX
-)
-from utilities import get_logger, print_message, uamqp_transport as get_uamqp_transport, ArgPasser
-uamqp_transport_params, uamqp_transport_ids = get_uamqp_transport()
-
-
-_logger = get_logger(logging.DEBUG)
+# from devtools_testutils import AzureMgmtRecordedTestCase, RandomNameResourceGroupPreparer
+# from servicebus_preparer import (
+#     CachedServiceBusNamespacePreparer,
+#     CachedServiceBusTopicPreparer,
+#     CachedServiceBusSubscriptionPreparer,
+#     ServiceBusTopicPreparer,
+#     ServiceBusSubscriptionPreparer,
+#     CachedServiceBusResourceGroupPreparer,
+#     SERVICEBUS_ENDPOINT_SUFFIX
+# )
+# from utilities import get_logger, print_message, uamqp_transport as get_uamqp_transport, ArgPasser
+# uamqp_transport_params, uamqp_transport_ids = get_uamqp_transport()
 
 
-class TestServiceBusSubscription(AzureMgmtRecordedTestCase):
+# _logger = get_logger(logging.DEBUG)
 
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusTopicPreparer(name_prefix='servicebustest')
-    @ServiceBusSubscriptionPreparer(name_prefix='servicebustest')
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_subscription_by_subscription_client_conn_str_receive_basic(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_topic=None, servicebus_subscription=None, **kwargs):
 
-        with ServiceBusClient.from_connection_string(
-                servicebus_namespace_connection_string,
-                logging_enable=False,
-                uamqp_transport=uamqp_transport
-        ) as sb_client:
-            with sb_client.get_topic_sender(topic_name=servicebus_topic.name) as sender:
-                message = ServiceBusMessage(b"Sample topic message")
-                sender.send_messages(message)
+# class TestServiceBusSubscription(AzureMgmtRecordedTestCase):
 
-            with pytest.raises(ValueError):
-                sb_client.get_subscription_receiver(
-                    topic_name=servicebus_topic.name,
-                    subscription_name=servicebus_subscription.name,
-                    max_wait_time=0
-                )
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusTopicPreparer(name_prefix='servicebustest')
+#     @ServiceBusSubscriptionPreparer(name_prefix='servicebustest')
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_subscription_by_subscription_client_conn_str_receive_basic(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_topic=None, servicebus_subscription=None, **kwargs):
 
-            with sb_client.get_subscription_receiver(
-                    topic_name=servicebus_topic.name,
-                    subscription_name=servicebus_subscription.name,
-                    max_wait_time=5
-            ) as receiver:
+#         with ServiceBusClient.from_connection_string(
+#                 servicebus_namespace_connection_string,
+#                 logging_enable=False,
+#                 uamqp_transport=uamqp_transport
+#         ) as sb_client:
+#             with sb_client.get_topic_sender(topic_name=servicebus_topic.name) as sender:
+#                 message = ServiceBusMessage(b"Sample topic message")
+#                 sender.send_messages(message)
 
-                with pytest.raises(ValueError):
-                    receiver.receive_messages(max_wait_time=-1)
+#             with pytest.raises(ValueError):
+#                 sb_client.get_subscription_receiver(
+#                     topic_name=servicebus_topic.name,
+#                     subscription_name=servicebus_subscription.name,
+#                     max_wait_time=0
+#                 )
 
-                count = 0
-                for message in receiver:
-                    count += 1
-                    receiver.complete_message(message)
-            assert count == 1
+#             with sb_client.get_subscription_receiver(
+#                     topic_name=servicebus_topic.name,
+#                     subscription_name=servicebus_subscription.name,
+#                     max_wait_time=5
+#             ) as receiver:
 
-    
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusTopicPreparer(name_prefix='servicebustest')
-    @ServiceBusSubscriptionPreparer(name_prefix='servicebustest')
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_subscription_by_sas_token_credential_conn_str_send_basic(self, uamqp_transport, *, servicebus_namespace=None, servicebus_namespace_key_name=None, servicebus_namespace_primary_key=None, servicebus_topic=None, servicebus_subscription=None, **kwargs):
-        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
-        with ServiceBusClient(
-            fully_qualified_namespace=fully_qualified_namespace,
-            credential=ServiceBusSharedKeyCredential(
-                policy=servicebus_namespace_key_name,
-                key=servicebus_namespace_primary_key
-            ),
-            logging_enable=False,
-            uamqp_transport=uamqp_transport
-        ) as sb_client:
+#                 with pytest.raises(ValueError):
+#                     receiver.receive_messages(max_wait_time=-1)
 
-            with sb_client.get_topic_sender(topic_name=servicebus_topic.name) as sender:
-                message = ServiceBusMessage(b"Sample topic message")
-                sender.send_messages(message)
-
-            with sb_client.get_subscription_receiver(
-                    topic_name=servicebus_topic.name,
-                    subscription_name=servicebus_subscription.name,
-                    max_wait_time=5
-            ) as receiver:
-                count = 0
-                for message in receiver:
-                    count += 1
-                    receiver.complete_message(message)
-            assert count == 1
-
-    @pytest.mark.skip(reason="Pending management apis")
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @RandomNameResourceGroupPreparer()
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusTopicPreparer(name_prefix='servicebustest')
-    @ServiceBusSubscriptionPreparer(name_prefix='servicebustest')
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_subscription_by_servicebus_client_list_subscriptions(self, uamqp_transport, *, servicebus_namespace=None, servicebus_namespace_key_name=None, servicebus_namespace_primary_key=None, servicebus_topic=None, servicebus_subscription=None, **kwargs):
-
-        client = ServiceBusClient(
-            service_namespace=servicebus_namespace.name,
-            shared_access_key_name=servicebus_namespace_key_name,
-            shared_access_key_value=servicebus_namespace_primary_key,
-            logging_enable=False,
-            uamqp_transport=uamqp_transport
-            )
-
-        subs = client.list_subscriptions(servicebus_topic.name)
-        assert len(subs) >= 1
-        # assert all(isinstance(s, SubscriptionClient) for s in subs)
-        assert subs[0].name == servicebus_subscription.name
-        assert subs[0].topic_name == servicebus_topic.name
+#                 count = 0
+#                 for message in receiver:
+#                     count += 1
+#                     receiver.complete_message(message)
+#             assert count == 1
 
     
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusTopicPreparer(name_prefix='servicebustest')
-    @ServiceBusSubscriptionPreparer(name_prefix='servicebustest')
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_subscription_by_servicebus_client_receive_batch_with_deadletter(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_topic=None, servicebus_subscription=None, **kwargs):
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusTopicPreparer(name_prefix='servicebustest')
+#     @ServiceBusSubscriptionPreparer(name_prefix='servicebustest')
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_subscription_by_sas_token_credential_conn_str_send_basic(self, uamqp_transport, *, servicebus_namespace=None, servicebus_namespace_key_name=None, servicebus_namespace_primary_key=None, servicebus_topic=None, servicebus_subscription=None, **kwargs):
+#         fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+#         with ServiceBusClient(
+#             fully_qualified_namespace=fully_qualified_namespace,
+#             credential=ServiceBusSharedKeyCredential(
+#                 policy=servicebus_namespace_key_name,
+#                 key=servicebus_namespace_primary_key
+#             ),
+#             logging_enable=False,
+#             uamqp_transport=uamqp_transport
+#         ) as sb_client:
 
-        with ServiceBusClient.from_connection_string(
-                servicebus_namespace_connection_string,
-                logging_enable=False,
-                uamqp_transport=uamqp_transport
-        ) as sb_client:
+#             with sb_client.get_topic_sender(topic_name=servicebus_topic.name) as sender:
+#                 message = ServiceBusMessage(b"Sample topic message")
+#                 sender.send_messages(message)
 
-            with sb_client.get_subscription_receiver(
-                topic_name=servicebus_topic.name,
-                subscription_name=servicebus_subscription.name,
-                max_wait_time=5,
-                receive_mode=ServiceBusReceiveMode.PEEK_LOCK,
-                prefetch_count=10
-            ) as receiver:
+#             with sb_client.get_subscription_receiver(
+#                     topic_name=servicebus_topic.name,
+#                     subscription_name=servicebus_subscription.name,
+#                     max_wait_time=5
+#             ) as receiver:
+#                 count = 0
+#                 for message in receiver:
+#                     count += 1
+#                     receiver.complete_message(message)
+#             assert count == 1
 
-                with sb_client.get_topic_sender(servicebus_topic.name) as sender:
-                    for i in range(10):
-                        message = ServiceBusMessage("Dead lettered message no. {}".format(i))
-                        sender.send_messages(message)
+#     @pytest.mark.skip(reason="Pending management apis")
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @RandomNameResourceGroupPreparer()
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusTopicPreparer(name_prefix='servicebustest')
+#     @ServiceBusSubscriptionPreparer(name_prefix='servicebustest')
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_subscription_by_servicebus_client_list_subscriptions(self, uamqp_transport, *, servicebus_namespace=None, servicebus_namespace_key_name=None, servicebus_namespace_primary_key=None, servicebus_topic=None, servicebus_subscription=None, **kwargs):
 
-                count = 0
-                messages = receiver.receive_messages()
-                while messages:
-                    for message in messages:
-                        print_message(_logger, message)
-                        count += 1
-                        receiver.dead_letter_message(message, reason="Testing reason", error_description="Testing description")
-                    messages = receiver.receive_messages()
+#         client = ServiceBusClient(
+#             service_namespace=servicebus_namespace.name,
+#             shared_access_key_name=servicebus_namespace_key_name,
+#             shared_access_key_value=servicebus_namespace_primary_key,
+#             logging_enable=False,
+#             uamqp_transport=uamqp_transport
+#             )
 
-            assert count == 10
+#         subs = client.list_subscriptions(servicebus_topic.name)
+#         assert len(subs) >= 1
+#         # assert all(isinstance(s, SubscriptionClient) for s in subs)
+#         assert subs[0].name == servicebus_subscription.name
+#         assert subs[0].topic_name == servicebus_topic.name
 
-            with sb_client.get_subscription_receiver(
-                topic_name=servicebus_topic.name,
-                subscription_name=servicebus_subscription.name,
-                max_wait_time=5,
-                receive_mode=ServiceBusReceiveMode.PEEK_LOCK
-            ) as receiver:
-                count = 0
-                for message in receiver:
-                    print_message(_logger, message)
-                    receiver.complete_message(message)
-                    count += 1
-            assert count == 0
+    
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusTopicPreparer(name_prefix='servicebustest')
+#     @ServiceBusSubscriptionPreparer(name_prefix='servicebustest')
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_subscription_by_servicebus_client_receive_batch_with_deadletter(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_topic=None, servicebus_subscription=None, **kwargs):
 
-            with sb_client.get_subscription_receiver(
-                topic_name=servicebus_topic.name,
-                subscription_name=servicebus_subscription.name,
-                sub_queue = ServiceBusSubQueue.DEAD_LETTER,
-                max_wait_time=5,
-                receive_mode=ServiceBusReceiveMode.PEEK_LOCK
-            ) as dl_receiver:
-                count = 0
-                for message in dl_receiver:
-                    dl_receiver.complete_message(message)
-                    count += 1
-                    assert message.dead_letter_reason == 'Testing reason'
-                    assert message.dead_letter_error_description == 'Testing description'
-                    assert message.application_properties[b'DeadLetterReason'] == b'Testing reason'
-                    assert message.application_properties[b'DeadLetterErrorDescription'] == b'Testing description'
-                assert count == 10
+#         with ServiceBusClient.from_connection_string(
+#                 servicebus_namespace_connection_string,
+#                 logging_enable=False,
+#                 uamqp_transport=uamqp_transport
+#         ) as sb_client:
 
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusTopicPreparer(name_prefix='servicebustest')
-    @ServiceBusSubscriptionPreparer(name_prefix='servicebustest', lock_duration='PT5S')
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_subscription_message_expiry(self, uamqp_transport, *, servicebus_namespace=None, servicebus_namespace_key_name=None, servicebus_namespace_primary_key=None, servicebus_topic=None, servicebus_subscription=None, **kwargs):
-        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
-        with ServiceBusClient(
-            fully_qualified_namespace=fully_qualified_namespace,
-            credential=ServiceBusSharedKeyCredential(
-                policy=servicebus_namespace_key_name,
-                key=servicebus_namespace_primary_key
-            ),
-            logging_enable=False,
-            uamqp_transport=uamqp_transport
-        ) as sb_client:
+#             with sb_client.get_subscription_receiver(
+#                 topic_name=servicebus_topic.name,
+#                 subscription_name=servicebus_subscription.name,
+#                 max_wait_time=5,
+#                 receive_mode=ServiceBusReceiveMode.PEEK_LOCK,
+#                 prefetch_count=10
+#             ) as receiver:
 
-            with sb_client.get_topic_sender(topic_name=servicebus_topic.name) as sender:
-                message = ServiceBusMessage(b"Testing topic message expiry")
-                sender.send_messages(message)
+#                 with sb_client.get_topic_sender(servicebus_topic.name) as sender:
+#                     for i in range(10):
+#                         message = ServiceBusMessage("Dead lettered message no. {}".format(i))
+#                         sender.send_messages(message)
 
-            with sb_client.get_subscription_receiver(
-                    topic_name=servicebus_topic.name,
-                    subscription_name=servicebus_subscription.name
-            ) as receiver:
-                messages = receiver.receive_messages(max_wait_time=10)
-                assert len(messages) == 1
-                time.sleep((messages[0].locked_until_utc - utc_now()).total_seconds()+1)
-                assert messages[0]._lock_expired
-                with pytest.raises(MessageLockLostError):
-                    receiver.complete_message(messages[0])
-                with pytest.raises(MessageLockLostError):
-                    receiver.renew_message_lock(messages[0])
-            with sb_client.get_subscription_receiver(
-                    topic_name=servicebus_topic.name,
-                    subscription_name=servicebus_subscription.name
-            ) as receiver:
-                messages = receiver.receive_messages(max_wait_time=10)
-                assert len(messages) == 1
-                assert messages[0].delivery_count > 0
-                receiver.complete_message(messages[0])
+#                 count = 0
+#                 messages = receiver.receive_messages()
+#                 while messages:
+#                     for message in messages:
+#                         print_message(_logger, message)
+#                         count += 1
+#                         receiver.dead_letter_message(message, reason="Testing reason", error_description="Testing description")
+#                     messages = receiver.receive_messages()
 
-    @pytest.mark.liveTest
-    @pytest.mark.live_test_only
-    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @ServiceBusTopicPreparer(name_prefix='servicebustest')
-    @ServiceBusSubscriptionPreparer(name_prefix='servicebustest', lock_duration='PT5S')
-    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-    @ArgPasser()
-    def test_subscription_receive_and_delete_with_send_and_wait(self, uamqp_transport, *, servicebus_namespace=None, servicebus_namespace_key_name=None, servicebus_namespace_primary_key=None, servicebus_topic=None, servicebus_subscription=None, **kwargs):
-        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
-        with ServiceBusClient(
-            fully_qualified_namespace=fully_qualified_namespace,
-            credential=ServiceBusSharedKeyCredential(
-                policy=servicebus_namespace_key_name,
-                key=servicebus_namespace_primary_key
-            ),
-            logging_enable=False,
-            uamqp_transport=uamqp_transport
-        ) as sb_client:
+#             assert count == 10
 
-            sender = sb_client.get_topic_sender(topic_name=servicebus_topic.name)
-            receiver = sb_client.get_subscription_receiver(
-                    topic_name=servicebus_topic.name,
-                    subscription_name=servicebus_subscription.name,
-                    receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE,
-            )
-            with sender, receiver:
-                # queue should be empty
-                received_msgs = receiver.receive_messages(max_message_count=10, max_wait_time=10)
-                assert len(received_msgs) == 0
+#             with sb_client.get_subscription_receiver(
+#                 topic_name=servicebus_topic.name,
+#                 subscription_name=servicebus_subscription.name,
+#                 max_wait_time=5,
+#                 receive_mode=ServiceBusReceiveMode.PEEK_LOCK
+#             ) as receiver:
+#                 count = 0
+#                 for message in receiver:
+#                     print_message(_logger, message)
+#                     receiver.complete_message(message)
+#                     count += 1
+#             assert count == 0
 
-                messages = [ServiceBusMessage("Message") for _ in range(10)]
-                sender.send_messages(messages)
-                # wait for all messages to be sent to queue
-                time.sleep(10)
+#             with sb_client.get_subscription_receiver(
+#                 topic_name=servicebus_topic.name,
+#                 subscription_name=servicebus_subscription.name,
+#                 sub_queue = ServiceBusSubQueue.DEAD_LETTER,
+#                 max_wait_time=5,
+#                 receive_mode=ServiceBusReceiveMode.PEEK_LOCK
+#             ) as dl_receiver:
+#                 count = 0
+#                 for message in dl_receiver:
+#                     dl_receiver.complete_message(message)
+#                     count += 1
+#                     assert message.dead_letter_reason == 'Testing reason'
+#                     assert message.dead_letter_error_description == 'Testing description'
+#                     assert message.application_properties[b'DeadLetterReason'] == b'Testing reason'
+#                     assert message.application_properties[b'DeadLetterErrorDescription'] == b'Testing description'
+#                 assert count == 10
 
-                # receive messages + add to internal buffer should have messages now
-                received_msgs = receiver.receive_messages(max_message_count=10, max_wait_time=10)
-                assert len(received_msgs) == 10
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusTopicPreparer(name_prefix='servicebustest')
+#     @ServiceBusSubscriptionPreparer(name_prefix='servicebustest', lock_duration='PT5S')
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_subscription_message_expiry(self, uamqp_transport, *, servicebus_namespace=None, servicebus_namespace_key_name=None, servicebus_namespace_primary_key=None, servicebus_topic=None, servicebus_subscription=None, **kwargs):
+#         fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+#         with ServiceBusClient(
+#             fully_qualified_namespace=fully_qualified_namespace,
+#             credential=ServiceBusSharedKeyCredential(
+#                 policy=servicebus_namespace_key_name,
+#                 key=servicebus_namespace_primary_key
+#             ),
+#             logging_enable=False,
+#             uamqp_transport=uamqp_transport
+#         ) as sb_client:
+
+#             with sb_client.get_topic_sender(topic_name=servicebus_topic.name) as sender:
+#                 message = ServiceBusMessage(b"Testing topic message expiry")
+#                 sender.send_messages(message)
+
+#             with sb_client.get_subscription_receiver(
+#                     topic_name=servicebus_topic.name,
+#                     subscription_name=servicebus_subscription.name
+#             ) as receiver:
+#                 messages = receiver.receive_messages(max_wait_time=10)
+#                 assert len(messages) == 1
+#                 time.sleep((messages[0].locked_until_utc - utc_now()).total_seconds()+1)
+#                 assert messages[0]._lock_expired
+#                 with pytest.raises(MessageLockLostError):
+#                     receiver.complete_message(messages[0])
+#                 with pytest.raises(MessageLockLostError):
+#                     receiver.renew_message_lock(messages[0])
+#             with sb_client.get_subscription_receiver(
+#                     topic_name=servicebus_topic.name,
+#                     subscription_name=servicebus_subscription.name
+#             ) as receiver:
+#                 messages = receiver.receive_messages(max_wait_time=10)
+#                 assert len(messages) == 1
+#                 assert messages[0].delivery_count > 0
+#                 receiver.complete_message(messages[0])
+
+#     @pytest.mark.liveTest
+#     @pytest.mark.live_test_only
+#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+#     @ServiceBusTopicPreparer(name_prefix='servicebustest')
+#     @ServiceBusSubscriptionPreparer(name_prefix='servicebustest', lock_duration='PT5S')
+#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+#     @ArgPasser()
+#     def test_subscription_receive_and_delete_with_send_and_wait(self, uamqp_transport, *, servicebus_namespace=None, servicebus_namespace_key_name=None, servicebus_namespace_primary_key=None, servicebus_topic=None, servicebus_subscription=None, **kwargs):
+#         fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+#         with ServiceBusClient(
+#             fully_qualified_namespace=fully_qualified_namespace,
+#             credential=ServiceBusSharedKeyCredential(
+#                 policy=servicebus_namespace_key_name,
+#                 key=servicebus_namespace_primary_key
+#             ),
+#             logging_enable=False,
+#             uamqp_transport=uamqp_transport
+#         ) as sb_client:
+
+#             sender = sb_client.get_topic_sender(topic_name=servicebus_topic.name)
+#             receiver = sb_client.get_subscription_receiver(
+#                     topic_name=servicebus_topic.name,
+#                     subscription_name=servicebus_subscription.name,
+#                     receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE,
+#             )
+#             with sender, receiver:
+#                 # queue should be empty
+#                 received_msgs = receiver.receive_messages(max_message_count=10, max_wait_time=10)
+#                 assert len(received_msgs) == 0
+
+#                 messages = [ServiceBusMessage("Message") for _ in range(10)]
+#                 sender.send_messages(messages)
+#                 # wait for all messages to be sent to queue
+#                 time.sleep(10)
+
+#                 # receive messages + add to internal buffer should have messages now
+#                 received_msgs = receiver.receive_messages(max_message_count=10, max_wait_time=10)
+#                 assert len(received_msgs) == 10
     

--- a/sdk/servicebus/azure-servicebus/tests/test_subscriptions.py
+++ b/sdk/servicebus/azure-servicebus/tests/test_subscriptions.py
@@ -1,296 +1,301 @@
-# #-------------------------------------------------------------------------
-# # Copyright (c) Microsoft Corporation. All rights reserved.
-# # Licensed under the MIT License. See License.txt in the project root for
-# # license information.
-# #-------------------------------------------------------------------------
+#-------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+#-------------------------------------------------------------------------
 
-# import logging
-# import sys
-# import os
-# import pytest
-# import time
-# from datetime import datetime, timedelta
+import logging
+import sys
+import os
+import pytest
+import time
+from datetime import datetime, timedelta
 
-# from azure.servicebus._common.utils import utc_now
-# from azure.servicebus import ServiceBusClient, ServiceBusMessage, ServiceBusReceiveMode
-# from azure.servicebus._base_handler import ServiceBusSharedKeyCredential
-# from azure.servicebus.exceptions import ServiceBusError, MessageLockLostError
-# from azure.servicebus._common.constants import ServiceBusSubQueue
+from azure.servicebus._common.utils import utc_now
+from azure.servicebus import ServiceBusClient, ServiceBusMessage, ServiceBusReceiveMode
+from azure.servicebus._base_handler import ServiceBusSharedKeyCredential
+from azure.servicebus.exceptions import ServiceBusError, MessageLockLostError
+from azure.servicebus._common.constants import ServiceBusSubQueue
 
-# from devtools_testutils import AzureMgmtRecordedTestCase, RandomNameResourceGroupPreparer
-# from servicebus_preparer import (
-#     CachedServiceBusNamespacePreparer,
-#     CachedServiceBusTopicPreparer,
-#     CachedServiceBusSubscriptionPreparer,
-#     ServiceBusTopicPreparer,
-#     ServiceBusSubscriptionPreparer,
-#     CachedServiceBusResourceGroupPreparer,
-#     SERVICEBUS_ENDPOINT_SUFFIX
-# )
-# from utilities import get_logger, print_message, uamqp_transport as get_uamqp_transport, ArgPasser
-# uamqp_transport_params, uamqp_transport_ids = get_uamqp_transport()
-
-
-# _logger = get_logger(logging.DEBUG)
+from devtools_testutils import AzureMgmtRecordedTestCase, RandomNameResourceGroupPreparer, get_credential
+from servicebus_preparer import (
+    CachedServiceBusNamespacePreparer,
+    CachedServiceBusTopicPreparer,
+    CachedServiceBusSubscriptionPreparer,
+    ServiceBusTopicPreparer,
+    ServiceBusSubscriptionPreparer,
+    CachedServiceBusResourceGroupPreparer,
+    SERVICEBUS_ENDPOINT_SUFFIX
+)
+from utilities import get_logger, print_message, uamqp_transport as get_uamqp_transport, ArgPasser
+uamqp_transport_params, uamqp_transport_ids = get_uamqp_transport()
 
 
-# class TestServiceBusSubscription(AzureMgmtRecordedTestCase):
+_logger = get_logger(logging.DEBUG)
 
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusTopicPreparer(name_prefix='servicebustest')
-#     @ServiceBusSubscriptionPreparer(name_prefix='servicebustest')
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_subscription_by_subscription_client_conn_str_receive_basic(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_topic=None, servicebus_subscription=None, **kwargs):
 
-#         with ServiceBusClient.from_connection_string(
-#                 servicebus_namespace_connection_string,
-#                 logging_enable=False,
-#                 uamqp_transport=uamqp_transport
-#         ) as sb_client:
-#             with sb_client.get_topic_sender(topic_name=servicebus_topic.name) as sender:
-#                 message = ServiceBusMessage(b"Sample topic message")
-#                 sender.send_messages(message)
+class TestServiceBusSubscription(AzureMgmtRecordedTestCase):
 
-#             with pytest.raises(ValueError):
-#                 sb_client.get_subscription_receiver(
-#                     topic_name=servicebus_topic.name,
-#                     subscription_name=servicebus_subscription.name,
-#                     max_wait_time=0
-#                 )
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusTopicPreparer(name_prefix='servicebustest')
+    @ServiceBusSubscriptionPreparer(name_prefix='servicebustest')
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_subscription_by_subscription_client_conn_str_receive_basic(self, uamqp_transport, *, servicebus_namespace=None, servicebus_topic=None, servicebus_subscription=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+                fully_qualified_namespace=fully_qualified_namespace,
+                credential=credential,
+                logging_enable=False,
+                uamqp_transport=uamqp_transport
+        ) as sb_client:
+            with sb_client.get_topic_sender(topic_name=servicebus_topic.name) as sender:
+                message = ServiceBusMessage(b"Sample topic message")
+                sender.send_messages(message)
 
-#             with sb_client.get_subscription_receiver(
-#                     topic_name=servicebus_topic.name,
-#                     subscription_name=servicebus_subscription.name,
-#                     max_wait_time=5
-#             ) as receiver:
+            with pytest.raises(ValueError):
+                sb_client.get_subscription_receiver(
+                    topic_name=servicebus_topic.name,
+                    subscription_name=servicebus_subscription.name,
+                    max_wait_time=0
+                )
 
-#                 with pytest.raises(ValueError):
-#                     receiver.receive_messages(max_wait_time=-1)
+            with sb_client.get_subscription_receiver(
+                    topic_name=servicebus_topic.name,
+                    subscription_name=servicebus_subscription.name,
+                    max_wait_time=5
+            ) as receiver:
 
-#                 count = 0
-#                 for message in receiver:
-#                     count += 1
-#                     receiver.complete_message(message)
-#             assert count == 1
+                with pytest.raises(ValueError):
+                    receiver.receive_messages(max_wait_time=-1)
 
-    
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusTopicPreparer(name_prefix='servicebustest')
-#     @ServiceBusSubscriptionPreparer(name_prefix='servicebustest')
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_subscription_by_sas_token_credential_conn_str_send_basic(self, uamqp_transport, *, servicebus_namespace=None, servicebus_namespace_key_name=None, servicebus_namespace_primary_key=None, servicebus_topic=None, servicebus_subscription=None, **kwargs):
-#         fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
-#         with ServiceBusClient(
-#             fully_qualified_namespace=fully_qualified_namespace,
-#             credential=ServiceBusSharedKeyCredential(
-#                 policy=servicebus_namespace_key_name,
-#                 key=servicebus_namespace_primary_key
-#             ),
-#             logging_enable=False,
-#             uamqp_transport=uamqp_transport
-#         ) as sb_client:
-
-#             with sb_client.get_topic_sender(topic_name=servicebus_topic.name) as sender:
-#                 message = ServiceBusMessage(b"Sample topic message")
-#                 sender.send_messages(message)
-
-#             with sb_client.get_subscription_receiver(
-#                     topic_name=servicebus_topic.name,
-#                     subscription_name=servicebus_subscription.name,
-#                     max_wait_time=5
-#             ) as receiver:
-#                 count = 0
-#                 for message in receiver:
-#                     count += 1
-#                     receiver.complete_message(message)
-#             assert count == 1
-
-#     @pytest.mark.skip(reason="Pending management apis")
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @RandomNameResourceGroupPreparer()
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusTopicPreparer(name_prefix='servicebustest')
-#     @ServiceBusSubscriptionPreparer(name_prefix='servicebustest')
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_subscription_by_servicebus_client_list_subscriptions(self, uamqp_transport, *, servicebus_namespace=None, servicebus_namespace_key_name=None, servicebus_namespace_primary_key=None, servicebus_topic=None, servicebus_subscription=None, **kwargs):
-
-#         client = ServiceBusClient(
-#             service_namespace=servicebus_namespace.name,
-#             shared_access_key_name=servicebus_namespace_key_name,
-#             shared_access_key_value=servicebus_namespace_primary_key,
-#             logging_enable=False,
-#             uamqp_transport=uamqp_transport
-#             )
-
-#         subs = client.list_subscriptions(servicebus_topic.name)
-#         assert len(subs) >= 1
-#         # assert all(isinstance(s, SubscriptionClient) for s in subs)
-#         assert subs[0].name == servicebus_subscription.name
-#         assert subs[0].topic_name == servicebus_topic.name
+                count = 0
+                for message in receiver:
+                    count += 1
+                    receiver.complete_message(message)
+            assert count == 1
 
     
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusTopicPreparer(name_prefix='servicebustest')
-#     @ServiceBusSubscriptionPreparer(name_prefix='servicebustest')
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_subscription_by_servicebus_client_receive_batch_with_deadletter(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_topic=None, servicebus_subscription=None, **kwargs):
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusTopicPreparer(name_prefix='servicebustest')
+    @ServiceBusSubscriptionPreparer(name_prefix='servicebustest')
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_subscription_by_sas_token_credential_conn_str_send_basic(self, uamqp_transport, *, servicebus_namespace=None, servicebus_namespace_key_name=None, servicebus_namespace_primary_key=None, servicebus_topic=None, servicebus_subscription=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        with ServiceBusClient(
+            fully_qualified_namespace=fully_qualified_namespace,
+            credential=ServiceBusSharedKeyCredential(
+                policy=servicebus_namespace_key_name,
+                key=servicebus_namespace_primary_key
+            ),
+            logging_enable=False,
+            uamqp_transport=uamqp_transport
+        ) as sb_client:
 
-#         with ServiceBusClient.from_connection_string(
-#                 servicebus_namespace_connection_string,
-#                 logging_enable=False,
-#                 uamqp_transport=uamqp_transport
-#         ) as sb_client:
+            with sb_client.get_topic_sender(topic_name=servicebus_topic.name) as sender:
+                message = ServiceBusMessage(b"Sample topic message")
+                sender.send_messages(message)
 
-#             with sb_client.get_subscription_receiver(
-#                 topic_name=servicebus_topic.name,
-#                 subscription_name=servicebus_subscription.name,
-#                 max_wait_time=5,
-#                 receive_mode=ServiceBusReceiveMode.PEEK_LOCK,
-#                 prefetch_count=10
-#             ) as receiver:
+            with sb_client.get_subscription_receiver(
+                    topic_name=servicebus_topic.name,
+                    subscription_name=servicebus_subscription.name,
+                    max_wait_time=5
+            ) as receiver:
+                count = 0
+                for message in receiver:
+                    count += 1
+                    receiver.complete_message(message)
+            assert count == 1
 
-#                 with sb_client.get_topic_sender(servicebus_topic.name) as sender:
-#                     for i in range(10):
-#                         message = ServiceBusMessage("Dead lettered message no. {}".format(i))
-#                         sender.send_messages(message)
+    @pytest.mark.skip(reason="Pending management apis")
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @RandomNameResourceGroupPreparer()
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusTopicPreparer(name_prefix='servicebustest')
+    @ServiceBusSubscriptionPreparer(name_prefix='servicebustest')
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_subscription_by_servicebus_client_list_subscriptions(self, uamqp_transport, *, servicebus_namespace=None, servicebus_namespace_key_name=None, servicebus_namespace_primary_key=None, servicebus_topic=None, servicebus_subscription=None, **kwargs):
 
-#                 count = 0
-#                 messages = receiver.receive_messages()
-#                 while messages:
-#                     for message in messages:
-#                         print_message(_logger, message)
-#                         count += 1
-#                         receiver.dead_letter_message(message, reason="Testing reason", error_description="Testing description")
-#                     messages = receiver.receive_messages()
+        client = ServiceBusClient(
+            service_namespace=servicebus_namespace.name,
+            shared_access_key_name=servicebus_namespace_key_name,
+            shared_access_key_value=servicebus_namespace_primary_key,
+            logging_enable=False,
+            uamqp_transport=uamqp_transport
+            )
 
-#             assert count == 10
+        subs = client.list_subscriptions(servicebus_topic.name)
+        assert len(subs) >= 1
+        # assert all(isinstance(s, SubscriptionClient) for s in subs)
+        assert subs[0].name == servicebus_subscription.name
+        assert subs[0].topic_name == servicebus_topic.name
 
-#             with sb_client.get_subscription_receiver(
-#                 topic_name=servicebus_topic.name,
-#                 subscription_name=servicebus_subscription.name,
-#                 max_wait_time=5,
-#                 receive_mode=ServiceBusReceiveMode.PEEK_LOCK
-#             ) as receiver:
-#                 count = 0
-#                 for message in receiver:
-#                     print_message(_logger, message)
-#                     receiver.complete_message(message)
-#                     count += 1
-#             assert count == 0
+    
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusTopicPreparer(name_prefix='servicebustest')
+    @ServiceBusSubscriptionPreparer(name_prefix='servicebustest')
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_subscription_by_servicebus_client_receive_batch_with_deadletter(self, uamqp_transport, *, servicebus_namespace=None, servicebus_topic=None, servicebus_subscription=None, **kwargs):
 
-#             with sb_client.get_subscription_receiver(
-#                 topic_name=servicebus_topic.name,
-#                 subscription_name=servicebus_subscription.name,
-#                 sub_queue = ServiceBusSubQueue.DEAD_LETTER,
-#                 max_wait_time=5,
-#                 receive_mode=ServiceBusReceiveMode.PEEK_LOCK
-#             ) as dl_receiver:
-#                 count = 0
-#                 for message in dl_receiver:
-#                     dl_receiver.complete_message(message)
-#                     count += 1
-#                     assert message.dead_letter_reason == 'Testing reason'
-#                     assert message.dead_letter_error_description == 'Testing description'
-#                     assert message.application_properties[b'DeadLetterReason'] == b'Testing reason'
-#                     assert message.application_properties[b'DeadLetterErrorDescription'] == b'Testing description'
-#                 assert count == 10
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = get_credential()
+        with ServiceBusClient(
+                fully_qualified_namespace=fully_qualified_namespace,
+                credential=credential,
+                logging_enable=False,
+                uamqp_transport=uamqp_transport
+        ) as sb_client:
 
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusTopicPreparer(name_prefix='servicebustest')
-#     @ServiceBusSubscriptionPreparer(name_prefix='servicebustest', lock_duration='PT5S')
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_subscription_message_expiry(self, uamqp_transport, *, servicebus_namespace=None, servicebus_namespace_key_name=None, servicebus_namespace_primary_key=None, servicebus_topic=None, servicebus_subscription=None, **kwargs):
-#         fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
-#         with ServiceBusClient(
-#             fully_qualified_namespace=fully_qualified_namespace,
-#             credential=ServiceBusSharedKeyCredential(
-#                 policy=servicebus_namespace_key_name,
-#                 key=servicebus_namespace_primary_key
-#             ),
-#             logging_enable=False,
-#             uamqp_transport=uamqp_transport
-#         ) as sb_client:
+            with sb_client.get_subscription_receiver(
+                topic_name=servicebus_topic.name,
+                subscription_name=servicebus_subscription.name,
+                max_wait_time=5,
+                receive_mode=ServiceBusReceiveMode.PEEK_LOCK,
+                prefetch_count=10
+            ) as receiver:
 
-#             with sb_client.get_topic_sender(topic_name=servicebus_topic.name) as sender:
-#                 message = ServiceBusMessage(b"Testing topic message expiry")
-#                 sender.send_messages(message)
+                with sb_client.get_topic_sender(servicebus_topic.name) as sender:
+                    for i in range(10):
+                        message = ServiceBusMessage("Dead lettered message no. {}".format(i))
+                        sender.send_messages(message)
 
-#             with sb_client.get_subscription_receiver(
-#                     topic_name=servicebus_topic.name,
-#                     subscription_name=servicebus_subscription.name
-#             ) as receiver:
-#                 messages = receiver.receive_messages(max_wait_time=10)
-#                 assert len(messages) == 1
-#                 time.sleep((messages[0].locked_until_utc - utc_now()).total_seconds()+1)
-#                 assert messages[0]._lock_expired
-#                 with pytest.raises(MessageLockLostError):
-#                     receiver.complete_message(messages[0])
-#                 with pytest.raises(MessageLockLostError):
-#                     receiver.renew_message_lock(messages[0])
-#             with sb_client.get_subscription_receiver(
-#                     topic_name=servicebus_topic.name,
-#                     subscription_name=servicebus_subscription.name
-#             ) as receiver:
-#                 messages = receiver.receive_messages(max_wait_time=10)
-#                 assert len(messages) == 1
-#                 assert messages[0].delivery_count > 0
-#                 receiver.complete_message(messages[0])
+                count = 0
+                messages = receiver.receive_messages()
+                while messages:
+                    for message in messages:
+                        print_message(_logger, message)
+                        count += 1
+                        receiver.dead_letter_message(message, reason="Testing reason", error_description="Testing description")
+                    messages = receiver.receive_messages()
 
-#     @pytest.mark.liveTest
-#     @pytest.mark.live_test_only
-#     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
-#     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-#     @ServiceBusTopicPreparer(name_prefix='servicebustest')
-#     @ServiceBusSubscriptionPreparer(name_prefix='servicebustest', lock_duration='PT5S')
-#     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
-#     @ArgPasser()
-#     def test_subscription_receive_and_delete_with_send_and_wait(self, uamqp_transport, *, servicebus_namespace=None, servicebus_namespace_key_name=None, servicebus_namespace_primary_key=None, servicebus_topic=None, servicebus_subscription=None, **kwargs):
-#         fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
-#         with ServiceBusClient(
-#             fully_qualified_namespace=fully_qualified_namespace,
-#             credential=ServiceBusSharedKeyCredential(
-#                 policy=servicebus_namespace_key_name,
-#                 key=servicebus_namespace_primary_key
-#             ),
-#             logging_enable=False,
-#             uamqp_transport=uamqp_transport
-#         ) as sb_client:
+            assert count == 10
 
-#             sender = sb_client.get_topic_sender(topic_name=servicebus_topic.name)
-#             receiver = sb_client.get_subscription_receiver(
-#                     topic_name=servicebus_topic.name,
-#                     subscription_name=servicebus_subscription.name,
-#                     receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE,
-#             )
-#             with sender, receiver:
-#                 # queue should be empty
-#                 received_msgs = receiver.receive_messages(max_message_count=10, max_wait_time=10)
-#                 assert len(received_msgs) == 0
+            with sb_client.get_subscription_receiver(
+                topic_name=servicebus_topic.name,
+                subscription_name=servicebus_subscription.name,
+                max_wait_time=5,
+                receive_mode=ServiceBusReceiveMode.PEEK_LOCK
+            ) as receiver:
+                count = 0
+                for message in receiver:
+                    print_message(_logger, message)
+                    receiver.complete_message(message)
+                    count += 1
+            assert count == 0
 
-#                 messages = [ServiceBusMessage("Message") for _ in range(10)]
-#                 sender.send_messages(messages)
-#                 # wait for all messages to be sent to queue
-#                 time.sleep(10)
+            with sb_client.get_subscription_receiver(
+                topic_name=servicebus_topic.name,
+                subscription_name=servicebus_subscription.name,
+                sub_queue = ServiceBusSubQueue.DEAD_LETTER,
+                max_wait_time=5,
+                receive_mode=ServiceBusReceiveMode.PEEK_LOCK
+            ) as dl_receiver:
+                count = 0
+                for message in dl_receiver:
+                    dl_receiver.complete_message(message)
+                    count += 1
+                    assert message.dead_letter_reason == 'Testing reason'
+                    assert message.dead_letter_error_description == 'Testing description'
+                    assert message.application_properties[b'DeadLetterReason'] == b'Testing reason'
+                    assert message.application_properties[b'DeadLetterErrorDescription'] == b'Testing description'
+                assert count == 10
 
-#                 # receive messages + add to internal buffer should have messages now
-#                 received_msgs = receiver.receive_messages(max_message_count=10, max_wait_time=10)
-#                 assert len(received_msgs) == 10
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusTopicPreparer(name_prefix='servicebustest')
+    @ServiceBusSubscriptionPreparer(name_prefix='servicebustest', lock_duration='PT5S')
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_subscription_message_expiry(self, uamqp_transport, *, servicebus_namespace=None, servicebus_namespace_key_name=None, servicebus_namespace_primary_key=None, servicebus_topic=None, servicebus_subscription=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        with ServiceBusClient(
+            fully_qualified_namespace=fully_qualified_namespace,
+            credential=ServiceBusSharedKeyCredential(
+                policy=servicebus_namespace_key_name,
+                key=servicebus_namespace_primary_key
+            ),
+            logging_enable=False,
+            uamqp_transport=uamqp_transport
+        ) as sb_client:
+
+            with sb_client.get_topic_sender(topic_name=servicebus_topic.name) as sender:
+                message = ServiceBusMessage(b"Testing topic message expiry")
+                sender.send_messages(message)
+
+            with sb_client.get_subscription_receiver(
+                    topic_name=servicebus_topic.name,
+                    subscription_name=servicebus_subscription.name
+            ) as receiver:
+                messages = receiver.receive_messages(max_wait_time=10)
+                assert len(messages) == 1
+                time.sleep((messages[0].locked_until_utc - utc_now()).total_seconds()+1)
+                assert messages[0]._lock_expired
+                with pytest.raises(MessageLockLostError):
+                    receiver.complete_message(messages[0])
+                with pytest.raises(MessageLockLostError):
+                    receiver.renew_message_lock(messages[0])
+            with sb_client.get_subscription_receiver(
+                    topic_name=servicebus_topic.name,
+                    subscription_name=servicebus_subscription.name
+            ) as receiver:
+                messages = receiver.receive_messages(max_wait_time=10)
+                assert len(messages) == 1
+                assert messages[0].delivery_count > 0
+                receiver.complete_message(messages[0])
+
+    @pytest.mark.liveTest
+    @pytest.mark.live_test_only
+    @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
+    @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
+    @ServiceBusTopicPreparer(name_prefix='servicebustest')
+    @ServiceBusSubscriptionPreparer(name_prefix='servicebustest', lock_duration='PT5S')
+    @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
+    @ArgPasser()
+    def test_subscription_receive_and_delete_with_send_and_wait(self, uamqp_transport, *, servicebus_namespace=None, servicebus_namespace_key_name=None, servicebus_namespace_primary_key=None, servicebus_topic=None, servicebus_subscription=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        with ServiceBusClient(
+            fully_qualified_namespace=fully_qualified_namespace,
+            credential=ServiceBusSharedKeyCredential(
+                policy=servicebus_namespace_key_name,
+                key=servicebus_namespace_primary_key
+            ),
+            logging_enable=False,
+            uamqp_transport=uamqp_transport
+        ) as sb_client:
+
+            sender = sb_client.get_topic_sender(topic_name=servicebus_topic.name)
+            receiver = sb_client.get_subscription_receiver(
+                    topic_name=servicebus_topic.name,
+                    subscription_name=servicebus_subscription.name,
+                    receive_mode=ServiceBusReceiveMode.RECEIVE_AND_DELETE,
+            )
+            with sender, receiver:
+                # queue should be empty
+                received_msgs = receiver.receive_messages(max_message_count=10, max_wait_time=10)
+                assert len(received_msgs) == 0
+
+                messages = [ServiceBusMessage("Message") for _ in range(10)]
+                sender.send_messages(messages)
+                # wait for all messages to be sent to queue
+                time.sleep(10)
+
+                # receive messages + add to internal buffer should have messages now
+                received_msgs = receiver.receive_messages(max_message_count=10, max_wait_time=10)
+                assert len(received_msgs) == 10
     

--- a/sdk/servicebus/azure-servicebus/tests/test_topic.py
+++ b/sdk/servicebus/azure-servicebus/tests/test_topic.py
@@ -7,7 +7,7 @@
 import logging
 import pytest
 
-from devtools_testutils import AzureMgmtRecordedTestCase, RandomNameResourceGroupPreparer
+from devtools_testutils import AzureMgmtRecordedTestCase, RandomNameResourceGroupPreparer, get_credential
 
 from azure.servicebus import ServiceBusClient
 from azure.servicebus._base_handler import ServiceBusSharedKeyCredential
@@ -37,7 +37,7 @@ class TestServiceBusTopics(AzureMgmtRecordedTestCase):
     @ArgPasser()
     def test_topic_by_servicebus_client_conn_str_send_basic(self, uamqp_transport, *, servicebus_namespace=None, servicebus_topic=None, **kwargs):
         fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
-        credential = self.get_credential(ServiceBusClient)
+        credential = get_credential()
         with ServiceBusClient(
             fully_qualified_namespace=fully_qualified_namespace,
             credential=credential,

--- a/sdk/servicebus/azure-servicebus/tests/test_topic.py
+++ b/sdk/servicebus/azure-servicebus/tests/test_topic.py
@@ -5,11 +5,7 @@
 #--------------------------------------------------------------------------
 
 import logging
-import sys
-import os
 import pytest
-import time
-from datetime import datetime, timedelta
 
 from devtools_testutils import AzureMgmtRecordedTestCase, RandomNameResourceGroupPreparer
 
@@ -24,7 +20,7 @@ from servicebus_preparer import (
     CachedServiceBusResourceGroupPreparer,
     SERVICEBUS_ENDPOINT_SUFFIX
 )
-from utilities import get_logger, print_message, uamqp_transport as get_uamqp_transport, ArgPasser
+from utilities import get_logger, uamqp_transport as get_uamqp_transport, ArgPasser
 uamqp_transport_params, uamqp_transport_ids = get_uamqp_transport()
 
 
@@ -39,10 +35,12 @@ class TestServiceBusTopics(AzureMgmtRecordedTestCase):
     @CachedServiceBusTopicPreparer(name_prefix='servicebustest')
     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
     @ArgPasser()
-    def test_topic_by_servicebus_client_conn_str_send_basic(self, uamqp_transport, *, servicebus_namespace_connection_string=None, servicebus_topic=None, **kwargs):
-
-        with ServiceBusClient.from_connection_string(
-            servicebus_namespace_connection_string,
+    def test_topic_by_servicebus_client_conn_str_send_basic(self, uamqp_transport, *, servicebus_namespace=None, servicebus_topic=None, **kwargs):
+        fully_qualified_namespace = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
+        credential = self.get_credential(ServiceBusClient)
+        with ServiceBusClient(
+            fully_qualified_namespace=fully_qualified_namespace,
+            credential=credential,
             logging_enable=False,
             uamqp_transport=uamqp_transport
         ) as sb_client:

--- a/sdk/servicebus/tests.yml
+++ b/sdk/servicebus/tests.yml
@@ -18,12 +18,18 @@ extends:
       CloudConfig:
         Public:
           SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
+          ServiceConnection: azure-sdk-tests
+          SubscriptionConfigurationFilePath: eng/common/TestResources/sub-config/AzurePublicMsft.json
         Canary:
           SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
           Location: 'eastus2euap'
+          ServiceConnection: azure-sdk-tests
+          SubscriptionConfigurationFilePath: eng/common/TestResources/sub-config/AzurePublicMsft.json
         UsGov:
           SubscriptionConfiguration: $(sub-config-gov-test-resources)
+          ServiceConnection: azure-sdk-tests
           Location: 'usgovarizona'
         China:
           SubscriptionConfiguration: $(sub-config-cn-test-resources)
+          ServiceConnection: azure-sdk-tests
           Location: 'chinanorth3'

--- a/sdk/servicebus/tests.yml
+++ b/sdk/servicebus/tests.yml
@@ -5,12 +5,10 @@ extends:
     parameters:
       ServiceDirectory: servicebus
       TestTimeoutInMinutes: 480
+      UseFederatedAuth: true
       BuildTargetingString: azure-servicebus*
       EnvVars:
         AZURE_SUBSCRIPTION_ID: $(SERVICEBUS_SUBSCRIPTION_ID)
-        AZURE_TENANT_ID: $(SERVICEBUS_TENANT_ID)
-        AZURE_CLIENT_ID: $(SERVICEBUS_CLIENT_ID)
-        AZURE_CLIENT_SECRET: $(SERVICEBUS_CLIENT_SECRET)
         AZURE_TEST_RUN_LIVE: 'true'
         AZURE_SKIP_LIVE_RECORDING: 'True'
       MatrixFilters:


### PR DESCRIPTION
This PR sets the correct scope uri when the credential is not a SharedAccessCredential. This will fix a bug if people are using `TokenCredential` with the management client to create subscriptions with forwarding. 