### PR TITLE
[Storage] [STG 95] Updated Test Share Paid Bursting

### DIFF
--- a/sdk/storage/azure-storage-file-share/tests/test_share.py
+++ b/sdk/storage/azure-storage-file-share/tests/test_share.py
@@ -1651,47 +1651,53 @@ class TestStorageShare(StorageRecordedTestCase):
         premium_storage_file_account_name = kwargs.pop("premium_storage_file_account_name")
         premium_storage_file_account_key = kwargs.pop("premium_storage_file_account_key")
 
-        # Arrange
-        self._setup(premium_storage_file_account_name, premium_storage_file_account_key)
-        mibps = 10340
-        iops = 102400
+        try:
+            # Arrange
+            self._setup(premium_storage_file_account_name, premium_storage_file_account_key)
+            mibps = 10340
+            iops = 102400
 
-        # Act / Assert
-        share = self._create_share(
-            paid_bursting_enabled=True,
-            paid_bursting_bandwidth_mibps=5000,
-            paid_bursting_iops=1000
-        )
-        share_props = share.get_share_properties()
-        assert share_props.paid_bursting_enabled
-        assert share_props.paid_bursting_bandwidth_mibps == 5000
-        assert share_props.paid_bursting_iops == 1000
+            # Act / Assert
+            share = self._create_share(
+                paid_bursting_enabled=True,
+                paid_bursting_bandwidth_mibps=5000,
+                paid_bursting_iops=1000
+            )
+            share_props = share.get_share_properties()
+            assert share_props.paid_bursting_enabled
+            assert share_props.paid_bursting_bandwidth_mibps == 5000
+            assert share_props.paid_bursting_iops == 1000
 
-        share.set_share_properties(
-            root_squash="NoRootSquash",
-            paid_bursting_enabled=True,
-            paid_bursting_bandwidth_mibps=mibps,
-            paid_bursting_iops=iops
-        )
-        share_props = share.get_share_properties()
-        share_name = share_props.name
-        assert share_props.paid_bursting_enabled
-        assert share_props.paid_bursting_bandwidth_mibps == mibps
-        assert share_props.paid_bursting_iops == iops
+            share.set_share_properties(
+                root_squash="NoRootSquash",
+                paid_bursting_enabled=True,
+                paid_bursting_bandwidth_mibps=mibps,
+                paid_bursting_iops=iops
+            )
+            share_props = share.get_share_properties()
+            share_name = share_props.name
+            assert share_props.paid_bursting_enabled
+            assert share_props.paid_bursting_bandwidth_mibps == mibps
+            assert share_props.paid_bursting_iops == iops
 
-        shares = list(self.fsc.list_shares())
-        assert shares is not None
-        assert len(shares) >= 1
-        for share in shares:
-            if share.name == share_name:
-                assert share is not None
-                assert share.paid_bursting_enabled
-                assert share.paid_bursting_bandwidth_mibps == mibps
-                assert share.paid_bursting_iops == iops
-                break
-            raise ValueError("Share with modified bursting values not found.")
+            shares = list(self.fsc.list_shares())
+            assert shares is not None
+            assert len(shares) >= 1
 
-        self._delete_shares()
+            share_exists = False
+            for share in shares:
+                if share.name == share_name:
+                    assert share is not None
+                    assert share.paid_bursting_enabled
+                    assert share.paid_bursting_bandwidth_mibps == mibps
+                    assert share.paid_bursting_iops == iops
+                    share_exists = True
+                    break
+
+            if not share_exists:
+                raise ValueError("Share with modified bursting values not found.")
+        finally:
+            self._delete_shares()
 
     @FileSharePreparer()
     @recorded_by_proxy

--- a/sdk/storage/azure-storage-file-share/tests/test_share_async.py
+++ b/sdk/storage/azure-storage-file-share/tests/test_share_async.py
@@ -1689,44 +1689,48 @@ class TestStorageShareAsync(AsyncStorageRecordedTestCase):
         premium_storage_file_account_key = kwargs.pop("premium_storage_file_account_key")
 
         # Arrange
-        self._setup(premium_storage_file_account_name, premium_storage_file_account_key)
-        mibps = 10340
-        iops = 102400
+        try:
+            self._setup(premium_storage_file_account_name, premium_storage_file_account_key)
+            mibps = 10340
+            iops = 102400
 
-        # Act / Assert
-        share = await self._create_share(
-            paid_bursting_enabled=True,
-            paid_bursting_bandwidth_mibps=5000,
-            paid_bursting_iops=1000
-        )
-        share_props = await share.get_share_properties()
-        share_name = share_props.name
-        assert share_props.paid_bursting_enabled
-        assert share_props.paid_bursting_bandwidth_mibps == 5000
-        assert share_props.paid_bursting_iops == 1000
+            # Act / Assert
+            share = await self._create_share(
+                paid_bursting_enabled=True,
+                paid_bursting_bandwidth_mibps=5000,
+                paid_bursting_iops=1000
+            )
+            share_props = await share.get_share_properties()
+            share_name = share_props.name
+            assert share_props.paid_bursting_enabled
+            assert share_props.paid_bursting_bandwidth_mibps == 5000
+            assert share_props.paid_bursting_iops == 1000
 
-        await share.set_share_properties(
-            root_squash="NoRootSquash",
-            paid_bursting_enabled=True,
-            paid_bursting_bandwidth_mibps=mibps,
-            paid_bursting_iops=iops
-        )
-        share_props = await share.get_share_properties()
-        assert share_props.paid_bursting_enabled
-        assert share_props.paid_bursting_bandwidth_mibps == mibps
-        assert share_props.paid_bursting_iops == iops
+            await share.set_share_properties(
+                root_squash="NoRootSquash",
+                paid_bursting_enabled=True,
+                paid_bursting_bandwidth_mibps=mibps,
+                paid_bursting_iops=iops
+            )
+            share_props = await share.get_share_properties()
+            assert share_props.paid_bursting_enabled
+            assert share_props.paid_bursting_bandwidth_mibps == mibps
+            assert share_props.paid_bursting_iops == iops
 
-        async for share in self.fsc.list_shares():
-            if share.name == share_name:
+            share_exists = False
+            async for share in self.fsc.list_shares():
+                if share.name == share_name:
+                    assert share is not None
+                    assert share.paid_bursting_enabled
+                    assert share.paid_bursting_bandwidth_mibps == mibps
+                    assert share.paid_bursting_iops == iops
+                    share_exists = True
+                    break
 
-                assert share is not None
-                assert share.paid_bursting_enabled
-                assert share.paid_bursting_bandwidth_mibps == mibps
-                assert share.paid_bursting_iops == iops
-                break
-            raise ValueError("Share with modified bursting values not found.")
-
-        await self._delete_shares()
+            if not share_exists:
+                raise ValueError("Share with modified bursting values not found.")
+        finally:
+            await self._delete_shares()
 
     @FileSharePreparer()
     @recorded_by_proxy_async


### PR DESCRIPTION
Updated `test_share_paid_bursting` for both sync and async to ensure tests clean up resources as well as enforce existence of the test share when calling the `list_shares` API.