### PR TITLE
[auto release pipeline] add allowlist for flatten models

### DIFF
--- a/scripts/auto_release/main.py
+++ b/scripts/auto_release/main.py
@@ -392,6 +392,8 @@ class CodegenTestPR:
                     )
 
     def check_model_flatten(self):
+        if self.whole_package_name in ["azure-mgmt-mysqlflexibleservers", "azure-mgmt-postgresqlflexibleservers"]:
+            return
         if self.from_swagger:
             last_version = self.get_last_release_version()
             if last_version == "" or last_version.startswith("1.0.0b"):


### PR DESCRIPTION
"azure-mgmt-mysqlflexibleservers" and "azure-mgmt-postgresqlflexibleservers" is split from azure-mgmt-rdbms so still need flatten models to avoid break existing users.

test link: https://github.com/Azure/azure-sdk-for-python/pull/37027