### PR TITLE
[Storage] [STG 95] API View Beta Feedback Fix

### DIFF
--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_models.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_models.py
@@ -345,8 +345,8 @@ class ShareProperties(DictMixin):
         Specifies whether the snapshot virtual directory should be accessible at the root of the share
         mount point when NFS is enabled. If not specified, it will be accessible.
     :ivar bool paid_bursting_enabled: This property enables paid bursting.
-    :ivar int paid_bursting_max_bandwidth_mibps: The maximum throughput the file share can support in MiB/s.
-    :ivar int paid_bursting_max_iops: The maximum IOPS the file share can support.
+    :ivar int paid_bursting_bandwidth_mibps: The maximum throughput the file share can support in MiB/s.
+    :ivar int paid_bursting_iops: The maximum IOPS the file share can support.
     """
 
     def __init__(self, **kwargs):
@@ -373,8 +373,8 @@ class ShareProperties(DictMixin):
         self.enable_snapshot_virtual_directory_access = \
             kwargs.get('x-ms-enable-snapshot-virtual-directory-access')
         self.paid_bursting_enabled = kwargs.get('x-ms-share-paid-bursting-enabled')
-        self.paid_bursting_max_bandwidth_mibps = kwargs.get('x-ms-share-paid-bursting-max-bandwidth-mibps')
-        self.paid_bursting_max_iops = kwargs.get('x-ms-share-paid-bursting-max-iops')
+        self.paid_bursting_bandwidth_mibps = kwargs.get('x-ms-share-paid-bursting-max-bandwidth-mibps')
+        self.paid_bursting_iops = kwargs.get('x-ms-share-paid-bursting-max-iops')
 
     @classmethod
     def _from_generated(cls, generated):
@@ -401,8 +401,8 @@ class ShareProperties(DictMixin):
         props.root_squash = generated.properties.root_squash
         props.enable_snapshot_virtual_directory_access = generated.properties.enable_snapshot_virtual_directory_access
         props.paid_bursting_enabled = generated.properties.paid_bursting_enabled
-        props.paid_bursting_max_bandwidth_mibps = generated.properties.paid_bursting_max_bandwidth_mibps
-        props.paid_bursting_max_iops = generated.properties.paid_bursting_max_iops
+        props.paid_bursting_bandwidth_mibps = generated.properties.paid_bursting_max_bandwidth_mibps
+        props.paid_bursting_iops = generated.properties.paid_bursting_max_iops
         return props
 
 

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_share_client.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_share_client.py
@@ -375,8 +375,8 @@ class ShareClient(StorageAccountHostsMixin): # pylint: disable=too-many-public-m
             Only valid for NFS shares. Possible values include: 'NoRootSquash', 'RootSquash', 'AllSquash'.
         :paramtype root_squash: str or ~azure.storage.fileshare.ShareRootSquash
         :keyword bool paid_bursting_enabled: This property enables paid bursting.
-        :keyword int paid_bursting_max_bandwidth_mibps: The maximum throughput the file share can support in MiB/s.
-        :keyword int paid_bursting_max_iops: The maximum IOPS the file share can support.
+        :keyword int paid_bursting_bandwidth_mibps: The maximum throughput the file share can support in MiB/s.
+        :keyword int paid_bursting_iops: The maximum IOPS the file share can support.
         :returns: Share-updated property dict (Etag and last modified).
         :rtype: Dict[str, Any]
 
@@ -395,6 +395,8 @@ class ShareClient(StorageAccountHostsMixin): # pylint: disable=too-many-public-m
         timeout = kwargs.pop('timeout', None)
         root_squash = kwargs.pop('root_squash', None)
         protocols = kwargs.pop('protocols', None)
+        paid_bursting_bandwidth_mibps = kwargs.pop('paid_bursting_bandwidth_mibps', None)
+        paid_bursting_iops = kwargs.pop('paid_bursting_iops', None)
         if protocols and protocols not in ['NFS', 'SMB', ShareProtocols.SMB, ShareProtocols.NFS]:
             raise ValueError("The enabled protocol must be set to either SMB or NFS.")
         if root_squash and protocols not in ['NFS', ShareProtocols.NFS]:
@@ -410,6 +412,8 @@ class ShareClient(StorageAccountHostsMixin): # pylint: disable=too-many-public-m
                 access_tier=access_tier,
                 root_squash=root_squash,
                 enabled_protocols=protocols,
+                paid_bursting_max_bandwidth_mibps=paid_bursting_bandwidth_mibps,
+                paid_bursting_max_iops=paid_bursting_iops,
                 cls=return_response_headers,
                 headers=headers,
                 **kwargs)
@@ -647,8 +651,8 @@ class ShareClient(StorageAccountHostsMixin): # pylint: disable=too-many-public-m
             Required if the share has an active lease. Value can be a ShareLeaseClient object
             or the lease ID as a string.
         :keyword bool paid_bursting_enabled: This property enables paid bursting.
-        :keyword int paid_bursting_max_bandwidth_mibps: The maximum throughput the file share can support in MiB/s.
-        :keyword int paid_bursting_max_iops: The maximum IOPS the file share can support.
+        :keyword int paid_bursting_bandwidth_mibps: The maximum throughput the file share can support in MiB/s.
+        :keyword int paid_bursting_iops: The maximum IOPS the file share can support.
         :returns: Share-updated property dict (Etag and last modified).
         :rtype: dict[str, Any]
 
@@ -666,6 +670,8 @@ class ShareClient(StorageAccountHostsMixin): # pylint: disable=too-many-public-m
         access_tier = kwargs.pop('access_tier', None)
         quota = kwargs.pop('quota', None)
         root_squash = kwargs.pop('root_squash', None)
+        paid_bursting_bandwidth_mibps = kwargs.pop('paid_bursting_bandwidth_mibps', None)
+        paid_bursting_iops = kwargs.pop('paid_bursting_iops', None)
         if all(parameter is None for parameter in [access_tier, quota, root_squash]):
             raise ValueError("set_share_properties should be called with at least one parameter.")
         try:
@@ -675,6 +681,8 @@ class ShareClient(StorageAccountHostsMixin): # pylint: disable=too-many-public-m
                 access_tier=access_tier,
                 root_squash=root_squash,
                 lease_access_conditions=access_conditions,
+                paid_bursting_max_bandwidth_mibps=paid_bursting_bandwidth_mibps,
+                paid_bursting_max_iops=paid_bursting_iops,
                 cls=return_response_headers,
                 **kwargs)
         except HttpResponseError as error:

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_share_service_client.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_share_service_client.py
@@ -301,9 +301,6 @@ class ShareServiceClient(StorageAccountHostsMixin):
             This value is not tracked or validated on the client. To configure client-side network timesouts
             see `here <https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/storage/azure-storage-file-share
             #other-client--per-operation-configuration>`__.
-        :keyword bool paid_bursting_enabled: This property enables paid bursting.
-        :keyword int paid_bursting_max_bandwidth_mibps: The maximum throughput the file share can support in MiB/s.
-        :keyword int paid_bursting_max_iops: The maximum IOPS the file share can support.
         :returns: An iterable (auto-paging) of ShareProperties.
         :rtype: ~azure.core.paging.ItemPaged[~azure.storage.fileshare.ShareProperties]
 

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/aio/_share_client_async.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/aio/_share_client_async.py
@@ -224,8 +224,8 @@ class ShareClient(AsyncStorageAccountHostsMixin, ShareClientBase):
             Only valid for NFS shares. Possible values include: 'NoRootSquash', 'RootSquash', 'AllSquash'.
         :paramtype root_squash: str or ~azure.storage.fileshare.ShareRootSquash
         :keyword bool paid_bursting_enabled: This property enables paid bursting.
-        :keyword int paid_bursting_max_bandwidth_mibps: The maximum throughput the file share can support in MiB/s.
-        :keyword int paid_bursting_max_iops: The maximum IOPS the file share can support.
+        :keyword int paid_bursting_bandwidth_mibps: The maximum throughput the file share can support in MiB/s.
+        :keyword int paid_bursting_iops: The maximum IOPS the file share can support.
         :returns: Share-updated property dict (Etag and last modified).
         :rtype: Dict[str, Any]
 
@@ -244,6 +244,8 @@ class ShareClient(AsyncStorageAccountHostsMixin, ShareClientBase):
         timeout = kwargs.pop('timeout', None)
         root_squash = kwargs.pop('root_squash', None)
         protocols = kwargs.pop('protocols', None)
+        paid_bursting_bandwidth_mibps = kwargs.pop('paid_bursting_bandwidth_mibps', None)
+        paid_bursting_iops = kwargs.pop('paid_bursting_iops', None)
         if protocols and protocols not in ['NFS', 'SMB', ShareProtocols.SMB, ShareProtocols.NFS]:
             raise ValueError("The enabled protocol must be set to either SMB or NFS.")
         if root_squash and protocols not in ['NFS', ShareProtocols.NFS]:
@@ -259,6 +261,8 @@ class ShareClient(AsyncStorageAccountHostsMixin, ShareClientBase):
                 access_tier=access_tier,
                 root_squash=root_squash,
                 enabled_protocols=protocols,
+                paid_bursting_max_bandwidth_mibps=paid_bursting_bandwidth_mibps,
+                paid_bursting_max_iops=paid_bursting_iops,
                 cls=return_response_headers,
                 headers=headers,
                 **kwargs)
@@ -495,8 +499,8 @@ class ShareClient(AsyncStorageAccountHostsMixin, ShareClientBase):
             Required if the share has an active lease. Value can be a ShareLeaseClient object
             or the lease ID as a string.
         :keyword bool paid_bursting_enabled: This property enables paid bursting.
-        :keyword int paid_bursting_max_bandwidth_mibps: The maximum throughput the file share can support in MiB/s.
-        :keyword int paid_bursting_max_iops: The maximum IOPS the file share can support.
+        :keyword int paid_bursting_bandwidth_mibps: The maximum throughput the file share can support in MiB/s.
+        :keyword int paid_bursting_iops: The maximum IOPS the file share can support.
         :returns: Share-updated property dict (Etag and last modified).
         :rtype: dict[str, Any]
 
@@ -514,6 +518,8 @@ class ShareClient(AsyncStorageAccountHostsMixin, ShareClientBase):
         access_tier = kwargs.pop('access_tier', None)
         quota = kwargs.pop('quota', None)
         root_squash = kwargs.pop('root_squash', None)
+        paid_bursting_bandwidth_mibps = kwargs.pop('paid_bursting_bandwidth_mibps', None)
+        paid_bursting_iops = kwargs.pop('paid_bursting_iops', None)
         if all(parameter is None for parameter in [access_tier, quota, root_squash]):
             raise ValueError("set_share_properties should be called with at least one parameter.")
         try:
@@ -523,6 +529,8 @@ class ShareClient(AsyncStorageAccountHostsMixin, ShareClientBase):
                 access_tier=access_tier,
                 root_squash=root_squash,
                 lease_access_conditions=access_conditions,
+                paid_bursting_max_bandwidth_mibps=paid_bursting_bandwidth_mibps,
+                paid_bursting_max_iops=paid_bursting_iops,
                 cls=return_response_headers,
                 **kwargs)
         except HttpResponseError as error:

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/aio/_share_service_client_async.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/aio/_share_service_client_async.py
@@ -240,9 +240,6 @@ class ShareServiceClient(AsyncStorageAccountHostsMixin, ShareServiceClientBase):
             This value is not tracked or validated on the client. To configure client-side network timesouts
             see `here <https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/storage/azure-storage-file-share
             #other-client--per-operation-configuration>`__.
-        :keyword bool paid_bursting_enabled: This property enables paid bursting.
-        :keyword int paid_bursting_max_bandwidth_mibps: The maximum throughput the file share can support in MiB/s.
-        :keyword int paid_bursting_max_iops: The maximum IOPS the file share can support.
         :returns: An iterable (auto-paging) of ShareProperties.
         :rtype: ~azure.core.async_paging.AsyncItemPaged[~azure.storage.fileshare.ShareProperties]
 

--- a/sdk/storage/azure-storage-file-share/tests/test_share.py
+++ b/sdk/storage/azure-storage-file-share/tests/test_share.py
@@ -1653,38 +1653,38 @@ class TestStorageShare(StorageRecordedTestCase):
 
         # Arrange
         self._setup(premium_storage_file_account_name, premium_storage_file_account_key)
-        max_mibps = 10340
-        max_iops = 102400
+        mibps = 10340
+        iops = 102400
 
         # Act / Assert
         share = self._create_share(
             paid_bursting_enabled=True,
-            paid_bursting_max_bandwidth_mibps=5000,
-            paid_bursting_max_iops=1000
+            paid_bursting_bandwidth_mibps=5000,
+            paid_bursting_iops=1000
         )
         share_props = share.get_share_properties()
         assert share_props.paid_bursting_enabled
-        assert share_props.paid_bursting_max_bandwidth_mibps == 5000
-        assert share_props.paid_bursting_max_iops == 1000
+        assert share_props.paid_bursting_bandwidth_mibps == 5000
+        assert share_props.paid_bursting_iops == 1000
 
         share.set_share_properties(
             root_squash="NoRootSquash",
             paid_bursting_enabled=True,
-            paid_bursting_max_bandwidth_mibps=max_mibps,
-            paid_bursting_max_iops=max_iops
+            paid_bursting_bandwidth_mibps=mibps,
+            paid_bursting_iops=iops
         )
         share_props = share.get_share_properties()
         assert share_props.paid_bursting_enabled
-        assert share_props.paid_bursting_max_bandwidth_mibps == max_mibps
-        assert share_props.paid_bursting_max_iops == max_iops
+        assert share_props.paid_bursting_bandwidth_mibps == mibps
+        assert share_props.paid_bursting_iops == iops
 
         shares = list(self.fsc.list_shares())
         assert shares is not None
         assert len(shares) == 1
         assert shares[0] is not None
         assert shares[0].paid_bursting_enabled
-        assert shares[0].paid_bursting_max_bandwidth_mibps == max_mibps
-        assert shares[0].paid_bursting_max_iops == max_iops
+        assert shares[0].paid_bursting_bandwidth_mibps == mibps
+        assert shares[0].paid_bursting_iops == iops
 
         self._delete_shares()
 

--- a/sdk/storage/azure-storage-file-share/tests/test_share_async.py
+++ b/sdk/storage/azure-storage-file-share/tests/test_share_async.py
@@ -1690,30 +1690,30 @@ class TestStorageShareAsync(AsyncStorageRecordedTestCase):
 
         # Arrange
         self._setup(premium_storage_file_account_name, premium_storage_file_account_key)
-        max_mibps = 10340
-        max_iops = 102400
+        mibps = 10340
+        iops = 102400
 
         # Act / Assert
         share = await self._create_share(
             paid_bursting_enabled=True,
-            paid_bursting_max_bandwidth_mibps=5000,
-            paid_bursting_max_iops=1000
+            paid_bursting_bandwidth_mibps=5000,
+            paid_bursting_iops=1000
         )
         share_props = await share.get_share_properties()
         assert share_props.paid_bursting_enabled
-        assert share_props.paid_bursting_max_bandwidth_mibps == 5000
-        assert share_props.paid_bursting_max_iops == 1000
+        assert share_props.paid_bursting_bandwidth_mibps == 5000
+        assert share_props.paid_bursting_iops == 1000
 
         await share.set_share_properties(
             root_squash="NoRootSquash",
             paid_bursting_enabled=True,
-            paid_bursting_max_bandwidth_mibps=max_mibps,
-            paid_bursting_max_iops=max_iops
+            paid_bursting_bandwidth_mibps=mibps,
+            paid_bursting_iops=iops
         )
         share_props = await share.get_share_properties()
         assert share_props.paid_bursting_enabled
-        assert share_props.paid_bursting_max_bandwidth_mibps == max_mibps
-        assert share_props.paid_bursting_max_iops == max_iops
+        assert share_props.paid_bursting_bandwidth_mibps == mibps
+        assert share_props.paid_bursting_iops == iops
 
         shares = []
         async for share in self.fsc.list_shares():
@@ -1722,8 +1722,8 @@ class TestStorageShareAsync(AsyncStorageRecordedTestCase):
         assert len(shares) == 1
         assert shares[0] is not None
         assert shares[0].paid_bursting_enabled
-        assert shares[0].paid_bursting_max_bandwidth_mibps == max_mibps
-        assert shares[0].paid_bursting_max_iops == max_iops
+        assert shares[0].paid_bursting_bandwidth_mibps == mibps
+        assert shares[0].paid_bursting_iops == iops
 
         await self._delete_shares()
 


### PR DESCRIPTION
One of two PRs to fix API View Beta feedbacks. The next one will be string to sign supportability feature.

This one removes the `max` name from `paid_burst_*` keywords, as well as unnecessary optional keywords for the `list_shares` API.