### PR TITLE
[breaking change detector] update allowlist

### DIFF
--- a/scripts/breaking_changes_checker/breaking_changes_allowlist.py
+++ b/scripts/breaking_changes_checker/breaking_changes_allowlist.py
@@ -32,5 +32,10 @@ IGNORE_BREAKING_CHANGES = {
         ("RemovedOrRenamedPositionalParam", "*", "*", "as_dict", "key_transformer"),
         ("RemovedOrRenamedPositionalParam", "*", "*", "as_dict"),
         ("RemovedFunctionKwargs", "*", "*", "as_dict"),
+        # operation group can't be instantiated independently so don't need check for it
+        ("RemovedOrRenamedPositionalParam", "*", "__init__", "client", "positional_or_keyword"),
+        ("RemovedOrRenamedPositionalParam", "*", "__init__", "config", "positional_or_keyword"),
+        ("RemovedOrRenamedPositionalParam", "*", "__init__", "serializer", "positional_or_keyword"),
+        ("RemovedOrRenamedPositionalParam", "*", "__init__", "deserializer", "positional_or_keyword"),
     ]
 }


### PR DESCRIPTION
operation group can't be instantiated independently so don't need check for it. After merged, we can reduce manual work like https://github.com/Azure/azure-sdk-for-python/pull/37170/commits/57dbcdc6e37c0c21449b218ec2d0d57ba5782b48