### PR TITLE
[CognitiveServices] remove ci_enabled=false from qnamaker for release

### DIFF
--- a/sdk/cognitiveservices/azure-cognitiveservices-knowledge-qnamaker/CHANGELOG.md
+++ b/sdk/cognitiveservices/azure-cognitiveservices-knowledge-qnamaker/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 0.3.1 (2024-08-14)
+## 0.3.1 (2024-08-13)
 
 ### Other Changes
 

--- a/sdk/cognitiveservices/azure-cognitiveservices-knowledge-qnamaker/CHANGELOG.md
+++ b/sdk/cognitiveservices/azure-cognitiveservices-knowledge-qnamaker/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 0.3.1 (2024-08-13)
+## 0.3.1 (2024-08-14)
 
 ### Other Changes
 

--- a/sdk/cognitiveservices/azure-cognitiveservices-knowledge-qnamaker/pyproject.toml
+++ b/sdk/cognitiveservices/azure-cognitiveservices-knowledge-qnamaker/pyproject.toml
@@ -1,3 +1,2 @@
 [tool.azure-sdk-build]
 pylint = false
-ci_enabled = false


### PR DESCRIPTION
`ci_enabled=false` should not be set in pyproject.toml in order to release. Fixing here and will add back in after package is released.