### PR TITLE
[CognitiveServices] remove qnamaker from CI post deprecation

### DIFF
--- a/sdk/cognitiveservices/azure-cognitiveservices-knowledge-qnamaker/pyproject.toml
+++ b/sdk/cognitiveservices/azure-cognitiveservices-knowledge-qnamaker/pyproject.toml
@@ -1,2 +1,3 @@
 [tool.azure-sdk-build]
 pylint = false
+ci_enabled = false

--- a/sdk/cognitiveservices/ci.yml
+++ b/sdk/cognitiveservices/ci.yml
@@ -29,8 +29,6 @@ extends:
     ServiceDirectory: cognitiveservices
     TestTimeoutInMinutes: 150
     Artifacts:
-    - name: azure-cognitiveservices-knowledge-qnamaker
-      safeName: azurecognitiveservicesknowledgeqnamaker
     - name: azure-cognitiveservices-language-luis
       safeName: azurecognitiveserviceslanguageluis
     - name: azure-cognitiveservices-language-spellcheck


### PR DESCRIPTION
Removing qnamaker from the CI after releasing the deprecated package.