### PR TITLE
Document alternate solution to PermissionError during test proxy use

### DIFF
--- a/doc/dev/test_proxy_troubleshooting.md
+++ b/doc/dev/test_proxy_troubleshooting.md
@@ -260,12 +260,18 @@ While the test proxy is being invoked during the start of a test run, you may se
 PermissionError: [Errno 13] Permission denied: '.../azure-sdk-for-python/.proxy/Azure.Sdk.Tools.TestProxy'
 ```
 
-This means that the test proxy tool was successfully installed at the location in the error message, but we don't have
+This can mean that the test proxy tool was successfully installed at the location in the error message, but we don't have
 sufficient permissions to run it with the tool startup script. We can set the correct permissions on the file by using
 `chmod`. Using the tool path that was provided in the `PermissionError` message, run the following command:
 ```
 chmod +x .../azure-sdk-for-python/.proxy/Azure.Sdk.Tools.TestProxy
 ```
+
+Alternatively, you can delete the installed tool and re-run your tests to automatically reinstall it correctly.
+
+- Open Task Manager, search for a process named "Azure.Sdk.Tools.TestProxy", and end the task if one is running.
+- Delete the `.proxy` folder at the root of your local `azure-sdk-for-python` clone.
+- Re-run your tests; the test proxy will be reinstalled and should correctly set file permissions.
 
 
 [custom_default_matcher]: https://github.com/Azure/azure-sdk-for-python/blob/497f5f3435162c4f2086d1429fc1bba4f31a4354/tools/azure-sdk-tools/devtools_testutils/sanitizers.py#L85


### PR DESCRIPTION
# Description

Using `chmod` to modify file permissions for the test proxy can solve `PermissionError`s, but the issue can also be solved by deleting the tool and having it reinstall upon test startup. This updates the troubleshooting guide to document the latter approach.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
