### PR TITLE
Update Component Governance to reduce scanned directories for Build Extended template

### DIFF
--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -130,6 +130,9 @@ jobs:
       name: $(LINUXPOOL)
       image: $(LINUXVMIMAGE)
       os: linux
+    
+    variables:
+      ComponentDetection.SourcePath: '$(Build.SourcesDirectory)/sdk/${{ parameters.ServiceDirectory }}'
 
     steps:
     - template: /eng/pipelines/templates/steps/download-package-artifacts.yml

--- a/eng/pipelines/templates/steps/build-extended-artifacts.yml
+++ b/eng/pipelines/templates/steps/build-extended-artifacts.yml
@@ -23,9 +23,6 @@ parameters:
 #     eng/pipelines/templates/jobs/live.test.yml
 
 # Please use `$(TargetingString)` to refer to the python packages glob string. This was previously `${{ parameters.BuildTargetingString }}`.
-variables:
-  - name: ComponentDetection.SourcePath
-    value: '$(Build.SourcesDirectory)/sdk/${{ parameters.ServiceDirectory }}'
 steps:
   - task: UsePythonVersion@0
     displayName: 'Use Python 3.11'

--- a/eng/pipelines/templates/steps/build-extended-artifacts.yml
+++ b/eng/pipelines/templates/steps/build-extended-artifacts.yml
@@ -23,6 +23,8 @@ parameters:
 #     eng/pipelines/templates/jobs/live.test.yml
 
 # Please use `$(TargetingString)` to refer to the python packages glob string. This was previously `${{ parameters.BuildTargetingString }}`.
+variables:
+  ComponentDetection.SourcePath: '$(Build.SourcesDirectory)/sdk/${{ parameters.ServiceDirectory }}'
 steps:
   - task: UsePythonVersion@0
     displayName: 'Use Python 3.11'
@@ -77,12 +79,6 @@ steps:
     parameters:
       ServiceDirectory: ${{ parameters.ServiceDirectory }}
       AdditionalTestArgs: '--wheel_dir="$(Build.ArtifactStagingDirectory)"'
-
-  - task: ComponentGovernanceComponentDetection@0
-    displayName: 'Component Governance - Component Detection'
-    inputs:
-      scanType: Register
-      sourceScanPath: '$(Build.SourcesDirectory)/sdk/${{ parameters.ServiceDirectory }}'
 
   - ${{ parameters.BeforePublishSteps }}
 

--- a/eng/pipelines/templates/steps/build-extended-artifacts.yml
+++ b/eng/pipelines/templates/steps/build-extended-artifacts.yml
@@ -95,3 +95,8 @@ steps:
       ArtifactPath: '$(Build.SourcesDirectory)/_docs'
       CustomCondition: and(${{ parameters.BuildDocs }}, eq(variables['DirectoryExists'], 'True'))
       ArtifactName: 'documentation'
+
+  - task: ComponentGovernanceComponentDetection@0
+    displayName: 'Component Governance - Component Detection'
+    inputs:
+      sourceScanPath: '$(Build.SourcesDirectory)/sdk/${{ parameters.ServiceDirectory }}'

--- a/eng/pipelines/templates/steps/build-extended-artifacts.yml
+++ b/eng/pipelines/templates/steps/build-extended-artifacts.yml
@@ -24,7 +24,8 @@ parameters:
 
 # Please use `$(TargetingString)` to refer to the python packages glob string. This was previously `${{ parameters.BuildTargetingString }}`.
 variables:
-  ComponentDetection.SourcePath: '$(Build.SourcesDirectory)/sdk/${{ parameters.ServiceDirectory }}'
+  - name: ComponentDetection.SourcePath
+    value: '$(Build.SourcesDirectory)/sdk/${{ parameters.ServiceDirectory }}'
 steps:
   - task: UsePythonVersion@0
     displayName: 'Use Python 3.11'

--- a/eng/pipelines/templates/steps/build-extended-artifacts.yml
+++ b/eng/pipelines/templates/steps/build-extended-artifacts.yml
@@ -81,6 +81,7 @@ steps:
   - task: ComponentGovernanceComponentDetection@0
     displayName: 'Component Governance - Component Detection'
     inputs:
+      scanType: Register
       sourceScanPath: '$(Build.SourcesDirectory)/sdk/${{ parameters.ServiceDirectory }}'
 
   - ${{ parameters.BeforePublishSteps }}

--- a/eng/pipelines/templates/steps/build-extended-artifacts.yml
+++ b/eng/pipelines/templates/steps/build-extended-artifacts.yml
@@ -78,6 +78,11 @@ steps:
       ServiceDirectory: ${{ parameters.ServiceDirectory }}
       AdditionalTestArgs: '--wheel_dir="$(Build.ArtifactStagingDirectory)"'
 
+  - task: ComponentGovernanceComponentDetection@0
+    displayName: 'Component Governance - Component Detection'
+    inputs:
+      sourceScanPath: '$(Build.SourcesDirectory)/sdk/${{ parameters.ServiceDirectory }}'
+
   - ${{ parameters.BeforePublishSteps }}
 
   - template: /eng/common/pipelines/templates/steps/publish-1es-artifact.yml
@@ -95,8 +100,3 @@ steps:
       ArtifactPath: '$(Build.SourcesDirectory)/_docs'
       CustomCondition: and(${{ parameters.BuildDocs }}, eq(variables['DirectoryExists'], 'True'))
       ArtifactName: 'documentation'
-
-  - task: ComponentGovernanceComponentDetection@0
-    displayName: 'Component Governance - Component Detection'
-    inputs:
-      sourceScanPath: '$(Build.SourcesDirectory)/sdk/${{ parameters.ServiceDirectory }}'


### PR DESCRIPTION
# Description

This pull request reduces the scope of the Build Extended run of Component Governance to the relevant directory that is being built. Previously, Component Governance was running on the entire repository, causing long task times. 

Old example: https://dev.azure.com/azure-sdk/public/_build/results?buildId=4077914&view=logs&j=4259cd7e-6a4b-5ca5-581a-0ae020cd9d20&t=3a70d42c-4cbe-5d44-55a0-70dc5de3988f
New example: https://dev.azure.com/azure-sdk/public/_build/results?buildId=4081557&view=logs&j=4259cd7e-6a4b-5ca5-581a-0ae020cd9d20&t=3a70d42c-4cbe-5d44-55a0-70dc5de3988f

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [ ] ~**CHANGELOG is updated for new features, bug fixes or other significant changes.**~
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [ ] Pull request includes test coverage for the included changes.
