### PR TITLE
[ml] workspace delete_dependent_resources does not work for non-public clouds

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/_utils/_workspace_utils.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/_utils/_workspace_utils.py
@@ -6,7 +6,7 @@ import logging
 import random
 import uuid
 
-from azure.ai.ml._azure_environments import _get_base_url_from_metadata
+from azure.ai.ml._azure_environments import _get_base_url_from_metadata, _resource_to_scopes
 from azure.ai.ml._vendor.azure_resources._resource_management_client import ResourceManagementClient
 from azure.ai.ml._vendor.azure_resources.models import GenericResource
 from azure.ai.ml.constants._common import ArmConstants
@@ -31,11 +31,13 @@ def get_deployment_name(name: str):
 
 
 def get_resource_group_location(credentials: TokenCredential, subscription_id: str, resource_group_name: str) -> str:
+    arm_hostname = _get_base_url_from_metadata()
     client = ResourceManagementClient(
         credential=credentials,
         subscription_id=subscription_id,
-        base_url=_get_base_url_from_metadata(),
+        base_url=arm_hostname,
         api_version=ArmConstants.AZURE_MGMT_RESOURCE_API_VERSION,
+        credential_scopes=_resource_to_scopes(arm_hostname),
     )
     rg = client.resource_groups.get(resource_group_name)
     return rg.location
@@ -48,11 +50,13 @@ def get_generic_arm_resource_by_arm_id(
     api_version: str,
 ) -> GenericResource:
     if arm_id:
+        arm_hostname = _get_base_url_from_metadata()
         client = ResourceManagementClient(
             credential=credentials,
             subscription_id=subscription_id,
-            base_url=_get_base_url_from_metadata(),
+            base_url=arm_hostname,
             api_version=ArmConstants.AZURE_MGMT_RESOURCE_API_VERSION,
+            credential_scopes=_resource_to_scopes(arm_hostname),
         )
         return client.resources.get_by_id(arm_id, api_version)
     return None
@@ -65,11 +69,13 @@ def delete_resource_by_arm_id(
     api_version: str,
 ) -> None:
     if arm_id:
+        arm_hostname = _get_base_url_from_metadata()
         client = ResourceManagementClient(
             credential=credentials,
             subscription_id=subscription_id,
-            base_url=_get_base_url_from_metadata(),
+            base_url=arm_hostname,
             api_version=ArmConstants.AZURE_MGMT_RESOURCE_API_VERSION,
+            credential_scopes=_resource_to_scopes(arm_hostname),
         )
         client.resources.begin_delete_by_id(arm_id, api_version)
 


### PR DESCRIPTION
# Description

Using delete workspace with delete_dependent_resources in non-public clouds will fail as the credential scopes used are pointing to public cloud. So we get failures like: "Authentication failed... resource principal named https://management.azure.com/ was not found in the tenant named ____"

Here is an example guidance doc that calls it out: [Multicloud: Connect to all regions with the Azure libraries for Python](https://learn.microsoft.com/en-us/azure/developer/python/sdk/azure-sdk-sovereign-domain)

# All SDK Contribution checklist:
- [X] **The pull request does not introduce [breaking changes]**
- [X] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [X] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [X] Title of the pull request is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [X] Pull request includes test coverage for the included changes.
