### PR TITLE
[Cosmos] fix resource validation to allow longer strings

### DIFF
--- a/sdk/cosmos/azure-cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 #### Bugs Fixed
 * Consolidated Container Properties Cache to be in the Client to cache partition key definition and container rid to avoid unnecessary container reads. See [PR 35731](https://github.com/Azure/azure-sdk-for-python/pull/35731)
-* Fixed SDK regex validation that would not allow for item ids to be longer than 255 characters. See [PR ]().
+* Fixed SDK regex validation that would not allow for item ids to be longer than 255 characters. See [PR 36569](https://github.com/Azure/azure-sdk-for-python/pull/36569).
 
 #### Other Changes
 

--- a/sdk/cosmos/azure-cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure-cosmos/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 #### Bugs Fixed
 * Consolidated Container Properties Cache to be in the Client to cache partition key definition and container rid to avoid unnecessary container reads. See [PR 35731](https://github.com/Azure/azure-sdk-for-python/pull/35731)
+* Fixed SDK regex validation that would not allow for item ids to be longer than 255 characters. See [PR ]().
 
 #### Other Changes
 

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_base.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_base.py
@@ -65,9 +65,9 @@ _COMMON_OPTIONS = {
 
 # Cosmos resource ID validation regex breakdown:
 # ^ Match start of string.
-# [^/\#?]{0,255} Match any character that is not /\#? for between 0-255 characters.
+# [^/\#?] Match any character that is not /\#?\n\r\t.
 # $ End of string
-_VALID_COSMOS_RESOURCE = re.compile(r"^[^/\\#?\t\r\n]{0,255}$")
+_VALID_COSMOS_RESOURCE = re.compile(r"^[^/\\#?\t\r\n]*$")
 
 
 def _get_match_headers(kwargs: Dict[str, Any]) -> Tuple[Optional[str], Optional[str]]:

--- a/sdk/cosmos/azure-cosmos/test/test_resource_id.py
+++ b/sdk/cosmos/azure-cosmos/test/test_resource_id.py
@@ -86,7 +86,7 @@ class TestResourceIds(unittest.TestCase):
             "ID\r_with_return_carriage",
             "ID_with_newline\n",
             "ID_with_newline\n2",
-            "ID_with_more_than_255" + "_" * 255,
+            "ID_with_more_than_255" + "_add" * 255,
             "ID_with_trailing_spaces   "
         ]
 

--- a/sdk/cosmos/azure-cosmos/test/test_resource_id.py
+++ b/sdk/cosmos/azure-cosmos/test/test_resource_id.py
@@ -118,7 +118,7 @@ class TestResourceIds(unittest.TestCase):
                 assert str(e) in error_strings
             except exceptions.CosmosHttpResponseError as e:
                 assert e.status_code == http_constants.StatusCodes.BAD_REQUEST
-                assert "Ensure to provide a unique non-empty string less than '1023' characters." in e.message
+                assert "Ensure to provide a unique non-empty string less than '1024' characters." in e.message
 
             try:
                 created_container.upsert_item({"id": resource_id})
@@ -127,7 +127,7 @@ class TestResourceIds(unittest.TestCase):
                 assert str(e) in error_strings
             except exceptions.CosmosHttpResponseError as e:
                 assert e.status_code == http_constants.StatusCodes.BAD_REQUEST
-                assert "Ensure to provide a unique non-empty string less than '1023' characters." in e.message
+                assert "Ensure to provide a unique non-empty string less than '1024' characters." in e.message
 
         self.client.delete_database(database_id)
 

--- a/sdk/cosmos/azure-cosmos/test/test_resource_id.py
+++ b/sdk/cosmos/azure-cosmos/test/test_resource_id.py
@@ -8,7 +8,7 @@ import pytest
 
 import azure.cosmos
 import test_config
-from azure.cosmos import PartitionKey, cosmos_client
+from azure.cosmos import PartitionKey, cosmos_client, exceptions, http_constants
 
 
 @pytest.mark.cosmosEmulator
@@ -65,7 +65,7 @@ class TestResourceIds(unittest.TestCase):
         self.client.delete_database(resource_id1)
         self.client.delete_database(resource_id2)
 
-    def test_create_illegal_characters_async(self):
+    def test_create_illegal_characters(self):
         database_id = str(uuid.uuid4())
         container_id = str(uuid.uuid4())
         partition_key = PartitionKey(path="/id")
@@ -97,23 +97,37 @@ class TestResourceIds(unittest.TestCase):
                 self.fail("Database create should have failed for id {}".format(resource_id))
             except ValueError as e:
                 assert str(e) in error_strings
+            # Let service throw size exception
+            except exceptions.CosmosHttpResponseError as e:
+                assert e.status_code == http_constants.StatusCodes.BAD_REQUEST
+                assert "Ensure to provide a unique non-empty string less than '255' characters." in e.message
 
             try:
                 created_database.create_container(id=resource_id, partition_key=partition_key)
                 self.fail("Container create should have failed for id {}".format(resource_id))
             except ValueError as e:
                 assert str(e) in error_strings
+            except exceptions.CosmosHttpResponseError as e:
+                assert e.status_code == http_constants.StatusCodes.BAD_REQUEST
+                assert "Ensure to provide a unique non-empty string less than '255' characters." in e.message
 
             try:
                 created_container.create_item({"id": resource_id})
                 self.fail("Item create should have failed for id {}".format(resource_id))
             except ValueError as e:
                 assert str(e) in error_strings
+            except exceptions.CosmosHttpResponseError as e:
+                assert e.status_code == http_constants.StatusCodes.BAD_REQUEST
+                assert "Ensure to provide a unique non-empty string less than '1023' characters." in e.message
+
             try:
                 created_container.upsert_item({"id": resource_id})
                 self.fail("Item upsert should have failed for id {}".format(resource_id))
             except ValueError as e:
                 assert str(e) in error_strings
+            except exceptions.CosmosHttpResponseError as e:
+                assert e.status_code == http_constants.StatusCodes.BAD_REQUEST
+                assert "Ensure to provide a unique non-empty string less than '1023' characters." in e.message
 
         self.client.delete_database(database_id)
 

--- a/sdk/cosmos/azure-cosmos/test/test_resource_id_async.py
+++ b/sdk/cosmos/azure-cosmos/test/test_resource_id_async.py
@@ -7,7 +7,7 @@ import uuid
 import pytest
 
 import test_config
-from azure.cosmos import PartitionKey
+from azure.cosmos import PartitionKey, http_constants, exceptions
 from azure.cosmos.aio import CosmosClient, DatabaseProxy
 
 
@@ -103,23 +103,36 @@ class TestResourceIdsAsync(unittest.IsolatedAsyncioTestCase):
                 self.fail("Database create should have failed for id {}".format(resource_id))
             except ValueError as e:
                 assert str(e) in error_strings
+            except exceptions.CosmosHttpResponseError as e:
+                assert e.status_code == http_constants.StatusCodes.BAD_REQUEST
+                assert "Ensure to provide a unique non-empty string less than '255' characters." in e.message
 
             try:
                 await created_database.create_container(id=resource_id, partition_key=partition_key)
                 self.fail("Container create should have failed for id {}".format(resource_id))
             except ValueError as e:
                 assert str(e) in error_strings
+            except exceptions.CosmosHttpResponseError as e:
+                assert e.status_code == http_constants.StatusCodes.BAD_REQUEST
+                assert "Ensure to provide a unique non-empty string less than '255' characters." in e.message
 
             try:
                 await created_container.create_item({"id": resource_id})
                 self.fail("Item create should have failed for id {}".format(resource_id))
             except ValueError as e:
                 assert str(e) in error_strings
+            except exceptions.CosmosHttpResponseError as e:
+                assert e.status_code == http_constants.StatusCodes.BAD_REQUEST
+                assert "Ensure to provide a unique non-empty string less than '1023' characters." in e.message
+
             try:
                 await created_container.upsert_item({"id": resource_id})
                 self.fail("Item upsert should have failed for id {}".format(resource_id))
             except ValueError as e:
                 assert str(e) in error_strings
+            except exceptions.CosmosHttpResponseError as e:
+                assert e.status_code == http_constants.StatusCodes.BAD_REQUEST
+                assert "Ensure to provide a unique non-empty string less than '1023' characters." in e.message
 
         await self.client.delete_database(created_database)
 

--- a/sdk/cosmos/azure-cosmos/test/test_resource_id_async.py
+++ b/sdk/cosmos/azure-cosmos/test/test_resource_id_async.py
@@ -123,7 +123,7 @@ class TestResourceIdsAsync(unittest.IsolatedAsyncioTestCase):
                 assert str(e) in error_strings
             except exceptions.CosmosHttpResponseError as e:
                 assert e.status_code == http_constants.StatusCodes.BAD_REQUEST
-                assert "Ensure to provide a unique non-empty string less than '1023' characters." in e.message
+                assert "Ensure to provide a unique non-empty string less than '1024' characters." in e.message
 
             try:
                 await created_container.upsert_item({"id": resource_id})
@@ -132,7 +132,7 @@ class TestResourceIdsAsync(unittest.IsolatedAsyncioTestCase):
                 assert str(e) in error_strings
             except exceptions.CosmosHttpResponseError as e:
                 assert e.status_code == http_constants.StatusCodes.BAD_REQUEST
-                assert "Ensure to provide a unique non-empty string less than '1023' characters." in e.message
+                assert "Ensure to provide a unique non-empty string less than '1024' characters." in e.message
 
         await self.client.delete_database(created_database)
 

--- a/sdk/cosmos/azure-cosmos/test/test_resource_id_async.py
+++ b/sdk/cosmos/azure-cosmos/test/test_resource_id_async.py
@@ -92,7 +92,7 @@ class TestResourceIdsAsync(unittest.IsolatedAsyncioTestCase):
             "ID\r_with_return_carriage",
             "ID_with_newline\n",
             "ID_with_newline\n2",
-            "ID_with_more_than_255" + "_" * 255,
+            "ID_with_more_than_255" + "_added" * 255,
             "ID_with_trailing_spaces   "
         ]
 


### PR DESCRIPTION
Issue https://github.com/Azure/azure-sdk-for-python/issues/35044 pointed out that we accidentally introduced a limit of 255 characters for all resource ids even though our public docs mention item ids can have up to 1023: https://learn.microsoft.com/en-us/azure/cosmos-db/concepts-limits#per-item-limits

This PR makes the validation not worry about size, since the service will always validate that for each resource.