### PR TITLE
Add pylint checker for connection_verify hardcoded settings

### DIFF
--- a/eng/pylintrc
+++ b/eng/pylintrc
@@ -10,7 +10,7 @@ ignore-paths=
     # Exclude any path that contains the following directory names
     (?:.*[/\\]|^)(?:_vendor|_generated|_restclient|samples|examples|test|tests|doc|\.tox)(?:[/\\]|$)
 
-load-plugins=pylint_guidelines_checker
+load-plugins=pylint_guidelines_checker,connection_verify_hardcoded
 
 [MESSAGES CONTROL]
 # For all codes, run 'pylint --list-msgs' or go to 'https://pylint.pycqa.org/en/latest/technical_reference/features.html'
@@ -23,7 +23,7 @@ load-plugins=pylint_guidelines_checker
 disable=useless-object-inheritance,missing-docstring,locally-disabled,fixme,cyclic-import,too-many-arguments,invalid-name,duplicate-code,too-few-public-methods,consider-using-f-string,super-with-arguments,redefined-builtin,import-outside-toplevel,client-suffix-needed,unnecessary-dunder-call,unnecessary-ellipsis,client-paging-methods-use-list,consider-using-max-builtin
 
 # Add enable for useless disables
-enable=useless-suppression
+enable=useless-suppression,connection_verify_hardcoded
 
 
 [FORMAT]

--- a/eng/tox/run_pylint.py
+++ b/eng/tox/run_pylint.py
@@ -65,6 +65,7 @@ if __name__ == "__main__":
                 "pylint",
                 "--rcfile={}".format(rcFileLocation),
                 "--output-format=parseable",
+                "--load-plugins=pylint_guidelines_checker.connection_verify_hardcoded",
                 os.path.join(args.target_package, top_level_module),
             ]
         )

--- a/pylint_guidelines_checker/connection_verify_hardcoded.py
+++ b/pylint_guidelines_checker/connection_verify_hardcoded.py
@@ -1,0 +1,24 @@
+from pylint.checkers import BaseChecker
+from pylint.interfaces import IAstroidChecker
+
+class ConnectionVerifyHardcodedChecker(BaseChecker):
+    __implements__ = IAstroidChecker
+
+    name = 'connection_verify_hardcoded'
+    priority = -1
+    msgs = {
+        'C9999': (
+            'Avoid hardcoding connection_verify to a boolean value',
+            'connection-verify-hardcoded',
+            'Ensure connection_verify is not hardcoded to a boolean value',
+        ),
+    }
+    options = ()
+
+    def visit_assign(self, node):
+        if isinstance(node.targets[0], astroid.AssignName) and node.targets[0].name == 'connection_verify':
+            if isinstance(node.value, astroid.Const) and isinstance(node.value.value, bool):
+                self.add_message('connection-verify-hardcoded', node=node)
+
+def register(linter):
+    linter.register_checker(ConnectionVerifyHardcodedChecker(linter))

--- a/sdk/core/azure-core/README.md
+++ b/sdk/core/azure-core/README.md
@@ -1,4 +1,3 @@
-
 # Azure Core shared client library for Python
 
 Azure core provides shared exceptions and modules for Python SDK client libraries.
@@ -228,6 +227,10 @@ foo = Foo(
     attr=NULL
 )
 ```
+
+### Pylint Check for `connection_verify` Hardcoded Settings
+
+A custom pylint checker has been added to ensure that the `connection_verify` setting is not hardcoded to a boolean value. This check helps to ensure that the `connection_verify` setting can be adjusted by the user and is not fixed to a specific value in the code.
 
 ## Contributing
 

--- a/sdk/core/azure-core/azure/core/configuration.py
+++ b/sdk/core/azure-core/azure/core/configuration.py
@@ -146,3 +146,5 @@ class ConnectionConfiguration:
         self.verify = connection_verify
         self.cert = connection_cert
         self.data_block_size = connection_data_block_size
+        # Ensure connection_verify is not hardcoded to a boolean value
+        # pylint: disable=connection_verify_hardcoded


### PR DESCRIPTION
Related to #35355

Add a custom pylint checker to ensure `connection_verify` is not hardcoded to a boolean value.
