### PR TITLE
[Identity] Convert remaining cache.find usage

### DIFF
--- a/sdk/identity/azure-identity/azure/identity/_internal/shared_token_cache.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/shared_token_cache.py
@@ -159,7 +159,7 @@ class SharedTokenCacheBase(ABC):  # pylint: disable=too-many-instance-attributes
 
         cache = self._cae_cache if is_cae else self._cache
         items = []
-        for item in cache.find(credential_type):
+        for item in cast(msal.TokenCache, cache).search(credential_type):
             environment = item.get("environment")
             if environment in self._environment_aliases:
                 items.append(item)
@@ -234,7 +234,7 @@ class SharedTokenCacheBase(ABC):  # pylint: disable=too-many-instance-attributes
 
         cache = self._cae_cache if is_cae else self._cache
         try:
-            cache_entries = cache.find(
+            cache_entries = cast(msal.TokenCache, cache).search(
                 msal.TokenCache.CredentialType.ACCESS_TOKEN,
                 target=list(scopes),
                 query={"home_account_id": account["home_account_id"]},
@@ -255,7 +255,7 @@ class SharedTokenCacheBase(ABC):  # pylint: disable=too-many-instance-attributes
 
         cache = self._cae_cache if is_cae else self._cache
         try:
-            cache_entries = cache.find(
+            cache_entries = cast(msal.TokenCache, cache).search(
                 msal.TokenCache.CredentialType.REFRESH_TOKEN, query={"home_account_id": account["home_account_id"]}
             )
             return [token["secret"] for token in cache_entries if "secret" in token]

--- a/sdk/identity/azure-identity/azure/identity/_internal/shared_token_cache.py
+++ b/sdk/identity/azure-identity/azure/identity/_internal/shared_token_cache.py
@@ -157,9 +157,9 @@ class SharedTokenCacheBase(ABC):  # pylint: disable=too-many-instance-attributes
         :rtype: list[CacheItem]
         """
 
-        cache = self._cae_cache if is_cae else self._cache
+        cache = cast(msal.TokenCache, self._cae_cache if is_cae else self._cache)
         items = []
-        for item in cast(msal.TokenCache, cache).search(credential_type):
+        for item in cache.search(credential_type):
             environment = item.get("environment")
             if environment in self._environment_aliases:
                 items.append(item)
@@ -232,9 +232,9 @@ class SharedTokenCacheBase(ABC):  # pylint: disable=too-many-instance-attributes
         if "home_account_id" not in account:
             return None
 
-        cache = self._cae_cache if is_cae else self._cache
+        cache = cast(msal.TokenCache, self._cae_cache if is_cae else self._cache)
         try:
-            cache_entries = cast(msal.TokenCache, cache).search(
+            cache_entries = cache.search(
                 msal.TokenCache.CredentialType.ACCESS_TOKEN,
                 target=list(scopes),
                 query={"home_account_id": account["home_account_id"]},
@@ -253,9 +253,9 @@ class SharedTokenCacheBase(ABC):  # pylint: disable=too-many-instance-attributes
         if "home_account_id" not in account:
             return []
 
-        cache = self._cae_cache if is_cae else self._cache
+        cache = cast(msal.TokenCache, self._cae_cache if is_cae else self._cache)
         try:
-            cache_entries = cast(msal.TokenCache, cache).search(
+            cache_entries = cache.search(
                 msal.TokenCache.CredentialType.REFRESH_TOKEN, query={"home_account_id": account["home_account_id"]}
             )
             return [token["secret"] for token in cache_entries if "secret" in token]

--- a/sdk/identity/azure-identity/tests/test_aad_client.py
+++ b/sdk/identity/azure-identity/tests/test_aad_client.py
@@ -202,8 +202,8 @@ def test_evicts_invalid_refresh_token():
     cache = TokenCache()
     cache.add({"response": build_aad_response(uid="id1", utid="tid1", access_token="*", refresh_token=invalid_token)})
     cache.add({"response": build_aad_response(uid="id2", utid="tid2", access_token="*", refresh_token="...")})
-    assert len(cache.find(TokenCache.CredentialType.REFRESH_TOKEN)) == 2
-    assert len(cache.find(TokenCache.CredentialType.REFRESH_TOKEN, query={"secret": invalid_token})) == 1
+    assert len(list(cache.search(TokenCache.CredentialType.REFRESH_TOKEN))) == 2
+    assert len(list(cache.search(TokenCache.CredentialType.REFRESH_TOKEN, query={"secret": invalid_token}))) == 1
 
     def send(request, **_):
         assert request.data["refresh_token"] == invalid_token
@@ -216,8 +216,8 @@ def test_evicts_invalid_refresh_token():
         client.obtain_token_by_refresh_token(scopes=("scope",), refresh_token=invalid_token)
 
     assert transport.send.call_count == 1
-    assert len(cache.find(TokenCache.CredentialType.REFRESH_TOKEN)) == 1
-    assert len(cache.find(TokenCache.CredentialType.REFRESH_TOKEN, query={"secret": invalid_token})) == 0
+    assert len(list(cache.search(TokenCache.CredentialType.REFRESH_TOKEN))) == 1
+    assert len(list(cache.search(TokenCache.CredentialType.REFRESH_TOKEN, query={"secret": invalid_token}))) == 0
 
 
 def test_retries_token_requests():

--- a/sdk/identity/azure-identity/tests/test_aad_client_async.py
+++ b/sdk/identity/azure-identity/tests/test_aad_client_async.py
@@ -196,8 +196,8 @@ async def test_evicts_invalid_refresh_token():
     cache = TokenCache()
     cache.add({"response": build_aad_response(uid="id1", utid="tid1", access_token="*", refresh_token=invalid_token)})
     cache.add({"response": build_aad_response(uid="id2", utid="tid2", access_token="*", refresh_token="...")})
-    assert len(cache.find(TokenCache.CredentialType.REFRESH_TOKEN)) == 2
-    assert len(cache.find(TokenCache.CredentialType.REFRESH_TOKEN, query={"secret": invalid_token})) == 1
+    assert len(list(cache.search(TokenCache.CredentialType.REFRESH_TOKEN))) == 2
+    assert len(list(cache.search(TokenCache.CredentialType.REFRESH_TOKEN, query={"secret": invalid_token}))) == 1
 
     async def send(request, **_):
         assert request.data["refresh_token"] == invalid_token
@@ -210,8 +210,8 @@ async def test_evicts_invalid_refresh_token():
         await client.obtain_token_by_refresh_token(scopes=("scope",), refresh_token=invalid_token)
 
     assert transport.send.call_count == 1
-    assert len(cache.find(TokenCache.CredentialType.REFRESH_TOKEN)) == 1
-    assert len(cache.find(TokenCache.CredentialType.REFRESH_TOKEN, query={"secret": invalid_token})) == 0
+    assert len(list(cache.search(TokenCache.CredentialType.REFRESH_TOKEN))) == 1
+    assert len(list(cache.search(TokenCache.CredentialType.REFRESH_TOKEN, query={"secret": invalid_token}))) == 0
 
 
 async def test_retries_token_requests():

--- a/sdk/identity/azure-identity/tests/test_auth_code.py
+++ b/sdk/identity/azure-identity/tests/test_auth_code.py
@@ -136,7 +136,7 @@ def test_auth_code_credential():
     assert transport.send.call_count == 1
 
     # no auth code, no cached token -> credential should redeem refresh token
-    cached_access_token = cache.find(cache.CredentialType.ACCESS_TOKEN)[0]
+    cached_access_token = list(cache.search(cache.CredentialType.ACCESS_TOKEN))[0]
     cache.remove_at(cached_access_token)
     token = credential.get_token(expected_scope)
     assert token.token == expected_access_token

--- a/sdk/identity/azure-identity/tests/test_auth_code_async.py
+++ b/sdk/identity/azure-identity/tests/test_auth_code_async.py
@@ -160,7 +160,7 @@ async def test_auth_code_credential():
     assert transport.send.call_count == 1
 
     # no auth code, no cached token -> credential should redeem refresh token
-    cached_access_token = cache.find(cache.CredentialType.ACCESS_TOKEN)[0]
+    cached_access_token = list(cache.search(cache.CredentialType.ACCESS_TOKEN))[0]
     cache.remove_at(cached_access_token)
     token = await credential.get_token(expected_scope)
     assert token.token == expected_access_token

--- a/sdk/identity/azure-identity/tests/test_certificate_credential.py
+++ b/sdk/identity/azure-identity/tests/test_certificate_credential.py
@@ -414,7 +414,7 @@ def test_persistent_cache_multiple_clients(cert_path, cert_password):
         assert token_b.token == access_token_b
         assert transport_b.send.call_count == 2
 
-        assert len(cache.find(TokenCache.CredentialType.ACCESS_TOKEN)) == 2
+        assert len(list(cache.search(TokenCache.CredentialType.ACCESS_TOKEN))) == 2
 
 
 def test_certificate_arguments():

--- a/sdk/identity/azure-identity/tests/test_certificate_credential_async.py
+++ b/sdk/identity/azure-identity/tests/test_certificate_credential_async.py
@@ -334,7 +334,7 @@ async def test_persistent_cache_multiple_clients(cert_path, cert_password):
         assert transport_b.send.call_count == 1
         assert mock_cache_loader.call_count == 2
 
-        assert len(cache.find(TokenCache.CredentialType.ACCESS_TOKEN)) == 2
+        assert len(list(cache.search(TokenCache.CredentialType.ACCESS_TOKEN))) == 2
 
 
 def test_certificate_arguments():

--- a/sdk/identity/azure-identity/tests/test_client_secret_credential.py
+++ b/sdk/identity/azure-identity/tests/test_client_secret_credential.py
@@ -260,7 +260,7 @@ def test_cache_multiple_clients():
         assert token_b.token == access_token_b
         assert transport_b.send.call_count == 2
 
-        assert len(cache.find(TokenCache.CredentialType.ACCESS_TOKEN)) == 2
+        assert len(list(cache.search(TokenCache.CredentialType.ACCESS_TOKEN))) == 2
 
 
 def test_multitenant_authentication():

--- a/sdk/identity/azure-identity/tests/test_client_secret_credential_async.py
+++ b/sdk/identity/azure-identity/tests/test_client_secret_credential_async.py
@@ -304,7 +304,7 @@ async def test_cache_multiple_clients():
         assert transport_b.send.call_count == 1
         assert mock_cache_loader.call_count == 2
 
-        assert len(cache.find(TokenCache.CredentialType.ACCESS_TOKEN)) == 2
+        assert len(list(cache.search(TokenCache.CredentialType.ACCESS_TOKEN))) == 2
 
 
 @pytest.mark.asyncio

--- a/sdk/identity/azure-identity/tests/test_shared_cache_credential.py
+++ b/sdk/identity/azure-identity/tests/test_shared_cache_credential.py
@@ -752,7 +752,7 @@ def test_writes_to_cache():
     assert token.token == second_access_token
 
     # verify the credential didn't add a new cache entry
-    assert len(cache.find(TokenCache.CredentialType.REFRESH_TOKEN)) == 1
+    assert len(list(cache.search(TokenCache.CredentialType.REFRESH_TOKEN))) == 1
 
 
 def test_initialization():


### PR DESCRIPTION
Since MSAL's cache `find` is deprecated, `search` is the API we should be using.