### PR TITLE
[Storage] [Typing] [File Share] Typed `_shared_access_signature.py`

### DIFF
--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared_access_signature.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared_access_signature.py
@@ -14,7 +14,6 @@ from urllib.parse import parse_qs
 from ._shared import sign_string
 from ._shared.constants import X_MS_VERSION
 from ._shared.models import Services
-from ._shared.parser import _str
 from ._shared.shared_access_signature import QueryStringConstants, SharedAccessSignature, _SharedAccessHelper
 
 if TYPE_CHECKING:
@@ -131,9 +130,9 @@ class FileSharedAccessSignature(SharedAccessSignature):
         """
         resource_path = share_name
         if directory_name is not None:
-            resource_path += '/' + _str(directory_name)
+            resource_path += '/' + str(directory_name)
         if file_name is not None:
-            resource_path += '/' + _str(file_name)
+            resource_path += '/' + str(file_name)
 
         sas = _FileSharedAccessHelper()
         sas.add_base(permission, expiry, start, ip, protocol, self.x_ms_version)

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared_access_signature.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared_access_signature.py
@@ -14,62 +14,63 @@ from urllib.parse import parse_qs
 from ._shared import sign_string
 from ._shared.constants import X_MS_VERSION
 from ._shared.models import Services
-from ._shared.shared_access_signature import SharedAccessSignature, _SharedAccessHelper, QueryStringConstants
 from ._shared.parser import _str
+from ._shared.shared_access_signature import QueryStringConstants, SharedAccessSignature, _SharedAccessHelper
 
 if TYPE_CHECKING:
     from datetime import datetime
     from azure.storage.fileshare import (
-        ResourceTypes,
         AccountSasPermissions,
+        FileSasPermissions,
         ShareSasPermissions,
-        FileSasPermissions
+        ResourceTypes
     )
 
+
 class FileSharedAccessSignature(SharedAccessSignature):
-    '''
+    """
     Provides a factory for creating file and share access
     signature tokens with a common account name and account key.  Users can either
     use the factory or can construct the appropriate service and use the
     generate_*_shared_access_signature method directly.
-    '''
+    """
 
-    def __init__(self, account_name, account_key):
-        '''
+    def __init__(self, account_name: str, account_key: str) -> None:
+        """
         :param str account_name:
             The storage account name used to generate the shared access signatures.
         :param str account_key:
             The access key to generate the shares access signatures.
-        '''
+        """
         super(FileSharedAccessSignature, self).__init__(account_name, account_key, x_ms_version=X_MS_VERSION)
 
     def generate_file(
-        self, share_name,
-        directory_name=None,
-        file_name=None,
-        permission=None,
-        expiry=None,
-        start=None,
-        policy_id=None,
-        ip=None,
-        protocol=None,
-        cache_control=None,
-        content_disposition=None,
-        content_encoding=None,
-        content_language=None,
-        content_type=None,
-        sts_hook=None
-    ):
-        '''
+        self, share_name: str,
+        directory_name: Optional[str] = None,
+        file_name: Optional[str] = None,
+        permission: Optional[Union["FileSasPermissions", str]] = None,
+        expiry: Optional[Union["datetime", str]] = None,
+        start: Optional[Union["datetime", str]] = None,
+        policy_id: Optional[str] = None,
+        ip: Optional[str] = None,
+        protocol: Optional[str] = None,
+        cache_control: Optional[str] = None,
+        content_disposition: Optional[str] = None,
+        content_encoding: Optional[str] = None,
+        content_language: Optional[str] = None,
+        content_type: Optional[str] = None,
+        sts_hook: Optional[Callable[[str], None]] = None
+    ) -> str:
+        """
         Generates a shared access signature for the file.
         Use the returned signature with the sas_token parameter of FileService.
 
         :param str share_name:
             Name of share.
-        :param str directory_name:
+        :param Optional[str] directory_name:
             Name of directory. SAS tokens cannot be created for directories, so
             this parameter should only be present if file_name is provided.
-        :param str file_name:
+        :param Optional[str] file_name:
             Name of file.
         :param permission:
             The permissions associated with the shared access signature. The
@@ -78,7 +79,7 @@ class FileSharedAccessSignature(SharedAccessSignature):
             Required unless an id is given referencing a stored access policy
             which contains this field. This field must be omitted if it has been
             specified in an associated stored access policy.
-        :type permission: str or FileSasPermissions
+        :type permission: str or FileSasPermissions or None
         :param expiry:
             The time at which the shared access signature becomes invalid.
             Required unless an id is given referencing a stored access policy
@@ -86,39 +87,39 @@ class FileSharedAccessSignature(SharedAccessSignature):
             been specified in an associated stored access policy. Azure will always
             convert values to UTC. If a date is passed in without timezone info, it
             is assumed to be UTC.
-        :type expiry: datetime or str
+        :type expiry: ~datetime.datetime or str or None
         :param start:
             The time at which the shared access signature becomes valid. If
             omitted, start time for this call is assumed to be the time when the
             storage service receives the request. The provided datetime will always
             be interpreted as UTC.
-        :type start: datetime or str
-        :param str policy_id:
+        :type start: ~datetime.datetime or str or None
+        :param Optional[str] policy_id:
             A unique value up to 64 characters in length that correlates to a
             stored access policy. To create a stored access policy, use
             set_file_service_properties.
-        :param str ip:
+        :param Optional[str] ip:
             Specifies an IP address or a range of IP addresses from which to accept requests.
             If the IP address from which the request originates does not match the IP address
             or address range specified on the SAS token, the request is not authenticated.
             For example, specifying sip=168.1.5.65 or sip=168.1.5.60-168.1.5.70 on the SAS
             restricts the request to those IP addresses.
-        :param str protocol:
+        :param Optional[str] protocol:
             Specifies the protocol permitted for a request made. The default value
             is https,http. See :class:`~azure.storage.common.models.Protocol` for possible values.
-        :param str cache_control:
+        :param Optional[str] cache_control:
             Response header value for Cache-Control when resource is accessed
             using this shared access signature.
-        :param str content_disposition:
+        :param Optional[str] content_disposition:
             Response header value for Content-Disposition when resource is accessed
             using this shared access signature.
-        :param str content_encoding:
+        :param Optional[str] content_encoding:
             Response header value for Content-Encoding when resource is accessed
             using this shared access signature.
-        :param str content_language:
+        :param Optional[str] content_language:
             Response header value for Content-Language when resource is accessed
             using this shared access signature.
-        :param str content_type:
+        :param Optional[str] content_type:
             Response header value for Content-Type when resource is accessed
             using this shared access signature.
         :param sts_hook:
@@ -127,11 +128,12 @@ class FileSharedAccessSignature(SharedAccessSignature):
         :type sts_hook: Optional[Callable[[str], None]]
         :returns: The generated SAS token for the account.
         :rtype: str
-        '''
+        """
         resource_path = share_name
         if directory_name is not None:
-            resource_path += '/' + _str(directory_name) if directory_name is not None else None
-        resource_path += '/' + _str(file_name) if file_name is not None else None
+            resource_path += '/' + _str(directory_name)
+        if file_name is not None:
+            resource_path += '/' + _str(file_name)
 
         sas = _FileSharedAccessHelper()
         sas.add_base(permission, expiry, start, ip, protocol, self.x_ms_version)
@@ -148,20 +150,20 @@ class FileSharedAccessSignature(SharedAccessSignature):
         return sas.get_token()
 
     def generate_share(
-        self, share_name,
-        permission=None,
-        expiry=None,
-        start=None,
-        policy_id=None,
-        ip=None,
-        protocol=None,
-        cache_control=None,
-        content_disposition=None,
-        content_encoding=None,
-        content_language=None,
-        content_type=None,
-        sts_hook=None
-    ):
+        self, share_name: str,
+        permission: Optional[Union["ShareSasPermissions", str]] = None,
+        expiry: Optional[Union["datetime", str]] = None,
+        start: Optional[Union["datetime", str]] = None,
+        policy_id: Optional[str] = None,
+        ip: Optional[str] = None,
+        protocol: Optional[str] = None,
+        cache_control: Optional[str] = None,
+        content_disposition: Optional[str] = None,
+        content_encoding: Optional[str] = None,
+        content_language: Optional[str] = None,
+        content_type: Optional[str] = None,
+        sts_hook: Optional[Callable[[str], None]] = None,
+    ) -> str:
         '''
         Generates a shared access signature for the share.
         Use the returned signature with the sas_token parameter of FileService.
@@ -175,7 +177,7 @@ class FileSharedAccessSignature(SharedAccessSignature):
             Required unless an id is given referencing a stored access policy
             which contains this field. This field must be omitted if it has been
             specified in an associated stored access policy.
-        :type permission: str or ShareSasPermissions
+        :type permission: ~azure.storage.fileshare.ShareSasPermissions or str or None
         :param expiry:
             The time at which the shared access signature becomes invalid.
             Required unless an id is given referencing a stored access policy
@@ -183,39 +185,39 @@ class FileSharedAccessSignature(SharedAccessSignature):
             been specified in an associated stored access policy. Azure will always
             convert values to UTC. If a date is passed in without timezone info, it
             is assumed to be UTC.
-        :type expiry: datetime or str
+        :type expiry: ~datetime.datetime or str or None
         :param start:
             The time at which the shared access signature becomes valid. If
             omitted, start time for this call is assumed to be the time when the
             storage service receives the request. The provided datetime will always
             be interpreted as UTC.
-        :type start: datetime or str
-        :param str policy_id:
+        :type start: ~datetime.datetime or str or None
+        :param Optional[str] policy_id:
             A unique value up to 64 characters in length that correlates to a
             stored access policy. To create a stored access policy, use
             set_file_service_properties.
-        :param str ip:
+        :param Optional[str] ip:
             Specifies an IP address or a range of IP addresses from which to accept requests.
             If the IP address from which the request originates does not match the IP address
             or address range specified on the SAS token, the request is not authenticated.
             For example, specifying sip=168.1.5.65 or sip=168.1.5.60-168.1.5.70 on the SAS
             restricts the request to those IP addresses.
-        :param str protocol:
+        :param Optional[str] protocol:
             Specifies the protocol permitted for a request made. The default value
             is https,http. See :class:`~azure.storage.common.models.Protocol` for possible values.
-        :param str cache_control:
+        :param Optional[str] cache_control:
             Response header value for Cache-Control when resource is accessed
             using this shared access signature.
-        :param str content_disposition:
+        :param Optional[str] content_disposition:
             Response header value for Content-Disposition when resource is accessed
             using this shared access signature.
-        :param str content_encoding:
+        :param Optional[str] content_encoding:
             Response header value for Content-Encoding when resource is accessed
             using this shared access signature.
-        :param str content_language:
+        :param Optional[str] content_language:
             Response header value for Content-Language when resource is accessed
             using this shared access signature.
-        :param str content_type:
+        :param Optional[str] content_type:
             Response header value for Content-Type when resource is accessed
             using this shared access signature.
         :param sts_hook:
@@ -300,11 +302,13 @@ def generate_account_sas(
         The storage account name used to generate the shared access signature.
     :param str account_key:
         The account key, also called shared key or access key, to generate the shared access signature.
-    :param ~azure.storage.fileshare.ResourceTypes resource_types:
+    :param resource_types:
         Specifies the resource types that are accessible with the account SAS.
-    :param ~azure.storage.fileshare.AccountSasPermissions permission:
+    :type resource_types: ~azure.storage.fileshare.ResourceTypes or str
+    :param permission:
         The permissions associated with the shared access signature. The
         user is restricted to operations allowed by the permissions.
+    :type permission: ~azure.storage.fileshare.AccountSasPermissions or str
     :param expiry:
         The time at which the shared access signature becomes invalid.
         The provided datetime will always be interpreted as UTC.
@@ -314,7 +318,7 @@ def generate_account_sas(
         omitted, start time for this call is assumed to be the time when the
         storage service receives the request. The provided datetime will always
         be interpreted as UTC.
-    :type start: ~datetime.datetime or str
+    :type start: ~datetime.datetime or str or None
     :param str ip:
         Specifies an IP address or a range of IP addresses from which to accept requests.
         If the IP address from which the request originates does not match the IP address
@@ -352,22 +356,22 @@ def generate_account_sas(
         ip=ip,
         sts_hook=sts_hook,
         **kwargs
-    ) # type: ignore
+    )
 
 
 def generate_share_sas(
-    account_name,  # type: str
-    share_name,  # type: str
-    account_key,  # type: str
-    permission=None,  # type: Optional[Union[ShareSasPermissions, str]]
-    expiry=None,  # type: Optional[Union[datetime, str]]
-    start=None,  # type: Optional[Union[datetime, str]]
-    policy_id=None,  # type: Optional[str]
-    ip=None,  # type: Optional[str]
+    account_name: str,
+    share_name: str,
+    account_key: str,
+    permission: Optional[Union["ShareSasPermissions", str]] = None,
+    expiry: Optional[Union["datetime", str]] = None,
+    start: Optional[Union["datetime", str]] = None,
+    policy_id: Optional[str] = None,
+    ip: Optional[str] = None,
     *,
-    sts_hook=None,  # Optional[Callable[[str], None]]
-    **kwargs # type: Any
-):  # type: (...) -> str
+    sts_hook: Optional[Callable[[str], None]] = None,
+    **kwargs: Any
+) -> str:
     """Generates a shared access signature for a share.
 
     Use the returned signature with the credential parameter of any ShareServiceClient,
@@ -386,7 +390,7 @@ def generate_share_sas(
         Required unless an id is given referencing a stored access policy
         which contains this field. This field must be omitted if it has been
         specified in an associated stored access policy.
-    :type permission: str or ~azure.storage.fileshare.ShareSasPermissions
+    :type permission: ~azure.storage.fileshare.ShareSasPermissions or str or None
     :param expiry:
         The time at which the shared access signature becomes invalid.
         Required unless an id is given referencing a stored access policy
@@ -394,18 +398,18 @@ def generate_share_sas(
         been specified in an associated stored access policy. Azure will always
         convert values to UTC. If a date is passed in without timezone info, it
         is assumed to be UTC.
-    :type expiry: ~datetime.datetime or str
+    :type expiry: ~datetime.datetime or str or None
     :param start:
         The time at which the shared access signature becomes valid. If
         omitted, start time for this call is assumed to be the time when the
         storage service receives the request. The provided datetime will always
         be interpreted as UTC.
-    :type start: ~datetime.datetime or str
-    :param str policy_id:
+    :type start: ~datetime.datetime or str or None
+    :param Optional[str] policy_id:
         A unique value up to 64 characters in length that correlates to a
         stored access policy. To create a stored access policy, use
         :func:`~azure.storage.fileshare.ShareClient.set_share_access_policy`.
-    :param str ip:
+    :param Optional[str] ip:
         Specifies an IP address or a range of IP addresses from which to accept requests.
         If the IP address from which the request originates does not match the IP address
         or address range specified on the SAS token, the request is not authenticated.
@@ -454,20 +458,19 @@ def generate_share_sas(
 
 
 def generate_file_sas(
-    account_name,  # type: str
-    share_name,  # type: str
-    file_path,  # type: List[str]
-    account_key,  # type: str
-    permission=None,  # type: Optional[Union[FileSasPermissions, str]]
-    expiry=None,  # type: Optional[Union[datetime, str]]
-    start=None,  # type: Optional[Union[datetime, str]]
-    policy_id=None,  # type: Optional[str]
-    ip=None,  # type: Optional[str]
+    account_name: str,
+    share_name: str,
+    file_path: List[str],
+    account_key: str,
+    permission: Optional[Union["FileSasPermissions", str]] = None,
+    expiry: Optional[Union["datetime", str]] = None,
+    start: Optional[Union["datetime", str]] = None,
+    policy_id: Optional[str] = None,
+    ip: Optional[str] = None,
     *,
-    sts_hook=None,  # type: Optional[Callable[[str], None]]
-    **kwargs # type: Any
-):
-    # type: (...) -> str
+    sts_hook: Optional[Callable[[str], None]] = None,
+    **kwargs: Any
+) -> str:
     """Generates a shared access signature for a file.
 
     Use the returned signature with the credential parameter of any ShareServiceClient,
@@ -489,7 +492,7 @@ def generate_file_sas(
         Required unless an id is given referencing a stored access policy
         which contains this field. This field must be omitted if it has been
         specified in an associated stored access policy.
-    :type permission: str or ~azure.storage.fileshare.FileSasPermissions
+    :type permission: ~azure.storage.fileshare.FileSasPermissions or str or None
     :param expiry:
         The time at which the shared access signature becomes invalid.
         Required unless an id is given referencing a stored access policy
@@ -497,17 +500,17 @@ def generate_file_sas(
         been specified in an associated stored access policy. Azure will always
         convert values to UTC. If a date is passed in without timezone info, it
         is assumed to be UTC.
-    :type expiry: ~datetime.datetime or str
+    :type expiry: ~datetime.datetime or str or None
     :param start:
         The time at which the shared access signature becomes valid. If
         omitted, start time for this call is assumed to be the time when the
         storage service receives the request. The provided datetime will always
         be interpreted as UTC.
-    :type start: ~datetime.datetime or str
-    :param str policy_id:
+    :type start: ~datetime.datetime or str or None
+    :param Optional[str] policy_id:
         A unique value up to 64 characters in length that correlates to a
         stored access policy.
-    :param str ip:
+    :param Optional[str] ip:
         Specifies an IP address or a range of IP addresses from which to accept requests.
         If the IP address from which the request originates does not match the IP address
         or address range specified on the SAS token, the request is not authenticated.
@@ -546,8 +549,8 @@ def generate_file_sas(
     if len(file_path) > 1:
         dir_path = '/'.join(file_path[:-1])
     else:
-        dir_path = None # type: ignore
-    return sas.generate_file( # type: ignore
+        dir_path = None
+    return sas.generate_file(
         share_name=share_name,
         directory_name=dir_path,
         file_name=file_path[-1],
@@ -559,6 +562,7 @@ def generate_file_sas(
         sts_hook=sts_hook,
         **kwargs
     )
+
 
 def _is_credential_sastoken(credential: Any) -> bool:
     if not credential or not isinstance(credential, str):


### PR DESCRIPTION
As usual, this typing PR includes:

- Reordering of imports
- Updated docstring type annotations to match current style
- Typed function parameters and return types
- Removed unnecessary `# type: ignore` statements

:shipit: 