### PR TITLE
[Storage] [STG 95] Added support to log `string_to_sign` for `SAS`

### DIFF
--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/shared_access_signature.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/shared_access_signature.py
@@ -164,7 +164,7 @@ class SharedAccessSignature(object):
         :param sts_hook:
             For debugging purposes only. If provided, the hook is called with the string to sign
             that was used to generate the SAS.
-        :type sts_hook: Optional[Callable[[str], Any]]
+        :type sts_hook: Optional[Callable[[str], None]]
         :returns: The generated SAS token for the account.
         :rtype: str
         '''

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/shared_access_signature.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/shared_access_signature.py
@@ -107,8 +107,17 @@ class SharedAccessSignature(object):
         self.account_key = account_key
         self.x_ms_version = x_ms_version
 
-    def generate_account(self, services, resource_types, permission, expiry, start=None,
-                         ip=None, protocol=None, **kwargs) -> str:
+    def generate_account(
+        self, services,
+        resource_types,
+        permission,
+        expiry,
+        start=None,
+        ip=None,
+        protocol=None,
+        sts_hook=None,
+        **kwargs
+    ) -> str:
         '''
         Generates a shared access signature for the account.
         Use the returned signature with the sas_token parameter of the service
@@ -152,6 +161,10 @@ class SharedAccessSignature(object):
         :keyword str encryption_scope:
             Optional. If specified, this is the encryption scope to use when sending requests
             authorized with this SAS URI.
+        :param sts_hook:
+            For debugging purposes only. If provided, the hook is called with the string to sign
+            that was used to generate the SAS.
+        :type sts_hook: Optional[Callable[[str], Any]]
         :returns: The generated SAS token for the account.
         :rtype: str
         '''
@@ -161,12 +174,16 @@ class SharedAccessSignature(object):
         sas.add_encryption_scope(**kwargs)
         sas.add_account_signature(self.account_name, self.account_key)
 
+        if sts_hook is not None:
+            sts_hook(sas.string_to_sign)
+
         return sas.get_token()
 
 
 class _SharedAccessHelper(object):
     def __init__(self):
         self.query_dict = {}
+        self.string_to_sign = ""
 
     def _add_query(self, name, val):
         if val:
@@ -229,6 +246,7 @@ class _SharedAccessHelper(object):
 
         self._add_query(QueryStringConstants.SIGNED_SIGNATURE,
                         sign_string(account_key, string_to_sign))
+        self.string_to_sign = string_to_sign
 
     def get_token(self) -> str:
         return '&'.join([f'{n}={url_quote(v)}' for n, v in self.query_dict.items() if v is not None])

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared_access_signature.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared_access_signature.py
@@ -5,7 +5,10 @@
 # --------------------------------------------------------------------------
 # pylint: disable=docstring-keyword-should-match-keyword-only
 
-from typing import Union, Optional, Any, TYPE_CHECKING
+from typing import (
+    Any, Callable, Optional, Union,
+    TYPE_CHECKING
+)
 from urllib.parse import parse_qs
 
 from ._shared import sign_string, url_quote
@@ -64,6 +67,7 @@ class BlobSharedAccessSignature(SharedAccessSignature):
         content_encoding: Optional[str] = None,
         content_language: Optional[str] = None,
         content_type: Optional[str] = None,
+        sts_hook: Optional[Callable[[str], Any]] = None,
         **kwargs: Any
     ) -> str:
         '''
@@ -132,6 +136,10 @@ class BlobSharedAccessSignature(SharedAccessSignature):
         :param str content_type:
             Response header value for Content-Type when resource is accessed
             using this shared access signature.
+        :param sts_hook:
+            For debugging purposes only. If provided, the hook is called with the string to sign
+            that was used to generate the SAS.
+        :type sts_hook: Optional[Callable[[str], Any]]
         :return: A Shared Access Signature (sas) token.
         :rtype: str
         '''
@@ -155,6 +163,9 @@ class BlobSharedAccessSignature(SharedAccessSignature):
         sas.add_resource_signature(self.account_name, self.account_key, resource_path,
                                    user_delegation_key=self.user_delegation_key)
 
+        if sts_hook is not None:
+            sts_hook(sas.string_to_sign)
+
         return sas.get_token()
 
     def generate_container(
@@ -170,6 +181,7 @@ class BlobSharedAccessSignature(SharedAccessSignature):
         content_encoding: Optional[str] = None,
         content_language: Optional[str] = None,
         content_type: Optional[str] = None,
+        sts_hook: Optional[Callable[[str], Any]] = None,
         **kwargs: Any
     ) -> str:
         '''
@@ -228,6 +240,10 @@ class BlobSharedAccessSignature(SharedAccessSignature):
         :param str content_type:
             Response header value for Content-Type when resource is accessed
             using this shared access signature.
+        :param sts_hook:
+            For debugging purposes only. If provided, the hook is called with the string to sign
+            that was used to generate the SAS.
+        :type sts_hook: Optional[Callable[[str], Any]]
         :return: A Shared Access Signature (sas) token.
         :rtype: str
         '''
@@ -242,6 +258,10 @@ class BlobSharedAccessSignature(SharedAccessSignature):
         sas.add_info_for_hns_account(**kwargs)
         sas.add_resource_signature(self.account_name, self.account_key, container_name,
                                    user_delegation_key=self.user_delegation_key)
+
+        if sts_hook is not None:
+            sts_hook(sas.string_to_sign)
+
         return sas.get_token()
 
 
@@ -316,6 +336,7 @@ class _BlobSharedAccessHelper(_SharedAccessHelper):
         self._add_query(QueryStringConstants.SIGNED_SIGNATURE,
                         sign_string(account_key if user_delegation_key is None else user_delegation_key.value,
                                     string_to_sign))
+        self.string_to_sign = string_to_sign
 
     def get_token(self) -> str:
         # a conscious decision was made to exclude the timestamp in the generated token
@@ -335,6 +356,7 @@ def generate_account_sas(
     ip: Optional[str] = None,
     *,
     services: Union[Services, str] = Services(blob=True),
+    sts_hook: Optional[Callable[[str], Any]] = None,
     **kwargs: Any
 ) -> str:
     """Generates a shared access signature for the blob service.
@@ -376,6 +398,10 @@ def generate_account_sas(
         Specifies the protocol permitted for a request made. The default value is https.
     :keyword str encryption_scope:
         Specifies the encryption scope for a request made so that all write operations will be service encrypted.
+    :keyword sts_hook:
+        For debugging purposes only. If provided, the hook is called with the string to sign
+        that was used to generate the SAS.
+    :paramtype sts_hook: Optional[Callable[[str], Any]]
     :return: A Shared Access Signature (sas) token.
     :rtype: str
 
@@ -396,6 +422,7 @@ def generate_account_sas(
         expiry=expiry,
         start=start,
         ip=ip,
+        sts_hook=sts_hook,
         **kwargs
     )
 
@@ -410,6 +437,8 @@ def generate_container_sas(
     start: Optional[Union["datetime", str]] = None,
     policy_id: Optional[str] = None,
     ip: Optional[str] = None,
+    *,
+    sts_hook: Optional[Callable[[str], Any]] = None,
     **kwargs: Any
 ) -> str:
     """Generates a shared access signature for a container.
@@ -483,6 +512,10 @@ def generate_container_sas(
     :keyword str correlation_id:
         The correlation id to correlate the storage audit logs with the audit logs used by the principal
         generating and distributing the SAS. This can only be used when generating a SAS with delegation key.
+    :keyword sts_hook:
+        For debugging purposes only. If provided, the hook is called with the string to sign
+        that was used to generate the SAS.
+    :paramtype sts_hook: Optional[Callable[[str], Any]]
     :return: A Shared Access Signature (sas) token.
     :rtype: str
 
@@ -515,6 +548,7 @@ def generate_container_sas(
         start=start,
         policy_id=policy_id,
         ip=ip,
+        sts_hook=sts_hook,
         **kwargs
     )
 
@@ -531,6 +565,8 @@ def generate_blob_sas(
     start: Optional[Union["datetime", str]] = None,
     policy_id: Optional[str] = None,
     ip: Optional[str] = None,
+    *,
+    sts_hook: Optional[Callable[[str], Any]] = None,
     **kwargs: Any
 ) -> str:
     """Generates a shared access signature for a blob.
@@ -616,6 +652,10 @@ def generate_blob_sas(
     :keyword str correlation_id:
         The correlation id to correlate the storage audit logs with the audit logs used by the principal
         generating and distributing the SAS. This can only be used when generating a SAS with delegation key.
+    :keyword sts_hook:
+        For debugging purposes only. If provided, the hook is called with the string to sign
+        that was used to generate the SAS.
+    :paramtype sts_hook: Optional[Callable[[str], Any]]
     :return: A Shared Access Signature (sas) token.
     :rtype: str
     """
@@ -645,6 +685,7 @@ def generate_blob_sas(
         start=start,
         policy_id=policy_id,
         ip=ip,
+        sts_hook=sts_hook,
         **kwargs
     )
 

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared_access_signature.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared_access_signature.py
@@ -67,7 +67,7 @@ class BlobSharedAccessSignature(SharedAccessSignature):
         content_encoding: Optional[str] = None,
         content_language: Optional[str] = None,
         content_type: Optional[str] = None,
-        sts_hook: Optional[Callable[[str], Any]] = None,
+        sts_hook: Optional[Callable[[str], None]] = None,
         **kwargs: Any
     ) -> str:
         '''
@@ -139,7 +139,7 @@ class BlobSharedAccessSignature(SharedAccessSignature):
         :param sts_hook:
             For debugging purposes only. If provided, the hook is called with the string to sign
             that was used to generate the SAS.
-        :type sts_hook: Optional[Callable[[str], Any]]
+        :type sts_hook: Optional[Callable[[str], None]]
         :return: A Shared Access Signature (sas) token.
         :rtype: str
         '''
@@ -181,7 +181,7 @@ class BlobSharedAccessSignature(SharedAccessSignature):
         content_encoding: Optional[str] = None,
         content_language: Optional[str] = None,
         content_type: Optional[str] = None,
-        sts_hook: Optional[Callable[[str], Any]] = None,
+        sts_hook: Optional[Callable[[str], None]] = None,
         **kwargs: Any
     ) -> str:
         '''
@@ -243,7 +243,7 @@ class BlobSharedAccessSignature(SharedAccessSignature):
         :param sts_hook:
             For debugging purposes only. If provided, the hook is called with the string to sign
             that was used to generate the SAS.
-        :type sts_hook: Optional[Callable[[str], Any]]
+        :type sts_hook: Optional[Callable[[str], None]]
         :return: A Shared Access Signature (sas) token.
         :rtype: str
         '''
@@ -356,7 +356,7 @@ def generate_account_sas(
     ip: Optional[str] = None,
     *,
     services: Union[Services, str] = Services(blob=True),
-    sts_hook: Optional[Callable[[str], Any]] = None,
+    sts_hook: Optional[Callable[[str], None]] = None,
     **kwargs: Any
 ) -> str:
     """Generates a shared access signature for the blob service.
@@ -401,7 +401,7 @@ def generate_account_sas(
     :keyword sts_hook:
         For debugging purposes only. If provided, the hook is called with the string to sign
         that was used to generate the SAS.
-    :paramtype sts_hook: Optional[Callable[[str], Any]]
+    :paramtype sts_hook: Optional[Callable[[str], None]]
     :return: A Shared Access Signature (sas) token.
     :rtype: str
 
@@ -438,7 +438,7 @@ def generate_container_sas(
     policy_id: Optional[str] = None,
     ip: Optional[str] = None,
     *,
-    sts_hook: Optional[Callable[[str], Any]] = None,
+    sts_hook: Optional[Callable[[str], None]] = None,
     **kwargs: Any
 ) -> str:
     """Generates a shared access signature for a container.
@@ -515,7 +515,7 @@ def generate_container_sas(
     :keyword sts_hook:
         For debugging purposes only. If provided, the hook is called with the string to sign
         that was used to generate the SAS.
-    :paramtype sts_hook: Optional[Callable[[str], Any]]
+    :paramtype sts_hook: Optional[Callable[[str], None]]
     :return: A Shared Access Signature (sas) token.
     :rtype: str
 
@@ -566,7 +566,7 @@ def generate_blob_sas(
     policy_id: Optional[str] = None,
     ip: Optional[str] = None,
     *,
-    sts_hook: Optional[Callable[[str], Any]] = None,
+    sts_hook: Optional[Callable[[str], None]] = None,
     **kwargs: Any
 ) -> str:
     """Generates a shared access signature for a blob.
@@ -655,7 +655,7 @@ def generate_blob_sas(
     :keyword sts_hook:
         For debugging purposes only. If provided, the hook is called with the string to sign
         that was used to generate the SAS.
-    :paramtype sts_hook: Optional[Callable[[str], Any]]
+    :paramtype sts_hook: Optional[Callable[[str], None]]
     :return: A Shared Access Signature (sas) token.
     :rtype: str
     """

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/shared_access_signature.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/shared_access_signature.py
@@ -164,7 +164,7 @@ class SharedAccessSignature(object):
         :param sts_hook:
             For debugging purposes only. If provided, the hook is called with the string to sign
             that was used to generate the SAS.
-        :type sts_hook: Optional[Callable[[str], Any]]
+        :type sts_hook: Optional[Callable[[str], None]]
         :returns: The generated SAS token for the account.
         :rtype: str
         '''

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/shared_access_signature.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/shared_access_signature.py
@@ -107,8 +107,17 @@ class SharedAccessSignature(object):
         self.account_key = account_key
         self.x_ms_version = x_ms_version
 
-    def generate_account(self, services, resource_types, permission, expiry, start=None,
-                         ip=None, protocol=None, **kwargs) -> str:
+    def generate_account(
+        self, services,
+        resource_types,
+        permission,
+        expiry,
+        start=None,
+        ip=None,
+        protocol=None,
+        sts_hook=None,
+        **kwargs
+    ) -> str:
         '''
         Generates a shared access signature for the account.
         Use the returned signature with the sas_token parameter of the service
@@ -152,6 +161,10 @@ class SharedAccessSignature(object):
         :keyword str encryption_scope:
             Optional. If specified, this is the encryption scope to use when sending requests
             authorized with this SAS URI.
+        :param sts_hook:
+            For debugging purposes only. If provided, the hook is called with the string to sign
+            that was used to generate the SAS.
+        :type sts_hook: Optional[Callable[[str], Any]]
         :returns: The generated SAS token for the account.
         :rtype: str
         '''
@@ -161,12 +174,16 @@ class SharedAccessSignature(object):
         sas.add_encryption_scope(**kwargs)
         sas.add_account_signature(self.account_name, self.account_key)
 
+        if sts_hook is not None:
+            sts_hook(sas.string_to_sign)
+
         return sas.get_token()
 
 
 class _SharedAccessHelper(object):
     def __init__(self):
         self.query_dict = {}
+        self.string_to_sign = ""
 
     def _add_query(self, name, val):
         if val:
@@ -229,6 +246,7 @@ class _SharedAccessHelper(object):
 
         self._add_query(QueryStringConstants.SIGNED_SIGNATURE,
                         sign_string(account_key, string_to_sign))
+        self.string_to_sign = string_to_sign
 
     def get_token(self) -> str:
         return '&'.join([f'{n}={url_quote(v)}' for n, v in self.query_dict.items() if v is not None])

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared_access_signature.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared_access_signature.py
@@ -37,7 +37,7 @@ def generate_account_sas(
     expiry: Union["datetime", str],
     *,
     services: Union[Services, str] = Services(blob=True),
-    sts_hook: Optional[Callable[[str], Any]] = None,
+    sts_hook: Optional[Callable[[str], None]] = None,
     **kwargs: Any
 ) -> str:
     """Generates a shared access signature for the DataLake service.
@@ -82,7 +82,7 @@ def generate_account_sas(
     :keyword sts_hook:
         For debugging purposes only. If provided, the hook is called with the string to sign
         that was used to generate the SAS.
-    :paramtype sts_hook: Optional[Callable[[str], Any]]
+    :paramtype sts_hook: Optional[Callable[[str], None]]
     :return: A Shared Access Signature (sas) token.
     :rtype: str
     """
@@ -105,7 +105,7 @@ def generate_file_system_sas(
     permission=None,  # type: Optional[Union[FileSystemSasPermissions, str]]
     expiry=None,  # type: Optional[Union[datetime, str]]
     *,
-    sts_hook=None,  # type: Optional[Callable[[str], Any]]
+    sts_hook=None,  # type: Optional[Callable[[str], None]]
     **kwargs  # type: Any
 ):
     # type: (...) -> str
@@ -194,7 +194,7 @@ def generate_file_system_sas(
     :keyword sts_hook:
         For debugging purposes only. If provided, the hook is called with the string to sign
         that was used to generate the SAS.
-    :paramtype sts_hook: Optional[Callable[[str], Any]]
+    :paramtype sts_hook: Optional[Callable[[str], None]]
     :return: A Shared Access Signature (sas) token.
     :rtype: str
     """
@@ -218,7 +218,7 @@ def generate_directory_sas(
     permission=None,  # type: Optional[Union[DirectorySasPermissions, str]]
     expiry=None,  # type: Optional[Union[datetime, str]]
     *,
-    sts_hook=None,  # type: Optional[Callable[[str], Any]]
+    sts_hook=None,  # type: Optional[Callable[[str], None]]
     **kwargs  # type: Any
 ):
     # type: (...) -> str
@@ -309,7 +309,7 @@ def generate_directory_sas(
     :keyword sts_hook:
         For debugging purposes only. If provided, the hook is called with the string to sign
         that was used to generate the SAS.
-    :paramtype sts_hook: Optional[Callable[[str], Any]]
+    :paramtype sts_hook: Optional[Callable[[str], None]]
     :return: A Shared Access Signature (sas) token.
     :rtype: str
     """
@@ -338,7 +338,7 @@ def generate_file_sas(
     permission=None,  # type: Optional[Union[FileSasPermissions, str]]
     expiry=None,  # type: Optional[Union[datetime, str]]
     *,
-    sts_hook=None,  # type: Optional[Callable[[str], Any]]
+    sts_hook=None,  # type: Optional[Callable[[str], None]]
     **kwargs  # type: Any
 ):
     # type: (...) -> str
@@ -431,7 +431,8 @@ def generate_file_sas(
     :keyword sts_hook:
         For debugging purposes only. If provided, the hook is called with the string to sign
         that was used to generate the SAS.
-    :paramtype sts_hook: Optional[Callable[[str], Any]]
+    :paramtype sts_hook: Optional[Callable[[str], None
+    ]]
     :return: A Shared Access Signature (sas) token.
     :rtype: str
     """

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared_access_signature.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared_access_signature.py
@@ -431,8 +431,7 @@ def generate_file_sas(
     :keyword sts_hook:
         For debugging purposes only. If provided, the hook is called with the string to sign
         that was used to generate the SAS.
-    :paramtype sts_hook: Optional[Callable[[str], None
-    ]]
+    :paramtype sts_hook: Optional[Callable[[str], None]]
     :return: A Shared Access Signature (sas) token.
     :rtype: str
     """

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared_access_signature.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared_access_signature.py
@@ -6,7 +6,8 @@
 # pylint: disable=docstring-keyword-should-match-keyword-only
 
 from typing import (  # pylint: disable=unused-import
-    Union, Optional, Any, TYPE_CHECKING
+    Any, Callable, Optional, Union,
+    TYPE_CHECKING
 )
 from urllib.parse import parse_qs
 
@@ -36,6 +37,7 @@ def generate_account_sas(
     expiry: Union["datetime", str],
     *,
     services: Union[Services, str] = Services(blob=True),
+    sts_hook: Optional[Callable[[str], Any]] = None,
     **kwargs: Any
 ) -> str:
     """Generates a shared access signature for the DataLake service.
@@ -77,6 +79,10 @@ def generate_account_sas(
         Specifies the protocol permitted for a request made. The default value is https.
     :keyword str encryption_scope:
         Specifies the encryption scope for a request made so that all write operations will be service encrypted.
+    :keyword sts_hook:
+        For debugging purposes only. If provided, the hook is called with the string to sign
+        that was used to generate the SAS.
+    :paramtype sts_hook: Optional[Callable[[str], Any]]
     :return: A Shared Access Signature (sas) token.
     :rtype: str
     """
@@ -87,18 +93,21 @@ def generate_account_sas(
         permission=permission,
         expiry=expiry,
         services=services,
+        sts_hook=sts_hook,
         **kwargs
     )
 
 
 def generate_file_system_sas(
-        account_name,  # type: str
-        file_system_name,  # type: str
-        credential,  # type: Union[str, UserDelegationKey]
-        permission=None,  # type: Optional[Union[FileSystemSasPermissions, str]]
-        expiry=None,  # type: Optional[Union[datetime, str]]
-        **kwargs # type: Any
-    ):
+    account_name,  # type: str
+    file_system_name,  # type: str
+    credential,  # type: Union[str, UserDelegationKey]
+    permission=None,  # type: Optional[Union[FileSystemSasPermissions, str]]
+    expiry=None,  # type: Optional[Union[datetime, str]]
+    *,
+    sts_hook=None,  # type: Optional[Callable[[str], Any]]
+    **kwargs  # type: Any
+):
     # type: (...) -> str
     """Generates a shared access signature for a file system.
 
@@ -182,6 +191,10 @@ def generate_file_system_sas(
         generating and distributing the SAS.
     :keyword str encryption_scope:
         Specifies the encryption scope for a request made so that all write operations will be service encrypted.
+    :keyword sts_hook:
+        For debugging purposes only. If provided, the hook is called with the string to sign
+        that was used to generate the SAS.
+    :paramtype sts_hook: Optional[Callable[[str], Any]]
     :return: A Shared Access Signature (sas) token.
     :rtype: str
     """
@@ -192,18 +205,22 @@ def generate_file_system_sas(
         user_delegation_key=credential if not isinstance(credential, str) else None,
         permission=permission,
         expiry=expiry,
-        **kwargs)
+        sts_hook=sts_hook,
+        **kwargs
+    )
 
 
 def generate_directory_sas(
-        account_name,  # type: str
-        file_system_name,  # type: str
-        directory_name,  # type: str
-        credential,  # type: Union[str, UserDelegationKey]
-        permission=None,  # type: Optional[Union[DirectorySasPermissions, str]]
-        expiry=None,  # type: Optional[Union[datetime, str]]
-        **kwargs # type: Any
-    ):
+    account_name,  # type: str
+    file_system_name,  # type: str
+    directory_name,  # type: str
+    credential,  # type: Union[str, UserDelegationKey]
+    permission=None,  # type: Optional[Union[DirectorySasPermissions, str]]
+    expiry=None,  # type: Optional[Union[datetime, str]]
+    *,
+    sts_hook=None,  # type: Optional[Callable[[str], Any]]
+    **kwargs  # type: Any
+):
     # type: (...) -> str
     """Generates a shared access signature for a directory.
 
@@ -289,6 +306,10 @@ def generate_directory_sas(
         generating and distributing the SAS.
     :keyword str encryption_scope:
         Specifies the encryption scope for a request made so that all write operations will be service encrypted.
+    :keyword sts_hook:
+        For debugging purposes only. If provided, the hook is called with the string to sign
+        that was used to generate the SAS.
+    :paramtype sts_hook: Optional[Callable[[str], Any]]
     :return: A Shared Access Signature (sas) token.
     :rtype: str
     """
@@ -303,19 +324,23 @@ def generate_directory_sas(
         expiry=expiry,
         sdd=depth,
         is_directory=True,
-        **kwargs)
+        sts_hook=sts_hook,
+        **kwargs
+    )
 
 
 def generate_file_sas(
-        account_name,  # type: str
-        file_system_name,  # type: str
-        directory_name,  # type: str
-        file_name,  # type: str
-        credential,  # type: Union[str, UserDelegationKey]
-        permission=None,  # type: Optional[Union[FileSasPermissions, str]]
-        expiry=None,  # type: Optional[Union[datetime, str]]
-        **kwargs  # type: Any
-    ):
+    account_name,  # type: str
+    file_system_name,  # type: str
+    directory_name,  # type: str
+    file_name,  # type: str
+    credential,  # type: Union[str, UserDelegationKey]
+    permission=None,  # type: Optional[Union[FileSasPermissions, str]]
+    expiry=None,  # type: Optional[Union[datetime, str]]
+    *,
+    sts_hook=None,  # type: Optional[Callable[[str], Any]]
+    **kwargs  # type: Any
+):
     # type: (...) -> str
     """Generates a shared access signature for a file.
 
@@ -403,6 +428,10 @@ def generate_file_sas(
         generating and distributing the SAS. This can only be used when generating a SAS with delegation key.
     :keyword str encryption_scope:
         Specifies the encryption scope for a request made so that all write operations will be service encrypted.
+    :keyword sts_hook:
+        For debugging purposes only. If provided, the hook is called with the string to sign
+        that was used to generate the SAS.
+    :paramtype sts_hook: Optional[Callable[[str], Any]]
     :return: A Shared Access Signature (sas) token.
     :rtype: str
     """
@@ -418,7 +447,9 @@ def generate_file_sas(
         user_delegation_key=credential if not isinstance(credential, str) else None,
         permission=permission,
         expiry=expiry,
-        **kwargs)
+        sts_hook=sts_hook,
+        **kwargs
+    )
 
 def _is_credential_sastoken(credential: Any) -> bool:
     if not credential or not isinstance(credential, str):

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/shared_access_signature.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/shared_access_signature.py
@@ -106,8 +106,16 @@ class SharedAccessSignature(object):
         self.account_key = account_key
         self.x_ms_version = x_ms_version
 
-    def generate_account(self, services, resource_types, permission, expiry, start=None,
-                         ip=None, protocol=None) -> str:
+    def generate_account(
+        self, services,
+        resource_types,
+        permission,
+        expiry,
+        start=None,
+        ip=None,
+        protocol=None,
+        sts_hook=None
+    ) -> str:
         '''
         Generates a shared access signature for the account.
         Use the returned signature with the sas_token parameter of the service
@@ -148,6 +156,10 @@ class SharedAccessSignature(object):
         :param str protocol:
             Specifies the protocol permitted for a request made. The default value
             is https,http. See :class:`~azure.storage.common.models.Protocol` for possible values.
+        :param sts_hook:
+            For debugging purposes only. If provided, the hook is called with the string to sign
+            that was used to generate the SAS.
+        :type sts_hook: Optional[Callable[[str], Any]]
         :returns: The generated SAS token for the account.
         :rtype: str
         '''
@@ -156,12 +168,16 @@ class SharedAccessSignature(object):
         sas.add_account(services, resource_types)
         sas.add_account_signature(self.account_name, self.account_key)
 
+        if sts_hook is not None:
+            sts_hook(sas.string_to_sign)
+
         return sas.get_token()
 
 
 class _SharedAccessHelper(object):
     def __init__(self):
         self.query_dict = {}
+        self.string_to_sign = ""
 
     def _add_query(self, name, val):
         if val:
@@ -207,7 +223,7 @@ class _SharedAccessHelper(object):
             return_value = self.query_dict.get(query) or ''
             return return_value + '\n'
 
-        string_to_sign = \
+        self.string_to_sign = \
             (account_name + '\n' +
              get_value_to_append(QueryStringConstants.SIGNED_PERMISSION) +
              get_value_to_append(QueryStringConstants.SIGNED_SERVICES) +
@@ -221,7 +237,7 @@ class _SharedAccessHelper(object):
              )
 
         self._add_query(QueryStringConstants.SIGNED_SIGNATURE,
-                        sign_string(account_key, string_to_sign))
+                        sign_string(account_key, self.string_to_sign))
 
     def get_token(self) -> str:
         return '&'.join([f'{n}={url_quote(v)}' for n, v in self.query_dict.items() if v is not None])

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/shared_access_signature.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/shared_access_signature.py
@@ -159,7 +159,7 @@ class SharedAccessSignature(object):
         :param sts_hook:
             For debugging purposes only. If provided, the hook is called with the string to sign
             that was used to generate the SAS.
-        :type sts_hook: Optional[Callable[[str], Any]]
+        :type sts_hook: Optional[Callable[[str], None]]
         :returns: The generated SAS token for the account.
         :rtype: str
         '''

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared_access_signature.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared_access_signature.py
@@ -6,7 +6,8 @@
 # pylint: disable=docstring-keyword-should-match-keyword-only
 
 from typing import (  # pylint: disable=unused-import
-    Union, Optional, Any, List, TYPE_CHECKING
+    Any, Callable, List, Optional, Union,
+    TYPE_CHECKING
 )
 from urllib.parse import parse_qs
 
@@ -42,11 +43,23 @@ class FileSharedAccessSignature(SharedAccessSignature):
         '''
         super(FileSharedAccessSignature, self).__init__(account_name, account_key, x_ms_version=X_MS_VERSION)
 
-    def generate_file(self, share_name, directory_name=None, file_name=None,
-                      permission=None, expiry=None, start=None, policy_id=None,
-                      ip=None, protocol=None, cache_control=None,
-                      content_disposition=None, content_encoding=None,
-                      content_language=None, content_type=None):
+    def generate_file(
+        self, share_name,
+        directory_name=None,
+        file_name=None,
+        permission=None,
+        expiry=None,
+        start=None,
+        policy_id=None,
+        ip=None,
+        protocol=None,
+        cache_control=None,
+        content_disposition=None,
+        content_encoding=None,
+        content_language=None,
+        content_type=None,
+        sts_hook=None
+    ):
         '''
         Generates a shared access signature for the file.
         Use the returned signature with the sas_token parameter of FileService.
@@ -108,6 +121,10 @@ class FileSharedAccessSignature(SharedAccessSignature):
         :param str content_type:
             Response header value for Content-Type when resource is accessed
             using this shared access signature.
+        :param sts_hook:
+            For debugging purposes only. If provided, the hook is called with the string to sign
+            that was used to generate the SAS.
+        :type sts_hook: Optional[Callable[[str], Any]]
         :returns: The generated SAS token for the account.
         :rtype: str
         '''
@@ -125,13 +142,26 @@ class FileSharedAccessSignature(SharedAccessSignature):
                                           content_type)
         sas.add_resource_signature(self.account_name, self.account_key, resource_path)
 
+        if sts_hook is not None:
+            sts_hook(sas.string_to_sign)
+
         return sas.get_token()
 
-    def generate_share(self, share_name, permission=None, expiry=None,
-                       start=None, policy_id=None, ip=None, protocol=None,
-                       cache_control=None, content_disposition=None,
-                       content_encoding=None, content_language=None,
-                       content_type=None):
+    def generate_share(
+        self, share_name,
+        permission=None,
+        expiry=None,
+        start=None,
+        policy_id=None,
+        ip=None,
+        protocol=None,
+        cache_control=None,
+        content_disposition=None,
+        content_encoding=None,
+        content_language=None,
+        content_type=None,
+        sts_hook=None
+    ):
         '''
         Generates a shared access signature for the share.
         Use the returned signature with the sas_token parameter of FileService.
@@ -188,6 +218,10 @@ class FileSharedAccessSignature(SharedAccessSignature):
         :param str content_type:
             Response header value for Content-Type when resource is accessed
             using this shared access signature.
+        :param sts_hook:
+            For debugging purposes only. If provided, the hook is called with the string to sign
+            that was used to generate the SAS.
+        :type sts_hook: Optional[Callable[[str], Any]]
         :returns: The generated SAS token for the account.
         :rtype: str
         '''
@@ -199,6 +233,9 @@ class FileSharedAccessSignature(SharedAccessSignature):
                                           content_encoding, content_language,
                                           content_type)
         sas.add_resource_signature(self.account_name, self.account_key, share_name)
+
+        if sts_hook is not None:
+            sts_hook(sas.string_to_sign)
 
         return sas.get_token()
 
@@ -238,6 +275,7 @@ class _FileSharedAccessHelper(_SharedAccessHelper):
 
         self._add_query(QueryStringConstants.SIGNED_SIGNATURE,
                         sign_string(account_key, string_to_sign))
+        self.string_to_sign = string_to_sign
 
 
 def generate_account_sas(
@@ -250,6 +288,7 @@ def generate_account_sas(
     ip: Optional[str] = None,
     *,
     services: Union[Services, str] = Services(fileshare=True),
+    sts_hook: Optional[Callable[[str], Any]] = None,
     **kwargs: Any
 ) -> str:
     """Generates a shared access signature for the file service.
@@ -287,6 +326,10 @@ def generate_account_sas(
         Will default to only this package (i.e. fileshare) if not provided.
     :keyword str protocol:
         Specifies the protocol permitted for a request made. The default value is https.
+    :keyword sts_hook:
+        For debugging purposes only. If provided, the hook is called with the string to sign
+        that was used to generate the SAS.
+    :paramtype sts_hook: Optional[Callable[[str], Any]]
     :return: A Shared Access Signature (sas) token.
     :rtype: str
 
@@ -307,6 +350,7 @@ def generate_account_sas(
         expiry=expiry,
         start=start,
         ip=ip,
+        sts_hook=sts_hook,
         **kwargs
     ) # type: ignore
 
@@ -320,6 +364,8 @@ def generate_share_sas(
     start=None,  # type: Optional[Union[datetime, str]]
     policy_id=None,  # type: Optional[str]
     ip=None,  # type: Optional[str]
+    *,
+    sts_hook=None,  # Optional[Callable[[str], Any]]
     **kwargs # type: Any
 ):  # type: (...) -> str
     """Generates a shared access signature for a share.
@@ -382,6 +428,10 @@ def generate_share_sas(
         using this shared access signature.
     :keyword str protocol:
         Specifies the protocol permitted for a request made. The default value is https.
+    :keyword sts_hook:
+        For debugging purposes only. If provided, the hook is called with the string to sign
+        that was used to generate the SAS.
+    :paramtype sts_hook: Optional[Callable[[str], Any]]
     :return: A Shared Access Signature (sas) token.
     :rtype: str
     """
@@ -398,6 +448,7 @@ def generate_share_sas(
         start=start,
         policy_id=policy_id,
         ip=ip,
+        sts_hook=sts_hook,
         **kwargs
     )
 
@@ -412,6 +463,8 @@ def generate_file_sas(
     start=None,  # type: Optional[Union[datetime, str]]
     policy_id=None,  # type: Optional[str]
     ip=None,  # type: Optional[str]
+    *,
+    sts_hook=None,  # type: Optional[Callable[[str], Any]]
     **kwargs # type: Any
 ):
     # type: (...) -> str
@@ -477,6 +530,10 @@ def generate_file_sas(
         using this shared access signature.
     :keyword str protocol:
         Specifies the protocol permitted for a request made. The default value is https.
+    :keyword sts_hook:
+        For debugging purposes only. If provided, the hook is called with the string to sign
+        that was used to generate the SAS.
+    :paramtype sts_hook: Optional[Callable[[str], Any]]
     :return: A Shared Access Signature (sas) token.
     :rtype: str
     """
@@ -499,6 +556,7 @@ def generate_file_sas(
         start=start,
         policy_id=policy_id,
         ip=ip,
+        sts_hook=sts_hook,
         **kwargs
     )
 

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared_access_signature.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared_access_signature.py
@@ -124,7 +124,7 @@ class FileSharedAccessSignature(SharedAccessSignature):
         :param sts_hook:
             For debugging purposes only. If provided, the hook is called with the string to sign
             that was used to generate the SAS.
-        :type sts_hook: Optional[Callable[[str], Any]]
+        :type sts_hook: Optional[Callable[[str], None]]
         :returns: The generated SAS token for the account.
         :rtype: str
         '''
@@ -221,7 +221,7 @@ class FileSharedAccessSignature(SharedAccessSignature):
         :param sts_hook:
             For debugging purposes only. If provided, the hook is called with the string to sign
             that was used to generate the SAS.
-        :type sts_hook: Optional[Callable[[str], Any]]
+        :type sts_hook: Optional[Callable[[str], None]]
         :returns: The generated SAS token for the account.
         :rtype: str
         '''
@@ -288,7 +288,7 @@ def generate_account_sas(
     ip: Optional[str] = None,
     *,
     services: Union[Services, str] = Services(fileshare=True),
-    sts_hook: Optional[Callable[[str], Any]] = None,
+    sts_hook: Optional[Callable[[str], None]] = None,
     **kwargs: Any
 ) -> str:
     """Generates a shared access signature for the file service.
@@ -329,7 +329,7 @@ def generate_account_sas(
     :keyword sts_hook:
         For debugging purposes only. If provided, the hook is called with the string to sign
         that was used to generate the SAS.
-    :paramtype sts_hook: Optional[Callable[[str], Any]]
+    :paramtype sts_hook: Optional[Callable[[str], None]]
     :return: A Shared Access Signature (sas) token.
     :rtype: str
 
@@ -365,7 +365,7 @@ def generate_share_sas(
     policy_id=None,  # type: Optional[str]
     ip=None,  # type: Optional[str]
     *,
-    sts_hook=None,  # Optional[Callable[[str], Any]]
+    sts_hook=None,  # Optional[Callable[[str], None]]
     **kwargs # type: Any
 ):  # type: (...) -> str
     """Generates a shared access signature for a share.
@@ -431,7 +431,7 @@ def generate_share_sas(
     :keyword sts_hook:
         For debugging purposes only. If provided, the hook is called with the string to sign
         that was used to generate the SAS.
-    :paramtype sts_hook: Optional[Callable[[str], Any]]
+    :paramtype sts_hook: Optional[Callable[[str], None]]
     :return: A Shared Access Signature (sas) token.
     :rtype: str
     """
@@ -464,7 +464,7 @@ def generate_file_sas(
     policy_id=None,  # type: Optional[str]
     ip=None,  # type: Optional[str]
     *,
-    sts_hook=None,  # type: Optional[Callable[[str], Any]]
+    sts_hook=None,  # type: Optional[Callable[[str], None]]
     **kwargs # type: Any
 ):
     # type: (...) -> str
@@ -533,7 +533,7 @@ def generate_file_sas(
     :keyword sts_hook:
         For debugging purposes only. If provided, the hook is called with the string to sign
         that was used to generate the SAS.
-    :paramtype sts_hook: Optional[Callable[[str], Any]]
+    :paramtype sts_hook: Optional[Callable[[str], None]]
     :return: A Shared Access Signature (sas) token.
     :rtype: str
     """

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/shared_access_signature.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/shared_access_signature.py
@@ -106,8 +106,16 @@ class SharedAccessSignature(object):
         self.account_key = account_key
         self.x_ms_version = x_ms_version
 
-    def generate_account(self, services, resource_types, permission, expiry, start=None,
-                         ip=None, protocol=None) -> str:
+    def generate_account(
+        self, services,
+        resource_types,
+        permission,
+        expiry,
+        start=None,
+        ip=None,
+        protocol=None,
+        sts_hook=None,
+    ) -> str:
         '''
         Generates a shared access signature for the account.
         Use the returned signature with the sas_token parameter of the service
@@ -148,6 +156,10 @@ class SharedAccessSignature(object):
         :param str protocol:
             Specifies the protocol permitted for a request made. The default value
             is https,http. See :class:`~azure.storage.common.models.Protocol` for possible values.
+        :param sts_hook:
+            For debugging purposes only. If provided, the hook is called with the string to sign
+            that was used to generate the SAS.
+        :type sts_hook: Optional[Callable[[str], Any]]
         :returns: The generated SAS token for the account.
         :rtype: str
         '''
@@ -156,12 +168,16 @@ class SharedAccessSignature(object):
         sas.add_account(services, resource_types)
         sas.add_account_signature(self.account_name, self.account_key)
 
+        if sts_hook is not None:
+            sts_hook(sas.string_to_sign)
+
         return sas.get_token()
 
 
 class _SharedAccessHelper(object):
     def __init__(self):
         self.query_dict = {}
+        self.string_to_sign = ""
 
     def _add_query(self, name, val):
         if val:
@@ -222,6 +238,7 @@ class _SharedAccessHelper(object):
 
         self._add_query(QueryStringConstants.SIGNED_SIGNATURE,
                         sign_string(account_key, string_to_sign))
+        self.string_to_sign = string_to_sign
 
     def get_token(self) -> str:
         return '&'.join([f'{n}={url_quote(v)}' for n, v in self.query_dict.items() if v is not None])

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/shared_access_signature.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/shared_access_signature.py
@@ -159,7 +159,7 @@ class SharedAccessSignature(object):
         :param sts_hook:
             For debugging purposes only. If provided, the hook is called with the string to sign
             that was used to generate the SAS.
-        :type sts_hook: Optional[Callable[[str], Any]]
+        :type sts_hook: Optional[Callable[[str], None]]
         :returns: The generated SAS token for the account.
         :rtype: str
         '''

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_shared_access_signature.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_shared_access_signature.py
@@ -5,7 +5,10 @@
 # --------------------------------------------------------------------------
 # pylint: disable=docstring-keyword-should-match-keyword-only
 
-from typing import Any, Optional, TYPE_CHECKING, Union
+from typing import (
+    Any, Callable, Optional, Union,
+    TYPE_CHECKING
+)
 from urllib.parse import parse_qs
 
 from azure.storage.queue._shared import sign_string
@@ -49,7 +52,8 @@ class QueueSharedAccessSignature(SharedAccessSignature):
         start: Optional[Union["datetime", str]] = None,
         policy_id: Optional[str] = None,
         ip: Optional[str] = None,
-        protocol: Optional[str] = None
+        protocol: Optional[str] = None,
+        sts_hook: Optional[Callable[[str], Any]] = None
     ) -> str:
         '''
         Generates a shared access signature for the queue.
@@ -90,6 +94,10 @@ class QueueSharedAccessSignature(SharedAccessSignature):
         :param str protocol:
             Specifies the protocol permitted for a request made. The default value
             is https,http. See :class:`~azure.storage.common.models.Protocol` for possible values.
+        :param sts_hook:
+            For debugging purposes only. If provided, the hook is called with the string to sign
+            that was used to generate the SAS.
+        :type sts_hook: Optional[Callable[[str], Any]]
         :return: A Shared Access Signature (sas) token.
         :rtype: str
         '''
@@ -97,6 +105,9 @@ class QueueSharedAccessSignature(SharedAccessSignature):
         sas.add_base(permission, expiry, start, ip, protocol, self.x_ms_version)
         sas.add_id(policy_id)
         sas.add_resource_signature(self.account_name, self.account_key, queue_name)
+
+        if sts_hook is not None:
+            sts_hook(sas.string_to_sign)
 
         return sas.get_token()
 
@@ -131,6 +142,7 @@ class _QueueSharedAccessHelper(_SharedAccessHelper):
 
         self._add_query(QueryStringConstants.SIGNED_SIGNATURE,
                         sign_string(account_key, string_to_sign))
+        self.string_to_sign = string_to_sign
 
 
 def generate_account_sas(
@@ -143,6 +155,7 @@ def generate_account_sas(
     ip: Optional[str] = None,
     *,
     services: Union[Services, str] = Services(queue=True),
+    sts_hook: Optional[Callable[[str], Any]] = None,
     **kwargs: Any
 ) -> str:
     """Generates a shared access signature for the queue service.
@@ -180,6 +193,10 @@ def generate_account_sas(
         Will default to only this package (i.e. queue) if not provided.
     :keyword str protocol:
         Specifies the protocol permitted for a request made. The default value is https.
+    :keyword sts_hook:
+        For debugging purposes only. If provided, the hook is called with the string to sign
+        that was used to generate the SAS.
+    :paramtype sts_hook: Optional[Callable[[str], Any]]
     :return: A Shared Access Signature (sas) token.
     :rtype: str
     """
@@ -191,6 +208,7 @@ def generate_account_sas(
         expiry=expiry,
         start=start,
         ip=ip,
+        sts_hook=sts_hook,
         **kwargs
     )
 
@@ -204,6 +222,8 @@ def generate_queue_sas(
     start: Optional[Union["datetime", str]] = None,
     policy_id: Optional[str] = None,
     ip: Optional[str] = None,
+    *,
+    sts_hook: Optional[Callable[[str], Any]] = None,
     **kwargs: Any
 ) -> str:
     """Generates a shared access signature for a queue.
@@ -249,6 +269,10 @@ def generate_queue_sas(
         restricts the request to those IP addresses.
     :keyword str protocol:
         Specifies the protocol permitted for a request made. The default value is https.
+    :keyword sts_hook:
+        For debugging purposes only. If provided, the hook is called with the string to sign
+        that was used to generate the SAS.
+    :paramtype sts_hook: Optional[Callable[[str], Any]]
     :return: A Shared Access Signature (sas) token.
     :rtype: str
 
@@ -274,6 +298,7 @@ def generate_queue_sas(
         start=start,
         policy_id=policy_id,
         ip=ip,
+        sts_hook=sts_hook,
         **kwargs
     )
 

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_shared_access_signature.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_shared_access_signature.py
@@ -53,7 +53,7 @@ class QueueSharedAccessSignature(SharedAccessSignature):
         policy_id: Optional[str] = None,
         ip: Optional[str] = None,
         protocol: Optional[str] = None,
-        sts_hook: Optional[Callable[[str], Any]] = None
+        sts_hook: Optional[Callable[[str], None]] = None
     ) -> str:
         '''
         Generates a shared access signature for the queue.
@@ -97,7 +97,7 @@ class QueueSharedAccessSignature(SharedAccessSignature):
         :param sts_hook:
             For debugging purposes only. If provided, the hook is called with the string to sign
             that was used to generate the SAS.
-        :type sts_hook: Optional[Callable[[str], Any]]
+        :type sts_hook: Optional[Callable[[str], None]]
         :return: A Shared Access Signature (sas) token.
         :rtype: str
         '''
@@ -155,7 +155,7 @@ def generate_account_sas(
     ip: Optional[str] = None,
     *,
     services: Union[Services, str] = Services(queue=True),
-    sts_hook: Optional[Callable[[str], Any]] = None,
+    sts_hook: Optional[Callable[[str], None]] = None,
     **kwargs: Any
 ) -> str:
     """Generates a shared access signature for the queue service.
@@ -196,7 +196,7 @@ def generate_account_sas(
     :keyword sts_hook:
         For debugging purposes only. If provided, the hook is called with the string to sign
         that was used to generate the SAS.
-    :paramtype sts_hook: Optional[Callable[[str], Any]]
+    :paramtype sts_hook: Optional[Callable[[str], None]]
     :return: A Shared Access Signature (sas) token.
     :rtype: str
     """
@@ -223,7 +223,7 @@ def generate_queue_sas(
     policy_id: Optional[str] = None,
     ip: Optional[str] = None,
     *,
-    sts_hook: Optional[Callable[[str], Any]] = None,
+    sts_hook: Optional[Callable[[str], None]] = None,
     **kwargs: Any
 ) -> str:
     """Generates a shared access signature for a queue.
@@ -272,7 +272,7 @@ def generate_queue_sas(
     :keyword sts_hook:
         For debugging purposes only. If provided, the hook is called with the string to sign
         that was used to generate the SAS.
-    :paramtype sts_hook: Optional[Callable[[str], Any]]
+    :paramtype sts_hook: Optional[Callable[[str], None]]
     :return: A Shared Access Signature (sas) token.
     :rtype: str
 


### PR DESCRIPTION
Per Arch Board feedback, this PR will enable customers to pass a `string_to_sign` hook called `sts_hook` to `generate_*_sas` methods across all four packages to diagnose their own SAS and User Delegation SAS issues.