### PR TITLE
[Storage] Add crc64 support for substream uploads

### DIFF
--- a/sdk/storage/azure-storage-blob/assets.json
+++ b/sdk/storage/azure-storage-blob/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "python",
   "TagPrefix": "python/storage/azure-storage-blob",
-  "Tag": "python/storage/azure-storage-blob_25230e96c7"
+  "Tag": "python/storage/azure-storage-blob_66c4f1234f"
 }

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/streams.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/streams.py
@@ -168,6 +168,7 @@ class StructuredMessageEncodeStream(IOBase):  # pylint: disable=too-many-instanc
             self._initial_content_position = self._inner_stream.tell()
         except (AttributeError, UnsupportedOperation, OSError):
             self._initial_content_position = None
+        super().__init__()
 
     @property
     def _message_header_length(self) -> int:
@@ -206,6 +207,10 @@ class StructuredMessageEncodeStream(IOBase):  # pylint: disable=too-many-instanc
 
     def __len__(self):
         return self.message_length
+
+    def close(self) -> None:
+        self._inner_stream.close()
+        super().close()
 
     def readable(self) -> bool:
         return True
@@ -304,6 +309,9 @@ class StructuredMessageEncodeStream(IOBase):  # pylint: disable=too-many-instanc
         return position
 
     def read(self, size: int = -1) -> bytes:
+        if self.closed:
+            raise ValueError("Stream is closed")
+
         if size == 0:
             return b''
         if size < 0:

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/streams.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/streams.py
@@ -309,7 +309,7 @@ class StructuredMessageEncodeStream(IOBase):  # pylint: disable=too-many-instanc
         return position
 
     def read(self, size: int = -1) -> bytes:
-        if self.closed:
+        if self.closed:  # pylint: disable=using-constant-test
             raise ValueError("Stream is closed")
 
         if size == 0:

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/uploads.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/uploads.py
@@ -519,7 +519,6 @@ class DataLakeFileChunkUploader(_ChunkUploader):  # pylint: disable=abstract-met
             )
         finally:
             block_stream.close()
-        return None
 
 
 class FileChunkUploader(_ChunkUploader):  # pylint: disable=abstract-method

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/uploads.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/uploads.py
@@ -142,20 +142,21 @@ def upload_data_chunks(
     else:
         chunks = [uploader.process_chunk(result) for result in uploader.get_chunk_streams()]
 
-    chunks.sort(key=lambda c: c.offset)
-    # If there is a crc64, do overall crc check
-    if chunks[0].crc64 is not None:
-        combined = combine_crc64([(c.crc64, c.length) for c in chunks])
-        if combined != uploader.overall_crc64:
-            raise ValueError("Checksum mismatch detected during upload. Any data written may be invalid.")
+    if chunks:
+        chunks.sort(key=lambda c: c.offset)
+        # If there is a crc64, do overall crc check
+        if chunks[0].crc64 is not None:
+            combined = combine_crc64([(c.crc64, c.length) for c in chunks])
+            if combined != uploader.overall_crc64:
+                raise ValueError("Checksum mismatch detected during upload. Any data written may be invalid.")
 
-    # If chunks have an id, return list of ids
-    if chunks[0].id is not None:
-        return [c.id for c in chunks]
-    # Else, return the response headers for the last chunk that had a response. (Page Blobs can have empty responses)
-    for c in reversed(chunks):
-        if c.response_headers:
-            return c.response_headers
+        # If chunks have an id, return list of ids
+        if chunks[0].id is not None:
+            return [c.id for c in chunks]
+        # Else, return response headers for the last chunk that had a response. (Page Blobs can have empty responses)
+        for c in reversed(chunks):
+            if c.response_headers:
+                return c.response_headers
     return {}
 
 
@@ -188,11 +189,11 @@ def upload_substream_blocks(
                 executor.submit(with_current_context(uploader.process_substream_block), u)
                 for u in islice(upload_tasks, 0, max_concurrency)
             ]
-            range_ids = _parallel_uploads(executor, uploader.process_substream_block, upload_tasks, running_futures)
+            chunks = _parallel_uploads(executor, uploader.process_substream_block, upload_tasks, running_futures)
     else:
-        range_ids = [uploader.process_substream_block(b) for b in uploader.get_substream_blocks()]
-    if any(range_ids):
-        return sorted(range_ids)
+        chunks = [uploader.process_substream_block(b) for b in uploader.get_substream_blocks()]
+    if any(chunks):
+        return sorted(chunks)
     return []
 
 
@@ -206,14 +207,11 @@ class ChunkInfo:
     response_headers: Dict[str, Any] = {}
     """The response headers from the upload chunk operation."""
 
-    def __init__(self, offset: int, data: bytes, checksum_algorithm: Optional[Union[bool, str]]):
+    def __init__(self, offset: int, length: int, md5: Optional[bytes] = None, crc64: Optional[int] = None):
         self.offset = offset
-        self.length = len(data)
-
-        if checksum_algorithm == ChecksumAlgorithm.MD5:
-            self.md5 = calculate_md5(data)
-        if checksum_algorithm == ChecksumAlgorithm.CRC64:
-            self.crc64 = calculate_crc64(data, 0)
+        self.length = length
+        self.md5 = md5
+        self.crc64 = crc64
 
     @property
     def crc64_bytes(self) -> Optional[bytes]:
@@ -260,7 +258,8 @@ class _ChunkUploader(object):  # pylint: disable=too-many-instance-attributes
 
     def get_chunk_streams(self) -> Generator[Tuple[bytes, ChunkInfo], None, None]:
         index = 0
-        while True:
+        last_chunk = False
+        while not last_chunk:
             data = b""
             read_size = self.chunk_size
 
@@ -278,25 +277,27 @@ class _ChunkUploader(object):  # pylint: disable=too-many-instance-attributes
                 if temp == b"" or len(data) == self.chunk_size:
                     break
 
-            # Content validation and encryption cannot be enabled at the same time,
-            # so this is safe to do here, before encryption
-            if self.validate_content == ChecksumAlgorithm.CRC64:
-                self.overall_crc64 = calculate_crc64(data, self.overall_crc64)
-
             if len(data) == self.chunk_size:
                 if self.padder:
                     data = self.padder.update(data)
                 if self.encryptor:
                     data = self.encryptor.update(data)
-                yield data, ChunkInfo(index, data, self.validate_content)
             else:
                 if self.padder:
                     data = self.padder.update(data) + self.padder.finalize()
                 if self.encryptor:
                     data = self.encryptor.update(data) + self.encryptor.finalize()
-                if data:
-                    yield data, ChunkInfo(index, data, self.validate_content)
-                break
+                last_chunk = True
+
+            if data:
+                md5, crc64 = None, None
+                if self.validate_content == ChecksumAlgorithm.CRC64:
+                    crc64 = calculate_crc64(data, 0)
+                    self.overall_crc64 = calculate_crc64(data, self.overall_crc64)
+                elif self.validate_content == ChecksumAlgorithm.MD5:
+                    md5 = calculate_md5(data)
+
+                yield data, ChunkInfo(index, len(data), md5, crc64)
             index += len(data)
 
     def process_chunk(self, chunk_data: Tuple[bytes, ChunkInfo]) -> ChunkInfo:
@@ -336,15 +337,12 @@ class _ChunkUploader(object):  # pylint: disable=too-many-instance-attributes
             yield index, SubStream(self.stream, index, length, lock)
 
     def process_substream_block(self, block_data):
-        return self._upload_substream_block_with_progress(block_data[0], block_data[1])
+        range_id = self._upload_substream_block(block_data[0], block_data[1])
+        self._update_progress(len(block_data))
+        return range_id
 
     def _upload_substream_block(self, index, block_stream):
         raise NotImplementedError("Must be implemented by child class.")
-
-    def _upload_substream_block_with_progress(self, index, block_stream):
-        range_id = self._upload_substream_block(index, block_stream)
-        self._update_progress(len(block_stream))
-        return range_id
 
     def set_response_properties(self, resp):
         self.etag = resp.etag
@@ -379,10 +377,8 @@ class BlockBlobChunkUploader(_ChunkUploader):
 
     def _upload_substream_block(self, index, block_stream):
         try:
-            structured_type, structured_length = None, None
+            data_length = len(block_stream)
             if self.validate_content == ChecksumAlgorithm.CRC64:
-                structured_type = SM_HEADER_V1_CRC64
-                structured_length = len(block_stream)
                 block_stream = StructuredMessageEncodeStream(
                     block_stream,
                     len(block_stream),
@@ -393,8 +389,8 @@ class BlockBlobChunkUploader(_ChunkUploader):
                 block_id,
                 len(block_stream),
                 block_stream,
-                structured_body_type=structured_type,
-                structured_content_length=structured_length,
+                structured_body_type=SM_HEADER_V1_CRC64 if self.validate_content == ChecksumAlgorithm.CRC64 else None,
+                structured_content_length=data_length if self.validate_content == ChecksumAlgorithm.CRC64 else None,
                 data_stream_total=self.total_size,
                 upload_stream_current=self.progress_total,
                 **self.request_options

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/uploads_async.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_shared/uploads_async.py
@@ -438,10 +438,19 @@ class DataLakeFileChunkUploader(_ChunkUploader):  # pylint: disable=abstract-met
 
     async def _upload_substream_block(self, index, block_stream):
         try:
+            data_length = len(block_stream)
+            if self.validate_content == ChecksumAlgorithm.CRC64:
+                block_stream = StructuredMessageEncodeStream(
+                    block_stream,
+                    len(block_stream),
+                    StructuredMessageProperties.CRC64)
+
             await self.service.append_data(
                 body=block_stream,
                 position=index,
                 content_length=len(block_stream),
+                structured_body_type=SM_HEADER_V1_CRC64 if self.validate_content == ChecksumAlgorithm.CRC64 else None,
+                structured_content_length=data_length if self.validate_content == ChecksumAlgorithm.CRC64 else None,
                 cls=return_response_headers,
                 data_stream_total=self.total_size,
                 upload_stream_current=self.progress_total,
@@ -449,6 +458,7 @@ class DataLakeFileChunkUploader(_ChunkUploader):  # pylint: disable=abstract-met
             )
         finally:
             block_stream.close()
+        return None
 
 
 class FileChunkUploader(_ChunkUploader):  # pylint: disable=abstract-method

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/_upload_helpers.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/_upload_helpers.py
@@ -133,11 +133,13 @@ def upload_block_blob(  # pylint: disable=too-many-locals, too-many-statements
 
             return cast(Dict[str, Any], response)
 
-        use_original_upload_path = blob_settings.use_byte_buffer or \
-            validate_content or encryption_options.get('required') or \
-            blob_settings.max_block_size < blob_settings.min_large_block_upload_threshold or \
-            hasattr(stream, 'seekable') and not stream.seekable() or \
-            not hasattr(stream, 'seek') or not hasattr(stream, 'tell')
+        use_original_upload_path = (blob_settings.use_byte_buffer or
+                                    (validate_content and validate_content != ChecksumAlgorithm.CRC64) or
+                                    encryption_options.get('required') or
+                                    blob_settings.max_block_size < blob_settings.min_large_block_upload_threshold or
+                                    (hasattr(stream, 'seekable') and not stream.seekable()) or
+                                    not hasattr(stream, 'seek') or
+                                    not hasattr(stream, 'tell'))
 
         if use_original_upload_path:
             total_size = length

--- a/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_upload_helpers.py
+++ b/sdk/storage/azure-storage-blob/azure/storage/blob/aio/_upload_helpers.py
@@ -113,11 +113,13 @@ async def upload_block_blob(  # pylint: disable=too-many-locals, too-many-statem
 
             return response
 
-        use_original_upload_path = blob_settings.use_byte_buffer or \
-            validate_content or encryption_options.get('required') or \
-            blob_settings.max_block_size < blob_settings.min_large_block_upload_threshold or \
-            hasattr(stream, 'seekable') and not stream.seekable() or \
-            not hasattr(stream, 'seek') or not hasattr(stream, 'tell')
+        use_original_upload_path = (blob_settings.use_byte_buffer or
+                                    (validate_content and validate_content != ChecksumAlgorithm.CRC64) or
+                                    encryption_options.get('required') or
+                                    blob_settings.max_block_size < blob_settings.min_large_block_upload_threshold or
+                                    (hasattr(stream, 'seekable') and not stream.seekable()) or
+                                    not hasattr(stream, 'seek') or
+                                    not hasattr(stream, 'tell'))
 
         if use_original_upload_path:
             total_size = length

--- a/sdk/storage/azure-storage-blob/tests/test_content_validation.py
+++ b/sdk/storage/azure-storage-blob/tests/test_content_validation.py
@@ -224,6 +224,31 @@ class TestStorageContentValidation(StorageRecordedTestCase):
     @pytest.mark.parametrize('a', [True, 'md5', 'crc64'])  # a: validate_content
     @GenericTestProxyParametrize1()
     @recorded_by_proxy
+    def test_upload_blob_substream(self, a, **kwargs):
+        storage_account_name = kwargs.pop("storage_account_name")
+        storage_account_key = kwargs.pop("storage_account_key")
+
+        self._setup(storage_account_name, storage_account_key)
+        self.container._config.max_single_put_size = 512
+        self.container._config.max_block_size = 512
+        self.container._config.min_large_block_upload_threshold = 1  # Set less than block size to enable substream
+        blob = self.container.get_blob_client(self._get_blob_reference())
+        assert_method = assert_structured_message if a == 'crc64' else assert_content_md5
+
+        data = b'abc' * 512 + b'abcde'
+        io = BytesIO(data)
+
+        # Act
+        blob.upload_blob(io, validate_content=a, raw_request_hook=assert_method)
+
+        # Assert
+        content = blob.download_blob()
+        assert content.read() == data
+
+    @BlobPreparer()
+    @pytest.mark.parametrize('a', [True, 'md5', 'crc64'])  # a: validate_content
+    @GenericTestProxyParametrize1()
+    @recorded_by_proxy
     def test_stage_block(self, a, **kwargs):
         storage_account_name = kwargs.pop("storage_account_name")
         storage_account_key = kwargs.pop("storage_account_key")

--- a/sdk/storage/azure-storage-blob/tests/test_content_validation_async.py
+++ b/sdk/storage/azure-storage-blob/tests/test_content_validation_async.py
@@ -216,6 +216,32 @@ class TestStorageContentValidationAsync(AsyncStorageRecordedTestCase):
     @pytest.mark.parametrize('a', [True, 'md5', 'crc64'])  # a: validate_content
     @GenericTestProxyParametrize1()
     @recorded_by_proxy_async
+    async def test_upload_blob_substream(self, a, **kwargs):
+        storage_account_name = kwargs.pop("storage_account_name")
+        storage_account_key = kwargs.pop("storage_account_key")
+
+        await self._setup(storage_account_name, storage_account_key)
+        self.container._config.max_single_put_size = 512
+        self.container._config.max_block_size = 512
+        self.container._config.min_large_block_upload_threshold = 1  # Set less than block size to enable substream
+        blob = self.container.get_blob_client(self._get_blob_reference())
+        assert_method = assert_structured_message if a == 'crc64' else assert_content_md5
+
+        data = b'abc' * 512 + b'abcde'
+        io = BytesIO(data)
+
+        # Act
+        await blob.upload_blob(io, validate_content=a, raw_request_hook=assert_method)
+
+        # Assert
+        content = await blob.download_blob()
+        assert await content.read() == data
+        await self._teardown()
+
+    @BlobPreparer()
+    @pytest.mark.parametrize('a', [True, 'md5', 'crc64'])  # a: validate_content
+    @GenericTestProxyParametrize1()
+    @recorded_by_proxy_async
     async def test_stage_block(self, a, **kwargs):
         storage_account_name = kwargs.pop("storage_account_name")
         storage_account_key = kwargs.pop("storage_account_key")

--- a/sdk/storage/azure-storage-blob/tests/test_streams.py
+++ b/sdk/storage/azure-storage-blob/tests/test_streams.py
@@ -337,11 +337,10 @@ class TestStructuredMessageEncodeStream:
     @pytest.mark.parametrize("flags", [StructuredMessageProperties.NONE, StructuredMessageProperties.CRC64])
     def test_seek_reverse_random(self, flags):
         data = os.urandom(1024)
-        inner_stream = BytesIO(data)
         expected = _build_structured_message(data, 500, flags)[0].getvalue()
 
         for _ in range(10):
-            inner_stream.seek(0)
+            inner_stream = BytesIO(data)
             sm_stream = StructuredMessageEncodeStream(inner_stream, len(data), flags, segment_size=500)
 
             initial_read = random.randint(5, len(data))

--- a/sdk/storage/azure-storage-blob/tests/test_streams.py
+++ b/sdk/storage/azure-storage-blob/tests/test_streams.py
@@ -96,6 +96,19 @@ def _build_structured_message(
 
 
 class TestStructuredMessageEncodeStream:
+    def test_close(self):
+        inner = BytesIO()
+        stream = StructuredMessageEncodeStream(inner, 0, StructuredMessageProperties.NONE)
+        assert not stream.closed
+        assert not inner.closed
+
+        stream.close()
+        assert stream.closed
+        assert inner.closed
+
+        with pytest.raises(ValueError):
+            stream.read(0)
+
     def test_read_past_end(self):
         data = os.urandom(10)
         inner_stream = BytesIO(data)

--- a/sdk/storage/azure-storage-file-datalake/assets.json
+++ b/sdk/storage/azure-storage-file-datalake/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "python",
   "TagPrefix": "python/storage/azure-storage-file-datalake",
-  "Tag": "python/storage/azure-storage-file-datalake_a10b50cfd1"
+  "Tag": "python/storage/azure-storage-file-datalake_131e71ad1e"
 }

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/streams.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/streams.py
@@ -168,6 +168,7 @@ class StructuredMessageEncodeStream(IOBase):  # pylint: disable=too-many-instanc
             self._initial_content_position = self._inner_stream.tell()
         except (AttributeError, UnsupportedOperation, OSError):
             self._initial_content_position = None
+        super().__init__()
 
     @property
     def _message_header_length(self) -> int:
@@ -206,6 +207,10 @@ class StructuredMessageEncodeStream(IOBase):  # pylint: disable=too-many-instanc
 
     def __len__(self):
         return self.message_length
+
+    def close(self) -> None:
+        self._inner_stream.close()
+        super().close()
 
     def readable(self) -> bool:
         return True
@@ -304,6 +309,9 @@ class StructuredMessageEncodeStream(IOBase):  # pylint: disable=too-many-instanc
         return position
 
     def read(self, size: int = -1) -> bytes:
+        if self.closed:
+            raise ValueError("Stream is closed")
+
         if size == 0:
             return b''
         if size < 0:

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/streams.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/streams.py
@@ -309,7 +309,7 @@ class StructuredMessageEncodeStream(IOBase):  # pylint: disable=too-many-instanc
         return position
 
     def read(self, size: int = -1) -> bytes:
-        if self.closed:
+        if self.closed:  # pylint: disable=using-constant-test
             raise ValueError("Stream is closed")
 
         if size == 0:

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/uploads.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/uploads.py
@@ -519,7 +519,6 @@ class DataLakeFileChunkUploader(_ChunkUploader):  # pylint: disable=abstract-met
             )
         finally:
             block_stream.close()
-        return None
 
 
 class FileChunkUploader(_ChunkUploader):  # pylint: disable=abstract-method

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/uploads.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/uploads.py
@@ -142,20 +142,21 @@ def upload_data_chunks(
     else:
         chunks = [uploader.process_chunk(result) for result in uploader.get_chunk_streams()]
 
-    chunks.sort(key=lambda c: c.offset)
-    # If there is a crc64, do overall crc check
-    if chunks[0].crc64 is not None:
-        combined = combine_crc64([(c.crc64, c.length) for c in chunks])
-        if combined != uploader.overall_crc64:
-            raise ValueError("Checksum mismatch detected during upload. Any data written may be invalid.")
+    if chunks:
+        chunks.sort(key=lambda c: c.offset)
+        # If there is a crc64, do overall crc check
+        if chunks[0].crc64 is not None:
+            combined = combine_crc64([(c.crc64, c.length) for c in chunks])
+            if combined != uploader.overall_crc64:
+                raise ValueError("Checksum mismatch detected during upload. Any data written may be invalid.")
 
-    # If chunks have an id, return list of ids
-    if chunks[0].id is not None:
-        return [c.id for c in chunks]
-    # Else, return the response headers for the last chunk that had a response. (Page Blobs can have empty responses)
-    for c in reversed(chunks):
-        if c.response_headers:
-            return c.response_headers
+        # If chunks have an id, return list of ids
+        if chunks[0].id is not None:
+            return [c.id for c in chunks]
+        # Else, return response headers for the last chunk that had a response. (Page Blobs can have empty responses)
+        for c in reversed(chunks):
+            if c.response_headers:
+                return c.response_headers
     return {}
 
 
@@ -188,11 +189,11 @@ def upload_substream_blocks(
                 executor.submit(with_current_context(uploader.process_substream_block), u)
                 for u in islice(upload_tasks, 0, max_concurrency)
             ]
-            range_ids = _parallel_uploads(executor, uploader.process_substream_block, upload_tasks, running_futures)
+            chunks = _parallel_uploads(executor, uploader.process_substream_block, upload_tasks, running_futures)
     else:
-        range_ids = [uploader.process_substream_block(b) for b in uploader.get_substream_blocks()]
-    if any(range_ids):
-        return sorted(range_ids)
+        chunks = [uploader.process_substream_block(b) for b in uploader.get_substream_blocks()]
+    if any(chunks):
+        return sorted(chunks)
     return []
 
 
@@ -206,14 +207,11 @@ class ChunkInfo:
     response_headers: Dict[str, Any] = {}
     """The response headers from the upload chunk operation."""
 
-    def __init__(self, offset: int, data: bytes, checksum_algorithm: Optional[Union[bool, str]]):
+    def __init__(self, offset: int, length: int, md5: Optional[bytes] = None, crc64: Optional[int] = None):
         self.offset = offset
-        self.length = len(data)
-
-        if checksum_algorithm == ChecksumAlgorithm.MD5:
-            self.md5 = calculate_md5(data)
-        if checksum_algorithm == ChecksumAlgorithm.CRC64:
-            self.crc64 = calculate_crc64(data, 0)
+        self.length = length
+        self.md5 = md5
+        self.crc64 = crc64
 
     @property
     def crc64_bytes(self) -> Optional[bytes]:
@@ -260,7 +258,8 @@ class _ChunkUploader(object):  # pylint: disable=too-many-instance-attributes
 
     def get_chunk_streams(self) -> Generator[Tuple[bytes, ChunkInfo], None, None]:
         index = 0
-        while True:
+        last_chunk = False
+        while not last_chunk:
             data = b""
             read_size = self.chunk_size
 
@@ -278,25 +277,27 @@ class _ChunkUploader(object):  # pylint: disable=too-many-instance-attributes
                 if temp == b"" or len(data) == self.chunk_size:
                     break
 
-            # Content validation and encryption cannot be enabled at the same time,
-            # so this is safe to do here, before encryption
-            if self.validate_content == ChecksumAlgorithm.CRC64:
-                self.overall_crc64 = calculate_crc64(data, self.overall_crc64)
-
             if len(data) == self.chunk_size:
                 if self.padder:
                     data = self.padder.update(data)
                 if self.encryptor:
                     data = self.encryptor.update(data)
-                yield data, ChunkInfo(index, data, self.validate_content)
             else:
                 if self.padder:
                     data = self.padder.update(data) + self.padder.finalize()
                 if self.encryptor:
                     data = self.encryptor.update(data) + self.encryptor.finalize()
-                if data:
-                    yield data, ChunkInfo(index, data, self.validate_content)
-                break
+                last_chunk = True
+
+            if data:
+                md5, crc64 = None, None
+                if self.validate_content == ChecksumAlgorithm.CRC64:
+                    crc64 = calculate_crc64(data, 0)
+                    self.overall_crc64 = calculate_crc64(data, self.overall_crc64)
+                elif self.validate_content == ChecksumAlgorithm.MD5:
+                    md5 = calculate_md5(data)
+
+                yield data, ChunkInfo(index, len(data), md5, crc64)
             index += len(data)
 
     def process_chunk(self, chunk_data: Tuple[bytes, ChunkInfo]) -> ChunkInfo:
@@ -336,15 +337,12 @@ class _ChunkUploader(object):  # pylint: disable=too-many-instance-attributes
             yield index, SubStream(self.stream, index, length, lock)
 
     def process_substream_block(self, block_data):
-        return self._upload_substream_block_with_progress(block_data[0], block_data[1])
+        range_id = self._upload_substream_block(block_data[0], block_data[1])
+        self._update_progress(len(block_data))
+        return range_id
 
     def _upload_substream_block(self, index, block_stream):
         raise NotImplementedError("Must be implemented by child class.")
-
-    def _upload_substream_block_with_progress(self, index, block_stream):
-        range_id = self._upload_substream_block(index, block_stream)
-        self._update_progress(len(block_stream))
-        return range_id
 
     def set_response_properties(self, resp):
         self.etag = resp.etag
@@ -379,10 +377,8 @@ class BlockBlobChunkUploader(_ChunkUploader):
 
     def _upload_substream_block(self, index, block_stream):
         try:
-            structured_type, structured_length = None, None
+            data_length = len(block_stream)
             if self.validate_content == ChecksumAlgorithm.CRC64:
-                structured_type = SM_HEADER_V1_CRC64
-                structured_length = len(block_stream)
                 block_stream = StructuredMessageEncodeStream(
                     block_stream,
                     len(block_stream),
@@ -393,8 +389,8 @@ class BlockBlobChunkUploader(_ChunkUploader):
                 block_id,
                 len(block_stream),
                 block_stream,
-                structured_body_type=structured_type,
-                structured_content_length=structured_length,
+                structured_body_type=SM_HEADER_V1_CRC64 if self.validate_content == ChecksumAlgorithm.CRC64 else None,
+                structured_content_length=data_length if self.validate_content == ChecksumAlgorithm.CRC64 else None,
                 data_stream_total=self.total_size,
                 upload_stream_current=self.progress_total,
                 **self.request_options

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/uploads_async.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/_shared/uploads_async.py
@@ -438,10 +438,19 @@ class DataLakeFileChunkUploader(_ChunkUploader):  # pylint: disable=abstract-met
 
     async def _upload_substream_block(self, index, block_stream):
         try:
+            data_length = len(block_stream)
+            if self.validate_content == ChecksumAlgorithm.CRC64:
+                block_stream = StructuredMessageEncodeStream(
+                    block_stream,
+                    len(block_stream),
+                    StructuredMessageProperties.CRC64)
+
             await self.service.append_data(
                 body=block_stream,
                 position=index,
                 content_length=len(block_stream),
+                structured_body_type=SM_HEADER_V1_CRC64 if self.validate_content == ChecksumAlgorithm.CRC64 else None,
+                structured_content_length=data_length if self.validate_content == ChecksumAlgorithm.CRC64 else None,
                 cls=return_response_headers,
                 data_stream_total=self.total_size,
                 upload_stream_current=self.progress_total,
@@ -449,6 +458,7 @@ class DataLakeFileChunkUploader(_ChunkUploader):  # pylint: disable=abstract-met
             )
         finally:
             block_stream.close()
+        return None
 
 
 class FileChunkUploader(_ChunkUploader):  # pylint: disable=abstract-method

--- a/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/aio/_upload_helper.py
+++ b/sdk/storage/azure-storage-file-datalake/azure/storage/filedatalake/aio/_upload_helper.py
@@ -4,12 +4,14 @@
 # license information.
 # --------------------------------------------------------------------------
 from azure.core.exceptions import HttpResponseError
+
 from .._deserialize import (
     process_storage_error)
 from .._shared.response_handlers import return_response_headers
 from .._shared.uploads_async import (
     upload_data_chunks,
     DataLakeFileChunkUploader, upload_substream_blocks)
+from .._shared.validation import ChecksumAlgorithm
 
 
 def _any_conditions(modified_access_conditions=None, **kwargs):  # pylint: disable=unused-argument
@@ -67,10 +69,12 @@ async def upload_datalake_file(  # pylint: disable=unused-argument
             modified_access_conditions.if_modified_since = None
             modified_access_conditions.if_unmodified_since = None
 
-        use_original_upload_path = file_settings.use_byte_buffer or \
-            validate_content or chunk_size < file_settings.min_large_chunk_upload_threshold or \
-            hasattr(stream, 'seekable') and not stream.seekable() or \
-            not hasattr(stream, 'seek') or not hasattr(stream, 'tell')
+        use_original_upload_path = (file_settings.use_byte_buffer or
+                                    (validate_content and validate_content != ChecksumAlgorithm.CRC64) or
+                                    chunk_size < file_settings.min_large_chunk_upload_threshold or
+                                    (hasattr(stream, 'seekable') and not stream.seekable()) or
+                                    not hasattr(stream, 'seek') or
+                                    not hasattr(stream, 'tell'))
 
         if use_original_upload_path:
             await upload_data_chunks(

--- a/sdk/storage/azure-storage-file-datalake/tests/test_content_validation.py
+++ b/sdk/storage/azure-storage-file-datalake/tests/test_content_validation.py
@@ -105,6 +105,29 @@ class TestStorageContentValidation(StorageRecordedTestCase):
     @pytest.mark.parametrize('a', [True, 'md5', 'crc64'])  # a: validate_content
     @GenericTestProxyParametrize1()
     @recorded_by_proxy
+    def test_upload_data_substream(self, a, **kwargs):
+        datalake_storage_account_name = kwargs.pop("datalake_storage_account_name")
+        datalake_storage_account_key = kwargs.pop("datalake_storage_account_key")
+
+        self._setup(datalake_storage_account_name, datalake_storage_account_key)
+        self.file_system._config.min_large_chunk_upload_threshold = 1  # Set less than chunk size to enable substream
+        file = self.file_system.get_file_client(self._get_file_reference())
+        assert_method = assert_structured_message if a == 'crc64' else assert_content_md5
+
+        data = b'abc' * 512 + b'abcde'
+        io = BytesIO(data)
+
+        # Act
+        file.upload_data(io, overwrite=True, validate_content=a, chunk_size=512, raw_request_hook=assert_method)
+
+        # Assert
+        content = file.download_file()
+        assert content.read() == data
+
+    @DataLakePreparer()
+    @pytest.mark.parametrize('a', [True, 'md5', 'crc64'])  # a: validate_content
+    @GenericTestProxyParametrize1()
+    @recorded_by_proxy
     def test_append_data(self, a, **kwargs):
         datalake_storage_account_name = kwargs.pop("datalake_storage_account_name")
         datalake_storage_account_key = kwargs.pop("datalake_storage_account_key")

--- a/sdk/storage/azure-storage-file-datalake/tests/test_content_validation.py
+++ b/sdk/storage/azure-storage-file-datalake/tests/test_content_validation.py
@@ -72,10 +72,11 @@ class TestStorageContentValidation(StorageRecordedTestCase):
         assert_method = assert_content_crc64 if a == 'crc64' else assert_content_md5
 
         # Act
-        response = file.upload_data(data, overwrite=True, validate_content=a, raw_request_hook=assert_method)
+        file.upload_data(data, overwrite=True, validate_content=a, raw_request_hook=assert_method)
 
         # Assert
-        assert response
+        content = file.download_file()
+        assert content.read() == data
 
     @DataLakePreparer()
     @pytest.mark.parametrize('a', [True, 'md5', 'crc64'])  # a: validate_content
@@ -91,15 +92,11 @@ class TestStorageContentValidation(StorageRecordedTestCase):
         assert_method = assert_content_crc64 if a == 'crc64' else assert_content_md5
 
         # Act
-        response = file.upload_data(
-            data,
-            overwrite=True,
-            validate_content=a,
-            chunk_size=1024,
-            raw_request_hook=assert_method)
+        file.upload_data(data, overwrite=True, validate_content=a, chunk_size=1024, raw_request_hook=assert_method)
 
         # Assert
-        assert response
+        content = file.download_file()
+        assert content.read() == data
 
     @DataLakePreparer()
     @pytest.mark.parametrize('a', [True, 'md5', 'crc64'])  # a: validate_content

--- a/sdk/storage/azure-storage-file-datalake/tests/test_content_validation_async.py
+++ b/sdk/storage/azure-storage-file-datalake/tests/test_content_validation_async.py
@@ -58,7 +58,8 @@ class TestStorageContentValidation(AsyncStorageRecordedTestCase):
         response = await file.upload_data(data, overwrite=True, validate_content=a, raw_request_hook=assert_method)
 
         # Assert
-        assert response
+        content = await file.download_file()
+        assert await content.read() == data
         await self._teardown()
 
     @DataLakePreparer()
@@ -75,15 +76,11 @@ class TestStorageContentValidation(AsyncStorageRecordedTestCase):
         assert_method = assert_content_crc64 if a == 'crc64' else assert_content_md5
 
         # Act
-        response = await file.upload_data(
-            data,
-            overwrite=True,
-            validate_content=a,
-            chunk_size=1024,
-            raw_request_hook=assert_method)
+        await file.upload_data(data, overwrite=True, validate_content=a, chunk_size=1024, raw_request_hook=assert_method)
 
         # Assert
-        assert response
+        content = await file.download_file()
+        assert await content.read() == data
         await self._teardown()
 
     @DataLakePreparer()

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/streams.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/streams.py
@@ -168,6 +168,7 @@ class StructuredMessageEncodeStream(IOBase):  # pylint: disable=too-many-instanc
             self._initial_content_position = self._inner_stream.tell()
         except (AttributeError, UnsupportedOperation, OSError):
             self._initial_content_position = None
+        super().__init__()
 
     @property
     def _message_header_length(self) -> int:
@@ -206,6 +207,10 @@ class StructuredMessageEncodeStream(IOBase):  # pylint: disable=too-many-instanc
 
     def __len__(self):
         return self.message_length
+
+    def close(self) -> None:
+        self._inner_stream.close()
+        super().close()
 
     def readable(self) -> bool:
         return True
@@ -304,6 +309,9 @@ class StructuredMessageEncodeStream(IOBase):  # pylint: disable=too-many-instanc
         return position
 
     def read(self, size: int = -1) -> bytes:
+        if self.closed:
+            raise ValueError("Stream is closed")
+
         if size == 0:
             return b''
         if size < 0:

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/streams.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/streams.py
@@ -309,7 +309,7 @@ class StructuredMessageEncodeStream(IOBase):  # pylint: disable=too-many-instanc
         return position
 
     def read(self, size: int = -1) -> bytes:
-        if self.closed:
+        if self.closed:  # pylint: disable=using-constant-test
             raise ValueError("Stream is closed")
 
         if size == 0:

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/uploads.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/uploads.py
@@ -519,7 +519,6 @@ class DataLakeFileChunkUploader(_ChunkUploader):  # pylint: disable=abstract-met
             )
         finally:
             block_stream.close()
-        return None
 
 
 class FileChunkUploader(_ChunkUploader):  # pylint: disable=abstract-method

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/uploads.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/uploads.py
@@ -142,20 +142,21 @@ def upload_data_chunks(
     else:
         chunks = [uploader.process_chunk(result) for result in uploader.get_chunk_streams()]
 
-    chunks.sort(key=lambda c: c.offset)
-    # If there is a crc64, do overall crc check
-    if chunks[0].crc64 is not None:
-        combined = combine_crc64([(c.crc64, c.length) for c in chunks])
-        if combined != uploader.overall_crc64:
-            raise ValueError("Checksum mismatch detected during upload. Any data written may be invalid.")
+    if chunks:
+        chunks.sort(key=lambda c: c.offset)
+        # If there is a crc64, do overall crc check
+        if chunks[0].crc64 is not None:
+            combined = combine_crc64([(c.crc64, c.length) for c in chunks])
+            if combined != uploader.overall_crc64:
+                raise ValueError("Checksum mismatch detected during upload. Any data written may be invalid.")
 
-    # If chunks have an id, return list of ids
-    if chunks[0].id is not None:
-        return [c.id for c in chunks]
-    # Else, return the response headers for the last chunk that had a response. (Page Blobs can have empty responses)
-    for c in reversed(chunks):
-        if c.response_headers:
-            return c.response_headers
+        # If chunks have an id, return list of ids
+        if chunks[0].id is not None:
+            return [c.id for c in chunks]
+        # Else, return response headers for the last chunk that had a response. (Page Blobs can have empty responses)
+        for c in reversed(chunks):
+            if c.response_headers:
+                return c.response_headers
     return {}
 
 
@@ -188,11 +189,11 @@ def upload_substream_blocks(
                 executor.submit(with_current_context(uploader.process_substream_block), u)
                 for u in islice(upload_tasks, 0, max_concurrency)
             ]
-            range_ids = _parallel_uploads(executor, uploader.process_substream_block, upload_tasks, running_futures)
+            chunks = _parallel_uploads(executor, uploader.process_substream_block, upload_tasks, running_futures)
     else:
-        range_ids = [uploader.process_substream_block(b) for b in uploader.get_substream_blocks()]
-    if any(range_ids):
-        return sorted(range_ids)
+        chunks = [uploader.process_substream_block(b) for b in uploader.get_substream_blocks()]
+    if any(chunks):
+        return sorted(chunks)
     return []
 
 
@@ -206,14 +207,11 @@ class ChunkInfo:
     response_headers: Dict[str, Any] = {}
     """The response headers from the upload chunk operation."""
 
-    def __init__(self, offset: int, data: bytes, checksum_algorithm: Optional[Union[bool, str]]):
+    def __init__(self, offset: int, length: int, md5: Optional[bytes] = None, crc64: Optional[int] = None):
         self.offset = offset
-        self.length = len(data)
-
-        if checksum_algorithm == ChecksumAlgorithm.MD5:
-            self.md5 = calculate_md5(data)
-        if checksum_algorithm == ChecksumAlgorithm.CRC64:
-            self.crc64 = calculate_crc64(data, 0)
+        self.length = length
+        self.md5 = md5
+        self.crc64 = crc64
 
     @property
     def crc64_bytes(self) -> Optional[bytes]:
@@ -260,7 +258,8 @@ class _ChunkUploader(object):  # pylint: disable=too-many-instance-attributes
 
     def get_chunk_streams(self) -> Generator[Tuple[bytes, ChunkInfo], None, None]:
         index = 0
-        while True:
+        last_chunk = False
+        while not last_chunk:
             data = b""
             read_size = self.chunk_size
 
@@ -278,25 +277,27 @@ class _ChunkUploader(object):  # pylint: disable=too-many-instance-attributes
                 if temp == b"" or len(data) == self.chunk_size:
                     break
 
-            # Content validation and encryption cannot be enabled at the same time,
-            # so this is safe to do here, before encryption
-            if self.validate_content == ChecksumAlgorithm.CRC64:
-                self.overall_crc64 = calculate_crc64(data, self.overall_crc64)
-
             if len(data) == self.chunk_size:
                 if self.padder:
                     data = self.padder.update(data)
                 if self.encryptor:
                     data = self.encryptor.update(data)
-                yield data, ChunkInfo(index, data, self.validate_content)
             else:
                 if self.padder:
                     data = self.padder.update(data) + self.padder.finalize()
                 if self.encryptor:
                     data = self.encryptor.update(data) + self.encryptor.finalize()
-                if data:
-                    yield data, ChunkInfo(index, data, self.validate_content)
-                break
+                last_chunk = True
+
+            if data:
+                md5, crc64 = None, None
+                if self.validate_content == ChecksumAlgorithm.CRC64:
+                    crc64 = calculate_crc64(data, 0)
+                    self.overall_crc64 = calculate_crc64(data, self.overall_crc64)
+                elif self.validate_content == ChecksumAlgorithm.MD5:
+                    md5 = calculate_md5(data)
+
+                yield data, ChunkInfo(index, len(data), md5, crc64)
             index += len(data)
 
     def process_chunk(self, chunk_data: Tuple[bytes, ChunkInfo]) -> ChunkInfo:
@@ -336,15 +337,12 @@ class _ChunkUploader(object):  # pylint: disable=too-many-instance-attributes
             yield index, SubStream(self.stream, index, length, lock)
 
     def process_substream_block(self, block_data):
-        return self._upload_substream_block_with_progress(block_data[0], block_data[1])
+        range_id = self._upload_substream_block(block_data[0], block_data[1])
+        self._update_progress(len(block_data))
+        return range_id
 
     def _upload_substream_block(self, index, block_stream):
         raise NotImplementedError("Must be implemented by child class.")
-
-    def _upload_substream_block_with_progress(self, index, block_stream):
-        range_id = self._upload_substream_block(index, block_stream)
-        self._update_progress(len(block_stream))
-        return range_id
 
     def set_response_properties(self, resp):
         self.etag = resp.etag
@@ -379,10 +377,8 @@ class BlockBlobChunkUploader(_ChunkUploader):
 
     def _upload_substream_block(self, index, block_stream):
         try:
-            structured_type, structured_length = None, None
+            data_length = len(block_stream)
             if self.validate_content == ChecksumAlgorithm.CRC64:
-                structured_type = SM_HEADER_V1_CRC64
-                structured_length = len(block_stream)
                 block_stream = StructuredMessageEncodeStream(
                     block_stream,
                     len(block_stream),
@@ -393,8 +389,8 @@ class BlockBlobChunkUploader(_ChunkUploader):
                 block_id,
                 len(block_stream),
                 block_stream,
-                structured_body_type=structured_type,
-                structured_content_length=structured_length,
+                structured_body_type=SM_HEADER_V1_CRC64 if self.validate_content == ChecksumAlgorithm.CRC64 else None,
+                structured_content_length=data_length if self.validate_content == ChecksumAlgorithm.CRC64 else None,
                 data_stream_total=self.total_size,
                 upload_stream_current=self.progress_total,
                 **self.request_options

--- a/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/uploads_async.py
+++ b/sdk/storage/azure-storage-file-share/azure/storage/fileshare/_shared/uploads_async.py
@@ -438,10 +438,19 @@ class DataLakeFileChunkUploader(_ChunkUploader):  # pylint: disable=abstract-met
 
     async def _upload_substream_block(self, index, block_stream):
         try:
+            data_length = len(block_stream)
+            if self.validate_content == ChecksumAlgorithm.CRC64:
+                block_stream = StructuredMessageEncodeStream(
+                    block_stream,
+                    len(block_stream),
+                    StructuredMessageProperties.CRC64)
+
             await self.service.append_data(
                 body=block_stream,
                 position=index,
                 content_length=len(block_stream),
+                structured_body_type=SM_HEADER_V1_CRC64 if self.validate_content == ChecksumAlgorithm.CRC64 else None,
+                structured_content_length=data_length if self.validate_content == ChecksumAlgorithm.CRC64 else None,
                 cls=return_response_headers,
                 data_stream_total=self.total_size,
                 upload_stream_current=self.progress_total,
@@ -449,6 +458,7 @@ class DataLakeFileChunkUploader(_ChunkUploader):  # pylint: disable=abstract-met
             )
         finally:
             block_stream.close()
+        return None
 
 
 class FileChunkUploader(_ChunkUploader):  # pylint: disable=abstract-method

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/streams.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/streams.py
@@ -168,6 +168,7 @@ class StructuredMessageEncodeStream(IOBase):  # pylint: disable=too-many-instanc
             self._initial_content_position = self._inner_stream.tell()
         except (AttributeError, UnsupportedOperation, OSError):
             self._initial_content_position = None
+        super().__init__()
 
     @property
     def _message_header_length(self) -> int:
@@ -206,6 +207,10 @@ class StructuredMessageEncodeStream(IOBase):  # pylint: disable=too-many-instanc
 
     def __len__(self):
         return self.message_length
+
+    def close(self) -> None:
+        self._inner_stream.close()
+        super().close()
 
     def readable(self) -> bool:
         return True
@@ -304,6 +309,9 @@ class StructuredMessageEncodeStream(IOBase):  # pylint: disable=too-many-instanc
         return position
 
     def read(self, size: int = -1) -> bytes:
+        if self.closed:
+            raise ValueError("Stream is closed")
+
         if size == 0:
             return b''
         if size < 0:

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/streams.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/streams.py
@@ -309,7 +309,7 @@ class StructuredMessageEncodeStream(IOBase):  # pylint: disable=too-many-instanc
         return position
 
     def read(self, size: int = -1) -> bytes:
-        if self.closed:
+        if self.closed:  # pylint: disable=using-constant-test
             raise ValueError("Stream is closed")
 
         if size == 0:

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/uploads.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/uploads.py
@@ -519,7 +519,6 @@ class DataLakeFileChunkUploader(_ChunkUploader):  # pylint: disable=abstract-met
             )
         finally:
             block_stream.close()
-        return None
 
 
 class FileChunkUploader(_ChunkUploader):  # pylint: disable=abstract-method

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/uploads.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/uploads.py
@@ -142,20 +142,21 @@ def upload_data_chunks(
     else:
         chunks = [uploader.process_chunk(result) for result in uploader.get_chunk_streams()]
 
-    chunks.sort(key=lambda c: c.offset)
-    # If there is a crc64, do overall crc check
-    if chunks[0].crc64 is not None:
-        combined = combine_crc64([(c.crc64, c.length) for c in chunks])
-        if combined != uploader.overall_crc64:
-            raise ValueError("Checksum mismatch detected during upload. Any data written may be invalid.")
+    if chunks:
+        chunks.sort(key=lambda c: c.offset)
+        # If there is a crc64, do overall crc check
+        if chunks[0].crc64 is not None:
+            combined = combine_crc64([(c.crc64, c.length) for c in chunks])
+            if combined != uploader.overall_crc64:
+                raise ValueError("Checksum mismatch detected during upload. Any data written may be invalid.")
 
-    # If chunks have an id, return list of ids
-    if chunks[0].id is not None:
-        return [c.id for c in chunks]
-    # Else, return the response headers for the last chunk that had a response. (Page Blobs can have empty responses)
-    for c in reversed(chunks):
-        if c.response_headers:
-            return c.response_headers
+        # If chunks have an id, return list of ids
+        if chunks[0].id is not None:
+            return [c.id for c in chunks]
+        # Else, return response headers for the last chunk that had a response. (Page Blobs can have empty responses)
+        for c in reversed(chunks):
+            if c.response_headers:
+                return c.response_headers
     return {}
 
 
@@ -188,11 +189,11 @@ def upload_substream_blocks(
                 executor.submit(with_current_context(uploader.process_substream_block), u)
                 for u in islice(upload_tasks, 0, max_concurrency)
             ]
-            range_ids = _parallel_uploads(executor, uploader.process_substream_block, upload_tasks, running_futures)
+            chunks = _parallel_uploads(executor, uploader.process_substream_block, upload_tasks, running_futures)
     else:
-        range_ids = [uploader.process_substream_block(b) for b in uploader.get_substream_blocks()]
-    if any(range_ids):
-        return sorted(range_ids)
+        chunks = [uploader.process_substream_block(b) for b in uploader.get_substream_blocks()]
+    if any(chunks):
+        return sorted(chunks)
     return []
 
 
@@ -206,14 +207,11 @@ class ChunkInfo:
     response_headers: Dict[str, Any] = {}
     """The response headers from the upload chunk operation."""
 
-    def __init__(self, offset: int, data: bytes, checksum_algorithm: Optional[Union[bool, str]]):
+    def __init__(self, offset: int, length: int, md5: Optional[bytes] = None, crc64: Optional[int] = None):
         self.offset = offset
-        self.length = len(data)
-
-        if checksum_algorithm == ChecksumAlgorithm.MD5:
-            self.md5 = calculate_md5(data)
-        if checksum_algorithm == ChecksumAlgorithm.CRC64:
-            self.crc64 = calculate_crc64(data, 0)
+        self.length = length
+        self.md5 = md5
+        self.crc64 = crc64
 
     @property
     def crc64_bytes(self) -> Optional[bytes]:
@@ -260,7 +258,8 @@ class _ChunkUploader(object):  # pylint: disable=too-many-instance-attributes
 
     def get_chunk_streams(self) -> Generator[Tuple[bytes, ChunkInfo], None, None]:
         index = 0
-        while True:
+        last_chunk = False
+        while not last_chunk:
             data = b""
             read_size = self.chunk_size
 
@@ -278,25 +277,27 @@ class _ChunkUploader(object):  # pylint: disable=too-many-instance-attributes
                 if temp == b"" or len(data) == self.chunk_size:
                     break
 
-            # Content validation and encryption cannot be enabled at the same time,
-            # so this is safe to do here, before encryption
-            if self.validate_content == ChecksumAlgorithm.CRC64:
-                self.overall_crc64 = calculate_crc64(data, self.overall_crc64)
-
             if len(data) == self.chunk_size:
                 if self.padder:
                     data = self.padder.update(data)
                 if self.encryptor:
                     data = self.encryptor.update(data)
-                yield data, ChunkInfo(index, data, self.validate_content)
             else:
                 if self.padder:
                     data = self.padder.update(data) + self.padder.finalize()
                 if self.encryptor:
                     data = self.encryptor.update(data) + self.encryptor.finalize()
-                if data:
-                    yield data, ChunkInfo(index, data, self.validate_content)
-                break
+                last_chunk = True
+
+            if data:
+                md5, crc64 = None, None
+                if self.validate_content == ChecksumAlgorithm.CRC64:
+                    crc64 = calculate_crc64(data, 0)
+                    self.overall_crc64 = calculate_crc64(data, self.overall_crc64)
+                elif self.validate_content == ChecksumAlgorithm.MD5:
+                    md5 = calculate_md5(data)
+
+                yield data, ChunkInfo(index, len(data), md5, crc64)
             index += len(data)
 
     def process_chunk(self, chunk_data: Tuple[bytes, ChunkInfo]) -> ChunkInfo:
@@ -336,15 +337,12 @@ class _ChunkUploader(object):  # pylint: disable=too-many-instance-attributes
             yield index, SubStream(self.stream, index, length, lock)
 
     def process_substream_block(self, block_data):
-        return self._upload_substream_block_with_progress(block_data[0], block_data[1])
+        range_id = self._upload_substream_block(block_data[0], block_data[1])
+        self._update_progress(len(block_data))
+        return range_id
 
     def _upload_substream_block(self, index, block_stream):
         raise NotImplementedError("Must be implemented by child class.")
-
-    def _upload_substream_block_with_progress(self, index, block_stream):
-        range_id = self._upload_substream_block(index, block_stream)
-        self._update_progress(len(block_stream))
-        return range_id
 
     def set_response_properties(self, resp):
         self.etag = resp.etag
@@ -379,10 +377,8 @@ class BlockBlobChunkUploader(_ChunkUploader):
 
     def _upload_substream_block(self, index, block_stream):
         try:
-            structured_type, structured_length = None, None
+            data_length = len(block_stream)
             if self.validate_content == ChecksumAlgorithm.CRC64:
-                structured_type = SM_HEADER_V1_CRC64
-                structured_length = len(block_stream)
                 block_stream = StructuredMessageEncodeStream(
                     block_stream,
                     len(block_stream),
@@ -393,8 +389,8 @@ class BlockBlobChunkUploader(_ChunkUploader):
                 block_id,
                 len(block_stream),
                 block_stream,
-                structured_body_type=structured_type,
-                structured_content_length=structured_length,
+                structured_body_type=SM_HEADER_V1_CRC64 if self.validate_content == ChecksumAlgorithm.CRC64 else None,
+                structured_content_length=data_length if self.validate_content == ChecksumAlgorithm.CRC64 else None,
                 data_stream_total=self.total_size,
                 upload_stream_current=self.progress_total,
                 **self.request_options

--- a/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/uploads_async.py
+++ b/sdk/storage/azure-storage-queue/azure/storage/queue/_shared/uploads_async.py
@@ -438,10 +438,19 @@ class DataLakeFileChunkUploader(_ChunkUploader):  # pylint: disable=abstract-met
 
     async def _upload_substream_block(self, index, block_stream):
         try:
+            data_length = len(block_stream)
+            if self.validate_content == ChecksumAlgorithm.CRC64:
+                block_stream = StructuredMessageEncodeStream(
+                    block_stream,
+                    len(block_stream),
+                    StructuredMessageProperties.CRC64)
+
             await self.service.append_data(
                 body=block_stream,
                 position=index,
                 content_length=len(block_stream),
+                structured_body_type=SM_HEADER_V1_CRC64 if self.validate_content == ChecksumAlgorithm.CRC64 else None,
+                structured_content_length=data_length if self.validate_content == ChecksumAlgorithm.CRC64 else None,
                 cls=return_response_headers,
                 data_stream_total=self.total_size,
                 upload_stream_current=self.progress_total,
@@ -449,6 +458,7 @@ class DataLakeFileChunkUploader(_ChunkUploader):  # pylint: disable=abstract-met
             )
         finally:
             block_stream.close()
+        return None
 
 
 class FileChunkUploader(_ChunkUploader):  # pylint: disable=abstract-method


### PR DESCRIPTION
This adds support for crc64 to the bufferless substream upload code path for Block Blob and Datalake files (only places substream is currently supported). Since there is no buffering, this code path utilizing structured message for crc support and does not support an overall crc calculation, like the buffered upload does.

Includes some minor refactoring to some of the upload methods (I made some changes to support overall CRC in substream but then it didn't work out but kept some of the refactor around because it seemed better) and added close support to the encode stream to ensure we properly close the inner stream.