### PR TITLE
Keep only those artifacts that are ready for release

### DIFF
--- a/sdk/maps/ci.yml
+++ b/sdk/maps/ci.yml
@@ -29,13 +29,7 @@ extends:
     ServiceDirectory: maps
     TestProxy: true
     Artifacts:
-    - name: azure-mgmt-maps
-      safeName: azuremgmtmaps
     - name: azure-maps-search
       safeName: azuremapssearch
-    - name: azure-maps-geolocation
-      safeName: azuremapsgeolocation
     - name: azure-maps-render
       safeName: azuremapsrender
-    - name: azure-maps-route
-      safeName: azuremapsroute


### PR DESCRIPTION
Build keeps failing, and we want to build only those artifacts we're planning to release.

Link to the failed builds: https://dev.azure.com/azure-sdk/internal/_build?definitionId=1010&_a=summary 