### PR TITLE
Avoid package increment crash

### DIFF
--- a/eng/pipelines/templates/stages/archetype-python-release.yml
+++ b/eng/pipelines/templates/stages/archetype-python-release.yml
@@ -265,9 +265,15 @@ stages:
                       - script: |
                           python -m pip install "./tools/azure-sdk-tools[build]"
                         displayName: Install versioning tool dependencies
+
                       - pwsh: |
                           sdk_increment_version --package-name ${{ artifact.name }} --service ${{ parameters.ServiceDirectory }}
+                          if (Test-Path component-detection-pip-report.json) {
+                            Write-Host "Deleting component-detection-pip-report.json"
+                            rm component-detection-pip-report.json
+                          }
                         displayName: Increment package version
+
                       - template: /eng/common/pipelines/templates/steps/create-pull-request.yml
                         parameters:
                           RepoName: azure-sdk-for-python


### PR DESCRIPTION
[See example](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4033037&view=logs&j=3517b659-d3e8-545e-d9c6-aff172e087bb&t=42686c75-fc3b-5b85-fb33-e1e5e1db7daf&l=37)

This file is always getting introduced, so we can just clean it up.

On failing storage:
![image](https://github.com/user-attachments/assets/a3b35942-bf65-4ff9-8081-fe243905257e)

on a passing template:
![image](https://github.com/user-attachments/assets/aaac574c-fcee-4930-8637-a6b925ad19cf)