### PR TITLE
[bct] Clean up async reporting in changelog

### DIFF
--- a/scripts/breaking_changes_checker/changelog_tracker.py
+++ b/scripts/breaking_changes_checker/changelog_tracker.py
@@ -54,15 +54,16 @@ class ChangelogTracker(BreakingChangesTracker):
         non_aio_changes = [fa for fa in self.features_added if "aio" not in fa[2]]
         non_aio_changes = non_aio_changes + [bc for bc in self.breaking_changes if "aio" not in bc[2]]
         # Remove all aio related changes from the main list if the sync version of the change exists
+        def remove_aio_changes(change_list: List, change: tuple) -> None:
+            for c in change_list:
+                if "aio" in c[2]:
+                    if change[1] == c[1] and change[3:] == c[3:]:
+                        change_list.remove(c)
+                        break
+
         for c in non_aio_changes:
-            for fa in self.features_added:
-                if "aio" in fa[2]:
-                    if c[1] == fa[1] and c[3:] == fa[3:]:
-                        self.features_added.remove(fa)
-            for bc in self.breaking_changes:
-                if "aio" in bc[2]:
-                    if c[1] == bc[1] and c[3:] == bc[3:]:
-                        self.breaking_changes.remove(bc)
+            remove_aio_changes(self.features_added, c)
+            remove_aio_changes(self.breaking_changes, c)
 
     def run_non_breaking_change_diff_checks(self) -> None:
         for module_name, module in self.diff.items():

--- a/scripts/breaking_changes_checker/tests/test_changelog.py
+++ b/scripts/breaking_changes_checker/tests/test_changelog.py
@@ -20,7 +20,7 @@ def test_changelog_flag():
         current = json.load(fd)
     diff = jsondiff.diff(stable, current)
 
-    bc = ChangelogTracker(stable, current, diff, "azure-ai-contentsafety", changelog=True)
+    bc = ChangelogTracker(stable, current, diff, "azure-ai-contentsafety")
     bc.run_checks()
 
     assert len(bc.features_added) > 0
@@ -60,7 +60,7 @@ def test_new_class_property_added():
     }
 
     diff = jsondiff.diff(stable, current)
-    bc = ChangelogTracker(stable, current, diff, "azure-ai-contentsafety", changelog=True)
+    bc = ChangelogTracker(stable, current, diff, "azure-ai-contentsafety")
     bc.run_checks()
 
     assert len(bc.features_added) == 1
@@ -108,6 +108,7 @@ def test_async_cleanup_check():
                     "properties": {
                         "blocklists_match": "Optional",
                         "categories_analysis": "List[_models.TextCategoriesAnalysis]",
+                        "new_property": "str"
                     }
                 },
             }
@@ -120,6 +121,7 @@ def test_async_cleanup_check():
                     "properties": {
                         "blocklists_match": "Optional",
                         "categories_analysis": "List[_models.TextCategoriesAnalysis]",
+                        "new_property": "str"
                     }
                 },
             }
@@ -127,13 +129,17 @@ def test_async_cleanup_check():
     }
 
     diff = jsondiff.diff(stable, current)
-    bc = ChangelogTracker(stable, current, diff, "azure-mgmt-contentsafety", changelog=True)
+    bc = ChangelogTracker(stable, current, diff, "azure-mgmt-contentsafety")
     bc.run_checks()
 
     # Should only have 1 breaking change reported instead of 2
     assert len(bc.breaking_changes) == 1
     msg, _, *args = bc.breaking_changes[0]
     assert msg == BreakingChangesTracker.REMOVED_OR_RENAMED_INSTANCE_ATTRIBUTE_FROM_MODEL_MSG
+    # Should only have 1 feature added reported instead of 2
+    assert len(bc.features_added) == 1
+    msg, _, *args = bc.features_added[0]
+    assert msg == ChangelogTracker.ADDED_CLASS_PROPERTY_MSG
 
 
 def test_new_class_property_added_init():
@@ -204,7 +210,7 @@ def test_new_class_property_added_init():
     }
 
     diff = jsondiff.diff(stable, current)
-    bc = ChangelogTracker(stable, current, diff, "azure-ai-contentsafety", changelog=True)
+    bc = ChangelogTracker(stable, current, diff, "azure-ai-contentsafety")
     bc.run_checks()
 
     assert len(bc.features_added) == 1
@@ -276,7 +282,7 @@ def test_new_class_property_added_init_only():
     }
 
     diff = jsondiff.diff(stable, current)
-    bc = ChangelogTracker(stable, current, diff, "azure-ai-contentsafety", changelog=True)
+    bc = ChangelogTracker(stable, current, diff, "azure-ai-contentsafety")
     bc.run_checks()
 
     assert len(bc.features_added) == 1
@@ -365,7 +371,7 @@ def test_new_class_method_parameter_added():
     }
 
     diff = jsondiff.diff(stable, current)
-    bc = ChangelogTracker(stable, current, diff, "azure-ai-contentsafety", changelog=True)
+    bc = ChangelogTracker(stable, current, diff, "azure-ai-contentsafety")
     bc.run_checks()
 
     assert len(bc.features_added) == 1
@@ -424,7 +430,7 @@ def test_added_operation_group():
     }
 
     diff = jsondiff.diff(stable, current)
-    bc = ChangelogTracker(stable, current, diff, "azure-contoso", changelog=True)
+    bc = ChangelogTracker(stable, current, diff, "azure-contoso")
     bc.run_checks()
 
     assert len(bc.features_added) == 2

--- a/scripts/breaking_changes_checker/tests/test_changelog.py
+++ b/scripts/breaking_changes_checker/tests/test_changelog.py
@@ -69,7 +69,7 @@ def test_new_class_property_added():
     assert args == ['azure.ai.contentsafety', 'AnalyzeTextResult', 'new_class_att']
 
 
-def test_async_mgmt_cleanup_check():
+def test_async_cleanup_check():
     stable = {
         "azure.mgmt.contentsafety": {
             "class_nodes": {


### PR DESCRIPTION
Cleaning up async change reporting in the changelog. If a change is reported for sync methods and clients, we'll remove it and only report the change once. This makes the changelog less redundant particularly since we are no longer including the module in the change message.

Fixes [#36763](https://github.com/Azure/azure-sdk-for-python/issues/36763)