### PR TITLE
[Storage] [STG 95] Add `file_permission_format` keyword to `create_directory` API

### DIFF
--- a/sdk/storage/azure-storage-file-share/assets.json
+++ b/sdk/storage/azure-storage-file-share/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "python",
   "TagPrefix": "python/storage/azure-storage-file-share",
-  "Tag": "python/storage/azure-storage-file-share_3d5569ab64"
+  "Tag": "python/storage/azure-storage-file-share_14b8ccde96"
 }

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_directory_client.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_directory_client.py
@@ -341,6 +341,9 @@ class ShareDirectoryClient(StorageAccountHostsMixin):
         :keyword str file_permission_key:
             Key of the permission to be set for the directory/file.
             Note: Only one of the file-permission or file-permission-key should be specified.
+        :keyword file_permission_format:
+            Specifies the format in which the permission is returned. If not specified, SDDL will be the default.
+        :paramtype file_permission_format: Literal['sddl', 'binary']
         :keyword file_change_time:
             Change time for the directory. If not specified, change time will be set to the current date/time.
 

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/aio/_directory_client_async.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/aio/_directory_client_async.py
@@ -214,6 +214,9 @@ class ShareDirectoryClient(AsyncStorageAccountHostsMixin, ShareDirectoryClientBa
         :keyword str file_permission_key:
             Key of the permission to be set for the directory/file.
             Note: Only one of the file-permission or file-permission-key should be specified.
+        :keyword file_permission_format:
+            Specifies the format in which the permission is returned. If not specified, SDDL will be the default.
+        :paramtype file_permission_format: Literal['sddl', 'binary']
         :keyword file_change_time:
             Change time for the directory. If not specified, change time will be set to the current date/time.
 

--- a/sdk/storage/azure-storage-file-share/tests/test_directory.py
+++ b/sdk/storage/azure-storage-file-share/tests/test_directory.py
@@ -1404,13 +1404,22 @@ class TestStorageDirectory(StorageRecordedTestCase):
 
         self._setup(storage_account_name, storage_account_key)
         share_client = self.fsc.get_share_client(self.share_name)
-        directory_client = share_client.create_directory('dir1')
         user_given_permission_sddl = ("O:S-1-5-21-2127521184-1604012920-1887927527-21560751G:S-1-5-21-2127521184-"
                                       "1604012920-1887927527-513D:AI(A;;FA;;;SY)(A;;FA;;;BA)(A;;0x1200a9;;;"
                                       "S-1-5-21-397955417-626881126-188441444-3053964)S:NO_ACCESS_CONTROL")
         user_given_permission_binary = ("AQAUhGwAAACIAAAAAAAAABQAAAACAFgAAwAAAAAAFAD/AR8AAQEAAAAAAAUSAAAAAAAYAP8BHw"
                                         "ABAgAAAAAABSAAAAAgAgAAAAAkAKkAEgABBQAAAAAABRUAAABZUbgXZnJdJWRjOwuMmS4AAQUA"
                                         "AAAAAAUVAAAAoGXPfnhLm1/nfIdwr/1IAQEFAAAAAAAFFQAAAKBlz354S5tf53yHcAECAAA=")
+
+        directory_client = share_client.create_directory(
+            'dir1',
+            file_permission=user_given_permission_binary,
+            file_permission_format="binary"
+        )
+
+        props = directory_client.get_directory_properties()
+        assert props is not None
+        assert props.permission_key is not None
 
         directory_client.set_http_headers(
             file_permission=user_given_permission_binary,

--- a/sdk/storage/azure-storage-file-share/tests/test_directory_async.py
+++ b/sdk/storage/azure-storage-file-share/tests/test_directory_async.py
@@ -1505,13 +1505,22 @@ class TestStorageDirectoryAsync(AsyncStorageRecordedTestCase):
 
         await self._setup(storage_account_name, storage_account_key)
         share_client = self.fsc.get_share_client(self.share_name)
-        directory_client = await share_client.create_directory('dir1')
         user_given_permission_sddl = ("O:S-1-5-21-2127521184-1604012920-1887927527-21560751G:S-1-5-21-2127521184-"
                                       "1604012920-1887927527-513D:AI(A;;FA;;;SY)(A;;FA;;;BA)(A;;0x1200a9;;;"
                                       "S-1-5-21-397955417-626881126-188441444-3053964)S:NO_ACCESS_CONTROL")
         user_given_permission_binary = ("AQAUhGwAAACIAAAAAAAAABQAAAACAFgAAwAAAAAAFAD/AR8AAQEAAAAAAAUSAAAAAAAYAP8BHw"
                                         "ABAgAAAAAABSAAAAAgAgAAAAAkAKkAEgABBQAAAAAABRUAAABZUbgXZnJdJWRjOwuMmS4AAQUA"
                                         "AAAAAAUVAAAAoGXPfnhLm1/nfIdwr/1IAQEFAAAAAAAFFQAAAKBlz354S5tf53yHcAECAAA=")
+
+        directory_client = await share_client.create_directory(
+            'dir1',
+            file_permission=user_given_permission_binary,
+            file_permission_format="binary"
+        )
+
+        props = await directory_client.get_directory_properties()
+        assert props is not None
+        assert props.permission_key is not None
 
         await directory_client.set_http_headers(
             file_permission=user_given_permission_binary,

--- a/sdk/storage/azure-storage-file-share/tests/test_file.py
+++ b/sdk/storage/azure-storage-file-share/tests/test_file.py
@@ -3779,7 +3779,12 @@ class TestStorageFile(StorageRecordedTestCase):
                                         "ABAgAAAAAABSAAAAAgAgAAAAAkAKkAEgABBQAAAAAABRUAAABZUbgXZnJdJWRjOwuMmS4AAQUA"
                                         "AAAAAAUVAAAAoGXPfnhLm1/nfIdwr/1IAQEFAAAAAAAFFQAAAKBlz354S5tf53yHcAECAAA=")
 
-        source_file.create_file(1024)
+        source_file.create_file(
+            1024,
+            file_permission=user_given_permission_binary,
+            file_permission_format="binary"
+        )
+
         props = source_file.get_file_properties()
         assert props is not None
         assert props.permission_key is not None

--- a/sdk/storage/azure-storage-file-share/tests/test_file_async.py
+++ b/sdk/storage/azure-storage-file-share/tests/test_file_async.py
@@ -3896,7 +3896,12 @@ class TestStorageFileAsync(AsyncStorageRecordedTestCase):
                                         "ABAgAAAAAABSAAAAAgAgAAAAAkAKkAEgABBQAAAAAABRUAAABZUbgXZnJdJWRjOwuMmS4AAQUA"
                                         "AAAAAAUVAAAAoGXPfnhLm1/nfIdwr/1IAQEFAAAAAAAFFQAAAKBlz354S5tf53yHcAECAAA=")
 
-        await source_file.create_file(1024)
+        await source_file.create_file(
+            1024,
+            file_permission=user_given_permission_binary,
+            file_permission_format="binary"
+        )
+
         props = await source_file.get_file_properties()
         assert props is not None
         assert props.permission_key is not None


### PR DESCRIPTION
Last addition to STG 95 Beta :D

This is a part of the "REST API for Binary ACE in Azure Files" feature.

PR contains the following changes:
- Regenerated code
- Added new optional keyword `file_permission_format` to `create_directory` API.
- Modified tests for `create_directory` API to add `file_permission_format` keyword
- Modified tests for `create_file` API to add `file_permission_format` keyword

Currently, if we provide `create_*` API some user given permission in either SDDL or Binary format, the permission key given by the server passed to the `get_permission_for_share` API will not return the exact user given permission.

For example, in async's version of `test_file_permission_format`

```python3
await source_file.create_file(
    1024,
    file_permission=user_given_permission_binary,
    file_permission_format="binary"
)

props = await source_file.get_file_properties()
assert props is not None
assert props.permission_key is not None

server_returned_permission = await share_client.get_permission_for_share(
    props.permission_key,
    file_permission_format="binary"
)
assert server_returned_permission == user_given_permission_binary
```

The assertion fails. After some investigation, it is unclear whether this is SDK client-side or server-side issue. However, the other APIs return the correct permission. Thus, the `get_permission_for_share` and assertion has been removed for `create_file` and `create_directory` API calls in the tests, until we can find a workaround.