### PR TITLE
[SB] Fix the Scope In SB Management Client

### DIFF
--- a/sdk/servicebus/azure-servicebus/azure/servicebus/aio/management/_management_client_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/aio/management/_management_client_async.py
@@ -233,7 +233,7 @@ class ServiceBusAdministrationClient:  # pylint:disable=too-many-public-methods
         async def _populate_header_within_kwargs(uri, header):
             if not isinstance(
                 self._credential,
-                ServiceBusSharedKeyCredential):
+                (ServiceBusSASTokenCredential, ServiceBusSharedKeyCredential)):
                 uri = JWT_TOKEN_SCOPE
             token = (await self._credential.get_token(uri)).token
             if not isinstance(

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/aio/management/_management_client_async.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/aio/management/_management_client_async.py
@@ -231,6 +231,10 @@ class ServiceBusAdministrationClient:  # pylint:disable=too-many-public-methods
         kwargs["headers"] = kwargs.get("headers", {})
 
         async def _populate_header_within_kwargs(uri, header):
+            if not isinstance(
+                self._credential,
+                ServiceBusSharedKeyCredential):
+                uri = JWT_TOKEN_SCOPE
             token = (await self._credential.get_token(uri)).token
             if not isinstance(
                 self._credential,

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/management/_management_client.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/management/_management_client.py
@@ -231,7 +231,7 @@ class ServiceBusAdministrationClient:  # pylint:disable=too-many-public-methods
         def _populate_header_within_kwargs(uri, header):
             if not isinstance(
                 self._credential,
-                ServiceBusSharedKeyCredential):
+                (ServiceBusSASTokenCredential, ServiceBusSharedKeyCredential)):
                 uri = JWT_TOKEN_SCOPE
             token = self._credential.get_token(uri).token
             if not isinstance(

--- a/sdk/servicebus/azure-servicebus/azure/servicebus/management/_management_client.py
+++ b/sdk/servicebus/azure-servicebus/azure/servicebus/management/_management_client.py
@@ -229,6 +229,10 @@ class ServiceBusAdministrationClient:  # pylint:disable=too-many-public-methods
         kwargs["headers"] = kwargs.get("headers", {})
 
         def _populate_header_within_kwargs(uri, header):
+            if not isinstance(
+                self._credential,
+                ServiceBusSharedKeyCredential):
+                uri = JWT_TOKEN_SCOPE
             token = self._credential.get_token(uri).token
             if not isinstance(
                 self._credential,


### PR DESCRIPTION
Use the right scope when using TokenCredential and enabling forwarding on subscriptions. This fixes a bug where a `ResourceNotFoundError` would be raised when using token credential to create a subscription with forwarding.