### PR TITLE
[Identity] Support SecureString output for Pwsh cred

### DIFF
--- a/sdk/identity/azure-identity/CHANGELOG.md
+++ b/sdk/identity/azure-identity/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+- `AzurePowerShellCredential` now supports using secure strings when authenticating with PowerShell. ([#36653](https://github.com/Azure/azure-sdk-for-python/pull/36653))
+
 ## 1.18.0b1 (2024-07-16)
 
 - Fixed the issue that `SharedTokenCacheCredential` was not picklable.

--- a/sdk/identity/azure-identity/azure/identity/_credentials/azure_powershell.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/azure_powershell.py
@@ -37,7 +37,7 @@ if (! $m) {{
 $params = @{{ 'ResourceUrl' = '{}'; 'WarningAction' = 'Ignore' }}
 
 $tenantId = '{}'
-if (-not [string]::IsNullOrEmpty($tenantId)) {{
+if ($tenantId.Length -gt 0) {{
     $params['TenantId'] = $tenantId
 }}
 

--- a/sdk/identity/azure-identity/azure/identity/_credentials/azure_powershell.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/azure_powershell.py
@@ -34,9 +34,20 @@ if (! $m) {{
     exit
 }}
 
-$token = Get-AzAccessToken -ResourceUrl '{}'{}
+$useSecureString = $m.Version -ge [version]"2.17.0"
 
-Write-Output "`nazsdk%$($token.Token)%$($token.ExpiresOn.ToUnixTimeSeconds())`n"
+$command = "Get-AzAccessToken -ResourceUrl '{}'{}"
+
+if ($useSecureString) {{
+    $command += " -AsSecureString"
+}}
+
+$token = Invoke-Expression $command
+$tokenValue = $token.Token
+if ($useSecureString) {{
+    $tokenValue = $tokenValue | ConvertFrom-SecureString -AsPlainText
+}}
+Write-Output "`nazsdk%$($tokenValue)%$($token.ExpiresOn.ToUnixTimeSeconds())`n"
 """
 
 

--- a/sdk/identity/azure-identity/azure/identity/_credentials/azure_powershell.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/azure_powershell.py
@@ -223,4 +223,6 @@ def raise_for_error(return_code: int, stdout: str, stderr: str) -> None:
     if stderr:
         # stderr is too noisy to include with an exception but may be useful for debugging
         _LOGGER.debug('%s received an error from Azure PowerShell: "%s"', AzurePowerShellCredential.__name__, stderr)
-    raise CredentialUnavailableError(message="Failed to invoke PowerShell")
+    raise CredentialUnavailableError(
+        message="Failed to invoke PowerShell. Enable debug logging for additional information."
+    )

--- a/sdk/identity/azure-identity/tests/test_live_async.py
+++ b/sdk/identity/azure-identity/tests/test_live_async.py
@@ -73,18 +73,21 @@ async def test_default_credential(live_service_principal):
 
 
 @pytest.mark.manual
+@pytest.mark.asyncio
 async def test_cli_credential():
     credential = AzureCliCredential()
     await get_token(credential)
 
 
 @pytest.mark.manual
+@pytest.mark.asyncio
 async def test_dev_cli_credential():
     credential = AzureDeveloperCliCredential()
     await get_token(credential)
 
 
 @pytest.mark.manual
+@pytest.mark.asyncio
 async def test_powershell_credential():
     credential = AzurePowerShellCredential()
     await get_token(credential)

--- a/sdk/identity/azure-identity/tests/test_powershell_credential.py
+++ b/sdk/identity/azure-identity/tests/test_powershell_credential.py
@@ -114,8 +114,8 @@ def test_get_token(stderr):
     assert match, "couldn't find encoded script in command line"
     encoded_script = match.groups()[0]
     decoded_script = base64.b64decode(encoded_script).decode("utf-16-le")
-    assert "TenantId" not in decoded_script
-    assert "Get-AzAccessToken -ResourceUrl '{}'".format(scope) in decoded_script
+    assert "tenantId = ''" in decoded_script
+    assert f"'ResourceUrl' = '{scope}'" in decoded_script
 
     assert Popen().communicate.call_count == 1
     args, kwargs = Popen().communicate.call_args
@@ -301,12 +301,12 @@ def test_multitenant_authentication():
         assert match, "couldn't find encoded script in command line"
         encoded_script = match.groups()[0]
         decoded_script = base64.b64decode(encoded_script).decode("utf-16-le")
-        match = re.search(r"-ResourceUrl\s+'([^']+)'(?:\s+-TenantId\s+(\d+))?", decoded_script)
+        match = re.search(r"\$tenantId\s*=\s*'([^']*)'", decoded_script)
         assert match
-        tenant = match.groups()[1]
+        tenant = match.group(1)
 
-        assert tenant is None or tenant == second_tenant, 'unexpected tenant "{}"'.format(tenant)
-        token = first_token if tenant is None else second_token
+        assert not tenant or tenant == second_tenant, 'unexpected tenant "{}"'.format(tenant)
+        token = first_token if not tenant else second_token
         stdout = "azsdk%{}%{}".format(token, int(time.time()) + 3600)
 
         communicate = Mock(return_value=(stdout, ""))
@@ -334,11 +334,11 @@ def test_multitenant_authentication_not_allowed():
         assert match, "couldn't find encoded script in command line"
         encoded_script = match.groups()[0]
         decoded_script = base64.b64decode(encoded_script).decode("utf-16-le")
-        match = re.search(r"-ResourceUrl\s+'([^']+)'(?:\s+-TenantId\s+(\d+))?", decoded_script)
+        match = re.search(r"\$tenantId\s*=\s*'([^']*)'", decoded_script)
         assert match
-        tenant = match.groups()[1]
+        tenant = match.group(1)
 
-        assert tenant is None, "credential shouldn't accept an explicit tenant ID"
+        assert not tenant, "credential shouldn't accept an explicit tenant ID"
         stdout = "azsdk%{}%{}".format(expected_token, int(time.time()) + 3600)
 
         communicate = Mock(return_value=(stdout, ""))


### PR DESCRIPTION
The Az.Accounts module for PowerShell will soon start outputting token data as secure strings. This ensure that AzurePowerShellCredential can handle this format.

Closes: https://github.com/Azure/azure-sdk-for-python/issues/36596

