### PR TITLE
[Storage] [Typing] [File Share] `_deserialize.py`

### DIFF
--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_deserialize.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_deserialize.py
@@ -4,16 +4,20 @@
 # license information.
 # --------------------------------------------------------------------------_
 from typing import (  # pylint: disable=unused-import
-    Tuple, Dict, List,
+    Any, Dict, List, Optional, Tuple,
     TYPE_CHECKING
 )
 
-from ._models import ShareProperties, DirectoryProperties, FileProperties
-from ._shared.response_handlers import deserialize_metadata
 from ._generated.models import ShareFileRangeList
+from ._models import DirectoryProperties, FileProperties, ShareProperties
+from ._shared.response_handlers import deserialize_metadata
+
+if TYPE_CHECKING:
+    from azure.core.pipeline import PipelineResponse
+    from ._shared.models import LocationMode
 
 
-def deserialize_share_properties(response, obj, headers):
+def deserialize_share_properties(response: "PipelineResponse", obj: Any, headers: Dict[str, Any]) -> ShareProperties:
     metadata = deserialize_metadata(response, obj, headers)
     share_properties = ShareProperties(
         metadata=metadata,
@@ -22,7 +26,11 @@ def deserialize_share_properties(response, obj, headers):
     return share_properties
 
 
-def deserialize_directory_properties(response, obj, headers):
+def deserialize_directory_properties(
+    response: "PipelineResponse",
+    obj: Any,
+    headers: Dict[str, Any]
+) -> DirectoryProperties:
     metadata = deserialize_metadata(response, obj, headers)
     directory_properties = DirectoryProperties(
         metadata=metadata,
@@ -31,7 +39,7 @@ def deserialize_directory_properties(response, obj, headers):
     return directory_properties
 
 
-def deserialize_file_properties(response, obj, headers):
+def deserialize_file_properties(response: "PipelineResponse", obj: Any, headers: Dict[str, Any]) -> FileProperties:
     metadata = deserialize_metadata(response, obj, headers)
     file_properties = FileProperties(
         metadata=metadata,
@@ -45,31 +53,33 @@ def deserialize_file_properties(response, obj, headers):
     return file_properties
 
 
-def deserialize_file_stream(response, obj, headers):
+def deserialize_file_stream(
+    response: "PipelineResponse",
+    obj: Any,
+    headers: Dict[str, Any]
+) -> Tuple["LocationMode", Any]:
     file_properties = deserialize_file_properties(response, obj, headers)
     obj.properties = file_properties
     return response.http_response.location_mode, obj
 
 
 # Extracts out file permission
-def deserialize_permission(response, obj, headers):  # pylint: disable=unused-argument
+def deserialize_permission(response: "PipelineResponse", obj: Any, headers: Dict[str, Any]) -> Optional[str]:  # pylint: disable=unused-argument
     return obj.permission
 
+
 # Extracts out file permission key
-def deserialize_permission_key(response, obj, headers):  # pylint: disable=unused-argument
+def deserialize_permission_key(response: "PipelineResponse", obj: Any, headers: Dict[str, Any]) -> Optional[str]:  # pylint: disable=unused-argument
     if response is None or headers is None:
         return None
     return headers.get('x-ms-file-permission-key', None)
 
 
-def get_file_ranges_result(ranges):
-    # type: (ShareFileRangeList) -> Tuple[List[Dict[str, int]], List[Dict[str, int]]]
-    file_ranges = []  # type: ignore
-    clear_ranges = []  # type: List
+def get_file_ranges_result(ranges: ShareFileRangeList) -> Tuple[List[Dict[str, int]], List[Dict[str, int]]]:
+    file_ranges = []
+    clear_ranges = []
     if ranges.ranges:
-        file_ranges = [
-            {'start': file_range.start, 'end': file_range.end} for file_range in ranges.ranges]  # type: ignore
+        file_ranges = [{'start': file_range.start, 'end': file_range.end} for file_range in ranges.ranges]
     if ranges.clear_ranges:
-        clear_ranges = [
-            {'start': clear_range.start, 'end': clear_range.end} for clear_range in ranges.clear_ranges]
+        clear_ranges = [{'start': clear_range.start, 'end': clear_range.end} for clear_range in ranges.clear_ranges]
     return file_ranges, clear_ranges


### PR DESCRIPTION
Typed deserialize file utility functions. There are two functions that need some revisiting:

- `deserialize_permission`: the return type is technically a `str` (can this be `None`?). Only the `obj` parameter is used, and its type is `Any`. `mypy` cannot deduce an object of `Any` type that may or may not contain `permission` with the type `str`.
- `deserialize_permission_key`: the return type is technically an `Optional[str]` since the branching creates a possible `None` return value. Here, both `response` and `headers` are used. `headers` has a type of `Dict[str, Any]`, and we like to pull out `x-ms-file-permission-key`'s value, which hopefully should be a `str`. Again, `mypy` can't deduce `str` from `Any` from its type-checking rules.

Would appreciate some suggestions here. It seems like both are really only used from `_share_client.py` and async.