### PR TITLE
Update invocation of federated samples

### DIFF
--- a/eng/pipelines/templates/steps/build-test.yml
+++ b/eng/pipelines/templates/steps/build-test.yml
@@ -166,7 +166,7 @@ steps:
         azurePowerShellVersion: LatestVersion
         pwsh: true
         ScriptType: InlineScript
-        Inline: >-
+        Inline: |
           $account = (Get-AzContext).Account;
           $env:AZURESUBSCRIPTION_CLIENT_ID = $account.Id;
           $env:AZURESUBSCRIPTION_TENANT_ID = $account.Tenants;
@@ -179,10 +179,10 @@ steps:
           }
           Write-Host (Get-Command python).Source
 
-          scripts/devops_tasks/dispatch_tox.py
-          "$(TargetingString)"
-          --service="${{ parameters.ServiceDirectory }}"
-          --toxenv="samples";
+          python scripts/devops_tasks/dispatch_tox.py "$(TargetingString)" `
+            --service="${{ parameters.ServiceDirectory }}" `
+            --toxenv="samples"
+
           Write-Host "Last exit code: $LASTEXITCODE";
           exit $LASTEXITCODE;
   - ${{ else }}:


### PR DESCRIPTION
I'm 99% certain this never worked. Non-federated did though. Note the missing `python` invocation that I think is the prime suspect.

Resolves #36467

[Test run](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3987881&view=results)