### PR TITLE
Add namespaces to package info

### DIFF
--- a/eng/pipelines/templates/steps/build-extended-artifacts.yml
+++ b/eng/pipelines/templates/steps/build-extended-artifacts.yml
@@ -85,6 +85,16 @@ steps:
       ArtifactPath: '$(Build.ArtifactStagingDirectory)'
       ArtifactName: 'packages_extended'
 
+  - task: Powershell@2
+    inputs:
+      filePath: $(Build.SourcesDirectory)/eng/scripts/Save-Package-Namespaces-Property.ps1
+      arguments: >
+        -ArtifactStagingDirectory "$(Build.ArtifactStagingDirectory)/packages_extended"
+        -ArtifactsList '${{ convertToJson(parameters.Artifacts) }}' | ConvertFrom-Json
+      pwsh: true
+      workingDirectory: $(Pipeline.Workspace)
+    displayName: Update package properties with namespaces
+
   - pwsh: |
       $directoryExists = Test-Path -Path "$(Build.SourcesDirectory)/_docs"
       Write-Output "##vso[task.setvariable variable=DirectoryExists]$directoryExists"

--- a/eng/pipelines/templates/steps/build-extended-artifacts.yml
+++ b/eng/pipelines/templates/steps/build-extended-artifacts.yml
@@ -85,7 +85,7 @@ steps:
       filePath: $(Build.SourcesDirectory)/eng/scripts/Save-Package-Namespaces-Property.ps1
       arguments: >
         -ArtifactStagingDirectory "$(Build.ArtifactStagingDirectory)"
-        -ArtifactsList '${{ convertToJson(parameters.Artifacts) }}' | ConvertFrom-Json
+        -ArtifactsList ('${{ convertToJson(parameters.Artifacts) }}' | ConvertFrom-Json)
       pwsh: true
       workingDirectory: $(Pipeline.Workspace)
     displayName: Update package properties with namespaces

--- a/eng/pipelines/templates/steps/build-extended-artifacts.yml
+++ b/eng/pipelines/templates/steps/build-extended-artifacts.yml
@@ -80,20 +80,20 @@ steps:
 
   - ${{ parameters.BeforePublishSteps }}
 
-  - template: /eng/common/pipelines/templates/steps/publish-1es-artifact.yml
-    parameters:
-      ArtifactPath: '$(Build.ArtifactStagingDirectory)'
-      ArtifactName: 'packages_extended'
-
   - task: Powershell@2
     inputs:
       filePath: $(Build.SourcesDirectory)/eng/scripts/Save-Package-Namespaces-Property.ps1
       arguments: >
-        -ArtifactStagingDirectory "$(Build.ArtifactStagingDirectory)/packages_extended"
+        -ArtifactStagingDirectory "$(Build.ArtifactStagingDirectory)"
         -ArtifactsList '${{ convertToJson(parameters.Artifacts) }}' | ConvertFrom-Json
       pwsh: true
       workingDirectory: $(Pipeline.Workspace)
     displayName: Update package properties with namespaces
+
+  - template: /eng/common/pipelines/templates/steps/publish-1es-artifact.yml
+    parameters:
+      ArtifactPath: '$(Build.ArtifactStagingDirectory)'
+      ArtifactName: 'packages_extended'
 
   - pwsh: |
       $directoryExists = Test-Path -Path "$(Build.SourcesDirectory)/_docs"

--- a/eng/scripts/Save-Package-Namespaces-Property.ps1
+++ b/eng/scripts/Save-Package-Namespaces-Property.ps1
@@ -1,0 +1,106 @@
+<#
+.SYNOPSIS
+Given an artifact staging directory, loop through all of the PackageInfo files
+in the PackageInfo subdirectory and compute the namespaces if they don't already
+exist. Yes, they're called packages in Java but namespaces are being used to keep
+code that processes them common amongst the languages.
+
+.DESCRIPTION
+Given an artifact staging directory, loop through all of the PackageInfo files
+in the PackageInfo subdirectory. For each PackageInfo file, find its corresponding
+javadoc jar file and use that to compute the namespace information.
+
+.PARAMETER ArtifactStagingDirectory
+The root directory of the staged artifacts. The PackageInfo files will be in the
+PackageInfo subdirectory. The artifacts root directories are GroupId based, meaning
+any artifact with that GroupId will be in a subdirectory. For example: Most Spring
+libraries are com.azure.spring and their javadoc jars will be under that subdirectory
+but azure-spring-data-cosmos' GroupId is com.azure and its javadoc jar will be under
+com.azure.
+
+.PARAMETER ArtifactsList
+The list of artifacts to gather namespaces for, this is only done for libraries that are
+producing docs.
+-ArtifactsList '${{ convertToJson(parameters.Artifacts) }}' | ConvertFrom-Json
+#>
+[CmdletBinding()]
+Param (
+    [Parameter(Mandatory = $True)]
+    [string] $ArtifactStagingDirectory,
+    [Parameter(Mandatory=$true)]
+    [array] $ArtifactsList
+)
+
+$ArtifactsList = $ArtifactsList | Where-Object -Not "skipPublishDocMs"
+
+. (Join-Path $PSScriptRoot ".." common scripts common.ps1)
+
+if (-not $ArtifactsList) {
+    Write-Host "ArtifactsList is empty, nothing to process. This can happen if skipPublishDocMs is set to true for all libraries being built."
+    exit 0
+}
+
+Write-Host "ArtifactStagingDirectory=$ArtifactStagingDirectory"
+if (-not (Test-Path -Path $ArtifactStagingDirectory)) {
+    LogError "ArtifactStagingDirectory '$ArtifactStagingDirectory' does not exist."
+    exit 1
+}
+
+Write-Host ""
+Write-Host "ArtifactsList:"
+$ArtifactsList | Format-Table -Property GroupId, Name | Out-String | Write-Host
+
+$packageInfoDirectory = Join-Path $ArtifactStagingDirectory "PackageInfo"
+
+$foundError = $false
+# At this point the packageInfo files should have been already been created.
+# The only thing being done here is adding or updating namespaces for libraries
+# that will be producing docs.
+foreach($artifact in $ArtifactsList) {
+    # Get the version from the packageInfo file
+    $packageInfoFile = Join-Path $packageInfoDirectory "$($artifact.Name).json"
+    Write-Host "processing $($packageInfoFile.FullName)"
+    $packageInfo = ConvertFrom-Json (Get-Content $packageInfoFile -Raw)
+    $version = $packageInfo.Version
+    # If the dev version is set, use that. This will be set for nightly builds
+    if ($packageInfo.DevVersion) {
+      $version = $packageInfo.DevVersion
+    }
+    # From the $packageInfo piece together the path to the javadoc jar file
+    $WhlDir = Join-Path $ArtifactStagingDirectory $packageInfo.Name
+    $WhlName = $packageInfo.Name.Replace("-","_")
+    $WhlFile = Get-ChildItem -Path $WhlDir -File -Filter "$whlName-$version*.whl"
+
+    if (!(Test-Path $WhlFile -PathType Leaf)) {
+        LogError "Whl file for, $($packageInfo.Name), was not found in $WhlDir. Please ensure that a .whl file is being produced for the library."
+        $foundError = $true
+        continue
+    }
+    $namespaces = Get-NamespacesFromWhlFile $packageInfo.Name $version -PythonWhlFile $WhlFile
+    if ($namespaces.Count -gt 0) {
+        Write-Host "Adding/Updating Namespaces property with the following namespaces:"
+        $namespaces | Write-Host
+        if ($packageInfo.PSobject.Properties.Name -contains "Namespaces") {
+            Write-Host "Contains Namespaces property, updating"
+            $packageInfo.Namespaces = $namespaces
+        }
+        else {
+            Write-Host "Adding Namespaces property"
+            $packageInfo = $packageInfo | Add-Member -MemberType NoteProperty -Name Namespaces -Value $namespaces -PassThru
+        }
+        $packageInfoJson = ConvertTo-Json -InputObject $packageInfo -Depth 100
+        Write-Host "The updated packageInfo for $packageInfoFile is:"
+        Write-Host "$packageInfoJson"
+        Set-Content `
+            -Path $packageInfoFile `
+            -Value $packageInfoJson
+    } else {
+        LogError "Unable to determine namespaces for $($packageInfo.Name). Please ensure that skipPublishDocMs isn't incorrectly set to true."
+        $foundError = $true
+    }
+}
+
+if ($foundError) {
+    exit 1
+}
+exit 0

--- a/eng/scripts/Save-Package-Namespaces-Property.ps1
+++ b/eng/scripts/Save-Package-Namespaces-Property.ps1
@@ -18,7 +18,7 @@ is the same as the artifact's name but artifact name in the file's name will hav
 .PARAMETER ArtifactsList
 The list of artifacts to gather namespaces for, this is only done for libraries that are
 producing docs.
--ArtifactsList '${{ convertToJson(parameters.Artifacts) }}' | ConvertFrom-Json
+-ArtifactsList ('${{ convertToJson(parameters.Artifacts) }}' | ConvertFrom-Json)
 #>
 [CmdletBinding()]
 Param (

--- a/eng/scripts/Save-Package-Namespaces-Property.ps1
+++ b/eng/scripts/Save-Package-Namespaces-Property.ps1
@@ -1,22 +1,19 @@
 <#
 .SYNOPSIS
-Given an artifact staging directory, loop through all of the PackageInfo files
-in the PackageInfo subdirectory and compute the namespaces if they don't already
-exist. Yes, they're called packages in Java but namespaces are being used to keep
-code that processes them common amongst the languages.
+Given an artifact staging directory and the artifacts list, loop through all artifacts
+that docs that aren't skipping docs creation and add the namespace to the PackageInfo
+json file.
 
 .DESCRIPTION
-Given an artifact staging directory, loop through all of the PackageInfo files
-in the PackageInfo subdirectory. For each PackageInfo file, find its corresponding
-javadoc jar file and use that to compute the namespace information.
+Given an artifact staging directory and the artifacts list, loop through all artifacts
+that docs that aren't skipping docs creation and add the namespace to the PackageInfo
+json file. This is done using the .whl file from the build.
 
 .PARAMETER ArtifactStagingDirectory
 The root directory of the staged artifacts. The PackageInfo files will be in the
-PackageInfo subdirectory. The artifacts root directories are GroupId based, meaning
-any artifact with that GroupId will be in a subdirectory. For example: Most Spring
-libraries are com.azure.spring and their javadoc jars will be under that subdirectory
-but azure-spring-data-cosmos' GroupId is com.azure and its javadoc jar will be under
-com.azure.
+PackageInfo subdirectory. The whl files are going to be in the subdirectory which
+is the same as the artifact's name but artifact name in the file's name will have
+ underscores instead of dashes.
 
 .PARAMETER ArtifactsList
 The list of artifacts to gather namespaces for, this is only done for libraries that are

--- a/eng/scripts/Save-Package-Namespaces-Property.ps1
+++ b/eng/scripts/Save-Package-Namespaces-Property.ps1
@@ -45,7 +45,7 @@ if (-not (Test-Path -Path $ArtifactStagingDirectory)) {
 
 Write-Host ""
 Write-Host "ArtifactsList:"
-$ArtifactsList | Format-Table -Property GroupId, Name | Out-String | Write-Host
+$ArtifactsList | Format-Table -Property Name | Out-String | Write-Host
 
 $packageInfoDirectory = Join-Path $ArtifactStagingDirectory "PackageInfo"
 

--- a/eng/scripts/docs/Docs-ToC.ps1
+++ b/eng/scripts/docs/Docs-ToC.ps1
@@ -28,48 +28,63 @@ function Get-NamespacesFromWhlFile {
   param(
       [Parameter(Mandatory=$true)] [string]$Library,
       [Parameter(Mandatory=$true)] [string]$Version,
-      [Parameter(Mandatory=$false)] [string]$ExtraIndexUrl = ""
+      [Parameter(Mandatory=$false)] [string]$ExtraIndexUrl = "",
+      [Parameter(Mandatory=$false)] [string]$PythonWhlFile = $null
   )
 
   $destination = (Join-Path ([System.IO.Path]::GetTempPath()) "$Library$Version")
+  New-Item $destination -ItemType Directory | Out-Null
   $namespaces = @()
 
   try {
 
+    if ($PythonWhlFile) {
+      if (Test-Path $PythonWhlFile -PathType Leaf) {
+        Write-Host "Copying $PythonWhlFile to $destination"
+        Copy-Item $PythonWhlFile -Destination $destination
+      } else {
+        LogWarning "$PythonWhlFile, does not exist."
+      }
+    } else {
+      $success = Get-WhlFile $Library $Version $destination $ExtraIndexUrl
+      if (-not $success) {
+        LogWarning "Could not download Whl file for $Library $Version"
+      }
+    }
     # Pulling the whl file generates output, make sure it's sent to null so
     # it's not returned as part of this function.
-    $success = Get-WhlFile $Library $Version $destination $ExtraIndexUrl
-    if ($success) {
+    # Each library gets its own temporary directory. There should only be one whl
+    # file in the destination directory
+    $whlFile = Get-ChildItem -Path $destination -File -Filter "*.whl" | Select-Object -First 1
+    # If we can't download the file or the passed in file doesn't exist then the whlFile
+    # won't exist, there's nothing to process and an empty namesapces list will be returned
+    if ($whlFile) {
+      $unpackDir = Join-Path -Path $destination -ChildPath "$Library-$Version"
+      Expand-Archive -Path $whlFile -DestinationPath $unpackDir
 
-        # Each library gets its own temporary directory. There should only be one whl
-        # file in the destination directory
-        $whlFile = Get-ChildItem -Path $destination -File -Filter "*.whl" | Select-Object -First 1
-        $unpackDir = Join-Path -Path $destination -ChildPath "$Library-$Version"
-        Expand-Archive -Path $whlFile -DestinationPath $unpackDir
-
-        # Look for any directory that contains __init__.py with the following exceptions:
-        # 1. *.dist-info directories shouldn't be included in the results.
-        # 2. If any subdirectory starts with "_" it's internal and needs to be skipped
-        # 3. If there's a root level directory named "azure" with an __init__.py file then
-        # needs to be skipped. This doesn't happen with libraries released from the
-        # azure-sdk-for-python repository but there are older libraries that are in the
-        # docs directories which are/were released outside of the repository where this
-        # is true.
-        $rootLevelAzureDir = Join-Path -Path $unpackDir -ChildPath "azure"
-        $namespaceDirs = Get-ChildItem -Path $unpackDir -Recurse -Filter "__init__.py" |
-            Where-Object{$_.DirectoryName -notlike "*.dist-info"} |
-            Where-Object{$_.DirectoryName -notlike "*$([IO.Path]::DirectorySeparatorChar)_*" } |
-            Where-Object{$_.DirectoryName -ine $rootLevelAzureDir}
-        foreach($namespaceDir in $namespaceDirs) {
-            # Strip off the root directy, everything left will be subDir1/subDir2/../subDirN.
-            # The directory separators will be replaced with periods to compute the
-            # namespace
-            $partialDir = $namespaceDir.DirectoryName.Replace($unpackDir + $([IO.Path]::DirectorySeparatorChar), "")
-            $namespaces += $partialDir.Replace([IO.Path]::DirectorySeparatorChar, ".")
-            # Since only the primary namespace is being pulled, break out of the loop after
-            # the first one.
-            break
-        }
+      # Look for any directory that contains __init__.py with the following exceptions:
+      # 1. *.dist-info directories shouldn't be included in the results.
+      # 2. If any subdirectory starts with "_" it's internal and needs to be skipped
+      # 3. If there's a root level directory named "azure" with an __init__.py file then
+      # needs to be skipped. This doesn't happen with libraries released from the
+      # azure-sdk-for-python repository but there are older libraries that are in the
+      # docs directories which are/were released outside of the repository where this
+      # is true.
+      $rootLevelAzureDir = Join-Path -Path $unpackDir -ChildPath "azure"
+      $namespaceDirs = Get-ChildItem -Path $unpackDir -Recurse -Filter "__init__.py" |
+          Where-Object{$_.DirectoryName -notlike "*.dist-info"} |
+          Where-Object{$_.DirectoryName -notlike "*$([IO.Path]::DirectorySeparatorChar)_*" } |
+          Where-Object{$_.DirectoryName -ine $rootLevelAzureDir}
+      foreach($namespaceDir in $namespaceDirs) {
+          # Strip off the root directy, everything left will be subDir1/subDir2/../subDirN.
+          # The directory separators will be replaced with periods to compute the
+          # namespace
+          $partialDir = $namespaceDir.DirectoryName.Replace($unpackDir + $([IO.Path]::DirectorySeparatorChar), "")
+          $namespaces += $partialDir.Replace([IO.Path]::DirectorySeparatorChar, ".")
+          # Since only the primary namespace is being pulled, break out of the loop after
+          # the first one.
+          break
+      }
     }
   }
   finally {


### PR DESCRIPTION
Right now, the only thing that uses the namespace property in the packageInfo json files is the MS Docs. Currently, the namesapces are added as part of the docs publish step which, unfortunately, happens _after_ release in the case of both nightly and official releases which is already too later if there's an error. This change moves the addition to a task within the build job.

This fixes the Python portion of https://github.com/Azure/azure-sdk-tools/issues/7990