### PR TITLE
Fix api deprecation

### DIFF
--- a/sdk/ai/azure-ai-generative/azure/ai/generative/synthetic/qa.py
+++ b/sdk/ai/azure-ai-generative/azure/ai/generative/synthetic/qa.py
@@ -23,13 +23,15 @@ except ImportError as e:
     raise e
 
 try:
-    import pkg_resources  # type: ignore[import]
-
-    openai_version_str = pkg_resources.get_distribution("openai").version
-    openai_version = pkg_resources.parse_version(openai_version_str)
+    from importlib.metadata import version
+    from packaging.version import parse
     import openai
+    
+    openai_version_str = version("openai")
+    openai_version = parse(openai_version_str)
+    
 
-    if openai_version >= pkg_resources.parse_version("1.0.0"):
+    if openai_version >= parse("1.0.0"):
         _RETRY_ERRORS: Tuple = (openai.APIConnectionError, openai.APIError, openai.APIStatusError)
     else:
         _RETRY_ERRORS: Tuple = (  # type: ignore[no-redef]
@@ -56,7 +58,7 @@ def _completion_with_retries(*args, **kwargs):
     n = 1
     while True:
         try:
-            if openai_version >= pkg_resources.parse_version("1.0.0"):
+            if openai_version >= parse("1.0.0"):
                 if kwargs["api_type"].lower() == "azure":
                     from openai import AzureOpenAI
 
@@ -103,7 +105,7 @@ async def _completion_with_retries_async(*args, **kwargs):
     n = 1
     while True:
         try:
-            if openai_version >= pkg_resources.parse_version("1.0.0"):
+            if openai_version >= parse("1.0.0"):
                 if kwargs["api_type"].lower() == "azure":
                     from openai import AsyncAzureOpenAI
 


### PR DESCRIPTION
# Description

When using ` QADataGenerator` like so , `from azure.ai.generative.synthetic.qa import QADataGenerator` 

Under `python 3.12` we are getting a failure with error 
```
 ModuleNotFoundError: No module named 'pkg_resources'
 ```
If we install `setuptools` we are further hit with a deprecation notice - 
```
 DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
```

This PR uses alternative way to support functionality without breaking anything. 


If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
