### PR TITLE
[breaking change detector] optimize changelog output

### DIFF
--- a/scripts/breaking_changes_checker/changelog_tracker.py
+++ b/scripts/breaking_changes_checker/changelog_tracker.py
@@ -154,10 +154,9 @@ class ChangelogTracker(BreakingChangesTracker):
             return buffer
 
         buffer = []
-
-        if self.breaking_changes:
-            _build_md(self.breaking_changes, "### Breaking Changes", buffer)
         if self.features_added:
             _build_md(self.features_added, "### Features Added", buffer)
+        if self.breaking_changes:
+            _build_md(self.breaking_changes, "### Breaking Changes", buffer)
         content =  "\n".join(buffer).strip()
         return content

--- a/scripts/breaking_changes_checker/changelog_tracker.py
+++ b/scripts/breaking_changes_checker/changelog_tracker.py
@@ -149,7 +149,7 @@ class ChangelogTracker(BreakingChangesTracker):
             buffer.append("")
             for _, bc in enumerate(content):
                 msg, _, *args = bc
-                buffer.append(msg.format(*args))
+                buffer.append("  - " + msg.format(*args))
             buffer.append("")
             return buffer
 

--- a/scripts/breaking_changes_checker/detect_breaking_changes.py
+++ b/scripts/breaking_changes_checker/detect_breaking_changes.py
@@ -302,7 +302,9 @@ def test_compare_reports(pkg_dir: str, changelog: bool, source_report: str = "st
 
     remove_json_files(pkg_dir)
 
+    print("===== report changes begin =====")
     print(checker.report_changes())
+    print("===== report changes end =====")
     if not changelog and checker.breaking_changes:
         exit(1)
 

--- a/scripts/breaking_changes_checker/detect_breaking_changes.py
+++ b/scripts/breaking_changes_checker/detect_breaking_changes.py
@@ -302,7 +302,7 @@ def test_compare_reports(pkg_dir: str, changelog: bool, source_report: str = "st
 
     remove_json_files(pkg_dir)
 
-    print("===== report changes begin =====")
+    print("===== changelog start =====")
     print(checker.report_changes())
     print("===== changelog end =====")
     if not changelog and checker.breaking_changes:

--- a/scripts/breaking_changes_checker/detect_breaking_changes.py
+++ b/scripts/breaking_changes_checker/detect_breaking_changes.py
@@ -304,7 +304,7 @@ def test_compare_reports(pkg_dir: str, changelog: bool, source_report: str = "st
 
     print("===== report changes begin =====")
     print(checker.report_changes())
-    print("===== report changes end =====")
+    print("===== changelog end =====")
     if not changelog and checker.breaking_changes:
         exit(1)
 


### PR DESCRIPTION
I am working on apply the breaking change detection tool in SDK generation pipeline and this PR contains:
- add `-` for each item to make it clear which is also compatible with current changelog tool
- add `=== report changes begin/end === ` to make it easier to extract changelog from output
- according to https://azure.github.io/azure-sdk/policies_releases.html#change-logs, `Features Added` is ahead of `Breaking Changes`

Effect:
![image](https://github.com/user-attachments/assets/bf7b497f-3b3a-4d4e-b651-5a8b9ea3a49a)

