### PR TITLE
Removing VM size check from Azure Remote Rendering sdk tests.

### DIFF
--- a/sdk/remoterendering/azure-mixedreality-remoterendering/tests/test_client.py
+++ b/sdk/remoterendering/azure-mixedreality-remoterendering/tests/test_client.py
@@ -231,14 +231,12 @@ class TestRemoteRenderingClient(AzureRecordedTestCase):
 
         session = arr_client.get_rendering_session(session_id)
         assert session.id == session_id
-        assert session.size == RenderingSessionSize.STANDARD
 
         assert session.lease_time_minutes == 15
         assert session.status != RenderingSessionStatus.ERROR
 
         ready_session = session_poller.result()
         assert ready_session.id == session_id
-        assert ready_session.size == RenderingSessionSize.STANDARD
         assert ready_session.lease_time_minutes == 15
         assert ready_session.status == RenderingSessionStatus.READY
 
@@ -248,7 +246,6 @@ class TestRemoteRenderingClient(AzureRecordedTestCase):
 
         extended_session = arr_client.update_rendering_session(session_id=session_id,  lease_time_minutes=20)
         assert extended_session.id == session_id
-        assert extended_session.size == RenderingSessionSize.STANDARD
         assert extended_session.lease_time_minutes == 15 or extended_session.lease_time_minutes == 20
         assert extended_session.status == RenderingSessionStatus.READY
 

--- a/sdk/remoterendering/azure-mixedreality-remoterendering/tests/test_client_async.py
+++ b/sdk/remoterendering/azure-mixedreality-remoterendering/tests/test_client_async.py
@@ -226,14 +226,12 @@ class TestRemoteRenderingClientAsync(AzureRecordedTestCase):
 
         session = await async_arr_client.get_rendering_session(session_id)
         assert session.id == session_id
-        assert session.size == RenderingSessionSize.STANDARD
 
         assert session.lease_time_minutes == 15
         assert session.status != RenderingSessionStatus.ERROR
 
         ready_session = await session_poller.result()
         assert ready_session.id == session_id
-        assert ready_session.size == RenderingSessionSize.STANDARD
         assert ready_session.lease_time_minutes == 15
         assert ready_session.status == RenderingSessionStatus.READY
 
@@ -243,7 +241,6 @@ class TestRemoteRenderingClientAsync(AzureRecordedTestCase):
 
         extended_session = await async_arr_client.update_rendering_session(session_id=session_id, lease_time_minutes=20)
         assert extended_session.id == session_id
-        assert extended_session.size == RenderingSessionSize.STANDARD
         assert extended_session.lease_time_minutes == 15 or extended_session.lease_time_minutes == 20
         assert extended_session.status == RenderingSessionStatus.READY
 


### PR DESCRIPTION
The check is removed as we currently load-balance the session requests for the testing account specifically to avoid customer impact with regards to regular session availability. So in essence, the sessions the tests will get are not guaranteed to be 'standard' sized. Consequently, there is no point in testing this particular session property.
