### PR TITLE
Account for OS in PATH-setting

### DIFF
--- a/doc/dev/recording_migration_guide.md
+++ b/doc/dev/recording_migration_guide.md
@@ -65,20 +65,28 @@ This script -- [`generate-assets-json.ps1`][generate_assets_json] -- should be r
 In a PowerShell window:
 
 1. Add the test proxy executable to `PATH` if it's not already present. This can be done by adding the path to the
-  `.proxy` folder at the base of your Python repo. For example, if the Python repo is at `C:\azure-sdk-for-python`,
-  you can add the test proxy to `PATH` for the current session by running:
+  `.proxy` folder at the base of your Python repo. You can add the test proxy to `PATH` for the current session by
+  running the following:
 
+  - On Windows:
 ```PowerShell
-$env:Path += ';C:\azure-sdk-for-python\.proxy'
+$env:PATH += ';<path-to-repo>\azure-sdk-for-python\.proxy'
 ```
 
-2. Set your working directory to the root of the package you're migrating (`sdk/{service}/{package}`) -- for example:
-
+  - On Mac or Linux:
 ```PowerShell
-cd C:\azure-sdk-for-python\sdk\keyvault\azure-keyvault-keys
+$env:PATH += ':<path-to-repo>/azure-sdk-for-python/.proxy'
 ```
 
-3. Run the following command:
+2. Run `echo $env:PATH` to inspect `PATH` and confirm that the proxy path was correctly appended.
+
+3. Set your working directory to the root of the package you're migrating (`sdk/{service}/{package}`) -- for example:
+
+```PowerShell
+cd <path-to-repo>\azure-sdk-for-python\sdk\keyvault\azure-keyvault-keys
+```
+
+4. Run the following command:
 
 ```PowerShell
 ..\..\..\eng\common\testproxy\onboarding\generate-assets-json.ps1 -InitialPush


### PR DESCRIPTION
# Description

Someone from the Batch team recently tried to push recordings to the assets repo for the first time and had issues getting their test proxy tool registered on PATH. This turned out to be because environment variables are case-sensitive, and structured differently, on Mac and Linux. This updates the migration guide to explicitly give instructions for each OS and on verifying `PATH` afterward.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
