### PR TITLE
[Tests] Update various credential mocks

### DIFF
--- a/sdk/appconfiguration/azure-mgmt-appconfiguration/tests/_aio_testcase.py
+++ b/sdk/appconfiguration/azure-mgmt-appconfiguration/tests/_aio_testcase.py
@@ -19,7 +19,9 @@ class AzureMgmtAsyncTestCase(AzureMgmtRecordedTestCase):
 
             credential = DefaultAzureCredential()
         else:
-            credential = Mock(get_token=asyncio.coroutine(lambda _: AccessToken("fake-token", 0)))
+            credential = Mock(
+                spec_set=["get_token"], get_token=asyncio.coroutine(lambda _: AccessToken("fake-token", 0))
+            )
         return client(credential=credential, subscription_id=self.settings.SUBSCRIPTION_ID)
 
     def to_list(self, ait):

--- a/sdk/communication/azure-communication-chat/tests/test_chat_client_async.py
+++ b/sdk/communication/azure-communication-chat/tests/test_chat_client_async.py
@@ -29,7 +29,7 @@ def _convert_datetime_to_utc_int(input):
 async def mock_get_token(*_, **__):
     return AccessToken("some_token", _convert_datetime_to_utc_int(datetime.now().replace(tzinfo=timezone.utc)))
 
-credential = Mock(get_token=mock_get_token)
+credential = Mock(spec_set=["get_token"], get_token=mock_get_token)
 
 
 @pytest.mark.asyncio

--- a/sdk/communication/azure-communication-chat/tests/test_chat_thread_client_async.py
+++ b/sdk/communication/azure-communication-chat/tests/test_chat_thread_client_async.py
@@ -29,7 +29,7 @@ def _convert_datetime_to_utc_int(input):
 async def mock_get_token(*_, **__):
     return AccessToken("some_token", _convert_datetime_to_utc_int(datetime.now().replace(tzinfo=timezone.utc)))
 
-credential = Mock(get_token=mock_get_token)
+credential = Mock(spec_set=["get_token"], get_token=mock_get_token)
 
 
 @pytest.mark.asyncio

--- a/sdk/compute/azure-mgmt-compute/tests/_aio_testcase.py
+++ b/sdk/compute/azure-mgmt-compute/tests/_aio_testcase.py
@@ -23,7 +23,7 @@ class AzureMgmtAsyncTestCase(AzureMgmtRecordedTestCase):
             from azure.identity.aio import DefaultAzureCredential
             credential = DefaultAzureCredential()
         else:
-            credential = Mock(get_token=lambda _: self.mock_completed_future(AccessToken("fake-token", 0)))
+            credential = Mock(spec_set=["get_token"], get_token=lambda _: self.mock_completed_future(AccessToken("fake-token", 0)))
         return client(
             credential=credential,
             subscription_id=self.settings.SUBSCRIPTION_ID

--- a/sdk/core/azure-core/tests/async_tests/test_authentication_async.py
+++ b/sdk/core/azure-core/tests/async_tests/test_authentication_async.py
@@ -44,7 +44,7 @@ async def test_bearer_policy_adds_header(http_request):
         get_token_calls += 1
         return expected_token
 
-    fake_credential = Mock(get_token=get_token)
+    fake_credential = Mock(spec_set=["get_token"], get_token=get_token)
     policies = [AsyncBearerTokenCredentialPolicy(fake_credential, "scope"), Mock(send=verify_authorization_header)]
     pipeline = AsyncPipeline(transport=Mock(), policies=policies)
 
@@ -68,7 +68,7 @@ async def test_bearer_policy_send(http_request):
         return expected_response
 
     get_token = get_completed_future(AccessToken("***", 42))
-    fake_credential = Mock(get_token=lambda *_, **__: get_token)
+    fake_credential = Mock(spec_set=["get_token"], get_token=lambda *_, **__: get_token)
     policies = [AsyncBearerTokenCredentialPolicy(fake_credential, "scope"), Mock(send=verify_request)]
     response = await AsyncPipeline(transport=Mock(), policies=policies).run(expected_request)
 
@@ -87,7 +87,7 @@ async def test_bearer_policy_sync_send(http_request):
         return expected_response
 
     get_token = get_completed_future(AccessToken("***", 42))
-    fake_credential = Mock(get_token=lambda *_, **__: get_token)
+    fake_credential = Mock(spec_set=["get_token"], get_token=lambda *_, **__: get_token)
     policies = [AsyncBearerTokenCredentialPolicy(fake_credential, "scope"), Mock(send=verify_request)]
     response = await AsyncPipeline(transport=Mock(), policies=policies).run(expected_request)
 
@@ -106,7 +106,7 @@ async def test_bearer_policy_token_caching(http_request):
         get_token_calls += 1
         return expected_token
 
-    credential = Mock(get_token=get_token)
+    credential = Mock(spec_set=["get_token"], get_token=get_token)
     policies = [
         AsyncBearerTokenCredentialPolicy(credential, "scope"),
         Mock(send=Mock(return_value=get_completed_future(Mock()))),
@@ -144,7 +144,7 @@ async def test_bearer_policy_optionally_enforces_https(http_request):
         assert "enforce_https" not in kwargs, "AsyncBearerTokenCredentialPolicy didn't pop the 'enforce_https' option"
         return Mock()
 
-    credential = Mock(get_token=lambda *_, **__: get_completed_future(AccessToken("***", 42)))
+    credential = Mock(spec_set=["get_token"], get_token=lambda *_, **__: get_completed_future(AccessToken("***", 42)))
     pipeline = AsyncPipeline(
         transport=Mock(send=assert_option_popped), policies=[AsyncBearerTokenCredentialPolicy(credential, "scope")]
     )
@@ -175,7 +175,7 @@ async def test_bearer_policy_preserves_enforce_https_opt_out(http_request):
             return Mock()
 
     get_token = get_completed_future(AccessToken("***", 42))
-    credential = Mock(get_token=lambda *_, **__: get_token)
+    credential = Mock(spec_set=["get_token"], get_token=lambda *_, **__: get_token)
     policies = [AsyncBearerTokenCredentialPolicy(credential, "scope"), ContextValidator()]
     pipeline = AsyncPipeline(transport=Mock(send=lambda *_, **__: get_completed_future(Mock())), policies=policies)
 
@@ -193,7 +193,7 @@ async def test_bearer_policy_context_unmodified_by_default(http_request):
             return Mock()
 
     get_token = get_completed_future(AccessToken("***", 42))
-    credential = Mock(get_token=lambda *_, **__: get_token)
+    credential = Mock(spec_set=["get_token"], get_token=lambda *_, **__: get_token)
     policies = [AsyncBearerTokenCredentialPolicy(credential, "scope"), ContextValidator()]
     pipeline = AsyncPipeline(transport=Mock(send=lambda *_, **__: get_completed_future(Mock())), policies=policies)
 
@@ -217,7 +217,10 @@ async def test_bearer_policy_calls_sansio_methods(http_request):
             self.response = await super().send(request)
             return self.response
 
-    credential = Mock(get_token=Mock(return_value=get_completed_future(AccessToken("***", int(time.time()) + 3600))))
+    credential = Mock(
+        spec_set=["get_token"],
+        get_token=Mock(return_value=get_completed_future(AccessToken("***", int(time.time()) + 3600))),
+    )
     policy = TestPolicy(credential, "scope")
     transport = Mock(send=Mock(return_value=get_completed_future(Mock(status_code=200))))
 
@@ -300,7 +303,7 @@ async def test_bearer_policy_redirect_same_domain():
         token = AccessToken(auth_headder, 0)
         return token
 
-    credential = Mock(get_token=get_token)
+    credential = Mock(spec_set=["get_token"], get_token=get_token)
     auth_policy = AsyncBearerTokenCredentialPolicy(credential, expected_scope)
     redirect_policy = AsyncRedirectPolicy()
     header_clean_up_policy = SensitiveHeaderCleanupPolicy()
@@ -344,7 +347,7 @@ async def test_bearer_policy_redirect_different_domain():
         token = AccessToken(auth_headder, 0)
         return token
 
-    credential = Mock(get_token=get_token)
+    credential = Mock(spec_set=["get_token"], get_token=get_token)
     auth_policy = AsyncBearerTokenCredentialPolicy(credential, expected_scope)
     redirect_policy = AsyncRedirectPolicy()
     header_clean_up_policy = SensitiveHeaderCleanupPolicy()
@@ -388,7 +391,7 @@ async def test_bearer_policy_redirect_opt_out_clean_up():
         token = AccessToken(auth_headder, 0)
         return token
 
-    credential = Mock(get_token=get_token)
+    credential = Mock(spec_set=["get_token"], get_token=get_token)
     auth_policy = AsyncBearerTokenCredentialPolicy(credential, expected_scope)
     redirect_policy = AsyncRedirectPolicy()
     header_clean_up_policy = SensitiveHeaderCleanupPolicy(disable_redirect_cleanup=True)
@@ -432,7 +435,7 @@ async def test_bearer_policy_redirect_customize_sensitive_headers():
         token = AccessToken(auth_headder, 0)
         return token
 
-    credential = Mock(get_token=get_token)
+    credential = Mock(spec_set=["get_token"], get_token=get_token)
     auth_policy = AsyncBearerTokenCredentialPolicy(credential, expected_scope)
     redirect_policy = AsyncRedirectPolicy()
     header_clean_up_policy = SensitiveHeaderCleanupPolicy(blocked_redirect_headers=["x-ms-authorization-auxiliary"])

--- a/sdk/core/azure-core/tests/async_tests/test_pipeline_async.py
+++ b/sdk/core/azure-core/tests/async_tests/test_pipeline_async.py
@@ -239,7 +239,7 @@ async def test_conf_async_trio_auth_policy_concurrent(port, http_request):
         response = await p.run(request, enforce_https=False)
         assert isinstance(response.http_response.status_code, int)
 
-    fake_credential = Mock(get_token=get_token)
+    fake_credential = Mock(spec_set=["get_token"], get_token=get_token)
     policies = [AsyncBearerTokenCredentialPolicy(fake_credential, "scope")]
     async with AsyncPipeline(TrioRequestsTransport(), policies=policies) as pipeline, trio.open_nursery() as nursery:
         nursery.start_soon(run, pipeline)

--- a/sdk/core/azure-mgmt-core/tests/asynctests/test_authentication_async.py
+++ b/sdk/core/azure-mgmt-core/tests/asynctests/test_authentication_async.py
@@ -75,7 +75,7 @@ async def test_claims_challenge():
         assert scopes == (expected_scope,)
         return next(tokens)
 
-    credential = Mock(get_token=Mock(wraps=get_token))
+    credential = Mock(spec_set=["get_token"], get_token=Mock(wraps=get_token))
     transport = Mock(send=Mock(wraps=send))
     policies = [AsyncARMChallengeAuthenticationPolicy(credential, expected_scope)]
     pipeline = AsyncPipeline(transport=transport, policies=policies)
@@ -113,7 +113,7 @@ async def test_multiple_claims_challenges():
         return AccessToken("***", 42)
 
     transport = Mock(send=Mock(wraps=send))
-    credential = Mock(get_token=Mock(wraps=get_token))
+    credential = Mock(spec_set=["get_token"], get_token=Mock(wraps=get_token))
     policies = [AsyncARMChallengeAuthenticationPolicy(credential, "scope")]
     pipeline = AsyncPipeline(transport=transport, policies=policies)
 
@@ -151,8 +151,8 @@ async def test_auxiliary_authentication_policy():
         get_token_calls2 += 1
         return second_token
 
-    fake_credential1 = Mock(get_token=get_token1)
-    fake_credential2 = Mock(get_token=get_token2)
+    fake_credential1 = Mock(spec_set=["get_token"], get_token=get_token1)
+    fake_credential2 = Mock(spec_set=["get_token"], get_token=get_token2)
     policies = [
         AsyncAuxiliaryAuthenticationPolicy([fake_credential1, fake_credential2], "scope"),
         Mock(send=verify_authorization_header),

--- a/sdk/core/azure-mgmt-core/tests/test_authentication.py
+++ b/sdk/core/azure-mgmt-core/tests/test_authentication.py
@@ -81,8 +81,8 @@ def test_auxiliary_authentication_policy():
         )
         return Mock()
 
-    fake_credential1 = Mock(get_token=Mock(return_value=first_token))
-    fake_credential2 = Mock(get_token=Mock(return_value=second_token))
+    fake_credential1 = Mock(spec_set=["get_token"], get_token=Mock(return_value=first_token))
+    fake_credential2 = Mock(spec_set=["get_token"], get_token=Mock(return_value=second_token))
     policies = [
         AuxiliaryAuthenticationPolicy([fake_credential1, fake_credential2], "scope"),
         Mock(send=verify_authorization_header),
@@ -136,7 +136,7 @@ def test_claims_challenge():
         assert scopes == (expected_scope,)
         return next(tokens)
 
-    credential = Mock(get_token=Mock(wraps=get_token))
+    credential = Mock(spec_set=["get_token"], get_token=Mock(wraps=get_token))
     transport = Mock(send=Mock(wraps=send))
     policies = [ARMChallengeAuthenticationPolicy(credential, expected_scope)]
     pipeline = Pipeline(transport=transport, policies=policies)

--- a/sdk/core/corehttp/tests/async_tests/test_authentication_async.py
+++ b/sdk/core/corehttp/tests/async_tests/test_authentication_async.py
@@ -38,7 +38,7 @@ async def test_bearer_policy_adds_header():
         get_token_calls += 1
         return expected_token
 
-    fake_credential = Mock(get_token=get_token)
+    fake_credential = Mock(spec_set=["get_token"], get_token=get_token)
     policies = [AsyncBearerTokenCredentialPolicy(fake_credential, "scope"), Mock(send=verify_authorization_header)]
     pipeline = AsyncPipeline(transport=Mock(), policies=policies)
 
@@ -60,7 +60,7 @@ async def test_bearer_policy_send():
         return expected_response
 
     get_token = get_completed_future(AccessToken("***", 42))
-    fake_credential = Mock(get_token=lambda *_, **__: get_token)
+    fake_credential = Mock(spec_set=["get_token"], get_token=lambda *_, **__: get_token)
     policies = [AsyncBearerTokenCredentialPolicy(fake_credential, "scope"), Mock(send=verify_request)]
     response = await AsyncPipeline(transport=Mock(), policies=policies).run(expected_request)
 
@@ -77,7 +77,7 @@ async def test_bearer_policy_sync_send():
         return expected_response
 
     get_token = get_completed_future(AccessToken("***", 42))
-    fake_credential = Mock(get_token=lambda *_, **__: get_token)
+    fake_credential = Mock(spec_set=["get_token"], get_token=lambda *_, **__: get_token)
     policies = [AsyncBearerTokenCredentialPolicy(fake_credential, "scope"), Mock(send=verify_request)]
     response = await AsyncPipeline(transport=Mock(), policies=policies).run(expected_request)
 
@@ -97,7 +97,7 @@ async def test_bearer_policy_token_caching():
     async def send_mock(_):
         return Mock(http_response=Mock(status_code=200))
 
-    credential = Mock(get_token=get_token)
+    credential = Mock(spec_set=["get_token"], get_token=get_token)
     policies = [
         AsyncBearerTokenCredentialPolicy(credential, "scope"),
         Mock(send=send_mock),
@@ -133,7 +133,7 @@ async def test_bearer_policy_optionally_enforces_https():
         assert "enforce_https" not in kwargs, "AsyncBearerTokenCredentialPolicy didn't pop the 'enforce_https' option"
         return Mock()
 
-    credential = Mock(get_token=lambda *_, **__: get_completed_future(AccessToken("***", 42)))
+    credential = Mock(spec_set=["get_token"], get_token=lambda *_, **__: get_completed_future(AccessToken("***", 42)))
     pipeline = AsyncPipeline(
         transport=Mock(send=assert_option_popped), policies=[AsyncBearerTokenCredentialPolicy(credential, "scope")]
     )
@@ -162,7 +162,7 @@ async def test_bearer_policy_preserves_enforce_https_opt_out():
             return Mock()
 
     get_token = get_completed_future(AccessToken("***", 42))
-    credential = Mock(get_token=lambda *_, **__: get_token)
+    credential = Mock(spec_set=["get_token"], get_token=lambda *_, **__: get_token)
     policies = [AsyncBearerTokenCredentialPolicy(credential, "scope"), ContextValidator()]
     pipeline = AsyncPipeline(transport=Mock(send=lambda *_, **__: get_completed_future(Mock())), policies=policies)
 
@@ -178,7 +178,7 @@ async def test_bearer_policy_context_unmodified_by_default():
             return Mock()
 
     get_token = get_completed_future(AccessToken("***", 42))
-    credential = Mock(get_token=lambda *_, **__: get_token)
+    credential = Mock(spec_set=["get_token"], get_token=lambda *_, **__: get_token)
     policies = [AsyncBearerTokenCredentialPolicy(credential, "scope"), ContextValidator()]
     pipeline = AsyncPipeline(transport=Mock(send=lambda *_, **__: get_completed_future(Mock())), policies=policies)
 
@@ -200,7 +200,10 @@ async def test_bearer_policy_calls_sansio_methods():
             self.response = await super().send(request)
             return self.response
 
-    credential = Mock(get_token=Mock(return_value=get_completed_future(AccessToken("***", int(time.time()) + 3600))))
+    credential = Mock(
+        spec_set=["get_token"],
+        get_token=Mock(return_value=get_completed_future(AccessToken("***", int(time.time()) + 3600))),
+    )
     policy = TestPolicy(credential, "scope")
     transport = Mock(send=Mock(return_value=get_completed_future(Mock(status_code=200))))
 
@@ -251,9 +254,7 @@ async def test_azure_core_sans_io_policy():
             self.on_exception = Mock(return_value=False)
             self.on_request = Mock()
 
-    credential = Mock(
-        get_token=Mock(return_value=get_completed_future(AccessToken("***", int(time.time()) + 3600))), key="key"
-    )
+    credential = Mock(key="key")
     policy = TestPolicy(credential, "scope")
     transport = Mock(send=Mock(return_value=get_completed_future(Mock(status_code=200))))
 

--- a/sdk/eventhub/azure-mgmt-eventhub/tests/_aio_testcase.py
+++ b/sdk/eventhub/azure-mgmt-eventhub/tests/_aio_testcase.py
@@ -23,12 +23,12 @@ class AzureMgmtAsyncTestCase(AzureMgmtRecordedTestCase):
             from azure.identity.aio import DefaultAzureCredential
             credential = DefaultAzureCredential()
         else:
-            credential = Mock(get_token=lambda _: self.mock_completed_future(AccessToken("fake-token", 0)))
+            credential = Mock(spec_set=["get_token"], get_token=lambda _: self.mock_completed_future(AccessToken("fake-token", 0)))
         return client(
             credential=credential,
             subscription_id=self.settings.SUBSCRIPTION_ID
         )
-    
+
     def mock_completed_future(self, result=None):
         future = asyncio.Future()
         future.set_result = result

--- a/sdk/identity/azure-identity/tests/perfstress_tests/bearer_token_auth_policy.py
+++ b/sdk/identity/azure-identity/tests/perfstress_tests/bearer_token_auth_policy.py
@@ -23,12 +23,12 @@ class BearerTokenPolicyTest(PerfStressTest):
 
         self.request = HttpRequest("GET", "https://localhost")
 
-        credential = Mock(get_token=Mock(return_value=token))
+        credential = Mock(spec_set=["get_token"], get_token=Mock(return_value=token))
         self.pipeline = Pipeline(transport=Mock(), policies=[BearerTokenCredentialPolicy(credential=credential)])
 
         get_token_future = asyncio.Future()
         get_token_future.set_result(token)
-        async_credential = Mock(get_token=Mock(return_value=get_token_future))
+        async_credential = Mock(spec_set=["get_token"], get_token=Mock(return_value=get_token_future))
 
         send_future = asyncio.Future()
         send_future.set_result(Mock())

--- a/sdk/identity/azure-identity/tests/test_application_credential.py
+++ b/sdk/identity/azure-identity/tests/test_application_credential.py
@@ -43,14 +43,19 @@ def test_iterates_only_once():
     """When a credential succeeds, AzureApplicationCredential should use that credential thereafter"""
 
     expected_token = AccessToken("***", 42)
-    unavailable_credential = Mock(get_token=Mock(side_effect=CredentialUnavailableError(message="...")))
-    successful_credential = Mock(get_token=Mock(return_value=expected_token))
+    unavailable_credential = Mock(
+        spec_set=["get_token"], get_token=Mock(side_effect=CredentialUnavailableError(message="..."))
+    )
+    successful_credential = Mock(spec_set=["get_token"], get_token=Mock(return_value=expected_token))
 
     credential = AzureApplicationCredential()
     credential.credentials = [
         unavailable_credential,
         successful_credential,
-        Mock(get_token=Mock(side_effect=Exception("iteration didn't stop after a credential provided a token"))),
+        Mock(
+            spec_set=["get_token"],
+            get_token=Mock(side_effect=Exception("iteration didn't stop after a credential provided a token")),
+        ),
     ]
 
     for n in range(3):

--- a/sdk/identity/azure-identity/tests/test_application_credential_async.py
+++ b/sdk/identity/azure-identity/tests/test_application_credential_async.py
@@ -21,14 +21,21 @@ async def test_iterates_only_once():
     """When a credential succeeds, AzureApplicationCredential should use that credential thereafter"""
 
     expected_token = AccessToken("***", 42)
-    unavailable_credential = Mock(get_token=Mock(side_effect=CredentialUnavailableError(message="...")))
-    successful_credential = Mock(get_token=Mock(return_value=get_completed_future(expected_token)))
+    unavailable_credential = Mock(
+        spec_set=["get_token"], get_token=Mock(side_effect=CredentialUnavailableError(message="..."))
+    )
+    successful_credential = Mock(
+        spec_set=["get_token"], get_token=Mock(return_value=get_completed_future(expected_token))
+    )
 
     credential = AzureApplicationCredential()
     credential.credentials = [
         unavailable_credential,
         successful_credential,
-        Mock(get_token=Mock(side_effect=Exception("iteration didn't stop after a credential provided a token"))),
+        Mock(
+            spec_set=["get_token"],
+            get_token=Mock(side_effect=Exception("iteration didn't stop after a credential provided a token")),
+        ),
     ]
 
     for n in range(3):

--- a/sdk/identity/azure-identity/tests/test_azd_cli_credential_async.py
+++ b/sdk/identity/azure-identity/tests/test_azd_cli_credential_async.py
@@ -81,7 +81,7 @@ async def test_windows_fallback():
 
     sync_get_token = mock.Mock()
     with mock.patch("azure.identity.aio._credentials.azd_cli._SyncAzureDeveloperCliCredential") as fallback:
-        fallback.return_value = mock.Mock(get_token=sync_get_token)
+        fallback.return_value = mock.Mock(spec_set=["get_token"], get_token=sync_get_token)
         with mock.patch(AzureDeveloperCliCredential.__module__ + ".asyncio.get_event_loop"):
             # asyncio.get_event_loop now returns Mock, i.e. never ProactorEventLoop
             credential = AzureDeveloperCliCredential()

--- a/sdk/identity/azure-identity/tests/test_chained_credential.py
+++ b/sdk/identity/azure-identity/tests/test_chained_credential.py
@@ -73,9 +73,9 @@ def test_attempts_all_credentials():
     expected_token = AccessToken("expected_token", 0)
 
     credentials = [
-        Mock(get_token=Mock(side_effect=CredentialUnavailableError(message=""))),
-        Mock(get_token=Mock(side_effect=CredentialUnavailableError(message=""))),
-        Mock(get_token=Mock(return_value=expected_token)),
+        Mock(spec_set=["get_token"], get_token=Mock(side_effect=CredentialUnavailableError(message=""))),
+        Mock(spec_set=["get_token"], get_token=Mock(side_effect=CredentialUnavailableError(message=""))),
+        Mock(spec_set=["get_token"], get_token=Mock(return_value=expected_token)),
     ]
 
     token = ChainedTokenCredential(*credentials).get_token("scope")
@@ -91,9 +91,9 @@ def test_raises_for_unexpected_error():
     expected_message = "it can't be done"
 
     credentials = [
-        Mock(get_token=Mock(side_effect=CredentialUnavailableError(message=""))),
-        Mock(get_token=Mock(side_effect=ValueError(expected_message))),
-        Mock(get_token=Mock(return_value=AccessToken("**", 42))),
+        Mock(spec_set=["get_token"], get_token=Mock(side_effect=CredentialUnavailableError(message=""))),
+        Mock(spec_set=["get_token"], get_token=Mock(side_effect=ValueError(expected_message))),
+        Mock(spec_set=["get_token"], get_token=Mock(return_value=AccessToken("**", 42))),
     ]
 
     with pytest.raises(ClientAuthenticationError) as ex:
@@ -105,8 +105,8 @@ def test_raises_for_unexpected_error():
 
 def test_returns_first_token():
     expected_token = Mock()
-    first_credential = Mock(get_token=lambda _, **__: expected_token)
-    second_credential = Mock(get_token=Mock())
+    first_credential = Mock(spec_set=["get_token"], get_token=lambda _, **__: expected_token)
+    second_credential = Mock(spec_set=["get_token"], get_token=Mock())
 
     aggregate = ChainedTokenCredential(first_credential, second_credential)
     credential = aggregate.get_token("scope")
@@ -149,7 +149,7 @@ def test_managed_identity_imds_probe():
 
     with patch.dict("os.environ", clear=True):
         credentials = [
-            Mock(get_token=Mock(side_effect=CredentialUnavailableError(message=""))),
+            Mock(spec_set=["get_token"], get_token=Mock(side_effect=CredentialUnavailableError(message=""))),
             ManagedIdentityCredential(transport=transport),
         ]
         token = ChainedTokenCredential(*credentials).get_token(scope)
@@ -162,9 +162,9 @@ def test_managed_identity_failed_probe():
     expected_token = Mock()
 
     credentials = [
-        Mock(get_token=Mock(side_effect=CredentialUnavailableError(message=""))),
+        Mock(spec_set=["get_token"], get_token=Mock(side_effect=CredentialUnavailableError(message=""))),
         ManagedIdentityCredential(transport=transport),
-        Mock(get_token=Mock(return_value=expected_token)),
+        Mock(spec_set=["get_token"], get_token=Mock(return_value=expected_token)),
     ]
 
     with patch.dict("os.environ", clear=True):

--- a/sdk/identity/azure-identity/tests/test_chained_token_credential_async.py
+++ b/sdk/identity/azure-identity/tests/test_chained_token_credential_async.py
@@ -66,9 +66,9 @@ async def test_chain_attempts_all_credentials():
 
     expected_token = AccessToken("expected_token", 0)
     credentials = [
-        Mock(get_token=Mock(wraps=credential_unavailable)),
-        Mock(get_token=Mock(wraps=credential_unavailable)),
-        Mock(get_token=wrap_in_future(lambda _, **__: expected_token)),
+        Mock(spec_set=["get_token"], get_token=Mock(wraps=credential_unavailable)),
+        Mock(spec_set=["get_token"], get_token=Mock(wraps=credential_unavailable)),
+        Mock(spec_set=["get_token"], get_token=wrap_in_future(lambda _, **__: expected_token)),
     ]
 
     token = await ChainedTokenCredential(*credentials).get_token("scope")
@@ -88,9 +88,9 @@ async def test_chain_raises_for_unexpected_error():
     expected_message = "it can't be done"
 
     credentials = [
-        Mock(get_token=Mock(wraps=credential_unavailable)),
-        Mock(get_token=Mock(side_effect=ValueError(expected_message))),
-        Mock(get_token=Mock(wraps=wrap_in_future(lambda _, **__: AccessToken("**", 42)))),
+        Mock(spec_set=["get_token"], get_token=Mock(wraps=credential_unavailable)),
+        Mock(spec_set=["get_token"], get_token=Mock(side_effect=ValueError(expected_message))),
+        Mock(spec_set=["get_token"], get_token=Mock(wraps=wrap_in_future(lambda _, **__: AccessToken("**", 42)))),
     ]
 
     with pytest.raises(ClientAuthenticationError) as ex:
@@ -103,8 +103,8 @@ async def test_chain_raises_for_unexpected_error():
 @pytest.mark.asyncio
 async def test_returns_first_token():
     expected_token = Mock()
-    first_credential = Mock(get_token=wrap_in_future(lambda _, **__: expected_token))
-    second_credential = Mock(get_token=Mock())
+    first_credential = Mock(spec_set=["get_token"], get_token=wrap_in_future(lambda _, **__: expected_token))
+    second_credential = Mock(spec_set=["get_token"], get_token=Mock())
 
     aggregate = ChainedTokenCredential(first_credential, second_credential)
     credential = await aggregate.get_token("scope")
@@ -148,7 +148,7 @@ async def test_managed_identity_imds_probe():
     # ensure e.g. $MSI_ENDPOINT isn't set, so we get ImdsCredential
     with patch.dict("os.environ", clear=True):
         credentials = [
-            Mock(get_token=Mock(side_effect=CredentialUnavailableError(message=""))),
+            Mock(spec_set=["get_token"], get_token=Mock(side_effect=CredentialUnavailableError(message=""))),
             ManagedIdentityCredential(transport=transport),
         ]
         token = await ChainedTokenCredential(*credentials).get_token(scope)
@@ -165,9 +165,9 @@ async def test_managed_identity_failed_probe():
 
     expected_token = AccessToken("**", 42)
     credentials = [
-        Mock(get_token=Mock(wraps=credential_unavailable)),
+        Mock(spec_set=["get_token"], get_token=Mock(wraps=credential_unavailable)),
         ManagedIdentityCredential(transport=transport),
-        Mock(get_token=Mock(wraps=wrap_in_future(lambda _, **__: expected_token))),
+        Mock(spec_set=["get_token"], get_token=Mock(wraps=wrap_in_future(lambda _, **__: expected_token))),
     ]
 
     with patch.dict("os.environ", clear=True):

--- a/sdk/identity/azure-identity/tests/test_cli_credential_async.py
+++ b/sdk/identity/azure-identity/tests/test_cli_credential_async.py
@@ -85,7 +85,7 @@ async def test_windows_fallback():
 
     sync_get_token = mock.Mock()
     with mock.patch("azure.identity.aio._credentials.azure_cli._SyncAzureCliCredential") as fallback:
-        fallback.return_value = mock.Mock(get_token=sync_get_token)
+        fallback.return_value = mock.Mock(spec_set=["get_token"], get_token=sync_get_token)
         with mock.patch(AzureCliCredential.__module__ + ".asyncio.get_event_loop"):
             # asyncio.get_event_loop now returns Mock, i.e. never ProactorEventLoop
             credential = AzureCliCredential()

--- a/sdk/identity/azure-identity/tests/test_default.py
+++ b/sdk/identity/azure-identity/tests/test_default.py
@@ -53,14 +53,19 @@ def test_context_manager():
 def test_iterates_only_once():
     """When a credential succeeds, DefaultAzureCredential should use that credential thereafter, ignoring the others"""
 
-    unavailable_credential = Mock(get_token=Mock(side_effect=CredentialUnavailableError(message="...")))
-    successful_credential = Mock(get_token=Mock(return_value=AccessToken("***", 42)))
+    unavailable_credential = Mock(
+        spec_set=["get_token"], get_token=Mock(side_effect=CredentialUnavailableError(message="..."))
+    )
+    successful_credential = Mock(spec_set=["get_token"], get_token=Mock(return_value=AccessToken("***", 42)))
 
     credential = DefaultAzureCredential()
     credential.credentials = [
         unavailable_credential,
         successful_credential,
-        Mock(get_token=Mock(side_effect=Exception("iteration didn't stop after a credential provided a token"))),
+        Mock(
+            spec_set=["get_token"],
+            get_token=Mock(side_effect=Exception("iteration didn't stop after a credential provided a token")),
+        ),
     ]
 
     for n in range(3):

--- a/sdk/identity/azure-identity/tests/test_default_async.py
+++ b/sdk/identity/azure-identity/tests/test_default_async.py
@@ -29,14 +29,21 @@ from test_shared_cache_credential import build_aad_response, get_account_event, 
 async def test_iterates_only_once():
     """When a credential succeeds, DefaultAzureCredential should use that credential thereafter, ignoring the others"""
 
-    unavailable_credential = Mock(get_token=Mock(side_effect=CredentialUnavailableError(message="...")))
-    successful_credential = Mock(get_token=Mock(return_value=get_completed_future(AccessToken("***", 42))))
+    unavailable_credential = Mock(
+        spec_set=["get_token"], get_token=Mock(side_effect=CredentialUnavailableError(message="..."))
+    )
+    successful_credential = Mock(
+        spec_set=["get_token"], get_token=Mock(return_value=get_completed_future(AccessToken("***", 42)))
+    )
 
     credential = DefaultAzureCredential()
     credential.credentials = [
         unavailable_credential,
         successful_credential,
-        Mock(get_token=Mock(side_effect=Exception("iteration didn't stop after a credential provided a token"))),
+        Mock(
+            spec_set=["get_token"],
+            get_token=Mock(side_effect=Exception("iteration didn't stop after a credential provided a token")),
+        ),
     ]
 
     for n in range(3):

--- a/sdk/identity/azure-identity/tests/test_powershell_credential_async.py
+++ b/sdk/identity/azure-identity/tests/test_powershell_credential_async.py
@@ -240,7 +240,7 @@ async def test_windows_event_loop():
     credential = AzurePowerShellCredential()
 
     with patch(AzurePowerShellCredential.__module__ + "._SyncCredential") as fallback:
-        fallback.return_value = Mock(get_token=sync_get_token)
+        fallback.return_value = Mock(spec_set=["get_token"], get_token=sync_get_token)
         with patch(AzurePowerShellCredential.__module__ + ".asyncio.get_event_loop"):
             # asyncio.get_event_loop now returns Mock, i.e. never ProactorEventLoop
             await credential.get_token("scope")

--- a/sdk/keyvault/azure-keyvault-administration/tests/_shared/preparer.py
+++ b/sdk/keyvault/azure-keyvault-administration/tests/_shared/preparer.py
@@ -21,7 +21,7 @@ class KeyVaultClientPreparer(AzureMgmtPreparer):
         if self.is_live:
             return EnvironmentCredential()
 
-        return Mock(get_token=lambda *_: AccessToken("fake-token", 0))
+        return Mock(spec_set=["get_token"], get_token=lambda *_: AccessToken("fake-token", 0))
 
     def create_resource(self, _, **kwargs):
         credential = self.create_credential()

--- a/sdk/keyvault/azure-keyvault-administration/tests/_shared/preparer_async.py
+++ b/sdk/keyvault/azure-keyvault-administration/tests/_shared/preparer_async.py
@@ -16,4 +16,4 @@ class KeyVaultClientPreparer(_KeyVaultClientPreparer):
         if self.is_live:
             return EnvironmentCredential()
 
-        return Mock(get_token=lambda *_: get_completed_future(AccessToken("fake-token", 0)))
+        return Mock(spec_set=["get_token"], get_token=lambda *_: get_completed_future(AccessToken("fake-token", 0)))

--- a/sdk/keyvault/azure-keyvault-certificates/tests/_shared/preparer.py
+++ b/sdk/keyvault/azure-keyvault-certificates/tests/_shared/preparer.py
@@ -21,7 +21,7 @@ class KeyVaultClientPreparer(AzureMgmtPreparer):
         if self.is_live:
             return EnvironmentCredential()
 
-        return Mock(get_token=lambda *_: AccessToken("fake-token", 0))
+        return Mock(spec_set=["get_token"], get_token=lambda *_: AccessToken("fake-token", 0))
 
     def create_resource(self, _, **kwargs):
         credential = self.create_credential()

--- a/sdk/keyvault/azure-keyvault-certificates/tests/_shared/preparer_async.py
+++ b/sdk/keyvault/azure-keyvault-certificates/tests/_shared/preparer_async.py
@@ -16,4 +16,4 @@ class KeyVaultClientPreparer(_KeyVaultClientPreparer):
         if self.is_live:
             return EnvironmentCredential()
 
-        return Mock(get_token=lambda *_: get_completed_future(AccessToken("fake-token", 0)))
+        return Mock(spec_set=["get_token"], get_token=lambda *_: get_completed_future(AccessToken("fake-token", 0)))

--- a/sdk/keyvault/azure-keyvault-keys/tests/_shared/preparer.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/_shared/preparer.py
@@ -21,7 +21,7 @@ class KeyVaultClientPreparer(AzureMgmtPreparer):
         if self.is_live:
             return EnvironmentCredential()
 
-        return Mock(get_token=lambda *_: AccessToken("fake-token", 0))
+        return Mock(spec_set=["get_token"], get_token=lambda *_: AccessToken("fake-token", 0))
 
     def create_resource(self, _, **kwargs):
         credential = self.create_credential()

--- a/sdk/keyvault/azure-keyvault-keys/tests/_shared/preparer_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/_shared/preparer_async.py
@@ -16,4 +16,4 @@ class KeyVaultClientPreparer(_KeyVaultClientPreparer):
         if self.is_live:
             return EnvironmentCredential()
 
-        return Mock(get_token=lambda *_: get_completed_future(AccessToken("fake-token", 0)))
+        return Mock(spec_set=["get_token"], get_token=lambda *_: get_completed_future(AccessToken("fake-token", 0)))

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_challenge_auth.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_challenge_auth.py
@@ -171,7 +171,7 @@ def test_scope():
             assert scopes[0] == expected_scope
             return AccessToken(expected_token, 0)
 
-        credential = Mock(get_token=Mock(wraps=get_token))
+        credential = Mock(spec_set=["get_token"], get_token=Mock(wraps=get_token))
         pipeline = Pipeline(policies=[ChallengeAuthPolicy(credential=credential)], transport=Mock(send=send))
         request = HttpRequest("POST", get_random_url())
         request.set_bytes_body(expected_content)
@@ -229,7 +229,7 @@ def test_tenant():
             assert kwargs.get("tenant_id") == expected_tenant
             return AccessToken(expected_token, 0)
 
-        credential = Mock(get_token=Mock(wraps=get_token))
+        credential = Mock(spec_set=["get_token"], get_token=Mock(wraps=get_token))
         pipeline = Pipeline(policies=[ChallengeAuthPolicy(credential=credential)], transport=Mock(send=send))
         request = HttpRequest("POST", get_random_url())
         request.set_bytes_body(expected_content)
@@ -281,7 +281,7 @@ def test_adfs():
             assert "tenant_id" not in kwargs
             return AccessToken(expected_token, 0)
 
-        credential = Mock(get_token=Mock(wraps=get_token))
+        credential = Mock(spec_set=["get_token"], get_token=Mock(wraps=get_token))
         policy = ChallengeAuthPolicy(credential=credential)
         pipeline = Pipeline(policies=[policy], transport=Mock(send=send))
         request = HttpRequest("POST", get_random_url())
@@ -345,7 +345,7 @@ def test_policy_updates_cache():
         ),
     )
 
-    credential = Mock(get_token=Mock(return_value=AccessToken(first_token, time.time() + 3600)))
+    credential = Mock(spec_set=["get_token"], get_token=Mock(return_value=AccessToken(first_token, time.time() + 3600)))
     pipeline = Pipeline(policies=[ChallengeAuthPolicy(credential=credential)], transport=transport)
 
     # policy should complete and cache the first challenge and access token
@@ -376,7 +376,7 @@ def test_token_expiration():
     def get_token(*_, **__):
         return token
 
-    credential = Mock(get_token=Mock(wraps=get_token))
+    credential = Mock(spec_set=["get_token"], get_token=Mock(wraps=get_token))
     transport = validating_transport(
         requests=[
             Request(),
@@ -414,7 +414,7 @@ def test_preserves_options_and_headers():
     def get_token(*_, **__):
         return AccessToken(token, 0)
 
-    credential = Mock(get_token=Mock(wraps=get_token))
+    credential = Mock(spec_set=["get_token"], get_token=Mock(wraps=get_token))
 
     transport = validating_transport(
         requests=[Request()] * 2 + [Request(required_headers={"Authorization": "Bearer " + token})],
@@ -468,7 +468,7 @@ def test_verify_challenge_resource_matches(verify_challenge_resource):
     def get_token(*_, **__):
         return AccessToken(token, 0)
 
-    credential = Mock(get_token=Mock(wraps=get_token))
+    credential = Mock(spec_set=["get_token"], get_token=Mock(wraps=get_token))
 
     transport = validating_transport(
         requests=[Request(), Request(required_headers={"Authorization": f"Bearer {token}"})],
@@ -520,7 +520,7 @@ def test_verify_challenge_resource_valid(verify_challenge_resource):
     def get_token(*_, **__):
         return AccessToken(token, 0)
 
-    credential = Mock(get_token=Mock(wraps=get_token))
+    credential = Mock(spec_set=["get_token"], get_token=Mock(wraps=get_token))
 
     transport = validating_transport(
         requests=[Request(), Request(required_headers={"Authorization": f"Bearer {token}"})],

--- a/sdk/keyvault/azure-keyvault-keys/tests/test_challenge_auth_async.py
+++ b/sdk/keyvault/azure-keyvault-keys/tests/test_challenge_auth_async.py
@@ -121,7 +121,7 @@ async def test_scope():
             assert scopes[0] == expected_scope
             return AccessToken(expected_token, 0)
 
-        credential = Mock(get_token=Mock(wraps=get_token))
+        credential = Mock(spec_set=["get_token"], get_token=Mock(wraps=get_token))
         pipeline = AsyncPipeline(
             policies=[AsyncChallengeAuthPolicy(credential=credential)], transport=Mock(send=send)
         )
@@ -182,7 +182,7 @@ async def test_tenant():
             assert kwargs.get("tenant_id") == expected_tenant
             return AccessToken(expected_token, 0)
 
-        credential = Mock(get_token=Mock(wraps=get_token))
+        credential = Mock(spec_set=["get_token"], get_token=Mock(wraps=get_token))
         pipeline = AsyncPipeline(
             policies=[AsyncChallengeAuthPolicy(credential=credential)], transport=Mock(send=send)
         )
@@ -237,7 +237,7 @@ async def test_adfs():
             assert "tenant_id" not in kwargs
             return AccessToken(expected_token, 0)
 
-        credential = Mock(get_token=Mock(wraps=get_token))
+        credential = Mock(spec_set=["get_token"], get_token=Mock(wraps=get_token))
         policy = AsyncChallengeAuthPolicy(credential=credential)
         pipeline = AsyncPipeline(policies=[policy], transport=Mock(send=send))
         request = HttpRequest("POST", get_random_url())
@@ -308,7 +308,7 @@ async def test_policy_updates_cache():
     async def get_token(*_, **__):
         return token
 
-    credential = Mock(get_token=Mock(wraps=get_token))
+    credential = Mock(spec_set=["get_token"], get_token=Mock(wraps=get_token))
     pipeline = AsyncPipeline(policies=[AsyncChallengeAuthPolicy(credential=credential)], transport=transport)
 
     # policy should complete and cache the first challenge and access token
@@ -340,7 +340,7 @@ async def test_token_expiration():
     async def get_token(*_, **__):
         return token
 
-    credential = Mock(get_token=Mock(wraps=get_token))
+    credential = Mock(spec_set=["get_token"], get_token=Mock(wraps=get_token))
     transport = async_validating_transport(
         requests=[
             Request(),
@@ -379,7 +379,7 @@ async def test_preserves_options_and_headers():
     async def get_token(*_, **__):
         return AccessToken(token, 0)
 
-    credential = Mock(get_token=Mock(wraps=get_token))
+    credential = Mock(spec_set=["get_token"], get_token=Mock(wraps=get_token))
 
     transport = async_validating_transport(
         requests=[Request()] * 2 + [Request(required_headers={"Authorization": "Bearer " + token})],
@@ -433,7 +433,7 @@ async def test_verify_challenge_resource_matches(verify_challenge_resource):
     async def get_token(*_, **__):
         return AccessToken(token, 0)
 
-    credential = Mock(get_token=Mock(wraps=get_token))
+    credential = Mock(spec_set=["get_token"], get_token=Mock(wraps=get_token))
 
     transport = async_validating_transport(
         requests=[Request(), Request(required_headers={"Authorization": f"Bearer {token}"})],
@@ -486,7 +486,7 @@ async def test_verify_challenge_resource_valid(verify_challenge_resource):
     async def get_token(*_, **__):
         return AccessToken(token, 0)
 
-    credential = Mock(get_token=Mock(wraps=get_token))
+    credential = Mock(spec_set=["get_token"], get_token=Mock(wraps=get_token))
 
     transport = async_validating_transport(
         requests=[Request(), Request(required_headers={"Authorization": f"Bearer {token}"})],

--- a/sdk/keyvault/azure-keyvault-secrets/tests/_shared/preparer.py
+++ b/sdk/keyvault/azure-keyvault-secrets/tests/_shared/preparer.py
@@ -21,7 +21,7 @@ class KeyVaultClientPreparer(AzureMgmtPreparer):
         if self.is_live:
             return EnvironmentCredential()
 
-        return Mock(get_token=lambda *_: AccessToken("fake-token", 0))
+        return Mock(spec_set=["get_token"], get_token=lambda *_: AccessToken("fake-token", 0))
 
     def create_resource(self, _, **kwargs):
         credential = self.create_credential()

--- a/sdk/keyvault/azure-keyvault-secrets/tests/_shared/preparer_async.py
+++ b/sdk/keyvault/azure-keyvault-secrets/tests/_shared/preparer_async.py
@@ -16,4 +16,4 @@ class KeyVaultClientPreparer(_KeyVaultClientPreparer):
         if self.is_live:
             return EnvironmentCredential()
 
-        return Mock(get_token=lambda *_: get_completed_future(AccessToken("fake-token", 0)))
+        return Mock(spec_set=["get_token"], get_token=lambda *_: get_completed_future(AccessToken("fake-token", 0)))

--- a/sdk/monitor/azure-mgmt-monitor/tests/_aio_testcase.py
+++ b/sdk/monitor/azure-mgmt-monitor/tests/_aio_testcase.py
@@ -18,7 +18,7 @@ class AzureMgmtAsyncTestCase(AzureMgmtRecordedTestCase):
             from azure.identity.aio import DefaultAzureCredential
             credential = DefaultAzureCredential()
         else:
-            credential = Mock(get_token=asyncio.coroutine(lambda _: AccessToken("fake-token", 0)))
+            credential = Mock(spec_set=["get_token"], get_token=asyncio.coroutine(lambda _: AccessToken("fake-token", 0)))
         return client(
             credential=credential,
             subscription_id=self.settings.SUBSCRIPTION_ID

--- a/sdk/network/azure-mgmt-network/tests/_aio_testcase.py
+++ b/sdk/network/azure-mgmt-network/tests/_aio_testcase.py
@@ -16,7 +16,7 @@ class AzureMgmtRecordedAsyncTestCase(AzureMgmtRecordedTestCase):
             from azure.identity.aio import DefaultAzureCredential
             credential = DefaultAzureCredential()
         else:
-            credential = Mock(get_token=asyncio.coroutine(lambda _: AccessToken("fake-token", 0)))
+            credential = Mock(spec_set=["get_token"], get_token=asyncio.coroutine(lambda _: AccessToken("fake-token", 0)))
         return client(
             credential=credential,
             subscription_id=self.get_settings_value("SUBSCRIPTION_ID")

--- a/sdk/storage/azure-mgmt-storage/tests/_aio_testcase.py
+++ b/sdk/storage/azure-mgmt-storage/tests/_aio_testcase.py
@@ -18,7 +18,7 @@ class AzureMgmtAsyncTestCase(AzureMgmtRecordedTestCase):
             from azure.identity.aio import DefaultAzureCredential
             credential = DefaultAzureCredential()
         else:
-            credential = Mock(get_token=asyncio.coroutine(lambda _: AccessToken("fake-token", 0)))
+            credential = Mock(spec_set=["get_token"], get_token=asyncio.coroutine(lambda _: AccessToken("fake-token", 0)))
         return client(
             credential=credential,
             subscription_id=self.settings.SUBSCRIPTION_ID

--- a/sdk/tables/azure-data-tables/tests/test_challenge_auth.py
+++ b/sdk/tables/azure-data-tables/tests/test_challenge_auth.py
@@ -116,7 +116,7 @@ def test_challenge_policy_uses_scopes_and_tenant(http_request):
                 return AccessToken(expected_token, 0)
             raise ValueError("unexpected token request")
 
-        credential = Mock(get_token=Mock(wraps=get_token))
+        credential = Mock(spec_set=["get_token"], get_token=Mock(wraps=get_token))
         policy = BearerTokenChallengePolicy(credential, "scope")
         pipeline = Pipeline(policies=[policy], transport=Mock(send=send))
         pipeline.run(http_request("GET", "https://localhost"))
@@ -188,7 +188,7 @@ def test_challenge_policy_disable_tenant_discovery(http_request):
                 return AccessToken(bad_token, 0)
             raise ValueError("unexpected token request")
 
-        credential = Mock(get_token=Mock(wraps=get_token))
+        credential = Mock(spec_set=["get_token"], get_token=Mock(wraps=get_token))
         policy = BearerTokenChallengePolicy(credential, "scope", discover_tenant=False)
         pipeline = Pipeline(policies=[policy], transport=Mock(send=send))
         pipeline.run(http_request("GET", "https://localhost"))
@@ -248,7 +248,7 @@ def test_challenge_policy_disable_scopes_discovery(http_request):
                 return AccessToken(bad_token, 0)
             raise ValueError("unexpected token request")
 
-        credential = Mock(get_token=Mock(wraps=get_token))
+        credential = Mock(spec_set=["get_token"], get_token=Mock(wraps=get_token))
         policy = BearerTokenChallengePolicy(credential, "scope", discover_scopes=False)
         pipeline = Pipeline(policies=[policy], transport=Mock(send=send))
         pipeline.run(http_request("GET", "https://localhost"))
@@ -299,7 +299,7 @@ def test_challenge_policy_disable_any_discovery(http_request):
                 return AccessToken(bad_token, 0)
             raise ValueError("unexpected token request")
 
-        credential = Mock(get_token=Mock(wraps=get_token))
+        credential = Mock(spec_set=["get_token"], get_token=Mock(wraps=get_token))
         policy = BearerTokenChallengePolicy(credential, "scope", discover_tenant=False, discover_scopes=False)
         pipeline = Pipeline(policies=[policy], transport=Mock(send=send))
         pipeline.run(http_request("GET", "https://localhost"))
@@ -358,7 +358,7 @@ def test_challenge_policy_no_scope_in_challenge(http_request):
                 return AccessToken(bad_token, 0)
             raise ValueError("unexpected token request")
 
-        credential = Mock(get_token=Mock(wraps=get_token))
+        credential = Mock(spec_set=["get_token"], get_token=Mock(wraps=get_token))
         policy = BearerTokenChallengePolicy(credential, "scope")
         pipeline = Pipeline(policies=[policy], transport=Mock(send=send))
         pipeline.run(http_request("GET", "https://localhost"))

--- a/sdk/tables/azure-data-tables/tests/test_challenge_auth_async.py
+++ b/sdk/tables/azure-data-tables/tests/test_challenge_auth_async.py
@@ -117,7 +117,7 @@ async def test_challenge_policy_uses_scopes_and_tenant(http_request):
                 raise ValueError("unexpected token request")
             return AccessToken(expected_token, 0)
 
-        credential = Mock(get_token=Mock(wraps=get_token))
+        credential = Mock(spec_set=["get_token"], get_token=Mock(wraps=get_token))
         policy = AsyncBearerTokenChallengePolicy(credential, "scope")
         pipeline = AsyncPipeline(policies=[policy], transport=Mock(send=send))
         await pipeline.run(http_request("GET", "https://localhost"))
@@ -189,7 +189,7 @@ async def test_challenge_policy_disable_tenant_discovery(http_request):
                 return AccessToken(bad_token, 0)
             raise ValueError("unexpected token request")
 
-        credential = Mock(get_token=Mock(wraps=get_token))
+        credential = Mock(spec_set=["get_token"], get_token=Mock(wraps=get_token))
         policy = AsyncBearerTokenChallengePolicy(credential, "scope", discover_tenant=False)
         pipeline = AsyncPipeline(policies=[policy], transport=Mock(send=send))
         await pipeline.run(http_request("GET", "https://localhost"))
@@ -249,7 +249,7 @@ async def test_challenge_policy_disable_scopes_discovery(http_request):
                 return AccessToken(bad_token, 0)
             raise ValueError("unexpected token request")
 
-        credential = Mock(get_token=Mock(wraps=get_token))
+        credential = Mock(spec_set=["get_token"], get_token=Mock(wraps=get_token))
         policy = AsyncBearerTokenChallengePolicy(credential, "scope", discover_scopes=False)
         pipeline = AsyncPipeline(policies=[policy], transport=Mock(send=send))
         await pipeline.run(http_request("GET", "https://localhost"))
@@ -300,7 +300,7 @@ async def test_challenge_policy_disable_any_discovery(http_request):
                 return AccessToken(bad_token, 0)
             raise ValueError("unexpected token request")
 
-        credential = Mock(get_token=Mock(wraps=get_token))
+        credential = Mock(spec_set=["get_token"], get_token=Mock(wraps=get_token))
         policy = AsyncBearerTokenChallengePolicy(credential, "scope", discover_tenant=False, discover_scopes=False)
         pipeline = AsyncPipeline(policies=[policy], transport=Mock(send=send))
         await pipeline.run(http_request("GET", "https://localhost"))
@@ -359,7 +359,7 @@ async def test_challenge_policy_no_scope_in_challenge(http_request):
                 return AccessToken(bad_token, 0)
             raise ValueError("unexpected token request")
 
-        credential = Mock(get_token=Mock(wraps=get_token))
+        credential = Mock(spec_set=["get_token"], get_token=Mock(wraps=get_token))
         policy = AsyncBearerTokenChallengePolicy(credential, "scope")
         pipeline = AsyncPipeline(policies=[policy], transport=Mock(send=send))
         await pipeline.run(http_request("GET", "https://localhost"))


### PR DESCRIPTION
This is a minor change to various credential mocks to keep things passing if/when we do additional attribute checking in the core credential policies. As it is currently, `hasattr` will return `True` for anything with Mocks.