### PR TITLE
Do not use deprecated `TokenCache.find()`

### DIFF
--- a/sdk/identity/azure-identity/azure/identity/_internal/managed_identity_client.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/managed_identity_client.py
@@ -82,8 +82,10 @@ class ManagedIdentityClientBase(abc.ABC):
 
     def get_cached_token(self, *scopes: str) -> Optional[AccessToken]:
         resource = _scopes_to_resource(*scopes)
-        tokens = self._cache.find(TokenCache.CredentialType.ACCESS_TOKEN, target=[resource])
-        for token in tokens:
+        for token in self._cache.search(
+            TokenCache.CredentialType.ACCESS_TOKEN,
+            target=[resource],
+        ):
             expires_on = int(token["expires_on"])
             if expires_on > time.time():
                 return AccessToken(token["secret"], expires_on)


### PR DESCRIPTION
# Description

Fixes #36713 by not using the deprecated `TokenCache.find()` method.

azure-identity already requires msal>=1.29.0, so this should be safe.

There are other uses of `_cache.find()` around the monorepo, but no other package declares that it depends on msal 1.29.0+, so changing those may not be safe.


# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
