### PR TITLE
Fix skipPublishDocGithubIo variable

### DIFF
--- a/eng/pipelines/templates/stages/archetype-python-release.yml
+++ b/eng/pipelines/templates/stages/archetype-python-release.yml
@@ -176,7 +176,7 @@ stages:
                           ArtifactName: ${{parameters.ArtifactName}}
                           PackageName: ${{artifact.name}}
 
-          - ${{if ne(artifact.skipPublishDocs, 'true')}}:
+          - ${{if ne(artifact.skipPublishDocGithubIo, 'true')}}:
             - deployment: PublishGitHubIODocs
               displayName: Publish Docs to GitHubIO Blob Storage
               condition: and(succeeded(), ne(variables['Skip.PublishDocs'], 'true'))
@@ -243,8 +243,8 @@ stages:
                                 - metadata/
                               PackageSourceOverride: ${{parameters.PackageSourceOverride}}
                               DocValidationImageId: ${{parameters.DocValidationImageId}}
-          - ${{if ne(artifact.skipPublishDocGithubIo, 'true')}}:
-            - deployment: UpdatePackageVersion
+
+          - deployment: UpdatePackageVersion
               displayName: "Update Package Version"
               condition: and(succeeded(), ne(variables['Skip.UpdatePackageVersion'], 'true'))
               environment: github

--- a/eng/pipelines/templates/stages/archetype-python-release.yml
+++ b/eng/pipelines/templates/stages/archetype-python-release.yml
@@ -245,41 +245,42 @@ stages:
                               DocValidationImageId: ${{parameters.DocValidationImageId}}
 
           - deployment: UpdatePackageVersion
-              displayName: "Update Package Version"
-              condition: and(succeeded(), ne(variables['Skip.UpdatePackageVersion'], 'true'))
-              environment: github
-              dependsOn: PublishPackage
+            displayName: "Update Package Version"
+            condition: and(succeeded(), ne(variables['Skip.UpdatePackageVersion'], 'true'))
+            environment: github
+            dependsOn: PublishPackage
 
-              pool:
-                image: azsdk-pool-mms-ubuntu-2004-1espt
-                name: azsdk-pool-mms-ubuntu-2004-general
-                os: linux
+            pool:
+              image: azsdk-pool-mms-ubuntu-2004-1espt
+              name: azsdk-pool-mms-ubuntu-2004-general
+              os: linux
 
-              strategy:
-                runOnce:
-                  deploy:
-                    steps:
-                      - checkout: self
-                      - task: UsePythonVersion@0
-                      - script: |
-                          python -m pip install "./tools/azure-sdk-tools[build]"
-                        displayName: Install versioning tool dependencies
+            strategy:
+              runOnce:
+                deploy:
+                  steps:
+                    - checkout: self
+                    - task: UsePythonVersion@0
+                    - script: |
+                        python -m pip install "./tools/azure-sdk-tools[build]"
+                      displayName: Install versioning tool dependencies
 
-                      - pwsh: |
-                          sdk_increment_version --package-name ${{ artifact.name }} --service ${{ parameters.ServiceDirectory }}
-                          if (Test-Path component-detection-pip-report.json) {
-                            Write-Host "Deleting component-detection-pip-report.json"
-                            rm component-detection-pip-report.json
-                          }
-                        displayName: Increment package version
+                    - pwsh: |
+                        sdk_increment_version --package-name ${{ artifact.name }} --service ${{ parameters.ServiceDirectory }}
+                        if (Test-Path component-detection-pip-report.json) {
+                          Write-Host "Deleting component-detection-pip-report.json"
+                          rm component-detection-pip-report.json
+                        }
+                      displayName: Increment package version
 
-                      - template: /eng/common/pipelines/templates/steps/create-pull-request.yml
-                        parameters:
-                          RepoName: azure-sdk-for-python
-                          PRBranchName: increment-package-version-${{ parameters.ServiceDirectory }}-$(Build.BuildId)
-                          CommitMsg: "Increment package version after release of ${{ artifact.name }}"
-                          PRTitle: "Increment version for ${{ parameters.ServiceDirectory }} releases"
-                          CloseAfterOpenForTesting: '${{ parameters.TestPipeline }}'
+                    - template: /eng/common/pipelines/templates/steps/create-pull-request.yml
+                      parameters:
+                        RepoName: azure-sdk-for-python
+                        PRBranchName: increment-package-version-${{ parameters.ServiceDirectory }}-$(Build.BuildId)
+                        CommitMsg: "Increment package version after release of ${{ artifact.name }}"
+                        PRTitle: "Increment version for ${{ parameters.ServiceDirectory }} releases"
+                        CloseAfterOpenForTesting: '${{ parameters.TestPipeline }}'
+
           - ${{if and(eq(variables['Build.Reason'], 'Manual'), eq(variables['System.TeamProject'], 'internal'))}}:
             - template: /eng/pipelines/templates/jobs/smoke.tests.yml
               parameters:

--- a/sdk/storage/ci.yml
+++ b/sdk/storage/ci.yml
@@ -50,7 +50,7 @@ extends:
     - name: azure-storage-extensions
       safeName: azurestorageextensions
       # Pure C-based storage extension package, not generating docs at this moment.
-      skipPublishDocs: true
+      skipPublishDocGithubIo: true
       skipPublishDocMs: true
     - name: azure-mgmt-storage
       safeName: azuremgmtstorage

--- a/sdk/template/ci.yml
+++ b/sdk/template/ci.yml
@@ -50,5 +50,3 @@ extends:
     Artifacts:
     - name: azure-template
       safeName: azuretemplate
-      # JRS - This will be removed prior to merge
-      skipPublishDocGithubIo: true

--- a/sdk/template/ci.yml
+++ b/sdk/template/ci.yml
@@ -50,3 +50,5 @@ extends:
     Artifacts:
     - name: azure-template
       safeName: azuretemplate
+      # JRS - This will be removed prior to merge
+      skipPublishDocGithubIo: true


### PR DESCRIPTION
There are two docs publish skip variables, skipPublishDocGithubIo and skipPublishDocMs which skip their respective docs publishes. As it turns out skipPublishDocs was caused the GitHubIo docs to skip publishing where skipPublishDocGithubIo would have prevented the version increment PRs from being created. Thankfully, skipPublishDocGithubIo wasn't being used and the only place skipPublishDocs was being used was in sdk/storage/ci.yml

1. Make skipPublishDocGithubIo the variable that'll actually skip GitHubIO publishing
2. Remove the if skipPublishDocGithubIo statement that would have prevented the version increment PRs, if set.
3. Change skipPublishDocMs in sdk/storage/ci.yml to skipPublishDocGithubIo.

With this change there are no more references to skipPublishDocMs and skipPublishDocGithubIo now behaves as it would in every other language repository.

Note: Template's ci.yml changes were reverted. [This was the template release used to test these changes](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4058225&view=results) and everything behaved as expected.