### PR TITLE
Always Verify Changelog during release

### DIFF
--- a/eng/pipelines/templates/stages/archetype-python-release.yml
+++ b/eng/pipelines/templates/stages/archetype-python-release.yml
@@ -52,12 +52,11 @@ stages:
                         ServiceDirectory: "template"
                         TestPipeline: ${{ parameters.TestPipeline }}
 
-                    - ${{if ne(artifact.skipVerifyChangeLog, 'true')}}:
-                      - template: /eng/common/pipelines/templates/steps/verify-changelog.yml
-                        parameters:
-                          PackageName: ${{artifact.name}}
-                          ServiceName: ${{parameters.ServiceDirectory}}
-                          ForRelease: true
+                    - template: /eng/common/pipelines/templates/steps/verify-changelog.yml
+                      parameters:
+                        PackageName: ${{artifact.name}}
+                        ServiceName: ${{parameters.ServiceDirectory}}
+                        ForRelease: true
 
                     - template: /eng/common/pipelines/templates/steps/verify-restapi-spec-location.yml
                       parameters:


### PR DESCRIPTION
We hit a situation recently where a GA package was attempted to be released with bad values for changelog. This was due to a confluence of factors:

- Changelog verification was disabled in artifacts list from ci.yml
- The changelog itself had `(unreleased)` in the package version being released, so `APIView` didn't automatically block on manual `internal` build

This PR merely removes the _option_ of being able to disable changelog verification during RELEASE. it's still optional during build.

Is this too restrictive? @kristapratico FYI 