### PR TITLE
Align `eng/common/scripts/common.ps1`

### DIFF
--- a/eng/common/scripts/common.ps1
+++ b/eng/common/scripts/common.ps1
@@ -62,6 +62,7 @@ $GetEmitterAdditionalOptionsFn = "Get-${Language}-EmitterAdditionalOptions"
 $GetEmitterNameFn = "Get-${Language}-EmitterName"
 $GetDirectoriesForGenerationFn = "Get-${Language}-DirectoriesForGeneration"
 $UpdateGeneratedSdksFn = "Update-${Language}-GeneratedSdks"
+$IsApiviewStatusCheckRequiredFn = "Get-${Language}-ApiviewStatusCheckRequirement"
 
 # Expected to be set in eng/scripts/docs/Docs-Onboarding.ps1
 $SetDocsPackageOnboarding = "Set-${Language}-DocsPackageOnboarding"


### PR DESCRIPTION
Hey @praveenkuttappan  given the fact that we're now _defining_ something that WASNT DEFINED in `common.ps1` for `python apiview` before, I wanted to get your sign off.

I don't have any idea how 8/10 were updated with the new `common.ps1`, but `python` and `android` were left behind 😂 

This is to unblock `eng/common` pr over in Azure/azure-sdk-tools#8878 which is crashing due to misaligned files.