### PR TITLE
[ServiceBus] fix failing uamqp tests

### DIFF
--- a/sdk/servicebus/azure-servicebus/dev_requirements.txt
+++ b/sdk/servicebus/azure-servicebus/dev_requirements.txt
@@ -5,4 +5,3 @@ azure-mgmt-servicebus~=8.0.0
 aiohttp>=3.0
 websocket-client
 azure-mgmt-resource<=16.0.0
-uamqp

--- a/sdk/servicebus/azure-servicebus/dev_requirements.txt
+++ b/sdk/servicebus/azure-servicebus/dev_requirements.txt
@@ -5,3 +5,4 @@ azure-mgmt-servicebus~=8.0.0
 aiohttp>=3.0
 websocket-client
 azure-mgmt-resource<=16.0.0
+uamqp

--- a/sdk/servicebus/azure-servicebus/tests/test_sb_client.py
+++ b/sdk/servicebus/azure-servicebus/tests/test_sb_client.py
@@ -13,6 +13,7 @@ from datetime import datetime, timedelta
 import hmac
 import hashlib
 import base64
+import certifi
 try:
     from urllib.parse import quote as url_parse_quote
 except ImportError:
@@ -689,11 +690,11 @@ class TestServiceBusClient(AzureMgmtRecordedTestCase):
         hostname = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
         credential = AzureNamedKeyCredential(servicebus_namespace_key_name, servicebus_namespace_primary_key)
 
-        client = ServiceBusClient(hostname, credential, connection_verify="cacert.pem", uamqp_transport=uamqp_transport)
+        certfile = certifi.where()
+        client = ServiceBusClient(hostname, credential, connection_verify=certfile, uamqp_transport=uamqp_transport)
         with client:
-            with pytest.raises(ServiceBusError):
-                with client.get_queue_sender(servicebus_queue.name) as sender:
-                    sender.send_messages(ServiceBusMessage("foo"))
+            with client.get_queue_sender(servicebus_queue.name) as sender:
+                sender.send_messages(ServiceBusMessage("foo"))
 
         # Skipping on OSX uamqp - it's raising an Authentication/TimeoutError
         if not uamqp_transport or not sys.platform.startswith('darwin'):
@@ -714,7 +715,7 @@ class TestServiceBusClient(AzureMgmtRecordedTestCase):
                 hostname,
                 credential,
                 custom_endpoint_address=fake_addr,
-                connection_verify="cacert.pem",
+                connection_verify=certfile,
                 retry_total=0,
                 uamqp_transport=uamqp_transport,
             )

--- a/sdk/servicebus/azure-servicebus/tests/test_sb_client.py
+++ b/sdk/servicebus/azure-servicebus/tests/test_sb_client.py
@@ -690,14 +690,23 @@ class TestServiceBusClient(AzureMgmtRecordedTestCase):
         hostname = f"{servicebus_namespace.name}{SERVICEBUS_ENDPOINT_SUFFIX}"
         credential = AzureNamedKeyCredential(servicebus_namespace_key_name, servicebus_namespace_primary_key)
 
+        # ensure regular connection_verify works
         certfile = certifi.where()
         client = ServiceBusClient(hostname, credential, connection_verify=certfile, uamqp_transport=uamqp_transport)
         with client:
             with client.get_queue_sender(servicebus_queue.name) as sender:
                 sender.send_messages(ServiceBusMessage("foo"))
 
+        # invalid cert file to connection_verify should fail
+        client = ServiceBusClient(hostname, credential, connection_verify="fakecertfile.pem", uamqp_transport=uamqp_transport)
+        with client:
+            with pytest.raises(ServiceBusError):
+                with client.get_queue_sender(servicebus_queue.name) as sender:
+                    sender.send_messages(ServiceBusMessage("foo"))
+
         # Skipping on OSX uamqp - it's raising an Authentication/TimeoutError
         if not uamqp_transport or not sys.platform.startswith('darwin'):
+            # invalid custom endpoint should fail
             fake_addr = "fakeaddress.com:1111"
             client = ServiceBusClient(
                 hostname,

--- a/sdk/servicebus/tests.yml
+++ b/sdk/servicebus/tests.yml
@@ -4,7 +4,7 @@ extends:
     template: ../../eng/pipelines/templates/stages/archetype-sdk-tests.yml
     parameters:
       ServiceDirectory: servicebus
-      TestTimeoutInMinutes: 480
+      TestTimeoutInMinutes: 960
       UseFederatedAuth: true
       BuildTargetingString: azure-servicebus*
       EnvVars:

--- a/sdk/servicebus/tests.yml
+++ b/sdk/servicebus/tests.yml
@@ -11,6 +11,7 @@ extends:
         AZURE_SUBSCRIPTION_ID: $(SERVICEBUS_SUBSCRIPTION_ID)
         AZURE_TEST_RUN_LIVE: 'true'
         AZURE_SKIP_LIVE_RECORDING: 'True'
+        TEST_PYAMQP: 'false'
       MatrixFilters:
         - PythonVersion=^(?!pypy3).*
       Clouds: 'Public,Canary'

--- a/sdk/servicebus/tests.yml
+++ b/sdk/servicebus/tests.yml
@@ -11,7 +11,6 @@ extends:
         AZURE_SUBSCRIPTION_ID: $(SERVICEBUS_SUBSCRIPTION_ID)
         AZURE_TEST_RUN_LIVE: 'true'
         AZURE_SKIP_LIVE_RECORDING: 'True'
-        TEST_PYAMQP: 'false'
       MatrixFilters:
         - PythonVersion=^(?!pypy3).*
       Clouds: 'Public,Canary'


### PR DESCRIPTION
Specifically, fix:
- test_sb_client/test_custom_endpoint_connection_verify (sync and async)