### PR TITLE
[ServiceBus] allow optionally testing pyamqp

### DIFF
--- a/sdk/servicebus/azure-servicebus/tests/test_queues.py
+++ b/sdk/servicebus/azure-servicebus/tests/test_queues.py
@@ -1151,7 +1151,7 @@ class TestServiceBusQueue(AzureMgmtRecordedTestCase):
     @pytest.mark.live_test_only
     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @CachedServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
     @ArgPasser()
     def test_queue_by_servicebus_client_session_fail(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):
@@ -2651,7 +2651,7 @@ class TestServiceBusQueue(AzureMgmtRecordedTestCase):
     @pytest.mark.live_test_only
     @CachedServiceBusResourceGroupPreparer(name_prefix='servicebustest')
     @CachedServiceBusNamespacePreparer(name_prefix='servicebustest')
-    @CachedServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
+    @ServiceBusQueuePreparer(name_prefix='servicebustest', dead_lettering_on_message_expiration=True)
     @pytest.mark.parametrize("uamqp_transport", uamqp_transport_params, ids=uamqp_transport_ids)
     @ArgPasser()
     def test_queue_send_large_message_receive(self, uamqp_transport, *, servicebus_namespace=None, servicebus_queue=None, **kwargs):

--- a/sdk/servicebus/azure-servicebus/tests/utilities.py
+++ b/sdk/servicebus/azure-servicebus/tests/utilities.py
@@ -17,7 +17,7 @@ from azure.servicebus._common.utils import utc_now
 
 # temporary - disable uamqp if China b/c of 8+ hr runtime
 uamqp_available = uamqp_available and os.environ.get('SERVICEBUS_ENDPOINT_SUFFIX') != '.servicebus.chinacloudapi.cn'
-
+test_pyamqp = os.environ.get('TEST_PYAMQP', 'true') == 'true'
 
 def _get_default_handler():
     handler = logging.StreamHandler(stream=sys.stdout)
@@ -60,7 +60,7 @@ def sleep_until_expired(entity):
     time.sleep(max(0,(entity.locked_until_utc - utc_now()).total_seconds()+1))
 
 
-def uamqp_transport(use_uamqp=uamqp_available, use_pyamqp=True):
+def uamqp_transport(use_uamqp=uamqp_available, use_pyamqp=test_pyamqp):
     uamqp_transport_params = []
     uamqp_transport_ids = []
     if use_uamqp:


### PR DESCRIPTION
Adding an environment variable to check whether pyamqp should be tested. By default, pyamqp will be tested. This will allow for opting out of pyamqp testing in the uamqp test pipeline. uamqp only run here: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4076976&view=logs&j=3264ca38-67bb-54fa-fd91-0bce2e49d546

Additionally fixing flaky tests that are failing in the uamqp test run, following this PR: https://github.com/Azure/azure-sdk-for-python/pull/35394/files