### PR TITLE
[AppConfig] Fix failing live pipeline

### DIFF
--- a/sdk/appconfiguration/azure-appconfiguration/CHANGELOG.md
+++ b/sdk/appconfiguration/azure-appconfiguration/CHANGELOG.md
@@ -1,14 +1,9 @@
 # Release History
 
-## 1.7.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 1.7.1 (2024-08-22)
 
 ### Bugs Fixed
-
-### Other Changes
+- Fixed a bug in serializing/deserializing tags filter in `ConfigurationSnapshot`.
 
 ## 1.7.0 (2024-08-15)
 

--- a/sdk/appconfiguration/azure-appconfiguration/azure/appconfiguration/_models.py
+++ b/sdk/appconfiguration/azure-appconfiguration/azure/appconfiguration/_models.py
@@ -488,7 +488,11 @@ class ConfigurationSnapshot:  # pylint: disable=too-many-instance-attributes
         if generated.filters:
             for config_setting_filter in generated.filters:
                 filters.append(
-                    ConfigurationSettingsFilter(key=config_setting_filter.key, label=config_setting_filter.label)
+                    ConfigurationSettingsFilter(
+                        key=config_setting_filter.key,
+                        label=config_setting_filter.label,
+                        tags=config_setting_filter.tags,
+                    )
                 )
         snapshot = cls(
             filters=filters,
@@ -519,7 +523,11 @@ class ConfigurationSnapshot:  # pylint: disable=too-many-instance-attributes
         if deserialized.filters:
             for config_setting_filter in deserialized.filters:
                 filters.append(
-                    ConfigurationSettingsFilter(key=config_setting_filter.key, label=config_setting_filter.label)
+                    ConfigurationSettingsFilter(
+                        key=config_setting_filter.key,
+                        label=config_setting_filter.label,
+                        tags=config_setting_filter.tags,
+                    )
                 )
         snapshot = cls(
             filters=filters,
@@ -540,7 +548,7 @@ class ConfigurationSnapshot:  # pylint: disable=too-many-instance-attributes
     def _to_generated(self) -> GeneratedConfigurationSnapshot:
         config_setting_filters = []
         for kv_filter in self.filters:
-            config_setting_filters.append(KeyValueFilter(key=kv_filter.key, label=kv_filter.label))
+            config_setting_filters.append(KeyValueFilter(key=kv_filter.key, label=kv_filter.label, tags=kv_filter.tags))
         return GeneratedConfigurationSnapshot(
             filters=config_setting_filters,
             composition_type=self.composition_type,

--- a/sdk/appconfiguration/tests.yml
+++ b/sdk/appconfiguration/tests.yml
@@ -5,7 +5,7 @@ parameters:
     type: object
     default:
       - azure-appconfiguration
-      - azure-appconfiguration-provider
+      # - azure-appconfiguration-provider
 
 extends:
     template: ../../eng/pipelines/templates/stages/archetype-sdk-tests.yml


### PR DESCRIPTION
There are two tests failing in AppConfig live pipeline([link](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4074001&view=logs&j=1311fad6-188f-57a1-d782-fae0b206ecfd&t=59f9e1fc-4ef2-5878-651b-288f47e07920&l=2563)):
```
FAILED tests/test_azure_appconfiguration_client.py::TestAppConfigurationClient::test_list_snapshot_configuration_settings
FAILED tests/test_azure_appconfiguration_client_async.py::TestAppConfigurationClientAsync::test_list_snapshot_configuration_settings
```