### PR TITLE
Handle final release of inactive package's docs

### DIFF
--- a/eng/pipelines/templates/stages/archetype-python-release.yml
+++ b/eng/pipelines/templates/stages/archetype-python-release.yml
@@ -195,8 +195,11 @@ stages:
                       - checkout: self
 
                       - pwsh: |
-                          if (Test-Path $(Pipeline.Workspace)/${{parameters.DocArtifact}}/${{artifact.name}}) {
-                            Get-ChildItem -Recurse $(Pipeline.Workspace)/${{parameters.DocArtifact}}/${{artifact.name}}
+                          if (Test-Path "$(Pipeline.Workspace)/${{parameters.DocArtifact}}/${{artifact.name}}") {
+                            Get-ChildItem -Recurse "$(Pipeline.Workspace)/${{parameters.DocArtifact}}/${{artifact.name}}"
+                          }
+                          else {
+                            New-Item -ItemType Directory -Path "$(Pipeline.Workspace)/${{parameters.DocArtifact}}/${{artifact.name}}"
                           }
                         workingDirectory: $(Pipeline.Workspace)
                         displayName: Output Visible Artifacts

--- a/eng/pipelines/templates/stages/archetype-python-release.yml
+++ b/eng/pipelines/templates/stages/archetype-python-release.yml
@@ -199,7 +199,7 @@ stages:
                             Get-ChildItem -Recurse "$(Pipeline.Workspace)/${{parameters.DocArtifact}}/${{artifact.name}}"
                           }
                           else {
-                            New-Item -ItemType Directory -Path "$(Pipeline.Workspace)/${{parameters.DocArtifact}}/${{artifact.name}}"
+                            New-Item -ItemType Directory -Force -Path "$(Pipeline.Workspace)/${{parameters.DocArtifact}}/${{artifact.name}}"
                           }
                         workingDirectory: $(Pipeline.Workspace)
                         displayName: Output Visible Artifacts

--- a/eng/pipelines/templates/stages/archetype-python-release.yml
+++ b/eng/pipelines/templates/stages/archetype-python-release.yml
@@ -195,7 +195,9 @@ stages:
                       - checkout: self
 
                       - pwsh: |
-                          Get-ChildItem -Recurse $(Pipeline.Workspace)/${{parameters.DocArtifact}}/${{artifact.name}}
+                          if (Test-Path $(Pipeline.Workspace)/${{parameters.DocArtifact}}/${{artifact.name}}) {
+                            Get-ChildItem -Recurse $(Pipeline.Workspace)/${{parameters.DocArtifact}}/${{artifact.name}}
+                          }
                         workingDirectory: $(Pipeline.Workspace)
                         displayName: Output Visible Artifacts
 


### PR DESCRIPTION
Resolving this [example failure](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4082736&view=logs&j=ba65ba83-2eec-5379-41a2-2e6e266f5589&t=4125dffe-b022-5304-48e8-1d3961e0b3fd)

`UploadBlobs` actually gracefully handles when it can't find artifacts, we just need to make our artifact dump aware of that 👍.

@swathipil this should resolve the error you saw.