### PR TITLE
[Storage] Add overall crc64 calculation to partitioned upload for all packages

### DIFF
--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/uploads.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/uploads.py
@@ -95,30 +95,6 @@ def _parallel_uploads(executor, uploader, pending, running):
     return chunks
 
 
-class ChunkInfo:
-    offset: int
-    length: int
-    md5: Optional[bytes] = None
-    crc64: Optional[int] = None
-    id: Optional[str] = None
-    """The id of the chunk. Only set if chunk needs to be committed."""
-    response_headers: Dict[str, Any] = {}
-    """The response headers from the upload chunk operation."""
-
-    def __init__(self, offset: int, data: bytes, checksum_algorithm: Optional[Union[bool, str]]):
-        self.offset = offset
-        self.length = len(data)
-
-        if checksum_algorithm == ChecksumAlgorithm.MD5:
-            self.md5 = calculate_md5(data)
-        if checksum_algorithm == ChecksumAlgorithm.CRC64:
-            self.crc64 = calculate_crc64(data, 0)
-
-    @property
-    def crc64_bytes(self) -> Optional[bytes]:
-        return get_crc64_bytes(self.crc64) if self.crc64 is not None else None
-
-
 def upload_data_chunks(
         service=None,
         uploader_class=None,
@@ -203,6 +179,30 @@ def upload_substream_blocks(
     if any(range_ids):
         return sorted(range_ids)
     return []
+
+
+class ChunkInfo:
+    offset: int
+    length: int
+    md5: Optional[bytes] = None
+    crc64: Optional[int] = None
+    id: Optional[str] = None
+    """The id of the chunk. Only set if chunk needs to be committed."""
+    response_headers: Dict[str, Any] = {}
+    """The response headers from the upload chunk operation."""
+
+    def __init__(self, offset: int, data: bytes, checksum_algorithm: Optional[Union[bool, str]]):
+        self.offset = offset
+        self.length = len(data)
+
+        if checksum_algorithm == ChecksumAlgorithm.MD5:
+            self.md5 = calculate_md5(data)
+        if checksum_algorithm == ChecksumAlgorithm.CRC64:
+            self.crc64 = calculate_crc64(data, 0)
+
+    @property
+    def crc64_bytes(self) -> Optional[bytes]:
+        return get_crc64_bytes(self.crc64) if self.crc64 is not None else None
 
 
 class _ChunkUploader(object):  # pylint: disable=too-many-instance-attributes

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/uploads.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/uploads.py
@@ -390,7 +390,7 @@ class PageBlobChunkUploader(_ChunkUploader):  # pylint: disable=abstract-method
 
     def _upload_chunk(self, data: bytes, chunk_info: ChunkInfo) -> ChunkInfo:
         # avoid uploading the empty pages
-        response_headers = None
+        response_headers = {}
         if not self._is_chunk_empty(data):
             chunk_end = chunk_info.offset + chunk_info.length - 1
             content_range = f"bytes={chunk_info.offset}-{chunk_end}"

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/uploads_async.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/uploads_async.py
@@ -110,8 +110,11 @@ async def upload_data_chunks(
     # If chunks have an id, return list of ids
     if chunks[0].id is not None:
         return [c.id for c in chunks]
-    # Else, return the last chunk's response headers
-    return chunks[-1].response_headers
+    # Else, return the response headers for the last chunk that had a response. (Page Blobs can have empty responses)
+    for c in reversed(chunks):
+        if c.response_headers:
+            return c.response_headers
+    return {}
 
 
 async def upload_substream_blocks(

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/validation.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/validation.py
@@ -86,7 +86,7 @@ def combine_crc64(values: List[Tuple[int, int]]) -> int:
     from azure.storage.extensions import crc64
 
     if len(values) == 0:
-        raise ValueError("Must provide at elast one crc value.")
+        raise ValueError("Must provide at least one crc value.")
 
     crc = values[0][0]
     length = values[0][1]

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/validation.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/validation.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import hashlib
 from enum import Enum
-from typing import cast, Literal, Optional, Union
+from typing import cast, List, Literal, Optional, Tuple, Union
 
 from azure.core import CaseInsensitiveEnumMeta
 
@@ -75,3 +75,23 @@ def calculate_crc64_bytes(data: bytes) -> bytes:
     from azure.storage.extensions import crc64
 
     return cast(bytes, crc64.compute(data, 0).to_bytes(CRC64_LENGTH, 'little'))
+
+
+def get_crc64_bytes(crc: int) -> bytes:
+    return crc.to_bytes(CRC64_LENGTH, 'little')
+
+
+def combine_crc64(values: List[Tuple[int, int]]) -> int:
+    # Locally import to avoid error if not installed.
+    from azure.storage.extensions import crc64
+
+    if len(values) == 0:
+        raise ValueError("Must provide at elast one crc value.")
+
+    crc = values[0][0]
+    length = values[0][1]
+    for i in range(1, len(values)):
+        crc = crc64.concat(0, 0, crc, length, 0, values[i][0], values[i][1])
+        length += values[i][1]
+
+    return crc

--- a/sdk/storage/azure-storage-blob/tests/test_content_validation.py
+++ b/sdk/storage/azure-storage-blob/tests/test_content_validation.py
@@ -123,33 +123,6 @@ class TestStorageContentValidation(StorageRecordedTestCase):
         assert response
 
     @BlobPreparer()
-    def testing_upload(self, **kwargs):
-        storage_account_name = kwargs.pop("storage_account_name")
-        storage_account_key = kwargs.pop("storage_account_key")
-
-        self._setup(storage_account_name, storage_account_key)
-        blob = self.container.get_blob_client(self._get_blob_reference())
-        self.container._config.max_single_put_size = 512
-        self.container._config.max_block_size = 512
-        # self.container._config.min_large_block_upload_threshold = 100
-        data = b'abc' * 512
-
-        # Act
-        response = blob.upload_blob(data, max_concurrency=1)
-        result = blob.download_blob().read()
-
-        # Assert
-        assert response['etag']
-        assert result == data
-
-        response = blob.upload_blob(data, overwrite=True, validate_content=True, max_concurrency=2)
-        result = blob.download_blob().read()
-
-        # Assert
-        assert response['etag']
-        assert result == data
-
-    @BlobPreparer()
     @pytest.mark.parametrize('a', [BlobType.BLOCKBLOB, BlobType.PAGEBLOB, BlobType.APPENDBLOB])  # a: blob_type
     @GenericTestProxyParametrize1()
     @recorded_by_proxy

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/uploads.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/uploads.py
@@ -95,30 +95,6 @@ def _parallel_uploads(executor, uploader, pending, running):
     return chunks
 
 
-class ChunkInfo:
-    offset: int
-    length: int
-    md5: Optional[bytes] = None
-    crc64: Optional[int] = None
-    id: Optional[str] = None
-    """The id of the chunk. Only set if chunk needs to be committed."""
-    response_headers: Dict[str, Any] = {}
-    """The response headers from the upload chunk operation."""
-
-    def __init__(self, offset: int, data: bytes, checksum_algorithm: Optional[Union[bool, str]]):
-        self.offset = offset
-        self.length = len(data)
-
-        if checksum_algorithm == ChecksumAlgorithm.MD5:
-            self.md5 = calculate_md5(data)
-        if checksum_algorithm == ChecksumAlgorithm.CRC64:
-            self.crc64 = calculate_crc64(data, 0)
-
-    @property
-    def crc64_bytes(self) -> Optional[bytes]:
-        return get_crc64_bytes(self.crc64) if self.crc64 is not None else None
-
-
 def upload_data_chunks(
         service=None,
         uploader_class=None,
@@ -203,6 +179,30 @@ def upload_substream_blocks(
     if any(range_ids):
         return sorted(range_ids)
     return []
+
+
+class ChunkInfo:
+    offset: int
+    length: int
+    md5: Optional[bytes] = None
+    crc64: Optional[int] = None
+    id: Optional[str] = None
+    """The id of the chunk. Only set if chunk needs to be committed."""
+    response_headers: Dict[str, Any] = {}
+    """The response headers from the upload chunk operation."""
+
+    def __init__(self, offset: int, data: bytes, checksum_algorithm: Optional[Union[bool, str]]):
+        self.offset = offset
+        self.length = len(data)
+
+        if checksum_algorithm == ChecksumAlgorithm.MD5:
+            self.md5 = calculate_md5(data)
+        if checksum_algorithm == ChecksumAlgorithm.CRC64:
+            self.crc64 = calculate_crc64(data, 0)
+
+    @property
+    def crc64_bytes(self) -> Optional[bytes]:
+        return get_crc64_bytes(self.crc64) if self.crc64 is not None else None
 
 
 class _ChunkUploader(object):  # pylint: disable=too-many-instance-attributes

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/uploads.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/uploads.py
@@ -390,7 +390,7 @@ class PageBlobChunkUploader(_ChunkUploader):  # pylint: disable=abstract-method
 
     def _upload_chunk(self, data: bytes, chunk_info: ChunkInfo) -> ChunkInfo:
         # avoid uploading the empty pages
-        response_headers = None
+        response_headers = {}
         if not self._is_chunk_empty(data):
             chunk_end = chunk_info.offset + chunk_info.length - 1
             content_range = f"bytes={chunk_info.offset}-{chunk_end}"

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/uploads_async.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/uploads_async.py
@@ -110,8 +110,11 @@ async def upload_data_chunks(
     # If chunks have an id, return list of ids
     if chunks[0].id is not None:
         return [c.id for c in chunks]
-    # Else, return the last chunk's response headers
-    return chunks[-1].response_headers
+    # Else, return the response headers for the last chunk that had a response. (Page Blobs can have empty responses)
+    for c in reversed(chunks):
+        if c.response_headers:
+            return c.response_headers
+    return {}
 
 
 async def upload_substream_blocks(

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/validation.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/validation.py
@@ -86,7 +86,7 @@ def combine_crc64(values: List[Tuple[int, int]]) -> int:
     from azure.storage.extensions import crc64
 
     if len(values) == 0:
-        raise ValueError("Must provide at elast one crc value.")
+        raise ValueError("Must provide at least one crc value.")
 
     crc = values[0][0]
     length = values[0][1]

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/validation.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/validation.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import hashlib
 from enum import Enum
-from typing import cast, Literal, Optional, Union
+from typing import cast, List, Literal, Optional, Tuple, Union
 
 from azure.core import CaseInsensitiveEnumMeta
 
@@ -75,3 +75,23 @@ def calculate_crc64_bytes(data: bytes) -> bytes:
     from azure.storage.extensions import crc64
 
     return cast(bytes, crc64.compute(data, 0).to_bytes(CRC64_LENGTH, 'little'))
+
+
+def get_crc64_bytes(crc: int) -> bytes:
+    return crc.to_bytes(CRC64_LENGTH, 'little')
+
+
+def combine_crc64(values: List[Tuple[int, int]]) -> int:
+    # Locally import to avoid error if not installed.
+    from azure.storage.extensions import crc64
+
+    if len(values) == 0:
+        raise ValueError("Must provide at elast one crc value.")
+
+    crc = values[0][0]
+    length = values[0][1]
+    for i in range(1, len(values)):
+        crc = crc64.concat(0, 0, crc, length, 0, values[i][0], values[i][1])
+        length += values[i][1]
+
+    return crc

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_file_client.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_file_client.py
@@ -89,7 +89,7 @@ def _upload_file_helper(
         if size == 0:
             return response
 
-        responses = upload_data_chunks(
+        return upload_data_chunks(
             service=client,
             uploader_class=FileChunkUploader,
             total_size=size,
@@ -101,7 +101,6 @@ def _upload_file_helper(
             timeout=timeout,
             **kwargs
         )
-        return sorted(responses, key=lambda r: r.get('last_modified'))[-1]
     except HttpResponseError as error:
         process_storage_error(error)
 

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/uploads.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/uploads.py
@@ -95,30 +95,6 @@ def _parallel_uploads(executor, uploader, pending, running):
     return chunks
 
 
-class ChunkInfo:
-    offset: int
-    length: int
-    md5: Optional[bytes] = None
-    crc64: Optional[int] = None
-    id: Optional[str] = None
-    """The id of the chunk. Only set if chunk needs to be committed."""
-    response_headers: Dict[str, Any] = {}
-    """The response headers from the upload chunk operation."""
-
-    def __init__(self, offset: int, data: bytes, checksum_algorithm: Optional[Union[bool, str]]):
-        self.offset = offset
-        self.length = len(data)
-
-        if checksum_algorithm == ChecksumAlgorithm.MD5:
-            self.md5 = calculate_md5(data)
-        if checksum_algorithm == ChecksumAlgorithm.CRC64:
-            self.crc64 = calculate_crc64(data, 0)
-
-    @property
-    def crc64_bytes(self) -> Optional[bytes]:
-        return get_crc64_bytes(self.crc64) if self.crc64 is not None else None
-
-
 def upload_data_chunks(
         service=None,
         uploader_class=None,
@@ -203,6 +179,30 @@ def upload_substream_blocks(
     if any(range_ids):
         return sorted(range_ids)
     return []
+
+
+class ChunkInfo:
+    offset: int
+    length: int
+    md5: Optional[bytes] = None
+    crc64: Optional[int] = None
+    id: Optional[str] = None
+    """The id of the chunk. Only set if chunk needs to be committed."""
+    response_headers: Dict[str, Any] = {}
+    """The response headers from the upload chunk operation."""
+
+    def __init__(self, offset: int, data: bytes, checksum_algorithm: Optional[Union[bool, str]]):
+        self.offset = offset
+        self.length = len(data)
+
+        if checksum_algorithm == ChecksumAlgorithm.MD5:
+            self.md5 = calculate_md5(data)
+        if checksum_algorithm == ChecksumAlgorithm.CRC64:
+            self.crc64 = calculate_crc64(data, 0)
+
+    @property
+    def crc64_bytes(self) -> Optional[bytes]:
+        return get_crc64_bytes(self.crc64) if self.crc64 is not None else None
 
 
 class _ChunkUploader(object):  # pylint: disable=too-many-instance-attributes

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/uploads.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/uploads.py
@@ -390,7 +390,7 @@ class PageBlobChunkUploader(_ChunkUploader):  # pylint: disable=abstract-method
 
     def _upload_chunk(self, data: bytes, chunk_info: ChunkInfo) -> ChunkInfo:
         # avoid uploading the empty pages
-        response_headers = None
+        response_headers = {}
         if not self._is_chunk_empty(data):
             chunk_end = chunk_info.offset + chunk_info.length - 1
             content_range = f"bytes={chunk_info.offset}-{chunk_end}"

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/uploads_async.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/uploads_async.py
@@ -110,8 +110,11 @@ async def upload_data_chunks(
     # If chunks have an id, return list of ids
     if chunks[0].id is not None:
         return [c.id for c in chunks]
-    # Else, return the last chunk's response headers
-    return chunks[-1].response_headers
+    # Else, return the response headers for the last chunk that had a response. (Page Blobs can have empty responses)
+    for c in reversed(chunks):
+        if c.response_headers:
+            return c.response_headers
+    return {}
 
 
 async def upload_substream_blocks(

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/validation.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/validation.py
@@ -86,7 +86,7 @@ def combine_crc64(values: List[Tuple[int, int]]) -> int:
     from azure.storage.extensions import crc64
 
     if len(values) == 0:
-        raise ValueError("Must provide at elast one crc value.")
+        raise ValueError("Must provide at least one crc value.")
 
     crc = values[0][0]
     length = values[0][1]

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/validation.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/validation.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import hashlib
 from enum import Enum
-from typing import cast, Literal, Optional, Union
+from typing import cast, List, Literal, Optional, Tuple, Union
 
 from azure.core import CaseInsensitiveEnumMeta
 
@@ -75,3 +75,23 @@ def calculate_crc64_bytes(data: bytes) -> bytes:
     from azure.storage.extensions import crc64
 
     return cast(bytes, crc64.compute(data, 0).to_bytes(CRC64_LENGTH, 'little'))
+
+
+def get_crc64_bytes(crc: int) -> bytes:
+    return crc.to_bytes(CRC64_LENGTH, 'little')
+
+
+def combine_crc64(values: List[Tuple[int, int]]) -> int:
+    # Locally import to avoid error if not installed.
+    from azure.storage.extensions import crc64
+
+    if len(values) == 0:
+        raise ValueError("Must provide at elast one crc value.")
+
+    crc = values[0][0]
+    length = values[0][1]
+    for i in range(1, len(values)):
+        crc = crc64.concat(0, 0, crc, length, 0, values[i][0], values[i][1])
+        length += values[i][1]
+
+    return crc

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/aio/_file_client_async.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/aio/_file_client_async.py
@@ -92,7 +92,7 @@ async def _upload_file_helper(
         if size == 0:
             return response
 
-        responses = await upload_data_chunks(
+        return await upload_data_chunks(
             service=client,
             uploader_class=FileChunkUploader,
             total_size=size,
@@ -104,7 +104,6 @@ async def _upload_file_helper(
             timeout=timeout,
             **kwargs
         )
-        return sorted(responses, key=lambda r: r.get('last_modified'))[-1]
     except HttpResponseError as error:
         process_storage_error(error)
 

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/uploads.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/uploads.py
@@ -95,30 +95,6 @@ def _parallel_uploads(executor, uploader, pending, running):
     return chunks
 
 
-class ChunkInfo:
-    offset: int
-    length: int
-    md5: Optional[bytes] = None
-    crc64: Optional[int] = None
-    id: Optional[str] = None
-    """The id of the chunk. Only set if chunk needs to be committed."""
-    response_headers: Dict[str, Any] = {}
-    """The response headers from the upload chunk operation."""
-
-    def __init__(self, offset: int, data: bytes, checksum_algorithm: Optional[Union[bool, str]]):
-        self.offset = offset
-        self.length = len(data)
-
-        if checksum_algorithm == ChecksumAlgorithm.MD5:
-            self.md5 = calculate_md5(data)
-        if checksum_algorithm == ChecksumAlgorithm.CRC64:
-            self.crc64 = calculate_crc64(data, 0)
-
-    @property
-    def crc64_bytes(self) -> Optional[bytes]:
-        return get_crc64_bytes(self.crc64) if self.crc64 is not None else None
-
-
 def upload_data_chunks(
         service=None,
         uploader_class=None,
@@ -203,6 +179,30 @@ def upload_substream_blocks(
     if any(range_ids):
         return sorted(range_ids)
     return []
+
+
+class ChunkInfo:
+    offset: int
+    length: int
+    md5: Optional[bytes] = None
+    crc64: Optional[int] = None
+    id: Optional[str] = None
+    """The id of the chunk. Only set if chunk needs to be committed."""
+    response_headers: Dict[str, Any] = {}
+    """The response headers from the upload chunk operation."""
+
+    def __init__(self, offset: int, data: bytes, checksum_algorithm: Optional[Union[bool, str]]):
+        self.offset = offset
+        self.length = len(data)
+
+        if checksum_algorithm == ChecksumAlgorithm.MD5:
+            self.md5 = calculate_md5(data)
+        if checksum_algorithm == ChecksumAlgorithm.CRC64:
+            self.crc64 = calculate_crc64(data, 0)
+
+    @property
+    def crc64_bytes(self) -> Optional[bytes]:
+        return get_crc64_bytes(self.crc64) if self.crc64 is not None else None
 
 
 class _ChunkUploader(object):  # pylint: disable=too-many-instance-attributes

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/uploads.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/uploads.py
@@ -390,7 +390,7 @@ class PageBlobChunkUploader(_ChunkUploader):  # pylint: disable=abstract-method
 
     def _upload_chunk(self, data: bytes, chunk_info: ChunkInfo) -> ChunkInfo:
         # avoid uploading the empty pages
-        response_headers = None
+        response_headers = {}
         if not self._is_chunk_empty(data):
             chunk_end = chunk_info.offset + chunk_info.length - 1
             content_range = f"bytes={chunk_info.offset}-{chunk_end}"

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/uploads_async.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/uploads_async.py
@@ -110,8 +110,11 @@ async def upload_data_chunks(
     # If chunks have an id, return list of ids
     if chunks[0].id is not None:
         return [c.id for c in chunks]
-    # Else, return the last chunk's response headers
-    return chunks[-1].response_headers
+    # Else, return the response headers for the last chunk that had a response. (Page Blobs can have empty responses)
+    for c in reversed(chunks):
+        if c.response_headers:
+            return c.response_headers
+    return {}
 
 
 async def upload_substream_blocks(

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/validation.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/validation.py
@@ -86,7 +86,7 @@ def combine_crc64(values: List[Tuple[int, int]]) -> int:
     from azure.storage.extensions import crc64
 
     if len(values) == 0:
-        raise ValueError("Must provide at elast one crc value.")
+        raise ValueError("Must provide at least one crc value.")
 
     crc = values[0][0]
     length = values[0][1]

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/validation.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/validation.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import hashlib
 from enum import Enum
-from typing import cast, Literal, Optional, Union
+from typing import cast, List, Literal, Optional, Tuple, Union
 
 from azure.core import CaseInsensitiveEnumMeta
 
@@ -75,3 +75,23 @@ def calculate_crc64_bytes(data: bytes) -> bytes:
     from azure.storage.extensions import crc64
 
     return cast(bytes, crc64.compute(data, 0).to_bytes(CRC64_LENGTH, 'little'))
+
+
+def get_crc64_bytes(crc: int) -> bytes:
+    return crc.to_bytes(CRC64_LENGTH, 'little')
+
+
+def combine_crc64(values: List[Tuple[int, int]]) -> int:
+    # Locally import to avoid error if not installed.
+    from azure.storage.extensions import crc64
+
+    if len(values) == 0:
+        raise ValueError("Must provide at elast one crc value.")
+
+    crc = values[0][0]
+    length = values[0][1]
+    for i in range(1, len(values)):
+        crc = crc64.concat(0, 0, crc, length, 0, values[i][0], values[i][1])
+        length += values[i][1]
+
+    return crc


### PR DESCRIPTION
This change adds the calculation and check for an overall, cumulative crc during partitioned upload for all packages. Basically, it maintains two things, an overall crc while reading from the input stream and the individual crcs for each chunk. Once all chunks are uploaded, the list of chunks is sorted and all the chunk crc values are concatenated together. This can then be compared to the overall crc from the input stream. This can potentially catch issues in the internal upload code with regards to chunk partitioning or ordering.

This required some refactoring to how information about the chunks are stored and returned. Some changes were to existing logic before content validation to make the logic common across different types of uploads. Also sprinkled in some type hints to make the file a little easier to work with/understand.