### PR TITLE
Test-Proxy enabled by default

### DIFF
--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -68,7 +68,7 @@ parameters:
     default: false
   - name: TestProxy
     type: boolean
-    default: false
+    default: true
   - name: GenerateApiReviewForManualOnly
     type: boolean
     default: false

--- a/sdk/core/ci.yml
+++ b/sdk/core/ci.yml
@@ -37,6 +37,7 @@ extends:
     ServiceDirectory: core
     BuildTargetingString: "*"
     ValidateFormatting: true
+    TestProxy: false
     Artifacts:
     - name: azure-core
       safeName: azurecore


### PR DESCRIPTION
This means that a dev doesn't have to remember to put `TestProxy: true` on their `ci.yml` file.

Adding based on feedback from @GrahamMThomas and @mccoyp 