### PR TITLE
Do not publish to the nightly MSDocs branch if nightly PublishPackages fails

### DIFF
--- a/eng/pipelines/templates/stages/archetype-python-release.yml
+++ b/eng/pipelines/templates/stages/archetype-python-release.yml
@@ -327,7 +327,7 @@ stages:
 
       - job: PublishDocsToNightlyBranch
         dependsOn: PublishPackages
-        condition: or(eq(variables['SetDevVersion'], 'true'), and(eq(variables['Build.Reason'],'Schedule'), eq(variables['System.TeamProject'], 'internal')))
+        condition: and(succeeded(), or(eq(variables['SetDevVersion'], 'true'), and(eq(variables['Build.Reason'],'Schedule'), eq(variables['System.TeamProject'], 'internal'))))
         pool:
           image: azsdk-pool-mms-ubuntu-2004-1espt
           name: azsdk-pool-mms-ubuntu-2004-general


### PR DESCRIPTION
There was an issue with the nightly MSDocs build where it was trying to install a preview version of a library whose nightly publish to the dev feed had failed. As expected, this caused the nightly MSDocs build to fail. The nightly MSDocs publish step depends on nightly PublishPackages step but, for whatever reason, never checked if it succeeded. The MSDocs publish for an official release correctly checks if the publish succeeded.

NET, Java, JS and Python are all getting this same fix.

Testing was done by running [python - template](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4029272&view=results) with SetDevVersion set to True to produce a nightly release which succeeded.