### PR TITLE
[Storage] Update for structured message support

### DIFF
--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/policies.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/policies.py
@@ -37,7 +37,10 @@ from .models import LocationMode
 
 if TYPE_CHECKING:
     from azure.core.credentials import TokenCredential
-    from azure.core.pipeline import PipelineRequest, PipelineResponse
+    from azure.core.pipeline.transport import (  # pylint: disable=non-abstract-transport-import
+        PipelineRequest,
+        PipelineResponse
+    )
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -132,8 +135,8 @@ class StorageHeadersPolicy(HeadersPolicy):
                 'x-ms-structured-body' not in response.http_response.headers and is_success):
             raise ValueError("Response did not acknowledge structured body. "
                              "Unexpected data may have been persisted to storage.")
-        elif ('x-ms-structured-body' in request.http_request.headers and
-              'x-ms-structured-body' not in response.http_response.headers and is_success):
+        if ('x-ms-structured-body' in request.http_request.headers and
+                'x-ms-structured-body' not in response.http_response.headers and is_success):
             raise ValueError("Response did not acknowledge structured body. Unknown structure in response body.")
 
     # # raise exception if the echoed client request id from the service is not identical to the one we sent

--- a/sdk/storage/azure-storage-blob/tests/test_streams.py
+++ b/sdk/storage/azure-storage-blob/tests/test_streams.py
@@ -16,7 +16,6 @@ from azure.storage.blob._shared.streams import (
     StructuredMessageConstants,
     StructuredMessageDecodeStream,
     StructuredMessageEncodeStream,
-    StructuredMessageError,
     StructuredMessageProperties,
 )
 from azure.storage.extensions import crc64
@@ -510,7 +509,7 @@ class TestStructuredMessageDecodeStream:
             invalid_segment)
 
         stream = StructuredMessageDecodeStream(message_stream, length)
-        with pytest.raises(StructuredMessageError) as e:
+        with pytest.raises(ValueError) as e:
             stream.read()
         assert 'CRC64 mismatch' in str(e.value)
 
@@ -526,7 +525,7 @@ class TestStructuredMessageDecodeStream:
         stream = StructuredMessageDecodeStream(message_stream, length)
         # Since we only check CRC on segment borders, some reads will succeed, but we test
         # to ensure eventually the stream reading will error out.
-        with pytest.raises(StructuredMessageError) as e:
+        with pytest.raises(ValueError) as e:
             read = 0
             while read < len(data):
                 stream.read(512)
@@ -543,7 +542,7 @@ class TestStructuredMessageDecodeStream:
         message_stream.seek(0)
 
         stream = StructuredMessageDecodeStream(message_stream, length)
-        with pytest.raises(StructuredMessageError):
+        with pytest.raises(ValueError):
             stream.read()
 
     @pytest.mark.parametrize("message_length", [100, 1234567])  # Correct value: 1057
@@ -557,7 +556,7 @@ class TestStructuredMessageDecodeStream:
         message_stream.seek(0)
 
         stream = StructuredMessageDecodeStream(message_stream, length)
-        with pytest.raises(StructuredMessageError):
+        with pytest.raises(ValueError):
             stream.read()
 
     @pytest.mark.parametrize("segment_count", [2, 123])  # Correct value: 4
@@ -571,7 +570,7 @@ class TestStructuredMessageDecodeStream:
         message_stream.seek(0)
 
         stream = StructuredMessageDecodeStream(message_stream, length)
-        with pytest.raises(StructuredMessageError):
+        with pytest.raises(ValueError):
             stream.read()
 
     @pytest.mark.parametrize("segment_number", [1, 123])  # Correct value: 2
@@ -590,7 +589,7 @@ class TestStructuredMessageDecodeStream:
         message_stream.seek(0)
 
         stream = StructuredMessageDecodeStream(message_stream, length)
-        with pytest.raises(StructuredMessageError):
+        with pytest.raises(ValueError):
             stream.read()
 
     @pytest.mark.parametrize("segment_size", [123, 345])  # Correct value: 256
@@ -610,7 +609,7 @@ class TestStructuredMessageDecodeStream:
         message_stream.seek(0)
 
         stream = StructuredMessageDecodeStream(message_stream, length)
-        with pytest.raises(StructuredMessageError):
+        with pytest.raises(ValueError):
             stream.read()
 
     @pytest.mark.parametrize("segment_size", [123, 345])  # Correct value: 256
@@ -624,7 +623,7 @@ class TestStructuredMessageDecodeStream:
         message_stream.seek(0)
 
         stream = StructuredMessageDecodeStream(message_stream, length)
-        with pytest.raises(StructuredMessageError):
+        with pytest.raises(ValueError):
             stream.read()
 
 

--- a/sdk/storage/azure-storage-blob/tests/test_streams_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_streams_async.py
@@ -11,7 +11,6 @@ from io import BytesIO
 import pytest
 from azure.storage.blob._shared.streams import (
     StructuredMessageConstants,
-    StructuredMessageError,
     StructuredMessageProperties,
 )
 from azure.storage.blob._shared.streams_async import AsyncIterStreamer, StructuredMessageDecodeStream
@@ -135,7 +134,7 @@ class TestStructuredMessageDecodeStreamAsync:
             invalid_segment)
 
         stream = StructuredMessageDecodeStream(message_stream, length)
-        with pytest.raises(StructuredMessageError) as e:
+        with pytest.raises(ValueError) as e:
             await stream.read()
         assert 'CRC64 mismatch' in str(e.value)
 
@@ -151,7 +150,7 @@ class TestStructuredMessageDecodeStreamAsync:
         stream = StructuredMessageDecodeStream(message_stream, length)
         # Since we only check CRC on segment borders, some reads will succeed, but we test
         # to ensure eventually the stream reading will error out.
-        with pytest.raises(StructuredMessageError) as e:
+        with pytest.raises(ValueError) as e:
             read = 0
             while read < len(data):
                 await stream.read(512)
@@ -168,7 +167,7 @@ class TestStructuredMessageDecodeStreamAsync:
         message_stream.seek(0)
 
         stream = StructuredMessageDecodeStream(message_stream, length)
-        with pytest.raises(StructuredMessageError):
+        with pytest.raises(ValueError):
             await stream.read()
 
     @pytest.mark.parametrize("message_length", [100, 1234567])  # Correct value: 1057
@@ -182,7 +181,7 @@ class TestStructuredMessageDecodeStreamAsync:
         message_stream.seek(0)
 
         stream = StructuredMessageDecodeStream(message_stream, length)
-        with pytest.raises(StructuredMessageError):
+        with pytest.raises(ValueError):
             await stream.read()
 
     @pytest.mark.parametrize("segment_count", [2, 123])  # Correct value: 4
@@ -196,7 +195,7 @@ class TestStructuredMessageDecodeStreamAsync:
         message_stream.seek(0)
 
         stream = StructuredMessageDecodeStream(message_stream, length)
-        with pytest.raises(StructuredMessageError):
+        with pytest.raises(ValueError):
             await stream.read()
 
     @pytest.mark.parametrize("segment_number", [1, 123])  # Correct value: 2
@@ -215,7 +214,7 @@ class TestStructuredMessageDecodeStreamAsync:
         message_stream.seek(0)
 
         stream = StructuredMessageDecodeStream(message_stream, length)
-        with pytest.raises(StructuredMessageError):
+        with pytest.raises(ValueError):
             await stream.read()
 
     @pytest.mark.parametrize("segment_size", [123, 345])  # Correct value: 256
@@ -235,7 +234,7 @@ class TestStructuredMessageDecodeStreamAsync:
         message_stream.seek(0)
 
         stream = StructuredMessageDecodeStream(message_stream, length)
-        with pytest.raises(StructuredMessageError):
+        with pytest.raises(ValueError):
             await stream.read()
 
     @pytest.mark.parametrize("segment_size", [123, 345])  # Correct value: 256
@@ -249,7 +248,7 @@ class TestStructuredMessageDecodeStreamAsync:
         message_stream.seek(0)
 
         stream = StructuredMessageDecodeStream(message_stream, length)
-        with pytest.raises(StructuredMessageError):
+        with pytest.raises(ValueError):
             await stream.read()
 
     @pytest.mark.parametrize("flags", [StructuredMessageProperties.NONE, StructuredMessageProperties.CRC64])

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/policies.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/policies.py
@@ -35,24 +35,16 @@ from .authentication import AzureSigningError, StorageHttpChallenge
 from .constants import DEFAULT_OAUTH_SCOPE
 from .models import LocationMode
 
-try:
-    _unicode_type = unicode # type: ignore
-except NameError:
-    _unicode_type = str
-
 if TYPE_CHECKING:
     from azure.core.credentials import TokenCredential
-    from azure.core.pipeline import (  # pylint: disable=non-abstract-transport-import
-        PipelineRequest,
-        PipelineResponse
-    )
+    from azure.core.pipeline import PipelineRequest, PipelineResponse
 
 
 _LOGGER = logging.getLogger(__name__)
 
 
 def encode_base64(data):
-    if isinstance(data, _unicode_type):
+    if isinstance(data, str):
         data = data.encode('utf-8')
     encoded = base64.b64encode(data)
     return encoded.decode('utf-8')
@@ -96,7 +88,8 @@ def is_retry(response, mode):   # pylint: disable=too-many-return-statements
             return False
         return True
     # retry if invalid content md5
-    if response.context.get('validate_content', False) and response.http_response.headers.get('content-md5'):
+    validate_content = response.context.get('validate_content', None)
+    if validate_content is True and response.http_response.headers.get('content-md5'):
         computed_md5 = response.http_request.headers.get('content-md5', None) or \
                        encode_base64(StorageContentValidation.get_content_md5(response.http_response.body()))
         if response.http_response.headers['content-md5'] != computed_md5:
@@ -131,20 +124,31 @@ class StorageHeadersPolicy(HeadersPolicy):
         custom_id = request.context.options.pop('client_request_id', None)
         request.http_request.headers['x-ms-client-request-id'] = custom_id or str(uuid.uuid1())
 
-    # def on_response(self, request, response):
-    #     # raise exception if the echoed client request id from the service is not identical to the one we sent
-    #     if self.request_id_header_name in response.http_response.headers:
+    def on_response(self, request: "PipelineRequest", response: "PipelineResponse") -> None:
+        is_success = response.http_response.status_code < 300
+        # Validate structured body PUT/GET requests
+        if ('x-ms-structured-body' in request.http_request.headers and
+                'x-ms-structured-content-length' in request.http_request.headers and
+                'x-ms-structured-body' not in response.http_response.headers and is_success):
+            raise ValueError("Response did not acknowledge structured body. "
+                             "Unexpected data may have been persisted to storage.")
+        elif ('x-ms-structured-body' in request.http_request.headers and
+              'x-ms-structured-body' not in response.http_response.headers and is_success):
+            raise ValueError("Response did not acknowledge structured body. Unknown structure in response body.")
 
-    #         client_request_id = request.http_request.headers.get(self.request_id_header_name)
-
-    #         if response.http_response.headers[self.request_id_header_name] != client_request_id:
-    #             raise AzureError(
-    #                 "Echoed client request ID: {} does not match sent client request ID: {}.  "
-    #                 "Service request ID: {}".format(
-    #                     response.http_response.headers[self.request_id_header_name], client_request_id,
-    #                     response.http_response.headers['x-ms-request-id']),
-    #                 response=response.http_response
-    #             )
+    # # raise exception if the echoed client request id from the service is not identical to the one we sent
+    # if self.request_id_header_name in response.http_response.headers:
+    #
+    #     client_request_id = request.http_request.headers.get(self.request_id_header_name)
+    #
+    #     if response.http_response.headers[self.request_id_header_name] != client_request_id:
+    #         raise AzureError(
+    #             "Echoed client request ID: {} does not match sent client request ID: {}.  "
+    #             "Service request ID: {}".format(
+    #                 response.http_response.headers[self.request_id_header_name], client_request_id,
+    #                 response.http_response.headers['x-ms-request-id']),
+    #             response=response.http_response
+    #         )
 
 
 class StorageHosts(SansIOHTTPPolicy):
@@ -364,15 +368,16 @@ class StorageContentValidation(SansIOHTTPPolicy):
         return md5.digest()
 
     def on_request(self, request: "PipelineRequest") -> None:
-        validate_content = request.context.options.pop('validate_content', False)
-        if validate_content and request.http_request.method != 'GET':
+        validate_content = request.context.options.pop('validate_content', None)
+        if validate_content is True and request.http_request.method != 'GET':
             computed_md5 = encode_base64(StorageContentValidation.get_content_md5(request.http_request.data))
             request.http_request.headers[self.header_name] = computed_md5
             request.context['validate_content_md5'] = computed_md5
         request.context['validate_content'] = validate_content
 
     def on_response(self, request: "PipelineRequest", response: "PipelineResponse") -> None:
-        if response.context.get('validate_content', False) and response.http_response.headers.get('content-md5'):
+        validate_content = request.context.options.pop('validate_content', None)
+        if validate_content is True and response.http_response.headers.get('content-md5'):
             computed_md5 = request.context.get('validate_content_md5') or \
                 encode_base64(StorageContentValidation.get_content_md5(response.http_response.body()))
             if response.http_response.headers['content-md5'] != computed_md5:
@@ -451,7 +456,7 @@ class StorageRetryPolicy(HTTPPolicy):
         """ Formula for computing the current backoff.
         Should be calculated by child class.
 
-        :param dict[str, Any]] settings: The configurable values pertaining to the backoff time.
+        :param Dict[str, Any]] settings: The configurable values pertaining to the backoff time.
         :returns: The backoff time.
         :rtype: float
         """
@@ -471,14 +476,12 @@ class StorageRetryPolicy(HTTPPolicy):
     ) -> bool:
         """Increment the retry counters.
 
-        :param dict[str, Any]] settings: The configurable values pertaining to the increment operation.
-        :param request: A pipeline request object.
-        :type request: ~azure.core.pipeline.PipelineRequest
-        :param response: A pipeline response object.
-        :type response: ~azure.core.pipeline.PipelineResponse or None
+        :param Dict[str, Any]] settings: The configurable values pertaining to the increment operation.
+        :param PipelineRequest request: A pipeline request object.
+        :param Optional[PipelineResponse] response: A pipeline response object.
         :param error: An error encountered during the request, or
             None if the response was received successfully.
-        :type error: ~azure.core.exceptions.AzureError or None
+        :type error: Optional[AzureError]
         :returns: Whether the retry attempts are exhausted.
         :rtype: bool
         """
@@ -612,7 +615,7 @@ class ExponentialRetry(StorageRetryPolicy):
         """
         Calculates how long to sleep before retrying.
 
-        :param dict[str, Any]] settings: The configurable values pertaining to get backoff time.
+        :param Dict[str, Any]] settings: The configurable values pertaining to get backoff time.
         :returns:
             A float indicating how long to wait before retrying the request,
             or None to indicate no retry should be performed.
@@ -664,7 +667,7 @@ class LinearRetry(StorageRetryPolicy):
         """
         Calculates how long to sleep before retrying.
 
-        :param dict[str, Any]] settings: The configurable values pertaining to the backoff time.
+        :param Dict[str, Any]] settings: The configurable values pertaining to the backoff time.
         :returns:
             A float indicating how long to wait before retrying the request,
             or None to indicate no retry should be performed.

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/policies.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/policies.py
@@ -37,7 +37,10 @@ from .models import LocationMode
 
 if TYPE_CHECKING:
     from azure.core.credentials import TokenCredential
-    from azure.core.pipeline import PipelineRequest, PipelineResponse
+    from azure.core.pipeline.transport import (  # pylint: disable=non-abstract-transport-import
+        PipelineRequest,
+        PipelineResponse
+    )
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -132,8 +135,8 @@ class StorageHeadersPolicy(HeadersPolicy):
                 'x-ms-structured-body' not in response.http_response.headers and is_success):
             raise ValueError("Response did not acknowledge structured body. "
                              "Unexpected data may have been persisted to storage.")
-        elif ('x-ms-structured-body' in request.http_request.headers and
-              'x-ms-structured-body' not in response.http_response.headers and is_success):
+        if ('x-ms-structured-body' in request.http_request.headers and
+                'x-ms-structured-body' not in response.http_response.headers and is_success):
             raise ValueError("Response did not acknowledge structured body. Unknown structure in response body.")
 
     # # raise exception if the echoed client request id from the service is not identical to the one we sent

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/policies.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/policies.py
@@ -35,24 +35,16 @@ from .authentication import AzureSigningError, StorageHttpChallenge
 from .constants import DEFAULT_OAUTH_SCOPE
 from .models import LocationMode
 
-try:
-    _unicode_type = unicode # type: ignore
-except NameError:
-    _unicode_type = str
-
 if TYPE_CHECKING:
     from azure.core.credentials import TokenCredential
-    from azure.core.pipeline.transport import (  # pylint: disable=non-abstract-transport-import
-        PipelineRequest,
-        PipelineResponse
-    )
+    from azure.core.pipeline import PipelineRequest, PipelineResponse
 
 
 _LOGGER = logging.getLogger(__name__)
 
 
 def encode_base64(data):
-    if isinstance(data, _unicode_type):
+    if isinstance(data, str):
         data = data.encode('utf-8')
     encoded = base64.b64encode(data)
     return encoded.decode('utf-8')
@@ -96,7 +88,8 @@ def is_retry(response, mode):   # pylint: disable=too-many-return-statements
             return False
         return True
     # retry if invalid content md5
-    if response.context.get('validate_content', False) and response.http_response.headers.get('content-md5'):
+    validate_content = response.context.get('validate_content', None)
+    if validate_content is True and response.http_response.headers.get('content-md5'):
         computed_md5 = response.http_request.headers.get('content-md5', None) or \
                        encode_base64(StorageContentValidation.get_content_md5(response.http_response.body()))
         if response.http_response.headers['content-md5'] != computed_md5:
@@ -131,20 +124,31 @@ class StorageHeadersPolicy(HeadersPolicy):
         custom_id = request.context.options.pop('client_request_id', None)
         request.http_request.headers['x-ms-client-request-id'] = custom_id or str(uuid.uuid1())
 
-    # def on_response(self, request, response):
-    #     # raise exception if the echoed client request id from the service is not identical to the one we sent
-    #     if self.request_id_header_name in response.http_response.headers:
+    def on_response(self, request: "PipelineRequest", response: "PipelineResponse") -> None:
+        is_success = response.http_response.status_code < 300
+        # Validate structured body PUT/GET requests
+        if ('x-ms-structured-body' in request.http_request.headers and
+                'x-ms-structured-content-length' in request.http_request.headers and
+                'x-ms-structured-body' not in response.http_response.headers and is_success):
+            raise ValueError("Response did not acknowledge structured body. "
+                             "Unexpected data may have been persisted to storage.")
+        elif ('x-ms-structured-body' in request.http_request.headers and
+              'x-ms-structured-body' not in response.http_response.headers and is_success):
+            raise ValueError("Response did not acknowledge structured body. Unknown structure in response body.")
 
-    #         client_request_id = request.http_request.headers.get(self.request_id_header_name)
-
-    #         if response.http_response.headers[self.request_id_header_name] != client_request_id:
-    #             raise AzureError(
-    #                 "Echoed client request ID: {} does not match sent client request ID: {}.  "
-    #                 "Service request ID: {}".format(
-    #                     response.http_response.headers[self.request_id_header_name], client_request_id,
-    #                     response.http_response.headers['x-ms-request-id']),
-    #                 response=response.http_response
-    #             )
+    # # raise exception if the echoed client request id from the service is not identical to the one we sent
+    # if self.request_id_header_name in response.http_response.headers:
+    #
+    #     client_request_id = request.http_request.headers.get(self.request_id_header_name)
+    #
+    #     if response.http_response.headers[self.request_id_header_name] != client_request_id:
+    #         raise AzureError(
+    #             "Echoed client request ID: {} does not match sent client request ID: {}.  "
+    #             "Service request ID: {}".format(
+    #                 response.http_response.headers[self.request_id_header_name], client_request_id,
+    #                 response.http_response.headers['x-ms-request-id']),
+    #             response=response.http_response
+    #         )
 
 
 class StorageHosts(SansIOHTTPPolicy):
@@ -364,15 +368,16 @@ class StorageContentValidation(SansIOHTTPPolicy):
         return md5.digest()
 
     def on_request(self, request: "PipelineRequest") -> None:
-        validate_content = request.context.options.pop('validate_content', False)
-        if validate_content and request.http_request.method != 'GET':
+        validate_content = request.context.options.pop('validate_content', None)
+        if validate_content is True and request.http_request.method != 'GET':
             computed_md5 = encode_base64(StorageContentValidation.get_content_md5(request.http_request.data))
             request.http_request.headers[self.header_name] = computed_md5
             request.context['validate_content_md5'] = computed_md5
         request.context['validate_content'] = validate_content
 
     def on_response(self, request: "PipelineRequest", response: "PipelineResponse") -> None:
-        if response.context.get('validate_content', False) and response.http_response.headers.get('content-md5'):
+        validate_content = request.context.options.pop('validate_content', None)
+        if validate_content is True and response.http_response.headers.get('content-md5'):
             computed_md5 = request.context.get('validate_content_md5') or \
                 encode_base64(StorageContentValidation.get_content_md5(response.http_response.body()))
             if response.http_response.headers['content-md5'] != computed_md5:
@@ -471,11 +476,12 @@ class StorageRetryPolicy(HTTPPolicy):
     ) -> bool:
         """Increment the retry counters.
 
-        :param dict[str, Any]] settings: The configurable values pertaining to the increment operation.
+        :param Dict[str, Any]] settings: The configurable values pertaining to the increment operation.
         :param PipelineRequest request: A pipeline request object.
         :param Optional[PipelineResponse] response: A pipeline response object.
-        :param Optional[AzureError] error: An error encountered during the request, or
+        :param error: An error encountered during the request, or
             None if the response was received successfully.
+        :type error: Optional[AzureError]
         :returns: Whether the retry attempts are exhausted.
         :rtype: bool
         """

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/policies.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/policies.py
@@ -37,7 +37,10 @@ from .models import LocationMode
 
 if TYPE_CHECKING:
     from azure.core.credentials import TokenCredential
-    from azure.core.pipeline import PipelineRequest, PipelineResponse
+    from azure.core.pipeline.transport import (  # pylint: disable=non-abstract-transport-import
+        PipelineRequest,
+        PipelineResponse
+    )
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -132,8 +135,8 @@ class StorageHeadersPolicy(HeadersPolicy):
                 'x-ms-structured-body' not in response.http_response.headers and is_success):
             raise ValueError("Response did not acknowledge structured body. "
                              "Unexpected data may have been persisted to storage.")
-        elif ('x-ms-structured-body' in request.http_request.headers and
-              'x-ms-structured-body' not in response.http_response.headers and is_success):
+        if ('x-ms-structured-body' in request.http_request.headers and
+                'x-ms-structured-body' not in response.http_response.headers and is_success):
             raise ValueError("Response did not acknowledge structured body. Unknown structure in response body.")
 
     # # raise exception if the echoed client request id from the service is not identical to the one we sent

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/policies.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/policies.py
@@ -37,7 +37,10 @@ from .models import LocationMode
 
 if TYPE_CHECKING:
     from azure.core.credentials import TokenCredential
-    from azure.core.pipeline import PipelineRequest, PipelineResponse
+    from azure.core.pipeline.transport import (  # pylint: disable=non-abstract-transport-import
+        PipelineRequest,
+        PipelineResponse
+    )
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -138,8 +141,8 @@ class StorageHeadersPolicy(HeadersPolicy):
                 'x-ms-structured-body' not in response.http_response.headers and is_success):
             raise ValueError("Response did not acknowledge structured body. "
                              "Unexpected data may have been persisted to storage.")
-        elif ('x-ms-structured-body' in request.http_request.headers and
-              'x-ms-structured-body' not in response.http_response.headers and is_success):
+        if ('x-ms-structured-body' in request.http_request.headers and
+                'x-ms-structured-body' not in response.http_response.headers and is_success):
             raise ValueError("Response did not acknowledge structured body. Unknown structure in response body.")
 
     # # raise exception if the echoed client request id from the service is not identical to the one we sent

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/policies.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/policies.py
@@ -35,24 +35,16 @@ from .authentication import AzureSigningError, StorageHttpChallenge
 from .constants import DEFAULT_OAUTH_SCOPE
 from .models import LocationMode
 
-try:
-    _unicode_type = unicode # type: ignore
-except NameError:
-    _unicode_type = str
-
 if TYPE_CHECKING:
     from azure.core.credentials import TokenCredential
-    from azure.core.pipeline.transport import (  # pylint: disable=non-abstract-transport-import
-        PipelineRequest,
-        PipelineResponse
-    )
+    from azure.core.pipeline import PipelineRequest, PipelineResponse
 
 
 _LOGGER = logging.getLogger(__name__)
 
 
 def encode_base64(data):
-    if isinstance(data, _unicode_type):
+    if isinstance(data, str):
         data = data.encode('utf-8')
     encoded = base64.b64encode(data)
     return encoded.decode('utf-8')
@@ -96,7 +88,8 @@ def is_retry(response, mode):   # pylint: disable=too-many-return-statements
             return False
         return True
     # retry if invalid content md5
-    if response.context.get('validate_content', False) and response.http_response.headers.get('content-md5'):
+    validate_content = response.context.get('validate_content', None)
+    if validate_content is True and response.http_response.headers.get('content-md5'):
         computed_md5 = response.http_request.headers.get('content-md5', None) or \
                        encode_base64(StorageContentValidation.get_content_md5(response.http_response.body()))
         if response.http_response.headers['content-md5'] != computed_md5:
@@ -137,20 +130,31 @@ class StorageHeadersPolicy(HeadersPolicy):
         custom_id = request.context.options.pop('client_request_id', None)
         request.http_request.headers['x-ms-client-request-id'] = custom_id or str(uuid.uuid1())
 
-    # def on_response(self, request, response):
-    #     # raise exception if the echoed client request id from the service is not identical to the one we sent
-    #     if self.request_id_header_name in response.http_response.headers:
+    def on_response(self, request: "PipelineRequest", response: "PipelineResponse") -> None:
+        is_success = response.http_response.status_code < 300
+        # Validate structured body PUT/GET requests
+        if ('x-ms-structured-body' in request.http_request.headers and
+                'x-ms-structured-content-length' in request.http_request.headers and
+                'x-ms-structured-body' not in response.http_response.headers and is_success):
+            raise ValueError("Response did not acknowledge structured body. "
+                             "Unexpected data may have been persisted to storage.")
+        elif ('x-ms-structured-body' in request.http_request.headers and
+              'x-ms-structured-body' not in response.http_response.headers and is_success):
+            raise ValueError("Response did not acknowledge structured body. Unknown structure in response body.")
 
-    #         client_request_id = request.http_request.headers.get(self.request_id_header_name)
-
-    #         if response.http_response.headers[self.request_id_header_name] != client_request_id:
-    #             raise AzureError(
-    #                 "Echoed client request ID: {} does not match sent client request ID: {}.  "
-    #                 "Service request ID: {}".format(
-    #                     response.http_response.headers[self.request_id_header_name], client_request_id,
-    #                     response.http_response.headers['x-ms-request-id']),
-    #                 response=response.http_response
-    #             )
+    # # raise exception if the echoed client request id from the service is not identical to the one we sent
+    # if self.request_id_header_name in response.http_response.headers:
+    #
+    #     client_request_id = request.http_request.headers.get(self.request_id_header_name)
+    #
+    #     if response.http_response.headers[self.request_id_header_name] != client_request_id:
+    #         raise AzureError(
+    #             "Echoed client request ID: {} does not match sent client request ID: {}.  "
+    #             "Service request ID: {}".format(
+    #                 response.http_response.headers[self.request_id_header_name], client_request_id,
+    #                 response.http_response.headers['x-ms-request-id']),
+    #             response=response.http_response
+    #         )
 
 
 class StorageHosts(SansIOHTTPPolicy):
@@ -370,15 +374,16 @@ class StorageContentValidation(SansIOHTTPPolicy):
         return md5.digest()
 
     def on_request(self, request: "PipelineRequest") -> None:
-        validate_content = request.context.options.pop('validate_content', False)
-        if validate_content and request.http_request.method != 'GET':
+        validate_content = request.context.options.pop('validate_content', None)
+        if validate_content is True and request.http_request.method != 'GET':
             computed_md5 = encode_base64(StorageContentValidation.get_content_md5(request.http_request.data))
             request.http_request.headers[self.header_name] = computed_md5
             request.context['validate_content_md5'] = computed_md5
         request.context['validate_content'] = validate_content
 
     def on_response(self, request: "PipelineRequest", response: "PipelineResponse") -> None:
-        if response.context.get('validate_content', False) and response.http_response.headers.get('content-md5'):
+        validate_content = request.context.options.pop('validate_content', None)
+        if validate_content is True and response.http_response.headers.get('content-md5'):
             computed_md5 = request.context.get('validate_content_md5') or \
                 encode_base64(StorageContentValidation.get_content_md5(response.http_response.body()))
             if response.http_response.headers['content-md5'] != computed_md5:
@@ -477,11 +482,12 @@ class StorageRetryPolicy(HTTPPolicy):
     ) -> bool:
         """Increment the retry counters.
 
-        :param dict[str, Any] settings: The configurable values pertaining to the increment operation.
+        :param Dict[str, Any]] settings: The configurable values pertaining to the increment operation.
         :param PipelineRequest request: A pipeline request object.
         :param Optional[PipelineResponse] response: A pipeline response object.
-        :param Optional[AzureError] error: An error encountered during the request, or
+        :param error: An error encountered during the request, or
             None if the response was received successfully.
+        :type error: Optional[AzureError]
         :returns: Whether the retry attempts are exhausted.
         :rtype: bool
         """


### PR DESCRIPTION
This change includes a couple of smaller updates for Structured Message support across all relevant packages:

- Add checks to ensure when structured message is requested (in PUT or GET), the service echoes back the structured message in the response. This was done via a pipeline policy. 
  - Came with a couple of tweaks to `policies` including bringing the files back in sync across packages (mostly) from lingering typing updates.
- Removing the custom error type in favor of `ValueError`.
- The structured message streams now assert on size whenever they are reading from the internal stream. This is to harden the implementation a little or to allow for the streams to fail faster when the data is invalid.