### PR TITLE
Repair Nightly Storage Build

### DIFF
--- a/tools/azure-sdk-tools/ci_tools/functions.py
+++ b/tools/azure-sdk-tools/ci_tools/functions.py
@@ -370,7 +370,8 @@ def process_requires(setup_py_path: str, is_dev_build: bool = False):
             #        )?
             #       )?
             rx = r"{}(((a|b|rc)\d+)?(\.post\d+)?)?".format(base_version)
-            new_req = re.sub(rx, "{}{}1".format(base_version, DEV_BUILD_IDENTIFIER), str(req), flags=re.IGNORECASE)
+            new_req_format = f"{base_version}{DEV_BUILD_IDENTIFIER}1,<{base_version}b0"
+            new_req = re.sub(rx, new_req_format, str(req), flags=re.IGNORECASE)
             logging.info("New requirement for package {0}: {1}".format(pkg_name, new_req))
             requirement_to_update[old_req] = new_req
 


### PR DESCRIPTION
`azure-storage-file-datalake` nightly run is [failing](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4102172&view=logs&j=418474da-bc95-5d2e-443a-6890a46f19ae&t=31e5c6c0-d900-5284-91a4-f3792a0f14ad&l=35972)

The link above takes you directly to the _reason_ that the test is failing. Namely, that the version of `azure-storage-blob` installed for `latestdependency` and `mindependency` environments is resolving to `azure-storage-blob==12.23.0b1`.

This is due to the way that python versioning works. When we want to pull in a "dev" version of the package for nightly, we need to update the requirement to an alpha one.

`azure-storage-blob>12.23.0` becomes `azure-storage-blob>12.23.0a1`. However, due to how pip version resolution works, `b1` is considered _newer_ than `a1`. As a result, we are never resolving the alpha version we expect, and are instead picking up a previously published `azure-storage-blob==12.23.0b1`. 

This PR updates our `set_dev_version` script to add the beta restriction, so any actually intentionally published `beta` packages don't collide in `latest` / `minimum` dependency checks.

- [This storage build should succeed if my hunch is right](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4105136&view=results)
