### PR TITLE
[breaking change detector] optimize changelog template

### DIFF
--- a/scripts/breaking_changes_checker/breaking_changes_tracker.py
+++ b/scripts/breaking_changes_checker/breaking_changes_tracker.py
@@ -36,57 +36,57 @@ class BreakingChangeType(str, Enum):
 
 class BreakingChangesTracker:
     REMOVED_OR_RENAMED_CLIENT_MSG = \
-        "Deleted or renamed client '{}'"
+        "Deleted or renamed client `{}`"
     REMOVED_OR_RENAMED_CLIENT_METHOD_MSG = \
-        "Deleted or renamed client method '{}.{}'"
+        "Deleted or renamed client method `{}.{}`"
     REMOVED_OR_RENAMED_CLASS_MSG = \
-        "Deleted or renamed model '{}'"
+        "Deleted or renamed model `{}`"
     REMOVED_OR_RENAMED_CLASS_METHOD_MSG = \
-        "Deleted or renamed method '{}.{}'"
+        "Deleted or renamed method `{}.{}`"
     REMOVED_OR_RENAMED_MODULE_LEVEL_FUNCTION_MSG = \
-        "Deleted or renamed function '{}'"
+        "Deleted or renamed function `{}`"
     REMOVED_OR_RENAMED_POSITIONAL_PARAM_OF_METHOD_MSG = \
-        "'{}.{}' method deleted or renamed its parameter '{}' of kind '{}'"
+        "`{}.{}` method deleted or renamed its parameter `{}` of kind `{}`"
     REMOVED_OR_RENAMED_POSITIONAL_PARAM_OF_FUNCTION_MSG = \
-        "'{}' function deleted or renamed its parameter '{}' of kind '{}'"
+        "`{}` function deleted or renamed its parameter `{}` of kind `{}`"
     ADDED_POSITIONAL_PARAM_TO_METHOD_MSG = \
-        "'{}.{}' method inserted a '{}' parameter '{}'"
+        "`{}.{}` method inserted a `{}` parameter `{}`"
     ADDED_POSITIONAL_PARAM_TO_FUNCTION_MSG = \
-        "'{}' function inserted a '{}' parameter '{}'"
+        "`{}` function inserted a `{}` parameter `{}`"
     REMOVED_OR_RENAMED_INSTANCE_ATTRIBUTE_FROM_CLIENT_MSG = \
-        "'{}' deleted or renamed client instance variable '{}'"
+        "`{}` deleted or renamed client instance variable `{}`"
     REMOVED_OR_RENAMED_INSTANCE_ATTRIBUTE_FROM_MODEL_MSG = \
-        "'{}' model deleted or renamed its instance variable '{}'"
+        "`{}` model deleted or renamed its instance variable `{}`"
     REMOVED_OR_RENAMED_ENUM_VALUE_MSG = \
-        "Deleted or renamed enum value '{}.{}'"
+        "Deleted or renamed enum value `{}.{}`"
     CHANGED_PARAMETER_DEFAULT_VALUE_MSG = \
-        "'{}.{}' method parameter '{}' changed default value from '{}' to '{}'"
+        "`{}.{}` method parameter `{}` changed default value from `{}` to `{}`"
     CHANGED_PARAMETER_DEFAULT_VALUE_OF_FUNCTION_MSG = \
-        "'{}' function parameter '{}' changed default value from '{}' to '{}'"
+        "`{}` function parameter `{}` changed default value from `{}` to `{}`"
     REMOVED_PARAMETER_DEFAULT_VALUE_MSG = \
-        "'{}.{}' removed default method value '{}' from its parameter '{}'"
+        "`{}.{}` removed default method value `{}` from its parameter `{}`"
     REMOVED_PARAMETER_DEFAULT_VALUE_OF_FUNCTION_MSG = \
-        "'{}' function removed default value '{}' from its parameter '{}'"
+        "`{}` function removed default value `{}` from its parameter `{}`"
     CHANGED_PARAMETER_ORDERING_MSG = \
-        "'{}.{}' method re-ordered its parameters from '{}' to '{}'"
+        "`{}.{}` method re-ordered its parameters from `{}` to `{}`"
     CHANGED_PARAMETER_ORDERING_OF_FUNCTION_MSG = \
-        "'{}' function re-ordered its parameters from '{}' to '{}'"
+        "`{}` function re-ordered its parameters from `{}` to `{}`"
     CHANGED_PARAMETER_KIND_MSG = \
-        "'{}.{}' method changed its parameter '{}' from '{}' to '{}'"
+        "`{}.{}` method changed its parameter `{}` from `{}` to `{}`"
     CHANGED_PARAMETER_KIND_OF_FUNCTION_MSG = \
-        "'{}' function changed its parameter '{}' from '{}' to '{}'"
+        "`{}` function changed its parameter `{}` from `{}` to `{}`"
     CHANGED_CLASS_FUNCTION_KIND_MSG = \
-        "'{}.{}' method changed from '{}' to '{}'"
+        "`{}.{}` method changed from `{}` to `{}`"
     CHANGED_FUNCTION_KIND_MSG = \
-        "Changed function '{}' from '{}' to '{}'"
+        "Changed function `{}` from `{}` to `{}`"
     REMOVED_OR_RENAMED_MODULE_MSG = \
-        "Deleted or renamed module '{}'"
+        "Deleted or renamed module `{}`"
     REMOVED_CLASS_FUNCTION_KWARGS_MSG = \
-        "'{}.{}' method changed from accepting keyword arguments to not accepting them"
+        "`{}.{}` method changed from accepting keyword arguments to not accepting them"
     REMOVED_FUNCTION_KWARGS_MSG = \
-        "'{}' function changed from accepting keyword arguments to not accepting them"
+        "`{}` function changed from accepting keyword arguments to not accepting them"
     REMOVED_OR_RENAMED_OPERATION_GROUP_MSG = \
-        "Deleted or renamed client operation group '{}.{}'"
+        "Deleted or renamed client operation group `{}.{}`"
 
     def __init__(self, stable: Dict, current: Dict, diff: Dict, package_name: str, **kwargs: Any) -> None:
         self.stable = stable

--- a/scripts/breaking_changes_checker/breaking_changes_tracker.py
+++ b/scripts/breaking_changes_checker/breaking_changes_tracker.py
@@ -46,45 +46,45 @@ class BreakingChangesTracker:
     REMOVED_OR_RENAMED_MODULE_LEVEL_FUNCTION_MSG = \
         "Deleted or renamed function `{}`"
     REMOVED_OR_RENAMED_POSITIONAL_PARAM_OF_METHOD_MSG = \
-        "`{}.{}` method deleted or renamed its parameter `{}` of kind `{}`"
+        "Method `{}.{}` deleted or renamed its parameter `{}` of kind `{}`"
     REMOVED_OR_RENAMED_POSITIONAL_PARAM_OF_FUNCTION_MSG = \
-        "`{}` function deleted or renamed its parameter `{}` of kind `{}`"
+        "Function `{}` deleted or renamed its parameter `{}` of kind `{}`"
     ADDED_POSITIONAL_PARAM_TO_METHOD_MSG = \
-        "`{}.{}` method inserted a `{}` parameter `{}`"
+        "Method `{}.{}` inserted a `{}` parameter `{}`"
     ADDED_POSITIONAL_PARAM_TO_FUNCTION_MSG = \
-        "`{}` function inserted a `{}` parameter `{}`"
+        "Function `{}` inserted a `{}` parameter `{}`"
     REMOVED_OR_RENAMED_INSTANCE_ATTRIBUTE_FROM_CLIENT_MSG = \
-        "`{}` deleted or renamed client instance variable `{}`"
+        "Client `{}` deleted or renamed instance variable `{}`"
     REMOVED_OR_RENAMED_INSTANCE_ATTRIBUTE_FROM_MODEL_MSG = \
-        "`{}` model deleted or renamed its instance variable `{}`"
+        "Model `{}` deleted or renamed its instance variable `{}`"
     REMOVED_OR_RENAMED_ENUM_VALUE_MSG = \
         "Deleted or renamed enum value `{}.{}`"
     CHANGED_PARAMETER_DEFAULT_VALUE_MSG = \
-        "`{}.{}` method parameter `{}` changed default value from `{}` to `{}`"
+        "Method `{}.{}` parameter `{}` changed default value from `{}` to `{}`"
     CHANGED_PARAMETER_DEFAULT_VALUE_OF_FUNCTION_MSG = \
-        "`{}` function parameter `{}` changed default value from `{}` to `{}`"
+        "Function `{}` parameter `{}` changed default value from `{}` to `{}`"
     REMOVED_PARAMETER_DEFAULT_VALUE_MSG = \
-        "`{}.{}` removed default method value `{}` from its parameter `{}`"
+        "Method `{}.{}` removed default value `{}` from its parameter `{}`"
     REMOVED_PARAMETER_DEFAULT_VALUE_OF_FUNCTION_MSG = \
-        "`{}` function removed default value `{}` from its parameter `{}`"
+        "Function `{}` removed default value `{}` from its parameter `{}`"
     CHANGED_PARAMETER_ORDERING_MSG = \
-        "`{}.{}` method re-ordered its parameters from `{}` to `{}`"
+        "Method `{}.{}` re-ordered its parameters from `{}` to `{}`"
     CHANGED_PARAMETER_ORDERING_OF_FUNCTION_MSG = \
-        "`{}` function re-ordered its parameters from `{}` to `{}`"
+        "Function `{}` re-ordered its parameters from `{}` to `{}`"
     CHANGED_PARAMETER_KIND_MSG = \
-        "`{}.{}` method changed its parameter `{}` from `{}` to `{}`"
+        "Method `{}.{}` changed its parameter `{}` from `{}` to `{}`"
     CHANGED_PARAMETER_KIND_OF_FUNCTION_MSG = \
-        "`{}` function changed its parameter `{}` from `{}` to `{}`"
+        "Function `{}` changed its parameter `{}` from `{}` to `{}`"
     CHANGED_CLASS_FUNCTION_KIND_MSG = \
-        "`{}.{}` method changed from `{}` to `{}`"
+        "Method `{}.{}` changed from `{}` to `{}`"
     CHANGED_FUNCTION_KIND_MSG = \
         "Changed function `{}` from `{}` to `{}`"
     REMOVED_OR_RENAMED_MODULE_MSG = \
         "Deleted or renamed module `{}`"
     REMOVED_CLASS_FUNCTION_KWARGS_MSG = \
-        "`{}.{}` method changed from accepting keyword arguments to not accepting them"
+        "Method `{}.{}` changed from accepting keyword arguments to not accepting them"
     REMOVED_FUNCTION_KWARGS_MSG = \
-        "`{}` function changed from accepting keyword arguments to not accepting them"
+        "Function `{}` changed from accepting keyword arguments to not accepting them"
     REMOVED_OR_RENAMED_OPERATION_GROUP_MSG = \
         "Deleted or renamed client operation group `{}.{}`"
 

--- a/scripts/breaking_changes_checker/changelog_tracker.py
+++ b/scripts/breaking_changes_checker/changelog_tracker.py
@@ -31,7 +31,7 @@ class ChangelogTracker(BreakingChangesTracker):
     ADDED_CLASS_METHOD_MSG = \
         "Model `{}` added method `{}`"
     ADDED_CLASS_METHOD_PARAMETER_MSG = \
-        "Model `{}` added parameter `{}` in the `{}` method"
+        "Model `{}` added parameter `{}` in method `{}`"
     ADDED_FUNCTION_PARAMETER_MSG = \
         "Function `{}` added parameter `{}`"
     ADDED_CLASS_PROPERTY_MSG = \

--- a/scripts/breaking_changes_checker/changelog_tracker.py
+++ b/scripts/breaking_changes_checker/changelog_tracker.py
@@ -23,21 +23,21 @@ class ChangeType(str, Enum):
 
 class ChangelogTracker(BreakingChangesTracker):
     ADDED_CLIENT_MSG = \
-        "Added client '{}'"
+        "Added client `{}`"
     ADDED_CLIENT_METHOD_MSG = \
-        "Client '{}' added method '{}'"
+        "Client `{}` added method `{}`"
     ADDED_CLASS_MSG = \
-        "Added model '{}'"
+        "Added model `{}`"
     ADDED_CLASS_METHOD_MSG = \
-        "Model '{}' added method '{}'"
+        "Model `{}` added method `{}`"
     ADDED_CLASS_METHOD_PARAMETER_MSG = \
-        "Model '{}' added parameter '{}' in the '{}' method"
+        "Model `{}` added parameter `{}` in the `{}` method"
     ADDED_FUNCTION_PARAMETER_MSG = \
-        "Function '{}' added parameter '{}'"
+        "Function `{}` added parameter `{}`"
     ADDED_CLASS_PROPERTY_MSG = \
-        "Model '{}' added property '{}'"
+        "Model `{}` added property `{}`"
     ADDED_OPERATION_GROUP_MSG = \
-        "Client '{}' added operation group '{}'"
+        "Client `{}` added operation group `{}`"
 
 
     def __init__(self, stable: Dict, current: Dict, diff: Dict, package_name: str, **kwargs: Any) -> None:

--- a/scripts/breaking_changes_checker/tests/test_breaking_changes.py
+++ b/scripts/breaking_changes_checker/tests/test_breaking_changes.py
@@ -24,25 +24,25 @@ def format_breaking_changes(breaking_changes):
     return formatted
 
 EXPECTED = [
-    "(RemovedOrRenamedInstanceAttribute): 'Metrics' model deleted or renamed its instance variable 'retention_policy'",
-    "(RemovedOrRenamedInstanceAttribute): 'QueueClient' deleted or renamed client instance variable 'queue_name'",
-    "(ChangedParameterKind): 'QueueClient.from_queue_url' method changed its parameter 'credential' from 'positional_or_keyword' to 'keyword_only'",
-    "(AddedPositionalParam): 'QueueClient.get_queue_access_policy' method inserted a 'positional_or_keyword' parameter 'queue_name'",
-    "(RemovedOrRenamedPositionalParam): 'QueueClient.set_queue_access_policy' method deleted or renamed its parameter 'signed_identifiers' of kind 'positional_or_keyword'",
-    "(ChangedParameterDefaultValue): 'QueueClient.set_queue_metadata' method parameter 'metadata' changed default value from 'None' to ''",
-    "(RemovedOrRenamedClassMethod): Deleted or renamed method 'QueueSasPermissions.from_string'",
-    "(RemovedFunctionKwargs): 'QueueServiceClient.set_service_properties' method changed from accepting keyword arguments to not accepting them",
-    "(RemovedOrRenamedClientMethod): Deleted or renamed client method 'QueueServiceClient.get_service_properties'",
-    "(RemovedOrRenamedEnumValue): Deleted or renamed enum value 'StorageErrorCode.queue_not_found'",
-    "(RemovedOrRenamedClass): Deleted or renamed model 'QueueMessage'",
-    "(ChangedParameterDefaultValue): 'generate_queue_sas' function parameter 'permission' changed default value from 'None' to ''",
-    "(ChangedParameterKind): 'generate_queue_sas' function changed its parameter 'ip' from 'positional_or_keyword' to 'keyword_only'",
-    "(AddedPositionalParam): 'generate_queue_sas' function inserted a 'positional_or_keyword' parameter 'conn_str'",
-    "(RemovedOrRenamedPositionalParam): 'generate_queue_sas' function deleted or renamed its parameter 'account_name' of kind 'positional_or_keyword'",
-    "(RemovedOrRenamedModuleLevelFunction): Deleted or renamed function 'generate_account_sas'",
-    "(RemovedParameterDefaultValue): 'QueueClient.update_message' removed default method value 'None' from its parameter 'pop_receipt'",
-    "(ChangedFunctionKind): 'QueueServiceClient.get_service_stats' method changed from 'asynchronous' to 'synchronous'",
-    "(ChangedParameterOrdering): 'QueueClient.from_connection_string' method re-ordered its parameters from '['conn_str', 'queue_name', 'credential', 'kwargs']' to '['queue_name', 'conn_str', 'credential', 'kwargs']'",
+    "(RemovedOrRenamedInstanceAttribute): Model `Metrics` deleted or renamed its instance variable `retention_policy`",
+    "(RemovedOrRenamedInstanceAttribute): Client `QueueClient` deleted or renamed instance variable `queue_name`",
+    "(ChangedParameterKind): Method `QueueClient.from_queue_url` changed its parameter `credential` from `positional_or_keyword` to `keyword_only`",
+    "(AddedPositionalParam): Method `QueueClient.get_queue_access_policy` inserted a `positional_or_keyword` parameter `queue_name`",
+    "(RemovedOrRenamedPositionalParam): Method `QueueClient.set_queue_access_policy` deleted or renamed its parameter `signed_identifiers` of kind `positional_or_keyword`",
+    "(ChangedParameterDefaultValue): Method `QueueClient.set_queue_metadata` parameter `metadata` changed default value from `None` to ``",
+    "(RemovedOrRenamedClassMethod): Deleted or renamed method `QueueSasPermissions.from_string`",
+    "(RemovedFunctionKwargs): Method `QueueServiceClient.set_service_properties` changed from accepting keyword arguments to not accepting them",
+    "(RemovedOrRenamedClientMethod): Deleted or renamed client method `QueueServiceClient.get_service_properties`",
+    "(RemovedOrRenamedEnumValue): Deleted or renamed enum value `StorageErrorCode.queue_not_found`",
+    "(RemovedOrRenamedClass): Deleted or renamed model `QueueMessage`",
+    "(ChangedParameterDefaultValue): Function `generate_queue_sas` parameter `permission` changed default value from `None` to ``",
+    "(ChangedParameterKind): Function `generate_queue_sas` changed its parameter `ip` from `positional_or_keyword` to `keyword_only`",
+    "(AddedPositionalParam): Function `generate_queue_sas` inserted a `positional_or_keyword` parameter `conn_str`",
+    "(RemovedOrRenamedPositionalParam): Function `generate_queue_sas` deleted or renamed its parameter `account_name` of kind `positional_or_keyword`",
+    "(RemovedOrRenamedModuleLevelFunction): Deleted or renamed function `generate_account_sas`",
+    "(RemovedParameterDefaultValue): Method `QueueClient.update_message` removed default value `None` from its parameter `pop_receipt`",
+    "(ChangedFunctionKind): Method `QueueServiceClient.get_service_stats` changed from `asynchronous` to `synchronous`",
+    "(ChangedParameterOrdering): Method `QueueClient.from_connection_string` re-ordered its parameters from `['conn_str', 'queue_name', 'credential', 'kwargs']` to `['queue_name', 'conn_str', 'credential', 'kwargs']`",
 ]
 
 
@@ -181,10 +181,10 @@ def test_replace_all_params():
     }
 
     EXPECTED = [
-        "(RemovedOrRenamedPositionalParam): 'class_name.one' method deleted or renamed its parameter 'testing' of kind 'positional_or_keyword'",
-        "(RemovedOrRenamedPositionalParam): 'class_name.two' method deleted or renamed its parameter 'testing2' of kind 'positional_or_keyword'",
-        "(RemovedOrRenamedPositionalParam): 'my_function_name' function deleted or renamed its parameter 'testing' of kind 'positional_or_keyword'",
-        "(RemovedOrRenamedPositionalParam): 'my_function_name' function deleted or renamed its parameter 'testing2' of kind 'positional_or_keyword'"
+        "(RemovedOrRenamedPositionalParam): Method `class_name.one` deleted or renamed its parameter `testing` of kind `positional_or_keyword`",
+        "(RemovedOrRenamedPositionalParam): Method `class_name.two` deleted or renamed its parameter `testing2` of kind `positional_or_keyword`",
+        "(RemovedOrRenamedPositionalParam): Function `my_function_name` deleted or renamed its parameter `testing` of kind `positional_or_keyword`",
+        "(RemovedOrRenamedPositionalParam): Function `my_function_name` deleted or renamed its parameter `testing2` of kind `positional_or_keyword`"
     ]
 
     diff = jsondiff.diff(stable, current)
@@ -269,10 +269,10 @@ def test_replace_all_functions():
     }
 
     EXPECTED = [
-        "(RemovedOrRenamedClassMethod): Deleted or renamed method 'class_name.one'",
-        "(RemovedOrRenamedClassMethod): Deleted or renamed method 'class_name.two'",
-        "(RemovedOrRenamedModuleLevelFunction): Deleted or renamed function 'my_function_name'",
-        "(RemovedOrRenamedModuleLevelFunction): Deleted or renamed function 'my_function_name2'"
+        "(RemovedOrRenamedClassMethod): Deleted or renamed method `class_name.one`",
+        "(RemovedOrRenamedClassMethod): Deleted or renamed method `class_name.two`",
+        "(RemovedOrRenamedModuleLevelFunction): Deleted or renamed function `my_function_name`",
+        "(RemovedOrRenamedModuleLevelFunction): Deleted or renamed function `my_function_name2`"
     ]
 
     diff = jsondiff.diff(stable, current)
@@ -345,8 +345,8 @@ def test_replace_all_classes():
     }
 
     EXPECTED = [
-        "(RemovedOrRenamedClass): Deleted or renamed model 'class_name'",
-        "(RemovedOrRenamedClass): Deleted or renamed model 'class_name2'"
+        "(RemovedOrRenamedClass): Deleted or renamed model `class_name`",
+        "(RemovedOrRenamedClass): Deleted or renamed model `class_name2`"
     ]
 
     diff = jsondiff.diff(stable, current)
@@ -373,7 +373,7 @@ def test_replace_all_modules():
     }
 
     EXPECTED = [
-        "(RemovedOrRenamedModule): Deleted or renamed module 'azure.ai.formrecognizer'",
+        "(RemovedOrRenamedModule): Deleted or renamed module `azure.ai.formrecognizer`",
     ]
 
     diff = jsondiff.diff(stable, current)
@@ -430,7 +430,7 @@ def test_removed_operation_group():
     }
 
     EXPECTED = [
-        "(RemovedOrRenamedOperationGroup): Deleted or renamed client operation group 'ContosoClient.foo'"
+        "(RemovedOrRenamedOperationGroup): Deleted or renamed client operation group `ContosoClient.foo`"
     ]
 
     diff = jsondiff.diff(stable, current)


### PR DESCRIPTION
Context:
- changelog is displayed in .md file so "`" is more clear to show compared with "'"
- Unify pattern to `Method/Functin/Client XXX ...` 
- changelog report will also be used in `sdk-suppressions.yaml` of swagger repo (e.g. https://github.com/Azure/azure-rest-api-specs/pull/30396/checks?check_run_id=29545715813). If the report item start with `'`, SDK owner will have to manually add `"` when add it in .yaml file which is inconvenient.



