### PR TITLE
[Core] add parallel=1 as perf scenario for core

### DIFF
--- a/sdk/core/azure-core/perf-tests.yml
+++ b/sdk/core/azure-core/perf-tests.yml
@@ -14,16 +14,20 @@ Tests:
   Arguments:
   - --size 1024 --parallel 64 --duration 60 --policies all
   - --size 1024 --parallel 64 --duration 60 --policies all --use-entra-id
+  - --size 1024 --parallel 64 --duration 60
   - --size 10240 --parallel 64 --duration 60
   - --size 10240 --parallel 64 --duration 60 --transport requests
+  - --size 10240 --parallel 1 --duration 60
 
 - Test: download-binary
   Class: DownloadBinaryDataTest
   Arguments:
   - --size 1024 --parallel 64 --duration 60
-  - --size 10240 --parallel 64 --duration 60 --transport requests
+  - --size 1024 --parallel 64 --duration 60 --transport requests
   - --size 1024 --parallel 64 --duration 60 --use-entra-id
   - --size 1024 --parallel 64 --duration 60 --policies all
+  - --size 1024 --parallel 1 --duration 60
+  - --size 10240 --parallel 64 --duration 60 --transport requests
 
 - Test: update-entity
   Class: UpdateEntityJSONTest
@@ -32,6 +36,7 @@ Tests:
   - --size 1024 --parallel 64 --duration 60 --transport requests
   - --size 1024 --parallel 64 --duration 60 --use-entra-id
   - --size 1024 --parallel 64 --duration 60 --policies all
+  - --size 1024 --parallel 1 --duration 60
 
 - Test: query-entities
   Class: QueryEntitiesJSONTest
@@ -40,6 +45,7 @@ Tests:
   - --size 1024 --parallel 64 --duration 60 --transport requests
   - --size 1024 --parallel 64 --duration 60 --use-entra-id
   - --size 1024 --parallel 64 --duration 60 --policies all
+  - --size 1024 --parallel 1 --duration 60
 
 - Test: list-entities
   Class: ListEntitiesPageableTest
@@ -48,3 +54,4 @@ Tests:
   - --count 500 --parallel 32 --warmup 60 --duration 60 --transport requests
   - --count 500 --parallel 32 --warmup 60 --duration 60 --use-entra-id
   - --count 500 --parallel 32 --warmup 60 --duration 60 --policies all
+  - --count 500 --parallel 1 --warmup 60 --duration 60

--- a/sdk/core/azure-core/perf.yml
+++ b/sdk/core/azure-core/perf.yml
@@ -14,7 +14,7 @@ parameters:
 - name: Arguments
   displayName: Arguments (regex of arguments to run)
   type: string
-  default: '(1024)|(10240)|(500)'
+  default: '(1024)|(10240)|(500)|(1)'
 - name: Iterations
   displayName: Iterations (times to run each test)
   type: number

--- a/sdk/core/corehttp/perf-tests.yml
+++ b/sdk/core/corehttp/perf-tests.yml
@@ -16,6 +16,7 @@ Tests:
   - --size 1024 --parallel 64 --duration 60 --policies all --use-entra-id
   - --size 10240 --parallel 64 --duration 60
   - --size 10240 --parallel 64 --duration 60 --transport httpx
+  - --size 10240 --parallel 1 --duration 60
 
 - Test: download-binary
   Class: DownloadBinaryDataTest
@@ -23,7 +24,9 @@ Tests:
   - --size 1024 --parallel 64 --duration 60
   - --size 1024 --parallel 64 --duration 60 --transport httpx
   - --size 1024 --parallel 64 --duration 60 --use-entra-id
+  - --size 1024 --parallel 64 --duration 60 --policies all
   - --size 10240 --parallel 64 --duration 60 --policies all
+  - --size 1024 --parallel 1 --duration 60
 
 - Test: update-entity
   Class: UpdateEntityJSONTest
@@ -32,6 +35,7 @@ Tests:
   - --size 1024 --parallel 64 --duration 60 --transport httpx
   - --size 1024 --parallel 64 --duration 60 --use-entra-id
   - --size 1024 --parallel 64 --duration 60 --policies all
+  - --size 1024 --parallel 1 --duration 60
 
 - Test: query-entities
   Class: QueryEntitiesJSONTest
@@ -40,6 +44,7 @@ Tests:
   - --size 1024 --parallel 64 --duration 60 --transport httpx
   - --size 1024 --parallel 64 --duration 60 --use-entra-id
   - --size 1024 --parallel 64 --duration 60 --policies all
+  - --size 1024 --parallel 1 --duration 60
 
 - Test: list-entities
   Class: ListEntitiesPageableTest
@@ -48,3 +53,4 @@ Tests:
   - --count 500 --parallel 32 --warmup 60 --duration 60 --transport httpx
   - --count 500 --parallel 32 --warmup 60 --duration 60 --use-entra-id
   - --count 500 --parallel 32 --warmup 60 --duration 60 --policies all
+  - --count 500 --parallel 1 --warmup 60 --duration 60

--- a/sdk/core/corehttp/perf.yml
+++ b/sdk/core/corehttp/perf.yml
@@ -14,7 +14,7 @@ parameters:
 - name: Arguments
   displayName: Arguments (regex of arguments to run)
   type: string
-  default: '(1024)|(10240)|(500)'
+  default: '(1024)|(10240)|(500)|(1)'
 - name: Iterations
   displayName: Iterations (times to run each test)
   type: number


### PR DESCRIPTION
Adding in parallel=1 to the perf scenarios, as many customers may not be parallelizing, as per @richardpark-msft's suggestion.