### PR TITLE
[SDK generation pipeline] multiapi package use old changelog tool

### DIFF
--- a/tools/azure-sdk-tools/packaging_tools/package_utils.py
+++ b/tools/azure-sdk-tools/packaging_tools/package_utils.py
@@ -40,7 +40,14 @@ def change_log_new(package_folder: str, lastest_pypi_version: bool) -> str:
     return "\n".join(result[begin + 1 : end]).strip()
 
 
-def change_log_generate(package_name, last_version, tag_is_stable: bool = False, *, prefolder: Optional[str] = None, is_multiapi: bool = False):
+def change_log_generate(
+    package_name,
+    last_version,
+    tag_is_stable: bool = False,
+    *,
+    prefolder: Optional[str] = None,
+    is_multiapi: bool = False,
+):
     from pypi_tools.pypi import PyPIClient
 
     client = PyPIClient()

--- a/tools/azure-sdk-tools/packaging_tools/package_utils.py
+++ b/tools/azure-sdk-tools/packaging_tools/package_utils.py
@@ -40,7 +40,7 @@ def change_log_new(package_folder: str, lastest_pypi_version: bool) -> str:
     return "\n".join(result[begin + 1 : end]).strip()
 
 
-def change_log_generate(package_name, last_version, tag_is_stable: bool = False, *, prefolder: Optional[str] = None):
+def change_log_generate(package_name, last_version, tag_is_stable: bool = False, *, prefolder: Optional[str] = None, is_multiapi: bool = False):
     from pypi_tools.pypi import PyPIClient
 
     client = PyPIClient()
@@ -57,7 +57,7 @@ def change_log_generate(package_name, last_version, tag_is_stable: bool = False,
         return "### Other Changes\n\n  - Initial version"
 
     # try new changelog tool
-    if prefolder:
+    if prefolder and not is_multiapi:
         try:
             return change_log_new(str(Path(prefolder) / package_name), not (last_stable_release and tag_is_stable))
         except Exception as e:

--- a/tools/azure-sdk-tools/packaging_tools/sdk_generator.py
+++ b/tools/azure-sdk-tools/packaging_tools/sdk_generator.py
@@ -8,6 +8,7 @@ from subprocess import check_call, getoutput
 import shutil
 import re
 import os
+
 try:
     # py 311 adds this library natively
     import tomllib as toml
@@ -67,6 +68,7 @@ def multiapi_combiner(sdk_code_path: str, package_name: str):
     )
     check_call("pip install -e .", shell=True)
 
+
 @return_origin_path
 def after_multiapi_combiner(sdk_code_path: str, package_name: str, folder_name: str):
     toml_file = Path(sdk_code_path) / CONF_NAME
@@ -81,12 +83,14 @@ def after_multiapi_combiner(sdk_code_path: str, package_name: str, folder_name: 
             # azure-mgmt-resource has subfolders
             subfolder_path = Path(sdk_code_path) / package_name.replace("-", "/")
             subfolders_name = [s.name for s in subfolder_path.iterdir() if s.is_dir() and not s.name.startswith("_")]
-            content["packaging"]["exclude_folders"] = ",".join([exclude(f"{package_name}-{s}") for s in subfolders_name])
+            content["packaging"]["exclude_folders"] = ",".join(
+                [exclude(f"{package_name}-{s}") for s in subfolders_name]
+            )
 
         with open(toml_file, "wb") as file_out:
             tomlw.dump(content, file_out)
         call_build_config(package_name, folder_name)
-        
+
         # remove .egg-info to reinstall package
         for item in Path(sdk_code_path).iterdir():
             if item.suffix == ".egg-info":
@@ -95,7 +99,6 @@ def after_multiapi_combiner(sdk_code_path: str, package_name: str, folder_name: 
         check_call("pip install -e .", shell=True)
     else:
         _LOGGER.info(f"do not find {toml_file}")
-
 
 
 # readme: ../azure-rest-api-specs/specification/paloaltonetworks/resource-manager/readme.md or absolute path
@@ -157,7 +160,7 @@ def get_related_swagger(readme_content: List[str], tag: str) -> List[str]:
 
 
 def get_last_commit_info(files: List[str]) -> str:
-    result = [getoutput(f'git log -1 --pretty="format:%ai %H" {f}').strip('\n ') + " " + f for f in files]
+    result = [getoutput(f'git log -1 --pretty="format:%ai %H" {f}').strip("\n ") + " " + f for f in files]
     result.sort()
     return result[-1]
 
@@ -206,7 +209,9 @@ def extract_version_info(config: Dict[str, Any]) -> str:
 def if_need_regenerate(meta: Dict[str, Any]) -> bool:
     with open(str(Path("../azure-sdk-for-python", CONFIG_FILE)), "r") as file_in:
         config = json.load(file_in)
-    current_info = config["meta"]["autorest_options"]["version"] + "".join(sorted(config["meta"]["autorest_options"]["use"]))
+    current_info = config["meta"]["autorest_options"]["version"] + "".join(
+        sorted(config["meta"]["autorest_options"]["use"])
+    )
     recorded_info = meta["autorest"] + "".join(sorted(meta["use"]))
     return recorded_info != current_info
 

--- a/tools/azure-sdk-tools/packaging_tools/sdk_generator.py
+++ b/tools/azure-sdk-tools/packaging_tools/sdk_generator.py
@@ -221,11 +221,13 @@ def if_need_regenerate(meta: Dict[str, Any]) -> bool:
 @return_origin_path
 def update_metadata_for_multiapi_package(spec_folder: str, input_readme: str):
     os.chdir(spec_folder)
-    python_md_content = get_readme_python_content(input_readme)
-    if not python_md_content:
+    python_readme = (Path(input_readme).parent / "readme.python.md").absolute()
+    if not python_readme.exists():
         _LOGGER.info(f"do not find python configuration: {python_readme}")
         return
 
+    with open(python_readme, "r") as file_in:
+        python_md_content = file_in.readlines()
     is_multiapi = is_multiapi_package(python_md_content)
     if not is_multiapi:
         _LOGGER.info(f"do not find multiapi configuration in {python_readme}")

--- a/tools/azure-sdk-tools/packaging_tools/sdk_package.py
+++ b/tools/azure-sdk-tools/packaging_tools/sdk_package.py
@@ -30,7 +30,7 @@ def main(generate_input, generate_output):
         last_version = ["first release"]
         if "azure-mgmt-" in package_name:
             try:
-                md_output = change_log_generate(package_name, last_version, package["tagIsStable"], prefolder=prefolder)
+                md_output = change_log_generate(package_name, last_version, package["tagIsStable"], prefolder=prefolder, is_multiapi=package["isMultiapi"])
             except:
                 md_output = "change log generation failed!!!"
         else:

--- a/tools/azure-sdk-tools/packaging_tools/sdk_package.py
+++ b/tools/azure-sdk-tools/packaging_tools/sdk_package.py
@@ -30,7 +30,13 @@ def main(generate_input, generate_output):
         last_version = ["first release"]
         if "azure-mgmt-" in package_name:
             try:
-                md_output = change_log_generate(package_name, last_version, package["tagIsStable"], prefolder=prefolder, is_multiapi=package["isMultiapi"])
+                md_output = change_log_generate(
+                    package_name,
+                    last_version,
+                    package["tagIsStable"],
+                    prefolder=prefolder,
+                    is_multiapi=package["isMultiapi"],
+                )
             except:
                 md_output = "change log generation failed!!!"
         else:


### PR DESCRIPTION
before https://github.com/Azure/azure-sdk-for-python/issues/36755 fix, multiapi package shall use old changelog tool.

test link: https://github.com/Azure/azure-sdk-for-python/pull/36756