### PR TITLE
[Identity] Update instance discovery error message

### DIFF
--- a/sdk/identity/azure-identity/tests/test_instance_discovery.py
+++ b/sdk/identity/azure-identity/tests/test_instance_discovery.py
@@ -2,7 +2,10 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
+import pytest
+
 from azure.identity._internal.msal_credentials import MsalCredential
+from azure.core.exceptions import ServiceRequestError
 
 
 def test_instance_discovery():
@@ -19,3 +22,24 @@ def test_instance_discovery():
     )
     app = credential._get_app()
     assert app._instance_discovery
+
+
+def test_unknown_authority():
+    credential = MsalCredential(
+        client_id="CLIENT_ID",
+        authority="unknown.authority",
+    )
+    with pytest.raises(ValueError) as ex:
+        credential._get_app()
+        assert "disable_instance_discovery" in str(ex)
+
+    credential = MsalCredential(
+        client_id="CLIENT_ID",
+        authority="unknown.authority",
+        disable_instance_discovery=True,
+    )
+
+    with pytest.raises(ServiceRequestError):
+        # Instance discovery is disabled, so the credential should not attempt to validate the authority, and instead
+        # attempt to use the authority as given. This is fail since unknown.authority is not resolvable.
+        credential._get_app()


### PR DESCRIPTION
With instance discovery enabled, MSAL will throw an error saying to use `instance_discovery=False` (see full message [here](https://github.com/AzureAD/microsoft-authentication-library-for-python/blob/dev/msal/authority.py#L143)) for authority hosts that are not well known. This can be misleading since our API uses `disabled_instance_discovery`.  This catches that error, and gives a more accurate error message.

Closes: https://github.com/Azure/azure-sdk-for-python/issues/35509
