### PR TITLE
[SchemaRegistry] handle unknown content types

### DIFF
--- a/sdk/schemaregistry/azure-schemaregistry/CHANGELOG.md
+++ b/sdk/schemaregistry/azure-schemaregistry/CHANGELOG.md
@@ -6,15 +6,16 @@ This version and all future versions will require Python 3.8+. Python 3.7 is no 
 
 ### Features Added
 
-- `V2022_10` has been added to `ApiVersion` and set as the default API version.
-  - `Json` and `Custom` have been added to supported formats in `SchemaFormat`.
 - Sync and async `JsonSchemaEncoder` have been added under `azure.schemaregistry.encoder.jsonencoder`.
 - `InvalidContentError` have been added under `azure.schemaregistry.encoder.jsonencoder` for use with the `JsonSchemaEncoder`.
 - `MessageContent`, `OutboundMessageContent`,`InboundMessageContent`, and `SchemaContentValidate` have been added under `azure.schemaregistry` as protocols for use with the `JsonSchemaEncoder` and/or future encoder implementations.
+- `Json` and `Custom` have been added to supported formats in `SchemaFormat`.
+- `V2022_10` has been added to `ApiVersion` and set as the default API version.
 
 ### Bugs Fixed
 
 - Fixed a bug in sync/async `register_schema` and `get_schema_properties` that did not accept case insensitive strings as an argument to the `format` parameter.
+- Fixed a bug where unknown content type strings from the service raised a client error, rather than being returned as a string in the SchemaProperties `format` property.
 
 ### Other Changes
 

--- a/sdk/schemaregistry/azure-schemaregistry/assets.json
+++ b/sdk/schemaregistry/azure-schemaregistry/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "python",
   "TagPrefix": "python/schemaregistry/azure-schemaregistry",
-  "Tag": "python/schemaregistry/azure-schemaregistry_a1c9d18bfd"
+  "Tag": "python/schemaregistry/azure-schemaregistry_0a27c7561c"
 }

--- a/sdk/schemaregistry/azure-schemaregistry/azure/schemaregistry/_patch.py
+++ b/sdk/schemaregistry/azure-schemaregistry/azure/schemaregistry/_patch.py
@@ -22,8 +22,8 @@ from typing import (
     overload,
     IO,
 )
-from typing_extensions import Protocol, TypedDict, Self
 from enum import Enum
+from typing_extensions import Protocol, TypedDict, Self
 from azure.core import CaseInsensitiveEnumMeta
 from azure.core.tracing.decorator import distributed_trace
 
@@ -61,7 +61,7 @@ def _parse_schema_properties_dict(response_headers: Mapping[str, Union[str, int]
 def _normalize_content_type(content_type: str) -> str:
     return content_type.replace(" ", "").lower()
 
-def _get_format(content_type: str) -> SchemaFormat:
+def _get_format(content_type: str) -> Union[SchemaFormat, str]:
     # pylint:disable=redefined-builtin
     # Exception cases may be due to forward compatibility.
     # i.e. Getting a schema with a content type from a future API version.

--- a/sdk/schemaregistry/azure-schemaregistry/azure/schemaregistry/_patch.py
+++ b/sdk/schemaregistry/azure-schemaregistry/azure/schemaregistry/_patch.py
@@ -340,8 +340,8 @@ class SchemaRegistryClient:
                 id=schema_id,
                 cls=prepare_schema_result,
                 headers={  # TODO: remove when multiple content types in response are supported
-                    "Accept": """application/json; serialization=Avro, application/json; \
-                        serialization=json, text/plain; charset=utf-8"""
+                    "Accept": """application/json; serialization=Avro, application/json; """
+                        """serialization=json, text/plain; charset=utf-8"""
                 },
                 stream=True,
                 **http_request_kwargs,
@@ -364,8 +364,8 @@ class SchemaRegistryClient:
                 schema_version=version,
                 cls=prepare_schema_result,
                 headers={  # TODO: remove when multiple content types in response are supported
-                    "Accept": """application/json; serialization=Avro, application/json; \
-                        serialization=json, text/plain; charset=utf-8"""
+                    "Accept": """application/json; serialization=Avro, application/json; """
+                        """serialization=json, text/plain; charset=utf-8"""
                 },
                 stream=True,
                 **http_request_kwargs,

--- a/sdk/schemaregistry/azure-schemaregistry/azure/schemaregistry/_patch.py
+++ b/sdk/schemaregistry/azure-schemaregistry/azure/schemaregistry/_patch.py
@@ -23,11 +23,12 @@ from typing import (
     IO,
 )
 from typing_extensions import Protocol, TypedDict, Self
-
+from enum import Enum
+from azure.core import CaseInsensitiveEnumMeta
 from azure.core.tracing.decorator import distributed_trace
 
 from ._client import SchemaRegistryClient as GeneratedServiceClient
-from .models._patch import SchemaFormat
+from .models._patch import SchemaFormat, NormalizedSchemaContentTypes
 
 if TYPE_CHECKING:
     from azure.core.credentials import TokenCredential
@@ -57,22 +58,24 @@ def _parse_schema_properties_dict(response_headers: Mapping[str, Union[str, int]
         "version": int(response_headers["Schema-Version"]),
     }
 
+def _normalize_content_type(content_type: str) -> str:
+    return content_type.replace(" ", "").lower()
 
 def _get_format(content_type: str) -> SchemaFormat:
     # pylint:disable=redefined-builtin
     # Exception cases may be due to forward compatibility.
     # i.e. Getting a schema with a content type from a future API version.
-    # In this case, we default to CUSTOM format.
-    try:
-        format = content_type.split("serialization=")[1]
-        try:
-            return SchemaFormat(format.capitalize())
-        except ValueError:
-            pass
-    except IndexError:
-        pass
-    return SchemaFormat.CUSTOM
+    # In this case, we default to returning the content type string.
 
+    # remove whitespace and case from string
+    normalized_content_type = _normalize_content_type(content_type)
+    if normalized_content_type == NormalizedSchemaContentTypes.AVRO.value:
+        return SchemaFormat.AVRO
+    if normalized_content_type == NormalizedSchemaContentTypes.JSON.value:
+        return SchemaFormat.JSON
+    if normalized_content_type == NormalizedSchemaContentTypes.CUSTOM.value:
+        return SchemaFormat.CUSTOM
+    return content_type
 
 def prepare_schema_properties_result(  # pylint:disable=unused-argument,redefined-builtin
     format: str,
@@ -220,10 +223,62 @@ class SchemaRegistryClient:
         return SchemaProperties(**properties)
 
     @overload
-    def get_schema(self, schema_id: str, **kwargs: Any) -> Schema: ...
+    def get_schema(self, schema_id: str, **kwargs: Any) -> Schema:
+        """Gets a registered schema.
+
+        To get a registered schema by its unique ID, pass the `schema_id` parameter and any optional
+        keyword arguments. Azure Schema Registry guarantees that ID is unique within a namespace.
+
+        WARNING: If retrieving a schema format that is unsupported by this client version, upgrade to a client
+         version that supports the schema format. Otherwise, the content MIME type string will be returned as
+         the `format` value in the `properties` of the returned Schema.
+
+        :param str schema_id: References specific schema in registry namespace. Required if `group_name`,
+         `name`, and `version` are not provided.
+        :return: The schema stored in the registry associated with the provided arguments.
+        :rtype: ~azure.schemaregistry.Schema
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+
+        .. admonition:: Example:
+
+            .. literalinclude:: ../samples/sync_samples/sample_code_schemaregistry.py
+                :start-after: [START get_schema_sync]
+                :end-before: [END get_schema_sync]
+                :language: python
+                :dedent: 4
+                :caption: Get schema by id.
+
+        """
+        ...
 
     @overload
-    def get_schema(self, *, group_name: str, name: str, version: int, **kwargs: Any) -> Schema: ...
+    def get_schema(self, *, group_name: str, name: str, version: int, **kwargs: Any) -> Schema:
+        """Gets a registered schema.
+
+        To get a specific version of a schema within the specified schema group, pass in the required
+        keyword arguments `group_name`, `name`, and `version` and any optional keyword arguments.
+
+        WARNING: If retrieving a schema format that is unsupported by this client version, upgrade to a client
+         version that supports the schema format. Otherwise, the content MIME type string will be returned as
+         the `format` value in the `properties` of the returned Schema.
+
+        :keyword str group_name: Name of schema group that contains the registered schema.
+        :keyword str name: Name of schema which should be retrieved.
+        :keyword int version: Version of schema which should be retrieved.
+        :return: The schema stored in the registry associated with the provided arguments.
+        :rtype: ~azure.schemaregistry.Schema
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+
+        .. admonition:: Example:
+
+            .. literalinclude:: ../samples/sync_samples/sample_code_schemaregistry.py
+                :start-after: [START get_schema_by_version_sync]
+                :end-before: [END get_schema_by_version_sync]
+                :language: python
+                :dedent: 4
+                :caption: Get schema by version.
+        """
+        ...
 
     @distributed_trace
     def get_schema(  # pylint: disable=docstring-missing-param,docstring-should-be-keyword
@@ -236,6 +291,10 @@ class SchemaRegistryClient:
 
         2) To get a specific version of a schema within the specified schema group, pass in the required
         keyword arguments `group_name`, `name`, and `version` and any optional keyword arguments.
+
+        WARNING: If retrieving a schema format that is unsupported by this client version, upgrade to a client
+         version that supports the schema format. Otherwise, the content MIME type string will be returned as
+         the `format` value in the `properties` of the returned Schema.
 
         :param str schema_id: References specific schema in registry namespace. Required if `group_name`,
          `name`, and `version` are not provided.
@@ -414,6 +473,16 @@ class Schema:
     def __repr__(self) -> str:
         return f"Schema(definition={self.definition}, properties={self.properties})"[:1024]
 
+# ApiVersion was added to a previously GA'd version. However, newer libraries should not
+# accept ApiVersion enums and only take strings. Leaving this here for backwards compatibility.
+class ApiVersion(str, Enum, metaclass=CaseInsensitiveEnumMeta):
+    """
+    Represents the Schema Registry API version to use for requests.
+    """
+
+    V2021_10 = "2021-10"
+    V2022_10 = "2022-10"
+    """This is the default version."""
 
 ###### Encoder Protocols ######
 

--- a/sdk/schemaregistry/azure-schemaregistry/azure/schemaregistry/aio/_patch.py
+++ b/sdk/schemaregistry/azure-schemaregistry/azure/schemaregistry/aio/_patch.py
@@ -143,10 +143,62 @@ class SchemaRegistryClient:
         return SchemaProperties(**properties)
 
     @overload
-    async def get_schema(self, schema_id: str, **kwargs: Any) -> Schema: ...
+    async def get_schema(self, schema_id: str, **kwargs: Any) -> Schema:
+        """Gets a registered schema.
+
+        To get a registered schema by its unique ID, pass the `schema_id` parameter and any optional
+        keyword arguments. Azure Schema Registry guarantees that ID is unique within a namespace.
+
+        WARNING: If retrieving a schema format that is unsupported by this client version, upgrade to a client
+         version that supports the schema format. Otherwise, the content MIME type string will be returned as
+         the `format` value in the `properties` of the returned Schema.
+
+        :param str schema_id: References specific schema in registry namespace. Required if `group_name`,
+         `name`, and `version` are not provided.
+        :return: The schema stored in the registry associated with the provided arguments.
+        :rtype: ~azure.schemaregistry.Schema
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+
+        .. admonition:: Example:
+
+            .. literalinclude:: ../samples/async_samples/sample_code_schemaregistry_async.py
+                :start-after: [START get_schema_async]
+                :end-before: [END get_schema_async]
+                :language: python
+                :dedent: 4
+                :caption: Get schema by id.
+
+        """
+        ...
 
     @overload
-    async def get_schema(self, *, group_name: str, name: str, version: int, **kwargs: Any) -> Schema: ...
+    async def get_schema(self, *, group_name: str, name: str, version: int, **kwargs: Any) -> Schema:
+        """Gets a registered schema.
+
+        To get a specific version of a schema within the specified schema group, pass in the required
+        keyword arguments `group_name`, `name`, and `version` and any optional keyword arguments.
+
+        WARNING: If retrieving a schema format that is unsupported by this client version, upgrade to a client
+         version that supports the schema format. Otherwise, the content MIME type string will be returned as
+         the `format` value in the `properties` of the returned Schema.
+
+        :keyword str group_name: Name of schema group that contains the registered schema.
+        :keyword str name: Name of schema which should be retrieved.
+        :keyword int version: Version of schema which should be retrieved.
+        :return: The schema stored in the registry associated with the provided arguments.
+        :rtype: ~azure.schemaregistry.Schema
+        :raises: :class:`~azure.core.exceptions.HttpResponseError`
+
+        .. admonition:: Example:
+
+            .. literalinclude:: ../samples/async_samples/sample_code_schemaregistry_async.py
+                :start-after: [START get_schema_by_version_async]
+                :end-before: [END get_schema_by_version_async]
+                :language: python
+                :dedent: 4
+                :caption: Get schema by version.
+        """
+        ...
 
     @distributed_trace_async
     async def get_schema(  # pylint: disable=docstring-missing-param,docstring-should-be-keyword
@@ -159,6 +211,10 @@ class SchemaRegistryClient:
 
         2) To get a specific version of a schema within the specified schema group, pass in the required
         keyword arguments `group_name`, `name`, and `version` and any optional keyword arguments.
+
+        WARNING: If retrieving a schema format that is unsupported by this client version, upgrade to a client
+         version that supports the schema format. Otherwise, the content MIME type string will be returned as
+         the `format` value in the `properties` of the returned Schema.
 
         :param str schema_id: References specific schema in registry namespace. Required if `group_name`,
          `name`, and `version` are not provided.

--- a/sdk/schemaregistry/azure-schemaregistry/azure/schemaregistry/aio/_patch.py
+++ b/sdk/schemaregistry/azure-schemaregistry/azure/schemaregistry/aio/_patch.py
@@ -260,8 +260,8 @@ class SchemaRegistryClient:
                 id=schema_id,
                 cls=prepare_schema_result,
                 headers={  # TODO: remove when multiple content types are supported
-                    "Accept": """application/json; serialization=Avro, application/json; \
-                        serialization=json, text/plain; charset=utf-8"""
+                    "Accept": """application/json; serialization=Avro, application/json; """
+                        """serialization=json, text/plain; charset=utf-8"""
                 },
                 stream=True,
                 **http_request_kwargs,
@@ -285,8 +285,8 @@ class SchemaRegistryClient:
                 schema_version=version,
                 cls=prepare_schema_result,
                 headers={  # TODO: remove when multiple content types are supported
-                    "Accept": """application/json; serialization=Avro, application/json; \
-                        serialization=json, text/plain; charset=utf-8"""
+                    "Accept": """application/json; serialization=Avro, application/json; """
+                        """serialization=json, text/plain; charset=utf-8"""
                 },
                 stream=True,
                 **http_request_kwargs,

--- a/sdk/schemaregistry/azure-schemaregistry/azure/schemaregistry/models/_patch.py
+++ b/sdk/schemaregistry/azure-schemaregistry/azure/schemaregistry/models/_patch.py
@@ -9,6 +9,8 @@ Follow our quickstart for examples: https://aka.ms/azsdk/python/dpcodegen/python
 from typing import List
 
 from enum import Enum
+
+from ._enums import SchemaContentTypeValues
 from azure.core import CaseInsensitiveEnumMeta
 
 
@@ -22,18 +24,16 @@ class SchemaFormat(str, Enum, metaclass=CaseInsensitiveEnumMeta):
     CUSTOM = "Custom"
     """Represents a custom schema format."""
 
+# Normalizing the schema content type strings for whitespace and case insensitive comparison.
+class NormalizedSchemaContentTypes(str, Enum, metaclass=CaseInsensitiveEnumMeta):
+    """Describes closed list of normalized schema content type values."""
 
-class ApiVersion(str, Enum, metaclass=CaseInsensitiveEnumMeta):
-    """
-    Represents the Schema Registry API version to use for requests.
-    """
-
-    V2021_10 = "2021-10"
-    V2022_10 = "2022-10"
-    """This is the default version."""
-
-
-DEFAULT_VERSION = ApiVersion.V2022_10
+    AVRO = SchemaContentTypeValues.AVRO.value.replace(" ", "").lower()
+    """Avro encoding."""
+    JSON = SchemaContentTypeValues.JSON.value.replace(" ", "").lower()
+    """JSON encoding"""
+    CUSTOM = SchemaContentTypeValues.CUSTOM.value.replace(" ", "").lower()
+    """Plain text custom encoding."""
 
 
 __all__: List[str] = []  # Add all objects you want publicly available to users at this package level

--- a/sdk/schemaregistry/azure-schemaregistry/azure/schemaregistry/models/_patch.py
+++ b/sdk/schemaregistry/azure-schemaregistry/azure/schemaregistry/models/_patch.py
@@ -10,8 +10,8 @@ from typing import List
 
 from enum import Enum
 
-from ._enums import SchemaContentTypeValues
 from azure.core import CaseInsensitiveEnumMeta
+from ._enums import SchemaContentTypeValues
 
 
 class SchemaFormat(str, Enum, metaclass=CaseInsensitiveEnumMeta):

--- a/sdk/schemaregistry/azure-schemaregistry/tests/async_tests/mock_transport_async.py
+++ b/sdk/schemaregistry/azure-schemaregistry/tests/async_tests/mock_transport_async.py
@@ -1,0 +1,102 @@
+# --------------------------------------------------------------------------
+#
+# Copyright (c) Microsoft Corporation. All rights reserved.
+#
+# The MIT License (MIT)
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the ""Software""), to
+# deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+# sell copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+#
+# --------------------------------------------------------------------------
+
+from azure.core.pipeline.transport import AsyncHttpTransport
+
+class AsyncMockResponse:
+    def __init__(
+        self,
+        schema_id,
+        schema_name,
+        schema_group_name,
+        schema_version,
+        content_type,
+        *,
+        content=b"",
+        status_code=200
+    ) -> None:
+        self._schema_id = schema_id
+        self._schema_name = schema_name
+        self._schema_group_name = schema_group_name
+        self._schema_version = schema_version
+        self._content = content
+        self.content_type = content_type
+        self._status_code = status_code
+
+    @property
+    def status_code(self):
+        return self._status_code
+
+    @property
+    def headers(self):
+        return {
+            "Schema-Version": self._schema_version,
+            "Schema-Group-Name": self._schema_group_name,
+            "Schema-Name": self._schema_name,
+            "Schema-Id": self._schema_id,
+            "Schema-Id-Location": "eastus",
+            "Location": "eastus",
+            "Content-Type": f"{self.content_type}",
+        }
+
+    @property
+    def content(self):
+        return self._content
+    
+    def iter_bytes(self):
+        pass
+
+    def raise_for_status(self):
+        pass
+    
+    async def read(self):
+        pass
+
+    def text(self, encoding=None):
+        pass
+
+    def reason(self):
+        pass
+
+class AsyncMockTransport(AsyncHttpTransport):
+        def __init__(self, response):
+            self._response = response
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            pass
+
+        async def open(self):
+            pass
+
+        async def close(self):
+            pass
+
+        async def send(self, request, **kwargs):
+            response = self._response
+            return response

--- a/sdk/schemaregistry/azure-schemaregistry/tests/async_tests/test_schema_registry_async.py
+++ b/sdk/schemaregistry/azure-schemaregistry/tests/async_tests/test_schema_registry_async.py
@@ -1,3 +1,9 @@
+# --------------------------------------------------------------------------
+#
+# Copyright (c) Microsoft Corporation. All rights reserved.
+#
+# The MIT License (MIT)
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the ""Software""), to
 # deal in the Software without restriction, including without limitation the

--- a/sdk/schemaregistry/azure-schemaregistry/tests/async_tests/test_schema_registry_async.py
+++ b/sdk/schemaregistry/azure-schemaregistry/tests/async_tests/test_schema_registry_async.py
@@ -29,12 +29,14 @@ import pytest
 import json
 import sys
 
+from azure.schemaregistry import SchemaFormat
 from azure.schemaregistry.aio import SchemaRegistryClient
 from azure.identity.aio import ClientSecretCredential
 from azure.core.exceptions import ClientAuthenticationError, ServiceRequestError, HttpResponseError
 
 from devtools_testutils import AzureRecordedTestCase, EnvironmentVariableLoader
 from devtools_testutils.aio import recorded_by_proxy_async
+from mock_transport_async import AsyncMockTransport, AsyncMockResponse
 
 # TODO: add protobuf env var for live testing when protobuf changes have been rolled out
 is_livetest = str(os.getenv("AZURE_TEST_RUN_LIVE")).lower()
@@ -460,3 +462,73 @@ class TestSchemaRegistryAsync(AzureRecordedTestCase):
             versions.append(version)
 
         assert len(versions) > 0
+
+    @pytest.mark.asyncio
+    async def test_get_schema_unknown_content_type(self, **kwargs):
+
+        # test known content type first
+        avro_schema_id = "avroschemaid123"
+        avro_schema_name = "avroname"
+        avro_group_name = "avrogroup"
+        avro_schema_version = "1"
+        avro_content_type = "application/json; serialization=Avro"
+        transport = AsyncMockTransport(response=AsyncMockResponse(
+            schema_id=avro_schema_id,
+            schema_name=avro_schema_name,
+            schema_group_name=avro_group_name,
+            schema_version=avro_schema_version,
+            content_type=avro_content_type,
+        ))
+        mock_fqn = f"schemaregistry_fqn"
+        credential = self.get_credential(SchemaRegistryClient)
+        mock_client = SchemaRegistryClient(
+            fully_qualified_namespace=mock_fqn, credential=credential, transport=transport
+        )
+
+        async with mock_client:
+
+            # content type should return SchemaFormat enum
+            schema = await mock_client.get_schema(avro_schema_id)
+            assert schema.properties.format == SchemaFormat.AVRO
+
+            # get unknown schema with content type of format "application/json; serialization=<format>"
+            foo_schema_id = "fooschemaid123"
+            foo_schema_name = "fooname"
+            foo_group_name = "foogroup"
+            foo_schema_version = "1"
+            foo_content_type = "application/json; serialization=Foo"
+            transport._response = AsyncMockResponse(
+                schema_id=foo_schema_id,
+                schema_name=foo_schema_name,
+                schema_group_name=foo_group_name,
+                schema_version=foo_schema_version,
+                content_type=foo_content_type,
+            )
+            # get unknown schema by id should return format of the content type string
+            schema = await mock_client.get_schema(foo_schema_id)
+            assert schema.properties.format == foo_content_type
+            # get unknown schema by version should return format of the content type string
+            schema = await mock_client.get_schema(group_name=foo_group_name, name=foo_schema_name, version=foo_schema_version)
+            assert schema.properties.format == foo_content_type
+
+            # get unknown schema with content type of format "contenttype/<unknown>"
+            bar_schema_id = "barschemaid123"
+            bar_schema_name = "barname"
+            bar_group_name = "bargroup"
+            bar_schema_version = "1"
+            bar_content_type = "contenttype/bar"
+            transport._response = AsyncMockResponse(
+                schema_id=bar_schema_id,
+                schema_name=bar_schema_name,
+                schema_group_name=bar_group_name,
+                schema_version=bar_schema_version,
+                content_type=bar_content_type,
+            )
+            schema = await mock_client.get_schema(bar_schema_id)
+
+            # get unknown schema by id should return format of the content type string
+            schema = await mock_client.get_schema(bar_schema_id)
+            assert schema.properties.format == bar_content_type
+            # get unknown schema by version should return format of the content type string
+            schema = await mock_client.get_schema(group_name=bar_group_name, name=bar_schema_name, version=bar_schema_version)
+            assert schema.properties.format == bar_content_type

--- a/sdk/schemaregistry/azure-schemaregistry/tests/async_tests/test_schema_registry_async.py
+++ b/sdk/schemaregistry/azure-schemaregistry/tests/async_tests/test_schema_registry_async.py
@@ -467,9 +467,9 @@ class TestSchemaRegistryAsync(AzureRecordedTestCase):
     async def test_get_schema_unknown_content_type(self, **kwargs):
 
         # test known content type first
-        avro_schema_id = "avroschemaid123"
-        avro_schema_name = "avroname"
-        avro_group_name = "avrogroup"
+        avro_schema_id = "avro_schema_id_123"
+        avro_schema_name = "avro_name"
+        avro_group_name = "avro_group"
         avro_schema_version = "1"
         avro_content_type = "application/json; serialization=Avro"
         transport = AsyncMockTransport(response=AsyncMockResponse(
@@ -492,9 +492,9 @@ class TestSchemaRegistryAsync(AzureRecordedTestCase):
             assert schema.properties.format == SchemaFormat.AVRO
 
             # get unknown schema with content type of format "application/json; serialization=<format>"
-            foo_schema_id = "fooschemaid123"
-            foo_schema_name = "fooname"
-            foo_group_name = "foogroup"
+            foo_schema_id = "foo_schema_id_123"
+            foo_schema_name = "foo_name"
+            foo_group_name = "foo_group"
             foo_schema_version = "1"
             foo_content_type = "application/json; serialization=Foo"
             transport._response = AsyncMockResponse(
@@ -512,9 +512,9 @@ class TestSchemaRegistryAsync(AzureRecordedTestCase):
             assert schema.properties.format == foo_content_type
 
             # get unknown schema with content type of format "contenttype/<unknown>"
-            bar_schema_id = "barschemaid123"
-            bar_schema_name = "barname"
-            bar_group_name = "bargroup"
+            bar_schema_id = "bar_schema_id_123"
+            bar_schema_name = "bar_name"
+            bar_group_name = "bar_group"
             bar_schema_version = "1"
             bar_content_type = "contenttype/bar"
             transport._response = AsyncMockResponse(

--- a/sdk/schemaregistry/azure-schemaregistry/tests/mock_transport.py
+++ b/sdk/schemaregistry/azure-schemaregistry/tests/mock_transport.py
@@ -1,0 +1,99 @@
+# --------------------------------------------------------------------------
+#
+# Copyright (c) Microsoft Corporation. All rights reserved.
+#
+# The MIT License (MIT)
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the ""Software""), to
+# deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+# sell copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+#
+# --------------------------------------------------------------------------
+
+from azure.core.pipeline.transport import HttpTransport
+
+class MockResponse:
+    def __init__(
+        self,
+        schema_id,
+        schema_name,
+        schema_group_name,
+        schema_version,
+        content_type,
+        *,
+        content=b"",
+        status_code=200
+    ) -> None:
+        self._schema_id = schema_id
+        self._schema_name = schema_name
+        self._schema_group_name = schema_group_name
+        self._schema_version = schema_version
+        self._content = content
+        self.content_type = content_type
+        self._status_code = status_code
+
+    @property
+    def status_code(self):
+        return self._status_code
+
+    @property
+    def headers(self):
+        return {
+            "Schema-Version": self._schema_version,
+            "Schema-Group-Name": self._schema_group_name,
+            "Schema-Name": self._schema_name,
+            "Schema-Id": self._schema_id,
+            "Schema-Id-Location": "eastus",
+            "Location": "eastus",
+            "Content-Type": f"{self.content_type}",
+        }
+
+    @property
+    def content(self):
+        return self._content
+    
+    def iter_bytes(self):
+        pass
+
+    def raise_for_status(self):
+        pass
+    
+    def read(self):
+        pass
+
+    def text(self, encoding=None):
+        pass
+
+    def reason(self):
+        pass
+
+class MockTransport(HttpTransport):
+        def __init__(self, response):
+            self._response = response
+
+        def __exit__(self, exc_type, exc_val, exc_tb):
+            pass
+
+        def close(self):
+            pass
+
+        def open(self):
+            pass
+
+        def send(self, request, **kwargs):
+            response = self._response
+            return response

--- a/sdk/schemaregistry/azure-schemaregistry/tests/test_schema_registry.py
+++ b/sdk/schemaregistry/azure-schemaregistry/tests/test_schema_registry.py
@@ -1,3 +1,9 @@
+# --------------------------------------------------------------------------
+#
+# Copyright (c) Microsoft Corporation. All rights reserved.
+#
+# The MIT License (MIT)
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the ""Software""), to
 # deal in the Software without restriction, including without limitation the

--- a/sdk/schemaregistry/azure-schemaregistry/tests/test_schema_registry.py
+++ b/sdk/schemaregistry/azure-schemaregistry/tests/test_schema_registry.py
@@ -437,9 +437,9 @@ class TestSchemaRegistry(AzureRecordedTestCase):
     def test_get_schema_unknown_content_type(self, **kwargs):
 
         # test known content type first
-        avro_schema_id = "avroschemaid123"
-        avro_schema_name = "avroname"
-        avro_group_name = "avrogroup"
+        avro_schema_id = "avro_schema_id_123"
+        avro_schema_name = "avro_name"
+        avro_group_name = "avro_group"
         avro_schema_version = "1"
         avro_content_type = "application/json; serialization=Avro"
         transport = MockTransport(response=MockResponse(
@@ -462,9 +462,9 @@ class TestSchemaRegistry(AzureRecordedTestCase):
             assert schema.properties.format == SchemaFormat.AVRO
 
             # get unknown schema with content type of format "application/json; serialization=<format>"
-            foo_schema_id = "fooschemaid123"
-            foo_schema_name = "fooname"
-            foo_group_name = "foogroup"
+            foo_schema_id = "foo_schema_id_123"
+            foo_schema_name = "foo_name"
+            foo_group_name = "foo_group"
             foo_schema_version = "1"
             foo_content_type = "application/json; serialization=Foo"
             transport._response = MockResponse(
@@ -482,9 +482,9 @@ class TestSchemaRegistry(AzureRecordedTestCase):
             assert schema.properties.format == foo_content_type
 
             # get unknown schema with content type of format "contenttype/<unknown>"
-            bar_schema_id = "barschemaid123"
-            bar_schema_name = "barname"
-            bar_group_name = "bargroup"
+            bar_schema_id = "bar_schema_id_123"
+            bar_schema_name = "bar_name"
+            bar_group_name = "bar_group"
             bar_schema_version = "1"
             bar_content_type = "contenttype/bar"
             transport._response = MockResponse(

--- a/sdk/schemaregistry/azure-schemaregistry/tests/test_schema_registry.py
+++ b/sdk/schemaregistry/azure-schemaregistry/tests/test_schema_registry.py
@@ -28,11 +28,12 @@ import functools
 import pytest
 import json
 
-from azure.schemaregistry import SchemaRegistryClient
+from azure.schemaregistry import SchemaRegistryClient, SchemaFormat
 from azure.identity import ClientSecretCredential
 from azure.core.exceptions import ClientAuthenticationError, ServiceRequestError, HttpResponseError
 
 from devtools_testutils import AzureRecordedTestCase, EnvironmentVariableLoader, recorded_by_proxy
+from mock_transport import MockResponse, MockTransport
 
 # TODO: add protobuf env var for live testing when protobuf changes have been rolled out
 is_livetest = str(os.getenv("AZURE_TEST_RUN_LIVE")).lower()
@@ -432,3 +433,72 @@ class TestSchemaRegistry(AzureRecordedTestCase):
             versions.append(version)
 
         assert len(versions) > 0
+
+    def test_get_schema_unknown_content_type(self, **kwargs):
+
+        # test known content type first
+        avro_schema_id = "avroschemaid123"
+        avro_schema_name = "avroname"
+        avro_group_name = "avrogroup"
+        avro_schema_version = "1"
+        avro_content_type = "application/json; serialization=Avro"
+        transport = MockTransport(response=MockResponse(
+            schema_id=avro_schema_id,
+            schema_name=avro_schema_name,
+            schema_group_name=avro_group_name,
+            schema_version=avro_schema_version,
+            content_type=avro_content_type,
+        ))
+        mock_fqn = f"schemaregistry_fqn"
+        credential = self.get_credential(SchemaRegistryClient)
+        mock_client = SchemaRegistryClient(
+            fully_qualified_namespace=mock_fqn, credential=credential, transport=transport
+        )
+
+        with mock_client:
+
+            # content type should return SchemaFormat enum
+            schema = mock_client.get_schema(avro_schema_id)
+            assert schema.properties.format == SchemaFormat.AVRO
+
+            # get unknown schema with content type of format "application/json; serialization=<format>"
+            foo_schema_id = "fooschemaid123"
+            foo_schema_name = "fooname"
+            foo_group_name = "foogroup"
+            foo_schema_version = "1"
+            foo_content_type = "application/json; serialization=Foo"
+            transport._response = MockResponse(
+                schema_id=foo_schema_id,
+                schema_name=foo_schema_name,
+                schema_group_name=foo_group_name,
+                schema_version=foo_schema_version,
+                content_type=foo_content_type,
+            )
+            # get unknown schema by id should return format of the content type string
+            schema = mock_client.get_schema(foo_schema_id)
+            assert schema.properties.format == foo_content_type
+            # get unknown schema by version should return format of the content type string
+            schema = mock_client.get_schema(group_name=foo_group_name, name=foo_schema_name, version=foo_schema_version)
+            assert schema.properties.format == foo_content_type
+
+            # get unknown schema with content type of format "contenttype/<unknown>"
+            bar_schema_id = "barschemaid123"
+            bar_schema_name = "barname"
+            bar_group_name = "bargroup"
+            bar_schema_version = "1"
+            bar_content_type = "contenttype/bar"
+            transport._response = MockResponse(
+                schema_id=bar_schema_id,
+                schema_name=bar_schema_name,
+                schema_group_name=bar_group_name,
+                schema_version=bar_schema_version,
+                content_type=bar_content_type,
+            )
+            schema = mock_client.get_schema(bar_schema_id)
+
+            # get unknown schema by id should return format of the content type string
+            schema = mock_client.get_schema(bar_schema_id)
+            assert schema.properties.format == bar_content_type
+            # get unknown schema by version should return format of the content type string
+            schema = mock_client.get_schema(group_name=bar_group_name, name=bar_schema_name, version=bar_schema_version)
+            assert schema.properties.format == bar_content_type


### PR DESCRIPTION
As per discussion with architects, return the content type string in SchemaProperties.format if unknown. Make sure the behavior is well-documented; added a warning to the get_schema method for this behavior.

TODO:
- [x] add a test with MockResponse for an unknown content type.