### PR TITLE
[sdk generation pipeline] update status after pipeline finish

### DIFF
--- a/scripts/automation_generate.sh
+++ b/scripts/automation_generate.sh
@@ -14,6 +14,10 @@ if [ ! -f "$TEMP_FILE" ]; then
   exit 1
 fi
 
+if [ -f "$2" ]; then
+  rm "$2"
+fi
+
 # package
 python -m packaging_tools.sdk_package "$TEMP_FILE" "$2" 2>&1
 echo "[Generate] generate done!!!"


### PR DESCRIPTION
When there are multi package to generate, the finish status shall be "failed" as long as one fails.

Test link: https://github.com/test-repo-billy/azure-rest-api-specs/pull/3485, https://github.com/test-repo-billy/azure-rest-api-specs/pull/3497/checks?check_run_id=29292294703