### PR TITLE
[CognitiveServices] luis post-deprecation

### DIFF
--- a/sdk/cognitiveservices/azure-cognitiveservices-language-luis/pyproject.toml
+++ b/sdk/cognitiveservices/azure-cognitiveservices-language-luis/pyproject.toml
@@ -1,2 +1,3 @@
 [tool.azure-sdk-build]
 pylint = false
+ci_enabled = false

--- a/sdk/cognitiveservices/ci.yml
+++ b/sdk/cognitiveservices/ci.yml
@@ -29,8 +29,6 @@ extends:
     ServiceDirectory: cognitiveservices
     TestTimeoutInMinutes: 150
     Artifacts:
-    - name: azure-cognitiveservices-language-luis
-      safeName: azurecognitiveserviceslanguageluis
     - name: azure-cognitiveservices-language-spellcheck
       safeName: azurecognitiveserviceslanguagespellcheck
     - name: azure-cognitiveservices-personalizer


### PR DESCRIPTION
As per deprecation guidelines on post-deprecation release:
- Add ci_enabled=false to pyproject.toml
- Remove the language-luis package artifact from ci.yml.