### PR TITLE
Fix Documented Mypy Version in Tox

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ sdist            -> Builds a source distribution and runs tests
 additional environments:
 pylint           -> Lints a package with a pinned version of pylint
 next-pylint      -> Lints a package with pylint (version 2.15.8)
-mypy             -> Typechecks a package with mypy (version 1.0.0)
+mypy             -> Typechecks a package with mypy (version 1.9.0)
 next-mypy        -> Typechecks a package with the latest version of mypy
 pyright          -> Typechecks a package with pyright (version 1.1.287)
 next-pyright     -> Typechecks a package with the latest version of static type-checker pyright

--- a/doc/dev/static_type_checking.md
+++ b/doc/dev/static_type_checking.md
@@ -183,7 +183,7 @@ environment run in CI and brings in the third party stub packages necessary. To 
 
 ### Run mypy
 
-mypy is currently pinned to version [1.0.0](https://pypi.org/project/mypy/1.0.0/).
+mypy is currently pinned to version [1.9.0](https://pypi.org/project/mypy/1.9.0/).
 
 To run mypy on your library, run the tox mypy env at the package level:
 
@@ -191,7 +191,7 @@ To run mypy on your library, run the tox mypy env at the package level:
 
 If you don't want to use `tox` you can also install and run mypy on its own:
 
-`pip install mypy==1.0.0`
+`pip install mypy==1.9.0`
 
 `.../azure-sdk-for-python/sdk/textanalytics/azure-ai-textanalytics>mypy azure`
 


### PR DESCRIPTION
# Description

Update the documentation to include the correct mypy version that is used in tox.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
