### PR TITLE
Log reason for skipping `WorkloadIdentityCredential` auth

### DIFF
--- a/sdk/identity/azure-identity/azure/identity/aio/_credentials/default.py
+++ b/sdk/identity/azure-identity/azure/identity/aio/_credentials/default.py
@@ -148,6 +148,8 @@ class DefaultAzureCredential(ChainedTokenCredential):
                         **kwargs
                     )
                 )
+            else:
+                _LOGGER.info("WorkloadIdentityCredential authentication unavailable. Environment variables are not fully configured.")
         if not exclude_managed_identity_credential:
             credentials.append(
                 ManagedIdentityCredential(


### PR DESCRIPTION
# Description

When using `DefaultAzureCredential`, `WorkloadIdentityCredential` auth is silently skipped if the required environment variables are not discovered, making auth issues harder to investigate.

The intent of the PR is to add a log line to the credential chain which gets printed on failure:
```
Attempted credentials:
	EnvironmentCredential: EnvironmentCredential authentication unavailable. Environment variables are not fully configured.
	ManagedIdentityCredential: Unexpected content type \"text/plain; charset=utf-8\"
	SharedTokenCacheCredential: Shared token cache unavailable
	AzureCliCredential: Azure CLI not found on path
	AzurePowerShellCredential: PowerShell is not installed
	AzureDeveloperCliCredential: Azure Developer CLI could not be found. Please visit https://aka.ms/azure-dev for installation instructions and then,once installed, authenticate to your Azure account using 'azd auth login'.
```

# All SDK Contribution checklist:
- [X] **The pull request does not introduce [breaking changes]**
- [I think this is N/A] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [X] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [X] Title of the pull request is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [I think this is N/A] Pull request includes test coverage for the included changes.
