### PR TITLE
Update owner/approver for EsrpRelease

### DIFF
--- a/eng/pipelines/templates/stages/partner-release.yml
+++ b/eng/pipelines/templates/stages/partner-release.yml
@@ -64,8 +64,8 @@ extends:
               Intent: 'PackageDistribution'
               ContentType: 'PyPI'
               FolderLocation: $(Artifacts)
-              Owners: $(Build.RequestedForEmail)
-              Approvers: $(Build.RequestedForEmail)
+              Owners: ${{ coalesce(variables['Build.RequestedForEmail'], 'azuresdk@microsoft.com') }}
+              Approvers: ${{ coalesce(variables['Build.RequestedForEmail'], 'azuresdk@microsoft.com') }}
               ServiceEndpointUrl: 'https://api.esrp.microsoft.com'
               MainPublisher: 'ESRPRELPACMANTEST'
               DomainTenantId: '72f988bf-86f1-41af-91ab-2d7cd011db47'


### PR DESCRIPTION
There are cases where the Build.RequestdForEmail is not set, for example when the build is started via service principal for automation. In those cases, lets fallback to our bot email.