### PR TITLE
update the package namespaces for all packages in the artifact directory

### DIFF
--- a/eng/pipelines/templates/steps/build-extended-artifacts.yml
+++ b/eng/pipelines/templates/steps/build-extended-artifacts.yml
@@ -84,7 +84,6 @@ steps:
       filePath: $(Build.SourcesDirectory)/eng/scripts/Save-Package-Namespaces-Property.ps1
       arguments: >
         -ArtifactStagingDirectory "$(Build.ArtifactStagingDirectory)"
-        -ArtifactsList ('${{ convertToJson(parameters.Artifacts) }}' | ConvertFrom-Json)
       pwsh: true
       workingDirectory: $(Pipeline.Workspace)
     displayName: Update package properties with namespaces

--- a/eng/scripts/Save-Package-Namespaces-Property.ps1
+++ b/eng/scripts/Save-Package-Namespaces-Property.ps1
@@ -41,8 +41,6 @@ if (-not $artifacts) {
     exit 0
 }
 
-
-
 # by this point, the PackageInfo folder will have a json file for each artifact
 # we simply need to read each file, get the appropriate metadata, and add the namespaces if necessary
 foreach($packageInfoFile in $artifacts) {

--- a/eng/scripts/Save-Package-Namespaces-Property.ps1
+++ b/eng/scripts/Save-Package-Namespaces-Property.ps1
@@ -14,28 +14,16 @@ The root directory of the staged artifacts. The PackageInfo files will be in the
 PackageInfo subdirectory. The whl files are going to be in the subdirectory which
 is the same as the artifact's name but artifact name in the file's name will have
  underscores instead of dashes.
-
-.PARAMETER ArtifactsList
-The list of artifacts to gather namespaces for, this is only done for libraries that are
-producing docs.
--ArtifactsList ('${{ convertToJson(parameters.Artifacts) }}' | ConvertFrom-Json)
 #>
 [CmdletBinding()]
 Param (
     [Parameter(Mandatory = $True)]
-    [string] $ArtifactStagingDirectory,
-    [Parameter(Mandatory=$true)]
-    [array] $ArtifactsList
+    [string] $ArtifactStagingDirectory
 )
 
 $ArtifactsList = $ArtifactsList | Where-Object -Not "skipPublishDocMs"
 
 . (Join-Path $PSScriptRoot ".." common scripts common.ps1)
-
-if (-not $ArtifactsList) {
-    Write-Host "ArtifactsList is empty, nothing to process. This can happen if skipPublishDocMs is set to true for all libraries being built."
-    exit 0
-}
 
 Write-Host "ArtifactStagingDirectory=$ArtifactStagingDirectory"
 if (-not (Test-Path -Path $ArtifactStagingDirectory)) {
@@ -43,19 +31,22 @@ if (-not (Test-Path -Path $ArtifactStagingDirectory)) {
     exit 1
 }
 
-Write-Host ""
-Write-Host "ArtifactsList:"
-$ArtifactsList | Format-Table -Property Name | Out-String | Write-Host
-
 $packageInfoDirectory = Join-Path $ArtifactStagingDirectory "PackageInfo"
-
 $foundError = $false
-# At this point the packageInfo files should have been already been created.
-# The only thing being done here is adding or updating namespaces for libraries
-# that will be producing docs.
-foreach($artifact in $ArtifactsList) {
+$artifacts = Get-ChildItem -Path $packageInfoDirectory -File -Filter "*.json"
+$artifacts | Format-Table -Property Name | Out-String | Write-Host
+
+if (-not $artifacts) {
+    Write-Host "Zero artifacts were discovered, nothing to process. This can happen if skipPublishDocMs is set to true for all libraries being built."
+    exit 0
+}
+
+
+
+# by this point, the PackageInfo folder will have a json file for each artifact
+# we simply need to read each file, get the appropriate metadata, and add the namespaces if necessary
+foreach($packageInfoFile in $artifacts) {
     # Get the version from the packageInfo file
-    $packageInfoFile = Join-Path $packageInfoDirectory "$($artifact.Name).json"
     Write-Host "processing $($packageInfoFile.FullName)"
     $packageInfo = ConvertFrom-Json (Get-Content $packageInfoFile -Raw)
     $version = $packageInfo.Version
@@ -69,8 +60,7 @@ foreach($artifact in $ArtifactsList) {
     $WhlFile = Get-ChildItem -Path $WhlDir -File -Filter "$whlName-$version*.whl"
 
     if (!(Test-Path $WhlFile -PathType Leaf)) {
-        LogError "Whl file for, $($packageInfo.Name), was not found in $WhlDir. Please ensure that a .whl file is being produced for the library."
-        $foundError = $true
+        Write-Host "Whl file for, $($packageInfo.Name), was not found in $WhlDir. Unable to update package namespaces."
         continue
     }
     $namespaces = Get-NamespacesFromWhlFile $packageInfo.Name $version -PythonWhlFile $WhlFile


### PR DESCRIPTION
If the file has been filtered out, do not hard error.

@msyyc this is in response to the failure [you shared with me](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4100410&view=logs&j=4259cd7e-6a4b-5ca5-581a-0ae020cd9d20&t=33503732-9121-5533-20a8-793d20d335b2) where a targeting string was set, thereby filtering the package that is actually built.