### PR TITLE
[Identity] Stop using deprecated datetime methods

### DIFF
--- a/sdk/identity/azure-identity/azure/identity/_credentials/device_code.py
+++ b/sdk/identity/azure-identity/azure/identity/_credentials/device_code.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 # ------------------------------------
-from datetime import datetime
+from datetime import datetime, timezone
 import time
 from typing import Dict, Optional, Callable, Any
 
@@ -93,10 +93,9 @@ class DeviceCodeCredential(InteractiveCredential):
             raise ClientAuthenticationError(
                 message="Couldn't begin authentication: {}".format(flow.get("error_description") or flow.get("error"))
             )
-
         if self._prompt_callback:
             self._prompt_callback(
-                flow["verification_uri"], flow["user_code"], datetime.utcfromtimestamp(flow["expires_at"])
+                flow["verification_uri"], flow["user_code"], datetime.fromtimestamp(flow["expires_at"], timezone.utc)
             )
         else:
             print(flow["message"])

--- a/sdk/identity/azure-identity/tests/test_device_code_credential.py
+++ b/sdk/identity/azure-identity/tests/test_device_code_credential.py
@@ -209,7 +209,7 @@ def test_device_code_credential():
         disable_instance_discovery=True,
     )
 
-    now = datetime.datetime.utcnow()
+    now = datetime.datetime.now(datetime.timezone.utc)
     token = credential.get_token("scope")
     assert token.token == expected_token
 
@@ -269,7 +269,6 @@ def test_tenant_id():
         additionally_allowed_tenants=["*"],
     )
 
-    now = datetime.datetime.utcnow()
     token = credential.get_token("scope", tenant_id="tenant_id")
     assert token.token == expected_token
 


### PR DESCRIPTION
The `datetime` methods `utcfromtimestamp` and `utcnow` are deprecated, so this PR is adjusting where we use these.