### PR TITLE
[bct] move changelog delimiters to changelog tracker

### DIFF
--- a/scripts/breaking_changes_checker/changelog_tracker.py
+++ b/scripts/breaking_changes_checker/changelog_tracker.py
@@ -170,4 +170,6 @@ class ChangelogTracker(BreakingChangesTracker):
         if self.breaking_changes:
             _build_md(self.breaking_changes, "### Breaking Changes", buffer)
         content =  "\n".join(buffer).strip()
+
+        content = "===== changelog start =====\n" + content + "\n===== changelog end =====\n"
         return content

--- a/scripts/breaking_changes_checker/detect_breaking_changes.py
+++ b/scripts/breaking_changes_checker/detect_breaking_changes.py
@@ -321,9 +321,8 @@ def test_compare_reports(pkg_dir: str, changelog: bool, source_report: str = "st
 
     remove_json_files(pkg_dir)
 
-    print("===== changelog start =====")
     print(checker.report_changes())
-    print("===== changelog end =====")
+
     if not changelog and checker.breaking_changes:
         exit(1)
 


### PR DESCRIPTION
Only print the changelog delimiters around the changelog