### PR TITLE
[SchemaRegistry] use federated auth

### DIFF
--- a/sdk/schemaregistry/test-resources.json
+++ b/sdk/schemaregistry/test-resources.json
@@ -9,32 +9,6 @@
           "description": "The base resource name."
         }
       },
-      "tenantId": {
-        "type": "string",
-        "defaultValue": "72f988bf-86f1-41af-91ab-2d7cd011db47",
-        "metadata": {
-          "description": "The tenant ID to which the application and resources belong."
-        }
-      },
-      "testApplicationId": {
-        "type": "string",
-        "metadata": {
-          "description": "The application client ID used to run tests."
-        }
-      },
-      "testApplicationSecret": {
-        "type": "string",
-        "metadata": {
-          "description": "The application client secret used to run tests."
-        }
-      },
-      "testApplicationOid": {
-        "type": "string",
-        "defaultValue": "b3653439-8136-4cd5-aac3-2a9460871ca6",
-        "metadata": {
-          "description": "The client OID to grant access to test resources."
-        }
-      },
       "location": {
         "type": "string",
         "defaultValue": "[resourceGroup().location]",
@@ -152,18 +126,6 @@
       "SCHEMAREGISTRY_GROUP": {
         "type": "string",
         "value": "[variables('schemaRegistryGroup')]"
-      },
-      "AZURE_CLIENT_ID": {
-        "type": "string",
-        "value": "[parameters('testApplicationId')]"
-      },
-      "AZURE_CLIENT_SECRET": {
-        "type": "string",
-        "value": "[parameters('testApplicationSecret')]"
-      },
-      "AZURE_TENANT_ID": {
-        "type": "string",
-        "value": "[parameters('tenantId')]"
       }
     }
   }

--- a/sdk/schemaregistry/tests.yml
+++ b/sdk/schemaregistry/tests.yml
@@ -6,14 +6,15 @@ extends:
       ServiceDirectory: schemaregistry
       TestTimeoutInMinutes: 300
       BuildTargetingString: azure-schemaregistry*
+      UseFederatedAuth: true
       EnvVars:
         AZURE_SUBSCRIPTION_ID: $(azure-subscription-id)
-        AZURE_TENANT_ID: $(python-schema-registry-sdk-test-tenant-id)
-        AZURE_CLIENT_ID: $(python-schema-registry-sdk-test-client-id)
-        AZURE_CLIENT_SECRET: $(python-schema-registry-sdk-test-client-secret)
-        SCHEMAREGISTRY_FULLY_QUALIFIED_NAMESPACE: $(python-schema-registry-sdk-test-endpoint)
-        SCHEMAREGISTRY_GROUP: $(python-schema-registry-sdk-test-group)
         AZURE_SKIP_LIVE_RECORDING: 'True'
         AZURE_TEST_RUN_LIVE: 'true'
       MatrixFilters:
         - '"PythonVersion=^(?!pypy3).*"'
+      CloudConfig:
+        Public:
+          ServiceConnection: azure-sdk-tests
+          SubscriptionConfigurationFilePaths:
+            - eng/common/TestResources/sub-config/AzurePublicMsft.json


### PR DESCRIPTION
- Added Federated Auth to tests.yml
- Removed Client Secret/Client ID/Tenant ID in test-resources.json