### PR TITLE
Correct util duration variables

### DIFF
--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_utils.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/azure/monitor/opentelemetry/exporter/_utils.py
@@ -121,12 +121,12 @@ azure_monitor_context = {
 
 def ns_to_duration(nanoseconds: int) -> str:
     value = (nanoseconds + 500000) // 1000000  # duration in milliseconds
-    value, microseconds = divmod(value, 1000)
+    value, milliseconds = divmod(value, 1000)
     value, seconds = divmod(value, 60)
     value, minutes = divmod(value, 60)
     days, hours = divmod(value, 24)
     return "{:d}.{:02d}:{:02d}:{:02d}.{:03d}".format(
-        days, hours, minutes, seconds, microseconds
+        days, hours, minutes, seconds, milliseconds
     )
 
 

--- a/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/test_utils.py
+++ b/sdk/monitor/azure-monitor-opentelemetry-exporter/tests/test_utils.py
@@ -40,7 +40,9 @@ class TestUtils(unittest.TestCase):
     def test_nanoseconds_to_duration(self):
         ns_to_duration = _utils.ns_to_duration
         self.assertEqual(ns_to_duration(0), "0.00:00:00.000")
+        self.assertEqual(ns_to_duration(500000), "0.00:00:00.001") # Rounding
         self.assertEqual(ns_to_duration(1000000), "0.00:00:00.001")
+        self.assertEqual(ns_to_duration(1500000), "0.00:00:00.002") # Rounding
         self.assertEqual(ns_to_duration(1000000000), "0.00:00:01.000")
         self.assertEqual(ns_to_duration(60 * 1000000000), "0.00:01:00.000")
         self.assertEqual(ns_to_duration(3600 * 1000000000), "0.01:00:00.000")


### PR DESCRIPTION
# Description

Utils previously labeled milliseconds as microseconds

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
