### PR TITLE
[Cosmos] Changes to Support Transport + Further core usage

### DIFF
--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_retry_utility.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_retry_utility.py
@@ -101,6 +101,8 @@ def Execute(client, global_endpoint_manager, function, *args, **kwargs):
                 client.last_response_headers = {}
 
             # setting the throttle related response headers before returning the result
+            # values like this should be store in the PipelinContext object. 
+            # https://github.com/Azure/azure-sdk-for-python/blob/1e860019db1831bf28ec60551f525e2b529c8237/sdk/core/azure-core/azure/core/pipeline/__init__.py#L38
             client.last_response_headers[
                 HttpHeaders.ThrottleRetryCount
             ] = resourceThrottle_retry_policy.current_retry_attempt_count
@@ -169,6 +171,7 @@ def Execute(client, global_endpoint_manager, function, *args, **kwargs):
             # is the request. It needs to be modified for write forbidden exception
             if not retry_policy.ShouldRetry(e):
                 if not client.last_response_headers:
+                    # similar to the comment above, values like this should be store in the PipelinContext object.
                     client.last_response_headers = {}
                 client.last_response_headers[
                     HttpHeaders.ThrottleRetryCount

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/_synchronized_request.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/_synchronized_request.py
@@ -141,6 +141,7 @@ def _Request(global_endpoint_manager, request_params, connection_policy, pipelin
     response = response.http_response
     headers = copy.copy(response.headers)
 
+    # new response objects have a content property, which is equivalent to body()
     data = response.body()
     if data:
         data = data.decode("utf-8")

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_asynchronous_request.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_asynchronous_request.py
@@ -109,6 +109,7 @@ async def _Request(global_endpoint_manager, request_params, connection_policy, p
     response = response.http_response
     headers = copy.copy(response.headers)
 
+    # new response objects have a content property, which is equivalent to body()
     data = response.body()
     if data:
         data = data.decode("utf-8")

--- a/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_retry_utility_async.py
+++ b/sdk/cosmos/azure-cosmos/azure/cosmos/aio/_retry_utility_async.py
@@ -100,6 +100,8 @@ async def ExecuteAsync(client, global_endpoint_manager, function, *args, **kwarg
                 client.last_response_headers = {}
 
             # setting the throttle related response headers before returning the result
+
+            # move this in to PipelineContext
             client.last_response_headers[
                 HttpHeaders.ThrottleRetryCount
             ] = resourceThrottle_retry_policy.current_retry_attempt_count
@@ -169,6 +171,7 @@ async def ExecuteAsync(client, global_endpoint_manager, function, *args, **kwarg
             # throttle related response headers and re-throw the exception back arg[0]
             # is the request. It needs to be modified for write forbidden exception
             if not retry_policy.ShouldRetry(e):
+                # move this in to PipelineContext
                 if not client.last_response_headers:
                     client.last_response_headers = {}
                 client.last_response_headers[


### PR DESCRIPTION
These changes are needed in cosmos to support further transports that maybe written. 

* In the `_retry_utility_*.py` files the retry values should be stored in the `PipelineContext`. HTTP response headers should be read-only, so they should be left as is. Other libraries such as httpx require that header values are `[str,str]` and can raise errors, there even instances where aiohttp can return a header dict that cant be modified at all. 
  * Usage inside the `RetryPolicy` in core [here](https://github.com/Azure/azure-sdk-for-python/blob/1e860019db1831bf28ec60551f525e2b529c8237/sdk/core/azure-core/azure/core/pipeline/policies/_retry.py#L334) 
  * Usage inside Tables Policy [here](https://github.com/Azure/azure-sdk-for-python/blob/1e860019db1831bf28ec60551f525e2b529c8237/sdk/tables/azure-data-tables/azure/data/tables/aio/_policies_async.py#L109)
*  Newer response objects might not have body, so the equivalent `.content` should be used