### PR TITLE
[Storage] [Typing] [File Share] Resolved `mypy` errors for `samples/`

### DIFF
--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_models.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_models.py
@@ -171,6 +171,24 @@ class CorsRule(GeneratedCorsRule):
         self.exposed_headers = ','.join(kwargs.get('exposed_headers', []))
         self.max_age_in_seconds = kwargs.get('max_age_in_seconds', 0)
 
+    @staticmethod
+    def _to_generated(rules: Optional[List["CorsRule"]]) -> Optional[List[GeneratedCorsRule]]:
+        if rules is None:
+            return rules
+
+        generated_cors_list = []
+        for cors_rule in rules:
+            generated_cors = GeneratedCorsRule(
+                allowed_origins=cors_rule.allowed_origins,
+                allowed_methods=cors_rule.allowed_methods,
+                allowed_headers=cors_rule.allowed_headers,
+                exposed_headers=cors_rule.exposed_headers,
+                max_age_in_seconds=cors_rule.max_age_in_seconds,
+            )
+            generated_cors_list.append(generated_cors)
+
+        return generated_cors_list
+
     @classmethod
     def _from_generated(cls, generated):
         return cls(

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_share_service_client.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_share_service_client.py
@@ -20,6 +20,7 @@ from azure.core.tracing.decorator import distributed_trace
 from ._generated import AzureFileStorage
 from ._generated.models import StorageServiceProperties
 from ._models import (
+    CorsRule,
     ShareProperties,
     SharePropertiesPaged,
     service_properties_deserialize,
@@ -37,7 +38,6 @@ else:
 
 if TYPE_CHECKING:
     from azure.core.credentials import AzureNamedKeyCredential, AzureSasCredential, TokenCredential
-    from ._generated.models import CorsRule
     from ._models import Metrics, ShareProtocolSettings
 
 
@@ -213,7 +213,7 @@ class ShareServiceClient(StorageAccountHostsMixin):
     def set_service_properties(
         self, hour_metrics: Optional["Metrics"] = None,
         minute_metrics: Optional["Metrics"] = None,
-        cors: Optional[List["CorsRule"]] = None,
+        cors: Optional[List[CorsRule]] = None,
         protocol: Optional["ShareProtocolSettings"] = None,
         **kwargs: Any
     ) -> None:
@@ -254,11 +254,14 @@ class ShareServiceClient(StorageAccountHostsMixin):
                 :dedent: 8
                 :caption: Sets file share service properties.
         """
+        if all(parameter is None for parameter in [hour_metrics, minute_metrics, cors, protocol]):
+            raise ValueError("set_service_properties should be called with at least one parameter")
+
         timeout = kwargs.pop('timeout', None)
         props = StorageServiceProperties(
             hour_metrics=hour_metrics,
             minute_metrics=minute_metrics,
-            cors=cors,
+            cors=CorsRule._to_generated(cors),  # pylint: disable=protected-access
             protocol=protocol
         )
         try:

--- a/sdk/storage/azure-storage-file-share/mypy.ini
+++ b/sdk/storage/azure-storage-file-share/mypy.ini
@@ -1,14 +1,2 @@
-[mypy]
-python_version = 3.7
-warn_return_any = True
-warn_unused_configs = True
-ignore_missing_imports = True
-
-# Per-module options:
-
 [mypy-azure.storage.fileshare._generated.*]
 ignore_errors = True
-
-[mypy-azure.core.*]
-ignore_errors = True
-

--- a/sdk/storage/azure-storage-file-share/samples/file_samples_authentication.py
+++ b/sdk/storage/azure-storage-file-share/samples/file_samples_authentication.py
@@ -26,6 +26,7 @@ USAGE:
 """
 
 import os
+import sys
 from datetime import datetime, timedelta
 
 
@@ -38,6 +39,11 @@ class FileAuthSamples(object):
     access_key = os.getenv("AZURE_STORAGE_ACCESS_KEY")
 
     def authentication_connection_string(self):
+        if self.connection_string is None:
+            print("Missing required environment variable: AZURE_STORAGE_CONNECTION_STRING." + '\n' +
+                  "Test: authentication_connection_string")
+            sys.exit(1)
+
         # Instantiate the ShareServiceClient from a connection string
         # [START create_share_service_client_from_conn_string]
         from azure.storage.fileshare import ShareServiceClient
@@ -45,6 +51,16 @@ class FileAuthSamples(object):
         # [END create_share_service_client_from_conn_string]
 
     def authentication_shared_access_key(self):
+        if self.account_url is None:
+            print("Missing required environment variable: AZURE_STORAGE_ACCOUNT_URL." + '\n' +
+                  "Test: authentication_shared_access_key")
+            sys.exit(1)
+
+        if self.access_key is None:
+            print("Missing required environment variable: AZURE_STORAGE_ACCESS_KEY." + '\n' +
+                  "Test: authentication_shared_access_key")
+            sys.exit(1)
+
         # Instantiate a ShareServiceClient using a shared access key
         # [START create_share_service_client]
         from azure.storage.fileshare import ShareServiceClient
@@ -55,6 +71,21 @@ class FileAuthSamples(object):
         # [END create_share_service_client]
 
     def authentication_shared_access_signature(self):
+        if self.connection_string is None:
+            print("Missing required environment variable: AZURE_STORAGE_CONNECTION_STRING." + '\n' +
+                  "Test: authentication_shared_access_signature")
+            sys.exit(1)
+
+        if self.account_name is None:
+            print("Missing required environment variable: AZURE_STORAGE_ACCOUNT_NAME." + '\n' +
+                  "Test: authentication_shared_access_signature")
+            sys.exit(1)
+
+        if self.access_key is None:
+            print("Missing required environment variable: AZURE_STORAGE_ACCESS_KEY." + '\n' +
+                  "Test: authentication_shared_access_signature")
+            sys.exit(1)
+
         # Instantiate a ShareServiceClient using a connection string
         # [START generate_sas_token]
         from azure.storage.fileshare import ShareServiceClient
@@ -73,6 +104,11 @@ class FileAuthSamples(object):
         # [END generate_sas_token]
 
     def authentication_default_azure_credential(self):
+        if self.account_url is None:
+            print("Missing required environment variable: AZURE_STORAGE_ACCOUNT_URL." + '\n' +
+                  "Test: authentication_default_azure_credential")
+            sys.exit(1)
+
         # [START file_share_oauth]
         # Get a credential for authentication
         # DefaultAzureCredential attempts a chained set of authentication methods.

--- a/sdk/storage/azure-storage-file-share/samples/file_samples_authentication_async.py
+++ b/sdk/storage/azure-storage-file-share/samples/file_samples_authentication_async.py
@@ -25,8 +25,9 @@ USAGE:
     4) AZURE_STORAGE_ACCESS_KEY - the storage account access key
 """
 
-import os
 import asyncio
+import os
+import sys
 from datetime import datetime, timedelta
 
 
@@ -39,6 +40,11 @@ class FileAuthSamplesAsync(object):
     access_key = os.getenv("AZURE_STORAGE_ACCESS_KEY")
 
     async def authentication_connection_string_async(self):
+        if self.connection_string is None:
+            print("Missing required environment variable: AZURE_STORAGE_CONNECTION_STRING." + '\n' +
+                  "Test: authentication_connection_string_async")
+            sys.exit(1)
+
         # Instantiate the ShareServiceClient from a connection string
         # [START create_share_service_client_from_conn_string]
         from azure.storage.fileshare.aio import ShareServiceClient
@@ -46,6 +52,16 @@ class FileAuthSamplesAsync(object):
         # [END create_share_service_client_from_conn_string]
 
     async def authentication_shared_access_key_async(self):
+        if self.account_url is None:
+            print("Missing required environment variable: AZURE_STORAGE_ACCOUNT_URL." + '\n' +
+                  "Test: authentication_shared_access_key_async")
+            sys.exit(1)
+
+        if self.access_key is None:
+            print("Missing required environment variable: AZURE_STORAGE_ACCESS_KEY." + '\n' +
+                  "Test: authentication_shared_access_key_async")
+            sys.exit(1)
+
         # Instantiate a ShareServiceClient using a shared access key
         # [START create_share_service_client]
         from azure.storage.fileshare.aio import ShareServiceClient
@@ -56,6 +72,21 @@ class FileAuthSamplesAsync(object):
         # [END create_share_service_client]
 
     async def authentication_shared_access_signature_async(self):
+        if self.connection_string is None:
+            print("Missing required environment variable: AZURE_STORAGE_CONNECTION_STRING." + '\n' +
+                  "Test: authentication_shared_access_signature_async")
+            sys.exit(1)
+
+        if self.account_name is None:
+            print("Missing required environment variable: AZURE_STORAGE_ACCOUNT_NAME." + '\n' +
+                  "Test: authentication_shared_access_signature_async")
+            sys.exit(1)
+
+        if self.access_key is None:
+            print("Missing required environment variable: AZURE_STORAGE_ACCESS_KEY." + '\n' +
+                  "Test: authentication_shared_access_signature_async")
+            sys.exit(1)
+
         # Instantiate a ShareServiceClient using a connection string
         from azure.storage.fileshare.aio import ShareServiceClient
         share_service_client = ShareServiceClient.from_connection_string(self.connection_string)
@@ -64,14 +95,19 @@ class FileAuthSamplesAsync(object):
         from azure.storage.fileshare import generate_account_sas, ResourceTypes, AccountSasPermissions
 
         sas_token = generate_account_sas(
-            share_service_client.account_name,
-            share_service_client.credential.account_key,
+            self.account_name,
+            self.access_key,
             resource_types=ResourceTypes(service=True),
             permission=AccountSasPermissions(read=True),
             expiry=datetime.utcnow() + timedelta(hours=1)
         )
 
     async def authentication_default_azure_credential_async(self):
+        if self.account_url is None:
+            print("Missing required environment variable: AZURE_STORAGE_ACCOUNT_URL." + '\n' +
+                  "Test: authentication_default_azure_credential_async")
+            sys.exit(1)
+
         # [START file_share_oauth]
         # Get a credential for authentication
         # DefaultAzureCredential attempts a chained set of authentication methods.

--- a/sdk/storage/azure-storage-file-share/samples/file_samples_client.py
+++ b/sdk/storage/azure-storage-file-share/samples/file_samples_client.py
@@ -22,6 +22,7 @@ USAGE:
 """
 
 import os
+import sys
 
 SOURCE_FILE = './SampleSource.txt'
 DEST_FILE = './SampleDestination.txt'
@@ -33,6 +34,11 @@ class FileSamples(object):
     account_name = os.getenv("AZURE_STORAGE_ACCOUNT_NAME")
 
     def simple_file_operations(self):
+        if self.connection_string is None:
+            print("Missing required environment variable: AZURE_STORAGE_CONNECTION_STRING." + '\n' +
+                  "Test: simple_file_operations")
+            sys.exit(1)
+
         # Instantiate the ShareClient from a connection string
         from azure.storage.fileshare import ShareClient
         share = ShareClient.from_connection_string(self.connection_string, "filesamples1")
@@ -74,6 +80,11 @@ class FileSamples(object):
             share.delete_share()
 
     def copy_file_from_url(self):
+        if self.connection_string is None:
+            print("Missing required environment variable: AZURE_STORAGE_CONNECTION_STRING." + '\n' +
+                  "Test: copy_file_from_url")
+            sys.exit(1)
+
         # Instantiate the ShareClient from a connection string
         from azure.storage.fileshare import ShareClient
         share = ShareClient.from_connection_string(self.connection_string, "filesamples2")
@@ -106,6 +117,11 @@ class FileSamples(object):
             share.delete_share()
 
     def acquire_file_lease(self):
+        if self.connection_string is None:
+            print("Missing required environment variable: AZURE_STORAGE_CONNECTION_STRING." + '\n' +
+                  "Test: acquire_file_lease")
+            sys.exit(1)
+
         # Instantiate the ShareClient from a connection string
         from azure.storage.fileshare import ShareClient
         share = ShareClient.from_connection_string(self.connection_string, "filesamples3")

--- a/sdk/storage/azure-storage-file-share/samples/file_samples_client_async.py
+++ b/sdk/storage/azure-storage-file-share/samples/file_samples_client_async.py
@@ -22,8 +22,9 @@ USAGE:
 """
 
 
-import os
 import asyncio
+import os
+import sys
 
 
 SOURCE_FILE = './SampleSource.txt'
@@ -36,6 +37,11 @@ class FileSamplesAsync(object):
     account_name = os.getenv("AZURE_STORAGE_ACCOUNT_NAME")
 
     async def simple_file_operations_async(self):
+        if self.connection_string is None:
+            print("Missing required environment variable: AZURE_STORAGE_CONNECTION_STRING." + '\n' +
+                  "Test: simple_file_operations_async")
+            sys.exit(1)
+
         # Instantiate the ShareClient from a connection string
         from azure.storage.fileshare.aio import ShareClient
         share = ShareClient.from_connection_string(self.connection_string, "filesamples1")
@@ -77,7 +83,12 @@ class FileSamplesAsync(object):
                 # Delete the share
                 await share.delete_share()
 
-    async def file_copy_from_url_async(self):
+    async def copy_file_from_url_async(self):
+        if self.connection_string is None:
+            print("Missing required environment variable: AZURE_STORAGE_CONNECTION_STRING." + '\n' +
+                  "Test: copy_file_from_url_async")
+            sys.exit(1)
+
         # Instantiate the ShareClient from a connection string
         from azure.storage.fileshare.aio import ShareClient
         share = ShareClient.from_connection_string(self.connection_string, "filesamples2")
@@ -114,7 +125,7 @@ class FileSamplesAsync(object):
 async def main():
     sample = FileSamplesAsync()
     await sample.simple_file_operations_async()
-    await sample.file_copy_from_url_async()
+    await sample.copy_file_from_url_async()
 
 if __name__ == '__main__':
     asyncio.run(main())

--- a/sdk/storage/azure-storage-file-share/samples/file_samples_directory.py
+++ b/sdk/storage/azure-storage-file-share/samples/file_samples_directory.py
@@ -21,6 +21,7 @@ USAGE:
 """
 
 import os
+import sys
 
 SOURCE_FILE = './SampleSource.txt'
 DEST_FILE = './SampleDestination.txt'
@@ -31,6 +32,11 @@ class DirectorySamples(object):
     connection_string = os.getenv('AZURE_STORAGE_CONNECTION_STRING')
 
     def create_directory_and_file(self):
+        if self.connection_string is None:
+            print("Missing required environment variable: AZURE_STORAGE_CONNECTION_STRING." + '\n' +
+                  "Test: create_directory_and_file")
+            sys.exit(1)
+
         # Instantiate the ShareClient from a connection string
         from azure.storage.fileshare import ShareClient
         share = ShareClient.from_connection_string(self.connection_string, "directorysamples1")
@@ -66,6 +72,11 @@ class DirectorySamples(object):
             share.delete_share()
 
     def create_subdirectory_and_file(self):
+        if self.connection_string is None:
+            print("Missing required environment variable: AZURE_STORAGE_CONNECTION_STRING." + '\n' +
+                  "Test: create_subdirectory_and_file")
+            sys.exit(1)
+
         # Instantiate the ShareClient from a connection string
         from azure.storage.fileshare import ShareClient
         share = ShareClient.from_connection_string(self.connection_string, "directorysamples2")
@@ -110,6 +121,11 @@ class DirectorySamples(object):
             share.delete_share()
 
     def get_subdirectory_client(self):
+        if self.connection_string is None:
+            print("Missing required environment variable: AZURE_STORAGE_CONNECTION_STRING." + '\n' +
+                  "Test: get_subdirectory_client")
+            sys.exit(1)
+
         # Instantiate the ShareClient from a connection string
         from azure.storage.fileshare import ShareClient
         share = ShareClient.from_connection_string(self.connection_string, "directorysamples3")

--- a/sdk/storage/azure-storage-file-share/samples/file_samples_directory_async.py
+++ b/sdk/storage/azure-storage-file-share/samples/file_samples_directory_async.py
@@ -20,8 +20,9 @@ USAGE:
     1) AZURE_STORAGE_CONNECTION_STRING - the connection string to your storage account
 """
 
-import os
 import asyncio
+import os
+import sys
 
 SOURCE_FILE = './SampleSource.txt'
 DEST_FILE = './SampleDestination.txt'
@@ -32,6 +33,11 @@ class DirectorySamplesAsync(object):
     connection_string = os.getenv('AZURE_STORAGE_CONNECTION_STRING')
 
     async def create_directory_and_file_async(self):
+        if self.connection_string is None:
+            print("Missing required environment variable: AZURE_STORAGE_CONNECTION_STRING." + '\n' +
+                  "Test: create_directory_and_file_async")
+            sys.exit(1)
+
         # Instantiate the ShareClient from a connection string
         from azure.storage.fileshare.aio import ShareClient
         share = ShareClient.from_connection_string(self.connection_string, "directorysamples1")
@@ -68,6 +74,11 @@ class DirectorySamplesAsync(object):
                 await share.delete_share()
 
     async def create_subdirectory_and_file_async(self):
+        if self.connection_string is None:
+            print("Missing required environment variable: AZURE_STORAGE_CONNECTION_STRING." + '\n' +
+                  "Test: create_subdirectory_and_file_async")
+            sys.exit(1)
+
         # Instantiate the ShareClient from a connection string
         from azure.storage.fileshare.aio import ShareClient
         share = ShareClient.from_connection_string(self.connection_string, "directorysamples2")
@@ -115,6 +126,11 @@ class DirectorySamplesAsync(object):
                 await share.delete_share()
 
     async def get_subdirectory_client_async(self):
+        if self.connection_string is None:
+            print("Missing required environment variable: AZURE_STORAGE_CONNECTION_STRING." + '\n' +
+                  "Test: get_subdirectory_client_async")
+            sys.exit(1)
+
         # Instantiate the ShareClient from a connection string
         from azure.storage.fileshare.aio import ShareClient
         share = ShareClient.from_connection_string(self.connection_string, "directorysamples3")

--- a/sdk/storage/azure-storage-file-share/samples/file_samples_hello_world.py
+++ b/sdk/storage/azure-storage-file-share/samples/file_samples_hello_world.py
@@ -21,6 +21,7 @@ USAGE:
 """
 
 import os
+import sys
 
 SOURCE_FILE = './SampleSource.txt'
 DEST_FILE = './SampleDestination.txt'
@@ -31,11 +32,21 @@ class HelloWorldSamples(object):
     connection_string = os.getenv('AZURE_STORAGE_CONNECTION_STRING')
 
     def create_client_with_connection_string(self):
+        if self.connection_string is None:
+            print("Missing required environment variable: AZURE_STORAGE_CONNECTION_STRING." + '\n' +
+                  "Test: create_client_with_connection_string")
+            sys.exit(1)
+
         # Instantiate the ShareServiceClient from a connection string
         from azure.storage.fileshare import ShareServiceClient
         file_service = ShareServiceClient.from_connection_string(self.connection_string)
 
     def create_file_share(self):
+        if self.connection_string is None:
+            print("Missing required environment variable: AZURE_STORAGE_CONNECTION_STRING." + '\n' +
+                  "Test: create_file_share")
+            sys.exit(1)
+
         # Instantiate the ShareClient from a connection string
         from azure.storage.fileshare import ShareClient
         share = ShareClient.from_connection_string(self.connection_string, share_name="helloworld1")
@@ -53,6 +64,11 @@ class HelloWorldSamples(object):
             share.delete_share()
 
     def upload_a_file_to_share(self):
+        if self.connection_string is None:
+            print("Missing required environment variable: AZURE_STORAGE_CONNECTION_STRING." + '\n' +
+                  "Test: upload_a_file_to_share")
+            sys.exit(1)
+
         # Instantiate the ShareClient from a connection string
         from azure.storage.fileshare import ShareClient
         share = ShareClient.from_connection_string(self.connection_string, share_name="helloworld2")

--- a/sdk/storage/azure-storage-file-share/samples/file_samples_hello_world_async.py
+++ b/sdk/storage/azure-storage-file-share/samples/file_samples_hello_world_async.py
@@ -20,8 +20,9 @@ USAGE:
     1) AZURE_STORAGE_CONNECTION_STRING - the connection string to your storage account
 """
 
-import os
 import asyncio
+import os
+import sys
 
 SOURCE_FILE = './SampleSource.txt'
 DEST_FILE = './SampleDestination.txt'
@@ -32,11 +33,22 @@ class HelloWorldSamplesAsync(object):
     connection_string = os.getenv('AZURE_STORAGE_CONNECTION_STRING')
 
     async def create_client_with_connection_string_async(self):
+        if self.connection_string is None:
+            print("Missing required environment variable: AZURE_STORAGE_CONNECTION_STRING." + '\n' +
+                  "Test: create_client_with_connection_string_async")
+            sys.exit(1)
+
+
         # Instantiate the ShareServiceClient from a connection string
         from azure.storage.fileshare.aio import ShareServiceClient
         file_service = ShareServiceClient.from_connection_string(self.connection_string)
 
     async def create_file_share_async(self):
+        if self.connection_string is None:
+            print("Missing required environment variable: AZURE_STORAGE_CONNECTION_STRING." + '\n' +
+                  "Test: create_file_share_async")
+            sys.exit(1)
+
         # Instantiate the ShareClient from a connection string
         from azure.storage.fileshare.aio import ShareClient
         share = ShareClient.from_connection_string(self.connection_string, share_name="helloworld1")
@@ -55,6 +67,11 @@ class HelloWorldSamplesAsync(object):
                 await share.delete_share()
 
     async def upload_a_file_to_share_async(self):
+        if self.connection_string is None:
+            print("Missing required environment variable: AZURE_STORAGE_CONNECTION_STRING." + '\n' +
+                  "Test: upload_a_file_to_share_async")
+            sys.exit(1)
+
         # Instantiate the ShareClient from a connection string
         from azure.storage.fileshare.aio import ShareClient
         share = ShareClient.from_connection_string(self.connection_string, share_name='helloworld2')

--- a/sdk/storage/azure-storage-file-share/samples/file_samples_service.py
+++ b/sdk/storage/azure-storage-file-share/samples/file_samples_service.py
@@ -22,6 +22,7 @@ USAGE:
 """
 
 import os
+import sys
 
 SOURCE_FILE = './SampleSource.txt'
 DEST_FILE = './SampleDestination.txt'
@@ -32,6 +33,11 @@ class FileShareServiceSamples(object):
     connection_string = os.getenv('AZURE_STORAGE_CONNECTION_STRING')
 
     def file_service_properties(self):
+        if self.connection_string is None:
+            print("Missing required environment variable: AZURE_STORAGE_CONNECTION_STRING." + '\n' +
+                  "Test: file_service_properties")
+            sys.exit(1)
+
         # Instantiate the ShareServiceClient from a connection string
         from azure.storage.fileshare import ShareServiceClient
         file_service = ShareServiceClient.from_connection_string(self.connection_string)
@@ -70,6 +76,11 @@ class FileShareServiceSamples(object):
         # [END get_service_properties]
 
     def list_shares_in_service(self):
+        if self.connection_string is None:
+            print("Missing required environment variable: AZURE_STORAGE_CONNECTION_STRING." + '\n' +
+                  "Test: list_shares_in_service")
+            sys.exit(1)
+
         # Instantiate the ShareServiceClient from a connection string
         from azure.storage.fileshare import ShareServiceClient
         file_service = ShareServiceClient.from_connection_string(self.connection_string)
@@ -93,6 +104,11 @@ class FileShareServiceSamples(object):
             # [END fsc_delete_shares]
 
     def get_share_client(self):
+        if self.connection_string is None:
+            print("Missing required environment variable: AZURE_STORAGE_CONNECTION_STRING." + '\n' +
+                  "Test: get_share_client")
+            sys.exit(1)
+
         # [START get_share_client]
         from azure.storage.fileshare import ShareServiceClient
         file_service = ShareServiceClient.from_connection_string(self.connection_string)

--- a/sdk/storage/azure-storage-file-share/samples/file_samples_service_async.py
+++ b/sdk/storage/azure-storage-file-share/samples/file_samples_service_async.py
@@ -23,6 +23,7 @@ USAGE:
 
 import asyncio
 import os
+import sys
 
 SOURCE_FILE = './SampleSource.txt'
 DEST_FILE = './SampleDestination.txt'
@@ -33,6 +34,11 @@ class FileShareServiceSamplesAsync(object):
     connection_string = os.getenv('AZURE_STORAGE_CONNECTION_STRING')
 
     async def file_service_properties_async(self):
+        if self.connection_string is None:
+            print("Missing required environment variable: AZURE_STORAGE_CONNECTION_STRING." + '\n' +
+                  "Test: file_service_properties_async")
+            sys.exit(1)
+
         # Instantiate the ShareServiceClient from a connection string
         from azure.storage.fileshare.aio import ShareServiceClient
         file_service = ShareServiceClient.from_connection_string(self.connection_string)
@@ -72,6 +78,11 @@ class FileShareServiceSamplesAsync(object):
             # [END get_service_properties]
 
     async def list_shares_in_service_async(self):
+        if self.connection_string is None:
+            print("Missing required environment variable: AZURE_STORAGE_CONNECTION_STRING." + '\n' +
+                  "Test: list_shares_in_service_async")
+            sys.exit(1)
+
         # Instantiate the ShareServiceClient from a connection string
         from azure.storage.fileshare.aio import ShareServiceClient
         file_service = ShareServiceClient.from_connection_string(self.connection_string)
@@ -98,6 +109,11 @@ class FileShareServiceSamplesAsync(object):
                 # [END fsc_delete_shares]
 
     async def get_share_client_async(self):
+        if self.connection_string is None:
+            print("Missing required environment variable: AZURE_STORAGE_CONNECTION_STRING." + '\n' +
+                  "Test: get_share_client_async")
+            sys.exit(1)
+
         # [START get_share_client]
         from azure.storage.fileshare.aio import ShareServiceClient
         file_service = ShareServiceClient.from_connection_string(self.connection_string)

--- a/sdk/storage/azure-storage-file-share/samples/file_samples_share.py
+++ b/sdk/storage/azure-storage-file-share/samples/file_samples_share.py
@@ -22,6 +22,8 @@ USAGE:
 """
 
 import os
+import sys
+
 from azure.storage.fileshare import ShareAccessTier
 
 SOURCE_FILE = './SampleSource.txt'
@@ -33,6 +35,11 @@ class ShareSamples(object):
     connection_string = os.getenv('AZURE_STORAGE_CONNECTION_STRING')
 
     def create_share_snapshot(self):
+        if self.connection_string is None:
+            print("Missing required environment variable: AZURE_STORAGE_CONNECTION_STRING." + '\n' +
+                  "Test: create_share_snapshot")
+            sys.exit(1)
+
         # Instantiate the ShareClient from a connection string
         from azure.storage.fileshare import ShareClient
         share = ShareClient.from_connection_string(self.connection_string, "sharesamples1")
@@ -51,6 +58,11 @@ class ShareSamples(object):
             # [END delete_share]
 
     def set_share_quota_and_metadata(self):
+        if self.connection_string is None:
+            print("Missing required environment variable: AZURE_STORAGE_CONNECTION_STRING." + '\n' +
+                  "Test: set_share_quota_and_metadata")
+            sys.exit(1)
+
         # [START create_share_client_from_conn_string]
         from azure.storage.fileshare import ShareClient
         share = ShareClient.from_connection_string(self.connection_string, "sharesamples2")
@@ -78,6 +90,11 @@ class ShareSamples(object):
             share.delete_share()
 
     def set_share_properties(self):
+        if self.connection_string is None:
+            print("Missing required environment variable: AZURE_STORAGE_CONNECTION_STRING." + '\n' +
+                  "Test: set_share_properties")
+            sys.exit(1)
+
         from azure.storage.fileshare import ShareClient
         share1 = ShareClient.from_connection_string(self.connection_string, "sharesamples3a")
         share2 = ShareClient.from_connection_string(self.connection_string, "sharesamples3b")
@@ -108,6 +125,11 @@ class ShareSamples(object):
             share2.delete_share()
 
     def list_directories_and_files(self):
+        if self.connection_string is None:
+            print("Missing required environment variable: AZURE_STORAGE_CONNECTION_STRING." + '\n' +
+                  "Test: list_directories_and_files")
+            sys.exit(1)
+
         # Instantiate the ShareClient from a connection string
         from azure.storage.fileshare import ShareClient
         share = ShareClient.from_connection_string(self.connection_string, "sharesamples4")
@@ -133,6 +155,11 @@ class ShareSamples(object):
             share.delete_share()
 
     def get_directory_or_file_client(self):
+        if self.connection_string is None:
+            print("Missing required environment variable: AZURE_STORAGE_CONNECTION_STRING." + '\n' +
+                  "Test: get_directory_or_file_client")
+            sys.exit(1)
+
         # Instantiate the ShareClient from a connection string
         from azure.storage.fileshare import ShareClient
         share = ShareClient.from_connection_string(self.connection_string, "sharesamples5")
@@ -144,6 +171,11 @@ class ShareSamples(object):
         my_file = share.get_file_client("dir1/myfile")
 
     def acquire_share_lease(self):
+        if self.connection_string is None:
+            print("Missing required environment variable: AZURE_STORAGE_CONNECTION_STRING." + '\n' +
+                  "Test: acquire_share_lease")
+            sys.exit(1)
+
         # Instantiate the ShareClient from a connection string
         from azure.storage.fileshare import ShareClient
         share = ShareClient.from_connection_string(self.connection_string, "sharesamples")

--- a/sdk/storage/azure-storage-file-share/samples/file_samples_share_async.py
+++ b/sdk/storage/azure-storage-file-share/samples/file_samples_share_async.py
@@ -21,8 +21,10 @@ USAGE:
     1) AZURE_STORAGE_CONNECTION_STRING - the connection string to your storage account
 """
 
-import os
 import asyncio
+import os
+import sys
+
 from azure.storage.fileshare import ShareAccessTier
 
 SOURCE_FILE = './SampleSource.txt'
@@ -34,6 +36,11 @@ class ShareSamplesAsync(object):
     connection_string = os.getenv('AZURE_STORAGE_CONNECTION_STRING')
 
     async def create_share_snapshot_async(self):
+        if self.connection_string is None:
+            print("Missing required environment variable: AZURE_STORAGE_CONNECTION_STRING." + '\n' +
+                  "Test: create_share_snapshot_async")
+            sys.exit(1)
+
         # Instantiate the ShareClient from a connection string
         from azure.storage.fileshare.aio import ShareClient
         share = ShareClient.from_connection_string(self.connection_string, "sharesamples1")
@@ -53,6 +60,11 @@ class ShareSamplesAsync(object):
                 # [END delete_share]
 
     async def set_share_quota_and_metadata_async(self):
+        if self.connection_string is None:
+            print("Missing required environment variable: AZURE_STORAGE_CONNECTION_STRING." + '\n' +
+                  "Test: set_share_quota_and_metadata_async")
+            sys.exit(1)
+
         # [START create_share_client_from_conn_string]
         from azure.storage.fileshare.aio import ShareClient
         share = ShareClient.from_connection_string(self.connection_string, "sharesamples2")
@@ -80,7 +92,12 @@ class ShareSamplesAsync(object):
                 # Delete the share
                 await share.delete_share()
 
-    async def set_share_properties(self):
+    async def set_share_properties_async(self):
+        if self.connection_string is None:
+            print("Missing required environment variable: AZURE_STORAGE_CONNECTION_STRING." + '\n' +
+                  "Test: set_share_properties_async")
+            sys.exit(1)
+
         from azure.storage.fileshare.aio import ShareClient
         share1 = ShareClient.from_connection_string(self.connection_string, "sharesamples3a")
         share2 = ShareClient.from_connection_string(self.connection_string, "sharesamples3b")
@@ -114,6 +131,11 @@ class ShareSamplesAsync(object):
                 await share2.delete_share()
 
     async def list_directories_and_files_async(self):
+        if self.connection_string is None:
+            print("Missing required environment variable: AZURE_STORAGE_CONNECTION_STRING." + '\n' +
+                  "Test: list_directories_and_files_async")
+            sys.exit(1)
+
         # Instantiate the ShareClient from a connection string
         from azure.storage.fileshare.aio import ShareClient
         share = ShareClient.from_connection_string(self.connection_string, "sharesamples4")
@@ -142,6 +164,11 @@ class ShareSamplesAsync(object):
                 await share.delete_share()
 
     async def get_directory_or_file_client_async(self):
+        if self.connection_string is None:
+            print("Missing required environment variable: AZURE_STORAGE_CONNECTION_STRING." + '\n' +
+                  "Test: get_directory_or_file_client_async")
+            sys.exit(1)
+
         # Instantiate the ShareClient from a connection string
         from azure.storage.fileshare.aio import ShareClient
         share = ShareClient.from_connection_string(self.connection_string, "sharesamples5")
@@ -157,7 +184,7 @@ async def main():
     sample = ShareSamplesAsync()
     await sample.create_share_snapshot_async()
     await sample.set_share_quota_and_metadata_async()
-    await sample.set_share_properties()
+    await sample.set_share_properties_async()
     await sample.list_directories_and_files_async()
     await sample.get_directory_or_file_client_async()
 


### PR DESCRIPTION
**Notes:**

1. There was an error with `CorsRule` sample, so had to implement a static method in `CorsRule` `_models.py` to convert the model's version of `CorsRule` to the acceptable generated version of `CorsRule` in order to pass `mypy`
2. A few async tests left out async in the suffix, so added that back. Also, a few async tests weren't exactly 1-1 with naming, so also fixed that.
3. Changed params in `file_samples_authentication_async.py` file's `authentication_shared_access_signature_async` sample to use `self.account_name` and `self.access_key`

**Follow-Ups:**

1. Should we change error message from "Test: X" to "Sample: X"? Blob currently uses "Test: X"
2. For the sake of thoroughness, should we add an async sample for lease APIs and update docstring?
    - `file_samples_client_async.py`
    - `file_samples_share_async.py`