### PR TITLE
[Storage] Add crc64 support to file-share download

### DIFF
--- a/sdk/storage/azure-storage-file-share/assets.json
+++ b/sdk/storage/azure-storage-file-share/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "python",
   "TagPrefix": "python/storage/azure-storage-file-share",
-  "Tag": "python/storage/azure-storage-file-share_1176d4af81"
+  "Tag": "python/storage/azure-storage-file-share_62cf50815b"
 }

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/aio/_download_async.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/aio/_download_async.py
@@ -15,16 +15,28 @@ from azure.core.exceptions import HttpResponseError, ResourceModifiedError
 from .._download import _ChunkDownloader
 from .._shared.request_handlers import validate_and_format_range_headers
 from .._shared.response_handlers import process_storage_error, parse_length_from_content_range
+from .._shared.streams import StructuredMessageDecodeStream
+from .._shared.validation import ChecksumAlgorithm, SM_HEADER_V1_CRC64
 
 
-async def process_content(data):
-    if data is None:
+async def process_content(download, validate_content):
+    if download is None:
         raise ValueError("Response cannot be None.")
 
     try:
-        return data.response.body()
+        if validate_content == ChecksumAlgorithm.CRC64:
+            # For async, the body is already in memory so wrap that in a stream
+            content = BytesIO(download.response.body())
+            stream = StructuredMessageDecodeStream(content, download.content_length)
+            content = stream.read()
+        else:
+            content = download.response.body()
+        return content
     except Exception as error:
-        raise HttpResponseError(message="Download stream interrupted.", response=data.response, error=error) from error
+        raise HttpResponseError(
+            message="Download stream interrupted.",
+            response=download.response, error=error
+        ) from error
 
 
 class _AsyncChunkDownloader(_ChunkDownloader):
@@ -64,16 +76,20 @@ class _AsyncChunkDownloader(_ChunkDownloader):
             self.stream.write(chunk_data)
 
     async def _download_chunk(self, chunk_start, chunk_end):
+        md5_validation = self.validate_content is True or self.validate_content == ChecksumAlgorithm.MD5
         range_header, range_validation = validate_and_format_range_headers(
             chunk_start,
             chunk_end,
-            check_content_md5=self.validate_content
+            check_content_md5=md5_validation
         )
+        structured_body_type = SM_HEADER_V1_CRC64 if self.validate_content == ChecksumAlgorithm.CRC64 else None
+
         try:
             _, response = await self.client.download(
                 range=range_header,
                 range_get_content_md5=range_validation,
-                validate_content=self.validate_content,
+                validate_content=True if md5_validation else None,
+                structured_body_type=structured_body_type,
                 data_stream_total=self.total_size,
                 download_stream_current=self.progress_total,
                 **self.request_options
@@ -83,7 +99,7 @@ class _AsyncChunkDownloader(_ChunkDownloader):
         except HttpResponseError as error:
             process_storage_error(error)
 
-        chunk_data = await process_content(response)
+        chunk_data = await process_content(response, self.validate_content)
         return chunk_data
 
 
@@ -233,21 +249,24 @@ class StorageStreamDownloader(object):  # pylint: disable=too-many-instance-attr
         if self.size == 0:
             self._current_content = b""
         else:
-            self._current_content = await process_content(self._response)
+            self._current_content = await process_content(self._response, self._validate_content)
 
     async def _initial_request(self):
+        md5_validation = self._validate_content is True or self._validate_content == ChecksumAlgorithm.MD5
         range_header, range_validation = validate_and_format_range_headers(
             self._initial_range[0],
             self._initial_range[1],
             start_range_required=False,
             end_range_required=False,
-            check_content_md5=self._validate_content)
+            check_content_md5=md5_validation)
+        structured_body_type = SM_HEADER_V1_CRC64 if self._validate_content == ChecksumAlgorithm.CRC64 else None
 
         try:
             location_mode, response = await self._client.download(
                 range=range_header,
                 range_get_content_md5=range_validation,
-                validate_content=self._validate_content,
+                validate_content=True if md5_validation else None,
+                structured_body_type=structured_body_type,
                 data_stream_total=None,
                 download_stream_current=0,
                 **self._request_options)
@@ -277,7 +296,8 @@ class StorageStreamDownloader(object):  # pylint: disable=too-many-instance-attr
                 # any properties.
                 try:
                     _, response = await self._client.download(
-                        validate_content=self._validate_content,
+                        validate_content=True if md5_validation else None,
+                        structured_body_type=structured_body_type,
                         data_stream_total=0,
                         download_stream_current=0,
                         **self._request_options)
@@ -292,6 +312,7 @@ class StorageStreamDownloader(object):  # pylint: disable=too-many-instance-attr
 
         # If the file is small, the download is complete at this point.
         # If file size is large, download the rest of the file in chunks.
+        # TODO: This probably needs to change
         if response.properties.size == self.size:
             self._download_complete = True
         self._etag = response.properties.etag

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/aio/_download_async.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/aio/_download_async.py
@@ -211,11 +211,13 @@ class StorageStreamDownloader(object):  # pylint: disable=too-many-instance-attr
         self._response = None
         self._etag = None
 
+        self._first_get_size = self._config.max_single_get_size
         # The service only provides transactional MD5s for chunks under 4MB.
-        # If validate_content is on, get only self.MAX_CHUNK_GET_SIZE for the first
+        # If validate_content is using MD5, get only self.MAX_CHUNK_GET_SIZE for the first
         # chunk so a transactional MD5 can be retrieved.
-        self._first_get_size = self._config.max_single_get_size if not self._validate_content \
-            else self._config.max_chunk_get_size
+        if self._validate_content is True or self._validate_content == ChecksumAlgorithm.MD5:
+            self._first_get_size = self._config.max_chunk_get_size
+
         initial_request_start = self._start_range if self._start_range is not None else 0
         if self._end_range is not None and self._end_range - self._start_range < self._first_get_size:
             initial_request_end = self._end_range
@@ -312,7 +314,6 @@ class StorageStreamDownloader(object):  # pylint: disable=too-many-instance-attr
 
         # If the file is small, the download is complete at this point.
         # If file size is large, download the rest of the file in chunks.
-        # TODO: This probably needs to change
         if response.properties.size == self.size:
             self._download_complete = True
         self._etag = response.properties.etag

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/aio/_file_client_async.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/aio/_file_client_async.py
@@ -1123,13 +1123,27 @@ class ShareFileClient(AsyncStorageAccountHostsMixin, ShareFileClientBase):
         :param int length:
             Number of bytes to use for uploading a section of the file.
             The range can be up to 4 MB in size.
-        :keyword bool validate_content:
-            If true, calculates an MD5 hash of the page content. The storage
-            service checks the hash of the content that has arrived
-            with the hash that was sent. This is primarily valuable for detecting
-            bitflips on the wire if using http instead of https as https (the default)
-            will already validate. Note that this MD5 hash is not stored with the
-            file.
+        :keyword validate_content:
+            Enables checksum validation for the transfer. Any hash calculated is NOT stored with the file.
+            The possible options for content validation are as follows:
+
+            bool - Passing a boolean is now deprecated. Will perform basic checksum validation via a pipeline
+            policy that calculates an MD5 hash for each request body and sends it to the service to verify
+            it matches. This is primarily valuable for detecting bit-flips on the wire if using http instead
+            of https. If using this option, the memory-efficient upload algorithm will not be used.
+
+            "auto" - Allows the SDK to choose the best checksum algorithm to use. Currently, chooses 'crc64'.
+
+            "crc64" - This is currently the preferred choice for performance reasons and the level of validation.
+            Performs validation using Azure Storage's specific implementation of CRC64 with a custom
+            polynomial. This also uses a more sophisticated algorithm internally that may help catch
+            client-side data integrity issues.
+            NOTE: This requires the `azure-storage-extensions` package to be installed.
+
+            "md5" - Performs validation using MD5. Where available this may use a more sophisticated algorithm
+            internally that may help catch client-side data integrity issues (similar to 'crc64') but it is
+            not possible in all scenarios and may revert to the naive approach of using a pipeline policy.
+        :paramtype validate_content: Literal['auto', 'crc64', 'md5']
         :keyword file_last_write_mode:
             If the file last write time should be preserved or overwritten. Possible values
             are "preserve" or "now". If not specified, file last write time will be changed to

--- a/sdk/storage/azure-storage-file-share/tests/test_content_validation.py
+++ b/sdk/storage/azure-storage-file-share/tests/test_content_validation.py
@@ -19,9 +19,19 @@ def assert_content_md5(request):
         assert request.http_request.headers.get('Content-MD5') is not None
 
 
+def assert_content_md5_get(response):
+    assert response.http_request.headers.get('x-ms-range-get-content-md5') == 'true'
+    assert response.http_response.headers.get('Content-MD5') is not None
+
+
 def assert_structured_message(request):
     if request.http_request.query.get('comp') == 'range':
         assert request.http_request.headers.get('x-ms-structured-body') is not None
+
+
+def assert_structured_message_get(response):
+    assert response.http_request.headers.get('x-ms-structured-body') is not None
+    assert response.http_response.headers.get('x-ms-structured-body') is not None
 
 
 class TestStorageContentValidation(StorageRecordedTestCase):
@@ -140,3 +150,59 @@ class TestStorageContentValidation(StorageRecordedTestCase):
         # Assert
         content = file.download_file()
         assert content.readall() == data * len(data_list)
+
+    @FileSharePreparer()
+    @pytest.mark.parametrize('a', [True, 'md5', 'crc64'])  # a: validate_content
+    @GenericTestProxyParametrize1()
+    @recorded_by_proxy
+    def test_download_file(self, a, **kwargs):
+        storage_account_name = kwargs.pop("storage_account_name")
+        storage_account_key = kwargs.pop("storage_account_key")
+
+        self._setup(storage_account_name, storage_account_key)
+        file = self.share_client.get_file_client(self._get_file_reference())
+        data = b'abc' * 512
+        file.upload_file(data)
+        assert_method = assert_structured_message_get if a == 'crc64' else assert_content_md5_get
+
+        # Act
+        downloader = file.download_file(validate_content=a, raw_response_hook=assert_method)
+        content = downloader.readall()
+
+        stream = BytesIO()
+        downloader = file.download_file(validate_content=a, raw_response_hook=assert_method)
+        downloader.readinto(stream)
+        stream.seek(0)
+
+        # Assert
+        assert content == data
+        assert stream.read() == data
+
+    @FileSharePreparer()
+    @pytest.mark.parametrize('a', [True, 'md5', 'crc64'])  # a: validate_content
+    @GenericTestProxyParametrize1()
+    @recorded_by_proxy
+    def test_download_file_chunks(self, a, **kwargs):
+        storage_account_name = kwargs.pop("storage_account_name")
+        storage_account_key = kwargs.pop("storage_account_key")
+
+        self._setup(storage_account_name, storage_account_key)
+        self.share_client._config.max_single_get_size = 512
+        self.share_client._config.max_chunk_get_size = 512
+        file = self.share_client.get_file_client(self._get_file_reference())
+        data = b'abc' * 512 + b'abcde'
+        file.upload_file(data)
+        assert_method = assert_structured_message_get if a == 'crc64' else assert_content_md5_get
+
+        # Act
+        downloader = file.download_file(validate_content=a, raw_response_hook=assert_method)
+        content = downloader.readall()
+
+        stream = BytesIO()
+        downloader = file.download_file(validate_content=a, raw_response_hook=assert_method)
+        downloader.readinto(stream)
+        stream.seek(0)
+
+        # Assert
+        assert content == data
+        assert stream.read() == data

--- a/sdk/storage/azure-storage-file-share/tests/test_content_validation.py
+++ b/sdk/storage/azure-storage-file-share/tests/test_content_validation.py
@@ -206,3 +206,28 @@ class TestStorageContentValidation(StorageRecordedTestCase):
         # Assert
         assert content == data
         assert stream.read() == data
+
+    @FileSharePreparer()
+    @pytest.mark.parametrize('a', [True, 'md5', 'crc64'])  # a: validate_content
+    @GenericTestProxyParametrize1()
+    @recorded_by_proxy
+    def test_download_file_boundary(self, a, **kwargs):
+        storage_account_name = kwargs.pop("storage_account_name")
+        storage_account_key = kwargs.pop("storage_account_key")
+
+        data = b'abcde'
+        self._setup(storage_account_name, storage_account_key)
+        # Set up so that the initial get is almost all data but structured message
+        # metadata length is more than remaining size
+        self.share_client._config.max_single_get_size = len(data) - 2
+        file = self.share_client.get_file_client(self._get_file_reference())
+        file.upload_file(data)
+        assert_method = assert_structured_message_get if a == 'crc64' else assert_content_md5_get
+
+        # Act
+        # Download almost all the data where the structured message metadata size will be greater than remaining data
+        downloader = file.download_file(validate_content=a, raw_response_hook=assert_method)
+        content = downloader.readall()
+
+        # Assert
+        assert content == data

--- a/sdk/storage/azure-storage-file-share/tests/test_content_validation_async.py
+++ b/sdk/storage/azure-storage-file-share/tests/test_content_validation_async.py
@@ -12,7 +12,12 @@ from azure.storage.fileshare.aio import ShareClient, ShareServiceClient
 from devtools_testutils.aio import recorded_by_proxy_async
 from devtools_testutils.storage.aio import AsyncStorageRecordedTestCase, GenericTestProxyParametrize1
 from settings.testcase import FileSharePreparer
-from test_content_validation import assert_content_md5, assert_structured_message
+from test_content_validation import (
+    assert_content_md5,
+    assert_content_md5_get,
+    assert_structured_message,
+    assert_structured_message_get
+)
 
 
 class TestStorageContentValidationAsync(AsyncStorageRecordedTestCase):
@@ -134,4 +139,62 @@ class TestStorageContentValidationAsync(AsyncStorageRecordedTestCase):
         # Assert
         content = await file.download_file()
         assert await content.readall() == data * len(data_list)
+        await self._teardown()
+
+    @FileSharePreparer()
+    @pytest.mark.parametrize('a', [True, 'md5', 'crc64'])  # a: validate_content
+    @GenericTestProxyParametrize1()
+    @recorded_by_proxy_async
+    async def test_download_file(self, a, **kwargs):
+        storage_account_name = kwargs.pop("storage_account_name")
+        storage_account_key = kwargs.pop("storage_account_key")
+
+        await self._setup(storage_account_name, storage_account_key)
+        file = self.share_client.get_file_client(self._get_file_reference())
+        data = b'abc' * 512
+        await file.upload_file(data)
+        assert_method = assert_structured_message_get if a == 'crc64' else assert_content_md5_get
+
+        # Act
+        downloader = await file.download_file(validate_content=a, raw_response_hook=assert_method)
+        content = await downloader.readall()
+
+        stream = BytesIO()
+        downloader = await file.download_file(validate_content=a, raw_response_hook=assert_method)
+        await downloader.readinto(stream)
+        stream.seek(0)
+
+        # Assert
+        assert content == data
+        assert stream.read() == data
+        await self._teardown()
+
+    @FileSharePreparer()
+    @pytest.mark.parametrize('a', [True, 'md5', 'crc64'])  # a: validate_content
+    @GenericTestProxyParametrize1()
+    @recorded_by_proxy_async
+    async def test_download_file_chunks(self, a, **kwargs):
+        storage_account_name = kwargs.pop("storage_account_name")
+        storage_account_key = kwargs.pop("storage_account_key")
+
+        await self._setup(storage_account_name, storage_account_key)
+        self.share_client._config.max_single_get_size = 512
+        self.share_client._config.max_chunk_get_size = 512
+        file = self.share_client.get_file_client(self._get_file_reference())
+        data = b'abc' * 512 + b'abcde'
+        await file.upload_file(data)
+        assert_method = assert_structured_message_get if a == 'crc64' else assert_content_md5_get
+
+        # Act
+        downloader = await file.download_file(validate_content=a, raw_response_hook=assert_method)
+        content = await downloader.readall()
+
+        stream = BytesIO()
+        downloader = await file.download_file(validate_content=a, raw_response_hook=assert_method)
+        await downloader.readinto(stream)
+        stream.seek(0)
+
+        # Assert
+        assert content == data
+        assert stream.read() == data
         await self._teardown()


### PR DESCRIPTION
This changes adds support for crc64, via structured body, to file-share `download_file`. It is mostly a pattern match from Blob/Datalake.