### PR TITLE
[EventHubs] skip samples until DefaultAzureCredential can be used

### DIFF
--- a/scripts/devops_tasks/test_run_samples.py
+++ b/scripts/devops_tasks/test_run_samples.py
@@ -96,6 +96,7 @@ IGNORED_SAMPLES = {
     ],
     "azure-eventhub": [
         "client_identity_authentication.py",    # TODO: remove after fixing issue #29177
+        "client_identity_authentication_async.py",    # TODO: remove after fixing issue #29177
         "connection_to_custom_endpoint_address.py",
         "proxy.py",
         "connection_to_custom_endpoint_address_async.py",

--- a/sdk/eventhub/tests.yml
+++ b/sdk/eventhub/tests.yml
@@ -22,8 +22,6 @@ extends:
           SubscriptionConfigurationFilePaths:
             - eng/common/TestResources/sub-config/AzureChinaMsft.json
           Location: 'chinanorth3'
-      MatrixReplace:
-        - TestSamples=.*/true
       MatrixFilters:
         - PythonVersion=^(?!pypy3).*
       EnvVars:


### PR DESCRIPTION
The Test Samples job is failing in the tests pipeline as DefaultAzureCredential doesn't work with samples yet. Skipping for now.

Explicitly skipping the client_identity_authentication samples, as those use EnvironmentCredential and will not work anyway.