### PR TITLE
Remove six as a dependency in core

### DIFF
--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Other Changes
 
 - The Azure Core OpenTelemetry tracing plugin will now be the preferred tracing plugin over the OpenCensus plugin. If both plugins are installed and `opentelemetry` is imported, then OpenTelemetry will be used to trace Azure SDK operations.  #35050
+- Remove `six` as a dependency, as it's not used anymore in the code base.
 
 ## 1.30.2 (2024-06-06)
 

--- a/sdk/core/azure-core/setup.py
+++ b/sdk/core/azure-core/setup.py
@@ -70,7 +70,6 @@ setup(
     python_requires=">=3.8",
     install_requires=[
         "requests>=2.21.0",
-        "six>=1.11.0",
         "typing-extensions>=4.6.0",
     ],
     extras_require={


### PR DESCRIPTION
Came in a discussion with @annatisch , and we feel it's probably time, that it wouldn't break anyone, and thee few if any would have done wrong things in the first place.

