### PR TITLE
ensure we run analyze weekly

### DIFF
--- a/sdk/ai/tests.yml
+++ b/sdk/ai/tests.yml
@@ -1,0 +1,7 @@
+trigger: none
+
+# NOTE: Service live tests are NOT enabled. This file only enables the analyze stage currently.
+extends:
+    template: /eng/pipelines/templates/stages/python-analyze-weekly-standalone.yml
+    parameters:
+      ServiceDirectory: ai

--- a/sdk/face/tests.yml
+++ b/sdk/face/tests.yml
@@ -1,0 +1,7 @@
+trigger: none
+
+# NOTE: Service live tests are NOT enabled. This file only enables the analyze stage currently.
+extends:
+    template: /eng/pipelines/templates/stages/python-analyze-weekly-standalone.yml
+    parameters:
+      ServiceDirectory: face

--- a/sdk/servicebus/tests.yml
+++ b/sdk/servicebus/tests.yml
@@ -30,8 +30,3 @@ extends:
           SubscriptionConfigurationFilePaths:
             - eng/common/TestResources/sub-config/AzureUsGovMsft.json
           Location: 'usgovarizona'
-        China:
-          ServiceConnection: china_azure-sdk-tests
-          SubscriptionConfigurationFilePaths:
-            - eng/common/TestResources/sub-config/AzureChinaMsft.json
-          Location: 'chinanorth3'

--- a/sdk/vision/tests.yml
+++ b/sdk/vision/tests.yml
@@ -1,8 +1,7 @@
-# This was the tests.yml file that was used when azure-ai-generative and azure-ai-resources packages were built.
 trigger: none
 
 # NOTE: Service live tests are NOT enabled. This file only enables the analyze stage currently.
 extends:
     template: /eng/pipelines/templates/stages/python-analyze-weekly-standalone.yml
     parameters:
-      ServiceDirectory: ai
+      ServiceDirectory: vision


### PR DESCRIPTION
Adds or adjusts tests.yml to enable the tests-weekly pipeline on a few libraries that were missing it. Tests-weekly will run analyze weekly checks on Saturday to evaluate library status for next-mypy, pylint, etc. 