### PR TITLE
[Storage] Refactor single upload APIs

### DIFF
--- a/sdk/storage/azure-storage-blob/assets.json
+++ b/sdk/storage/azure-storage-blob/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "python",
   "TagPrefix": "python/storage/azure-storage-blob",
-  "Tag": "python/storage/azure-storage-blob_65571078b7"
+  "Tag": "python/storage/azure-storage-blob_7c0818e3bd"
 }

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_client.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_client.py
@@ -3050,17 +3050,18 @@ class BlobClient(StorageAccountHostsMixin, StorageEncryptionMixin):  # pylint: d
 
     @distributed_trace
     def append_block(
-        self, data: Union[bytes, str, Iterable[AnyStr], IO[bytes]],
+        self, data: Union[bytes, Iterable[bytes], IO[bytes]],
         length: Optional[int] = None,
         **kwargs: Any
     ) -> Dict[str, Union[str, datetime, int]]:
         """Commits a new block of data to the end of the existing append blob.
 
         :param data:
-            Content of the block. This can be bytes, text, an iterable or a file-like object.
-        :type data: Union[bytes, str, Iterable[AnyStr], IO[bytes]]
+            Content of the block. This can be bytes, iterable or a file-like object.
+        :type data: Union[bytes, Iterable[bytes], IO[bytes]]
         :param int length:
-            Size of the block in bytes.
+            Size of the block. Optional if the length of data can be determined. For Iterable and IO, if the
+            length is not provided and cannot be determined, all data will be read into memory.
         :keyword validate_content:
             Enables checksum validation for the transfer. Any hash calculated is NOT stored with the blob.
             The possible options for content validation are as follows:

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_client.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_client.py
@@ -1937,7 +1937,7 @@ class BlobClient(StorageAccountHostsMixin, StorageEncryptionMixin):  # pylint: d
     @distributed_trace
     def stage_block(
         self, block_id: str,
-        data: Union[bytes, str, Iterable[AnyStr], IO[bytes]],
+        data: Union[bytes, Iterable[bytes], IO[bytes]],
         length: Optional[int] = None,
         **kwargs: Any
     ) -> Dict[str, Any]:
@@ -1947,8 +1947,10 @@ class BlobClient(StorageAccountHostsMixin, StorageEncryptionMixin):  # pylint: d
              The string should be less than or equal to 64 bytes in size.
              For a given blob, the block_id must be the same size for each block.
         :param data: The blob data.
-        :type data: Union[bytes, str, Iterable[AnyStr], IO[bytes]]
-        :param int length: Size of the block.
+        :type data: Union[bytes, Iterable[bytes], IO[bytes]]
+        :param int length:
+            Size of the block. Optional if the length of data can be determined. For Iterable and IO, if the
+            length is not provided and cannot be determined, all data will be read into memory.
         :keyword validate_content:
             Enables checksum validation for the transfer. Any hash calculated is NOT stored with the blob.
             The possible options for content validation are as follows:

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_client_helpers.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_client_helpers.py
@@ -953,7 +953,7 @@ def _upload_page_options(
     page = page[:length]
     if isinstance(page, str):
         page = page.encode(kwargs.pop('encoding', 'UTF-8'))
-        length = len(page)  # Account for change in length due ot encoding
+        length = len(page)  # Account for change in length due to encoding
 
     if offset is None or offset % 512 != 0:
         raise ValueError("offset must be an integer that aligns with 512 page size")

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_client_helpers.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_client_helpers.py
@@ -950,9 +950,10 @@ def _upload_page_options(
     length: int,
     **kwargs: Any
 ) -> Dict[str, Any]:
+    page = page[:length]
     if isinstance(page, str):
         page = page.encode(kwargs.pop('encoding', 'UTF-8'))
-    page = page[:length]
+        length = len(page)  # Account for change in length due ot encoding
 
     if offset is None or offset % 512 != 0:
         raise ValueError("offset must be an integer that aligns with 512 page size")

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_client_helpers.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_client_helpers.py
@@ -684,7 +684,7 @@ def _abort_copy_options(copy_id: Union[str, Dict[str, Any], BlobProperties], **k
 
 def _stage_block_options(
     block_id: str,
-    data: Union[bytes, str, Iterable[AnyStr], IO[bytes]],
+    data: Union[bytes, str, Iterable[AnyStr], IO[AnyStr]],
     length: Optional[int] = None,
     **kwargs: Any
 ) -> Dict[str, Any]:

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_client_helpers.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_client_helpers.py
@@ -684,7 +684,7 @@ def _abort_copy_options(copy_id: Union[str, Dict[str, Any], BlobProperties], **k
 
 def _stage_block_options(
     block_id: str,
-    data: Union[bytes, str, Iterable[AnyStr], IO[AnyStr]],
+    data: Union[bytes, IO[bytes], Iterable[bytes]],
     length: Optional[int] = None,
     **kwargs: Any
 ) -> Dict[str, Any]:
@@ -1093,7 +1093,7 @@ def _clear_page_options(
     return options
 
 def _append_block_options(
-    data: Union[bytes, str, Iterable[AnyStr], IO[bytes]],
+    data: Union[bytes, IO[bytes], Iterable[bytes]],
     length: Optional[int] = None,
     **kwargs: Any
 ) -> Dict[str, Any]:

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/uploads.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/uploads.py
@@ -4,6 +4,7 @@
 # license information.
 # --------------------------------------------------------------------------
 
+import warnings
 from collections import namedtuple
 from concurrent import futures
 from io import BytesIO, IOBase, SEEK_CUR, SEEK_END, SEEK_SET, UnsupportedOperation
@@ -26,7 +27,7 @@ _ERROR_VALUE_SHOULD_BE_SEEKABLE_STREAM = "{0} should be a seekable file-like/io.
 
 
 def prepare_upload_data(
-    data: Union[bytes, str, IO[bytes], Iterable[AnyStr]],
+    data: Union[bytes, str, IO[AnyStr], Iterable[AnyStr]],
     encoding: str,
     data_length: Optional[int],
     validate_content: Union[bool, str, None]
@@ -34,11 +35,9 @@ def prepare_upload_data(
     # Trim the incoming data per provided length
     if data_length is not None and isinstance(data, (str, bytes)) and data_length != len(data):
         data = data[:data_length]
-    # Encode raw string data
+
     if isinstance(data, str):
         data = data.encode(encoding)
-        # The user provided length was in terms of characters and has already been used to slice input.
-        # Now convert to a byte length.
         data_length = len(data)
 
     # Attempt to determine length of data if it's not provided
@@ -46,23 +45,29 @@ def prepare_upload_data(
         data_length = get_length(data)
     # If we still can't get the length, read all the data into memory
     if data_length is None:
+        warnings.warn("Unable to determine length for Iterable/IO, reading all data into memory.")
         data_length, data = read_length(data)
 
     structured_message = validate_content == ChecksumAlgorithm.CRC64
     md5 = validate_content in (True, ChecksumAlgorithm.MD5)
     if isinstance(data, bytes):
-        # Structured message requires a stream
         if structured_message:
             data = BytesIO(data)
     elif hasattr(data, 'read'):
-        # TODO: Block IO[str] here?
-        pass
+        # Block IO[str] with CRC64
+        if structured_message:
+            test = data.read(0)
+            if not isinstance(test, bytes):
+                raise TypeError("Only IO[bytes] is supported when using CRC64.")
     elif hasattr(data, '__iter__') and not isinstance(data, (list, tuple, set, dict)):
-        data = IterStreamer(cast(Iterable[AnyStr], data), encoding=encoding)
+        data = IterStreamer(
+            cast(Iterable[AnyStr], data),
+            length=data_length,
+            encoding='latin-1',  # Use latin-1 for backwards compatibility with Requests
+            block_str=structured_message)
     else:
         raise TypeError(f"Unsupported data type: {type(data)}")
 
-    # TODO: Do something about this?
     # If MD5, read data out of IterStreamer because the pipeline
     # will require a seekable stream which IterStreamer is not.
     if isinstance(data, IterStreamer) and md5:

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/uploads.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/uploads.py
@@ -11,7 +11,7 @@ from io import BytesIO, IOBase, SEEK_CUR, SEEK_END, SEEK_SET, UnsupportedOperati
 from itertools import islice
 from math import ceil
 from threading import Lock
-from typing import Any, AnyStr, cast, Dict, Generator, IO, Iterable, Optional, Sized, Tuple, Union
+from typing import Any, cast, Dict, Generator, IO, Iterable, Optional, Sized, Tuple, Union
 
 from azure.core.tracing.common import with_current_context
 
@@ -27,7 +27,7 @@ _ERROR_VALUE_SHOULD_BE_SEEKABLE_STREAM = "{0} should be a seekable file-like/io.
 
 
 def prepare_upload_data(
-    data: Union[bytes, str, IO[AnyStr], Iterable[AnyStr]],
+    data: Union[bytes, str, IO[bytes], IO[str], Iterable[bytes], Iterable[str]],
     encoding: str,
     data_length: Optional[int],
     validate_content: Union[bool, str, None]
@@ -61,7 +61,7 @@ def prepare_upload_data(
                 raise TypeError("Only IO[bytes] is supported when using CRC64.")
     elif hasattr(data, '__iter__') and not isinstance(data, (list, tuple, set, dict)):
         data = IterStreamer(
-            cast(Iterable[AnyStr], data),
+            cast(Iterable[bytes], data),
             length=data_length,
             encoding='latin-1',  # Use latin-1 for backwards compatibility with Requests
             block_str=structured_message)

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_blob_client_async.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_blob_client_async.py
@@ -1836,7 +1836,7 @@ class BlobClient(AsyncStorageAccountHostsMixin, StorageAccountHostsMixin, Storag
     @distributed_trace_async
     async def stage_block(
         self, block_id: str,
-        data: Union[bytes, str, Iterable[AnyStr], IO[bytes]],
+        data: Union[bytes, Iterable[bytes], IO[bytes]],
         length: Optional[int] = None,
         **kwargs: Any
     ) -> Dict[str, Any]:
@@ -1846,8 +1846,10 @@ class BlobClient(AsyncStorageAccountHostsMixin, StorageAccountHostsMixin, Storag
              The string should be less than or equal to 64 bytes in size.
              For a given blob, the block_id must be the same size for each block.
         :param data: The blob data.
-        :type data: Union[bytes, str, Iterable[AnyStr], IO[bytes]]
-        :param int length: Size of the block.
+        :type data: Union[bytes, Iterable[bytes], IO[bytes]]
+        :param int length:
+            Size of the block. Optional if the length of data can be determined. For Iterable and IO, if the
+            length is not provided and cannot be determined, all data will be read into memory.
         :keyword validate_content:
             Enables checksum validation for the transfer. Any hash calculated is NOT stored with the blob.
             The possible options for content validation are as follows:

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_blob_client_async.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_blob_client_async.py
@@ -2952,17 +2952,18 @@ class BlobClient(AsyncStorageAccountHostsMixin, StorageAccountHostsMixin, Storag
 
     @distributed_trace_async
     async def append_block(
-        self, data: Union[bytes, str, Iterable[AnyStr], IO[bytes]],
+        self, data: Union[bytes, Iterable[bytes], IO[bytes]],
         length: Optional[int] = None,
         **kwargs: Any
     ) -> Dict[str, Any]:
         """Commits a new block of data to the end of the existing append blob.
 
         :param data:
-            Content of the block.
-        :type data: Union[bytes, str, Iterable[AnyStr], IO[bytes]]
+            Content of the block. This can be bytes, iterable or a file-like object.
+        :type data: Union[bytes, Iterable[bytes], IO[bytes]]
         :param int length:
-            Size of the block in bytes.
+            Size of the block. Optional if the length of data can be determined. For Iterable and IO, if the
+            length is not provided and cannot be determined, all data will be read into memory.
         :keyword validate_content:
             Enables checksum validation for the transfer. Any hash calculated is NOT stored with the blob.
             The possible options for content validation are as follows:

--- a/sdk/storage/azure-storage-blob/tests/test_append_blob_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_append_blob_async.py
@@ -5,9 +5,8 @@
 # --------------------------------------------------------------------------
 
 import tempfile
-import uuid
 from datetime import datetime, timedelta
-from os import path, remove
+from io import BytesIO, StringIO
 
 import pytest
 from azure.core import MatchConditions
@@ -211,22 +210,59 @@ class TestStorageAppendBlobAsync(AsyncStorageRecordedTestCase):
 
     @BlobPreparer()
     @recorded_by_proxy_async
-    async def test_append_block_unicode(self, **kwargs):
+    async def test_append_block_bytes(self, **kwargs):
         storage_account_name = kwargs.pop("storage_account_name")
         storage_account_key = kwargs.pop("storage_account_key")
 
-        bsc = BlobServiceClient(self.account_url(storage_account_name, "blob"), storage_account_key, max_block_size=4 * 1024)
+        bsc = BlobServiceClient(self.account_url(storage_account_name, "blob"), storage_account_key)
         await self._setup(bsc)
         blob = await self._create_blob(bsc)
+        data = b'Hello World'
+        io = BytesIO(data)
+
+        def generator():
+            yield b'Hello'
+            yield b' '
+            yield b'World'
 
         # Act
-        resp = await blob.append_block(u'啊齄丂狛狜', encoding='utf-16')
-        assert int(resp['blob_append_offset']) == 0
-        assert resp['blob_committed_block_count'] == 1
-        assert resp['etag'] is not None
-        assert resp['last_modified'] is not None
+        await blob.append_block(data)
+        await blob.append_block(io)
+        await blob.append_block(generator())
+        await blob.append_block(generator(), length=len(data))
 
         # Assert
+        content = await (await blob.download_blob()).read()
+        assert content == data * 4
+
+    @BlobPreparer()
+    @recorded_by_proxy_async
+    async def test_append_block_str_legacy(self, **kwargs):
+        # Test operations with str types that are expected to work for legacy reasons but are no longer supported.
+        storage_account_name = kwargs.pop("storage_account_name")
+        storage_account_key = kwargs.pop("storage_account_key")
+
+        bsc = BlobServiceClient(self.account_url(storage_account_name, "blob"), storage_account_key)
+        await self._setup(bsc)
+        blob = await self._create_blob(bsc)
+        data = 'Hello World'
+        unicode_data = '你好世界'
+        io = StringIO(data)
+
+        def generator():
+            yield 'Hello'
+            yield ' '
+            yield 'World'
+
+        # Act
+        await blob.append_block(data)
+        await blob.append_block(io)
+        await blob.append_block(generator(), length=len(data))
+        await blob.append_block(unicode_data, encoding='utf-32')
+
+        # Assert
+        content = await (await blob.download_blob()).read()
+        assert content == data.encode('latin-1') * 3 + unicode_data.encode('utf-32')
 
     @BlobPreparer()
     @recorded_by_proxy_async

--- a/sdk/storage/azure-storage-blob/tests/test_block_blob.py
+++ b/sdk/storage/azure-storage-blob/tests/test_block_blob.py
@@ -5,7 +5,7 @@
 # --------------------------------------------------------------------------
 import tempfile
 from datetime import datetime, timedelta
-from io import BytesIO
+from io import BytesIO, StringIO
 
 import pytest
 from azure.core.exceptions import HttpResponseError, ResourceExistsError, ResourceModifiedError, ResourceNotFoundError
@@ -47,7 +47,8 @@ class TestStorageBlockBlob(StorageRecordedTestCase):
             self.account_url(storage_account_name, "blob"),
             credential=key,
             max_single_put_size=1024,
-            max_block_size=1024)
+            max_block_size=1024,
+            logging_enable=True)
         self.config = self.bsc._config
         self.container_name = self.get_resource_name(container_name)
         self.source_container_name = self.get_resource_name('utcontainersource1')
@@ -521,18 +522,59 @@ class TestStorageBlockBlob(StorageRecordedTestCase):
 
     @BlobPreparer()
     @recorded_by_proxy
-    def test_put_block_unicode(self, **kwargs):
+    def test_put_block_bytes(self, **kwargs):
         storage_account_name = kwargs.pop("storage_account_name")
         storage_account_key = kwargs.pop("storage_account_key")
 
         self._setup(storage_account_name, storage_account_key)
-        blob = self._create_blob()
+        blob = self.bsc.get_blob_client(self.container_name, self._get_blob_reference())
+        data = b'Hello World'
+        io = BytesIO(data)
+
+        def generator():
+            yield b'Hello'
+            yield b' '
+            yield b'World'
 
         # Act
-        headers = blob.stage_block('1', u'啊齄丂狛狜')
-        assert 'content_crc64' in headers
+        blob.stage_block('1', data)
+        blob.stage_block('2', io)
+        blob.stage_block('3', generator())
+        blob.stage_block('4', generator(), length=len(data))
+        blob.commit_block_list(['1', '2', '3', '4'])
 
         # Assert
+        content = blob.download_blob().read()
+        assert content == data * 4
+
+    @BlobPreparer()
+    @recorded_by_proxy
+    def test_put_block_str_legacy(self, **kwargs):
+        # Test operations with str types that are expected to work for legacy reasons but are no longer supported.
+        storage_account_name = kwargs.pop("storage_account_name")
+        storage_account_key = kwargs.pop("storage_account_key")
+
+        self._setup(storage_account_name, storage_account_key)
+        blob = self.bsc.get_blob_client(self.container_name, self._get_blob_reference())
+        data = 'Hello World'
+        unicode_data = '你好世界'
+        io = StringIO(data)
+
+        def generator():
+            yield 'Hello'
+            yield ' '
+            yield 'World'
+
+        # Act
+        blob.stage_block('1', data)
+        blob.stage_block('2', io)
+        blob.stage_block('3', generator(), length=len(data))
+        blob.stage_block('4', unicode_data, encoding='utf-32')
+        blob.commit_block_list(['1', '2', '3', '4'])
+
+        # Assert
+        content = blob.download_blob().read()
+        assert content == data.encode('latin-1') * 3 + unicode_data.encode('utf-32')
 
     @BlobPreparer()
     @recorded_by_proxy

--- a/sdk/storage/azure-storage-blob/tests/test_streams.py
+++ b/sdk/storage/azure-storage-blob/tests/test_streams.py
@@ -636,6 +636,19 @@ def data_generator(data, chunk_size):
 
 
 class TestIterStreamer:
+    def test_length_tell(self):
+        data = [b'abc', b'def']
+        stream = IterStreamer(data)
+        with pytest.raises(UnsupportedOperation):
+            len(stream)
+        stream = IterStreamer(data, length=6)
+        assert len(stream) == 6
+        assert stream.tell() == 0
+        stream.read(4)
+        assert stream.tell() == 4
+        stream.read()
+        assert stream.tell() == 6
+
     def test_empty(self):
         stream = IterStreamer([])
         assert stream.read() == b''

--- a/sdk/storage/azure-storage-blob/tests/test_streams_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_streams_async.py
@@ -6,7 +6,7 @@
 
 import os
 import random
-from io import BytesIO
+from io import BytesIO, UnsupportedOperation
 
 import pytest
 from azure.storage.blob._shared.streams import (
@@ -273,6 +273,19 @@ async def data_generator(data, chunk_size):
 
 @pytest.mark.asyncio
 class TestAsyncIterStreamer:
+    async def test_length_tell(self):
+        generator = data_generator(b'abcdef', 3)
+        stream = AsyncIterStreamer(generator)
+        with pytest.raises(UnsupportedOperation):
+            len(stream)
+        stream = AsyncIterStreamer(generator, length=6)
+        assert len(stream) == 6
+        assert stream.tell() == 0
+        await stream.read(4)
+        assert stream.tell() == 4
+        await stream.read()
+        assert stream.tell() == 6
+
     async def test_empty(self):
         async def empty_gen():
             yield b''

--- a/sdk/storage/azure-storage-file-datalake/assets.json
+++ b/sdk/storage/azure-storage-file-datalake/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "python",
   "TagPrefix": "python/storage/azure-storage-file-datalake",
-  "Tag": "python/storage/azure-storage-file-datalake_914a8f9400"
+  "Tag": "python/storage/azure-storage-file-datalake_a10b50cfd1"
 }

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_data_lake_file_client.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_data_lake_file_client.py
@@ -524,7 +524,7 @@ class DataLakeFileClient(PathClient):
 
     @staticmethod
     def _append_data_options(
-        data: Union[bytes, str, Iterable[AnyStr], IO[bytes]],
+        data: Union[bytes, Iterable[bytes], IO[bytes]],
         offset: int,
         scheme: str,
         length: Optional[int] = None,

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_data_lake_file_client.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_data_lake_file_client.py
@@ -557,7 +557,7 @@ class DataLakeFileClient(PathClient):
 
     @distributed_trace
     def append_data(
-        self, data: Union[bytes, str, Iterable[AnyStr], IO[bytes]],
+        self, data: Union[bytes, Iterable[bytes], IO[bytes]],
         offset: int,
         length: Optional[int] = None,
         **kwargs: Any
@@ -565,10 +565,11 @@ class DataLakeFileClient(PathClient):
         """Append data to the file.
 
         :param data: Content to be appended to file
-        :type data: bytes, str, Iterable[AnyStr], or IO[AnyStr]
+        :type data: Union[bytes, Iterable[bytes], IO[bytes]]
         :param int offset: start position of the data to be appended to.
-        :param length: Size of the data in bytes.
-        :type length: int or None
+        :param int length:
+            Size of the data to append. Optional if the length of data can be determined. For Iterable and IO,
+            if the length is not provided and cannot be determined, all data will be read into memory.
         :keyword bool flush:
             If true, will commit the data after it is appended.
         :keyword validate_content:

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/uploads.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/uploads.py
@@ -4,6 +4,7 @@
 # license information.
 # --------------------------------------------------------------------------
 
+import warnings
 from collections import namedtuple
 from concurrent import futures
 from io import BytesIO, IOBase, SEEK_CUR, SEEK_END, SEEK_SET, UnsupportedOperation
@@ -26,7 +27,7 @@ _ERROR_VALUE_SHOULD_BE_SEEKABLE_STREAM = "{0} should be a seekable file-like/io.
 
 
 def prepare_upload_data(
-    data: Union[bytes, str, IO[bytes], Iterable[AnyStr]],
+    data: Union[bytes, str, IO[AnyStr], Iterable[AnyStr]],
     encoding: str,
     data_length: Optional[int],
     validate_content: Union[bool, str, None]
@@ -34,11 +35,9 @@ def prepare_upload_data(
     # Trim the incoming data per provided length
     if data_length is not None and isinstance(data, (str, bytes)) and data_length != len(data):
         data = data[:data_length]
-    # Encode raw string data
+
     if isinstance(data, str):
         data = data.encode(encoding)
-        # The user provided length was in terms of characters and has already been used to slice input.
-        # Now convert to a byte length.
         data_length = len(data)
 
     # Attempt to determine length of data if it's not provided
@@ -46,23 +45,29 @@ def prepare_upload_data(
         data_length = get_length(data)
     # If we still can't get the length, read all the data into memory
     if data_length is None:
+        warnings.warn("Unable to determine length for Iterable/IO, reading all data into memory.")
         data_length, data = read_length(data)
 
     structured_message = validate_content == ChecksumAlgorithm.CRC64
     md5 = validate_content in (True, ChecksumAlgorithm.MD5)
     if isinstance(data, bytes):
-        # Structured message requires a stream
         if structured_message:
             data = BytesIO(data)
     elif hasattr(data, 'read'):
-        # TODO: Block IO[str] here?
-        pass
+        # Block IO[str] with CRC64
+        if structured_message:
+            test = data.read(0)
+            if not isinstance(test, bytes):
+                raise TypeError("Only IO[bytes] is supported when using CRC64.")
     elif hasattr(data, '__iter__') and not isinstance(data, (list, tuple, set, dict)):
-        data = IterStreamer(cast(Iterable[AnyStr], data), encoding=encoding)
+        data = IterStreamer(
+            cast(Iterable[AnyStr], data),
+            length=data_length,
+            encoding='latin-1',  # Use latin-1 for backwards compatibility with Requests
+            block_str=structured_message)
     else:
         raise TypeError(f"Unsupported data type: {type(data)}")
 
-    # TODO: Do something about this?
     # If MD5, read data out of IterStreamer because the pipeline
     # will require a seekable stream which IterStreamer is not.
     if isinstance(data, IterStreamer) and md5:

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/uploads.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/uploads.py
@@ -11,7 +11,7 @@ from io import BytesIO, IOBase, SEEK_CUR, SEEK_END, SEEK_SET, UnsupportedOperati
 from itertools import islice
 from math import ceil
 from threading import Lock
-from typing import Any, AnyStr, cast, Dict, Generator, IO, Iterable, Optional, Sized, Tuple, Union
+from typing import Any, cast, Dict, Generator, IO, Iterable, Optional, Sized, Tuple, Union
 
 from azure.core.tracing.common import with_current_context
 
@@ -27,7 +27,7 @@ _ERROR_VALUE_SHOULD_BE_SEEKABLE_STREAM = "{0} should be a seekable file-like/io.
 
 
 def prepare_upload_data(
-    data: Union[bytes, str, IO[AnyStr], Iterable[AnyStr]],
+    data: Union[bytes, str, IO[bytes], IO[str], Iterable[bytes], Iterable[str]],
     encoding: str,
     data_length: Optional[int],
     validate_content: Union[bool, str, None]
@@ -61,7 +61,7 @@ def prepare_upload_data(
                 raise TypeError("Only IO[bytes] is supported when using CRC64.")
     elif hasattr(data, '__iter__') and not isinstance(data, (list, tuple, set, dict)):
         data = IterStreamer(
-            cast(Iterable[AnyStr], data),
+            cast(Iterable[bytes], data),
             length=data_length,
             encoding='latin-1',  # Use latin-1 for backwards compatibility with Requests
             block_str=structured_message)

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/aio/_data_lake_file_client_async.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/aio/_data_lake_file_client_async.py
@@ -435,7 +435,7 @@ class DataLakeFileClient(PathClient, DataLakeFileClientBase):
 
     @distributed_trace_async
     async def append_data(
-        self, data: Union[bytes, str, Iterable[AnyStr], IO[bytes]],
+        self, data: Union[bytes, Iterable[bytes], IO[bytes]],
         offset: int,
         length: Optional[int] = None,
         **kwargs: Any
@@ -443,10 +443,11 @@ class DataLakeFileClient(PathClient, DataLakeFileClientBase):
         """Append data to the file.
 
         :param data: Content to be appended to file
-        :type data: bytes, str, Iterable[AnyStr], or IO[AnyStr]
+        :type data: Union[bytes, Iterable[bytes], IO[bytes]]
         :param int offset: start position of the data to be appended to.
-        :param length: Size of the data in bytes.
-        :type length: int or None
+        :param int length:
+            Size of the data to append. Optional if the length of data can be determined. For Iterable and IO,
+            if the length is not provided and cannot be determined, all data will be read into memory.
         :keyword bool flush:
             If true, will commit the data after it is appended.
         :keyword validate_content:

--- a/sdk/storage/azure-storage-file-share/assets.json
+++ b/sdk/storage/azure-storage-file-share/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "python",
   "TagPrefix": "python/storage/azure-storage-file-share",
-  "Tag": "python/storage/azure-storage-file-share_5868af5019"
+  "Tag": "python/storage/azure-storage-file-share_8191b3ae50"
 }

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_file_client.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_file_client.py
@@ -1268,7 +1268,7 @@ class ShareFileClient(StorageAccountHostsMixin):
 
     @distributed_trace
     def upload_range(
-        self, data: Union[bytes, str, Iterable[AnyStr], IO[bytes]],
+        self, data: Union[bytes, Iterable[bytes], IO[bytes]],
         offset: int,
         length: int,
         **kwargs: Any
@@ -1277,7 +1277,7 @@ class ShareFileClient(StorageAccountHostsMixin):
 
         :param data:
             The data to upload.
-        :type data: Union[bytes, str, Iterable[AnyStr], IO[bytes]]
+        :type data: Union[bytes, Iterable[bytes], IO[bytes]]
         :param int offset:
             Start of byte range to use for uploading a section of the file.
             The range can be up to 4 MB in size.

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/uploads.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/uploads.py
@@ -4,6 +4,7 @@
 # license information.
 # --------------------------------------------------------------------------
 
+import warnings
 from collections import namedtuple
 from concurrent import futures
 from io import BytesIO, IOBase, SEEK_CUR, SEEK_END, SEEK_SET, UnsupportedOperation
@@ -26,7 +27,7 @@ _ERROR_VALUE_SHOULD_BE_SEEKABLE_STREAM = "{0} should be a seekable file-like/io.
 
 
 def prepare_upload_data(
-    data: Union[bytes, str, IO[bytes], Iterable[AnyStr]],
+    data: Union[bytes, str, IO[AnyStr], Iterable[AnyStr]],
     encoding: str,
     data_length: Optional[int],
     validate_content: Union[bool, str, None]
@@ -34,11 +35,9 @@ def prepare_upload_data(
     # Trim the incoming data per provided length
     if data_length is not None and isinstance(data, (str, bytes)) and data_length != len(data):
         data = data[:data_length]
-    # Encode raw string data
+
     if isinstance(data, str):
         data = data.encode(encoding)
-        # The user provided length was in terms of characters and has already been used to slice input.
-        # Now convert to a byte length.
         data_length = len(data)
 
     # Attempt to determine length of data if it's not provided
@@ -46,23 +45,29 @@ def prepare_upload_data(
         data_length = get_length(data)
     # If we still can't get the length, read all the data into memory
     if data_length is None:
+        warnings.warn("Unable to determine length for Iterable/IO, reading all data into memory.")
         data_length, data = read_length(data)
 
     structured_message = validate_content == ChecksumAlgorithm.CRC64
     md5 = validate_content in (True, ChecksumAlgorithm.MD5)
     if isinstance(data, bytes):
-        # Structured message requires a stream
         if structured_message:
             data = BytesIO(data)
     elif hasattr(data, 'read'):
-        # TODO: Block IO[str] here?
-        pass
+        # Block IO[str] with CRC64
+        if structured_message:
+            test = data.read(0)
+            if not isinstance(test, bytes):
+                raise TypeError("Only IO[bytes] is supported when using CRC64.")
     elif hasattr(data, '__iter__') and not isinstance(data, (list, tuple, set, dict)):
-        data = IterStreamer(cast(Iterable[AnyStr], data), encoding=encoding)
+        data = IterStreamer(
+            cast(Iterable[AnyStr], data),
+            length=data_length,
+            encoding='latin-1',  # Use latin-1 for backwards compatibility with Requests
+            block_str=structured_message)
     else:
         raise TypeError(f"Unsupported data type: {type(data)}")
 
-    # TODO: Do something about this?
     # If MD5, read data out of IterStreamer because the pipeline
     # will require a seekable stream which IterStreamer is not.
     if isinstance(data, IterStreamer) and md5:

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/uploads.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/uploads.py
@@ -11,7 +11,7 @@ from io import BytesIO, IOBase, SEEK_CUR, SEEK_END, SEEK_SET, UnsupportedOperati
 from itertools import islice
 from math import ceil
 from threading import Lock
-from typing import Any, AnyStr, cast, Dict, Generator, IO, Iterable, Optional, Sized, Tuple, Union
+from typing import Any, cast, Dict, Generator, IO, Iterable, Optional, Sized, Tuple, Union
 
 from azure.core.tracing.common import with_current_context
 
@@ -27,7 +27,7 @@ _ERROR_VALUE_SHOULD_BE_SEEKABLE_STREAM = "{0} should be a seekable file-like/io.
 
 
 def prepare_upload_data(
-    data: Union[bytes, str, IO[AnyStr], Iterable[AnyStr]],
+    data: Union[bytes, str, IO[bytes], IO[str], Iterable[bytes], Iterable[str]],
     encoding: str,
     data_length: Optional[int],
     validate_content: Union[bool, str, None]
@@ -61,7 +61,7 @@ def prepare_upload_data(
                 raise TypeError("Only IO[bytes] is supported when using CRC64.")
     elif hasattr(data, '__iter__') and not isinstance(data, (list, tuple, set, dict)):
         data = IterStreamer(
-            cast(Iterable[AnyStr], data),
+            cast(Iterable[bytes], data),
             length=data_length,
             encoding='latin-1',  # Use latin-1 for backwards compatibility with Requests
             block_str=structured_message)

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/aio/_file_client_async.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/aio/_file_client_async.py
@@ -1115,7 +1115,7 @@ class ShareFileClient(AsyncStorageAccountHostsMixin, ShareFileClientBase):
 
     @distributed_trace_async
     async def upload_range(
-        self, data: Union[bytes, str, Iterable[AnyStr], IO[bytes]],
+        self, data: Union[bytes, Iterable[bytes], IO[bytes]],
         offset: int,
         length: int,
         **kwargs: Any
@@ -1124,7 +1124,7 @@ class ShareFileClient(AsyncStorageAccountHostsMixin, ShareFileClientBase):
 
         :param data:
             The data to upload.
-        :type data: Union[bytes, str, Iterable[AnyStr], IO[bytes]]
+        :type data: Union[bytes, Iterable[bytes], IO[bytes]]
         :param int offset:
             Start of byte range to use for uploading a section of the file.
             The range can be up to 4 MB in size.

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/uploads.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/uploads.py
@@ -4,6 +4,7 @@
 # license information.
 # --------------------------------------------------------------------------
 
+import warnings
 from collections import namedtuple
 from concurrent import futures
 from io import BytesIO, IOBase, SEEK_CUR, SEEK_END, SEEK_SET, UnsupportedOperation
@@ -26,7 +27,7 @@ _ERROR_VALUE_SHOULD_BE_SEEKABLE_STREAM = "{0} should be a seekable file-like/io.
 
 
 def prepare_upload_data(
-    data: Union[bytes, str, IO[bytes], Iterable[AnyStr]],
+    data: Union[bytes, str, IO[AnyStr], Iterable[AnyStr]],
     encoding: str,
     data_length: Optional[int],
     validate_content: Union[bool, str, None]
@@ -34,11 +35,9 @@ def prepare_upload_data(
     # Trim the incoming data per provided length
     if data_length is not None and isinstance(data, (str, bytes)) and data_length != len(data):
         data = data[:data_length]
-    # Encode raw string data
+
     if isinstance(data, str):
         data = data.encode(encoding)
-        # The user provided length was in terms of characters and has already been used to slice input.
-        # Now convert to a byte length.
         data_length = len(data)
 
     # Attempt to determine length of data if it's not provided
@@ -46,23 +45,29 @@ def prepare_upload_data(
         data_length = get_length(data)
     # If we still can't get the length, read all the data into memory
     if data_length is None:
+        warnings.warn("Unable to determine length for Iterable/IO, reading all data into memory.")
         data_length, data = read_length(data)
 
     structured_message = validate_content == ChecksumAlgorithm.CRC64
     md5 = validate_content in (True, ChecksumAlgorithm.MD5)
     if isinstance(data, bytes):
-        # Structured message requires a stream
         if structured_message:
             data = BytesIO(data)
     elif hasattr(data, 'read'):
-        # TODO: Block IO[str] here?
-        pass
+        # Block IO[str] with CRC64
+        if structured_message:
+            test = data.read(0)
+            if not isinstance(test, bytes):
+                raise TypeError("Only IO[bytes] is supported when using CRC64.")
     elif hasattr(data, '__iter__') and not isinstance(data, (list, tuple, set, dict)):
-        data = IterStreamer(cast(Iterable[AnyStr], data), encoding=encoding)
+        data = IterStreamer(
+            cast(Iterable[AnyStr], data),
+            length=data_length,
+            encoding='latin-1',  # Use latin-1 for backwards compatibility with Requests
+            block_str=structured_message)
     else:
         raise TypeError(f"Unsupported data type: {type(data)}")
 
-    # TODO: Do something about this?
     # If MD5, read data out of IterStreamer because the pipeline
     # will require a seekable stream which IterStreamer is not.
     if isinstance(data, IterStreamer) and md5:

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/uploads.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/uploads.py
@@ -11,7 +11,7 @@ from io import BytesIO, IOBase, SEEK_CUR, SEEK_END, SEEK_SET, UnsupportedOperati
 from itertools import islice
 from math import ceil
 from threading import Lock
-from typing import Any, AnyStr, cast, Dict, Generator, IO, Iterable, Optional, Sized, Tuple, Union
+from typing import Any, cast, Dict, Generator, IO, Iterable, Optional, Sized, Tuple, Union
 
 from azure.core.tracing.common import with_current_context
 
@@ -27,7 +27,7 @@ _ERROR_VALUE_SHOULD_BE_SEEKABLE_STREAM = "{0} should be a seekable file-like/io.
 
 
 def prepare_upload_data(
-    data: Union[bytes, str, IO[AnyStr], Iterable[AnyStr]],
+    data: Union[bytes, str, IO[bytes], IO[str], Iterable[bytes], Iterable[str]],
     encoding: str,
     data_length: Optional[int],
     validate_content: Union[bool, str, None]
@@ -61,7 +61,7 @@ def prepare_upload_data(
                 raise TypeError("Only IO[bytes] is supported when using CRC64.")
     elif hasattr(data, '__iter__') and not isinstance(data, (list, tuple, set, dict)):
         data = IterStreamer(
-            cast(Iterable[AnyStr], data),
+            cast(Iterable[bytes], data),
             length=data_length,
             encoding='latin-1',  # Use latin-1 for backwards compatibility with Requests
             block_str=structured_message)


### PR DESCRIPTION
Refactored the single upload APIs for all packages based on discussions with the architects. This meant deprecating `str` types from being officially supported and some refactoring to how we handle some bytes-based types. This also required some refactored to `IterStreamer` to make it work with the underlying HTTP libraries (they want `tell` and `__len__`).

Also added some tests for all the types for each API. I also checked out existing content validation tests and I think the coverage is already good enough there.