### PR TITLE
Update _patch.py related to endpoint KeyError

### DIFF
--- a/sdk/webpubsub/azure-messaging-webpubsubservice/azure/messaging/webpubsubservice/_operations/_patch.py
+++ b/sdk/webpubsub/azure-messaging-webpubsubservice/azure/messaging/webpubsubservice/_operations/_patch.py
@@ -637,7 +637,7 @@ class WebPubSubServiceClientOperationsMixin(WebPubSubServiceClientOperationsMixi
             params=_params,
         )
         path_format_arguments = {
-            "Endpoint": self._serialize.url("self._config.endpoint", self._config.endpoint, "str", skip_quote=True),
+            "endpoint": self._serialize.url("self._config.endpoint", self._config.endpoint, "str", skip_quote=True),
         }
         request.url = self._client.format_url(request.url, **path_format_arguments)  # type: ignore
 


### PR DESCRIPTION
Fix endpoint KeyError.

The value provided for the url part endpoint was incorrect, and resulted in an invalid url
Traceback (most recent call last):
  File "/usr/local/lib/python3.12/site-packages/azure/core/pipeline/transport/_base.py", line 664, in format_url
    base = self._base_url.format(**kwargs).rstrip("/")
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
KeyError: 'endpoint'